### PR TITLE
Add SSEEdgeTransport

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   - [stdio](#stdio)
   - [HTTP with SSE](#http-with-sse)
   - [HTTP on Edge](#http-on-edge)
-  - [Cloudflare Worker](#cloudflare-worker)
+  - [Cloudflare Worker](#cloudflare-worker-with-durable-object)
   - [Testing and Debugging](#testing-and-debugging)
 - [Examples](#examples)
   - [Echo Server](#echo-server)

--- a/src/server/sseEdge.ts
+++ b/src/server/sseEdge.ts
@@ -1,0 +1,133 @@
+import { Transport } from '../shared/transport.js';
+import { JSONRPCMessage, JSONRPCMessageSchema } from '../types.js';
+
+const MAXIMUM_MESSAGE_SIZE = 4 * 1024 * 1024; // 4MB
+
+/**
+ * This transport is compatible with Cloudflare Workers and other edge environments
+ */
+export class SSEEdgeTransport implements Transport {
+	private controller: ReadableStreamDefaultController<Uint8Array> | null = null;
+	readonly stream: ReadableStream<Uint8Array>;
+	private closed = false;
+
+	onclose?: () => void;
+	onerror?: (error: Error) => void;
+	onmessage?: (message: JSONRPCMessage) => void;
+
+	/**
+	 * Creates a new EdgeSSETransport, which will direct the MPC client to POST messages to messageUrl
+	 */
+	constructor(
+		private messageUrl: string,
+		readonly sessionId: string,
+	) {
+		// Create a readable stream for SSE
+		this.stream = new ReadableStream({
+			start: (controller) => {
+				this.controller = controller;
+			},
+			cancel: () => {
+				this.closed = true;
+				this.onclose?.();
+			},
+		});
+	}
+
+	async start(): Promise<void> {
+		if (this.closed) {
+			throw new Error(
+				'SSE transport already closed! If using Server class, note that connect() calls start() automatically.',
+			);
+		}
+
+		// Make sure the controller exists
+		if (!this.controller) {
+			throw new Error('Stream controller not initialized');
+		}
+
+		// Send the endpoint event
+		const endpointMessage = `event: endpoint\ndata: ${encodeURI(this.messageUrl)}?sessionId=${this.sessionId}\n\n`;
+		this.controller.enqueue(new TextEncoder().encode(endpointMessage));
+	}
+
+	get sseResponse(): Response {
+		// Ensure the stream is properly initialized
+		if (!this.stream) {
+			throw new Error('Stream not initialized');
+		}
+
+		// Return a response with the SSE stream
+		return new Response(this.stream, {
+			headers: {
+				'Content-Type': 'text/event-stream',
+				'Cache-Control': 'no-cache',
+				Connection: 'keep-alive',
+			},
+		});
+	}
+
+	/**
+	 * Handles incoming Requests
+	 */
+	async handlePostMessage(req: Request): Promise<Response> {
+		if (this.closed || !this.controller) {
+			const message = 'SSE connection not established';
+			return new Response(message, { status: 500 });
+		}
+
+		try {
+			const contentType = req.headers.get('content-type') || '';
+			if (!contentType.includes('application/json')) {
+				throw new Error(`Unsupported content-type: ${contentType}`);
+			}
+
+			// Check if the request body is too large
+			const contentLength = parseInt(req.headers.get('content-length') || '0', 10);
+			if (contentLength > MAXIMUM_MESSAGE_SIZE) {
+				throw new Error(`Request body too large: ${contentLength} bytes`);
+			}
+
+			// Clone the request before reading the body to avoid stream issues
+			const body = await req.json();
+			await this.handleMessage(body);
+			return new Response('Accepted', { status: 202 });
+		} catch (error) {
+			this.onerror?.(error as Error);
+			return new Response(String(error), { status: 400 });
+		}
+	}
+
+	/**
+	 * Handle a client message, regardless of how it arrived. This can be used to inform the server of messages that arrive via a means different than HTTP POST.
+	 */
+	async handleMessage(message: unknown): Promise<void> {
+		let parsedMessage: JSONRPCMessage;
+		try {
+			parsedMessage = JSONRPCMessageSchema.parse(message);
+		} catch (error) {
+			this.onerror?.(error as Error);
+			throw error;
+		}
+
+		this.onmessage?.(parsedMessage);
+	}
+
+	async close(): Promise<void> {
+		if (!this.closed && this.controller) {
+			this.controller.close();
+			this.stream.cancel();
+			this.closed = true;
+			this.onclose?.();
+		}
+	}
+
+	async send(message: JSONRPCMessage): Promise<void> {
+		if (this.closed || !this.controller) {
+			throw new Error('Not connected');
+		}
+
+		const messageText = `event: message\ndata: ${JSON.stringify(message)}\n\n`;
+		this.controller.enqueue(new TextEncoder().encode(messageText));
+	}
+}


### PR DESCRIPTION
Adds a transport which can be used in environments like Vercel and Cloudflare Workers. I called this SSEEdgeTransport but imagine there is some better naming.

I also added documentation to the readme on how to use it (with Hono which is a popular web framework for Cloudflare) and a section on using it with Cloudflare Durable Objects to keep track of different servers.
## Motivation and Context
The current documentation & transport only really work with Node or Express which is pretty limiting in my experience. I think Durable Objects offer a viable quick way to get something spun up, and regardless a Transport which works in Edge environments is useful.

## How Has This Been Tested?
Ran locally, deployed to cloudflare and tested with Cursor and a basic MCP Server (the greeting one).

I didn't test disconnects too much because I am not super familiar with MCP's reconnection protocol. But assuming the client keeps sending the same SessionID it will get directed to the same Durable Object (as described in the README, this is independent of the actual code change).

## Breaking Changes
None

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
