### PR TITLE
Updates SDK error codes to use JSON-RPC server error range

### DIFF
--- a/src/shared/protocol.test.ts
+++ b/src/shared/protocol.test.ts
@@ -1,0 +1,63 @@
+import { Protocol } from "./protocol.js";
+import { Transport } from "./transport.js";
+import {
+  McpError,
+  ErrorCode,
+  Request,
+  Result,
+  Notification,
+} from "../types.js";
+import { ZodType, z } from "zod";
+
+// Mock Transport class
+class MockTransport implements Transport {
+  onclose?: () => void;
+  onerror?: (error: Error) => void;
+  onmessage?: (message: unknown) => void;
+
+  async start(): Promise<void> {}
+  async close(): Promise<void> {
+    this.onclose?.();
+  }
+  async send(_message: unknown): Promise<void> {}
+}
+
+describe("protocol tests", () => {
+  let protocol: Protocol<Request, Notification, Result>;
+  let transport: MockTransport;
+
+  beforeEach(() => {
+    transport = new MockTransport();
+    protocol = new (class extends Protocol<Request, Notification, Result> {
+      protected assertCapabilityForMethod(): void {}
+      protected assertNotificationCapability(): void {}
+      protected assertRequestHandlerCapability(): void {}
+    })();
+  });
+
+  test("should throw a timeout error if the request exceeds the timeout", async () => {
+    await protocol.connect(transport);
+    const request = { method: "example", params: {} };
+    try {
+      const mockSchema: ZodType<{ result: string }> = z.object({
+        result: z.string(),
+      });
+      await protocol.request(request, mockSchema, {
+        timeout: 100,
+      }); // Short timeout for test
+    } catch (error) {
+      expect(error).toBeInstanceOf(McpError);
+      if (error instanceof McpError) {
+        expect(error.code).toBe(ErrorCode.RequestTimeout);
+      }
+    }
+  });
+
+  test("should invoke onclose when the connection is closed", async () => {
+    const oncloseMock = jest.fn();
+    protocol.onclose = oncloseMock;
+    await protocol.connect(transport);
+    await transport.close();
+    expect(oncloseMock).toHaveBeenCalled();
+  });
+});

--- a/src/shared/protocol.test.ts
+++ b/src/shared/protocol.test.ts
@@ -43,8 +43,8 @@ describe("protocol tests", () => {
         result: z.string(),
       });
       await protocol.request(request, mockSchema, {
-        timeout: 100,
-      }); // Short timeout for test
+        timeout: 0,
+      });
     } catch (error) {
       expect(error).toBeInstanceOf(McpError);
       if (error instanceof McpError) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,7 +29,7 @@ const BaseRequestParamsSchema = z
            */
           progressToken: z.optional(ProgressTokenSchema),
         })
-        .passthrough()
+        .passthrough(),
     ),
   })
   .passthrough();
@@ -100,16 +100,16 @@ export const JSONRPCResponseSchema = z
   .strict();
 
 /**
- * @author : Sumitesh Naithani
- * @link : https://docs.trafficserver.apache.org/en/latest/developer-guide/jsonrpc/jsonrpc-node-errors.en.html#standard-errors
- * @description : An incomplete set of error codes that may appear in JSON-RPC responses.
- * @note : SDK-specific errors should use the server error range (-32000 to -32099), as per JSON-RPC 2.0 specification.
- */
+* @author : Sumitesh Naithani
+* @link : https://docs.trafficserver.apache.org/en/latest/developer-guide/jsonrpc/jsonrpc-node-errors.en.html#standard-errors
+* @description : An incomplete set of error codes that may appear in JSON-RPC responses.
+* @note : SDK-specific errors should use the server error range (-32000 to -32099), as per JSON-RPC 2.0 specification.
+*/
 export enum ErrorCode {
   // SDK error codes (using server error range)
   ConnectionClosed = -32000,
   RequestTimeout = -32001,
-
+ 
   // Standard JSON-RPC error codes
   ParseError = -32700,
   InvalidRequest = -32600,
@@ -217,7 +217,7 @@ export const ClientCapabilitiesSchema = z
            */
           listChanged: z.optional(z.boolean()),
         })
-        .passthrough()
+        .passthrough(),
     ),
   })
   .passthrough();
@@ -261,7 +261,7 @@ export const ServerCapabilitiesSchema = z
            */
           listChanged: z.optional(z.boolean()),
         })
