### PR TITLE
fix: Forwarding EventSource headers to requests to reuse EventSource…

### DIFF
--- a/src/client/sse.ts
+++ b/src/client/sse.ts
@@ -116,6 +116,7 @@ export class SSEClientTransport implements Transport {
           fetch: (url, init) => this._commonHeaders().then((headers) => fetch(url, {
             ...init,
             headers: {
+              ...(init?.headers || {}),
               ...headers,
               Accept: "text/event-stream"
             }


### PR DESCRIPTION
fix: Forwarding EventSource headers to requests to reuse EventSource's Last-Event-ID, solving the session ID reuse problem during reconnection.

<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
The current MCP protocol in SSE mode does not yet support reconnection with sessionId. If we forward the last-event-id created by EventSource, and the SSE server delivers the sessionId as the SSE id, the client can leverage EventSource's last-event-id mechanism during reconnection to resume a connection with the same sessionId instead of issuing a new sessionId.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
