### PR TITLE
Pass request _meta to request handlers extra param

### DIFF
--- a/src/shared/protocol.ts
+++ b/src/shared/protocol.ts
@@ -21,6 +21,7 @@ import {
   RequestId,
   Result,
   ServerCapabilities,
+  RequestMeta,
 } from "../types.js";
 import { Transport, TransportSendOptions } from "./transport.js";
 import { AuthInfo } from "../server/auth/types.js";
@@ -114,6 +115,11 @@ export type RequestHandlerExtra<SendRequestT extends Request,
      * The session ID from the transport, if available.
      */
     sessionId?: string;
+
+    /**
+     * Metadata from the original request.
+     */
+    _meta?: RequestMeta;
 
     /**
      * The JSON-RPC ID of the request being handled.
@@ -361,6 +367,7 @@ export abstract class Protocol<
     const fullExtra: RequestHandlerExtra<SendRequestT, SendNotificationT> = {
       signal: abortController.signal,
       sessionId: this._transport?.sessionId,
+      _meta: request.params?._meta,
       sendNotification:
         (notification) =>
           this.notification(notification, { relatedRequestId: request.id }),

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,18 +19,18 @@ export const ProgressTokenSchema = z.union([z.string(), z.number().int()]);
  */
 export const CursorSchema = z.string();
 
+const RequestMetaSchema = z
+  .object({
+    /**
+     * If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications.
+     */
+    progressToken: z.optional(ProgressTokenSchema),
+  })
+  .passthrough();
+
 const BaseRequestParamsSchema = z
   .object({
-    _meta: z.optional(
-      z
-        .object({
-          /**
-           * If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications.
-           */
-          progressToken: z.optional(ProgressTokenSchema),
-        })
-        .passthrough(),
-    ),
+    _meta: z.optional(RequestMetaSchema),
   })
   .passthrough();
 
@@ -1240,6 +1240,7 @@ type Infer<Schema extends ZodTypeAny> = Flatten<z.infer<Schema>>;
 export type ProgressToken = Infer<typeof ProgressTokenSchema>;
 export type Cursor = Infer<typeof CursorSchema>;
 export type Request = Infer<typeof RequestSchema>;
+export type RequestMeta = Infer<typeof RequestMetaSchema>;
 export type Notification = Infer<typeof NotificationSchema>;
 export type Result = Infer<typeof ResultSchema>;
 export type RequestId = Infer<typeof RequestIdSchema>;


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context

The MCP client sends a progress token when calling tools, but there's currently no way for the server (in this SDK) to retrieve this progress token. While the client will receive the progress notifications, it won't associate them with the tool calls and thus it can't properly report on progress.

<!-- Why is this change needed? What problem does it solve? -->

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

In the inspector, of course, and my chat MCP client (SSE server).

Here's the setup, roughly:

```typescript
// Server
server.tool(
  "hello",
  { city: z.string() },
  async ({ city }, { sendNotification, _meta }) => {
    if (_meta?.progressToken) {
      await sendNotification({
        method: "notifications/progress",
        params: { progress: 1, progressToken: _meta.progressToken }
      })
    }

    return {
      content: [{ type: "text", text: `Hello, ${city}!` }]
    };
  }
);

// Client
await client.callTool(
  { name: "hello", arguments: { "city": "Ghent" } },
  undefined,
  {
    onprogress: progress => console.log("Hello progress", progress)
  }
);
```

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

None.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [X] I have added appropriate error handling
- [X] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->

This is the smallest possible way to implement the functionality in the SDK, but I'm not convinced on the ergonomics as a user.

I'm open to hear your ideas:

- Should we add a `sendProgress(progress: number, total?:number)` in the `extra` params instead? The Python SDK has a [`report_progress`](https://github.com/modelcontextprotocol/python-sdk/blob/70115b99b3ee267ef10f61df21f73a93db74db03/src/mcp/server/fastmcp/server.py#L623-L644) that it passes to the request context.
- Does the `progressToken` make sense, actually? There's already a `relatedRequestId` passed through by `sendNotification`—maybe that should be used instead of a separate progress token?