### PR TITLE
fix: 🐛 can't establish sse when server side enable compress

### DIFF
--- a/src/client/sse.test.ts
+++ b/src/client/sse.test.ts
@@ -24,7 +24,7 @@ describe("SSEClientTransport", () => {
       // Send SSE headers
       res.writeHead(200, {
         "Content-Type": "text/event-stream",
-        "Cache-Control": "no-cache",
+        "Cache-Control": "no-cache, no-transform",
         Connection: "keep-alive",
       });
 
@@ -183,7 +183,7 @@ describe("SSEClientTransport", () => {
         if (req.method === "GET") {
           res.writeHead(200, {
             "Content-Type": "text/event-stream",
-            "Cache-Control": "no-cache",
+            "Cache-Control": "no-cache, no-transform",
             Connection: "keep-alive",
           });
           res.write("event: endpoint\n");
@@ -397,7 +397,7 @@ describe("SSEClientTransport", () => {
 
             res.writeHead(200, {
               "Content-Type": "text/event-stream",
-              "Cache-Control": "no-cache",
+              "Cache-Control": "no-cache, no-transform",
               Connection: "keep-alive",
             });
             res.write("event: endpoint\n");
@@ -524,7 +524,7 @@ describe("SSEClientTransport", () => {
         if (auth === "Bearer new-token") {
           res.writeHead(200, {
             "Content-Type": "text/event-stream",
-            "Cache-Control": "no-cache",
+            "Cache-Control": "no-cache, no-transform",
             Connection: "keep-alive",
           });
           res.write("event: endpoint\n");
@@ -610,7 +610,7 @@ describe("SSEClientTransport", () => {
 
             res.writeHead(200, {
               "Content-Type": "text/event-stream",
-              "Cache-Control": "no-cache",
+              "Cache-Control": "no-cache, no-transform",
               Connection: "keep-alive",
             });
             res.write("event: endpoint\n");

--- a/src/server/sse.ts
+++ b/src/server/sse.ts
@@ -44,7 +44,7 @@ export class SSEServerTransport implements Transport {
 
     this.res.writeHead(200, {
       "Content-Type": "text/event-stream",
-      "Cache-Control": "no-cache",
+      "Cache-Control": "no-cache, no-transform",
       Connection: "keep-alive",
     });
 


### PR DESCRIPTION
Add "no-transform" cache-control header for sse.

## Motivation and Context
sse can't established when server side enable compress like gzip.

## How Has This Been Tested?
locally.

## Breaking Changes
no braking changes.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
no more.