-        .passthrough()
+        .passthrough(),
     ),
     /**
      * Present if the server offers any resources to read.
@@ -279,7 +279,7 @@ export const ServerCapabilitiesSchema = z
            */
           listChanged: z.optional(z.boolean()),
         })
-        .passthrough()
+        .passthrough(),
     ),
     /**
      * Present if the server offers any tools to call.
@@ -292,7 +292,7 @@ export const ServerCapabilitiesSchema = z
            */
           listChanged: z.optional(z.boolean()),
         })
-        .passthrough()
+        .passthrough(),
     ),
   })
   .passthrough();
@@ -483,7 +483,7 @@ export const ListResourcesResultSchema = PaginatedResultSchema.extend({
 export const ListResourceTemplatesRequestSchema = PaginatedRequestSchema.extend(
   {
     method: z.literal("resources/templates/list"),
-  }
+  },
 );
 
 /**
@@ -511,7 +511,7 @@ export const ReadResourceRequestSchema = RequestSchema.extend({
  */
 export const ReadResourceResultSchema = ResultSchema.extend({
   contents: z.array(
-    z.union([TextResourceContentsSchema, BlobResourceContentsSchema])
+    z.union([TextResourceContentsSchema, BlobResourceContentsSchema]),
   ),
 });
 
@@ -750,7 +750,7 @@ export const ListToolsResultSchema = PaginatedResultSchema.extend({
  */
 export const CallToolResultSchema = ResultSchema.extend({
   content: z.array(
-    z.union([TextContentSchema, ImageContentSchema, EmbeddedResourceSchema])
+    z.union([TextContentSchema, ImageContentSchema, EmbeddedResourceSchema]),
   ),
   isError: z.boolean().default(false).optional(),
 });
@@ -761,7 +761,7 @@ export const CallToolResultSchema = ResultSchema.extend({
 export const CompatibilityCallToolResultSchema = CallToolResultSchema.or(
   ResultSchema.extend({
     toolResult: z.unknown(),
-  })
+  }),
 );
 
 /**
@@ -922,7 +922,7 @@ export const CreateMessageResultSchema = ResultSchema.extend({
    * The reason why sampling stopped.
    */
   stopReason: z.optional(
-    z.enum(["endTurn", "stopSequence", "maxTokens"]).or(z.string())
+    z.enum(["endTurn", "stopSequence", "maxTokens"]).or(z.string()),
   ),
   role: z.enum(["user", "assistant"]),
   content: z.discriminatedUnion("type", [
@@ -1107,7 +1107,7 @@ export class McpError extends Error {
   constructor(
     public readonly code: number,
     message: string,
-    public readonly data?: unknown
+    public readonly data?: unknown,
   ) {
     super(`MCP error ${code}: ${message}`);
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -100,13 +100,10 @@ export const JSONRPCResponseSchema = z
   .strict();
 
 /**
-* @author : Sumitesh Naithani
-* @link : https://docs.trafficserver.apache.org/en/latest/developer-guide/jsonrpc/jsonrpc-node-errors.en.html#standard-errors
-* @description : An incomplete set of error codes that may appear in JSON-RPC responses.
-* @note : SDK-specific errors should use the server error range (-32000 to -32099), as per JSON-RPC 2.0 specification.
-*/
+ * Error codes defined by the JSON-RPC specification.
+ */
 export enum ErrorCode {
-  // SDK error codes (using server error range)
+  // SDK error codes
   ConnectionClosed = -32000,
   RequestTimeout = -32001,
  

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,7 +29,7 @@ const BaseRequestParamsSchema = z
            */
           progressToken: z.optional(ProgressTokenSchema),
         })
-        .passthrough(),
+        .passthrough()
     ),
   })
   .passthrough();
@@ -100,12 +100,15 @@ export const JSONRPCResponseSchema = z
   .strict();
 
 /**
- * An incomplete set of error codes that may appear in JSON-RPC responses.
+ * @author : Sumitesh Naithani
+ * @link : https://docs.trafficserver.apache.org/en/latest/developer-guide/jsonrpc/jsonrpc-node-errors.en.html#standard-errors
+ * @description : An incomplete set of error codes that may appear in JSON-RPC responses.
+ * @note : SDK-specific errors should use the server error range (-32000 to -32099), as per JSON-RPC 2.0 specification.
  */
 export enum ErrorCode {
-  // SDK error codes
-  ConnectionClosed = -1,
-  RequestTimeout = -2,
+  // SDK error codes (using server error range)
+  ConnectionClosed = -32000,
+  RequestTimeout = -32001,
 
   // Standard JSON-RPC error codes
   ParseError = -32700,
@@ -214,7 +217,7 @@ export const ClientCapabilitiesSchema = z
            */
           listChanged: z.optional(z.boolean()),
         })
-        .passthrough(),
+        .passthrough()
     ),
   })
   .passthrough();
