### PR TITLE
Add a parsedBody optional parameter

### DIFF
--- a/src/server/sse.ts
+++ b/src/server/sse.ts
@@ -94,7 +94,7 @@ export class SSEServerTransport implements Transport {
     }
 
     try {
-      await this.handleMessage(typeof body === 'string'? JSON.parse(body): body);
+      await this.handleMessage(typeof body === 'string' ? JSON.parse(body) : body);
     } catch {
       res.writeHead(400).end(`Invalid message: ${body}`);
       return;

--- a/src/server/sse.ts
+++ b/src/server/sse.ts
@@ -68,6 +68,7 @@ export class SSEServerTransport implements Transport {
   async handlePostMessage(
     req: IncomingMessage,
     res: ServerResponse,
+    parsedBody?: unknown,
   ): Promise<void> {
     if (!this._sseResponse) {
       const message = "SSE connection not established";
@@ -75,14 +76,14 @@ export class SSEServerTransport implements Transport {
       throw new Error(message);
     }
 
-    let body: string;
+    let body: string | unknown;
     try {
       const ct = contentType.parse(req.headers["content-type"] ?? "");
       if (ct.type !== "application/json") {
         throw new Error(`Unsupported content-type: ${ct}`);
       }
 
-      body = await getRawBody(req, {
+      body = parsedBody ?? await getRawBody(req, {
         limit: MAXIMUM_MESSAGE_SIZE,
         encoding: ct.parameters.charset ?? "utf-8",
       });
@@ -93,7 +94,7 @@ export class SSEServerTransport implements Transport {
     }
 
     try {
-      await this.handleMessage(JSON.parse(body));
+      await this.handleMessage(typeof body === 'string'? JSON.parse(body): body);
     } catch {
       res.writeHead(400).end(`Invalid message: ${body}`);
       return;


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
`SSEServerTransport` requires nodejs `IncomingMessage` as a first parameter, 
but this `IncomingMessage` need not to be consumed by other body parser middlewares,
because in `body-parser`, `_readableState` will be checked and if you already consumed request body, `body-parser` will be thrown an error.
If you use server framework like fastify, body parser is installed at an initialization timing.

So I'd like to add a third and forth parameter to handlePostMessage to use an already parsed raw body.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Yes, link library to real application.

## Breaking Changes
No.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
