### PR TITLE
Automatically publish `npm pack` to GH Releases

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,28 +26,6 @@ jobs:
       - run: npm test
       - run: npm run lint
 
-  package-test:
-    runs-on: ubuntu-latest
-
-    permissions:
-      contents: write
-
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 18
-          cache: npm
-
-      - run: npm ci
-      - run: npm pack
-
-      - name: Upload package to release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh release upload 0.1.0 ./*.tgz
-
   package:
     runs-on: ubuntu-latest
     if: github.event_name == 'release'


### PR DESCRIPTION
Should make it easier for folks to use dependent repos.