### PR TITLE
Revert "Remove `CompatibilityCallToolResult`"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/sdk",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Model Context Protocol implementation for TypeScript",
   "license": "MIT",
   "author": "Anthropic, PBC (https://anthropic.com)",

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -11,6 +11,7 @@ import {
   ClientNotification,
   ClientRequest,
   ClientResult,
+  CompatibilityCallToolResultSchema,
   CompleteRequest,
   CompleteResultSchema,
   EmptyResultSchema,
@@ -376,7 +377,9 @@ export class Client<
 
   async callTool(
     params: CallToolRequest["params"],
-    resultSchema: typeof CallToolResultSchema,
+    resultSchema:
+      | typeof CallToolResultSchema
+      | typeof CompatibilityCallToolResultSchema = CallToolResultSchema,
     options?: RequestOptions,
   ) {
     return this.request(

--- a/src/types.ts
+++ b/src/types.ts
@@ -753,6 +753,15 @@ export const CallToolResultSchema = ResultSchema.extend({
 });
 
 /**
+ * CallToolResultSchema extended with backwards compatibility to protocol version 2024-10-07.
+ */
+export const CompatibilityCallToolResultSchema = CallToolResultSchema.or(
+  ResultSchema.extend({
+    toolResult: z.unknown(),
+  }),
+);
+
+/**
  * Used by the client to invoke a tool provided by the server.
  */
 export const CallToolRequestSchema = RequestSchema.extend({
@@ -1186,6 +1195,9 @@ export type Tool = z.infer<typeof ToolSchema>;
 export type ListToolsRequest = z.infer<typeof ListToolsRequestSchema>;
 export type ListToolsResult = z.infer<typeof ListToolsResultSchema>;
 export type CallToolResult = z.infer<typeof CallToolResultSchema>;
+export type CompatibilityCallToolResult = z.infer<
+  typeof CompatibilityCallToolResultSchema
+>;
 export type CallToolRequest = z.infer<typeof CallToolRequestSchema>;
 export type ToolListChangedNotification = z.infer<
   typeof ToolListChangedNotificationSchema


### PR DESCRIPTION
Reverts modelcontextprotocol/typescript-sdk#83.

This was actually a breaking change—I don't know why I thought this would be okay in a point release. 😞 It also doesn't solve the underlying issue of _returning_ the wrong tool types, since unknown keys will typecheck just fine.

# To do

## After merging

- [ ] Release 1.0.3 with this revert and other fixes