### PR TITLE
Inherit environment variables deemed safe by default

### DIFF
--- a/src/client/stdio.ts
+++ b/src/client/stdio.ts
@@ -29,23 +29,17 @@ export type StdioServerParameters = {
 export const DEFAULT_INHERITED_ENV_VARS =
   process.platform === "win32"
     ? [
-        "ALLUSERSPROFILE",
         "APPDATA",
         "HOMEDRIVE",
         "HOMEPATH",
         "LOCALAPPDATA",
-        "NUMBER_OF_PROCESSORS",
-        "OS",
         "PATH",
-        "PATHEXT",
         "PROCESSOR_ARCHITECTURE",
         "SYSTEMDRIVE",
         "SYSTEMROOT",
         "TEMP",
-        "TMP",
         "USERNAME",
         "USERPROFILE",
-        "WINDIR",
       ]
     : /* list inspired by the default env inheritance of sudo */
       ["HOME", "LOGNAME", "PATH", "SHELL", "TERM", "USER"];


### PR DESCRIPTION
Will need to make the same changes in the Python SDK, but let's review this for correctness first.

# To do

## After merging

- [x] Release
- [x] [Update Python SDK](https://github.com/modelcontextprotocol/python-sdk/pull/27)