### PR TITLE
Streamable HTTP - resume streams on disconnect

### DIFF
--- a/src/examples/client/simpleStreamableHttp.ts
+++ b/src/examples/client/simpleStreamableHttp.ts
@@ -1,5 +1,6 @@
 import { Client } from '../../client/index.js';
 import { StreamableHTTPClientTransport } from '../../client/streamableHttp.js';
+import { createInterface } from 'node:readline';
 import {
   ListToolsRequest,
   ListToolsResultSchema,
@@ -15,139 +16,434 @@ import {
   ResourceListChangedNotificationSchema,
 } from '../../types.js';
 
+// Create readline interface for user input
+const readline = createInterface({
+  input: process.stdin,
+  output: process.stdout
+});
+
+// Track received notifications for debugging resumability
+let notificationCount = 0;
+
+// Global client and transport for interactive commands
+let client: Client | null = null;
+let transport: StreamableHTTPClientTransport | null = null;
+let serverUrl = 'http://localhost:3000/mcp';
+
 async function main(): Promise<void> {
-  // Create a new client with streamable HTTP transport
-  const client = new Client({
-    name: 'example-client',
-    version: '1.0.0'
-  });
+  console.log('MCP Interactive Client');
+  console.log('=====================');
 
-  const transport = new StreamableHTTPClientTransport(
-    new URL('http://localhost:3000/mcp')
-  );
+  // Connect to server immediately with default settings
+  await connect();
 
-  // Connect the client using the transport and initialize the server  
-  await client.connect(transport);
-  console.log('Connected to MCP server');
-
-  // Set up notification handlers for server-initiated messages
-  client.setNotificationHandler(LoggingMessageNotificationSchema, (notification) => {
-    console.log(`Notification received: ${notification.params.level} - ${notification.params.data}`);
-  });
-  client.setNotificationHandler(ResourceListChangedNotificationSchema, async (_) => {
-    console.log(`Resource list changed notification received!`);
-    const resourcesRequest: ListResourcesRequest = {
-      method: 'resources/list',
-      params: {}
-    };
-    const resourcesResult = await client.request(resourcesRequest, ListResourcesResultSchema);
-    console.log('Available resources count:', resourcesResult.resources.length);
-  });
-
-  // List and call tools
-  await listTools(client);
-
-  await callGreetTool(client);
-  await callMultiGreetTool(client);
-
-
-  // List available prompts
-  try {
-    const promptsRequest: ListPromptsRequest = {
-      method: 'prompts/list',
-      params: {}
-    };
-    const promptsResult = await client.request(promptsRequest, ListPromptsResultSchema);
-    console.log('Available prompts:', promptsResult.prompts);
-  } catch (error) {
-    console.log(`Prompts not supported by this server (${error})`);
-  }
-
-  // Get a prompt
-  try {
-    const promptRequest: GetPromptRequest = {
-      method: 'prompts/get',
-      params: {
-        name: 'greeting-template',
-        arguments: { name: 'MCP User' }
-      }
-    };
-    const promptResult = await client.request(promptRequest, GetPromptResultSchema);
-    console.log('Prompt template:', promptResult.messages[0].content.text);
-  } catch (error) {
-    console.log(`Prompt retrieval not supported by this server (${error})`);
-  }
-
-  // List available resources
-  try {
-    const resourcesRequest: ListResourcesRequest = {
-      method: 'resources/list',
-      params: {}
-    };
-    const resourcesResult = await client.request(resourcesRequest, ListResourcesResultSchema);
-    console.log('Available resources:', resourcesResult.resources);
-  } catch (error) {
-    console.log(`Resources not supported by this server (${error})`);
-  }
-  // Keep the connection open to receive notifications
-  console.log('\nKeeping connection open to receive notifications. Press Ctrl+C to exit.');
+  // Print help and start the command loop
+  printHelp();
+  commandLoop();
 }
 
-async function listTools(client: Client): Promise<void> {
+function printHelp(): void {
+  console.log('\nAvailable commands:');
+  console.log('  connect [url]              - Connect to MCP server (default: http://localhost:3000/mcp)');
+  console.log('  disconnect                 - Disconnect from server');
+  console.log('  reconnect                  - Reconnect to the server');
+  console.log('  list-tools                 - List available tools');
+  console.log('  call-tool <name> [args]    - Call a tool with optional JSON arguments');
+  console.log('  greet [name]               - Call the greet tool');
+  console.log('  multi-greet [name]         - Call the multi-greet tool with notifications');
+  console.log('  start-notifications [interval] [count] - Start periodic notifications');
+  console.log('  simulate-disconnect [delay] - Simulate network disconnection after delay seconds');
+  console.log('  list-prompts               - List available prompts');
+  console.log('  get-prompt [name] [args]   - Get a prompt with optional JSON arguments');
+  console.log('  list-resources             - List available resources');
+  console.log('  help                       - Show this help');
+  console.log('  quit                       - Exit the program');
+}
+
+function commandLoop(): void {
+  readline.question('\n> ', async (input) => {
+    const args = input.trim().split(/\s+/);
+    const command = args[0]?.toLowerCase();
+
+    try {
+      switch (command) {
+        case 'connect':
+          await connect(args[1]);
+          break;
+
+        case 'disconnect':
+          await disconnect();
+          break;
+
+        case 'reconnect':
+          await reconnect();
+          break;
+
+        case 'list-tools':
+          await listTools();
+          break;
+
+        case 'call-tool':
+          if (args.length < 2) {
+            console.log('Usage: call-tool <name> [args]');
+          } else {
+            const toolName = args[1];
+            let toolArgs = {};
+            if (args.length > 2) {
+              try {
+                toolArgs = JSON.parse(args.slice(2).join(' '));
+              } catch {
+                console.log('Invalid JSON arguments. Using empty args.');
+              }
+            }
+            await callTool(toolName, toolArgs);
+          }
+          break;
+
+        case 'greet':
+          await callGreetTool(args[1] || 'MCP User');
+          break;
+
+        case 'multi-greet':
+          await callMultiGreetTool(args[1] || 'MCP User');
+          break;
+
+        case 'start-notifications': {
+          const interval = args[1] ? parseInt(args[1], 10) : 2000;
+          const count = args[2] ? parseInt(args[2], 10) : 0;
+          await startNotifications(interval, count);
+          break;
+        }
+
+        case 'simulate-disconnect': {
+          const delay = args[1] ? parseInt(args[1], 10) : 5;
+          simulateDisconnect(delay);
+          break;
+        }
+
+        case 'list-prompts':
+          await listPrompts();
+          break;
+
+        case 'get-prompt':
+          if (args.length < 2) {
+            console.log('Usage: get-prompt <name> [args]');
+          } else {
+            const promptName = args[1];
+            let promptArgs = {};
+            if (args.length > 2) {
+              try {
+                promptArgs = JSON.parse(args.slice(2).join(' '));
+              } catch {
+                console.log('Invalid JSON arguments. Using empty args.');
+              }
+            }
+            await getPrompt(promptName, promptArgs);
+          }
+          break;
+
+        case 'list-resources':
+          await listResources();
+          break;
+
+        case 'help':
+          printHelp();
+          break;
+
+        case 'quit':
+        case 'exit':
+          await cleanup();
+          return;
+
+        default:
+          if (command) {
+            console.log(`Unknown command: ${command}`);
+          }
+          break;
+      }
+    } catch (error) {
+      console.error(`Error executing command: ${error}`);
+    }
+
+    // Continue the command loop
+    commandLoop();
+  });
+}
+
+async function connect(url?: string): Promise<void> {
+  if (client) {
+    console.log('Already connected. Disconnect first.');
+    return;
+  }
+
+  if (url) {
+    serverUrl = url;
+  }
+
+  console.log(`Connecting to ${serverUrl}...`);
+
+  try {
+    // Create a new client
+    client = new Client({
+      name: 'example-client',
+      version: '1.0.0'
+    });
+
+    transport = new StreamableHTTPClientTransport(
+      new URL(serverUrl)
+    );
+
+    // Set up notification handlers
+    client.setNotificationHandler(LoggingMessageNotificationSchema, (notification) => {
+      notificationCount++;
+      console.log(`\nNotification #${notificationCount}: ${notification.params.level} - ${notification.params.data}`);
+      // Re-display the prompt
+      process.stdout.write('> ');
+    });
+
+    client.setNotificationHandler(ResourceListChangedNotificationSchema, async (_) => {
+      console.log(`\nResource list changed notification received!`);
+      try {
+        if (!client) {
+          console.log('Client disconnected, cannot fetch resources');
+          return;
+        }
+        const resourcesResult = await client.request({
+          method: 'resources/list',
+          params: {}
+        }, ListResourcesResultSchema);
+        console.log('Available resources count:', resourcesResult.resources.length);
+      } catch {
+        console.log('Failed to list resources after change notification');
+      }
+      // Re-display the prompt
+      process.stdout.write('> ');
+    });
+
+    // Connect the client
+    await client.connect(transport);
+    console.log('Connected to MCP server');
+  } catch (error) {
+    console.error('Failed to connect:', error);
+    client = null;
+    transport = null;
+  }
+}
+
+async function disconnect(): Promise<void> {
+  if (!client || !transport) {
+    console.log('Not connected.');
+    return;
+  }
+
+  try {
+    await transport.close();
+    console.log('Disconnected from MCP server');
+    client = null;
+    transport = null;
+  } catch (error) {
+    console.error('Error disconnecting:', error);
+  }
+}
+
+async function reconnect(): Promise<void> {
+  if (client) {
+    await disconnect();
+  }
+  await connect();
+}
+
+async function listTools(): Promise<void> {
+  if (!client) {
+    console.log('Not connected to server.');
+    return;
+  }
+
   try {
     const toolsRequest: ListToolsRequest = {
       method: 'tools/list',
       params: {}
     };
     const toolsResult = await client.request(toolsRequest, ListToolsResultSchema);
-    console.log('Available tools:', toolsResult.tools);
+
+    console.log('Available tools:');
     if (toolsResult.tools.length === 0) {
-      console.log('No tools available from the server');
+      console.log('  No tools available');
+    } else {
+      for (const tool of toolsResult.tools) {
+        console.log(`  - ${tool.name}: ${tool.description}`);
+      }
     }
   } catch (error) {
     console.log(`Tools not supported by this server (${error})`);
-    return
   }
 }
 
-async function callGreetTool(client: Client): Promise<void> {
-  try {
-    const greetRequest: CallToolRequest = {
-      method: 'tools/call',
-      params: {
-        name: 'greet',
-        arguments: { name: 'MCP User' }
-      }
-    };
-    const greetResult = await client.request(greetRequest, CallToolResultSchema);
-    console.log('Greeting result:', greetResult.content[0].text);
-  } catch (error) {
-    console.log(`Error calling greet tool: ${error}`);
+async function callTool(name: string, args: Record<string, unknown>): Promise<void> {
+  if (!client) {
+    console.log('Not connected to server.');
+    return;
   }
-}
 
-async function callMultiGreetTool(client: Client): Promise<void> {
   try {
-    console.log('\nCalling multi-greet tool (with notifications)...');
-    const multiGreetRequest: CallToolRequest = {
+    const request: CallToolRequest = {
       method: 'tools/call',
       params: {
-        name: 'multi-greet',
-        arguments: { name: 'MCP User' }
+        name,
+        arguments: args
       }
     };
-    const multiGreetResult = await client.request(multiGreetRequest, CallToolResultSchema);
-    console.log('Multi-greet results:');
-    multiGreetResult.content.forEach(item => {
+
+    console.log(`Calling tool '${name}' with args:`, args);
+    const result = await client.request(request, CallToolResultSchema);
+
+    console.log('Tool result:');
+    result.content.forEach(item => {
       if (item.type === 'text') {
-        console.log(`- ${item.text}`);
+        console.log(`  ${item.text}`);
+      } else {
+        console.log(`  ${item.type} content:`, item);
       }
     });
   } catch (error) {
-    console.log(`Error calling multi-greet tool: ${error}`);
+    console.log(`Error calling tool ${name}: ${error}`);
   }
 }
 
+async function callGreetTool(name: string): Promise<void> {
+  await callTool('greet', { name });
+}
+
+async function callMultiGreetTool(name: string): Promise<void> {
+  console.log('Calling multi-greet tool with notifications...');
+  await callTool('multi-greet', { name });
+}
+
+async function startNotifications(interval: number, count: number): Promise<void> {
+  console.log(`Starting notification stream: interval=${interval}ms, count=${count || 'unlimited'}`);
+  await callTool('start-notification-stream', { interval, count });
+}
+
+function simulateDisconnect(delaySeconds: number): void {
+  if (!transport) {
+    console.log('Not connected.');
+    return;
+  }
+
+  console.log(`Will simulate network disconnect in ${delaySeconds} seconds...`);
+  setTimeout(async () => {
+    if (!transport) return;
+
+    console.log('\nSimulating network disconnect...');
+    await transport.close();
+    console.log('Transport closed. Client should automatically attempt to reconnect...');
+
+    // Keep the client object but null the transport
+    // This simulates a network disconnection without explicit user disconnect
+    transport = null;
+
+    // Re-display the prompt
+    process.stdout.write('> ');
+  }, delaySeconds * 1000);
+}
+
+async function listPrompts(): Promise<void> {
+  if (!client) {
+    console.log('Not connected to server.');
+    return;
+  }
+
+  try {
+    const promptsRequest: ListPromptsRequest = {
+      method: 'prompts/list',
+      params: {}
+    };
+    const promptsResult = await client.request(promptsRequest, ListPromptsResultSchema);
+    console.log('Available prompts:');
+    if (promptsResult.prompts.length === 0) {
+      console.log('  No prompts available');
+    } else {
+      for (const prompt of promptsResult.prompts) {
+        console.log(`  - ${prompt.name}: ${prompt.description}`);
+      }
+    }
+  } catch (error) {
+    console.log(`Prompts not supported by this server (${error})`);
+  }
+}
+
+async function getPrompt(name: string, args: Record<string, unknown>): Promise<void> {
+  if (!client) {
+    console.log('Not connected to server.');
+    return;
+  }
+
+  try {
+    const promptRequest: GetPromptRequest = {
+      method: 'prompts/get',
+      params: {
+        name,
+        arguments: args as Record<string, string>
+      }
+    };
+
+    const promptResult = await client.request(promptRequest, GetPromptResultSchema);
+    console.log('Prompt template:');
+    promptResult.messages.forEach((msg, index) => {
+      console.log(`  [${index + 1}] ${msg.role}: ${msg.content.text}`);
+    });
+  } catch (error) {
+    console.log(`Error getting prompt ${name}: ${error}`);
+  }
+}
+
+async function listResources(): Promise<void> {
+  if (!client) {
+    console.log('Not connected to server.');
+    return;
+  }
+
+  try {
+    const resourcesRequest: ListResourcesRequest = {
+      method: 'resources/list',
+      params: {}
+    };
+    const resourcesResult = await client.request(resourcesRequest, ListResourcesResultSchema);
+
+    console.log('Available resources:');
+    if (resourcesResult.resources.length === 0) {
+      console.log('  No resources available');
+    } else {
+      for (const resource of resourcesResult.resources) {
+        console.log(`  - ${resource.name}: ${resource.uri}`);
+      }
+    }
+  } catch (error) {
+    console.log(`Resources not supported by this server (${error})`);
+  }
+}
+
+async function cleanup(): Promise<void> {
+  if (client && transport) {
+    try {
+      await transport.close();
+    } catch (error) {
+      console.error('Error closing transport:', error);
+    }
+  }
+
+  readline.close();
+  console.log('\nGoodbye!');
+  process.exit(0);
+}
+
+// Handle Ctrl+C
+process.on('SIGINT', async () => {
+  console.log('\nReceived SIGINT. Cleaning up...');
+  await cleanup();
+});
+
+// Start the interactive client
 main().catch((error: unknown) => {
   console.error('Error running MCP client:', error);
   process.exit(1);

--- a/src/examples/client/simpleStreamableHttp.ts
+++ b/src/examples/client/simpleStreamableHttp.ts
@@ -405,10 +405,32 @@ async function cleanup(): Promise<void> {
     }
   }
 
+
+  process.stdin.setRawMode(false);
   readline.close();
   console.log('\nGoodbye!');
   process.exit(0);
 }
+
+// Set up raw mode for keyboard input to capture Escape key
+process.stdin.setRawMode(true);
+process.stdin.on('data', async (data) => {
+  // Check for Escape key (27)
+  if (data.length === 1 && data[0] === 27) {
+    console.log('\nESC key pressed. Disconnecting from server...');
+
+    // Abort current operation and disconnect from server
+    if (client && transport) {
+      await disconnect();
+      console.log('Disconnected. Press Enter to continue.');
+    } else {
+      console.log('Not connected to server.');
+    }
+
+    // Re-display the prompt
+    process.stdout.write('> ');
+  }
+});
 
 // Handle Ctrl+C
 process.on('SIGINT', async () => {

--- a/src/server/streamableHttp.test.ts
+++ b/src/server/streamableHttp.test.ts
@@ -72,8 +72,11 @@ async function createTestServer(config: TestServerConfig = {}): Promise<{
  * Helper to stop test server
  */
 async function stopTestServer({ server, transport }: { server: Server; transport: StreamableHTTPServerTransport }): Promise<void> {
+  // First close the transport to ensure all SSE streams are closed
   await transport.close();
-  await new Promise<void>((resolve) => server.close(() => resolve()));
+
+  // Close the server without waiting indefinitely
+  server.close();
 }
 
 /**
@@ -649,8 +652,8 @@ describe("StreamableHTTPServerTransport", () => {
 
     expect(deleteResponse.status).toBe(200);
 
-    // Clean up
-    await new Promise<void>((resolve) => tempServer.close(() => resolve()));
+    // Clean up - don't wait indefinitely for server close
+    tempServer.close();
   });
 
   it("should reject DELETE requests with invalid session ID", async () => {

--- a/src/server/streamableHttp.test.ts
+++ b/src/server/streamableHttp.test.ts
@@ -1,7 +1,7 @@
 import { createServer, type Server, IncomingMessage, ServerResponse } from "node:http";
 import { AddressInfo } from "node:net";
 import { randomUUID } from "node:crypto";
-import { StreamableHTTPServerTransport } from "./streamableHttp.js";
+import { EventStore, StreamableHTTPServerTransport } from "./streamableHttp.js";
 import { McpServer } from "./mcp.js";
 import { CallToolResult, JSONRPCMessage } from "../types.js";
 import { z } from "zod";
@@ -13,6 +13,7 @@ interface TestServerConfig {
   sessionIdGenerator?: () => string | undefined;
   enableJsonResponse?: boolean;
   customRequestHandler?: (req: IncomingMessage, res: ServerResponse, parsedBody?: unknown) => Promise<void>;
+  eventStore?: EventStore;
 }
 
 /**
@@ -26,7 +27,7 @@ async function createTestServer(config: TestServerConfig = {}): Promise<{
 }> {
   const mcpServer = new McpServer(
     { name: "test-server", version: "1.0.0" },
-    { capabilities: {} }
+    { capabilities: { logging: {} } }
   );
 
   mcpServer.tool(
@@ -40,7 +41,8 @@ async function createTestServer(config: TestServerConfig = {}): Promise<{
 
   const transport = new StreamableHTTPServerTransport({
     sessionIdGenerator: config.sessionIdGenerator ?? (() => randomUUID()),
-    enableJsonResponse: config.enableJsonResponse ?? false
+    enableJsonResponse: config.enableJsonResponse ?? false,
+    eventStore: config.eventStore
   });
 
   await mcpServer.connect(transport);
@@ -89,7 +91,10 @@ const TEST_MESSAGES = {
     params: {
       clientInfo: { name: "test-client", version: "1.0" },
       protocolVersion: "2025-03-26",
+      capabilities: {
+      },
     },
+
     id: "init-1",
   } as JSONRPCMessage,
 
@@ -893,6 +898,171 @@ describe("StreamableHTTPServerTransport with pre-parsed body", () => {
     expect(text).toContain('"id":"preparsed-wins"');
     expect(text).toContain('"tools"');
     expect(text).not.toContain('"ignored-id"');
+  });
+});
+
+// Test resumability support
+describe("StreamableHTTPServerTransport with resumability", () => {
+  let server: Server;
+  let transport: StreamableHTTPServerTransport;
+  let baseUrl: URL;
+  let sessionId: string;
+  let mcpServer: McpServer;
+  const storedEvents: Map<string, { eventId: string, message: JSONRPCMessage }> = new Map();
+
+  // Simple implementation of EventStore
+  const eventStore: EventStore = {
+    generateEventId(streamId: string): string {
+      return `${streamId}_${randomUUID()}`;
+    },
+    getStreamIdFromEventId(eventId: string): string {
+      return eventId.split('_')[0]; // Extract stream ID from the event ID
+    },
+    async storeEvent(streamId: string, message: JSONRPCMessage): Promise<string> {
+      const eventId = this.generateEventId(streamId);
+      storedEvents.set(eventId, { eventId, message });
+      return eventId;
+    },
+
+    async getEventsAfter(lastEventId: string): Promise<Array<{ eventId: string, message: JSONRPCMessage }>> {
+      const streamId = lastEventId.split('_')[0]; // Extract stream ID from the event ID
+      const result: Array<{ eventId: string, message: JSONRPCMessage }> = [];
+
+      // For test simplicity, just return all events with matching streamId that aren't the lastEventId
+      // This avoids issues with event ordering in tests
+      for (const [eventId, { message }] of storedEvents.entries()) {
+        if (eventId.startsWith(streamId) && eventId !== lastEventId) {
+          result.push({ eventId, message });
+        }
+      }
+
+      return result;
+    },
+  };
+
+  beforeEach(async () => {
+    storedEvents.clear();
+    const result = await createTestServer({
+      sessionIdGenerator: () => randomUUID(),
+      eventStore
+    });
+
+    server = result.server;
+    transport = result.transport;
+    baseUrl = result.baseUrl;
+    mcpServer = result.mcpServer;
+
+    // Verify resumability is enabled on the transport
+    expect((transport)['_eventStore']).toBeDefined();
+
+    // Initialize the server
+    const initResponse = await sendPostRequest(baseUrl, TEST_MESSAGES.initialize);
+    sessionId = initResponse.headers.get("mcp-session-id") as string;
+    expect(sessionId).toBeDefined();
+  });
+
+  afterEach(async () => {
+    await stopTestServer({ server, transport });
+    storedEvents.clear();
+  });
+
+  it("should store and include event IDs in server SSE messages", async () => {
+    // Open a standalone SSE stream
+    const sseResponse = await fetch(baseUrl, {
+      method: "GET",
+      headers: {
+        Accept: "text/event-stream",
+        "mcp-session-id": sessionId,
+      },
+    });
+
+    expect(sseResponse.status).toBe(200);
+    expect(sseResponse.headers.get("content-type")).toBe("text/event-stream");
+
+    // Send a notification that should be stored with an event ID
+    const notification: JSONRPCMessage = {
+      jsonrpc: "2.0",
+      method: "notifications/message",
+      params: { level: "info", data: "Test notification with event ID" },
+    };
+
+    // Send the notification via transport
+    await transport.send(notification);
+
+    // Read from the stream and verify we got the notification with an event ID
+    const reader = sseResponse.body?.getReader();
+    const { value } = await reader!.read();
+    const text = new TextDecoder().decode(value);
+
+    // The response should contain an event ID
+    expect(text).toContain('id: ');
+    expect(text).toContain('"method":"notifications/message"');
+
+    // Extract the event ID
+    const idMatch = text.match(/id: ([^\n]+)/);
+    expect(idMatch).toBeTruthy();
+
+    // Verify the event was stored
+    const eventId = idMatch![1];
+    expect(storedEvents.has(eventId)).toBe(true);
+    const storedEvent = storedEvents.get(eventId);
+    expect(eventId.startsWith('standalonesse')).toBe(true);
+    expect(storedEvent?.message).toMatchObject(notification);
+  });
+
+
+  it("should store and replay MCP server tool notifications", async () => {
+    // Establish a standalone SSE stream
+    const sseResponse = await fetch(baseUrl, {
+      method: "GET",
+      headers: {
+        Accept: "text/event-stream",
+        "mcp-session-id": sessionId,
+      },
+    });
+    expect(sseResponse.status).toBe(200);   // Send a server notification through the MCP server
+    await mcpServer.server.sendLoggingMessage({ level: "info", data: "First notification from MCP server" });
+
+    // Read the notification from the SSE stream
+    const reader = sseResponse.body?.getReader();
+    const { value } = await reader!.read();
+    const text = new TextDecoder().decode(value);
+
+    // Verify the notification was sent with an event ID
+    expect(text).toContain('id: ');
+    expect(text).toContain('First notification from MCP server');
+
+    // Extract the event ID
+    const idMatch = text.match(/id: ([^\n]+)/);
+    expect(idMatch).toBeTruthy();
+    const firstEventId = idMatch![1];
+
+    // Send a second notification 
+    await mcpServer.server.sendLoggingMessage({ level: "info", data: "Second notification from MCP server" });
+
+    // Close the first SSE stream to simulate a disconnect
+    await reader!.cancel();
+
+    // Reconnect with the Last-Event-ID to get missed messages
+    const reconnectResponse = await fetch(baseUrl, {
+      method: "GET",
+      headers: {
+        Accept: "text/event-stream",
+        "mcp-session-id": sessionId,
+        "last-event-id": firstEventId
+      },
+    });
+
+    expect(reconnectResponse.status).toBe(200);
+
+    // Read the replayed notification
+    const reconnectReader = reconnectResponse.body?.getReader();
+    const reconnectData = await reconnectReader!.read();
+    const reconnectText = new TextDecoder().decode(reconnectData.value);
+
+    // Verify we received the second notification that was sent after our stored eventId
+    expect(reconnectText).toContain('Second notification from MCP server');
+    expect(reconnectText).toContain('id: ');
   });
 });
 

--- a/src/server/streamableHttp.test.ts
+++ b/src/server/streamableHttp.test.ts
@@ -1,1590 +1,989 @@
-import { IncomingMessage, ServerResponse } from "node:http";
-import { StreamableHTTPServerTransport } from "./streamableHttp.js";
-import { JSONRPCMessage } from "../types.js";
-import { Readable } from "node:stream";
+import { createServer, type Server, IncomingMessage, ServerResponse } from "node:http";
+import { AddressInfo } from "node:net";
 import { randomUUID } from "node:crypto";
-// Mock IncomingMessage
-function createMockRequest(options: {
-  method: string;
-  headers: Record<string, string | string[] | undefined>;
-  body?: string;
-}): IncomingMessage {
-  const readable = new Readable();
-  readable._read = () => { };
-  if (options.body) {
-    readable.push(options.body);
-    readable.push(null);
-  }
+import { StreamableHTTPServerTransport } from "./streamableHttp.js";
+import { McpServer } from "./mcp.js";
+import { CallToolResult, JSONRPCMessage } from "../types.js";
+import { z } from "zod";
 
-  return Object.assign(readable, {
-    method: options.method,
-    headers: options.headers,
-  }) as IncomingMessage;
+/**
+ * Test server configuration for StreamableHTTPServerTransport tests
+ */
+interface TestServerConfig {
+  sessionIdGenerator?: () => string | undefined;
+  enableJsonResponse?: boolean;
+  customRequestHandler?: (req: IncomingMessage, res: ServerResponse, parsedBody?: unknown) => Promise<void>;
 }
 
-// Mock ServerResponse
-function createMockResponse(): jest.Mocked<ServerResponse> {
-  const response = {
-    writeHead: jest.fn().mockReturnThis(),
-    write: jest.fn().mockReturnThis(),
-    end: jest.fn().mockReturnThis(),
-    on: jest.fn().mockReturnThis(),
-    emit: jest.fn().mockReturnThis(),
-    getHeader: jest.fn(),
-    setHeader: jest.fn(),
-    flushHeaders: jest.fn(),
-  } as unknown as jest.Mocked<ServerResponse>;
-  return response;
+/**
+ * Helper to create and start test HTTP server with MCP setup
+ */
+async function createTestServer(config: TestServerConfig = {}): Promise<{
+  server: Server;
+  transport: StreamableHTTPServerTransport;
+  mcpServer: McpServer;
+  baseUrl: URL;
+}> {
+  const mcpServer = new McpServer(
+    { name: "test-server", version: "1.0.0" },
+    { capabilities: {} }
+  );
+
+  mcpServer.tool(
+    "greet",
+    "A simple greeting tool",
+    { name: z.string().describe("Name to greet") },
+    async ({ name }): Promise<CallToolResult> => {
+      return { content: [{ type: "text", text: `Hello, ${name}!` }] };
+    }
+  );
+
+  const transport = new StreamableHTTPServerTransport({
+    sessionIdGenerator: config.sessionIdGenerator ?? (() => randomUUID()),
+    enableJsonResponse: config.enableJsonResponse ?? false
+  });
+
+  await mcpServer.connect(transport);
+
+  const server = createServer(async (req, res) => {
+    try {
+      if (config.customRequestHandler) {
+        await config.customRequestHandler(req, res);
+      } else {
+        await transport.handleRequest(req, res);
+      }
+    } catch (error) {
+      console.error("Error handling request:", error);
+      if (!res.headersSent) res.writeHead(500).end();
+    }
+  });
+
+  const baseUrl = await new Promise<URL>((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address() as AddressInfo;
+      resolve(new URL(`http://127.0.0.1:${addr.port}`));
+    });
+  });
+
+  return { server, transport, mcpServer, baseUrl };
+}
+
+/**
+ * Helper to stop test server
+ */
+async function stopTestServer({ server, transport }: { server: Server; transport: StreamableHTTPServerTransport }): Promise<void> {
+  await transport.close();
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+}
+
+/**
+ * Common test messages
+ */
+const TEST_MESSAGES = {
+  initialize: {
+    jsonrpc: "2.0",
+    method: "initialize",
+    params: {
+      clientInfo: { name: "test-client", version: "1.0" },
+      protocolVersion: "2025-03-26",
+    },
+    id: "init-1",
+  } as JSONRPCMessage,
+
+  toolsList: {
+    jsonrpc: "2.0",
+    method: "tools/list",
+    params: {},
+    id: "tools-1",
+  } as JSONRPCMessage
+};
+
+/**
+ * Helper to extract text from SSE response
+ * Note: Can only be called once per response stream. For multiple reads,
+ * get the reader manually and read multiple times.
+ */
+async function readSSEEvent(response: Response): Promise<string> {
+  const reader = response.body?.getReader();
+  const { value } = await reader!.read();
+  return new TextDecoder().decode(value);
+}
+
+/**
+ * Helper to send JSON-RPC request
+ */
+async function sendPostRequest(baseUrl: URL, message: JSONRPCMessage | JSONRPCMessage[], sessionId?: string): Promise<Response> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    Accept: "application/json, text/event-stream",
+  };
+
+  if (sessionId) {
+    headers["mcp-session-id"] = sessionId;
+  }
+
+  return fetch(baseUrl, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(message),
+  });
+}
+
+function expectErrorResponse(data: unknown, expectedCode: number, expectedMessagePattern: RegExp): void {
+  expect(data).toMatchObject({
+    jsonrpc: "2.0",
+    error: expect.objectContaining({
+      code: expectedCode,
+      message: expect.stringMatching(expectedMessagePattern),
+    }),
+  });
 }
 
 describe("StreamableHTTPServerTransport", () => {
+  let server: Server;
   let transport: StreamableHTTPServerTransport;
-  let mockResponse: jest.Mocked<ServerResponse>;
-  let mockRequest: string;
+  let baseUrl: URL;
+  let sessionId: string;
 
-  beforeEach(() => {
-    transport = new StreamableHTTPServerTransport({
-      sessionIdGenerator: () => randomUUID(),
-    });
-    mockResponse = createMockResponse();
-    mockRequest = JSON.stringify({
+  beforeEach(async () => {
+    const result = await createTestServer();
+    server = result.server;
+    transport = result.transport;
+    baseUrl = result.baseUrl;
+  });
+
+  afterEach(async () => {
+    await stopTestServer({ server, transport });
+  });
+
+  async function initializeServer(): Promise<string> {
+    const response = await sendPostRequest(baseUrl, TEST_MESSAGES.initialize);
+
+    expect(response.status).toBe(200);
+    const newSessionId = response.headers.get("mcp-session-id");
+    expect(newSessionId).toBeDefined();
+    return newSessionId as string;
+  }
+
+  it("should initialize server and generate session ID", async () => {
+    const response = await sendPostRequest(baseUrl, TEST_MESSAGES.initialize);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("text/event-stream");
+    expect(response.headers.get("mcp-session-id")).toBeDefined();
+  });
+
+  it("should reject second initialization request", async () => {
+    // First initialize
+    const sessionId = await initializeServer();
+    expect(sessionId).toBeDefined();
+
+    // Try second initialize
+    const secondInitMessage: JSONRPCMessage = {
       jsonrpc: "2.0",
-      method: "test",
-      params: {},
-      id: 1,
-    });
+      method: "initialize",
+      params: {
+        clientInfo: { name: "test-client-2", version: "1.0" },
+        protocolVersion: "2025-03-26",
+      },
+      id: "init-2",
+    };
+    const response = await sendPostRequest(baseUrl, secondInitMessage);
+
+    expect(response.status).toBe(400);
+    const errorData = await response.json();
+    expectErrorResponse(errorData, -32600, /Server already initialized/);
   });
 
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
-
-  describe("Session Management", () => {
-    it("should generate session ID during initialization", async () => {
-      const initializeMessage: JSONRPCMessage = {
+  it("should reject batch initialize request", async () => {
+    const batchInitMessages: JSONRPCMessage[] = [
+      TEST_MESSAGES.initialize,
+      {
         jsonrpc: "2.0",
         method: "initialize",
         params: {
-          clientInfo: { name: "test-client", version: "1.0" },
-          protocolVersion: "2025-03-26"
-        },
-        id: "init-1",
-      };
-
-      const req = createMockRequest({
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          "accept": "application/json, text/event-stream",
-        },
-        body: JSON.stringify(initializeMessage),
-      });
-
-      expect(transport.sessionId).toBeUndefined();
-      expect(transport["_initialized"]).toBe(false);
-
-      await transport.handleRequest(req, mockResponse);
-
-      expect(transport.sessionId).toBeDefined();
-      expect(transport["_initialized"]).toBe(true);
-      expect(mockResponse.writeHead).toHaveBeenCalledWith(
-        200,
-        expect.objectContaining({
-          "mcp-session-id": transport.sessionId,
-        })
-      );
-    });
-
-    it("should reject second initialization request", async () => {
-      // First initialize
-      const initMessage1: JSONRPCMessage = {
-        jsonrpc: "2.0",
-        method: "initialize",
-        params: {
-          clientInfo: { name: "test-client", version: "1.0" },
-          protocolVersion: "2025-03-26"
-        },
-        id: "init-1",
-      };
-
-      const req1 = createMockRequest({
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          "accept": "application/json, text/event-stream",
-        },
-        body: JSON.stringify(initMessage1),
-      });
-
-      await transport.handleRequest(req1, mockResponse);
-      expect(transport["_initialized"]).toBe(true);
-
-      // Reset mock for second request
-      mockResponse.writeHead.mockClear();
-      mockResponse.end.mockClear();
-
-      // Try second initialize
-      const initMessage2: JSONRPCMessage = {
-        jsonrpc: "2.0",
-        method: "initialize",
-        params: {
-          clientInfo: { name: "test-client", version: "1.0" },
-          protocolVersion: "2025-03-26"
+          clientInfo: { name: "test-client-2", version: "1.0" },
+          protocolVersion: "2025-03-26",
         },
         id: "init-2",
-      };
+      }
+    ];
 
-      const req2 = createMockRequest({
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          "accept": "application/json, text/event-stream",
-        },
-        body: JSON.stringify(initMessage2),
-      });
+    const response = await sendPostRequest(baseUrl, batchInitMessages);
 
-      await transport.handleRequest(req2, mockResponse);
+    expect(response.status).toBe(400);
+    const errorData = await response.json();
+    expectErrorResponse(errorData, -32600, /Only one initialization request is allowed/);
+  });
 
-      expect(mockResponse.writeHead).toHaveBeenCalledWith(400);
-      expect(mockResponse.end).toHaveBeenCalledWith(expect.stringContaining('"message":"Invalid Request: Server already initialized"'));
+  it("should pandle post requests via sse response correctly", async () => {
+    sessionId = await initializeServer();
+
+    const response = await sendPostRequest(baseUrl, TEST_MESSAGES.toolsList, sessionId);
+
+    expect(response.status).toBe(200);
+
+    // Read the SSE stream for the response
+    const text = await readSSEEvent(response);
+
+    // Parse the SSE event
+    const eventLines = text.split("\n");
+    const dataLine = eventLines.find(line => line.startsWith("data:"));
+    expect(dataLine).toBeDefined();
+
+    const eventData = JSON.parse(dataLine!.substring(5));
+    expect(eventData).toMatchObject({
+      jsonrpc: "2.0",
+      result: expect.objectContaining({
+        tools: expect.arrayContaining([
+          expect.objectContaining({
+            name: "greet",
+            description: "A simple greeting tool",
+          }),
+        ]),
+      }),
+      id: "tools-1",
     });
+  });
 
-    it("should reject batch initialize request", async () => {
-      const batchInitialize: JSONRPCMessage[] = [
-        {
-          jsonrpc: "2.0",
-          method: "initialize",
-          params: {
-            clientInfo: { name: "test-client", version: "1.0" },
-            protocolVersion: "2025-03-26"
+  it("should call a tool and return the result", async () => {
+    sessionId = await initializeServer();
+
+    const toolCallMessage: JSONRPCMessage = {
+      jsonrpc: "2.0",
+      method: "tools/call",
+      params: {
+        name: "greet",
+        arguments: {
+          name: "Test User",
+        },
+      },
+      id: "call-1",
+    };
+
+    const response = await sendPostRequest(baseUrl, toolCallMessage, sessionId);
+    expect(response.status).toBe(200);
+
+    const text = await readSSEEvent(response);
+    const eventLines = text.split("\n");
+    const dataLine = eventLines.find(line => line.startsWith("data:"));
+    expect(dataLine).toBeDefined();
+
+    const eventData = JSON.parse(dataLine!.substring(5));
+    expect(eventData).toMatchObject({
+      jsonrpc: "2.0",
+      result: {
+        content: [
+          {
+            type: "text",
+            text: "Hello, Test User!",
           },
-          id: "init-1",
-        },
-        {
-          jsonrpc: "2.0",
-          method: "initialize",
-          params: {
-            clientInfo: { name: "test-client-2", version: "1.0" },
-            protocolVersion: "2025-03-26"
-          },
-          id: "init-2",
-        }
-      ];
-
-      const req = createMockRequest({
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          "accept": "application/json, text/event-stream",
-        },
-        body: JSON.stringify(batchInitialize),
-      });
-
-      await transport.handleRequest(req, mockResponse);
-
-      expect(mockResponse.writeHead).toHaveBeenCalledWith(400);
-      expect(mockResponse.end).toHaveBeenCalledWith(expect.stringContaining('"message":"Invalid Request: Only one initialization request is allowed"'));
-    });
-
-    it("should reject invalid session ID", async () => {
-      // First initialize the transport
-      const initMessage: JSONRPCMessage = {
-        jsonrpc: "2.0",
-        method: "initialize",
-        params: {
-          clientInfo: { name: "test-client", version: "1.0" },
-          protocolVersion: "2025-03-26"
-        },
-        id: "init-1",
-      };
-
-      const initReq = createMockRequest({
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          "accept": "application/json, text/event-stream",
-        },
-        body: JSON.stringify(initMessage),
-      });
-
-      await transport.handleRequest(initReq, mockResponse);
-      mockResponse.writeHead.mockClear();
-
-      // Now try with an invalid session ID
-      const req = createMockRequest({
-        method: "POST",
-        headers: {
-          "mcp-session-id": "invalid-session-id",
-          "accept": "application/json, text/event-stream",
-          "content-type": "application/json",
-        },
-        body: mockRequest,
-      });
-
-      await transport.handleRequest(req, mockResponse);
-
-      expect(mockResponse.writeHead).toHaveBeenCalledWith(404);
-      expect(mockResponse.end).toHaveBeenCalledWith(expect.stringContaining('"jsonrpc":"2.0"'));
-      expect(mockResponse.end).toHaveBeenCalledWith(expect.stringContaining('"message":"Session not found"'));
-    });
-
-    it("should reject non-initialization requests without session ID with 400 Bad Request", async () => {
-      // First initialize the transport
-      const initMessage: JSONRPCMessage = {
-        jsonrpc: "2.0",
-        method: "initialize",
-        params: {
-          clientInfo: { name: "test-client", version: "1.0" },
-          protocolVersion: "2025-03-26"
-        },
-        id: "init-1",
-      };
-
-      const initReq = createMockRequest({
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          "accept": "application/json, text/event-stream",
-        },
-        body: JSON.stringify(initMessage),
-      });
-
-      await transport.handleRequest(initReq, mockResponse);
-      mockResponse.writeHead.mockClear();
-
-      // Now try without session ID
-      const req = createMockRequest({
-        method: "POST",
-        headers: {
-          "accept": "application/json, text/event-stream",
-          "content-type": "application/json",
-          // No mcp-session-id header
-        },
-        body: mockRequest
-      });
-
-      await transport.handleRequest(req, mockResponse);
-
-      expect(mockResponse.writeHead).toHaveBeenCalledWith(400);
-      expect(mockResponse.end).toHaveBeenCalledWith(expect.stringContaining('"jsonrpc":"2.0"'));
-      expect(mockResponse.end).toHaveBeenCalledWith(expect.stringContaining('"message":"Bad Request: Mcp-Session-Id header is required"'));
-    });
-
-    it("should reject requests to uninitialized server", async () => {
-      // Create a new transport that hasn't been initialized
-      const uninitializedTransport = new StreamableHTTPServerTransport({
-        sessionIdGenerator: () => randomUUID(),
-      });
-
-      const req = createMockRequest({
-        method: "POST",
-        headers: {
-          "accept": "application/json, text/event-stream",
-          "content-type": "application/json",
-          "mcp-session-id": "any-session-id",
-        },
-        body: mockRequest
-      });
-
-      await uninitializedTransport.handleRequest(req, mockResponse);
-
-      expect(mockResponse.writeHead).toHaveBeenCalledWith(400);
-      expect(mockResponse.end).toHaveBeenCalledWith(expect.stringContaining('"message":"Bad Request: Server not initialized"'));
-    });
-
-    it("should reject session ID as array", async () => {
-      // First initialize the transport
-      const initMessage: JSONRPCMessage = {
-        jsonrpc: "2.0",
-        method: "initialize",
-        params: {
-          clientInfo: { name: "test-client", version: "1.0" },
-          protocolVersion: "2025-03-26"
-        },
-        id: "init-1",
-      };
-
-      const initReq = createMockRequest({
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          "accept": "application/json, text/event-stream",
-        },
-        body: JSON.stringify(initMessage),
-      });
-
-      await transport.handleRequest(initReq, mockResponse);
-      mockResponse.writeHead.mockClear();
-
-      // Now try with an array session ID
-      const req = createMockRequest({
-        method: "POST",
-        headers: {
-          "mcp-session-id": ["session1", "session2"],
-          "accept": "application/json, text/event-stream",
-          "content-type": "application/json",
-        },
-        body: mockRequest,
-      });
-
-      await transport.handleRequest(req, mockResponse);
-
-      expect(mockResponse.writeHead).toHaveBeenCalledWith(400);
-      expect(mockResponse.end).toHaveBeenCalledWith(expect.stringContaining('"message":"Bad Request: Mcp-Session-Id header must be a single value"'));
-    });
-  });
-  describe("Mode without state management", () => {
-    let transportWithoutState: StreamableHTTPServerTransport;
-    let mockResponse: jest.Mocked<ServerResponse>;
-
-    beforeEach(async () => {
-      transportWithoutState = new StreamableHTTPServerTransport({ sessionIdGenerator: () => undefined });
-      mockResponse = createMockResponse();
-
-      // Initialize the transport for each test
-      const initMessage: JSONRPCMessage = {
-        jsonrpc: "2.0",
-        method: "initialize",
-        params: {
-          clientInfo: { name: "test-client", version: "1.0" },
-          protocolVersion: "2025-03-26"
-        },
-        id: "init-1",
-      };
-
-      const initReq = createMockRequest({
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          "accept": "application/json, text/event-stream",
-        },
-        body: JSON.stringify(initMessage),
-      });
-
-      await transportWithoutState.handleRequest(initReq, mockResponse);
-      mockResponse.writeHead.mockClear();
-    });
-
-    it("should not include session ID in response headers when in mode without state management", async () => {
-      // Use a non-initialization request
-      const message: JSONRPCMessage = {
-        jsonrpc: "2.0",
-        method: "test",
-        params: {},
-        id: 1,
-      };
-
-      const req = createMockRequest({
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          "accept": "application/json, text/event-stream",
-        },
-        body: JSON.stringify(message),
-      });
-
-      await transportWithoutState.handleRequest(req, mockResponse);
-
-      expect(mockResponse.writeHead).toHaveBeenCalled();
-      // Extract the headers from writeHead call
-      const headers = mockResponse.writeHead.mock.calls[0][1];
-      expect(headers).not.toHaveProperty("mcp-session-id");
-    });
-
-    it("should not validate session ID in mode without state management", async () => {
-      const req = createMockRequest({
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          "accept": "application/json, text/event-stream",
-          "mcp-session-id": "invalid-session-id", // This would cause a 404 in mode with state management
-        },
-        body: JSON.stringify({
-          jsonrpc: "2.0",
-          method: "test",
-          params: {},
-          id: 1
-        }),
-      });
-
-      await transportWithoutState.handleRequest(req, mockResponse);
-
-      // Should still get 200 OK, not 404 Not Found
-      expect(mockResponse.writeHead).toHaveBeenCalledWith(
-        200,
-        expect.not.objectContaining({
-          "mcp-session-id": expect.anything(),
-        })
-      );
-    });
-
-    it("should handle POST requests without session validation in mode without state management", async () => {
-      const message: JSONRPCMessage = {
-        jsonrpc: "2.0",
-        method: "test",
-        params: {},
-        id: 1,
-      };
-
-      const req = createMockRequest({
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          "accept": "application/json, text/event-stream",
-          "mcp-session-id": "non-existent-session-id", // This would be rejected in mode with state management
-        },
-        body: JSON.stringify(message),
-      });
-
-      const onMessageMock = jest.fn();
-      transportWithoutState.onmessage = onMessageMock;
-
-      await transportWithoutState.handleRequest(req, mockResponse);
-
-      // Message should be processed despite invalid session ID
-      expect(onMessageMock).toHaveBeenCalledWith(message);
-    });
-
-    it("should work with a mix of requests with and without session IDs in mode without state management", async () => {
-      // First request without session ID
-      const req1 = createMockRequest({
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          accept: "application/json, text/event-stream",
-        },
-        body: JSON.stringify({
-          jsonrpc: "2.0",
-          method: "test",
-          params: {},
-          id: "test-id"
-        })
-      });
-
-      await transportWithoutState.handleRequest(req1, mockResponse);
-      expect(mockResponse.writeHead).toHaveBeenCalledWith(
-        200,
-        expect.objectContaining({
-          "Content-Type": "text/event-stream",
-        })
-      );
-
-      // Reset mock for second request
-      mockResponse.writeHead.mockClear();
-
-      // Second request with a session ID (which would be invalid in mode with state management)
-      const req2 = createMockRequest({
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          accept: "application/json, text/event-stream",
-          "mcp-session-id": "some-random-session-id",
-        },
-        body: JSON.stringify({
-          jsonrpc: "2.0",
-          method: "test2",
-          params: {},
-          id: "test-id-2"
-        })
-      });
-
-      await transportWithoutState.handleRequest(req2, mockResponse);
-
-      // Should still succeed
-      expect(mockResponse.writeHead).toHaveBeenCalledWith(
-        200,
-        expect.objectContaining({
-          "Content-Type": "text/event-stream",
-        })
-      );
-    });
-
-    it("should handle initialization in mode without state management", async () => {
-      const transportWithoutState = new StreamableHTTPServerTransport({ sessionIdGenerator: () => undefined });
-
-      // Initialize message
-      const initializeMessage: JSONRPCMessage = {
-        jsonrpc: "2.0",
-        method: "initialize",
-        params: {
-          clientInfo: { name: "test-client", version: "1.0" },
-          protocolVersion: "2025-03-26"
-        },
-        id: "init-1",
-      };
-
-      expect(transportWithoutState.sessionId).toBeUndefined();
-      expect(transportWithoutState["_initialized"]).toBe(false);
-
-      const req = createMockRequest({
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          "accept": "application/json, text/event-stream",
-        },
-        body: JSON.stringify(initializeMessage),
-      });
-
-      const newResponse = createMockResponse();
-      await transportWithoutState.handleRequest(req, newResponse);
-
-      // After initialization, the sessionId should still be undefined
-      expect(transportWithoutState.sessionId).toBeUndefined();
-      expect(transportWithoutState["_initialized"]).toBe(true);
-
-      // Headers should NOT include session ID in mode without state management
-      const headers = newResponse.writeHead.mock.calls[0][1];
-      expect(headers).not.toHaveProperty("mcp-session-id");
+        ],
+      },
+      id: "call-1",
     });
   });
 
-  describe("Request Handling", () => {
-    // Initialize the transport before tests that need initialization
-    beforeEach(async () => {
-      // For tests that need initialization, initialize here
-      const initMessage: JSONRPCMessage = {
-        jsonrpc: "2.0",
-        method: "initialize",
-        params: {
-          clientInfo: { name: "test-client", version: "1.0" },
-          protocolVersion: "2025-03-26"
-        },
-        id: "init-1",
-      };
+  it("should reject requests without a valid session ID", async () => {
+    const response = await sendPostRequest(baseUrl, TEST_MESSAGES.toolsList);
 
-      const initReq = createMockRequest({
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          "accept": "application/json, text/event-stream",
-        },
-        body: JSON.stringify(initMessage),
-      });
+    expect(response.status).toBe(400);
+    const errorData = await response.json();
+    expectErrorResponse(errorData, -32000, /Bad Request/);
+    expect(errorData.id).toBeNull();
+  });
 
-      await transport.handleRequest(initReq, mockResponse);
-      mockResponse.writeHead.mockClear();
+  it("should reject invalid session ID", async () => {
+    // First initialize to be in valid state
+    await initializeServer();
+
+    // Now try with invalid session ID
+    const response = await sendPostRequest(baseUrl, TEST_MESSAGES.toolsList, "invalid-session-id");
+
+    expect(response.status).toBe(404);
+    const errorData = await response.json();
+    expectErrorResponse(errorData, -32001, /Session not found/);
+  });
+
+  it("should establish standalone SSE stream and receive server-initiated messages", async () => {
+    // First initialize to get a session ID
+    sessionId = await initializeServer();
+
+    // Open a standalone SSE stream  
+    const sseResponse = await fetch(baseUrl, {
+      method: "GET",
+      headers: {
+        Accept: "text/event-stream",
+        "mcp-session-id": sessionId,
+      },
     });
 
-    it("should accept GET requests for SSE with proper Accept header", async () => {
-      const req = createMockRequest({
-        method: "GET",
-        headers: {
-          "accept": "text/event-stream",
-          "mcp-session-id": transport.sessionId,
-        },
-      });
+    expect(sseResponse.status).toBe(200);
+    expect(sseResponse.headers.get("content-type")).toBe("text/event-stream");
 
-      await transport.handleRequest(req, mockResponse);
 
-      expect(mockResponse.writeHead).toHaveBeenCalledWith(200, expect.objectContaining({
-        "Content-Type": "text/event-stream",
-        "Cache-Control": "no-cache, no-transform",
-        "Connection": "keep-alive",
-        "mcp-session-id": transport.sessionId,
-      }));
-    });
+    // Send a notification (server-initiated message) that should appear on SSE stream
+    const notification: JSONRPCMessage = {
+      jsonrpc: "2.0",
+      method: "notifications/message",
+      params: { level: "info", data: "Test notification" },
+    };
 
-    it("should reject GET requests without Accept: text/event-stream header", async () => {
-      const req = createMockRequest({
-        method: "GET",
-        headers: {
-          "accept": "application/json",
-          "mcp-session-id": transport.sessionId,
-        },
-      });
+    // Send the notification via transport
+    await transport.send(notification);
 
-      await transport.handleRequest(req, mockResponse);
+    // Read from the stream and verify we got the notification
+    const text = await readSSEEvent(sseResponse);
 
-      expect(mockResponse.writeHead).toHaveBeenCalledWith(406);
-      expect(mockResponse.end).toHaveBeenCalledWith(expect.stringContaining('"message":"Not Acceptable: Client must accept text/event-stream"'));
-    });
+    const eventLines = text.split("\n");
+    const dataLine = eventLines.find(line => line.startsWith("data:"));
+    expect(dataLine).toBeDefined();
 
-    it("should send server-initiated requests to GET SSE stream", async () => {
-      // Open a standalone SSE stream with GET
-      const req = createMockRequest({
-        method: "GET",
-        headers: {
-          "accept": "text/event-stream",
-          "mcp-session-id": transport.sessionId,
-        },
-      });
-
-      const sseResponse = createMockResponse();
-      await transport.handleRequest(req, sseResponse);
-
-      // Send a notification without a related request ID
-      const notification: JSONRPCMessage = {
-        jsonrpc: "2.0",
-        method: "notifications/resources/updated",
-        params: { uri: "someuri" }
-      };
-
-      await transport.send(notification);
-
-      // Verify notification was sent on SSE stream
-      expect(sseResponse.write).toHaveBeenCalledWith(
-        expect.stringContaining(`event: message\ndata: ${JSON.stringify(notification)}\n\n`)
-      );
-    });
-
-    it("should not close GET SSE stream after sending server requests or notifications", async () => {
-      // Open a standalone SSE stream
-      const req = createMockRequest({
-        method: "GET",
-        headers: {
-          "accept": "text/event-stream",
-          "mcp-session-id": transport.sessionId,
-        },
-      });
-
-      const sseResponse = createMockResponse();
-      await transport.handleRequest(req, sseResponse);
-
-      // Send multiple notifications
-      const notification1: JSONRPCMessage = { jsonrpc: "2.0", method: "event1", params: {} };
-      const notification2: JSONRPCMessage = { jsonrpc: "2.0", method: "event2", params: {} };
-
-      await transport.send(notification1);
-      await transport.send(notification2);
-
-      // Stream should remain open
-      expect(sseResponse.end).not.toHaveBeenCalled();
-    });
-
-    it("should reject second GET SSE stream for the same session", async () => {
-      // Open first SSE stream - should succeed
-      const req1 = createMockRequest({
-        method: "GET",
-        headers: {
-          "accept": "text/event-stream",
-          "mcp-session-id": transport.sessionId,
-        },
-      });
-
-      const sseResponse1 = createMockResponse();
-      await transport.handleRequest(req1, sseResponse1);
-
-      // Try to open a second SSE stream - should be rejected
-      const req2 = createMockRequest({
-        method: "GET",
-        headers: {
-          "accept": "text/event-stream",
-          "mcp-session-id": transport.sessionId,
-        },
-      });
-
-      const sseResponse2 = createMockResponse();
-      await transport.handleRequest(req2, sseResponse2);
-
-      // First stream should be good
-      expect(sseResponse1.writeHead).toHaveBeenCalledWith(200, expect.anything());
-
-      // Second stream should get 409 Conflict
-      expect(sseResponse2.writeHead).toHaveBeenCalledWith(409);
-      expect(sseResponse2.end).toHaveBeenCalledWith(expect.stringContaining('"message":"Conflict: Only one SSE stream is allowed per session"'));
-    });
-
-    it("should reject POST requests without proper Accept header", async () => {
-      const message: JSONRPCMessage = {
-        jsonrpc: "2.0",
-        method: "test",
-        params: {},
-        id: 1,
-      };
-
-      const req = createMockRequest({
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          "mcp-session-id": transport.sessionId,
-        },
-        body: JSON.stringify(message),
-      });
-
-      await transport.handleRequest(req, mockResponse);
-
-      expect(mockResponse.writeHead).toHaveBeenCalledWith(406);
-    });
-
-    it("should properly handle JSON-RPC request messages in POST requests", async () => {
-      const message: JSONRPCMessage = {
-        jsonrpc: "2.0",
-        method: "test",
-        params: {},
-        id: 1,
-      };
-
-      const req = createMockRequest({
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          "accept": "application/json, text/event-stream",
-          "mcp-session-id": transport.sessionId,
-        },
-        body: JSON.stringify(message),
-      });
-
-      const onMessageMock = jest.fn();
-      transport.onmessage = onMessageMock;
-
-      await transport.handleRequest(req, mockResponse);
-
-      expect(onMessageMock).toHaveBeenCalledWith(message);
-      expect(mockResponse.writeHead).toHaveBeenCalledWith(
-        200,
-        expect.objectContaining({
-          "Content-Type": "text/event-stream",
-        })
-      );
-    });
-
-    it("should properly handle JSON-RPC notification or response messages in POST requests", async () => {
-      const notification: JSONRPCMessage = {
-        jsonrpc: "2.0",
-        method: "test",
-        params: {},
-      };
-
-      const req = createMockRequest({
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          "accept": "application/json, text/event-stream",
-          "mcp-session-id": transport.sessionId,
-        },
-        body: JSON.stringify(notification),
-      });
-
-      const onMessageMock = jest.fn();
-      transport.onmessage = onMessageMock;
-
-      await transport.handleRequest(req, mockResponse);
-
-      expect(onMessageMock).toHaveBeenCalledWith(notification);
-      expect(mockResponse.writeHead).toHaveBeenCalledWith(202);
-    });
-
-    it("should handle batch notification messages properly with 202 response", async () => {
-      const batchMessages: JSONRPCMessage[] = [
-        { jsonrpc: "2.0", method: "test1", params: {} },
-        { jsonrpc: "2.0", method: "test2", params: {} },
-      ];
-
-      const req = createMockRequest({
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          "accept": "application/json, text/event-stream",
-          "mcp-session-id": transport.sessionId,
-        },
-        body: JSON.stringify(batchMessages),
-      });
-
-      const onMessageMock = jest.fn();
-      transport.onmessage = onMessageMock;
-
-      await transport.handleRequest(req, mockResponse);
-
-      expect(onMessageMock).toHaveBeenCalledTimes(2);
-      expect(mockResponse.writeHead).toHaveBeenCalledWith(202);
-    });
-
-    it("should handle batch request messages with SSE when Accept header includes text/event-stream", async () => {
-      const batchMessages: JSONRPCMessage[] = [
-        { jsonrpc: "2.0", method: "test1", params: {}, id: "req1" },
-        { jsonrpc: "2.0", method: "test2", params: {}, id: "req2" },
-      ];
-
-      const req = createMockRequest({
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          "accept": "text/event-stream, application/json",
-          "mcp-session-id": transport.sessionId,
-        },
-        body: JSON.stringify(batchMessages),
-      });
-
-      const onMessageMock = jest.fn();
-      transport.onmessage = onMessageMock;
-
-      mockResponse = createMockResponse(); // Create fresh mock
-      await transport.handleRequest(req, mockResponse);
-
-      // Should establish SSE connection
-      expect(mockResponse.writeHead).toHaveBeenCalledWith(
-        200,
-        expect.objectContaining({
-          "Content-Type": "text/event-stream"
-        })
-      );
-      expect(onMessageMock).toHaveBeenCalledTimes(2);
-      // Stream should remain open until responses are sent
-      expect(mockResponse.end).not.toHaveBeenCalled();
-    });
-
-    it("should reject unsupported Content-Type", async () => {
-      const req = createMockRequest({
-        method: "POST",
-        headers: {
-          "content-type": "text/plain",
-          "accept": "application/json, text/event-stream",
-          "mcp-session-id": transport.sessionId,
-        },
-        body: "test",
-      });
-
-      await transport.handleRequest(req, mockResponse);
-
-      expect(mockResponse.writeHead).toHaveBeenCalledWith(415);
-      expect(mockResponse.end).toHaveBeenCalledWith(expect.stringContaining('"jsonrpc":"2.0"'));
-    });
-
-    it("should properly handle DELETE requests and close session", async () => {
-      // First initialize the transport
-      const initMessage: JSONRPCMessage = {
-        jsonrpc: "2.0",
-        method: "initialize",
-        params: {
-          clientInfo: { name: "test-client", version: "1.0" },
-          protocolVersion: "2025-03-26"
-        },
-        id: "init-1",
-      };
-
-      const initReq = createMockRequest({
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          "accept": "application/json, text/event-stream",
-        },
-        body: JSON.stringify(initMessage),
-      });
-
-      await transport.handleRequest(initReq, mockResponse);
-      mockResponse.writeHead.mockClear();
-
-      // Now try DELETE with proper session ID
-      const req = createMockRequest({
-        method: "DELETE",
-        headers: {
-          "mcp-session-id": transport.sessionId,
-        },
-      });
-
-      const onCloseMock = jest.fn();
-      transport.onclose = onCloseMock;
-
-      await transport.handleRequest(req, mockResponse);
-
-      expect(mockResponse.writeHead).toHaveBeenCalledWith(200);
-      expect(onCloseMock).toHaveBeenCalled();
-    });
-
-    it("should reject DELETE requests with invalid session ID", async () => {
-      // First initialize the transport
-      const initMessage: JSONRPCMessage = {
-        jsonrpc: "2.0",
-        method: "initialize",
-        params: {
-          clientInfo: { name: "test-client", version: "1.0" },
-          protocolVersion: "2025-03-26"
-        },
-        id: "init-1",
-      };
-
-      const initReq = createMockRequest({
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          "accept": "application/json, text/event-stream",
-        },
-        body: JSON.stringify(initMessage),
-      });
-
-      await transport.handleRequest(initReq, mockResponse);
-      mockResponse.writeHead.mockClear();
-
-      // Now try DELETE with invalid session ID
-      const req = createMockRequest({
-        method: "DELETE",
-        headers: {
-          "mcp-session-id": "invalid-session-id",
-        },
-      });
-
-      const onCloseMock = jest.fn();
-      transport.onclose = onCloseMock;
-
-      await transport.handleRequest(req, mockResponse);
-
-      expect(mockResponse.writeHead).toHaveBeenCalledWith(404);
-      expect(onCloseMock).not.toHaveBeenCalled();
+    const eventData = JSON.parse(dataLine!.substring(5));
+    expect(eventData).toMatchObject({
+      jsonrpc: "2.0",
+      method: "notifications/message",
+      params: { level: "info", data: "Test notification" },
     });
   });
 
-  describe("SSE Response Handling", () => {
-    beforeEach(async () => {
-      // Initialize the transport
-      const initMessage: JSONRPCMessage = {
-        jsonrpc: "2.0",
-        method: "initialize",
-        params: {
-          clientInfo: { name: "test-client", version: "1.0" },
-          protocolVersion: "2025-03-26"
-        },
-        id: "init-1",
-      };
+  it("should not close GET SSE stream after sending multiple server notifications", async () => {
+    sessionId = await initializeServer();
 
-      const initReq = createMockRequest({
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          "accept": "application/json, text/event-stream",
-        },
-        body: JSON.stringify(initMessage),
-      });
-      const initResponse = createMockResponse();
-      await transport.handleRequest(initReq, initResponse);
-      mockResponse.writeHead.mockClear();
+    // Open a standalone SSE stream
+    const sseResponse = await fetch(baseUrl, {
+      method: "GET",
+      headers: {
+        Accept: "text/event-stream",
+        "mcp-session-id": sessionId,
+      },
     });
 
-    it("should send response messages as SSE events", async () => {
-      // Setup a POST request with JSON-RPC request that accepts SSE
-      const requestMessage: JSONRPCMessage = {
-        jsonrpc: "2.0",
-        method: "test",
-        params: {},
-        id: "test-req-id"
-      };
+    expect(sseResponse.status).toBe(200);
+    const reader = sseResponse.body?.getReader();
 
-      const req = createMockRequest({
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          "accept": "application/json, text/event-stream",
-          "mcp-session-id": transport.sessionId
-        },
-        body: JSON.stringify(requestMessage)
-      });
+    // Send multiple notifications
+    const notification1: JSONRPCMessage = {
+      jsonrpc: "2.0",
+      method: "notifications/message",
+      params: { level: "info", data: "First notification" }
+    };
 
-      await transport.handleRequest(req, mockResponse);
+    // Just send one and verify it comes through - then the stream should stay open
+    await transport.send(notification1);
 
-      // Send a response to the request
-      const responseMessage: JSONRPCMessage = {
-        jsonrpc: "2.0",
-        result: { value: "test-result" },
-        id: "test-req-id"
-      };
+    const { value, done } = await reader!.read();
+    const text = new TextDecoder().decode(value);
+    expect(text).toContain("First notification");
+    expect(done).toBe(false);  // Stream should still be open
+  });
 
-      await transport.send(responseMessage, { relatedRequestId: "test-req-id" });
+  it("should reject second SSE stream for the same session", async () => {
+    sessionId = await initializeServer();
 
-      // Verify response was sent as SSE event
-      expect(mockResponse.write).toHaveBeenCalledWith(
-        expect.stringContaining(`event: message\ndata: ${JSON.stringify(responseMessage)}\n\n`)
-      );
-
-      // Stream should be closed after sending response
-      expect(mockResponse.end).toHaveBeenCalled();
+    // Open first SSE stream
+    const firstStream = await fetch(baseUrl, {
+      method: "GET",
+      headers: {
+        Accept: "text/event-stream",
+        "mcp-session-id": sessionId,
+      },
     });
 
-    it("should keep stream open when sending intermediate notifications and requests", async () => {
-      // Setup a POST request with JSON-RPC request that accepts SSE
-      const requestMessage: JSONRPCMessage = {
-        jsonrpc: "2.0",
-        method: "test",
-        params: {},
-        id: "test-req-id"
-      };
+    expect(firstStream.status).toBe(200);
 
-      // Create fresh response for this test
-      mockResponse = createMockResponse();
-
-      const req = createMockRequest({
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          "accept": "application/json, text/event-stream",
-          "mcp-session-id": transport.sessionId
-        },
-        body: JSON.stringify(requestMessage)
-      });
-
-      await transport.handleRequest(req, mockResponse);
-
-      // Send an intermediate notification 
-      const notification: JSONRPCMessage = {
-        jsonrpc: "2.0",
-        method: "progress",
-        params: { progress: "50%" }
-      };
-
-      await transport.send(notification, { relatedRequestId: "test-req-id" });
-
-      // Stream should remain open
-      expect(mockResponse.end).not.toHaveBeenCalled();
-
-      // Send the final response
-      const responseMessage: JSONRPCMessage = {
-        jsonrpc: "2.0",
-        result: { value: "test-result" },
-        id: "test-req-id"
-      };
-
-      await transport.send(responseMessage, { relatedRequestId: "test-req-id" });
-
-      // Now stream should be closed
-      expect(mockResponse.end).toHaveBeenCalled();
+    // Try to open a second SSE stream with the same session ID
+    const secondStream = await fetch(baseUrl, {
+      method: "GET",
+      headers: {
+        Accept: "text/event-stream",
+        "mcp-session-id": sessionId,
+      },
     });
 
-    it("should keep stream open when multiple requests share the same connection", async () => {
-      // Create a fresh response for this test  
-      const sharedResponse = createMockResponse();
+    // Should be rejected
+    expect(secondStream.status).toBe(409); // Conflict
+    const errorData = await secondStream.json();
+    expectErrorResponse(errorData, -32000, /Only one SSE stream is allowed per session/);
+  });
 
-      // Send two requests in a batch that will share the same connection
-      const batchRequests: JSONRPCMessage[] = [
-        { jsonrpc: "2.0", method: "method1", params: {}, id: "req1" },
-        { jsonrpc: "2.0", method: "method2", params: {}, id: "req2" }
-      ];
+  it("should reject GET requests without Accept: text/event-stream header", async () => {
+    sessionId = await initializeServer();
 
-      const req = createMockRequest({
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          "accept": "application/json, text/event-stream",
-          "mcp-session-id": transport.sessionId
-        },
-        body: JSON.stringify(batchRequests)
-      });
-
-      await transport.handleRequest(req, sharedResponse);
-
-      // Respond to first request
-      const response1: JSONRPCMessage = {
-        jsonrpc: "2.0",
-        result: { value: "result1" },
-        id: "req1"
-      };
-
-      await transport.send(response1);
-
-      // Connection should remain open because req2 is still pending
-      expect(sharedResponse.write).toHaveBeenCalledWith(
-        expect.stringContaining(`event: message\ndata: ${JSON.stringify(response1)}\n\n`)
-      );
-      expect(sharedResponse.end).not.toHaveBeenCalled();
-
-      // Respond to second request
-      const response2: JSONRPCMessage = {
-        jsonrpc: "2.0",
-        result: { value: "result2" },
-        id: "req2"
-      };
-
-      await transport.send(response2);
-
-      // Now connection should close as all requests are complete
-      expect(sharedResponse.write).toHaveBeenCalledWith(
-        expect.stringContaining(`event: message\ndata: ${JSON.stringify(response2)}\n\n`)
-      );
-      expect(sharedResponse.end).toHaveBeenCalled();
+    // Try GET without proper Accept header
+    const response = await fetch(baseUrl, {
+      method: "GET",
+      headers: {
+        Accept: "application/json",
+        "mcp-session-id": sessionId,
+      },
     });
 
-    it("should clean up connection tracking when a response is sent", async () => {
-      const req = createMockRequest({
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          "accept": "application/json, text/event-stream",
-          "mcp-session-id": transport.sessionId
-        },
-        body: JSON.stringify({
-          jsonrpc: "2.0",
-          method: "test",
-          params: {},
-          id: "cleanup-test"
-        })
-      });
+    expect(response.status).toBe(406);
+    const errorData = await response.json();
+    expectErrorResponse(errorData, -32000, /Client must accept text\/event-stream/);
+  });
 
-      const response = createMockResponse();
-      await transport.handleRequest(req, response);
+  it("should reject POST requests without proper Accept header", async () => {
+    sessionId = await initializeServer();
 
-      // Verify that the request is tracked in the SSE map
-      expect(transport["_responseMapping"].size).toBe(2);
-      expect(transport["_responseMapping"].has("cleanup-test")).toBe(true);
-
-      // Send a response
-      await transport.send({
-        jsonrpc: "2.0",
-        result: {},
-        id: "cleanup-test"
-      });
-
-      // Verify that the mapping was cleaned up
-      expect(transport["_responseMapping"].size).toBe(1);
-      expect(transport["_responseMapping"].has("cleanup-test")).toBe(false);
+    // Try POST without Accept: text/event-stream
+    const response = await fetch(baseUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",  // Missing text/event-stream
+        "mcp-session-id": sessionId,
+      },
+      body: JSON.stringify(TEST_MESSAGES.toolsList),
     });
 
-    it("should clean up connection tracking when client disconnects", async () => {
-      // Setup two requests that share a connection
-      const req = createMockRequest({
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          "accept": "application/json, text/event-stream",
-          "mcp-session-id": transport.sessionId
-        },
-        body: JSON.stringify([
-          { jsonrpc: "2.0", method: "longRunning1", params: {}, id: "req1" },
-          { jsonrpc: "2.0", method: "longRunning2", params: {}, id: "req2" }
+    expect(response.status).toBe(406);
+    const errorData = await response.json();
+    expectErrorResponse(errorData, -32000, /Client must accept both application\/json and text\/event-stream/);
+  });
+
+  it("should reject unsupported Content-Type", async () => {
+    sessionId = await initializeServer();
+
+    // Try POST with text/plain Content-Type
+    const response = await fetch(baseUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "text/plain",
+        Accept: "application/json, text/event-stream",
+        "mcp-session-id": sessionId,
+      },
+      body: "This is plain text",
+    });
+
+    expect(response.status).toBe(415);
+    const errorData = await response.json();
+    expectErrorResponse(errorData, -32000, /Content-Type must be application\/json/);
+  });
+
+  it("should handle JSON-RPC batch notification messages with 202 response", async () => {
+    sessionId = await initializeServer();
+
+    // Send batch of notifications (no IDs)
+    const batchNotifications: JSONRPCMessage[] = [
+      { jsonrpc: "2.0", method: "someNotification1", params: {} },
+      { jsonrpc: "2.0", method: "someNotification2", params: {} },
+    ];
+    const response = await sendPostRequest(baseUrl, batchNotifications, sessionId);
+
+    expect(response.status).toBe(202);
+  });
+
+  it("should handle batch request messages with SSE stream for responses", async () => {
+    sessionId = await initializeServer();
+
+    // Send batch of requests
+    const batchRequests: JSONRPCMessage[] = [
+      { jsonrpc: "2.0", method: "tools/list", params: {}, id: "req-1" },
+      { jsonrpc: "2.0", method: "tools/call", params: { name: "greet", arguments: { name: "BatchUser" } }, id: "req-2" },
+    ];
+    const response = await sendPostRequest(baseUrl, batchRequests, sessionId);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("text/event-stream");
+
+    const reader = response.body?.getReader();
+
+    // The responses may come in any order or together in one chunk
+    const { value } = await reader!.read();
+    const text = new TextDecoder().decode(value);
+
+    // Check that both responses were sent on the same stream
+    expect(text).toContain('"id":"req-1"');
+    expect(text).toContain('"tools"'); // tools/list result
+    expect(text).toContain('"id":"req-2"');
+    expect(text).toContain('Hello, BatchUser'); // tools/call result
+  });
+
+  it("should properly handle invalid JSON data", async () => {
+    sessionId = await initializeServer();
+
+    // Send invalid JSON
+    const response = await fetch(baseUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+        "mcp-session-id": sessionId,
+      },
+      body: "This is not valid JSON",
+    });
+
+    expect(response.status).toBe(400);
+    const errorData = await response.json();
+    expectErrorResponse(errorData, -32700, /Parse error/);
+  });
+
+  it("should return 400 error for invalid JSON-RPC messages", async () => {
+    sessionId = await initializeServer();
+
+    // Invalid JSON-RPC (missing required jsonrpc version)
+    const invalidMessage = { method: "tools/list", params: {}, id: 1 }; // missing jsonrpc version
+    const response = await sendPostRequest(baseUrl, invalidMessage as JSONRPCMessage, sessionId);
+
+    expect(response.status).toBe(400);
+    const errorData = await response.json();
+    expect(errorData).toMatchObject({
+      jsonrpc: "2.0",
+      error: expect.anything(),
+    });
+  });
+
+  it("should reject requests to uninitialized server", async () => {
+    // Create a new HTTP server and transport without initializing
+    const { server: uninitializedServer, transport: uninitializedTransport, baseUrl: uninitializedUrl } = await createTestServer();
+    // Transport not used in test but needed for cleanup
+
+    // No initialization, just send a request directly
+    const uninitializedMessage: JSONRPCMessage = {
+      jsonrpc: "2.0",
+      method: "tools/list",
+      params: {},
+      id: "uninitialized-test",
+    };
+
+    // Send a request to uninitialized server
+    const response = await sendPostRequest(uninitializedUrl, uninitializedMessage, "any-session-id");
+
+    expect(response.status).toBe(400);
+    const errorData = await response.json();
+    expectErrorResponse(errorData, -32000, /Server not initialized/);
+
+    // Cleanup
+    await stopTestServer({ server: uninitializedServer, transport: uninitializedTransport });
+  });
+
+  it("should send response messages to the connection that sent the request", async () => {
+    sessionId = await initializeServer();
+
+    const message1: JSONRPCMessage = {
+      jsonrpc: "2.0",
+      method: "tools/list",
+      params: {},
+      id: "req-1"
+    };
+
+    const message2: JSONRPCMessage = {
+      jsonrpc: "2.0",
+      method: "tools/call",
+      params: {
+        name: "greet",
+        arguments: { name: "Connection2" }
+      },
+      id: "req-2"
+    };
+
+    // Make two concurrent fetch connections for different requests
+    const req1 = sendPostRequest(baseUrl, message1, sessionId);
+    const req2 = sendPostRequest(baseUrl, message2, sessionId);
+
+    // Get both responses
+    const [response1, response2] = await Promise.all([req1, req2]);
+    const reader1 = response1.body?.getReader();
+    const reader2 = response2.body?.getReader();
+
+    // Read responses from each stream (requires each receives its specific response)
+    const { value: value1 } = await reader1!.read();
+    const text1 = new TextDecoder().decode(value1);
+    expect(text1).toContain('"id":"req-1"');
+    expect(text1).toContain('"tools"');  // tools/list result
+
+    const { value: value2 } = await reader2!.read();
+    const text2 = new TextDecoder().decode(value2);
+    expect(text2).toContain('"id":"req-2"');
+    expect(text2).toContain('Hello, Connection2');  // tools/call result
+  });
+
+  it("should keep stream open after sending server notifications", async () => {
+    sessionId = await initializeServer();
+
+    // Open a standalone SSE stream
+    const sseResponse = await fetch(baseUrl, {
+      method: "GET",
+      headers: {
+        Accept: "text/event-stream",
+        "mcp-session-id": sessionId,
+      },
+    });
+
+    // Send several server-initiated notifications
+    await transport.send({
+      jsonrpc: "2.0",
+      method: "notifications/message",
+      params: { level: "info", data: "First notification" },
+    });
+
+    await transport.send({
+      jsonrpc: "2.0",
+      method: "notifications/message",
+      params: { level: "info", data: "Second notification" },
+    });
+
+    // Stream should still be open - it should not close after sending notifications
+    expect(sseResponse.bodyUsed).toBe(false);
+  });
+
+  // The current implementation will close the entire transport for DELETE
+  // Creating a temporary transport/server where we don't care if it gets closed
+  it("should properly handle DELETE requests and close session", async () => {
+    // Setup a temporary server for this test
+    const tempResult = await createTestServer();
+    const tempServer = tempResult.server;
+    const tempUrl = tempResult.baseUrl;
+
+    // Initialize to get a session ID
+    const initResponse = await sendPostRequest(tempUrl, TEST_MESSAGES.initialize);
+    const tempSessionId = initResponse.headers.get("mcp-session-id");
+
+    // Now DELETE the session
+    const deleteResponse = await fetch(tempUrl, {
+      method: "DELETE",
+      headers: { "mcp-session-id": tempSessionId || "" },
+    });
+
+    expect(deleteResponse.status).toBe(200);
+
+    // Clean up
+    await new Promise<void>((resolve) => tempServer.close(() => resolve()));
+  });
+
+  it("should reject DELETE requests with invalid session ID", async () => {
+    // Initialize the server first to activate it
+    sessionId = await initializeServer();
+
+    // Try to delete with invalid session ID
+    const response = await fetch(baseUrl, {
+      method: "DELETE",
+      headers: { "mcp-session-id": "invalid-session-id" },
+    });
+
+    expect(response.status).toBe(404);
+    const errorData = await response.json();
+    expectErrorResponse(errorData, -32001, /Session not found/);
+  });
+});
+
+// Test JSON Response Mode
+describe("StreamableHTTPServerTransport with JSON Response Mode", () => {
+  let server: Server;
+  let transport: StreamableHTTPServerTransport;
+  let baseUrl: URL;
+  let sessionId: string;
+
+  beforeEach(async () => {
+    const result = await createTestServer({ enableJsonResponse: true });
+    server = result.server;
+    transport = result.transport;
+    baseUrl = result.baseUrl;
+
+    // Initialize and get session ID
+    const initResponse = await sendPostRequest(baseUrl, TEST_MESSAGES.initialize);
+
+    sessionId = initResponse.headers.get("mcp-session-id") as string;
+  });
+
+  afterEach(async () => {
+    await stopTestServer({ server, transport });
+  });
+
+  it("should return JSON response for a single request", async () => {
+    const toolsListMessage: JSONRPCMessage = {
+      jsonrpc: "2.0",
+      method: "tools/list",
+      params: {},
+      id: "json-req-1",
+    };
+
+    const response = await sendPostRequest(baseUrl, toolsListMessage, sessionId);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("application/json");
+
+    const result = await response.json();
+    expect(result).toMatchObject({
+      jsonrpc: "2.0",
+      result: expect.objectContaining({
+        tools: expect.arrayContaining([
+          expect.objectContaining({ name: "greet" })
         ])
-      });
+      }),
+      id: "json-req-1"
+    });
+  });
 
-      const response = createMockResponse();
+  it("should return JSON response for batch requests", async () => {
+    const batchMessages: JSONRPCMessage[] = [
+      { jsonrpc: "2.0", method: "tools/list", params: {}, id: "batch-1" },
+      { jsonrpc: "2.0", method: "tools/call", params: { name: "greet", arguments: { name: "JSON" } }, id: "batch-2" }
+    ];
 
-      // We need to manually store the callback to trigger it later
-      let closeCallback: (() => void) | undefined;
-      response.on.mockImplementation((event, callback: () => void) => {
-        if (typeof event === "string" && event === "close") {
-          closeCallback = callback;
+    const response = await sendPostRequest(baseUrl, batchMessages, sessionId);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("application/json");
+
+    const results = await response.json();
+    expect(Array.isArray(results)).toBe(true);
+    expect(results).toHaveLength(2);
+
+    // Batch responses can come in any order
+    const listResponse = results.find((r: { id?: string }) => r.id === "batch-1");
+    const callResponse = results.find((r: { id?: string }) => r.id === "batch-2");
+
+    expect(listResponse).toEqual(expect.objectContaining({
+      jsonrpc: "2.0",
+      id: "batch-1",
+      result: expect.objectContaining({
+        tools: expect.arrayContaining([
+          expect.objectContaining({ name: "greet" })
+        ])
+      })
+    }));
+
+    expect(callResponse).toEqual(expect.objectContaining({
+      jsonrpc: "2.0",
+      id: "batch-2",
+      result: expect.objectContaining({
+        content: expect.arrayContaining([
+          expect.objectContaining({ type: "text", text: "Hello, JSON!" })
+        ])
+      })
+    }));
+  });
+});
+
+// Test pre-parsed body handling
+describe("StreamableHTTPServerTransport with pre-parsed body", () => {
+  let server: Server;
+  let transport: StreamableHTTPServerTransport;
+  let baseUrl: URL;
+  let sessionId: string;
+  let parsedBody: unknown = null;
+
+  beforeEach(async () => {
+    const result = await createTestServer({
+      customRequestHandler: async (req, res) => {
+        try {
+          if (parsedBody !== null) {
+            await transport.handleRequest(req, res, parsedBody);
+            parsedBody = null; // Reset after use
+          } else {
+            await transport.handleRequest(req, res);
+          }
+        } catch (error) {
+          console.error("Error handling request:", error);
+          if (!res.headersSent) res.writeHead(500).end();
         }
-        return response;
-      });
-
-      await transport.handleRequest(req, response);
-
-      // Both requests should be mapped to the same response
-      expect(transport["_responseMapping"].size).toBe(3);
-      expect(transport["_responseMapping"].get("req1")).toBe(response);
-      expect(transport["_responseMapping"].get("req2")).toBe(response);
-
-      // Simulate client disconnect by triggering the stored callback
-      if (closeCallback) closeCallback();
-
-      // All entries using this response should be removed
-      expect(transport["_responseMapping"].size).toBe(1);
-      expect(transport["_responseMapping"].has("req1")).toBe(false);
-      expect(transport["_responseMapping"].has("req2")).toBe(false);
+      }
     });
+
+    server = result.server;
+    transport = result.transport;
+    baseUrl = result.baseUrl;
+
+    // Initialize and get session ID
+    const initResponse = await sendPostRequest(baseUrl, TEST_MESSAGES.initialize);
+    sessionId = initResponse.headers.get("mcp-session-id") as string;
   });
 
-  describe("Message Targeting", () => {
-    beforeEach(async () => {
-      // Initialize the transport
-      const initMessage: JSONRPCMessage = {
-        jsonrpc: "2.0",
-        method: "initialize",
-        params: {
-          clientInfo: { name: "test-client", version: "1.0" },
-          protocolVersion: "2025-03-26"
-        },
-        id: "init-1",
-      };
-
-      const initReq = createMockRequest({
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          "accept": "application/json, text/event-stream",
-        },
-        body: JSON.stringify(initMessage),
-      });
-
-      await transport.handleRequest(initReq, mockResponse);
-      mockResponse.writeHead.mockClear();
-    });
-
-    it("should send response messages to the connection that sent the request", async () => {
-      // Create request with two separate connections
-      const requestMessage1: JSONRPCMessage = {
-        jsonrpc: "2.0",
-        method: "test1",
-        params: {},
-        id: "req-id-1",
-      };
-
-      const mockResponse1 = createMockResponse();
-      const req1 = createMockRequest({
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          "accept": "application/json, text/event-stream",
-          "mcp-session-id": transport.sessionId
-        },
-        body: JSON.stringify(requestMessage1),
-      });
-      await transport.handleRequest(req1, mockResponse1);
-
-      const requestMessage2: JSONRPCMessage = {
-        jsonrpc: "2.0",
-        method: "test2",
-        params: {},
-        id: "req-id-2",
-      };
-
-      const mockResponse2 = createMockResponse();
-      const req2 = createMockRequest({
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          "accept": "application/json, text/event-stream",
-          "mcp-session-id": transport.sessionId
-        },
-        body: JSON.stringify(requestMessage2),
-      });
-      await transport.handleRequest(req2, mockResponse2);
-
-      // Send responses with matching IDs
-      const responseMessage1: JSONRPCMessage = {
-        jsonrpc: "2.0",
-        result: { success: true },
-        id: "req-id-1",
-      };
-
-      await transport.send(responseMessage1, { relatedRequestId: "req-id-1" });
-
-      const responseMessage2: JSONRPCMessage = {
-        jsonrpc: "2.0",
-        result: { success: true },
-        id: "req-id-2",
-      };
-
-      await transport.send(responseMessage2, { relatedRequestId: "req-id-2" });
-
-      // Verify responses were sent to the right connections
-      expect(mockResponse1.write).toHaveBeenCalledWith(
-        expect.stringContaining(JSON.stringify(responseMessage1))
-      );
-
-      expect(mockResponse2.write).toHaveBeenCalledWith(
-        expect.stringContaining(JSON.stringify(responseMessage2))
-      );
-
-      // Verify responses were not sent to the wrong connections
-      const resp1HasResp2 = mockResponse1.write.mock.calls.some(call =>
-        typeof call[0] === 'string' && call[0].includes(JSON.stringify(responseMessage2))
-      );
-      expect(resp1HasResp2).toBe(false);
-
-      const resp2HasResp1 = mockResponse2.write.mock.calls.some(call =>
-        typeof call[0] === 'string' && call[0].includes(JSON.stringify(responseMessage1))
-      );
-      expect(resp2HasResp1).toBe(false);
-    });
+  afterEach(async () => {
+    await stopTestServer({ server, transport });
   });
 
-  describe("Error Handling", () => {
-    it("should return 400 error for invalid JSON data", async () => {
-      const req = createMockRequest({
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          "accept": "application/json, text/event-stream",
-        },
-        body: "invalid json",
-      });
+  it("should accept pre-parsed request body", async () => {
+    // Set up the pre-parsed body
+    parsedBody = {
+      jsonrpc: "2.0",
+      method: "tools/list",
+      params: {},
+      id: "preparsed-1",
+    };
 
-      const onErrorMock = jest.fn();
-      transport.onerror = onErrorMock;
-
-      await transport.handleRequest(req, mockResponse);
-
-      expect(mockResponse.writeHead).toHaveBeenCalledWith(400);
-      expect(mockResponse.end).toHaveBeenCalledWith(expect.stringContaining('"jsonrpc":"2.0"'));
-      expect(mockResponse.end).toHaveBeenCalledWith(expect.stringContaining('"code":-32700'));
-      expect(onErrorMock).toHaveBeenCalled();
+    // Send an empty body since we'll use pre-parsed body  
+    const response = await fetch(baseUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+        "mcp-session-id": sessionId,
+      },
+      // Empty body - we're testing pre-parsed body
+      body: ""
     });
 
-    it("should return 400 error for invalid JSON-RPC messages", async () => {
-      const req = createMockRequest({
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          "accept": "application/json, text/event-stream",
-        },
-        body: JSON.stringify({ invalid: "message" }),
-      });
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("text/event-stream");
 
-      const onErrorMock = jest.fn();
-      transport.onerror = onErrorMock;
+    const reader = response.body?.getReader();
+    const { value } = await reader!.read();
+    const text = new TextDecoder().decode(value);
 
-      await transport.handleRequest(req, mockResponse);
-
-      expect(mockResponse.writeHead).toHaveBeenCalledWith(400);
-      expect(mockResponse.end).toHaveBeenCalledWith(expect.stringContaining('"jsonrpc":"2.0"'));
-      expect(onErrorMock).toHaveBeenCalled();
-    });
+    // Verify the response used the pre-parsed body
+    expect(text).toContain('"id":"preparsed-1"');
+    expect(text).toContain('"tools"');
   });
 
-  describe("JSON Response Mode", () => {
-    let jsonResponseTransport: StreamableHTTPServerTransport;
-    let mockResponse: jest.Mocked<ServerResponse>;
+  it("should handle pre-parsed batch messages", async () => {
+    parsedBody = [
+      { jsonrpc: "2.0", method: "tools/list", params: {}, id: "batch-1" },
+      { jsonrpc: "2.0", method: "tools/call", params: { name: "greet", arguments: { name: "PreParsed" } }, id: "batch-2" }
+    ];
 
-    beforeEach(async () => {
-      jsonResponseTransport = new StreamableHTTPServerTransport({
-        sessionIdGenerator: () => randomUUID(),
-        enableJsonResponse: true,
-      });
-
-      // Initialize the transport
-      const initMessage: JSONRPCMessage = {
-        jsonrpc: "2.0",
-        method: "initialize",
-        params: {
-          clientInfo: { name: "test-client", version: "1.0" },
-          protocolVersion: "2025-03-26"
-        },
-        id: "init-1",
-      };
-
-      const initReq = createMockRequest({
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          "accept": "application/json, text/event-stream",
-        },
-        body: JSON.stringify(initMessage),
-      });
-
-      mockResponse = createMockResponse();
-      await jsonResponseTransport.handleRequest(initReq, mockResponse);
-      mockResponse = createMockResponse(); // Reset for tests
+    const response = await fetch(baseUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+        "mcp-session-id": sessionId,
+      },
+      body: "" // Empty as we're using pre-parsed
     });
 
-    it("should return JSON response for a single request", async () => {
-      const requestMessage: JSONRPCMessage = {
-        jsonrpc: "2.0",
-        method: "tools/list",
-        params: {},
-        id: "test-req-id",
-      };
+    expect(response.status).toBe(200);
 
-      const req = createMockRequest({
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          "accept": "application/json, text/event-stream",
-          "mcp-session-id": jsonResponseTransport.sessionId,
-        },
-        body: JSON.stringify(requestMessage),
-      });
+    const reader = response.body?.getReader();
+    const { value } = await reader!.read();
+    const text = new TextDecoder().decode(value);
 
-      // Mock immediate response
-      jsonResponseTransport.onmessage = (message) => {
-        if ('method' in message && 'id' in message) {
-          const responseMessage: JSONRPCMessage = {
-            jsonrpc: "2.0",
-            result: { value: `test-result` },
-            id: message.id,
-          };
-          void jsonResponseTransport.send(responseMessage);
-        }
-      };
-
-      await jsonResponseTransport.handleRequest(req, mockResponse);
-      // Should respond with application/json header
-      expect(mockResponse.writeHead).toHaveBeenCalledWith(
-        200,
-        expect.objectContaining({
-          "Content-Type": "application/json",
-        })
-      );
-
-      // Should return the response as JSON
-      const expectedResponse = {
-        jsonrpc: "2.0",
-        result: { value: "test-result" },
-        id: "test-req-id",
-      };
-
-      expect(mockResponse.end).toHaveBeenCalledWith(JSON.stringify(expectedResponse));
-    });
-
-    it("should return JSON response for batch requests", async () => {
-      const batchMessages: JSONRPCMessage[] = [
-        { jsonrpc: "2.0", method: "tools/list", params: {}, id: "req1" },
-        { jsonrpc: "2.0", method: "tools/call", params: {}, id: "req2" },
-      ];
-
-      const req = createMockRequest({
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          "accept": "application/json, text/event-stream",
-          "mcp-session-id": jsonResponseTransport.sessionId,
-        },
-        body: JSON.stringify(batchMessages),
-      });
-
-      // Mock responses without enforcing specific order
-      jsonResponseTransport.onmessage = (message) => {
-        if ('method' in message && 'id' in message) {
-          const responseMessage: JSONRPCMessage = {
-            jsonrpc: "2.0",
-            result: { value: `result-for-${message.id}` },
-            id: message.id,
-          };
-          void jsonResponseTransport.send(responseMessage);
-        }
-      };
-
-      await jsonResponseTransport.handleRequest(req, mockResponse);
-
-      // Should respond with application/json header
-      expect(mockResponse.writeHead).toHaveBeenCalledWith(
-        200,
-        expect.objectContaining({
-          "Content-Type": "application/json",
-        })
-      );
-
-      // Verify response was sent but don't assume specific order
-      expect(mockResponse.end).toHaveBeenCalled();
-      const responseJson = JSON.parse(mockResponse.end.mock.calls[0][0] as string);
-      expect(Array.isArray(responseJson)).toBe(true);
-      expect(responseJson).toHaveLength(2);
-
-      // Check each response exists separately without assuming order
-      expect(responseJson).toContainEqual(expect.objectContaining({ id: "req1", result: { value: "result-for-req1" } }));
-      expect(responseJson).toContainEqual(expect.objectContaining({ id: "req2", result: { value: "result-for-req2" } }));
-    });
+    expect(text).toContain('"id":"batch-1"');
+    expect(text).toContain('"tools"');
   });
 
-  describe("Handling Pre-Parsed Body", () => {
-    beforeEach(async () => {
-      // Initialize the transport
-      const initMessage: JSONRPCMessage = {
+  it("should prefer pre-parsed body over request body", async () => {
+    // Set pre-parsed to tools/list
+    parsedBody = {
+      jsonrpc: "2.0",
+      method: "tools/list",
+      params: {},
+      id: "preparsed-wins",
+    };
+
+    // Send actual body with tools/call - should be ignored
+    const response = await fetch(baseUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+        "mcp-session-id": sessionId,
+      },
+      body: JSON.stringify({
         jsonrpc: "2.0",
-        method: "initialize",
-        params: {
-          clientInfo: { name: "test-client", version: "1.0" },
-          protocolVersion: "2025-03-26"
-        },
-        id: "init-1",
-      };
-
-      const initReq = createMockRequest({
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          "accept": "application/json, text/event-stream",
-        },
-        body: JSON.stringify(initMessage),
-      });
-
-      await transport.handleRequest(initReq, mockResponse);
-      mockResponse.writeHead.mockClear();
+        method: "tools/call",
+        params: { name: "greet", arguments: { name: "Ignored" } },
+        id: "ignored-id"
+      })
     });
 
-    it("should accept pre-parsed request body", async () => {
-      const message: JSONRPCMessage = {
-        jsonrpc: "2.0",
-        method: "test",
-        params: {},
-        id: "pre-parsed-test",
-      };
+    expect(response.status).toBe(200);
 
-      // Create a request without actual body content
-      const req = createMockRequest({
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          "accept": "application/json, text/event-stream",
-          "mcp-session-id": transport.sessionId,
-        },
-        // No body provided here - it will be passed as parsedBody
-      });
+    const reader = response.body?.getReader();
+    const { value } = await reader!.read();
+    const text = new TextDecoder().decode(value);
 
-      const onMessageMock = jest.fn();
-      transport.onmessage = onMessageMock;
-
-      // Pass the pre-parsed body directly
-      await transport.handleRequest(req, mockResponse, message);
-
-      // Verify the message was processed correctly
-      expect(onMessageMock).toHaveBeenCalledWith(message);
-      expect(mockResponse.writeHead).toHaveBeenCalledWith(
-        200,
-        expect.objectContaining({
-          "Content-Type": "text/event-stream",
-        })
-      );
-    });
-
-    it("should handle pre-parsed batch messages", async () => {
-      const batchMessages: JSONRPCMessage[] = [
-        {
-          jsonrpc: "2.0",
-          method: "method1",
-          params: { data: "test1" },
-          id: "batch1"
-        },
-        {
-          jsonrpc: "2.0",
-          method: "method2",
-          params: { data: "test2" },
-          id: "batch2"
-        },
-      ];
-
-      // Create a request without actual body content
-      const req = createMockRequest({
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          "accept": "application/json, text/event-stream",
-          "mcp-session-id": transport.sessionId,
-        },
-        // No body provided here - it will be passed as parsedBody
-      });
-
-      const onMessageMock = jest.fn();
-      transport.onmessage = onMessageMock;
-
-      // Pass the pre-parsed body directly
-      await transport.handleRequest(req, mockResponse, batchMessages);
-
-      // Should be called for each message in the batch
-      expect(onMessageMock).toHaveBeenCalledTimes(2);
-      expect(onMessageMock).toHaveBeenCalledWith(batchMessages[0]);
-      expect(onMessageMock).toHaveBeenCalledWith(batchMessages[1]);
-    });
-
-    it("should prefer pre-parsed body over request body", async () => {
-      const requestBodyMessage: JSONRPCMessage = {
-        jsonrpc: "2.0",
-        method: "fromRequestBody",
-        params: {},
-        id: "request-body",
-      };
-
-      const parsedBodyMessage: JSONRPCMessage = {
-        jsonrpc: "2.0",
-        method: "fromParsedBody",
-        params: {},
-        id: "parsed-body",
-      };
-
-      // Create a request with actual body content
-      const req = createMockRequest({
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          "accept": "application/json, text/event-stream",
-          "mcp-session-id": transport.sessionId,
-        },
-        body: JSON.stringify(requestBodyMessage),
-      });
-
-      const onMessageMock = jest.fn();
-      transport.onmessage = onMessageMock;
-
-      // Pass the pre-parsed body directly
-      await transport.handleRequest(req, mockResponse, parsedBodyMessage);
-
-      // Should use the parsed body instead of the request body
-      expect(onMessageMock).toHaveBeenCalledWith(parsedBodyMessage);
-      expect(onMessageMock).not.toHaveBeenCalledWith(requestBodyMessage);
-    });
+    // Should have processed the pre-parsed body
+    expect(text).toContain('"id":"preparsed-wins"');
+    expect(text).toContain('"tools"');
+    expect(text).not.toContain('"ignored-id"');
   });
-}); 
+});
+
+// Test stateless mode
+describe("StreamableHTTPServerTransport in stateless mode", () => {
+  let server: Server;
+  let transport: StreamableHTTPServerTransport;
+  let baseUrl: URL;
+
+  beforeEach(async () => {
+    const result = await createTestServer({ sessionIdGenerator: () => undefined });
+    server = result.server;
+    transport = result.transport;
+    baseUrl = result.baseUrl;
+  });
+
+  afterEach(async () => {
+    await stopTestServer({ server, transport });
+  });
+
+  it("should operate without session ID validation", async () => {
+    // Initialize the server first
+    const initResponse = await sendPostRequest(baseUrl, TEST_MESSAGES.initialize);
+
+    expect(initResponse.status).toBe(200);
+    // Should NOT have session ID header in stateless mode
+    expect(initResponse.headers.get("mcp-session-id")).toBeNull();
+
+    // Try request without session ID - should work in stateless mode
+    const toolsResponse = await sendPostRequest(baseUrl, TEST_MESSAGES.toolsList);
+
+    expect(toolsResponse.status).toBe(200);
+  });
+
+  it("should handle POST requests with various session IDs in stateless mode", async () => {
+    // Initialize the server first
+    await fetch(baseUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "application/json, text/event-stream" },
+      body: JSON.stringify({
+        jsonrpc: "2.0", method: "initialize", params: { clientInfo: { name: "test-client", version: "1.0" }, protocolVersion: "2025-03-26" }, id: "init-1"
+      }),
+    });
+
+    // Try with a random session ID - should be accepted
+    const response1 = await fetch(baseUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+        "mcp-session-id": "random-id-1",
+      },
+      body: JSON.stringify({ jsonrpc: "2.0", method: "tools/list", params: {}, id: "t1" }),
+    });
+    expect(response1.status).toBe(200);
+
+    // Try with another random session ID - should also be accepted
+    const response2 = await fetch(baseUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+        "mcp-session-id": "different-id-2",
+      },
+      body: JSON.stringify({ jsonrpc: "2.0", method: "tools/list", params: {}, id: "t2" }),
+    });
+    expect(response2.status).toBe(200);
+  });
+
+  it("should reject second SSE stream even in stateless mode", async () => {
+    // Despite no session ID requirement, the transport still only allows 
+    // one standalone SSE stream at a time
+
+    // Initialize the server first
+    await fetch(baseUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "application/json, text/event-stream" },
+      body: JSON.stringify({
+        jsonrpc: "2.0", method: "initialize", params: { clientInfo: { name: "test-client", version: "1.0" }, protocolVersion: "2025-03-26" }, id: "init-1"
+      }),
+    });
+
+    // Open first SSE stream
+    const stream1 = await fetch(baseUrl, {
+      method: "GET",
+      headers: { Accept: "text/event-stream" },
+    });
+    expect(stream1.status).toBe(200);
+
+    // Open second SSE stream - should still be rejected, stateless mode still only allows one
+    const stream2 = await fetch(baseUrl, {
+      method: "GET",
+      headers: { Accept: "text/event-stream" },
+    });
+    expect(stream2.status).toBe(409); // Conflict - only one stream allowed
+  });
+});

