### PR TITLE
Include Authorization Info in Tool Calls (and request handlers generally)

### DIFF
--- a/src/inMemory.test.ts
+++ b/src/inMemory.test.ts
@@ -52,12 +52,12 @@ describe("InMemoryTransport", () => {
 
     let receivedMessage: JSONRPCMessage | undefined;
     let receivedAuthInfo: AuthInfo | undefined;
-    serverTransport.onmessage = (msg, auth) => {
+    serverTransport.onmessage = (msg, extra) => {
       receivedMessage = msg;
-      receivedAuthInfo = auth;
+      receivedAuthInfo = extra?.authInfo;
     };
 
-    await clientTransport.sendWithAuth(message, authInfo);
+    await clientTransport.send(message, { authInfo });
     expect(receivedMessage).toEqual(message);
     expect(receivedAuthInfo).toEqual(authInfo);
   });

--- a/src/inMemory.test.ts
+++ b/src/inMemory.test.ts
@@ -1,5 +1,6 @@
 import { InMemoryTransport } from "./inMemory.js";
 import { JSONRPCMessage } from "./types.js";
+import { AuthInfo } from "./server/auth/types.js";
 
 describe("InMemoryTransport", () => {
   let clientTransport: InMemoryTransport;
@@ -33,6 +34,32 @@ describe("InMemoryTransport", () => {
 
     await clientTransport.send(message);
     expect(receivedMessage).toEqual(message);
+  });
+
+  test("should send message with auth info from client to server", async () => {
+    const message: JSONRPCMessage = {
+      jsonrpc: "2.0",
+      method: "test",
+      id: 1,
+    };
+
+    const authInfo: AuthInfo = {
+      token: "test-token",
+      clientId: "test-client",
+      scopes: ["read", "write"],
+      expiresAt: Date.now() / 1000 + 3600,
+    };
+
+    let receivedMessage: JSONRPCMessage | undefined;
+    let receivedAuthInfo: AuthInfo | undefined;
+    serverTransport.onmessage = (msg, auth) => {
+      receivedMessage = msg;
+      receivedAuthInfo = auth;
+    };
+
+    await clientTransport.sendWithAuth(message, authInfo);
+    expect(receivedMessage).toEqual(message);
+    expect(receivedAuthInfo).toEqual(authInfo);
   });
 
   test("should send message from server to client", async () => {

--- a/src/inMemory.ts
+++ b/src/inMemory.ts
@@ -53,7 +53,7 @@ export class InMemoryTransport implements Transport {
    * Sends a message with optional auth info.
    * This is useful for testing authentication scenarios.
    */
-  async sendWithAuth(message: JSONRPCMessage, authInfo?: AuthInfo): Promise<void> {
+  async send(message: JSONRPCMessage, options?: { authInfo?: AuthInfo }): Promise<void>
     if (!this._otherTransport) {
       throw new Error("Not connected");
     }

--- a/src/inMemory.ts
+++ b/src/inMemory.ts
@@ -1,5 +1,5 @@
 import { Transport } from "./shared/transport.js";
-import { JSONRPCMessage } from "./types.js";
+import { JSONRPCMessage, RequestId } from "./types.js";
 import { AuthInfo } from "./server/auth/types.js";
 
 interface QueuedMessage {
@@ -49,7 +49,7 @@ export class InMemoryTransport implements Transport {
    * Sends a message with optional auth info.
    * This is useful for testing authentication scenarios.
    */
-  async send(message: JSONRPCMessage, options?: { authInfo?: AuthInfo }): Promise<void> {
+  async send(message: JSONRPCMessage, options?: { relatedRequestId?: RequestId, authInfo?: AuthInfo }): Promise<void> {
     if (!this._otherTransport) {
       throw new Error("Not connected");
     }

--- a/src/inMemory.ts
+++ b/src/inMemory.ts
@@ -1,16 +1,22 @@
 import { Transport } from "./shared/transport.js";
 import { JSONRPCMessage } from "./types.js";
+import { AuthInfo } from "./server/auth/types.js";
+
+interface QueuedMessage {
+  message: JSONRPCMessage;
+  authInfo?: AuthInfo;
+}
 
 /**
  * In-memory transport for creating clients and servers that talk to each other within the same process.
  */
 export class InMemoryTransport implements Transport {
   private _otherTransport?: InMemoryTransport;
-  private _messageQueue: JSONRPCMessage[] = [];
+  private _messageQueue: QueuedMessage[] = [];
 
   onclose?: () => void;
   onerror?: (error: Error) => void;
-  onmessage?: (message: JSONRPCMessage) => void;
+  onmessage?: (message: JSONRPCMessage, authInfo?: AuthInfo) => void;
   sessionId?: string;
 
   /**
@@ -27,10 +33,8 @@ export class InMemoryTransport implements Transport {
   async start(): Promise<void> {
     // Process any messages that were queued before start was called
     while (this._messageQueue.length > 0) {
-      const message = this._messageQueue.shift();
-      if (message) {
-        this.onmessage?.(message);
-      }
+      const queuedMessage = this._messageQueue.shift()!;
+      this.onmessage?.(queuedMessage.message, queuedMessage.authInfo);
     }
   }
 
@@ -42,14 +46,22 @@ export class InMemoryTransport implements Transport {
   }
 
   async send(message: JSONRPCMessage): Promise<void> {
+    return this.sendWithAuth(message);
+  }
+
+  /**
+   * Sends a message with optional auth info.
+   * This is useful for testing authentication scenarios.
+   */
+  async sendWithAuth(message: JSONRPCMessage, authInfo?: AuthInfo): Promise<void> {
     if (!this._otherTransport) {
       throw new Error("Not connected");
     }
 
     if (this._otherTransport.onmessage) {
-      this._otherTransport.onmessage(message);
+      this._otherTransport.onmessage(message, authInfo);
     } else {
-      this._otherTransport._messageQueue.push(message);
+      this._otherTransport._messageQueue.push({ message, authInfo });
     }
   }
 }

--- a/src/server/auth/types.ts
+++ b/src/server/auth/types.ts
@@ -21,4 +21,9 @@ export interface AuthInfo {
    * When the token expires (in seconds since epoch).
    */
   expiresAt?: number;
+
+  /**
+   * Additional arbitrary properties that may be included.
+   */
+  [key: string]: unknown;
 }

--- a/src/server/auth/types.ts
+++ b/src/server/auth/types.ts
@@ -23,7 +23,9 @@ export interface AuthInfo {
   expiresAt?: number;
 
   /**
-   * Additional arbitrary properties that may be included.
+   * Additional custom claims associated with the token.
+   * This field should be used for any additional data that needs to be attached to the auth info.
+   * Using this field instead of arbitrary keys ensures compatibility with future interface changes.
    */
-  [key: string]: unknown;
+  customClaims?: Record<string, unknown>;
 }

--- a/src/server/auth/types.ts
+++ b/src/server/auth/types.ts
@@ -23,9 +23,8 @@ export interface AuthInfo {
   expiresAt?: number;
 
   /**
-   * Additional custom claims associated with the token.
+   * Additional data associated with the token.
    * This field should be used for any additional data that needs to be attached to the auth info.
-   * Using this field instead of arbitrary keys ensures compatibility with future interface changes.
-   */
-  customClaims?: Record<string, unknown>;
+  */
+  extra?: Record<string, unknown>;
 }

--- a/src/server/sse.ts
+++ b/src/server/sse.ts
@@ -19,7 +19,7 @@ export class SSEServerTransport implements Transport {
 
   onclose?: () => void;
   onerror?: (error: Error) => void;
-  onmessage?: (message: JSONRPCMessage, authInfo?: AuthInfo) => void;
+  onmessage?: (message: JSONRPCMessage, extra?: { authInfo?: AuthInfo }) => void;
 
   /**
    * Creates a new SSE server transport, which will direct the client to POST messages to the relative or absolute URL identified by `_endpoint`.
@@ -96,7 +96,7 @@ export class SSEServerTransport implements Transport {
     }
 
     try {
-      await this.handleMessage(typeof body === 'string' ? JSON.parse(body) : body, authInfo);
+      await this.handleMessage(typeof body === 'string' ? JSON.parse(body) : body, { authInfo });
     } catch {
       res.writeHead(400).end(`Invalid message: ${body}`);
       return;
@@ -108,7 +108,7 @@ export class SSEServerTransport implements Transport {
   /**
    * Handle a client message, regardless of how it arrived. This can be used to inform the server of messages that arrive via a means different than HTTP POST.
    */
-  async handleMessage(message: unknown, authInfo?: AuthInfo): Promise<void> {
+  async handleMessage(message: unknown, extra?: { authInfo?: AuthInfo }): Promise<void> {
     let parsedMessage: JSONRPCMessage;
     try {
       parsedMessage = JSONRPCMessageSchema.parse(message);
@@ -117,7 +117,7 @@ export class SSEServerTransport implements Transport {
       throw error;
     }
 
-    this.onmessage?.(parsedMessage, authInfo);
+    this.onmessage?.(parsedMessage, extra);
   }
 
   async close(): Promise<void> {

--- a/src/shared/protocol.ts
+++ b/src/shared/protocol.ts
@@ -357,8 +357,6 @@ export abstract class Protocol<
     const abortController = new AbortController();
     this._requestHandlerAbortControllers.set(request.id, abortController);
 
-    // Create `fullExtra` object with both abort signal and sessionId from transport
-    // in addition to any authInfo provided
     const fullExtra: RequestHandlerExtra<SendRequestT, SendNotificationT> = {
       signal: abortController.signal,
       sessionId: this._transport?.sessionId,

--- a/src/shared/transport.ts
+++ b/src/shared/transport.ts
@@ -1,3 +1,4 @@
+import { AuthInfo } from "../server/auth/types.js";
 import { JSONRPCMessage } from "../types.js";
 
 /**
@@ -39,6 +40,9 @@ export interface Transport {
 
   /**
    * Callback for when a message (request or response) is received over the connection.
+   * 
+   * Includes the authInfo if the transport is authenticated.
+   * 
    */
-  onmessage?: (message: JSONRPCMessage) => void;
+  onmessage?: (message: JSONRPCMessage, authInfo?: AuthInfo) => void;
 }

--- a/src/shared/transport.ts
+++ b/src/shared/transport.ts
@@ -44,7 +44,7 @@ export interface Transport {
    * Includes the authInfo if the transport is authenticated.
    * 
    */
-  onmessage?: (message: JSONRPCMessage, authInfo?: AuthInfo) => void;
+  onmessage?: (message: JSONRPCMessage, extra?: { authInfo?: AuthInfo }) => void;
 
   /**
    * The session ID generated for this connection.


### PR DESCRIPTION
Includes the `req.auth` AuthInfo that's set by the MCP Server bearer auth middleware in the server request handler via SSE Transport, allowing for distinguishing of users in requests (eg. tool use).

## Motivation and Context
When an MCP Server makes a tool call it may need to validate that a particular user has the authorization necessary to access a particular resource. For instance, the MCP Client could give any email it would like to the MCP Server, say to fetch audit logs of a project, but the Server should verify that the user has access to that particular project, which has to happen at the tool call level in the server.

This PR allows the developer to access the auth info not only in the initial `/sse` or `/message` route handlers but in the server request handler (eg. tool call) itself.

## How Has This Been Tested?
Running an authenticated MCP Client session with a Server and validating that the `extra` param appears in the tool call with auth info.

This allows auth info to be easily used in a tool call:
```

export const createServer = () => {
    // Create server instance
    const server = new McpServer({
        name: "analytics",
        version: "1.0.0",
    });

    // Add get-schema tool
    server.tool(
        "get-schema",
        "Fetch the database schema",
        {},
        async (_, { authInfo }) => {
            const token = authInfo?.token;

            const scopes = authInfo?.scopes;
            if (!scopes || scopes && scopes.indexOf("get-schema") < 0) {
                return {
                    content: [
                        {
                            type: "text",
                            text: "Unauthorized: Missing get-schema scope",
                            code: 403
                        }
                    ]
                }
            }
```
```
import { z } from "zod";

/**
 * Information about a validated access token, provided to request handlers.
 */
export const AuthInfoSchema = z.object({
    /** The access token */
    token: z.string(),

    /** The client ID associated with this token */
    clientId: z.string(),

    /** Scopes associated with this token */
    scopes: z.array(z.string()),

    /** When the token expires (in seconds since epoch) */
    expiresAt: z.number().optional(),
});

export type AuthInfo = z.infer<typeof AuthInfoSchema>;
```

## Breaking Changes
None.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
This allows for simpler access of auth data than simply including the session id in the transport since you'd have to handle mapping in that case: https://github.com/modelcontextprotocol/typescript-sdk/pull/158

Fixes https://github.com/modelcontextprotocol/typescript-sdk/issues/171