### PR TITLE
add custom headers on initial _startOrAuth call

### DIFF
--- a/src/client/sse.test.ts
+++ b/src/client/sse.test.ts
@@ -329,6 +329,29 @@ describe("SSEClientTransport", () => {
       expect(mockAuthProvider.tokens).toHaveBeenCalled();
     });
 
+    it("attaches custom header from provider on initial SSE connection", async () => {
+      mockAuthProvider.tokens.mockResolvedValue({
+        access_token: "test-token",
+        token_type: "Bearer"
+      });
+      const customHeaders = {
+        "X-Custom-Header": "custom-value",
+      };
+
+      transport = new SSEClientTransport(baseUrl, {
+        authProvider: mockAuthProvider,
+        requestInit: {
+          headers: customHeaders,
+        },
+      });
+
+      await transport.start();
+
+      expect(lastServerRequest.headers.authorization).toBe("Bearer test-token");
+      expect(lastServerRequest.headers["x-custom-header"]).toBe("custom-value");
+      expect(mockAuthProvider.tokens).toHaveBeenCalled();
+    });
+
     it("attaches auth header from provider on POST requests", async () => {
       mockAuthProvider.tokens.mockResolvedValue({
         access_token: "test-token",

--- a/src/client/sse.ts
+++ b/src/client/sse.ts
@@ -113,13 +113,17 @@ export class SSEClientTransport implements Transport {
       this._eventSource = new EventSource(
         this._url.href,
         this._eventSourceInit ?? {
-          fetch: (url, init) => this._commonHeaders().then((headers) => fetch(url, {
-            ...init,
-            headers: {
-              ...headers,
-              Accept: "text/event-stream"
-            }
-          })),
+          fetch: async (url, init) => {
+            const commonHeaders = await this._commonHeaders();
+            const allHeaders = { ...commonHeaders, ...this._requestInit?.headers};
+            return fetch(url, {
+              ...init,
+              headers: {
+                ...allHeaders,
+                Accept: "text/event-stream"
+              }
+            })
+          }
         },
       );
       this._abortController = new AbortController();


### PR DESCRIPTION
Ensure that custom headers provided in `this._requestInit?.headers` are included in the initial call to the `/sse` endpoint.

## Motivation and Context
When integrating Roo with custom MCP servers behind a corporate proxy, some connections require specific headers (e.g., `Host`, custom `X-*` headers) to be passed through consistently. As reported in [issue #317](https://github.com/modelcontextprotocol/typescript-sdk/issues/317), the initial `/sse` request did not include these custom headers, even though they were correctly included in subsequent `/messages` requests via `send()`.

This PR aligns the behavior of the `/sse` request with `send()` by ensuring that all custom headers (when provided) are forwarded appropriately.

## How Has This Been Tested?
- Added a test case to verify that custom headers, when specified, are included in the initial `/sse` request.

## Breaking Changes
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
N/a