--- a/src/server/streamableHttp.ts
+++ b/src/server/streamableHttp.ts
@@ -1,10 +1,46 @@
 import { IncomingMessage, ServerResponse } from "node:http";
 import { Transport } from "../shared/transport.js";
-import { JSONRPCMessage, JSONRPCMessageSchema, RequestId } from "../types.js";
+import { isJSONRPCNotification, isJSONRPCRequest, isJSONRPCResponse, JSONRPCMessage, JSONRPCMessageSchema, RequestId } from "../types.js";
 import getRawBody from "raw-body";
 import contentType from "content-type";
+import { randomUUID } from "node:crypto";
 
 const MAXIMUM_MESSAGE_SIZE = "4mb";
+
+/**
+ * Interface for resumability support via event storage
+ */
+export interface EventStore {
+  /**
+   * Generates a unique event ID for a given stream ID
+   * @param streamId The stream ID to include in the event ID
+   * @returns A unique event ID that includes the stream ID
+   */
+  generateEventId(streamId: string): string;
+
+  /**
+   * Stores an event for later retrieval
+   * @param streamId ID of the stream the event belongs to
+   * @param message The JSON-RPC message to store
+   * @returns The generated event ID for the stored event
+   */
+  storeEvent(streamId: string, message: JSONRPCMessage): Promise<string>;
+
+  /**
+   * Retrieves events for a stream starting from a given event ID
+   * @param lastEventId The event ID to start from
+   * @returns Array of stored events with their event IDs
+   */
+  getEventsAfter(lastEventId: string): Promise<Array<{ eventId: string, message: JSONRPCMessage }>>;
+
+  /**
+   * Extracts the stream ID from an event ID
+   * This is necessary for resumability to identify which stream the event belongs to
+   * @param eventId The event ID to extract stream ID from
+   * @returns The stream ID portion of the event ID
+   */
+  getStreamIdFromEventId(eventId: string): string;
+}
 
 /**
  * Configuration options for StreamableHTTPServerTransport
@@ -24,6 +60,12 @@ export interface StreamableHTTPServerTransportOptions {
    * Default is false (SSE streams are preferred).
    */
   enableJsonResponse?: boolean;
