### PR TITLE
Remove `CompatibilityCallToolResult`

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -11,7 +11,6 @@ import {
   ClientNotification,
   ClientRequest,
   ClientResult,
-  CompatibilityCallToolResultSchema,
   CompleteRequest,
   CompleteResultSchema,
   EmptyResultSchema,
@@ -377,9 +376,7 @@ export class Client<
 
   async callTool(
     params: CallToolRequest["params"],
-    resultSchema:
-      | typeof CallToolResultSchema
-      | typeof CompatibilityCallToolResultSchema = CallToolResultSchema,
+    resultSchema: typeof CallToolResultSchema,
     options?: RequestOptions,
   ) {
     return this.request(

--- a/src/types.ts
+++ b/src/types.ts
@@ -753,15 +753,6 @@ export const CallToolResultSchema = ResultSchema.extend({
 });
 
 /**
- * CallToolResultSchema extended with backwards compatibility to protocol version 2024-10-07.
- */
-export const CompatibilityCallToolResultSchema = CallToolResultSchema.or(
-  ResultSchema.extend({
-    toolResult: z.unknown(),
-  }),
-);
-
-/**
  * Used by the client to invoke a tool provided by the server.
  */
 export const CallToolRequestSchema = RequestSchema.extend({
@@ -1195,9 +1186,6 @@ export type Tool = z.infer<typeof ToolSchema>;
 export type ListToolsRequest = z.infer<typeof ListToolsRequestSchema>;
 export type ListToolsResult = z.infer<typeof ListToolsResultSchema>;
 export type CallToolResult = z.infer<typeof CallToolResultSchema>;
-export type CompatibilityCallToolResult = z.infer<
-  typeof CompatibilityCallToolResultSchema
->;
 export type CallToolRequest = z.infer<typeof CallToolRequestSchema>;
 export type ToolListChangedNotification = z.infer<
   typeof ToolListChangedNotificationSchema


### PR DESCRIPTION
Resolves #82, by removing it entirely. This compatibility schema was only necessary for pre-release versions of the spec, so it should be safe to remove entirely now.