### PR TITLE
Add links to docs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,12 @@ const transport = new StdioServerTransport();
 await server.connect(transport);
 ```
 
+## Documentation
+
+- [Model Context Protocol documentation](https://modelcontextprotocol.io)
+- [MCP Specification](https://spec.modelcontextprotocol.io)
+- [Example Servers](https://github.com/modelcontextprotocol/servers)
+
 ## Contributing
 
 Issues and pull requests are welcome on GitHub at https://github.com/modelcontextprotocol/typescript-sdk.


### PR DESCRIPTION
Matches the python-sdk repo.