### PR TITLE
Restrict publishing to `release` environment

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,6 +29,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     if: github.event_name == 'release'
+    environment: release
     needs: build
 
     permissions:


### PR DESCRIPTION
Following a similar approach as https://github.com/modelcontextprotocol/python-sdk/pull/46.

I've already moved the `NPM_TOKEN` secret over.