### PR TITLE
feat: add mcp client instruction support

### DIFF
--- a/src/client/index.test.ts
+++ b/src/client/index.test.ts
@@ -36,6 +36,7 @@ test("should initialize with matching protocol version", async () => {
               name: "test",
               version: "1.0",
             },
+            instructions: "test instructions",
           },
         });
       }
@@ -66,6 +67,9 @@ test("should initialize with matching protocol version", async () => {
       }),
     }),
   );
+
+  // Should have the instructions returned
+  expect(client.getInstructions()).toEqual("test instructions");
 });
 
 test("should initialize with supported older protocol version", async () => {
@@ -111,6 +115,9 @@ test("should initialize with supported older protocol version", async () => {
     name: "test",
     version: "1.0",
   });
+
+  // Expect no instructions
+  expect(client.getInstructions()).toBeUndefined();
 });
 
 test("should reject unsupported protocol version", async () => {

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -85,6 +85,7 @@ export class Client<
   private _serverCapabilities?: ServerCapabilities;
   private _serverVersion?: Implementation;
   private _capabilities: ClientCapabilities;
+  private _instructions?: string;
 
   /**
    * Initializes this client with the given name and version information.
@@ -152,6 +153,8 @@ export class Client<
       this._serverCapabilities = result.capabilities;
       this._serverVersion = result.serverInfo;
 
+      this._instructions = result.instructions;
+
       await this.notification({
         method: "notifications/initialized",
       });
@@ -174,6 +177,13 @@ export class Client<
    */
   getServerVersion(): Implementation | undefined {
     return this._serverVersion;
+  }
+
+  /**
+   * After initialization has completed, this may be populated with information about the server's instructions.
+   */
+  getInstructions(): String | undefined {
+    return this._instructions;
   }
 
   protected assertCapabilityForMethod(method: RequestT["method"]): void {

--- a/src/types.ts
+++ b/src/types.ts
@@ -304,6 +304,12 @@ export const InitializeResultSchema = ResultSchema.extend({
   protocolVersion: z.string(),
   capabilities: ServerCapabilitiesSchema,
   serverInfo: ImplementationSchema,
+  /**
+   * Instructions describing how to use the server and its features.
+   *
+   * This can be used by clients to improve the LLM's understanding of available tools, resources, etc. It can be thought of like a "hint" to the model. For example, this information MAY be added to the system prompt.
+   */
+  instructions: z.optional(z.string()),
 });
 
 /**


### PR DESCRIPTION
The companion to https://github.com/modelcontextprotocol/typescript-sdk/pull/120, this adds `instruction` support on the `client` side.

Updates the types schema to include an optional instruction with a comment taken directly from the MCP schema spec at (https://github.com/modelcontextprotocol/specification/blob/main/schema/2024-11-05/schema.ts#L170-L174)

This adds a private getter to allow any applications building around the client to retrieve the instructions when needed.

## Motivation and Context
Allows users to get `instructions` from an mcp client object if the server sends one.

## How Has This Been Tested?
Updated tests for client to verify instructions when sent, and undefined when not.

## Breaking Changes
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
