### PR TITLE
fix: include the default env in the custom env

### DIFF
--- a/src/client/stdio.ts
+++ b/src/client/stdio.ts
@@ -109,7 +109,7 @@ export class StdioClientTransport implements Transport {
         this._serverParams.command,
         this._serverParams.args ?? [],
         {
-          env: this._serverParams.env ?? getDefaultEnvironment(),
+          env: {...getDefaultEnvironment(), ...(this._serverParams.env ?? {})},
           stdio: ["pipe", "pipe", this._serverParams.stderr ?? "inherit"],
           shell: false,
           signal: this._abortController.signal,


### PR DESCRIPTION
The default env parameters should be included in the custom env.

## Motivation and Context
When env is {}, the mcp server will not be able to find the binary because the PATH will be empty.

## How Has This Been Tested?
This is the patch we use in our projects to fix env problems.
[patch](https://github.com/OpenAgentPlatform/Dive/blob/main/patches/%40modelcontextprotocol%2Bsdk%2B1.4.1.patch#L29)

## Breaking Changes
no

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context

