### PR TITLE
fix: propagate notification params

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/sdk",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Model Context Protocol implementation for TypeScript",
   "license": "MIT",
   "author": "Anthropic, PBC (https://anthropic.com)",

--- a/src/shared/protocol.ts
+++ b/src/shared/protocol.ts
@@ -278,7 +278,7 @@ export abstract class Protocol<
   }
 
   private _onprogress(notification: ProgressNotification): void {
-    const { progress, total, progressToken } = notification.params;
+    const { progressToken, ...params } = notification.params;
     const handler = this._progressHandlers.get(Number(progressToken));
     if (handler === undefined) {
       this._onerror(
@@ -289,7 +289,7 @@ export abstract class Protocol<
       return;
     }
 
-    handler({ progress, total });
+    handler(params);
   }
 
   private _onresponse(response: JSONRPCResponse | JSONRPCError): void {


### PR DESCRIPTION
# Model Context Protocol SDK: Pass through progress params

## Motivation and Context
Support additional fields in progress notifications beyond just `progress` and `total` by passing through all notification parameters to handlers.

## How Has This Been Tested?
Verified through existing protocol tests and usage scenarios requiring extended progress information.

## Breaking Changes
None. Maintains backward compatibility while enabling additional progress parameters.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
Modified `_onprogress` to only extract `progressToken` and pass remaining params through to handlers. Version bump 1.0.3 → 1.0.4.