### PR TITLE
Don't open a terminal window on Windows

### DIFF
--- a/src/client/stdio.ts
+++ b/src/client/stdio.ts
@@ -103,6 +103,7 @@ export class StdioClientTransport implements Transport {
         {
           env: this._serverParams.env ?? getDefaultEnvironment(),
           stdio: ["pipe", "pipe", "inherit"],
+          shell: false,
           signal: this._abortController.signal,
         },
       );


### PR DESCRIPTION
Stop Claude Desktop from spamming the screen with dozens of terminal windows on startup