### PR TITLE
Revert "feat: support extending McpServer with authorization"

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,8 +1,0 @@
-{
-  "printWidth": 80,
-  "tabWidth": 2,
-  "trailingComma": "all",
-  "jsxBracketSameLine": true,
-  "semi": true,
-  "singleQuote": false
-}

--- a/jest.config.js
+++ b/jest.config.js
@@ -12,6 +12,5 @@ export default {
   transformIgnorePatterns: [
     "/node_modules/(?!eventsource)/"
   ],
-  collectCoverageFrom: ["src/**/*.ts"],
   testPathIgnorePatterns: ["/node_modules/", "/dist/"],
 };

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "prepack": "npm run build:esm && npm run build:cjs",
     "lint": "eslint src/",
     "test": "jest",
-    "coverage": "jest --coverage",
     "start": "npm run server",
     "server": "tsx watch --clear-screen=false src/cli.ts server",
     "client": "tsx src/cli.ts client"

--- a/src/inMemory.ts
+++ b/src/inMemory.ts
@@ -12,7 +12,6 @@ export class InMemoryTransport implements Transport {
   onerror?: (error: Error) => void;
   onmessage?: (message: JSONRPCMessage) => void;
   sessionId?: string;
-  user?: unknown;
 
   /**
    * Creates a pair of linked in-memory transports that can communicate with each other. One should be passed to a Client and one to a Server.

--- a/src/server/mcp.ts
+++ b/src/server/mcp.ts
@@ -54,17 +54,12 @@ export class McpServer {
    */
   public readonly server: Server;
 
-  protected _registeredResources: { [uri: string]: RegisteredResource } = {};
-  protected _registeredResourceTemplates: {
+  private _registeredResources: { [uri: string]: RegisteredResource } = {};
+  private _registeredResourceTemplates: {
     [name: string]: RegisteredResourceTemplate;
   } = {};
-  protected _registeredTools: { [name: string]: RegisteredTool } = {};
-  protected _registeredPrompts: { [name: string]: RegisteredPrompt } = {};
-
-  protected _toolHandlersInitialized = false;
-  protected _completionHandlerInitialized = false;
-  protected _resourceHandlersInitialized = false;
-  protected _promptHandlersInitialized = false;
+  private _registeredTools: { [name: string]: RegisteredTool } = {};
+  private _registeredPrompts: { [name: string]: RegisteredPrompt } = {};
 
   constructor(serverInfo: Implementation, options?: ServerOptions) {
     this.server = new Server(serverInfo, options);
@@ -86,11 +81,13 @@ export class McpServer {
     await this.server.close();
   }
 
+  private _toolHandlersInitialized = false;
+
   private setToolRequestHandlers() {
     if (this._toolHandlersInitialized) {
       return;
     }
-
+    
     this.server.assertCanSetRequestHandler(
       ListToolsRequestSchema.shape.method.value,
     );
@@ -180,6 +177,8 @@ export class McpServer {
     this._toolHandlersInitialized = true;
   }
 
+  private _completionHandlerInitialized = false;
+
   private setCompletionRequestHandler() {
     if (this._completionHandlerInitialized) {
       return;
@@ -267,6 +266,8 @@ export class McpServer {
     const suggestions = await completer(request.params.argument.value);
     return createCompletionResult(suggestions);
   }
+
+  private _resourceHandlersInitialized = false;
 
   private setResourceRequestHandlers() {
     if (this._resourceHandlersInitialized) {
@@ -365,9 +366,11 @@ export class McpServer {
     );
 
     this.setCompletionRequestHandler();
-
+    
     this._resourceHandlersInitialized = true;
   }
+
+  private _promptHandlersInitialized = false;
 
   private setPromptRequestHandlers() {
     if (this._promptHandlersInitialized) {
@@ -435,7 +438,7 @@ export class McpServer {
     );
 
     this.setCompletionRequestHandler();
-
+    
     this._promptHandlersInitialized = true;
   }
 
@@ -767,7 +770,7 @@ type RegisteredPrompt = {
   callback: PromptCallback<undefined | PromptArgsRawShape>;
 };
 
-export function promptArgumentsFromSchema(
+function promptArgumentsFromSchema(
   schema: ZodObject<PromptArgsRawShape>,
 ): PromptArgument[] {
   return Object.entries(schema.shape).map(

--- a/src/server/sse.ts
+++ b/src/server/sse.ts
@@ -19,7 +19,6 @@ export class SSEServerTransport implements Transport {
   onclose?: () => void;
   onerror?: (error: Error) => void;
   onmessage?: (message: JSONRPCMessage) => void;
-  user?: unknown;
 
   /**
    * Creates a new SSE server transport, which will direct the client to POST messages to the relative or absolute URL identified by `_endpoint`.

--- a/src/server/stdio.ts
+++ b/src/server/stdio.ts
@@ -21,7 +21,6 @@ export class StdioServerTransport implements Transport {
   onclose?: () => void;
   onerror?: (error: Error) => void;
   onmessage?: (message: JSONRPCMessage) => void;
-  user?: unknown;
 
   // Arrow functions to bind `this` properly, while maintaining function identity.
   _ondata = (chunk: Buffer) => {
@@ -74,7 +73,7 @@ export class StdioServerTransport implements Transport {
       // This prevents interfering with other parts of the application that might be using stdin
       this._stdin.pause();
     }
-
+    
     // Clear the buffer and notify closure
     this._readBuffer.clear();
     this.onclose?.();

--- a/src/shared/protocol.ts
+++ b/src/shared/protocol.ts
@@ -93,11 +93,6 @@ export type RequestHandlerExtra = {
    * The session ID from the transport, if available.
    */
   sessionId?: string;
-
-  /**
-   * The authenticated user, if available.
-   */
-  user?: unknown;
 };
 
 /**
@@ -324,7 +319,6 @@ export abstract class Protocol<
     const extra: RequestHandlerExtra = {
       signal: abortController.signal,
       sessionId: this._transport?.sessionId,
-      user: this._transport?.user,
     };
 
     // Starting with Promise.resolve() puts any synchronous errors into the monad as well.
@@ -370,7 +364,7 @@ export abstract class Protocol<
   private _onprogress(notification: ProgressNotification): void {
     const { progressToken, ...params } = notification.params;
     const messageId = Number(progressToken);
-
+    
     const handler = this._progressHandlers.get(messageId);
     if (!handler) {
       this._onerror(new Error(`Received a progress notification for an unknown token: ${JSON.stringify(notification)}`));

--- a/src/shared/transport.ts
+++ b/src/shared/transport.ts
@@ -46,9 +46,4 @@ export interface Transport {
    * The session ID generated for this connection.
    */
   sessionId?: string;
-
-  /**
-   * The authenticated user for this transport session.
-   */
-  user?: unknown;
 }


### PR DESCRIPTION
Reverts modelcontextprotocol/typescript-sdk#249, as I don't think the core changes of that PR are a good idea:

1. I think it's generally going to be a bad idea to subclass `McpServer`, and it will _definitely_ cause problems (now or in the future) to override the way it installs tool call handlers, etc. Two possible alternatives here:
    1. Either these kinds of customizations should go _into_ the callbacks given to `McpServer.tool`, _or_
    2. This should be done via composition rather than inheritance.
1. Adding a writable property `Transport.user` of `unknown` type—which isn't set anywhere in the SDK—isn't useful, and is _actively confusing_ because it provides no semantics or type information. Since object types are open-ended in JS, the correct approach would be to just save an additional property, and use a TS declaration _in your application_ to refer to that property. Something like this:
```typescript
declare module "@modelcontextprotocol/sdk" {
  declare class StdioServerTransport {
    user?: User;
  }
}
```

If there are ways in which these suggestions _prevent_ something from being possible, let's discuss, but I suspect there's no additional SDK support required here.