### PR TITLE
console.error pollution logs removed in tests

### DIFF
--- a/src/client/sse.test.ts
+++ b/src/client/sse.test.ts
@@ -56,6 +56,8 @@ describe("SSEClientTransport", () => {
       baseUrl = new URL(`http://127.0.0.1:${addr.port}`);
       done();
     });
+
+    jest.spyOn(console, 'error').mockImplementation(() => {});
   });
 
   afterEach(async () => {

--- a/src/server/auth/middleware/bearerAuth.test.ts
+++ b/src/server/auth/middleware/bearerAuth.test.ts
@@ -31,6 +31,10 @@ describe("requireBearerAuth middleware", () => {
       set: jest.fn().mockReturnThis(),
     };
     nextFunction = jest.fn();
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  })
+
+  afterEach(() => {
     jest.clearAllMocks();
   });
 

--- a/src/server/auth/router.test.ts
+++ b/src/server/auth/router.test.ts
@@ -259,6 +259,11 @@ describe('MCP Auth Router', () => {
         issuerUrl: new URL('https://auth.example.com')
       };
       app.use(mcpAuthRouter(options));
+      jest.spyOn(console, 'error').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
     });
 
     it('routes to authorization endpoint', async () => {


### PR DESCRIPTION
`console.error` mocked in tests (only locally where it's needed) to keep logs clear

## Motivation and Context
In current state when tests run there are several `console.error` prints which are signs of normal behaviour, but add additional noise and require careful checks ("green -- good" approach is not applicable). Mocking `console.error` allows to keep logs clear (and if logs are clear ANY new information is visible, can't be lost in other logs and chances that it would be treated properly are higher.
There is possibility to mock `console.error` globally (in jest.config.js), but IMO it could be potentially harmful (hides all error by default).

## How Has This Been Tested?
Tests themselves are fixed.

## Breaking Changes
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
before:
<img width="1069" alt="Screenshot 2025-03-14 at 20 02 17" src="https://github.com/user-attachments/assets/f6741a01-c16b-4a3f-9803-5dfbbdfaa528" />


after:
<img width="474" alt="Screenshot 2025-03-14 at 20 00 32" src="https://github.com/user-attachments/assets/a02af49c-6461-4ee7-9866-3a789c2e49e5" />