+
+  /**
+   * Event store for resumability support
+   * If provided, resumability will be enabled, allowing clients to reconnect and resume messages
+   */
+  eventStore?: EventStore;
 }
 
 /**
@@ -64,12 +106,13 @@ export class StreamableHTTPServerTransport implements Transport {
   // when sessionId is not set (undefined), it means the transport is in stateless mode
   private sessionIdGenerator: () => string | undefined;
   private _started: boolean = false;
-  private _responseMapping: Map<RequestId, ServerResponse> = new Map();
+  private _streamMapping: Map<string, ServerResponse> = new Map();
+  private _requestToStreamMapping: Map<RequestId, string> = new Map();
   private _requestResponseMap: Map<RequestId, JSONRPCMessage> = new Map();
   private _initialized: boolean = false;
   private _enableJsonResponse: boolean = false;
-  private _standaloneSSE: ServerResponse | undefined;
-
+  private _standaloneSseStreamId: string = 'standalonesse';
+  private _eventStore?: EventStore;
 
   sessionId?: string | undefined;
   onclose?: () => void;
@@ -79,6 +122,7 @@ export class StreamableHTTPServerTransport implements Transport {
   constructor(options: StreamableHTTPServerTransportOptions) {
     this.sessionIdGenerator = options.sessionIdGenerator;
     this._enableJsonResponse = options.enableJsonResponse ?? false;
+    this._eventStore = options.eventStore;
   }
 
   /**
@@ -131,6 +175,14 @@ export class StreamableHTTPServerTransport implements Transport {
     if (!this.validateSession(req, res)) {
       return;
     }
+    // Handle resumability: check for Last-Event-ID header
+    if (this._eventStore) {
+      const lastEventId = req.headers['last-event-id'] as string | undefined;
+      if (lastEventId) {
+        await this.replayEvents(lastEventId, res);
+        return;
+      }
+    }
 
     // The server MUST either return Content-Type: text/event-stream in response to this HTTP GET, 
     // or else return HTTP 405 Method Not Allowed
@@ -144,12 +196,9 @@ export class StreamableHTTPServerTransport implements Transport {
     if (this.sessionId !== undefined) {
       headers["mcp-session-id"] = this.sessionId;
     }
-    // The server MAY include a Last-Event-ID header in the response to this HTTP GET.
-    // Resumability will be supported in the future
 
     // Check if there's already an active standalone SSE stream for this session
-
-    if (this._standaloneSSE !== undefined) {
+    if (this._streamMapping.get(this._standaloneSseStreamId) !== undefined) {
       // Only one GET SSE stream is allowed per session
       res.writeHead(409).end(JSON.stringify({
         jsonrpc: "2.0",
@@ -161,17 +210,60 @@ export class StreamableHTTPServerTransport implements Transport {
       }));
       return;
     }
-    // We need to send headers immediately as message will arrive much later,
+
+    // We need to send headers immediately as messages will arrive much later,
     // otherwise the client will just wait for the first message
     res.writeHead(200, headers).flushHeaders();
 
-    // Assing the response to the standalone SSE stream
-    this._standaloneSSE = res;
+    // Assign the response to the standalone SSE stream
+    this._streamMapping.set(this._standaloneSseStreamId, res);
 
     // Set up close handler for client disconnects
     res.on("close", () => {
-      this._standaloneSSE = undefined;
+      this._streamMapping.delete(this._standaloneSseStreamId);
     });
+  }
+
+  /**
+   * Replays events that would have been sent after the specified event ID
+   * Only used when resumability is enabled
+   */
+  private async replayEvents(lastEventId: string, res: ServerResponse): Promise<void> {
+    if (!this._eventStore) {
+      return;
+    }
+
+    try {
+      const events = await this._eventStore.getEventsAfter(lastEventId);
+      const streamId = this._eventStore.getStreamIdFromEventId(lastEventId);
+
+      const oldResStream = this._streamMapping.get(streamId);
+      this._streamMapping.set(streamId, res);
+      if (oldResStream) {
+        // If we have an old response stream, close it
+        oldResStream.end();
+      }
+
+      for (const { eventId, message } of events) {
+        this.writeSSEEvent(res, message, eventId);
+      }
+    } catch (error) {
+      this.onerror?.(error as Error);
+    }
+  }
+
+  /**
+   * Writes an event to the SSE stream with proper formatting
+   */
+  private writeSSEEvent(res: ServerResponse, message: JSONRPCMessage, eventId?: string): boolean {
+    let eventData = `event: message\n`;
+    // Include event ID if provided - this is important for resumability
+    if (eventId) {
+      eventData += `id: ${eventId}\n`;
+    }
+    eventData += `data: ${JSON.stringify(message)}\n\n`;
+
+    return res.write(eventData);
   }
 
   /**
@@ -285,9 +377,9 @@ export class StreamableHTTPServerTransport implements Transport {
 
 
       // check if it contains requests
-      const hasRequests = messages.some(msg => 'method' in msg && 'id' in msg);
+      const hasRequests = messages.some(isJSONRPCRequest);
       const hasOnlyNotificationsOrResponses = messages.every(msg =>
-        ('method' in msg && !('id' in msg)) || ('result' in msg || 'error' in msg));
+        isJSONRPCNotification(msg) || isJSONRPCResponse(msg));
 
       if (hasOnlyNotificationsOrResponses) {
         // if it only contains notifications or responses, return 202
@@ -300,6 +392,7 @@ export class StreamableHTTPServerTransport implements Transport {
       } else if (hasRequests) {
         // The default behavior is to use SSE streaming
         // but in some cases server will return JSON responses
+        const streamId = randomUUID();
         if (!this._enableJsonResponse) {
           const headers: Record<string, string> = {
             "Content-Type": "text/event-stream",
@@ -318,19 +411,22 @@ export class StreamableHTTPServerTransport implements Transport {
         // We need to track by request ID to maintain the connection
         for (const message of messages) {
           if ('method' in message && 'id' in message) {
-            this._responseMapping.set(message.id, res);
+            this._streamMapping.set(streamId, res);
+            this._requestToStreamMapping.set(message.id, streamId);
           }
         }
 
         // Set up close handler for client disconnects
         res.on("close", () => {
+          // find a stream ID for this response
           // Remove all entries that reference this response
-          for (const [id, storedRes] of this._responseMapping.entries()) {
-            if (storedRes === res) {
-              this._responseMapping.delete(id);
+          for (const [id, stream] of this._requestToStreamMapping.entries()) {
+            if (streamId === stream) {
+              this._requestToStreamMapping.delete(id);
               this._requestResponseMap.delete(id);
             }
           }
+          this._streamMapping.delete(streamId);
         });
 
         // handle each message
@@ -431,16 +527,13 @@ export class StreamableHTTPServerTransport implements Transport {
 
   async close(): Promise<void> {
     // Close all SSE connections
-    this._responseMapping.forEach((response) => {
+    this._streamMapping.forEach((response) => {
       response.end();
     });
-    this._responseMapping.clear();
+    this._streamMapping.clear();
 
     // Clear any pending responses
     this._requestResponseMap.clear();
-    this._standaloneSSE?.end();
-    this._standaloneSSE = undefined;
-
     this.onclose?.();
   }
 
@@ -459,32 +552,47 @@ export class StreamableHTTPServerTransport implements Transport {
       if ('result' in message || 'error' in message) {
         throw new Error("Cannot send a response on a standalone SSE stream unless resuming a previous client request");
       }
-
-      if (this._standaloneSSE === undefined) {
+      const standaloneSse = this._streamMapping.get(this._standaloneSseStreamId)
+      if (standaloneSse === undefined) {
         // The spec says the server MAY send messages on the stream, so it's ok to discard if no stream
         return;
       }
 
+      // Generate and store event ID if event store is provided
+      let eventId: string | undefined;
+      if (this._eventStore) {
+        // Stores the event and gets the generated event ID
+        eventId = await this._eventStore.storeEvent(this._standaloneSseStreamId, message);
+      }
+
       // Send the message to the standalone SSE stream
-      this._standaloneSSE.write(`event: message\ndata: ${JSON.stringify(message)}\n\n`);
+      this.writeSSEEvent(standaloneSse, message, eventId);
       return;
     }
 
     // Get the response for this request
-    const response = this._responseMapping.get(requestId);
-    if (!response) {
+    const streamId = this._requestToStreamMapping.get(requestId);
+    const response = this._streamMapping.get(streamId!);
+    if (!streamId || !response) {
       throw new Error(`No connection established for request ID: ${String(requestId)}`);
     }
 
     if (!this._enableJsonResponse) {
-      response.write(`event: message\ndata: ${JSON.stringify(message)}\n\n`);
-    }
-    if ('result' in message || 'error' in message) {
-      this._requestResponseMap.set(requestId, message);
+      // For SSE responses, generate event ID if event store is provided
+      let eventId: string | undefined;
 
-      // Get all request IDs that share the same request response object
-      const relatedIds = Array.from(this._responseMapping.entries())
-        .filter(([_, res]) => res === response)
+      if (this._eventStore) {
+        eventId = await this._eventStore.storeEvent(streamId, message);
+      }
+
+      // Write the event to the response stream
+      this.writeSSEEvent(response, message, eventId);
+    }
+
+    if (isJSONRPCResponse(message)) {
+      this._requestResponseMap.set(requestId, message);
+      const relatedIds = Array.from(this._requestToStreamMapping.entries())
+        .filter(([_, streamId]) => this._streamMapping.get(streamId) === response)
         .map(([id]) => id);
 
       // Check if we have responses for all requests using this connection
@@ -516,7 +624,7 @@ export class StreamableHTTPServerTransport implements Transport {
         // Clean up
         for (const id of relatedIds) {
           this._requestResponseMap.delete(id);
-          this._responseMapping.delete(id);
+          this._requestToStreamMapping.delete(id);
         }
       }
     }

--- a/src/server/streamableHttp.ts
+++ b/src/server/streamableHttp.ts
@@ -438,6 +438,8 @@ export class StreamableHTTPServerTransport implements Transport {
 
     // Clear any pending responses
     this._requestResponseMap.clear();
+    this._standaloneSSE?.end();
+    this._standaloneSSE = undefined;
 
     this.onclose?.();
   }


### PR DESCRIPTION
As per [spec](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#resumability-and-redelivery) servers might support resumability and redelivery. 

Introducing resumability and re-delivery of events for disconnection within the same client.

- maintaining a map of streamID per request
- moved a special case for standalone stream to a map for simplicity
- adding `StreamableHTTPReconnectionOptions` interface for custom reconnection and backoff 
- adding example of `start-notification-stream'` tool which starts notifications for that can be used for testing

Follow ups: 
- resume long running requests from a new instance of the client
