### PR TITLE
StreamableHttp transport - resume long running requests

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -126,7 +126,11 @@ export class Client<
 
   override async connect(transport: Transport, options?: RequestOptions): Promise<void> {
     await super.connect(transport);
-
+    // When transport sessionId is already set this means we are trying to reconnect.
+    // In this case we don't need to initialize again.
+    if (transport.sessionId !== undefined) {
+      return;
+    }
     try {
       const result = await this.request(
         {

--- a/src/client/streamableHttp.test.ts
+++ b/src/client/streamableHttp.test.ts
@@ -313,9 +313,9 @@ describe("StreamableHTTPClientTransport", () => {
     await transport.start();
     // Type assertion to access private method
     const transportWithPrivateMethods = transport as unknown as {
-      _startOrAuthSse: (options: { lastEventId?: string }) => Promise<void>
+      _startOrAuthSse: (options: { resumptionToken?: string }) => Promise<void>
     };
-    await transportWithPrivateMethods._startOrAuthSse({ lastEventId: "test-event-id" });
+    await transportWithPrivateMethods._startOrAuthSse({ resumptionToken: "test-event-id" });
 
     // Verify fetch was called with the lastEventId header
     expect(fetchSpy).toHaveBeenCalled();

--- a/src/client/streamableHttp.test.ts
+++ b/src/client/streamableHttp.test.ts
@@ -164,7 +164,7 @@ describe("StreamableHTTPClientTransport", () => {
     // We expect the 405 error to be caught and handled gracefully
     // This should not throw an error that breaks the transport
     await transport.start();
-    await expect(transport["_startOrAuthStandaloneSSE"]()).resolves.not.toThrow("Failed to open SSE stream: Method Not Allowed");
+    await expect(transport["_startOrAuthSse"]()).resolves.not.toThrow("Failed to open SSE stream: Method Not Allowed");
     // Check that GET was attempted
     expect(global.fetch).toHaveBeenCalledWith(
       expect.anything(),
@@ -208,7 +208,7 @@ describe("StreamableHTTPClientTransport", () => {
     transport.onmessage = messageSpy;
 
     await transport.start();
-    await transport["_startOrAuthStandaloneSSE"]();
+    await transport["_startOrAuthSse"]();
 
     // Give time for the SSE event to be processed
     await new Promise(resolve => setTimeout(resolve, 50));
@@ -313,9 +313,9 @@ describe("StreamableHTTPClientTransport", () => {
     await transport.start();
     // Type assertion to access private method
     const transportWithPrivateMethods = transport as unknown as {
-      _startOrAuthStandaloneSSE: (lastEventId?: string) => Promise<void>
+      _startOrAuthSse: (lastEventId?: string) => Promise<void>
     };
-    await transportWithPrivateMethods._startOrAuthStandaloneSSE("test-event-id");
+    await transportWithPrivateMethods._startOrAuthSse("test-event-id");
 
     // Verify fetch was called with the lastEventId header
     expect(fetchSpy).toHaveBeenCalled();
@@ -382,7 +382,7 @@ describe("StreamableHTTPClientTransport", () => {
 
     await transport.start();
 
-    await transport["_startOrAuthStandaloneSSE"]();
+    await transport["_startOrAuthSse"]();
     expect((actualReqInit.headers as Headers).get("x-custom-header")).toBe("CustomValue");
 
     requestInit.headers["X-Custom-Header"] = "SecondCustomValue";

--- a/src/client/streamableHttp.ts
+++ b/src/client/streamableHttp.ts
@@ -23,17 +23,20 @@ export class StreamableHTTPError extends Error {
 /**
  * Options for starting or authenticating an SSE connection
  */
-export interface StartSSEOptions {
+interface StartSSEOptions {
   /**
    * The ID of the last received event, used for resuming a disconnected stream
    */
   lastEventId?: string;
+
   /**
    * The callback function that is invoked when the last event ID changes
    */
   onLastEventIdUpdate?: (event: string) => void
+
   /**
-  * When reconnecting to a long-running SSE stream, we need to make sure that message id matches
+  * Override Message ID to associate with the replay message
+  * so that response can be associate with the new resumed request.
   */
   replayMessageId?: string | number;
 }
@@ -358,7 +361,7 @@ export class StreamableHTTPClientTransport implements Transport {
     this.onclose?.();
   }
 
-  async send(message: JSONRPCMessage | JSONRPCMessage[], options?: { resumptionToken?: string, onresumptiontoken?: (event: string) => void }): Promise<void> {
+  async send(message: JSONRPCMessage | JSONRPCMessage[], options?: { resumptionToken?: string, onresumptiontoken?: (token: string) => void }): Promise<void> {
     try {
       // If client passes in a lastEventId in the request options, we need to reconnect the SSE stream
       const lastEventId = options?.resumptionToken

--- a/src/client/streamableHttp.ts
+++ b/src/client/streamableHttp.ts
@@ -123,7 +123,7 @@ export class StreamableHTTPClientTransport implements Transport {
       throw new UnauthorizedError();
     }
 
-    return await this._startOrAuthStandaloneSSE();
+    return await this._startOrAuthSse();
   }
 
   private async _commonHeaders(): Promise<Headers> {
@@ -144,7 +144,7 @@ export class StreamableHTTPClientTransport implements Transport {
     );
   }
 
-  private async _startOrAuthStandaloneSSE(lastEventId?: string): Promise<void> {
+  private async _startOrAuthSse(lastEventId?: string): Promise<void> {
     try {
       // Try to open an initial SSE stream with GET to listen for server messages
       // This is optional according to the spec - server may not support it
@@ -238,7 +238,7 @@ export class StreamableHTTPClientTransport implements Transport {
     // Schedule the reconnection
     setTimeout(() => {
       // Use the last event ID to resume where we left off
-      this._startOrAuthStandaloneSSE(lastEventId).catch(error => {
+      this._startOrAuthSse(lastEventId).catch(error => {
         this.onerror?.(new Error(`Failed to reconnect SSE stream: ${error instanceof Error ? error.message : String(error)}`));
         // Schedule another attempt if this one failed, incrementing the attempt counter
         this._scheduleReconnection(lastEventId, attemptCount + 1);
@@ -343,7 +343,7 @@ export class StreamableHTTPClientTransport implements Transport {
       const { lastEventId, onLastEventIdUpdate } = options ?? {};
       if (lastEventId) {
         // If we have at last event ID, we need to reconnect the SSE stream
-        this._startOrAuthStandaloneSSE(lastEventId).catch(err => this.onerror?.(err));
+        this._startOrAuthSse(lastEventId).catch(err => this.onerror?.(err));
         return;
       }
 
@@ -390,7 +390,7 @@ export class StreamableHTTPClientTransport implements Transport {
         // if it's supported by the server
         if (isJSONRPCNotification(message) && message.method === "notifications/initialized") {
           // Start without a lastEventId since this is a fresh connection
-          this._startOrAuthStandaloneSSE().catch(err => this.onerror?.(err));
+          this._startOrAuthSse().catch(err => this.onerror?.(err));
         }
         return;
       }

--- a/src/client/streamableHttp.ts
+++ b/src/client/streamableHttp.ts
@@ -88,6 +88,7 @@ export type StreamableHTTPClientTransportOptions = {
    * Options to configure the reconnection behavior.
    */
   reconnectionOptions?: StreamableHTTPReconnectionOptions;
+
   /**
    * Session ID for the connection. This is used to identify the session on the server.
    * When not provided and connecting to a server that supports session IDs, the server will generate a new session ID.
@@ -345,10 +346,11 @@ export class StreamableHTTPClientTransport implements Transport {
     this.onclose?.();
   }
 
-  async send(message: JSONRPCMessage | JSONRPCMessage[], options?: { lastEventId?: string, onLastEventIdUpdate?: (event: string) => void }): Promise<void> {
+  async send(message: JSONRPCMessage | JSONRPCMessage[], options?: { resumptionToken?: string, onresumptiontoken?: (event: string) => void }): Promise<void> {
     try {
       // If client passes in a lastEventId in the request options, we need to reconnect the SSE stream
-      const { lastEventId, onLastEventIdUpdate } = options ?? {};
+      const lastEventId = options?.resumptionToken
+      const onLastEventIdUpdate = options?.onresumptiontoken;
       if (lastEventId) {
         // If we have at last event ID, we need to reconnect the SSE stream
         this._startOrAuthSse({ lastEventId }).catch(err => this.onerror?.(err));

--- a/src/examples/client/simpleStreamableHttp.ts
+++ b/src/examples/client/simpleStreamableHttp.ts
@@ -29,6 +29,8 @@ let notificationCount = 0;
 let client: Client | null = null;
 let transport: StreamableHTTPClientTransport | null = null;
 let serverUrl = 'http://localhost:3000/mcp';
+let notificationsToolLastEventId: string | undefined = undefined;
+let sessionId: string | undefined = undefined;
 
 async function main(): Promise<void> {
   console.log('MCP Interactive Client');
@@ -186,7 +188,10 @@ async function connect(url?: string): Promise<void> {
     }
 
     transport = new StreamableHTTPClientTransport(
-      new URL(serverUrl)
+      new URL(serverUrl),
+      {
+        sessionId: sessionId
+      }
     );
 
     // Set up notification handlers
@@ -218,6 +223,8 @@ async function connect(url?: string): Promise<void> {
 
     // Connect the client
     await client.connect(transport);
+    sessionId = transport.sessionId
+    console.log('Transport created with session ID:', sessionId);
     console.log('Connected to MCP server');
   } catch (error) {
     console.error('Failed to connect:', error);
@@ -291,7 +298,12 @@ async function callTool(name: string, args: Record<string, unknown>): Promise<vo
     };
 
     console.log(`Calling tool '${name}' with args:`, args);
-    const result = await client.request(request, CallToolResultSchema);
+    const onLastEventIdUpdate = (event: string) => {
+      notificationsToolLastEventId = event;
+    };
+    const result = await client.request(request, CallToolResultSchema, {
+      lastEventId: notificationsToolLastEventId, onLastEventIdUpdate
+    });
 
     console.log('Tool result:');
     result.content.forEach(item => {

--- a/src/examples/client/simpleStreamableHttp.ts
+++ b/src/examples/client/simpleStreamableHttp.ts
@@ -302,7 +302,7 @@ async function callTool(name: string, args: Record<string, unknown>): Promise<vo
       notificationsToolLastEventId = event;
     };
     const result = await client.request(request, CallToolResultSchema, {
-      lastEventId: notificationsToolLastEventId, onLastEventIdUpdate
+      resumptionToken: notificationsToolLastEventId, onresumptiontoken: onLastEventIdUpdate
     });
 
     console.log('Tool result:');

--- a/src/examples/client/simpleStreamableHttp.ts
+++ b/src/examples/client/simpleStreamableHttp.ts
@@ -111,7 +111,7 @@ function commandLoop(): void {
 
         case 'start-notifications': {
           const interval = args[1] ? parseInt(args[1], 10) : 2000;
-          const count = args[2] ? parseInt(args[2], 10) : 0;
+          const count = args[2] ? parseInt(args[2], 10) : 10;
           await startNotifications(interval, count);
           break;
         }

--- a/src/examples/server/simpleStreamableHttp.ts
+++ b/src/examples/server/simpleStreamableHttp.ts
@@ -172,14 +172,18 @@ server.tool(
 
     while (count === 0 || counter < count) {
       counter++;
-      await sendNotification({
-        method: "notifications/message",
-        params: {
-          level: "info",
-          data: `Periodic notification #${counter} at ${new Date().toISOString()}`
-        }
-      });
-
+      try {
+        await sendNotification({
+          method: "notifications/message",
+          params: {
+            level: "info",
+            data: `Periodic notification #${counter} at ${new Date().toISOString()}`
+          }
+        });
+      }
+      catch (error) {
+        console.error("Error sending notification:", error);
+      }
       // Wait for the specified interval
       await sleep(interval);
     }

--- a/src/integration-tests/taskResumability.test.ts
+++ b/src/integration-tests/taskResumability.test.ts
@@ -247,8 +247,8 @@ describe('Transport resumability', () => {
         }
       }
     }, CallToolResultSchema, {
-      lastEventId,
-      onLastEventIdUpdate
+      resumptionToken: lastEventId,
+      onresumptiontoken: onLastEventIdUpdate
     });
 
     // Wait for some notifications to arrive (not all)
@@ -311,8 +311,8 @@ describe('Transport resumability', () => {
         }
       }
     }, CallToolResultSchema, {
-      lastEventId,  // Pass the lastEventId from the previous session
-      onLastEventIdUpdate
+      resumptionToken: lastEventId,  // Pass the lastEventId from the previous session
+      onresumptiontoken: onLastEventIdUpdate
     });
 
     // Verify we eventually received at leaset a few motifications

--- a/src/integration-tests/taskResumability.test.ts
+++ b/src/integration-tests/taskResumability.test.ts
@@ -260,8 +260,7 @@ describe('Transport resumability', () => {
     expect(onLastEventIdUpdate).toHaveBeenCalled();
     expect(lastEventId).toBeDefined();
 
-    // Store original notification count for later comparison
-    const firstClientNotificationCount = notifications.length;
+
     // Disconnect first client without waiting for completion
     // When we close the connection, it will cause a ConnectionClosed error for
     // any in-progress requests, which is expected behavior

--- a/src/integration-tests/taskResumability.test.ts
+++ b/src/integration-tests/taskResumability.test.ts
@@ -1,0 +1,329 @@
+import { createServer, type Server } from 'node:http';
+import { AddressInfo } from 'node:net';
+import { randomUUID } from 'node:crypto';
+import { Client } from '../client/index.js';
+import { StreamableHTTPClientTransport } from '../client/streamableHttp.js';
+import { McpServer } from '../server/mcp.js';
+import { EventStore, StreamableHTTPServerTransport } from '../server/streamableHttp.js';
+import { CallToolResult, CallToolResultSchema, JSONRPCMessage, LoggingMessageNotificationSchema } from '../types.js';
+import { z } from 'zod';
+
+/**
+ * Simple in-memory event store implementation for resumability
+ */
+class InMemoryEventStore implements EventStore {
+  private events: Map<string, { streamId: string, message: JSONRPCMessage }> = new Map();
+
+  generateEventId(streamId: string): string {
+    return `${streamId}_${Date.now()}_${Math.random().toString(36).substring(2, 10)}`;
+  }
+
+  getStreamIdFromEventId(eventId: string): string {
+    const parts = eventId.split('_');
+    return parts.length > 0 ? parts[0] : '';
+  }
+
+  async storeEvent(streamId: string, message: JSONRPCMessage): Promise<string> {
+    const eventId = this.generateEventId(streamId);
+    this.events.set(eventId, { streamId, message });
+    return eventId;
+  }
+
+  async getEventsAfter(lastEventId: string): Promise<Array<{ eventId: string, message: JSONRPCMessage }>> {
+    if (!lastEventId || !this.events.has(lastEventId)) {
+      return [];
+    }
+
+    // Extract the stream ID from the event ID
+    const streamId = this.getStreamIdFromEventId(lastEventId);
+    const result: Array<{ eventId: string, message: JSONRPCMessage }> = [];
+    let foundLastEvent = false;
+
+    // Sort events by eventId for chronological ordering
+    const sortedEvents = [...this.events.entries()].sort((a, b) => a[0].localeCompare(b[0]));
+
+    for (const [eventId, { streamId: eventStreamId, message }] of sortedEvents) {
+      // Only include events from the same stream
+      if (eventStreamId !== streamId) {
+        continue;
+      }
+
+      // Start collecting events after we find the lastEventId
+      if (eventId === lastEventId) {
+        foundLastEvent = true;
+        continue;
+      }
+
+      if (foundLastEvent) {
+        result.push({ eventId, message });
+      }
+    }
+
+    return result;
+  }
+}
+
+
+describe('Transport resumability', () => {
+  let server: Server;
+  let mcpServer: McpServer;
+  let serverTransport: StreamableHTTPServerTransport;
+  let baseUrl: URL;
+  let eventStore: InMemoryEventStore;
+
+  beforeEach(async () => {
+    // Create event store for resumability
+    eventStore = new InMemoryEventStore();
+
+    // Create a simple MCP server
+    mcpServer = new McpServer(
+      { name: 'test-server', version: '1.0.0' },
+      { capabilities: { logging: {} } }
+    );
+
+    // Add a simple notification tool that completes quickly
+    mcpServer.tool(
+      'send-notification',
+      'Sends a single notification',
+      {
+        message: z.string().describe('Message to send').default('Test notification')
+      },
+      async ({ message }, { sendNotification }) => {
+        // Send notification immediately
+        await sendNotification({
+          method: "notifications/message",
+          params: {
+            level: "info",
+            data: message
+          }
+        });
+
+        return {
+          content: [{ type: 'text', text: 'Notification sent' }]
+        };
+      }
+    );
+
+    // Add a long-running tool that sends multiple notifications
+    mcpServer.tool(
+      'run-notifications',
+      'Sends multiple notifications over time',
+      {
+        count: z.number().describe('Number of notifications to send').default(10),
+        interval: z.number().describe('Interval between notifications in ms').default(50)
+      },
+      async ({ count, interval }, { sendNotification }) => {
+        // Send notifications at specified intervals
+        for (let i = 0; i < count; i++) {
+          await sendNotification({
+            method: "notifications/message",
+            params: {
+              level: "info",
+              data: `Notification ${i + 1} of ${count}`
+            }
+          });
+
+          // Wait for the specified interval before sending next notification
+          if (i < count - 1) {
+            await new Promise(resolve => setTimeout(resolve, interval));
+          }
+        }
+
+        return {
+          content: [{ type: 'text', text: `Sent ${count} notifications` }]
+        };
+      }
+    );
+
+    // Create a transport with the event store
+    serverTransport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: () => randomUUID(),
+      eventStore
+    });
+
+    // Connect the transport to the MCP server
+    await mcpServer.connect(serverTransport);
+
+    // Create and start an HTTP server
+    server = createServer(async (req, res) => {
+      await serverTransport.handleRequest(req, res);
+    });
+
+    // Start the server on a random port
+    baseUrl = await new Promise<URL>((resolve) => {
+      server.listen(0, '127.0.0.1', () => {
+        const addr = server.address() as AddressInfo;
+        resolve(new URL(`http://127.0.0.1:${addr.port}`));
+      });
+    });
+  });
+
+  afterEach(async () => {
+    // Clean up resources
+    await mcpServer.close().catch(() => { });
+    await serverTransport.close().catch(() => { });
+    server.close();
+  });
+
+  it('should store session ID when client connects', async () => {
+    // Create and connect a client
+    const client = new Client({
+      name: 'test-client',
+      version: '1.0.0'
+    });
+
+    const transport = new StreamableHTTPClientTransport(baseUrl);
+    await client.connect(transport);
+
+    // Verify session ID was generated
+    expect(transport.sessionId).toBeDefined();
+
+    // Clean up
+    await transport.close();
+  });
+
+  it('should have session ID functionality', async () => {
+    // The ability to store a session ID when connecting
+    const client = new Client({
+      name: 'test-client-reconnection',
+      version: '1.0.0'
+    });
+
+    const transport = new StreamableHTTPClientTransport(baseUrl);
+
+    // Make sure the client can connect and get a session ID
+    await client.connect(transport);
+    expect(transport.sessionId).toBeDefined();
+
+    // Clean up
+    await transport.close();
+  });
+
+  // This test demonstrates the capability to resume long-running tools
+  // across client disconnection/reconnection
+  it('should resume long-running notifications with lastEventId', async () => {
+    // Create unique client ID for this test
+    const clientId = 'test-client-long-running';
+    const notifications: any[] = [];
+    let sessionId: string | undefined;
+    let lastEventId: string | undefined;
+
+    // Create first client
+    let client1 = new Client({
+      id: clientId,
+      name: 'test-client',
+      version: '1.0.0'
+    });
+
+    // Set up notification handler for first client
+    client1.setNotificationHandler(LoggingMessageNotificationSchema, (notification: any) => {
+      if (notification.method === 'notifications/message') {
+        notifications.push(notification.params);
+      }
+    });
+
+    // Connect first client
+    const transport1 = new StreamableHTTPClientTransport(baseUrl);
+    await client1.connect(transport1);
+    sessionId = transport1.sessionId;
+    expect(sessionId).toBeDefined();
+
+    // Start a long-running notification stream with tracking of lastEventId
+    const onLastEventIdUpdate = jest.fn((eventId: string) => {
+      lastEventId = eventId;
+    });
+
+    // Start the notification tool with event tracking using request
+    const toolPromise = client1.request({
+      method: 'tools/call',
+      params: {
+        name: 'run-notifications',
+        arguments: {
+          count: 5,
+          interval: 10
+        }
+      }
+    }, CallToolResultSchema, {
+      lastEventId,
+      onLastEventIdUpdate
+    });
+
+    // Wait for some notifications to arrive (not all)
+    await new Promise(resolve => setTimeout(resolve, 20));
+
+    // Verify we received some notifications and lastEventId was updated
+    expect(notifications.length).toBeGreaterThan(0);
+    expect(notifications.length).toBeLessThan(5);
+    expect(onLastEventIdUpdate).toHaveBeenCalled();
+    expect(lastEventId).toBeDefined();
+
+    // Store original notification count for later comparison
+    const firstClientNotificationCount = notifications.length;
+
+    // Disconnect first client without waiting for completion
+    // When we close the connection, it will cause a ConnectionClosed error for
+    // any in-progress requests, which is expected behavior
+    // We need to catch the error since closing the transport will
+    // cause the pending toolPromise to reject with a ConnectionClosed error
+    await transport1.close();
+
+    // Try to cancel the promise, but ignore errors since it's already being handled
+    toolPromise.catch(err => {
+      // This error is expected - the connection was intentionally closed
+      if (err?.code !== -32000) { // ConnectionClosed error code
+        console.error("Unexpected error type during transport close:", err);
+      }
+    });
+
+
+    // Create second client with same client ID
+    const client2 = new Client({
+      id: clientId,
+      name: 'test-client',
+      version: '1.0.0'
+    });
+
+    // Set up notification handler for second client
+    client2.setNotificationHandler(LoggingMessageNotificationSchema, (notification: any) => {
+      if (notification.method === 'notifications/message') {
+        notifications.push(notification.params);
+      }
+    });
+
+    // Connect second client with same session ID
+    const transport2 = new StreamableHTTPClientTransport(baseUrl, {
+      sessionId
+    });
+    await client2.connect(transport2);
+
+    // Resume the notification stream using lastEventId
+    // This is the key part - we're resuming the same long-running tool using lastEventId
+    const resumedToolPromise = client2.request({
+      method: 'tools/call',
+      params: {
+        name: 'run-notifications',
+        arguments: {
+          count: 5,
+          interval: 50
+        }
+      }
+    }, CallToolResultSchema, {
+      lastEventId,  // Pass the lastEventId from the previous session
+      onLastEventIdUpdate
+    });
+
+    // Wait for remaining notifications
+    await new Promise(resolve => setTimeout(resolve, 200));
+
+    // Verify we eventually received at leaset a few motifications
+    expect(notifications.length).toBeGreaterThan(2);
+
+    // Verify the second client received notifications that the first client didn't
+    expect(notifications.length).toBeGreaterThan(firstClientNotificationCount);
+
+    // Clean up
+
+    await transport2.close();
+
+  });
+});

--- a/src/server/streamableHttp.ts
+++ b/src/server/streamableHttp.ts
@@ -217,7 +217,6 @@ export class StreamableHTTPServerTransport implements Transport {
 
     // Assign the response to the standalone SSE stream
     this._streamMapping.set(this._standaloneSseStreamId, res);
-
     // Set up close handler for client disconnects
     res.on("close", () => {
       this._streamMapping.delete(this._standaloneSseStreamId);
@@ -345,8 +344,10 @@ export class StreamableHTTPServerTransport implements Transport {
       const isInitializationRequest = messages.some(
         msg => 'method' in msg && msg.method === 'initialize'
       );
+      const mcpSessionId = req.headers["mcp-session-id"] as string | undefined;
       if (isInitializationRequest) {
-        if (this._initialized) {
+        // if generateSessionId is not set, the server does not support session management
+        if (this._initialized && this.sessionId !== undefined && mcpSessionId !== this.sessionId) {
           res.writeHead(400).end(JSON.stringify({
             jsonrpc: "2.0",
             error: {
@@ -368,7 +369,7 @@ export class StreamableHTTPServerTransport implements Transport {
           }));
           return;
         }
-        this.sessionId = this.sessionIdGenerator();
+        this.sessionId = mcpSessionId ?? this.sessionIdGenerator();
         this._initialized = true;
 
       }
@@ -419,17 +420,8 @@ export class StreamableHTTPServerTransport implements Transport {
             this._requestToStreamMapping.set(message.id, streamId);
           }
         }
-
         // Set up close handler for client disconnects
         res.on("close", () => {
-          // find a stream ID for this response
-          // Remove all entries that reference this response
-          for (const [id, stream] of this._requestToStreamMapping.entries()) {
-            if (streamId === stream) {
-              this._requestToStreamMapping.delete(id);
-              this._requestResponseMap.delete(id);
-            }
-          }
           this._streamMapping.delete(streamId);
         });
 
@@ -577,7 +569,7 @@ export class StreamableHTTPServerTransport implements Transport {
     // Get the response for this request
     const streamId = this._requestToStreamMapping.get(requestId);
     const response = this._streamMapping.get(streamId!);
-    if (!streamId || !response) {
+    if (!streamId) {
       throw new Error(`No connection established for request ID: ${String(requestId)}`);
     }
 
@@ -588,9 +580,10 @@ export class StreamableHTTPServerTransport implements Transport {
       if (this._eventStore) {
         eventId = await this._eventStore.storeEvent(streamId, message);
       }
-
-      // Write the event to the response stream
-      this.writeSSEEvent(response, message, eventId);
+      if (response) {
+        // Write the event to the response stream
+        this.writeSSEEvent(response, message, eventId);
+      }
     }
 
     if (isJSONRPCResponse(message)) {
@@ -603,6 +596,9 @@ export class StreamableHTTPServerTransport implements Transport {
       const allResponsesReady = relatedIds.every(id => this._requestResponseMap.has(id));
 
       if (allResponsesReady) {
+        if (!response) {
+          throw new Error(`No connection established for request ID: ${String(requestId)}`);
+        }
         if (this._enableJsonResponse) {
           // All responses ready, send as JSON
           const headers: Record<string, string> = {

--- a/src/server/streamableHttp.ts
+++ b/src/server/streamableHttp.ts
@@ -346,7 +346,8 @@ export class StreamableHTTPServerTransport implements Transport {
       );
       const mcpSessionId = req.headers["mcp-session-id"] as string | undefined;
       if (isInitializationRequest) {
-        // if generateSessionId is not set, the server does not support session management
+        // If it's a server with session management and the session ID is already set we should reject the request
+        // to avoid re-initialization.
         if (this._initialized && this.sessionId !== undefined && mcpSessionId !== this.sessionId) {
           res.writeHead(400).end(JSON.stringify({
             jsonrpc: "2.0",

--- a/src/server/streamableHttp.ts
+++ b/src/server/streamableHttp.ts
@@ -331,11 +331,10 @@ export class StreamableHTTPServerTransport implements Transport {
       const isInitializationRequest = messages.some(
         msg => 'method' in msg && msg.method === 'initialize'
       );
-      const mcpSessionId = req.headers["mcp-session-id"] as string | undefined;
       if (isInitializationRequest) {
         // If it's a server with session management and the session ID is already set we should reject the request
         // to avoid re-initialization.
-        if (this._initialized && this.sessionId !== undefined && mcpSessionId !== this.sessionId) {
+        if (this._initialized) {
           res.writeHead(400).end(JSON.stringify({
             jsonrpc: "2.0",
             error: {
@@ -357,7 +356,7 @@ export class StreamableHTTPServerTransport implements Transport {
           }));
           return;
         }
-        this.sessionId = mcpSessionId ?? this.sessionIdGenerator();
+        this.sessionId = this.sessionIdGenerator();
         this._initialized = true;
 
       }

--- a/src/shared/protocol.ts
+++ b/src/shared/protocol.ts
@@ -87,16 +87,15 @@ export type RequestOptions = {
    * May be used to indicate to the transport which incoming request to associate this outgoing request with.
    */
   relatedRequestId?: RequestId;
-
   /**
-   * May be used to indicate to the transport which last event ID to associate this outgoing request with.
-   * This is used to resume a long-running requests that may have been interrupted and a new instance of a client is being created.
+   * The last event ID to associate with the request.
+   * Used to resume long-running requests that were interrupted when creating a new client instance.
    */
   lastEventId?: string;
 
   /**
    * A callback that is invoked when the last event ID is updated.
-   * This is used to notidy the client that the last event ID has changed, so that client can update its state accordingly.
+   * This is used to notify the client that the last event ID has changed, so the client can update its state accordingly.
    */
   onLastEventIdUpdate?: (event: string) => void;
 };

--- a/src/shared/protocol.ts
+++ b/src/shared/protocol.ts
@@ -22,7 +22,7 @@ import {
   Result,
   ServerCapabilities,
 } from "../types.js";
-import { Transport } from "./transport.js";
+import { Transport, TransportSendOptions } from "./transport.js";
 
 /**
  * Callback for progress notifications.
@@ -82,26 +82,7 @@ export type RequestOptions = {
    * If not specified, there is no maximum total timeout.
    */
   maxTotalTimeout?: number;
-
-  /**
-   * May be used to indicate to the transport which incoming request to associate this outgoing request with.
-   */
-  relatedRequestId?: RequestId;
-
-  /**
-   * The resumption token used to continue long-running requests that were interrupted.
-   *
-   * This allows clients to reconnect and continue from where they left off, if supported by the transport.
-   */
-  resumptionToken?: string;
-
-  /**
-   * A callback that is invoked when the resumption token changes, if supported by the transport.
-   *
-   * This allows clients to persist the latest token for potential reconnection.
-   */
-  onresumptiontoken?: (token: string) => void;
-};
+} & TransportSendOptions;
 
 /**
  * Options that can be given per notification.

--- a/src/shared/transport.ts
+++ b/src/shared/transport.ts
@@ -18,7 +18,7 @@ export interface Transport {
    * 
    * If present, `relatedRequestId` is used to indicate to the transport which incoming request to associate this outgoing message with.
    */
-  send(message: JSONRPCMessage, options?: { relatedRequestId?: RequestId }): Promise<void>;
+  send(message: JSONRPCMessage, options?: { relatedRequestId?: RequestId, lastEventId?: string, onLastEventIdUpdate?: (event: string) => void }): Promise<void>;
 
   /**
    * Closes the connection.

--- a/src/shared/transport.ts
+++ b/src/shared/transport.ts
@@ -1,6 +1,27 @@
 import { JSONRPCMessage, RequestId } from "../types.js";
 
 /**
+   * Options for sending a JSON-RPC message.
+   */
+export interface TransportSendOptions {
+  /** 
+   * If present, `relatedRequestId` is used to indicate to the transport which incoming request to associate this outgoing message with.
+  */
+  relatedRequestId?: RequestId;
+  /**
+   * The resumption token used to continue long-running requests that were interrupted.
+   *
+   * This allows clients to reconnect and continue from where they left off, if supported by the transport.
+   */
+  resumptionToken?: string;
+  /**
+   * A callback that is invoked when the resumption token changes, if supported by the transport.
+   *
+   * This allows clients to persist the latest token for potential reconnection.
+   */
+  onresumptiontoken?: (token: string) => void;
+}
+/**
  * Describes the minimal contract for a MCP transport that a client or server can communicate over.
  */
 export interface Transport {
@@ -18,7 +39,7 @@ export interface Transport {
    * 
    * If present, `relatedRequestId` is used to indicate to the transport which incoming request to associate this outgoing message with.
    */
-  send(message: JSONRPCMessage, options?: { relatedRequestId?: RequestId, lastEventId?: string, onLastEventIdUpdate?: (event: string) => void }): Promise<void>;
+  send(message: JSONRPCMessage, options?: TransportSendOptions): Promise<void>;
 
   /**
    * Closes the connection.

--- a/src/shared/transport.ts
+++ b/src/shared/transport.ts
@@ -1,19 +1,21 @@
 import { JSONRPCMessage, RequestId } from "../types.js";
 
 /**
-   * Options for sending a JSON-RPC message.
-   */
-export interface TransportSendOptions {
+ * Options for sending a JSON-RPC message.
+ */
+export type TransportSendOptions = {
   /** 
    * If present, `relatedRequestId` is used to indicate to the transport which incoming request to associate this outgoing message with.
-  */
+   */
   relatedRequestId?: RequestId;
+
   /**
    * The resumption token used to continue long-running requests that were interrupted.
    *
    * This allows clients to reconnect and continue from where they left off, if supported by the transport.
    */
   resumptionToken?: string;
+
   /**
    * A callback that is invoked when the resumption token changes, if supported by the transport.
    *


### PR DESCRIPTION
Introducing functionality that allows users to resume long-running requests. This feature is useful for scenarios where:

- Tools or processes require extended execution time
- Users need to check progress periodically (e.g., every few hours)
- Continuous client connection for notifications is unnecessary or impractical


Features:
- Clients can pass a session ID to reconnect with an existing session
- Resume and replay: Tools can accept the last event ID to resume from that point, replaying notifications and waiting for responses
