### PR TITLE
Update README.md new SSE Server to match defaults in inspector

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ const server = new McpServer({
 
 const app = express();
 
-app.get("/mcp", async (req, res) => {
+app.get("/sse", async (req, res) => {
   const transport = new SSEServerTransport("/messages", res);
   await server.connect(transport);
 });
@@ -236,7 +236,7 @@ app.post("/messages", async (req, res) => {
   await transport.handlePostMessage(req, res);
 });
 
-app.listen(3000);
+app.listen(3001);
 ```
 
 ### Testing and Debugging


### PR DESCRIPTION
When launching inspector and changing to use SSE, the URL is set to `http://localhost:3001/sse`. It's quite confusing to have an example use different endpoint names and port, hence the change.


## Motivation and Context
When following readme for creating sse server it became quite confusing which endpoint should be implemented.

## How Has This Been Tested?
Checked in the preview

## Breaking Changes
NA

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

<img width="310" alt="image" src="https://github.com/user-attachments/assets/76a0a75e-7dff-462a-95c4-a45b838118b7" />
