### PR TITLE
feat: Allow SSE transport to be initialized with a specific sessionId

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,8 @@ app.get("/sse", async (_: Request, res: Response) => {
 app.post("/messages", async (req: Request, res: Response) => {
   const sessionId = req.query.sessionId as string;
   const transport = transports[sessionId];
+  // or...
+  // const transport = new SSEServerTransport('/messages', res, sessionId);
   if (transport) {
     await transport.handlePostMessage(req, res);
   } else {

--- a/src/server/sse.test.ts
+++ b/src/server/sse.test.ts
@@ -1,0 +1,7 @@
+import { SSEServerTransport } from "./sse.js";
+
+test("should initialize with provided sessionId", async () => {
+  const res: any = null;
+  const server = new SSEServerTransport("/sse", res, "test-sessionId-123");
+  expect(server.sessionId).toBe("test-sessionId-123");
+});

--- a/src/server/sse.test.ts
+++ b/src/server/sse.test.ts
@@ -1,7 +1,8 @@
 import { SSEServerTransport } from "./sse.js";
 
 test("should initialize with provided sessionId", async () => {
-  const res: any = null;
+  /* eslint-disable  @typescript-eslint/no-explicit-any */
+  const res: any = null; // mocking HTTP res as it's irrelevant to the test
   const server = new SSEServerTransport("/sse", res, "test-sessionId-123");
   expect(server.sessionId).toBe("test-sessionId-123");
 });

--- a/src/server/sse.ts
+++ b/src/server/sse.ts
@@ -26,8 +26,9 @@ export class SSEServerTransport implements Transport {
   constructor(
     private _endpoint: string,
     private res: ServerResponse,
+    sessionId?: string
   ) {
-    this._sessionId = randomUUID();
+    this._sessionId = sessionId ?? randomUUID();
   }
 
   /**


### PR DESCRIPTION
Added the ability to initialize a SSEServerTransport with a specific sessionId, which enables stateless server handling and thus a horizontally scalable implementation.

## Motivation and Context
It allows stateless servers, where a single MCP deployment can handle multiple servers statelessly.

## How Has This Been Tested?
A specific test was added that validates that initializing the SSE transport with a specific ID works as expected.

## Breaking Changes
None

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
None
