### PR TITLE
feat(client/sse): allow custom fetch implementation

### DIFF
--- a/src/client/sse.ts
+++ b/src/client/sse.ts
@@ -68,7 +68,7 @@ export class SSEClientTransport implements Transport {
   private _eventSourceInit?: EventSourceInit;
   private _requestInit?: RequestInit;
   private _authProvider?: OAuthClientProvider;
-  private _fetch: FetchLike;
+  private _fetch?: FetchLike;
 
   onclose?: () => void;
   onerror?: (error: Error) => void;
@@ -82,7 +82,7 @@ export class SSEClientTransport implements Transport {
     this._eventSourceInit = opts?.eventSourceInit;
     this._requestInit = opts?.requestInit;
     this._authProvider = opts?.authProvider;
-    this._fetch = opts?.fetch ?? fetch;
+    this._fetch = opts?.fetch;
   }
 
   private async _authThenStart(): Promise<void> {
@@ -122,7 +122,7 @@ export class SSEClientTransport implements Transport {
       this._eventSource = new EventSource(
         this._url.href,
         this._eventSourceInit ?? {
-          fetch: (url, init) => this._commonHeaders().then((headers) => this._fetch(url, {
+          fetch: (url, init) => this._commonHeaders().then((headers) => (this._fetch ?? fetch)(url, {
             ...init,
             headers: {
               ...headers,
@@ -231,7 +231,7 @@ export class SSEClientTransport implements Transport {
         signal: this._abortController?.signal,
       };
 
-      const response = await this._fetch(this._endpoint, init);
+      const response = await (this._fetch ?? fetch)(this._endpoint, init);
       if (!response.ok) {
         if (response.status === 401 && this._authProvider) {
           const result = await auth(this._authProvider, { serverUrl: this._url });


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
Add an optional `fetch` param to SSEClientTransportOptions to allow custom fetch implementation.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
For SSE transport, previously the `eventSourceInit` param allowed to customize the `fetch` function used by EventSource. However, the `send` method still use the native `fetch`, which was not customizable. In some use cases, we might want both to use a custom `fetch` implementation. For example, in Tauri/Capacitor applications , the frontend runs in a webview, and the native `fetch` cannot perform cross-origin requests directly. Therefore, a custom `fetch` function is needed to bypass CORS.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
`npm test` passed. Additionally, I have used the modified transport in [AIaW](https://github.com/NitroRCr/AIaW) with a custom `fetch` function to test and verify cross-origin functionality.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
