### PR TITLE
Ensuring stdio transport closure despite server hanging. Fixing #271

### DIFF
--- a/src/client/stdio.ts
+++ b/src/client/stdio.ts
@@ -170,6 +170,13 @@ export class StdioClientTransport implements Transport {
     return this._process?.stderr ?? null;
   }
 
+  /**
+   * The process id of the child process, if it has been started.
+   */
+  get pid(): number | undefined {
+    return this._process?.pid;
+  }
+
   private processReadBuffer() {
     while (true) {
       try {
@@ -187,6 +194,7 @@ export class StdioClientTransport implements Transport {
 
   async close(): Promise<void> {
     this._abortController.abort();
+    process.kill(this._process!.pid!, 'SIGKILL');
     this._process = undefined;
     this._readBuffer.clear();
   }

--- a/src/integration-tests/server-that-hangs.js
+++ b/src/integration-tests/server-that-hangs.js
@@ -1,0 +1,20 @@
+import { McpServer } from "../../dist/esm/server/mcp.js";
+import { StdioServerTransport } from "../../dist/esm/server/stdio.js";
+import { spawn } from "node:child_process";
+
+const transport = new StdioServerTransport();
+
+const server = new McpServer({
+  name: "test-stdio-server",
+  version: "1.0.0"
+});
+
+await server.connect(transport);
+
+const doNotExitImmediately = async () => {
+  setTimeout(() => process.exit(0), 30 * 1000);
+};
+
+process.stdin.on('close', doNotExitImmediately);
+process.on('SIGINT', doNotExitImmediately);
+process.on('SIGTERM', doNotExitImmediately);


### PR DESCRIPTION
Force closing the child process upon closing the stdio process

## Motivation and Context
The issue was raised and reproducible in https://github.com/modelcontextprotocol/typescript-sdk/issues/271

## How Has This Been Tested?
Added a manual test + tried adding the scenario from the issue with Microsoft's playwright-mcp

## Breaking Changes
None

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
- https://github.com/modelcontextprotocol/typescript-sdk/issues/271
- https://github.com/microsoft/playwright-mcp/issues/141