### PR TITLE
fix: Environment variable merging in StdioClientTransport

### DIFF
--- a/src/client/cross-spawn.test.ts
+++ b/src/client/cross-spawn.test.ts
@@ -72,7 +72,26 @@ describe("StdioClientTransport using cross-spawn", () => {
       "test-command",
       [],
       expect.objectContaining({
-        env: customEnv
+        env: expect.objectContaining(customEnv)
+      })
+    );
+  });
+
+  test("should merge default and custom environment variables", async () => {
+    const customEnv = { CUSTOM_VAR: "custom-value" };
+    const transport = new StdioClientTransport({
+      command: "test-command",
+      env: customEnv
+    });
+
+    await transport.start();
+
+    // verify environment variables are merged correctly
+    expect(mockSpawn).toHaveBeenCalledWith(
+      "test-command",
+      [],
+      expect.objectContaining({
+        env: expect.objectContaining(customEnv)
       })
     );
   });

--- a/src/client/stdio.ts
+++ b/src/client/stdio.ts
@@ -117,7 +117,7 @@ export class StdioClientTransport implements Transport {
         this._serverParams.command,
         this._serverParams.args ?? [],
         {
-          env: this._serverParams.env ?? getDefaultEnvironment(),
+          env: { ...getDefaultEnvironment(), ...(this._serverParams.env ?? {}) },
           stdio: ["pipe", "pipe", this._serverParams.stderr ?? "inherit"],
           shell: false,
           signal: this._abortController.signal,


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
Fix environment variable handling in StdioClientTransport by properly merging default and custom environments.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Currently when providing custom environment variables, the code uses the nullish coalescing operator (`??`) which either uses custom environment OR default environment, not both. This fix ensures default environment variables are always included while still allowing custom variables to override them.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Updated the existing environment variable test and added a new test specifically for checking environment variable merging. All tests pass locally.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
None. This is a bugfix that maintains the existing API.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
This PR addresses issue #216.