### PR TITLE
add `cwd` to `StdioServerParameters`

### DIFF
--- a/src/client/stdio.ts
+++ b/src/client/stdio.ts
@@ -1,9 +1,9 @@
 import { ChildProcess, IOType, spawn } from "node:child_process";
 import process from "node:process";
-import { ReadBuffer, serializeMessage } from "../shared/stdio.js";
-import { JSONRPCMessage } from "../types.js";
-import { Transport } from "../shared/transport.js";
 import { Stream } from "node:stream";
+import { ReadBuffer, serializeMessage } from "../shared/stdio.js";
+import { Transport } from "../shared/transport.js";
+import { JSONRPCMessage } from "../types.js";
 
 export type StdioServerParameters = {
   /**
@@ -29,6 +29,13 @@ export type StdioServerParameters = {
    * The default is "inherit", meaning messages to stderr will be printed to the parent process's stderr.
    */
   stderr?: IOType | Stream | number;
+
+  /**
+   * The working directory to use when spawning the process.
+   *
+   * If not specified, the current working directory will be inherited.
+   */
+  cwd?: string;
 };
 
 /**
@@ -114,6 +121,7 @@ export class StdioClientTransport implements Transport {
           shell: false,
           signal: this._abortController.signal,
           windowsHide: process.platform === "win32" && isElectron(),
+          cwd: this._serverParams.cwd,
         }
       );
 


### PR DESCRIPTION
Add a `cwd` option to `StdioServerParameters`

## Motivation and Context
Some MCP authors have asked us to be able to set the current working directory of the process so that they can know where to find certain files.

## How Has This Been Tested?
I've tested manually, but given the quantity of tests this felt like it would have been a bit niche and slightly trivial. Happy to add a test though if it feels important

## Breaking Changes
N/A

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
N/A
