### PR TITLE
StreamableHTTPServerTransport should only check init status when sessionId existing

### DIFF
--- a/src/server/streamableHttp.ts
+++ b/src/server/streamableHttp.ts
@@ -371,7 +371,7 @@ export class StreamableHTTPServerTransport implements Transport {
    * Returns true if the session is valid, false otherwise
    */
   private validateSession(req: IncomingMessage, res: ServerResponse): boolean {
-    if (!this._initialized) {
+    if (this.sessionId && !this._initialized) {
       // If the server has not been initialized yet, reject all requests
       res.writeHead(400).end(JSON.stringify({
         jsonrpc: "2.0",


### PR DESCRIPTION
## Motivation and Context
When using stateless mode, the backend will create a new transport for each request. For new transport, the initialized filed is always false. So we should only check the initialized filed if there is session existing

## How Has This Been Tested?
Tested in local MCP Server. At backend, I create a new transport object and meet the issue. the PR fixed it.

## Breaking Changes
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ X] My code follows the repository's style guidelines
- [ X] New and existing tests pass locally
- [ X] I have added appropriate error handling
- [ X] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
