### PR TITLE
StreamableHTTPServerTransport should support multiple initializations 

### DIFF
--- a/src/server/streamableHttp.test.ts
+++ b/src/server/streamableHttp.test.ts
@@ -1077,6 +1077,13 @@ describe("StreamableHTTPServerTransport in stateless mode", () => {
     await stopTestServer({ server, transport });
   });
 
+  it("should support multiple initializations in stateless mode", async () => {
+    await sendPostRequest(baseUrl, TEST_MESSAGES.initialize);
+    const initResponse = await sendPostRequest(baseUrl, TEST_MESSAGES.initialize);
+    expect(initResponse.status).toBe(200);
+    expect(initResponse.headers.get("mcp-session-id")).toBeNull();
+  });
+
   it("should operate without session ID validation", async () => {
     // Initialize the server first
     const initResponse = await sendPostRequest(baseUrl, TEST_MESSAGES.initialize);

--- a/src/server/streamableHttp.ts
+++ b/src/server/streamableHttp.ts
@@ -334,7 +334,8 @@ export class StreamableHTTPServerTransport implements Transport {
       if (isInitializationRequest) {
         // If it's a server with session management and the session ID is already set we should reject the request
         // to avoid re-initialization.
-        if (this._initialized) {
+        // sessionId undefined means stateless mode, so we don't need to check for re-initialization
+        if (this._initialized && this.sessionId !== undefined) {
           res.writeHead(400).end(JSON.stringify({
             jsonrpc: "2.0",
             error: {


### PR DESCRIPTION
StreamableHTTPServerTransport should support multiple initialization

For stateless mode, mcp server should be able to handle multiple client request. Such as below usage 

```js
const server = new McpServer(
    {
      name: "mcp-typescript server on vercel",
      version: "0.1.0",
    },
    serverOptions
 );
 const statelessTransport = new StreamableHTTPServerTransport({
    sessionIdGenerator: ()=> undifined,
 });
server.connect(statelessTransport);
app.post('/mcp', (req, res) => {
  // only one  statelessTransport handle multi request
  // this is important for serverless mode
  statelessTransport.handleRequest(req, res, req.body);
});
```

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

## How Has This Been Tested?
Unit test and local test

## Breaking Changes
no

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
