### PR TITLE
Fixing for windows terminal forcing \r\n

### DIFF
--- a/src/shared/stdio.ts
+++ b/src/shared/stdio.ts
@@ -20,7 +20,7 @@ export class ReadBuffer {
       return null;
     }
 
-    const line = this._buffer.toString("utf8", 0, index);
+    const line = this._buffer.toString("utf8", 0, index).replace(/\r$/, '');
     this._buffer = this._buffer.subarray(index + 1);
     return deserializeMessage(line);
   }


### PR DESCRIPTION
Windows apps sometimes set the carriage return to `\r\n` which makes for instant disconnect. This allows stdio transport to be more reliable for windows. 

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
