### PR TITLE
chore: satisfies npm-pkg-lint & publint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,9 @@
         "typescript": "^5.5.4",
         "typescript-eslint": "^8.0.0",
         "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "git+https://github.com/modelcontextprotocol/typescript-sdk.git"
   },
   "engines": {
-    "node": ">=22.12.0"
+    "node": ">=18"
   },
   "keywords": [
     "modelcontextprotocol",

--- a/package.json
+++ b/package.json
@@ -7,8 +7,17 @@
   "homepage": "https://modelcontextprotocol.io",
   "bugs": "https://github.com/modelcontextprotocol/typescript-sdk/issues",
   "type": "module",
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/modelcontextprotocol/typescript-sdk.git"
+  },
+  "engines": {
+    "node": ">=22.12.0"
+  },
+  "keywords": [
+    "modelcontextprotocol",
+    "mcp"
+  ],
   "exports": {
     "./*": "./dist/*"
   },
@@ -23,8 +32,8 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc",
-    "prepack": "tsc",
+    "build": "tsc -p tsconfig.prod.json",
+    "prepack": "tsc -p tsconfig.prod.json",
     "lint": "eslint src/",
     "test": "jest",
     "start": "npm run server",

--- a/tsconfig.prod.json
+++ b/tsconfig.prod.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": [
+    "**/*.test.ts",
+  ]
+}


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

With the check of trending use of [`npm-pkg-lint`](https://www.npmjs.com/package/npm-pkg-lint) and [`publint`](publint.dev):

```shell
$ npm pack
$ npx npm-pkg-lint
~/Git/modelcontextprotocol/typescript-sdk/modelcontextprotocol-sdk-1.0.3.tgz
  1:1  error  dist/client/index.test.js is not allowed in tarball        no-disallowed-files
  1:1  error  dist/server/index.test.js is not allowed in tarball        no-disallowed-files
  1:1  error  dist/inMemory.test.js is not allowed in tarball            no-disallowed-files
  1:1  error  dist/client/stdio.test.js is not allowed in tarball        no-disallowed-files
  1:1  error  dist/server/stdio.test.js is not allowed in tarball        no-disallowed-files
  1:1  error  dist/shared/stdio.test.js is not allowed in tarball        no-disallowed-files
  1:1  error  dist/client/index.test.d.ts.map is not allowed in tarball  no-disallowed-files
  1:1  error  dist/server/index.test.d.ts.map is not allowed in tarball  no-disallowed-files
  1:1  error  dist/client/index.test.js.map is not allowed in tarball    no-disallowed-files
  1:1  error  dist/server/index.test.js.map is not allowed in tarball    no-disallowed-files
  1:1  error  dist/inMemory.test.d.ts.map is not allowed in tarball      no-disallowed-files
  1:1  error  dist/inMemory.test.js.map is not allowed in tarball        no-disallowed-files
  1:1  error  dist/client/stdio.test.d.ts.map is not allowed in tarball  no-disallowed-files
  1:1  error  dist/server/stdio.test.d.ts.map is not allowed in tarball  no-disallowed-files
  1:1  error  dist/shared/stdio.test.d.ts.map is not allowed in tarball  no-disallowed-files
  1:1  error  dist/client/stdio.test.js.map is not allowed in tarball    no-disallowed-files
  1:1  error  dist/server/stdio.test.js.map is not allowed in tarball    no-disallowed-files
  1:1  error  dist/shared/stdio.test.js.map is not allowed in tarball    no-disallowed-files
  1:1  error  dist/client/index.test.d.ts is not allowed in tarball      no-disallowed-files
  1:1  error  dist/server/index.test.d.ts is not allowed in tarball      no-disallowed-files
  1:1  error  dist/inMemory.test.d.ts is not allowed in tarball          no-disallowed-files
  1:1  error  dist/client/stdio.test.d.ts is not allowed in tarball      no-disallowed-files
  1:1  error  dist/server/stdio.test.d.ts is not allowed in tarball      no-disallowed-files
  1:1  error  dist/shared/stdio.test.d.ts is not allowed in tarball      no-disallowed-files
  1:1  error  ./dist/index.js (pkg.main) is not present in tarball       no-missing-main

~/Git/modelcontextprotocol/typescript-sdk/package.json
  1:1  error  "keywords" must be set      package-json-fields
  1:1  error  "repository" must be set    package-json-fields
  1:1  error  Missing engines.node field  outdated-engines

$ npx publint
@modelcontextprotocol/sdk lint results:
Warnings:
1. pkg.exports is missing the root entrypoint export, which is defined in pkg.main. Environments that support the "exports" field will ignore pkg.main as "exports" takes the highest priority. Consider adding pkg.exports["."]: "./dist/index.js".
Errors:
1. pkg.main is ./dist/index.js but the file does not exist.
```

Basically this means:

1. `src/**/*.test.ts` files should not be bundled into the package[^5].
2. specified `"main": "./dist/index.js"` doesn't exist, since this package is sub-directory oriented, `index.ts` doesn't exist
3. specified `"types": "./dist/index.d.ts"` doesn't exist either
4. since #90 has specified, this is a ESM only module, where as spec of ES6 specifies[^1][^2][^3][^4], `main` is only for Node.js, `"main"` is not needed
5. missing of `keywords`
6. missing of `repository`
7. missing of `engines.node`

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Follow the best practice of Node.js community projects and guidelines of how `package.json` and distributing packages can be organized.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Yes, locally tested with `verdaccio` (private npm registry) with my MCP projects.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->

[^1]: https://rollupjs.org/es-module-syntax/
[^2]: [Modules: Packages | Node.js v23.4.0 Documentation](https://nodejs.org/api/packages.html#main)
[^3]: [javascript - What is the "module" package.json field for? - Stack Overflow](https://stackoverflow.com/questions/42708484/what-is-the-module-package-json-field-for)
[^4]: https://github.com/nodejs/node-eps/blob/4217dca299d89c8c18ac44c878b5fe9581974ef3/002-es6-modules.md#51-determining-if-source-is-an-es-module
[^5]: [node.js - Is it a good practices to add tests files in the tsconfig.json exclude field? - Stack Overflow](https://stackoverflow.com/questions/61459764/is-it-a-good-practices-to-add-tests-files-in-the-tsconfig-json-exclude-field)