### PR TITLE
Bun compatibility for SSE

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@modelcontextprotocol/sdk",
-  "version": "1.5.0",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@modelcontextprotocol/sdk",
-      "version": "1.5.0",
+      "version": "1.7.0",
       "license": "MIT",
       "dependencies": {
         "content-type": "^1.0.5",

--- a/src/server/sse.ts
+++ b/src/server/sse.ts
@@ -53,6 +53,11 @@ export class SSEServerTransport implements Transport {
       `event: endpoint\ndata: ${encodeURI(this._endpoint)}?sessionId=${this._sessionId}\n\n`,
     );
 
+    // Support bun runtime which requires a follow-up message to be sent
+    if (process.versions.bun) {
+      this.res.write(`event: log\ndata: bun runtime compatibility message\n\n`);
+    }
+
     this._sseResponse = this.res;
     this.res.on("close", () => {
       this._sseResponse = undefined;

--- a/src/server/sse.ts
+++ b/src/server/sse.ts
@@ -53,9 +53,9 @@ export class SSEServerTransport implements Transport {
       `event: endpoint\ndata: ${encodeURI(this._endpoint)}?sessionId=${this._sessionId}\n\n`,
     );
 
-    // Support bun runtime which requires a follow-up message to be sent
+    // Support bun runtime which requires a follow-up message to be sent to establish the stream
     if (process.versions.bun) {
-      this.res.write(`event: log\ndata: bun runtime compatibility message\n\n`);
+      this.res.write('');
     }
 
     this._sseResponse = this.res;


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

when using the bun runtime, adds an empty message on the SSE connect call to establish the stream

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

SSE connections were failing when using the bun runtime, closes #201 

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

tested using the MCP inspector. 

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

no, all tests pass

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->

on the https://github.com/modelcontextprotocol/inspector there is an inactivity timeout after 30 seconds which throws this error in the console:

```sh
Error from MCP server: SseError: SSE error: TypeError: terminated: Body Timeout Error
```

however, there is no error in the actual server nor in the web UI.
