### PR TITLE
capture sse responses for streamable http transport

### DIFF
--- a/src/shared/protocol.ts
+++ b/src/shared/protocol.ts
@@ -369,7 +369,7 @@ export abstract class Protocol<
             result,
             jsonrpc: "2.0",
             id: request.id,
-          });
+          }, { relatedRequestId: request.id });
         },
         (error) => {
           if (abortController.signal.aborted) {
@@ -385,7 +385,7 @@ export abstract class Protocol<
                 : ErrorCode.InternalError,
               message: error.message ?? "Internal error",
             },
-          });
+          }, { relatedRequestId: request.id });
         },
       )
       .catch((error) =>


### PR DESCRIPTION
## Motivation and Context
I am trying to get Streamable HTTP Transport working on my local, and noticed that it's still experimental, lacks the capability to stream the response back to the client.

This change will allow the MCP Server to respond properly with Streamable HTTP Transport.

First PR on this Project. Please let me know if there are any specific guidelines I should be following.

## How Has This Been Tested?

This is now part of the test suite, and be individually tested by running:

```shell
npx jest src/server/streamableHttp.test.ts -t 'Connect to a MCP Server'
```

## Breaking Changes
No

## Types of changes
- [ ] Connect HTTP Streaming Transport to MCP Server such that responses are sent back to the client.

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ]  My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
NA
