### PR TITLE
make `onprogress` handler optional for progress flow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@modelcontextprotocol/sdk",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@modelcontextprotocol/sdk",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "license": "MIT",
       "dependencies": {
         "content-type": "^1.0.5",

--- a/src/shared/protocol.ts
+++ b/src/shared/protocol.ts
@@ -364,12 +364,6 @@ export abstract class Protocol<
   private _onprogress(notification: ProgressNotification): void {
     const { progressToken, ...params } = notification.params;
     const messageId = Number(progressToken);
-    
-    const handler = this._progressHandlers.get(messageId);
-    if (!handler) {
-      this._onerror(new Error(`Received a progress notification for an unknown token: ${JSON.stringify(notification)}`));
-      return;
-    }
 
     const responseHandler = this._responseHandlers.get(messageId);
     const timeoutInfo = this._timeoutInfo.get(messageId);
@@ -383,7 +377,10 @@ export abstract class Protocol<
       }
     }
 
-    handler(params);
+    const handler = this._progressHandlers.get(messageId);
+    if (handler) {
+      handler(params);
+    }
   }
 
   private _onresponse(response: JSONRPCResponse | JSONRPCError): void {


### PR DESCRIPTION
The protocol implementation indirectly [mandates](https://github.com/modelcontextprotocol/typescript-sdk/blob/854b55e0a1783e757c2e3dcfb9d088db31cc9821/src/shared/protocol.ts#L370) an `onprogress` handler to be set while [making a request](https://github.com/modelcontextprotocol/typescript-sdk/blob/854b55e0a1783e757c2e3dcfb9d088db31cc9821/src/shared/protocol.ts#L482) to a Server which is expected to send Progress notifications.

The [behaviour requirements](https://spec.modelcontextprotocol.io/specification/2025-03-26/basic/utilities/progress/#behavior-requirements) in the protocol don't seem to mandate this `onprogress` callback in the `Sender`. Hence, IMO `onprogress` handler should be optional. In case client is interested in logging/processing the progress updates) they can set it otherwise they should not be required to pass in the `onprogress` callback.

This was discovered while working on https://github.com/modelcontextprotocol/inspector/pull/271.

### To demonstrate further
Currently in order for progress notification based  timeout resets to work, this is the minimum setup:
```js
      const requestPromise = protocol.request(request, mockSchema, {
        timeout: 1000,
        resetTimeoutOnProgress: true,
        onprogress: (progress) => {
                  console.log("made some progress", progress);
        },
      });
```
^ Here `onprogress` is mandatory due to the way `_onprogress` hook is implemented in the protocol, it checks for presence of a `progressHandler` which is [only set](https://github.com/modelcontextprotocol/typescript-sdk/blob/854b55e0a1783e757c2e3dcfb9d088db31cc9821/src/shared/protocol.ts#L483) when using `onprogress`

### Post this PR, the following would work (added test for the same):
```js
      const requestPromise = protocol.request(request, mockSchema, {
        timeout: 1000,
        resetTimeoutOnProgress: true,
      });
```

## How Has This Been Tested?
* Added tests for the same

## Breaking Changes
* No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context