### PR TITLE
Misc fixes in auth

### DIFF
--- a/src/client/auth.test.ts
+++ b/src/client/auth.test.ts
@@ -48,7 +48,7 @@ describe("OAuth Authorization", () => {
       let callCount = 0;
       
       // Mock implementation that changes behavior based on call count
-      mockFetch.mockImplementation((url, options) => {
+      mockFetch.mockImplementation((_url, _options) => {
         callCount++;
         
         if (callCount === 1) {
@@ -81,7 +81,7 @@ describe("OAuth Authorization", () => {
       let callCount = 0;
       
       // Mock implementation that changes behavior based on call count
-      mockFetch.mockImplementation((url, options) => {
+      mockFetch.mockImplementation((_url, _options) => {
         callCount++;
         
         if (callCount === 1) {

--- a/src/client/auth.test.ts
+++ b/src/client/auth.test.ts
@@ -60,16 +60,18 @@ describe("OAuth Authorization", () => {
       // Verify second call was made without header
       expect(mockFetch).toHaveBeenCalledTimes(2);
       const secondCallOptions = mockFetch.mock.calls[1][1];
-      expect(secondCallOptions).toBeUndefined(); // No options means no headers
+      // The second call still has options but doesn't include MCP-Protocol-Version header
+      expect(secondCallOptions).toBeDefined();
+      expect(secondCallOptions?.headers).toBeUndefined();
     });
 
-    it("returns undefined when all fetch attempts fail", async () => {
+    it("throws an error when all fetch attempts fail", async () => {
       // Both requests fail
       mockFetch.mockRejectedValueOnce(new Error("Network error"));
       mockFetch.mockRejectedValueOnce(new Error("Network error"));
 
-      const metadata = await discoverOAuthMetadata("https://auth.example.com");
-      expect(metadata).toBeUndefined();
+      await expect(discoverOAuthMetadata("https://auth.example.com"))
+        .rejects.toThrow("Network error");
       expect(mockFetch).toHaveBeenCalledTimes(2);
     });
 

--- a/src/client/auth.ts
+++ b/src/client/auth.ts
@@ -163,11 +163,20 @@ export async function discoverOAuthMetadata(
   opts?: { protocolVersion?: string },
 ): Promise<OAuthMetadata | undefined> {
   const url = new URL("/.well-known/oauth-authorization-server", serverUrl);
-  const response = await fetch(url, {
-    headers: {
-      "MCP-Protocol-Version": opts?.protocolVersion ?? LATEST_PROTOCOL_VERSION
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      headers: {
+        "MCP-Protocol-Version": opts?.protocolVersion ?? LATEST_PROTOCOL_VERSION
+      }
+    });
+  } catch {
+    try {
+      response = await fetch(url);
+    } catch {
+      return undefined;
     }
-  });
+  }
 
   if (response.status === 404) {
     return undefined;

--- a/src/client/auth.ts
+++ b/src/client/auth.ts
@@ -170,11 +170,12 @@ export async function discoverOAuthMetadata(
         "MCP-Protocol-Version": opts?.protocolVersion ?? LATEST_PROTOCOL_VERSION
       }
     });
-  } catch {
-    try {
+  } catch (error) {
+    // CORS errors come back as TypeError
+    if (error instanceof TypeError) {
       response = await fetch(url);
-    } catch {
-      return undefined;
+    } else {
+      throw error;
     }
   }
 

--- a/src/server/auth/handlers/register.test.ts
+++ b/src/server/auth/handlers/register.test.ts
@@ -141,6 +141,37 @@ describe('Client Registration Handler', () => {
 
       expect(response.status).toBe(201);
       expect(response.body.client_secret).toBeUndefined();
+      expect(response.body.client_secret_expires_at).toBeUndefined();
+    });
+    
+    it('sets client_secret_expires_at for public clients only', async () => {
+      // Test for public client (token_endpoint_auth_method not 'none')
+      const publicClientMetadata: OAuthClientMetadata = {
+        redirect_uris: ['https://example.com/callback'],
+        token_endpoint_auth_method: 'client_secret_basic'
+      };
+
+      const publicResponse = await supertest(app)
+        .post('/register')
+        .send(publicClientMetadata);
+
+      expect(publicResponse.status).toBe(201);
+      expect(publicResponse.body.client_secret).toBeDefined();
+      expect(publicResponse.body.client_secret_expires_at).toBeDefined();
+      
+      // Test for non-public client (token_endpoint_auth_method is 'none')
+      const nonPublicClientMetadata: OAuthClientMetadata = {
+        redirect_uris: ['https://example.com/callback'],
+        token_endpoint_auth_method: 'none'
+      };
+
+      const nonPublicResponse = await supertest(app)
+        .post('/register')
+        .send(nonPublicClientMetadata);
+
+      expect(nonPublicResponse.status).toBe(201);
+      expect(nonPublicResponse.body.client_secret).toBeUndefined();
+      expect(nonPublicResponse.body.client_secret_expires_at).toBeUndefined();
     });
 
     it('sets expiry based on clientSecretExpirySeconds', async () => {

--- a/src/server/auth/handlers/register.ts
+++ b/src/server/auth/handlers/register.ts
@@ -75,10 +75,11 @@ export function clientRegistrationHandler({
       }
 
       const clientMetadata = parseResult.data;
+      const isPublicClient = clientMetadata.token_endpoint_auth_method !== 'none'
 
       // Generate client credentials
       const clientId = crypto.randomUUID();
-      const clientSecret = clientMetadata.token_endpoint_auth_method !== 'none'
+      const clientSecret = isPublicClient
         ? crypto.randomBytes(32).toString('hex')
         : undefined;
       const clientIdIssuedAt = Math.floor(Date.now() / 1000);
@@ -88,7 +89,11 @@ export function clientRegistrationHandler({
         client_id: clientId,
         client_secret: clientSecret,
         client_id_issued_at: clientIdIssuedAt,
-        client_secret_expires_at: clientSecretExpirySeconds > 0 ? clientIdIssuedAt + clientSecretExpirySeconds : 0
+        client_secret_expires_at: isPublicClient 
+          ? clientSecretExpirySeconds > 0 
+            ? clientIdIssuedAt + clientSecretExpirySeconds 
+            : 0
+          : undefined,
       };
 
       clientInfo = await clientsStore.registerClient!(clientInfo);

--- a/src/server/auth/handlers/register.ts
+++ b/src/server/auth/handlers/register.ts
@@ -75,13 +75,13 @@ export function clientRegistrationHandler({
       }
 
       const clientMetadata = parseResult.data;
-      const isPublicClient = clientMetadata.token_endpoint_auth_method !== 'none'
+      const isPublicClient = clientMetadata.token_endpoint_auth_method === 'none'
 
       // Generate client credentials
       const clientId = crypto.randomUUID();
       const clientSecret = isPublicClient
-        ? crypto.randomBytes(32).toString('hex')
-        : undefined;
+        ? undefined
+        : crypto.randomBytes(32).toString('hex');
       const clientIdIssuedAt = Math.floor(Date.now() / 1000);
 
       // Calculate client secret expiry time

--- a/src/server/auth/handlers/register.ts
+++ b/src/server/auth/handlers/register.ts
@@ -84,16 +84,17 @@ export function clientRegistrationHandler({
         : undefined;
       const clientIdIssuedAt = Math.floor(Date.now() / 1000);
 
+      // Calculate client secret expiry time
+      const clientsDoExpire = clientSecretExpirySeconds > 0
+      const secretExpiryTime = clientsDoExpire ? clientIdIssuedAt + clientSecretExpirySeconds : 0
+      const clientSecretExpiresAt = isPublicClient ? undefined : secretExpiryTime
+
       let clientInfo: OAuthClientInformationFull = {
         ...clientMetadata,
         client_id: clientId,
         client_secret: clientSecret,
         client_id_issued_at: clientIdIssuedAt,
-        client_secret_expires_at: isPublicClient 
-          ? clientSecretExpirySeconds > 0 
-            ? clientIdIssuedAt + clientSecretExpirySeconds 
-            : 0
-          : undefined,
+        client_secret_expires_at: clientSecretExpiresAt,
       };
 
       clientInfo = await clientsStore.registerClient!(clientInfo);

--- a/src/server/auth/middleware/bearerAuth.ts
+++ b/src/server/auth/middleware/bearerAuth.ts
@@ -55,6 +55,11 @@ export function requireBearerAuth({ provider, requiredScopes = [] }: BearerAuthM
         }
       }
 
+      // Check if the token is expired
+      if (!!authInfo.expiresAt && authInfo.expiresAt < Date.now() / 1000) {
+        throw new InvalidTokenError("Token has expired");
+      }
+
       req.auth = authInfo;
       next();
     } catch (error) {


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
While hacking with this I ran into a few little issues, these are the fixes.

* Check token expiry in requireAuth middleware
* Gracefully handle cors issues in metadata fetching (experienced due to MCP-Protocol-Version header)
* Don't set client secret expiry for public clients
