### PR TITLE
Add Authorization header if init SSETransport with token

### DIFF
--- a/src/client/sse.ts
+++ b/src/client/sse.ts
@@ -12,13 +12,15 @@ export class SSEClientTransport implements Transport {
   private _endpoint?: URL;
   private _abortController?: AbortController;
   private _url: URL;
-
+  private _token: string | undefined;
   onclose?: () => void;
   onerror?: (error: Error) => void;
   onmessage?: (message: JSONRPCMessage) => void;
 
-  constructor(url: URL) {
+  constructor(url: URL, token?: string) {
     this._url = url;
+    this._token = token
+
   }
 
   start(): Promise<void> {
@@ -90,10 +92,12 @@ export class SSEClientTransport implements Transport {
     }
 
     try {
+
       const response = await fetch(this._endpoint, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
+          ...(this._token && { "Authorization": `Bearer ${this._token}` }),
         },
         body: JSON.stringify(message),
         signal: this._abortController?.signal,


### PR DESCRIPTION
Add Authorization header if init SSETransport with token, you can protect your MCP SSE Server with Authorization header.

## Motivation and Context
I think MCP is great idea , we can provide service through SSE MCP Server , but this version client not support Auth header , so I add it to SDK

## How Has This Been Tested?
new SSEClientTransport(new URL("your mcp server url "),"you token")


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

