### PR TITLE
feat: add optional instructions field to server _oninitialize

### DIFF
--- a/src/server/index.test.ts
+++ b/src/server/index.test.ts
@@ -38,6 +38,7 @@ test("should accept latest protocol version", async () => {
             name: "test server",
             version: "1.0",
           },
+          instructions: "Test instructions",
         });
         sendPromiseResolve(undefined);
       }
@@ -57,6 +58,7 @@ test("should accept latest protocol version", async () => {
         tools: {},
         logging: {},
       },
+      instructions: "Test instructions",
     },
   );
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -241,7 +241,7 @@ export class Server<
         : LATEST_PROTOCOL_VERSION,
       capabilities: this.getCapabilities(),
       serverInfo: this._serverInfo,
-      ...(this.getInstructions() && { instructions: this.getInstructions() }),
+      ...(this._instructions && { instructions: this._instructions }),
     };
   }
 
@@ -261,10 +261,6 @@ export class Server<
 
   private getCapabilities(): ServerCapabilities {
     return this._capabilities;
-  }
-
-  private getInstructions(): string | undefined {
-    return this._instructions;
   }
 
   async ping() {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -33,6 +33,11 @@ export type ServerOptions = ProtocolOptions & {
    * Capabilities to advertise as being supported by this server.
    */
   capabilities: ServerCapabilities;
+
+  /**
+   * Optional instructions describing how to use the server and its features.
+   */
+  instructions?: string;
 };
 
 /**
@@ -72,6 +77,7 @@ export class Server<
   private _clientCapabilities?: ClientCapabilities;
   private _clientVersion?: Implementation;
   private _capabilities: ServerCapabilities;
+  private _instructions?: string;
 
   /**
    * Callback for when initialization has fully completed (i.e., the client has sent an `initialized` notification).
@@ -87,6 +93,7 @@ export class Server<
   ) {
     super(options);
     this._capabilities = options.capabilities;
+    this._instructions = options.instructions;
 
     this.setRequestHandler(InitializeRequestSchema, (request) =>
       this._oninitialize(request),
@@ -234,6 +241,7 @@ export class Server<
         : LATEST_PROTOCOL_VERSION,
       capabilities: this.getCapabilities(),
       serverInfo: this._serverInfo,
+      ...(this.getInstructions() && { instructions: this.getInstructions() }),
     };
   }
 
@@ -253,6 +261,10 @@ export class Server<
 
   private getCapabilities(): ServerCapabilities {
     return this._capabilities;
+  }
+
+  private getInstructions(): string | undefined {
+    return this._instructions;
   }
 
   async ping() {


### PR DESCRIPTION
Add the optional `instructions` field to the server per the [mcp spec](https://github.com/modelcontextprotocol/specification/blob/ce55bba19fc1f5a343e45ef1b47f9ccf1801d318/schema/schema.ts#L175)

## Motivation and Context
Allows setting up initial server instructions

## How Has This Been Tested?
Updated the test in `src/server/index.test.ts` to verify the `instruction` field is set

## Breaking Changes
None

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
