### PR TITLE
Add support for non default shells

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "eventsource": "^3.0.2",
         "express": "^5.0.1",
         "express-rate-limit": "^7.5.0",
+        "os": "^0.1.2",
         "pkce-challenge": "^5.0.0",
         "raw-body": "^3.0.0",
         "zod": "^3.23.8",
@@ -5273,6 +5274,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/os": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/os/-/os-0.1.2.tgz",
+      "integrity": "sha512-ZoXJkvAnljwvc56MbvhtKVWmSkzV712k42Is2mA0+0KTSRakq5XXuXpjZjgAt9ctzl51ojhQWakQQpmOvXWfjQ==",
+      "license": "MIT"
     },
     "node_modules/p-limit": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "eventsource": "^3.0.2",
     "express": "^5.0.1",
     "express-rate-limit": "^7.5.0",
+    "os": "^0.1.2",
     "pkce-challenge": "^5.0.0",
     "raw-body": "^3.0.0",
     "zod": "^3.23.8",

--- a/src/client/cross-spawn.test.ts
+++ b/src/client/cross-spawn.test.ts
@@ -2,7 +2,7 @@ import { StdioClientTransport } from "./stdio.js";
 import spawn from "cross-spawn";
 import { JSONRPCMessage } from "../types.js";
 import { ChildProcess } from "node:child_process";
-
+import os from 'os';
 // mock cross-spawn
 jest.mock("cross-spawn");
 const mockSpawn = spawn as jest.MockedFunction<typeof spawn>;
@@ -53,7 +53,7 @@ describe("StdioClientTransport using cross-spawn", () => {
       "test-command",
       ["arg1", "arg2"],
       expect.objectContaining({
-        shell: false
+        shell: os.userInfo().shell
       })
     );
   });

--- a/src/client/stdio.ts
+++ b/src/client/stdio.ts
@@ -5,6 +5,7 @@ import { Stream } from "node:stream";
 import { ReadBuffer, serializeMessage } from "../shared/stdio.js";
 import { Transport } from "../shared/transport.js";
 import { JSONRPCMessage } from "../types.js";
+import os from "os"
 
 export type StdioServerParameters = {
   /**
@@ -119,7 +120,7 @@ export class StdioClientTransport implements Transport {
         {
           env: this._serverParams.env ?? getDefaultEnvironment(),
           stdio: ["pipe", "pipe", this._serverParams.stderr ?? "inherit"],
-          shell: false,
+          shell: os.userInfo().shell || false,
           signal: this._abortController.signal,
           windowsHide: process.platform === "win32" && isElectron(),
           cwd: this._serverParams.cwd,


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
This PR adds support for non default user shells. This fixes the Issue https://github.com/modelcontextprotocol/servers/issues/64
## Motivation and Context

Without this changes MacUsers using the `zsh` shell failed to start applications via `npx` because spawn failed with 

`spawn npx ENOENT`

## How Has This Been Tested?

Tested locally and after the change `npx` and all related servers using it worked for me.

## Breaking Changes

no

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [X] I have added appropriate error handling
- [X] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
