### PR TITLE
stateless had a wrong example

### DIFF
--- a/src/server/streamableHttp.ts
+++ b/src/server/streamableHttp.ts
@@ -35,12 +35,12 @@ export interface StreamableHTTPServerTransportOptions {
  * ```typescript
  * // Stateful mode - server sets the session ID
  * const statefulTransport = new StreamableHTTPServerTransport({
- *  sessionId: randomUUID(),
+ *   sessionIdGenerator: () => randomUUID(),
  * });
  * 
  * // Stateless mode - explicitly set session ID to undefined
  * const statelessTransport = new StreamableHTTPServerTransport({
- *    sessionId: undefined,
+ *   sessionIdGenerator: () => undefined,
  * });
  * 
  * // Using with pre-parsed request body

--- a/src/server/streamableHttp.ts
+++ b/src/server/streamableHttp.ts
@@ -40,7 +40,7 @@ export interface StreamableHTTPServerTransportOptions {
  * 
  * // Stateless mode - explicitly set session ID to undefined
  * const statelessTransport = new StreamableHTTPServerTransport({
- *   sessionIdGenerator: () => undefined,
+ *   sessionIdGenerator: undefined,
  * });
  * 
  * // Using with pre-parsed request body


### PR DESCRIPTION

## Motivation and Context
Docs fauly

## How Has This Been Tested?
I'm baking MCP server so I saw

## Breaking Changes
No
## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
N/A