@@ -258,7 +261,7 @@ export const ServerCapabilitiesSchema = z
            */
           listChanged: z.optional(z.boolean()),
         })
-        .passthrough(),
+        .passthrough()
     ),
     /**
      * Present if the server offers any resources to read.
@@ -276,7 +279,7 @@ export const ServerCapabilitiesSchema = z
            */
           listChanged: z.optional(z.boolean()),
         })
-        .passthrough(),
+        .passthrough()
     ),
     /**
      * Present if the server offers any tools to call.
@@ -289,7 +292,7 @@ export const ServerCapabilitiesSchema = z
            */
           listChanged: z.optional(z.boolean()),
         })
-        .passthrough(),
+        .passthrough()
     ),
   })
   .passthrough();
@@ -480,7 +483,7 @@ export const ListResourcesResultSchema = PaginatedResultSchema.extend({
 export const ListResourceTemplatesRequestSchema = PaginatedRequestSchema.extend(
   {
     method: z.literal("resources/templates/list"),
-  },
+  }
 );
 
 /**
@@ -508,7 +511,7 @@ export const ReadResourceRequestSchema = RequestSchema.extend({
  */
 export const ReadResourceResultSchema = ResultSchema.extend({
   contents: z.array(
-    z.union([TextResourceContentsSchema, BlobResourceContentsSchema]),
+    z.union([TextResourceContentsSchema, BlobResourceContentsSchema])
   ),
 });
 
@@ -747,7 +750,7 @@ export const ListToolsResultSchema = PaginatedResultSchema.extend({
  */
 export const CallToolResultSchema = ResultSchema.extend({
   content: z.array(
-    z.union([TextContentSchema, ImageContentSchema, EmbeddedResourceSchema]),
+    z.union([TextContentSchema, ImageContentSchema, EmbeddedResourceSchema])
   ),
   isError: z.boolean().default(false).optional(),
 });
@@ -758,7 +761,7 @@ export const CallToolResultSchema = ResultSchema.extend({
 export const CompatibilityCallToolResultSchema = CallToolResultSchema.or(
   ResultSchema.extend({
     toolResult: z.unknown(),
-  }),
+  })
 );
 
 /**
@@ -919,7 +922,7 @@ export const CreateMessageResultSchema = ResultSchema.extend({
    * The reason why sampling stopped.
    */
   stopReason: z.optional(
-    z.enum(["endTurn", "stopSequence", "maxTokens"]).or(z.string()),
+    z.enum(["endTurn", "stopSequence", "maxTokens"]).or(z.string())
   ),
   role: z.enum(["user", "assistant"]),
   content: z.discriminatedUnion("type", [
@@ -1104,7 +1107,7 @@ export class McpError extends Error {
   constructor(
     public readonly code: number,
     message: string,
-    public readonly data?: unknown,
+    public readonly data?: unknown
   ) {
     super(`MCP error ${code}: ${message}`);
   }


### PR DESCRIPTION
Updates SDK error codes to use the JSON-RPC server error range (-32000 to -32099) instead of arbitrary negative numbers.

## Motivation and Context
The SDK was using arbitrary negative numbers (-1, -2) for custom error codes, which could potentially conflict with application-specific error codes. By restricting SDK errors to the JSON-RPC server error range (-32000 to -32099), we ensure compliance with the specification and leave other ranges available for application usage. This change makes the error handling more standardized and prevents potential conflicts.

## How Has This Been Tested?
- [x] Ran the existing tests
- [x] Added new tests for checking error codes in protocol layer

## Breaking Changes
This may be a breaking change as it modifies error codes that applications might be checking against. Applications that explicitly check for -1 or -2 error codes will need to update their checks to use the new values (-32000 and -32001 respectively).

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
This change aligns with JSON-RPC 2.0 specification's recommendation for implementation-defined server errors. The specification reserves codes -32000 to -32099 for this purpose, making it a natural fit for SDK-generated errors. I've chosen to start at -32000 and -32001, leaving plenty of room for additional SDK error codes in the future while maintaining a clear separation from application-specific error codes.
