### PR TITLE
Fix SSEClientTransport ReferenceError: EventSource is not defined

### DIFF
--- a/src/client/sse.ts
+++ b/src/client/sse.ts
@@ -1,5 +1,10 @@
+import eventsource from "eventsource";
+
 import { Transport } from "../shared/transport.js";
 import { JSONRPCMessage, JSONRPCMessageSchema } from "../types.js";
+
+// @ts-expect-error
+global.EventSource = eventsource;
 
 /**
  * Client transport for SSE: this will connect to a server using Server-Sent Events for receiving


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
Fix SSEClientTransport ReferenceError: EventSource is not defined, see issue [issue/96](https://github.com/modelcontextprotocol/typescript-sdk/issues/96)