### PR TITLE
chore: bump outdated versions in package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@modelcontextprotocol/sdk",
-  "version": "1.0.0",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@modelcontextprotocol/sdk",
-      "version": "1.0.0",
+      "version": "1.0.3",
       "license": "MIT",
       "dependencies": {
         "content-type": "^1.0.5",


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
Oudated version of `@modelcontextprotocol/sdk` package in `package-lock.json` after install before contributing.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Every later coming contributors would run `npm install`, and after installation, the `package-lock.json` file would be updated due to outdated version.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
No more changes occurred after fresh `npm install` with `node_modules` deleted.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
It's recommended to use workflows with [antfu-collective/bumpp](https://github.com/antfu-collective/bumpp) or [changesets/changesets](https://github.com/changesets/changesets) (purely CI/CD oriented) to help to release the module with version bumpping correctly. I could help to migrate to such workflow if agreed.