### PR TITLE
Fix method name in client cancellation send

### DIFF
--- a/src/shared/protocol.ts
+++ b/src/shared/protocol.ts
@@ -421,7 +421,7 @@ export abstract class Protocol<
         this._transport
           ?.send({
             jsonrpc: "2.0",
-            method: "cancelled",
+            method: "notifications/cancelled",
             params: {
               requestId: messageId,
               reason: String(reason),


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

The server registers a notification handler on `CancelledNotificationSchema`, but is never called on client cancellation because of a mismatch in the method name. This fixes that mismatch.

## Motivation and Context

Cancellation between server <-> client implementations does not seem to function correctly. There's no propagation of an abort signal from the client to the server.

## How Has This Been Tested?

I made this change in the dependency tree of a local application and saw that the server signal is properly canceled after the change.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
