### PR TITLE
Fix typo on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ server.tool(
 
 ### Dynamic Servers
 
-If you want to offer an initial set of tools/prompts/resources, but later add additional ones based on user action or external state change, you can add/update/remove them _after_ the Server is connected. This will automatically emit the corresponding `listChanged` notificaions:
+If you want to offer an initial set of tools/prompts/resources, but later add additional ones based on user action or external state change, you can add/update/remove them _after_ the Server is connected. This will automatically emit the corresponding `listChanged` notification:
 
 ```ts
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";


### PR DESCRIPTION
Fix a little typo on documentation.

## Motivation and Context
It could lead to the thought that multiple notifications are sent

## How Has This Been Tested?
--

## Breaking Changes
--

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
