### PR TITLE
fix: Ensure the correct capability is checked for `completion/complete`

### DIFF
--- a/src/client/index.test.ts
+++ b/src/client/index.test.ts
@@ -227,10 +227,19 @@ test("should respect server capabilities", async () => {
   await expect(client.listResources()).resolves.not.toThrow();
   await expect(client.listTools()).resolves.not.toThrow();
 
-  // This should throw because prompts are not supported
+  // These should throw because prompts, logging, and completions are not supported
   await expect(client.listPrompts()).rejects.toThrow(
     "Server does not support prompts",
   );
+  await expect(client.setLoggingLevel("error")).rejects.toThrow(
+    "Server does not support logging",
+  );
+  await expect(
+    client.complete({
+      ref: { type: "ref/prompt", name: "test" },
+      argument: { name: "test", value: "test" },
+    }),
+  ).rejects.toThrow("Server does not support completions");
 });
 
 test("should respect client notification capabilities", async () => {

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -237,9 +237,9 @@ export class Client<
         break;
 
       case "completion/complete":
-        if (!this._serverCapabilities?.prompts) {
+        if (!this._serverCapabilities?.completions) {
           throw new Error(
-            `Server does not support prompts (required for ${method})`,
+            `Server does not support completions (required for ${method})`,
           );
         }
         break;


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

Fixed an issue where prompts capability was being checked instead of completions in `assertCapabilityForMethod`. Now it properly checks the completions capability.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Updated the test to ensure that any request for a capability not listed in the server's capabilities results in an error.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
N/A

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
