### PR TITLE
Add sessionID to RequestHandlerExtra type for tool invocations so multi-user services can distinguish users

### DIFF
--- a/src/inMemory.ts
+++ b/src/inMemory.ts
@@ -11,6 +11,7 @@ export class InMemoryTransport implements Transport {
   onclose?: () => void;
   onerror?: (error: Error) => void;
   onmessage?: (message: JSONRPCMessage) => void;
+  sessionId?: string;
 
   /**
    * Creates a pair of linked in-memory transports that can communicate with each other. One should be passed to a Client and one to a Server.

--- a/src/server/sse.ts
+++ b/src/server/sse.ts
@@ -136,6 +136,8 @@ export class SSEServerTransport implements Transport {
 
   /**
    * Returns the session ID for this transport.
+   *
+   * This can be used to route incoming POST requests.
    */
   get sessionId(): string {
     return this._sessionId;

--- a/src/server/sse.ts
+++ b/src/server/sse.ts
@@ -136,8 +136,6 @@ export class SSEServerTransport implements Transport {
 
   /**
    * Returns the session ID for this transport.
-   *
-   * This can be used to route incoming POST requests.
    */
   get sessionId(): string {
     return this._sessionId;

--- a/src/shared/protocol.ts
+++ b/src/shared/protocol.ts
@@ -74,6 +74,11 @@ export type RequestHandlerExtra = {
    * An abort signal used to communicate if the request was cancelled from the sender's side.
    */
   signal: AbortSignal;
+
+  /**
+   * The session ID from the transport, if available.
+   */
+  sessionId?: string;
 };
 
 /**
@@ -239,9 +244,15 @@ export abstract class Protocol<
     const abortController = new AbortController();
     this._requestHandlerAbortControllers.set(request.id, abortController);
 
+    // Create extra object with both abort signal and sessionId from transport
+    const extra: RequestHandlerExtra = {
+      signal: abortController.signal,
+      sessionId: this._transport?.sessionId,
+    };
+
     // Starting with Promise.resolve() puts any synchronous errors into the monad as well.
     Promise.resolve()
-      .then(() => handler(request, { signal: abortController.signal }))
+      .then(() => handler(request, extra))
       .then(
         (result) => {
           if (abortController.signal.aborted) {

--- a/src/shared/transport.ts
+++ b/src/shared/transport.ts
@@ -42,5 +42,8 @@ export interface Transport {
    */
   onmessage?: (message: JSONRPCMessage) => void;
 
+  /**
+   * The session ID generated for this connection.
+   */
   sessionId?: string;
 }

--- a/src/shared/transport.ts
+++ b/src/shared/transport.ts
@@ -41,4 +41,6 @@ export interface Transport {
    * Callback for when a message (request or response) is received over the connection.
    */
   onmessage?: (message: JSONRPCMessage) => void;
+
+  sessionId?: string;
 }


### PR DESCRIPTION
Added a sessionID field to the RequestHandlerExtra data that gets passed to tool callbacks, and wired it through from the transport session ID. Exposed the sessionID field on the abstract Transport interface.

## Motivation and Context
This allows multi-user SSE-based MCP servers distinguish which user is invoking the tool based on their session ID (which in turn can be mapped to any data derived from the authentication token passed in HTTP headers).

Without this change, tool callbacks being served over SSE can't tell which user is making the request.

## How Has This Been Tested?
Made a test service and tested it with Inspector. The tool callback was able to resolve the user ID associated with the requester's API key by using a map from session ID to user ID.

## Breaking Changes
No.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
N/A
