### PR TITLE
fix: Add redirect_uri parameter to /token endpoint for the Authorization Code Flow

### DIFF
--- a/src/server/auth/handlers/token.ts
+++ b/src/server/auth/handlers/token.ts
@@ -31,6 +31,7 @@ const TokenRequestSchema = z.object({
 const AuthorizationCodeGrantSchema = z.object({
   code: z.string(),
   code_verifier: z.string(),
+  redirect_uri: z.string(),
 });
 
 const RefreshTokenGrantSchema = z.object({
@@ -88,7 +89,10 @@ export function tokenHandler({ provider, rateLimit: rateLimitConfig }: TokenHand
             throw new InvalidRequestError(parseResult.error.message);
           }
 
-          const { code, code_verifier } = parseResult.data;
+          const { code, code_verifier, redirect_uri } = parseResult.data;
+          if (!client.redirect_uris.includes(redirect_uri)) {
+            throw new InvalidRequestError("Unregistered redirect_uri");
+          }
 
           const skipLocalPkceValidation = provider.skipLocalPkceValidation;
 
@@ -102,7 +106,7 @@ export function tokenHandler({ provider, rateLimit: rateLimitConfig }: TokenHand
           }
 
           // Passes the code_verifier to the provider if PKCE validation didn't occur locally
-          const tokens = await provider.exchangeAuthorizationCode(client, code, skipLocalPkceValidation ? code_verifier : undefined);
+          const tokens = await provider.exchangeAuthorizationCode(client, code, redirect_uri, skipLocalPkceValidation ? code_verifier : undefined);
           res.status(200).json(tokens);
           break;
         }

--- a/src/server/auth/provider.ts
+++ b/src/server/auth/provider.ts
@@ -36,7 +36,7 @@ export interface OAuthServerProvider {
   /**
    * Exchanges an authorization code for an access token.
    */
-  exchangeAuthorizationCode(client: OAuthClientInformationFull, authorizationCode: string, codeVerifier?: string): Promise<OAuthTokens>;
+  exchangeAuthorizationCode(client: OAuthClientInformationFull, authorizationCode: string, redirectUri: string, codeVerifier?: string): Promise<OAuthTokens>;
 
   /**
    * Exchanges a refresh token for an access token.

--- a/src/server/auth/providers/proxyProvider.test.ts
+++ b/src/server/auth/providers/proxyProvider.test.ts
@@ -126,6 +126,7 @@ describe("Proxy OAuth Server Provider", () => {
       const tokens = await provider.exchangeAuthorizationCode(
         validClient,
         "test-code",
+        "https://example.com/callback",
         "test-verifier"
       );
 

--- a/src/server/auth/providers/proxyProvider.ts
+++ b/src/server/auth/providers/proxyProvider.ts
@@ -151,12 +151,14 @@ export class ProxyOAuthServerProvider implements OAuthServerProvider {
   async exchangeAuthorizationCode(
     client: OAuthClientInformationFull,
     authorizationCode: string,
+    redirectUri: string,
     codeVerifier?: string
   ): Promise<OAuthTokens> {
     const params = new URLSearchParams({
       grant_type: "authorization_code",
       client_id: client.client_id,
       code: authorizationCode,
+      redirect_uri: redirectUri,
     });
 
     if (client.client_secret) {


### PR DESCRIPTION
Add `redirect_uri` parameter to /token endpoint for the Authentication Code Flow.

## Motivation and Context

The `redirect_uri` parameter is required for the Authorization Code Flow defined in [RFC 6749](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.3).
But the current MCP SDK doesn't accept this parameter and just ignore it.

## How Has This Been Tested?

`npm test`. And I also tested by the below server implementation:

```typescript
import express, { Request, Response } from "express"
import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js"
import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js"
import { mcpAuthRouter } from '@modelcontextprotocol/sdk/server/auth/router.js'
import { ProxyOAuthServerProvider } from '@modelcontextprotocol/sdk/server/auth/providers/proxyProvider.js'
import { requireBearerAuth } from "@modelcontextprotocol/sdk/server/auth/middleware/bearerAuth.js"

const BASE_URL = "http://localhost:3001"
const ISSUER = "https://your-tenant.auth0.com/"

const server = new McpServer({
  name: "mcp-server",
  version: "1.0.0",
})

server.resource(
  "greeting",
  new ResourceTemplate("greeting://{name}", { list: undefined }),
  async (uri, { name }) => ({
    contents: [{
      uri: uri.href,
      text: `Hello, ${name}!`
    }]
  })
);

const app = express();

const proxyProvider = new ProxyOAuthServerProvider({
  endpoints: {
    authorizationUrl: new URL("/authorize", ISSUER).toString(),
    tokenUrl: new URL("/oauth/token", ISSUER).toString(),
    registrationUrl: new URL("/oidc/register", ISSUER).toString(),
  },
  verifyAccessToken: async (token) => {
    console.log(token)  // for test
    return {
      token,
      clientId: "dummy",
      scopes: [],
    }
  },
  getClient: async (client_id) => {
    return {
      client_id,
      redirect_uris: ["http://127.0.0.1:6274/oauth/callback"],
    }
  }
})

app.use(mcpAuthRouter({
  provider: proxyProvider,
  issuerUrl: new URL(ISSUER),
  baseUrl: new URL(BASE_URL),
}))


const transports: { [sessionId: string]: SSEServerTransport } = {};

app.get("/sse", requireBearerAuth({provider: proxyProvider}), async (_: Request, res: Response) => {
  const transport = new SSEServerTransport('/messages', res);
  transports[transport.sessionId] = transport;
  res.on("close", () => {
    delete transports[transport.sessionId];
  });
  await server.connect(transport);
});

app.post("/messages", requireBearerAuth({provider: proxyProvider}), async (req: Request, res: Response) => {
  const sessionId = req.query.sessionId as string;
  const transport = transports[sessionId];
  if (transport) {
    await transport.handlePostMessage(req, res);
  } else {
    res.status(400).send('No transport found for sessionId');
  }
});

app.listen(3001)
```

I verified that my Auth0 tenant returns an access token when accessed with MCP Inspector.

## Breaking Changes

The /token endpoint now requires a `redirect_uri`, however this is in accordance with the OAuth specification.

I also add `redirector` argument to`exchangeAuthorizationCode` of the `OAuthServerProvider`.
This might require some fix if developer uses `OAuthServerProvider` class.
(But I think it is few usage since currently this functionality missing required parameter)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
