### PR TITLE
Add StdioParseError for improved error handling in stdio stream processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,10 +325,9 @@ app.use(express.json());
 
 // Handle all MCP requests (GET, POST, DELETE) at a single endpoint
 app.all('/mcp', async (req, res) => {
-  // Create a transport with sessionIdGenerator set to return undefined
-  // This disables session tracking completely
+  // Disable session tracking by setting sessionIdGenerator to undefined  
   const transport = new StreamableHTTPServerTransport({
-    sessionIdGenerator: () => undefined,
+    sessionIdGenerator: undefined,
     req,
     res
   });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/sdk",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Model Context Protocol implementation for TypeScript",
   "license": "MIT",
   "author": "Anthropic, PBC (https://anthropic.com)",

--- a/src/client/stdio.ts
+++ b/src/client/stdio.ts
@@ -2,7 +2,7 @@ import { ChildProcess, IOType } from "node:child_process";
 import spawn from "cross-spawn";
 import process from "node:process";
 import { Stream } from "node:stream";
-import { ReadBuffer, serializeMessage } from "../shared/stdio.js";
+import { ReadBuffer, StdioParseError, serializeMessage } from "../shared/stdio.js";
 import { Transport } from "../shared/transport.js";
 import { JSONRPCMessage } from "../types.js";
 
@@ -180,7 +180,13 @@ export class StdioClientTransport implements Transport {
 
         this.onmessage?.(message);
       } catch (error) {
-        this.onerror?.(error as Error);
+        if (error instanceof StdioParseError) {
+          // print bare line message
+          console.log(error.line);
+          continue;
+        } else {
+          this.onerror?.(error as Error);
+        }
       }
     }
   }

--- a/src/client/streamableHttp.test.ts
+++ b/src/client/streamableHttp.test.ts
@@ -169,11 +169,7 @@ describe("StreamableHTTPClientTransport", () => {
       headers: new Headers()
     });
 
-    // This should not throw an error
-    await transport.terminateSession();
-
-    // The session ID should still be preserved since termination wasn't accepted
-    expect(transport.sessionId).toBe("test-session-id");
+    await expect(transport.terminateSession()).resolves.not.toThrow();
   });
 
   it("should handle 404 response when session expires", async () => {

--- a/src/client/streamableHttp.ts
+++ b/src/client/streamableHttp.ts
@@ -505,10 +505,7 @@ export class StreamableHTTPClientTransport implements Transport {
         );
       }
 
-      // If session termination was successful, clear our session ID
-      if (response.ok) {
-        this._sessionId = undefined;
-      }
+      this._sessionId = undefined;
     } catch (error) {
       this.onerror?.(error as Error);
       throw error;

--- a/src/client/streamableHttp.ts
+++ b/src/client/streamableHttp.ts
@@ -1,5 +1,5 @@
 import { Transport } from "../shared/transport.js";
-import { isInitializedNotification, isJSONRPCNotification, isJSONRPCRequest, isJSONRPCResponse, JSONRPCMessage, JSONRPCMessageSchema } from "../types.js";
+import { isInitializedNotification, isJSONRPCRequest, isJSONRPCResponse, JSONRPCMessage, JSONRPCMessageSchema } from "../types.js";
 import { auth, AuthResult, OAuthClientProvider, UnauthorizedError } from "./auth.js";
 import { EventSourceParserStream } from "eventsource-parser/stream";
 

--- a/src/client/streamableHttp.ts
+++ b/src/client/streamableHttp.ts
@@ -1,5 +1,5 @@
 import { Transport } from "../shared/transport.js";
-import { isJSONRPCNotification, isJSONRPCRequest, isJSONRPCResponse, JSONRPCMessage, JSONRPCMessageSchema } from "../types.js";
+import { isInitializedNotification, isJSONRPCNotification, isJSONRPCRequest, isJSONRPCResponse, JSONRPCMessage, JSONRPCMessageSchema } from "../types.js";
 import { auth, AuthResult, OAuthClientProvider, UnauthorizedError } from "./auth.js";
 import { EventSourceParserStream } from "eventsource-parser/stream";
 
@@ -420,7 +420,7 @@ export class StreamableHTTPClientTransport implements Transport {
       if (response.status === 202) {
         // if the accepted notification is initialized, we start the SSE stream
         // if it's supported by the server
-        if (isJSONRPCNotification(message) && message.method === "notifications/initialized") {
+        if (isInitializedNotification(message)) {
           // Start without a lastEventId since this is a fresh connection
           this._startOrAuthSse({ resumptionToken: undefined }).catch(err => this.onerror?.(err));
         }

--- a/src/examples/README.md
+++ b/src/examples/README.md
@@ -4,134 +4,294 @@ This directory contains example implementations of MCP clients and servers using
 
 ## Table of Contents
 
-- [Streamable HTTP Servers - Single Node Deployment](#streamable-http---single-node-deployment-with-basic-session-state-management)
-  - [Simple Server with Streamable HTTP](#simple-server-with-streamable-http-transport-serversimplestreamablehttpts)
-  - [Server Supporting SSE via GET](#server-supporting-with-sse-via-get-serverstandalonessewithgetstreamablehttpts)
-  - [Server with JSON Response Mode](#server-with-json-response-mode-serverjsonresponsestreamablehttpts)
-- [Client Example - Streamable HTTP](#client-clientsimplestreamablehttpts)
-- [Useful bash commands for testing](#useful-commands-for-testing)
+- [Client Implementations](#client-implementations)
+  - [Streamable HTTP Client](#streamable-http-client)
+  - [Backwards Compatible Client](#backwards-compatible-client)
+- [Server Implementations](#server-implementations)
+  - [Single Node Deployment](#single-node-deployment)
+    - [Streamable HTTP Transport](#streamable-http-transport)
+    - [Deprecated SSE Transport](#deprecated-sse-transport)
+    - [Backwards Compatible Server](#streamable-http-backwards-compatible-server-with-sse)
+  - [Multi-Node Deployment](#multi-node-deployment)
+- [Backwards Compatibility](#testing-streamable-http-backwards-compatibility-with-sse)
 
-## Streamable HTTP - single node deployment with basic session state management
+## Client Implementations
 
-Multi node with state management example will be added soon after we add support.
+### Streamable HTTP Client
 
+A full-featured interactive client that connects to a Streamable HTTP server, demonstrating how to:
 
-### Simple server with Streamable HTTP transport (`server/simpleStreamableHttp.ts`)
-
-A simple MCP server that uses the Streamable HTTP transport, implemented with Express. The server provides:
-
-- A simple `greet` tool that returns a greeting for a name
-- A `greeting-template` prompt that generates a greeting template
-- A static `greeting-resource` resource
-
-#### Running the server
-
-```bash
-npx tsx src/examples/server/simpleStreamableHttp.ts
-```
-
-The server will start on port 3000. You can test the initialization and tool listing:
-
-### Server supporting SSE via GET (`server/standaloneSseWithGetStreamableHttp.ts`)
-
-An MCP server that demonstrates how to support SSE notifications via GET requests using the Streamable HTTP transport with Express. The server dynamically adds resources at regular intervals and supports notifications for resource list changes (server notifications are available through the standalone SSE connection established by GET request).
-
-#### Running the server
-
-```bash
-npx tsx src/examples/server/standaloneSseWithGetStreamableHttp.ts
-```
-
-The server will start on port 3000 and automatically create new resources every 5 seconds.
-
-### Server with JSON response mode (`server/jsonResponseStreamableHttp.ts`)
-
-A simple MCP server that uses the Streamable HTTP transport with JSON response mode enabled, implemented with Express. The server provides a simple `greet` tool that returns a greeting for a name.
-
-_NOTE: This demonstrates a server that does not use SSE at all. Note that this limits its support for MCP features; for example, it cannot provide logging and progress notifications for tool execution._
-
-#### Running the server
-
-```bash
-npx tsx src/examples/server/jsonResponseStreamableHttp.ts
-```
-
-
-### Client (`client/simpleStreamableHttp.ts`)
-
-A client that connects to the server, initializes it, and demonstrates how to:
-
-- List available tools and call the `greet` tool
-- List available prompts and get the `greeting-template` prompt
+- Establish and manage a connection to an MCP server
+- List and call tools with arguments
+- Handle notifications through the SSE stream
+- List and get prompts with arguments
 - List available resources
-
-#### Running the client
+- Handle session termination and reconnection
+- Support for resumability with Last-Event-ID tracking
 
 ```bash
 npx tsx src/examples/client/simpleStreamableHttp.ts
 ```
 
-Make sure the server is running before starting the client.
+### Backwards Compatible Client
 
+A client that implements backwards compatibility according to the [MCP specification](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#backwards-compatibility), allowing it to work with both new and legacy servers. This client demonstrates:
 
-### Useful commands for testing
-
-#### Initialize
-Streamable HTTP transport requires to do the initialization first.
-
-```bash
-# First initialize the server and save the session ID to a variable
-SESSION_ID=$(curl -X POST \
-  -H "Content-Type: application/json" \
-  -H "Accept: application/json" \
-  -H "Accept: text/event-stream" \
-  -d '{
-    "jsonrpc": "2.0",
-    "method": "initialize",
-    "params": {
-      "capabilities": {},
-      "protocolVersion": "2025-03-26", 
-      "clientInfo": {
-        "name": "test",
-        "version": "1.0.0"
-      }
-    },
-    "id": "1"
-  }' \
-  -i http://localhost:3000/mcp 2>&1 | grep -i "mcp-session-id" | cut -d' ' -f2 | tr -d '\r')
-echo "Session ID: $SESSION_ID
-
-```
-Once a session is established, we can send POST requests:
-
-#### List tools
-```bash
-# Then list tools using the saved session ID 
-curl -X POST -H "Content-Type: application/json" -H "Accept: application/json, text/event-stream" \
-  -H "mcp-session-id: $SESSION_ID" \
-  -d '{"jsonrpc":"2.0","method":"tools/list","params":{},"id":"2"}' \
-  http://localhost:3000/mcp
-```
-
-#### Call tool 
+- The client first POSTs an initialize request to the server URL:
+  - If successful, it uses the Streamable HTTP transport
+  - If it fails with a 4xx status, it attempts a GET request to establish an SSE stream
 
 ```bash
-# Call the greet tool using the saved session ID
-curl -X POST \
-  -H "Content-Type: application/json" \
-  -H "Accept: application/json" \
-  -H "Accept: text/event-stream" \
-  -H "mcp-session-id: $SESSION_ID" \
-  -d '{
-    "jsonrpc": "2.0",
-    "method": "tools/call",
-    "params": {
-      "name": "greet",
-      "arguments": {
-        "name": "World"
-      }
-    },
-    "id": "2"
-  }' \
-  http://localhost:3000/mcp
+npx tsx src/examples/client/streamableHttpWithSseFallbackClient.ts
 ```
+
+## Server Implementations
+
+### Single Node Deployment
+
+These examples demonstrate how to set up an MCP server on a single node with different transport options.
+
+#### Streamable HTTP Transport
+
+##### Simple Streamable HTTP Server
+
+A server that implements the Streamable HTTP transport (protocol version 2025-03-26). 
+
+- Basic server setup with Express and the Streamable HTTP transport
+- Session management with an in-memory event store for resumability
+- Tool implementation with the `greet` and `multi-greet` tools
+- Prompt implementation with the `greeting-template` prompt
+- Static resource exposure
+- Support for notifications via SSE stream established by GET requests
+- Session termination via DELETE requests
+
+```bash
+npx tsx src/examples/server/simpleStreamableHttp.ts
+```
+
+##### JSON Response Mode Server
+
+A server that uses Streamable HTTP transport with JSON response mode enabled (no SSE). 
+
+- Streamable HTTP with JSON response mode, which returns responses directly in the response body
+- Limited support for notifications (since SSE is disabled)
+- Proper response handling according to the MCP specification for servers that don't support SSE
+- Returning appropriate HTTP status codes for unsupported methods
+
+```bash
+npx tsx src/examples/server/jsonResponseStreamableHttp.ts
+```
+
+##### Streamable HTTP with server notifications
+
+A server that demonstrates server notifications using Streamable HTTP. 
+
+- Resource list change notifications with dynamically added resources
+- Automatic resource creation on a timed interval
+
+
+```bash
+npx tsx src/examples/server/standaloneSseWithGetStreamableHttp.ts
+```
+
+#### Deprecated SSE Transport
+
+A server that implements the deprecated HTTP+SSE transport (protocol version 2024-11-05). This example only used for testing backwards compatibility for clients.
+
+- Two separate endpoints: `/mcp` for the SSE stream (GET) and `/messages` for client messages (POST)
+- Tool implementation with a `start-notification-stream` tool that demonstrates sending periodic notifications
+
+```bash
+npx tsx src/examples/server/simpleSseServer.ts
+```
+
+#### Streamable Http Backwards Compatible Server with SSE 
+
+A server that supports both Streamable HTTP and SSE transports, adhering to the [MCP specification for backwards compatibility](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#backwards-compatibility). 
+
+- Single MCP server instance with multiple transport options
+- Support for Streamable HTTP requests at `/mcp` endpoint (GET/POST/DELETE)
+- Support for deprecated SSE transport with `/sse` (GET) and `/messages` (POST)
+- Session type tracking to avoid mixing transport types
+- Notifications and tool execution across both transport types
+
+```bash
+npx tsx src/examples/server/sseAndStreamableHttpCompatibleServer.ts
+```
+
+### Multi-Node Deployment
+
+When deploying MCP servers in a horizontally scaled environment (multiple server instances), there are a few different options that can be useful for different use cases:
+- **Stateless mode** - No need to maintain state between calls to MCP servers. Useful for simple API wrapper servers.
+- **Persistent storage mode** - No local state needed, but session data is stored in a database. Example: an MCP server for online ordering where the shopping cart is stored in a database.
+- **Local state with message routing** - Local state is needed, and all requests for a session must be routed to the correct node. This can be done with a message queue and pub/sub system.
+
+#### Stateless Mode
+
+The Streamable HTTP transport can be configured to operate without tracking sessions. This is perfect for simple API proxies or when each request is completely independent.
+
+##### Implementation
+
+To enable stateless mode, configure the `StreamableHTTPServerTransport` with:
+```typescript
+sessionIdGenerator: () => undefined
+```
+
+This disables session management entirely, and the server won't generate or expect session IDs.
+
+- No session ID headers are sent or expected
+- Any server node can process any request
+- No state is preserved between requests
+- Perfect for RESTful or stateless API scenarios
+- Simplest deployment model with minimal infrastructure requirements
+
+```
+┌─────────────────────────────────────────────┐
+│                  Client                     │
+└─────────────────────────────────────────────┘
+                     │
+                     ▼
+┌─────────────────────────────────────────────┐
+│                Load Balancer                │
+└─────────────────────────────────────────────┘
+          │                       │
+          ▼                       ▼
+┌─────────────────┐     ┌─────────────────────┐
+│  MCP Server #1  │     │    MCP Server #2    │
+│ (Node.js)       │     │  (Node.js)          │
+└─────────────────┘     └─────────────────────┘
+```
+
+
+
+#### Persistent Storage Mode
+
+For cases where you need session continuity but don't need to maintain in-memory state on specific nodes, you can use a database to persist session data while still allowing any node to handle requests.
+
+##### Implementation
+
+Configure the transport with session management, but retrieve and store all state in an external persistent storage:
+
+```typescript
+sessionIdGenerator: () => randomUUID(),
+eventStore: databaseEventStore
+```
+
+All session state is stored in the database, and any node can serve any client by retrieving the state when needed.
+
+- Maintains sessions with unique IDs
+- Stores all session data in an external database
+- Provides resumability through the database-backed EventStore
+- Any node can handle any request for the same session
+- No node-specific memory state means no need for message routing
+- Good for applications where state can be fully externalized
+- Somewhat higher latency due to database access for each request
+
+
+```
+┌─────────────────────────────────────────────┐
+│                  Client                     │
+└─────────────────────────────────────────────┘
+                     │
+                     ▼
+┌─────────────────────────────────────────────┐
+│                Load Balancer                │
+└─────────────────────────────────────────────┘
+          │                       │
+          ▼                       ▼
+┌─────────────────┐     ┌─────────────────────┐
+│  MCP Server #1  │     │    MCP Server #2    │
+│ (Node.js)       │     │  (Node.js)          │
+└─────────────────┘     └─────────────────────┘
+          │                       │
+          │                       │
+          ▼                       ▼
+┌─────────────────────────────────────────────┐
+│           Database (PostgreSQL)             │
+│                                             │
+│  • Session state                            │
+│  • Event storage for resumability           │
+└─────────────────────────────────────────────┘
+```
+
+
+
+#### Streamable HTTP with Distributed Message Routing
+
+For scenarios where local in-memory state must be maintained on specific nodes (such as Computer Use or complex session state), the Streamable HTTP transport can be combined with a pub/sub system to route messages to the correct node handling each session.
+
+1. **Bidirectional Message Queue Integration**:
+   - All nodes both publish to and subscribe from the message queue
+   - Each node registers the sessions it's actively handling
+   - Messages are routed based on session ownership
+
+2. **Request Handling Flow**:
+   - When a client connects to Node A with an existing `mcp-session-id`
+   - If Node A doesn't own this session, it:
+     - Establishes and maintains the SSE connection with the client
+     - Publishes the request to the message queue with the session ID
+     - Node B (which owns the session) receives the request from the queue
+     - Node B processes the request with its local session state
+     - Node B publishes responses/notifications back to the queue
+     - Node A subscribes to the response channel and forwards to the client
+
+3. **Channel Identification**:
+   - Each message channel combines both `mcp-session-id` and `stream-id`
+   - This ensures responses are correctly routed back to the originating connection
+
+```
+┌─────────────────────────────────────────────┐
+│                  Client                     │
+└─────────────────────────────────────────────┘
+                     │
+                     ▼
+┌─────────────────────────────────────────────┐
+│                Load Balancer                │
+└─────────────────────────────────────────────┘
+          │                       │
+          ▼                       ▼
+┌─────────────────┐     ┌─────────────────────┐
+│  MCP Server #1  │◄───►│    MCP Server #2    │
+│ (Has Session A) │     │  (Has Session B)    │
+└─────────────────┘     └─────────────────────┘
+          ▲│                     ▲│
+          │▼                     │▼
+┌─────────────────────────────────────────────┐
+│         Message Queue / Pub-Sub             │
+│                                             │
+│  • Session ownership registry               │
+│  • Bidirectional message routing            │
+│  • Request/response forwarding              │
+└─────────────────────────────────────────────┘
+```
+
+
+- Maintains session affinity for stateful operations without client redirection
+- Enables horizontal scaling while preserving complex in-memory state
+- Provides fault tolerance through the message queue as intermediary
+
+
+## Backwards Compatibility
+
+### Testing Streamable HTTP Backwards Compatibility with SSE
+
+To test the backwards compatibility features:
+
+1. Start one of the server implementations:
+   ```bash
+   # Legacy SSE server (protocol version 2024-11-05)
+   npx tsx src/examples/server/simpleSseServer.ts
+   
+   # Streamable HTTP server (protocol version 2025-03-26)
+   npx tsx src/examples/server/simpleStreamableHttp.ts
+   
+   # Backwards compatible server (supports both protocols)
+   npx tsx src/examples/server/sseAndStreamableHttpCompatibleServer.ts
+   ```
+
+2. Then run the backwards compatible client:
+   ```bash
+   npx tsx src/examples/client/streamableHttpWithSseFallbackClient.ts
+   ```
+
+This demonstrates how the MCP ecosystem ensures interoperability between clients and servers regardless of which protocol version they were built for.

--- a/src/examples/README.md
+++ b/src/examples/README.md
@@ -134,7 +134,7 @@ The Streamable HTTP transport can be configured to operate without tracking sess
 
 To enable stateless mode, configure the `StreamableHTTPServerTransport` with:
 ```typescript
-sessionIdGenerator: () => undefined
+sessionIdGenerator: undefined
 ```
 
 This disables session management entirely, and the server won't generate or expect session IDs.

--- a/src/examples/client/streamableHttpWithSseFallbackClient.ts
+++ b/src/examples/client/streamableHttpWithSseFallbackClient.ts
@@ -1,0 +1,190 @@
+import { Client } from '../../client/index.js';
+import { StreamableHTTPClientTransport } from '../../client/streamableHttp.js';
+import { SSEClientTransport } from '../../client/sse.js';
+import {
+  ListToolsRequest,
+  ListToolsResultSchema,
+  CallToolRequest,
+  CallToolResultSchema,
+  LoggingMessageNotificationSchema,
+} from '../../types.js';
+
+/**
+ * Simplified Backwards Compatible MCP Client
+ * 
+ * This client demonstrates backward compatibility with both:
+ * 1. Modern servers using Streamable HTTP transport (protocol version 2025-03-26)
+ * 2. Older servers using HTTP+SSE transport (protocol version 2024-11-05)
+ * 
+ * Following the MCP specification for backwards compatibility:
+ * - Attempts to POST an initialize request to the server URL first (modern transport)
+ * - If that fails with 4xx status, falls back to GET request for SSE stream (older transport)
+ */
+
+// Command line args processing
+const args = process.argv.slice(2);
+const serverUrl = args[0] || 'http://localhost:3000/mcp';
+
+async function main(): Promise<void> {
+  console.log('MCP Backwards Compatible Client');
+  console.log('===============================');
+  console.log(`Connecting to server at: ${serverUrl}`);
+
+  let client: Client;
+  let transport: StreamableHTTPClientTransport | SSEClientTransport;
+  let transportType: 'streamable-http' | 'sse';
+
+  try {
+    // Try connecting with automatic transport detection
+    const connection = await connectWithBackwardsCompatibility(serverUrl);
+    client = connection.client;
+    transport = connection.transport;
+    transportType = connection.transportType;
+
+    // Set up notification handler
+    client.setNotificationHandler(LoggingMessageNotificationSchema, (notification) => {
+      console.log(`Notification: ${notification.params.level} - ${notification.params.data}`);
+    });
+
+    // DEMO WORKFLOW:
+    // 1. List available tools
+    console.log('\n=== Listing Available Tools ===');
+    await listTools(client);
+
+    // 2. Call the notification tool
+    console.log('\n=== Starting Notification Stream ===');
+    await startNotificationTool(client);
+
+    // 3. Wait for all notifications (5 seconds)
+    console.log('\n=== Waiting for all notifications ===');
+    await new Promise(resolve => setTimeout(resolve, 5000));
+
+    // 4. Disconnect
+    console.log('\n=== Disconnecting ===');
+    await transport.close();
+    console.log('Disconnected from MCP server');
+
+  } catch (error) {
+    console.error('Error running client:', error);
+    process.exit(1);
+  }
+}
+
+/**
+ * Connect to an MCP server with backwards compatibility
+ * Following the spec for client backward compatibility
+ */
+async function connectWithBackwardsCompatibility(url: string): Promise<{
+  client: Client,
+  transport: StreamableHTTPClientTransport | SSEClientTransport,
+  transportType: 'streamable-http' | 'sse'
+}> {
+  console.log('1. Trying Streamable HTTP transport first...');
+
+  // Step 1: Try Streamable HTTP transport first
+  const client = new Client({
+    name: 'backwards-compatible-client',
+    version: '1.0.0'
+  });
+
+  client.onerror = (error) => {
+    console.error('Client error:', error);
+  };
+  const baseUrl = new URL(url);
+
+  try {
+    // Create modern transport
+    const streamableTransport = new StreamableHTTPClientTransport(baseUrl);
+    await client.connect(streamableTransport);
+
+    console.log('Successfully connected using modern Streamable HTTP transport.');
+    return {
+      client,
+      transport: streamableTransport,
+      transportType: 'streamable-http'
+    };
+  } catch (error) {
+    // Step 2: If transport fails, try the older SSE transport
+    console.log(`StreamableHttp transport connection failed: ${error}`);
+    console.log('2. Falling back to deprecated HTTP+SSE transport...');
+
+    try {
+      // Create SSE transport pointing to /sse endpoint
+      const sseTransport = new SSEClientTransport(baseUrl);
+      await client.connect(sseTransport);
+
+      console.log('Successfully connected using deprecated HTTP+SSE transport.');
+      return {
+        client,
+        transport: sseTransport,
+        transportType: 'sse'
+      };
+    } catch (sseError) {
+      console.error(`Failed to connect with either transport method:\n1. Streamable HTTP error: ${error}\n2. SSE error: ${sseError}`);
+      throw new Error('Could not connect to server with any available transport');
+    }
+  }
+}
+
+/**
+ * List available tools on the server
+ */
+async function listTools(client: Client): Promise<void> {
+  try {
+    const toolsRequest: ListToolsRequest = {
+      method: 'tools/list',
+      params: {}
+    };
+    const toolsResult = await client.request(toolsRequest, ListToolsResultSchema);
+
+    console.log('Available tools:');
+    if (toolsResult.tools.length === 0) {
+      console.log('  No tools available');
+    } else {
+      for (const tool of toolsResult.tools) {
+        console.log(`  - ${tool.name}: ${tool.description}`);
+      }
+    }
+  } catch (error) {
+    console.log(`Tools not supported by this server: ${error}`);
+  }
+}
+
+/**
+ * Start a notification stream by calling the notification tool
+ */
+async function startNotificationTool(client: Client): Promise<void> {
+  try {
+    // Call the notification tool using reasonable defaults
+    const request: CallToolRequest = {
+      method: 'tools/call',
+      params: {
+        name: 'start-notification-stream',
+        arguments: {
+          interval: 1000, // 1 second between notifications
+          count: 5       // Send 5 notifications
+        }
+      }
+    };
+
+    console.log('Calling notification tool...');
+    const result = await client.request(request, CallToolResultSchema);
+
+    console.log('Tool result:');
+    result.content.forEach(item => {
+      if (item.type === 'text') {
+        console.log(`  ${item.text}`);
+      } else {
+        console.log(`  ${item.type} content:`, item);
+      }
+    });
+  } catch (error) {
+    console.log(`Error calling notification tool: ${error}`);
+  }
+}
+
+// Start the client
+main().catch((error: unknown) => {
+  console.error('Error running MCP client:', error);
+  process.exit(1);
+});

--- a/src/examples/client/streamableHttpWithSseFallbackClient.ts
+++ b/src/examples/client/streamableHttpWithSseFallbackClient.ts
@@ -109,11 +109,15 @@ async function connectWithBackwardsCompatibility(url: string): Promise<{
     try {
       // Create SSE transport pointing to /sse endpoint
       const sseTransport = new SSEClientTransport(baseUrl);
-      await client.connect(sseTransport);
+      const sseClient = new Client({
+        name: 'backwards-compatible-client',
+        version: '1.0.0'
+      });
+      await sseClient.connect(sseTransport);
 
       console.log('Successfully connected using deprecated HTTP+SSE transport.');
       return {
-        client,
+        client: sseClient,
         transport: sseTransport,
         transportType: 'sse'
       };

--- a/src/examples/client/streamableHttpWithSseFallbackClient.ts
+++ b/src/examples/client/streamableHttpWithSseFallbackClient.ts
@@ -32,14 +32,12 @@ async function main(): Promise<void> {
 
   let client: Client;
   let transport: StreamableHTTPClientTransport | SSEClientTransport;
-  let transportType: 'streamable-http' | 'sse';
 
   try {
     // Try connecting with automatic transport detection
     const connection = await connectWithBackwardsCompatibility(serverUrl);
     client = connection.client;
     transport = connection.transport;
-    transportType = connection.transportType;
 
     // Set up notification handler
     client.setNotificationHandler(LoggingMessageNotificationSchema, (notification) => {

--- a/src/examples/server/jsonResponseStreamableHttp.ts
+++ b/src/examples/server/jsonResponseStreamableHttp.ts
@@ -148,28 +148,6 @@ app.get('/mcp', async (req: Request, res: Response) => {
 const PORT = 3000;
 app.listen(PORT, () => {
   console.log(`MCP Streamable HTTP Server listening on port ${PORT}`);
-  console.log(`Initialize session with the command below id you are using curl for testing: 
-  -----------------------------
-  SESSION_ID=$(curl -X POST \
-  -H "Content-Type: application/json" \
-  -H "Accept: application/json" \
-  -H "Accept: text/event-stream" \
-  -d '{
-    "jsonrpc": "2.0",
-    "method": "initialize",
-    "params": {
-      "capabilities": {},
-      "protocolVersion": "2025-03-26", 
-      "clientInfo": {
-        "name": "test",
-        "version": "1.0.0"
-      }
-    },
-    "id": "1"
-  }' \
-  -i http://localhost:3000/mcp 2>&1 | grep -i "mcp-session-id" | cut -d' ' -f2 | tr -d '\\r')
-  echo "Session ID: $SESSION_ID"
-  -----------------------------`);
 });
 
 // Handle server shutdown

--- a/src/examples/server/jsonResponseStreamableHttp.ts
+++ b/src/examples/server/jsonResponseStreamableHttp.ts
@@ -3,7 +3,7 @@ import { randomUUID } from 'node:crypto';
 import { McpServer } from '../../server/mcp.js';
 import { StreamableHTTPServerTransport } from '../../server/streamableHttp.js';
 import { z } from 'zod';
-import { CallToolResult } from '../../types.js';
+import { CallToolResult, isInitializeRequest } from '../../types.js';
 
 // Create an MCP server with implementation details
 const server = new McpServer({
@@ -144,14 +144,6 @@ app.get('/mcp', async (req: Request, res: Response) => {
   // The spec requires returning 405 Method Not Allowed in this case
   res.status(405).set('Allow', 'POST').send('Method Not Allowed');
 });
-
-// Helper function to detect initialize requests
-function isInitializeRequest(body: unknown): boolean {
-  if (Array.isArray(body)) {
-    return body.some(msg => typeof msg === 'object' && msg !== null && 'method' in msg && msg.method === 'initialize');
-  }
-  return typeof body === 'object' && body !== null && 'method' in body && body.method === 'initialize';
-}
 
 // Start the server
 const PORT = 3000;

--- a/src/examples/server/jsonResponseStreamableHttp.ts
+++ b/src/examples/server/jsonResponseStreamableHttp.ts
@@ -95,18 +95,17 @@ app.post('/mcp', async (req: Request, res: Response) => {
       transport = new StreamableHTTPServerTransport({
         sessionIdGenerator: () => randomUUID(),
         enableJsonResponse: true, // Enable JSON response mode
+        onsessioninitialized: (sessionId) => {
+          // Store the transport by session ID when session is initialized
+          // This avoids race conditions where requests might come in before the session is stored
+          console.log(`Session initialized with ID: ${sessionId}`);
+          transports[sessionId] = transport;
+        }
       });
 
       // Connect the transport to the MCP server BEFORE handling the request
       await server.connect(transport);
-
-      // After handling the request, if we get a session ID back, store the transport
       await transport.handleRequest(req, res, req.body);
-
-      // Store the transport by session ID for future requests
-      if (transport.sessionId) {
-        transports[transport.sessionId] = transport;
-      }
       return; // Already handled
     } else {
       // Invalid request - no session ID or not initialization request

--- a/src/examples/server/simpleSseServer.ts
+++ b/src/examples/server/simpleSseServer.ts
@@ -1,0 +1,170 @@
+import express, { Request, Response } from 'express';
+import { randomUUID } from "node:crypto";
+import { McpServer } from '../../server/mcp.js';
+import { SSEServerTransport } from '../../server/sse.js';
+import { z } from 'zod';
+import { CallToolResult } from '../../types.js';
+
+/**
+ * This example server demonstrates the deprecated HTTP+SSE transport 
+ * (protocol version 2024-11-05). It mainly used for testing backward compatible clients.
+ * 
+ * The server exposes two endpoints:
+ * - /sse: For establishing the SSE stream (GET)
+ * - /messages: For receiving client messages (POST)
+ * 
+ */
+
+// Create an MCP server instance
+const server = new McpServer({
+  name: 'simple-sse-server',
+  version: '1.0.0',
+}, { capabilities: { logging: {} } });
+
+server.tool(
+  'start-notification-stream',
+  'Starts sending periodic notifications',
+  {
+    interval: z.number().describe('Interval in milliseconds between notifications').default(1000),
+    count: z.number().describe('Number of notifications to send').default(10),
+  },
+  async ({ interval, count }, { sendNotification }): Promise<CallToolResult> => {
+    const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+    let counter = 0;
+
+    // Send the initial notification
+    await sendNotification({
+      method: "notifications/message",
+      params: {
+        level: "info",
+        data: `Starting notification stream with ${count} messages every ${interval}ms`
+      }
+    });
+
+    // Send periodic notifications
+    while (counter < count) {
+      counter++;
+      await sleep(interval);
+
+      try {
+        await sendNotification({
+          method: "notifications/message",
+          params: {
+            level: "info",
+            data: `Notification #${counter} at ${new Date().toISOString()}`
+          }
+        });
+      }
+      catch (error) {
+        console.error("Error sending notification:", error);
+      }
+    }
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `Completed sending ${count} notifications every ${interval}ms`,
+        }
+      ],
+    };
+  }
+);
+
+const app = express();
+app.use(express.json());
+
+// Store transports by session ID
+const transports: Record<string, SSEServerTransport> = {};
+
+// SSE endpoint for establishing the stream
+app.get('/sse', async (req: Request, res: Response) => {
+  console.log('Received GET request to /sse (establishing SSE stream)');
+
+  try {
+    // Create a new SSE transport for the client
+    // The endpoint for POST messages is '/messages'
+    const transport = new SSEServerTransport('/messages', res);
+
+    // Store the transport by session ID
+    const sessionId = transport.sessionId;
+    transports[sessionId] = transport;
+
+    // Set up onclose handler to clean up transport when closed
+    transport.onclose = () => {
+      console.log(`SSE transport closed for session ${sessionId}`);
+      delete transports[sessionId];
+    };
+
+    // Connect the transport to the MCP server
+    await server.connect(transport);
+
+    // Start the SSE transport to begin streaming
+    // This sends an initial 'endpoint' event with the session ID in the URL
+    await transport.start();
+
+    console.log(`Established SSE stream with session ID: ${sessionId}`);
+  } catch (error) {
+    console.error('Error establishing SSE stream:', error);
+    if (!res.headersSent) {
+      res.status(500).send('Error establishing SSE stream');
+    }
+  }
+});
+
+// Messages endpoint for receiving client JSON-RPC requests
+app.post('/messages', async (req: Request, res: Response) => {
+  console.log('Received POST request to /messages');
+
+  // Extract session ID from URL query parameter
+  // In the SSE protocol, this is added by the client based on the endpoint event
+  const sessionId = req.query.sessionId as string | undefined;
+
+  if (!sessionId) {
+    console.error('No session ID provided in request URL');
+    res.status(400).send('Missing sessionId parameter');
+    return;
+  }
+
+  const transport = transports[sessionId];
+  if (!transport) {
+    console.error(`No active transport found for session ID: ${sessionId}`);
+    res.status(404).send('Session not found');
+    return;
+  }
+
+  try {
+    // Handle the POST message with the transport
+    await transport.handlePostMessage(req, res, req.body);
+  } catch (error) {
+    console.error('Error handling request:', error);
+    if (!res.headersSent) {
+      res.status(500).send('Error handling request');
+    }
+  }
+});
+
+// Start the server
+const PORT = 3000;
+app.listen(PORT, () => {
+  console.log(`Simple SSE Server (deprecated protocol version 2024-11-05) listening on port ${PORT}`);
+});
+
+// Handle server shutdown
+process.on('SIGINT', async () => {
+  console.log('Shutting down server...');
+
+  // Close all active transports to properly clean up resources
+  for (const sessionId in transports) {
+    try {
+      console.log(`Closing transport for session ${sessionId}`);
+      await transports[sessionId].close();
+      delete transports[sessionId];
+    } catch (error) {
+      console.error(`Error closing transport for session ${sessionId}:`, error);
+    }
+  }
+  await server.close();
+  console.log('Server shutdown complete');
+  process.exit(0);
+});

--- a/src/examples/server/simpleSseServer.ts
+++ b/src/examples/server/simpleSseServer.ts
@@ -78,7 +78,7 @@ app.use(express.json());
 const transports: Record<string, SSEServerTransport> = {};
 
 // SSE endpoint for establishing the stream
-app.get('/sse', async (req: Request, res: Response) => {
+app.get('/mcp', async (req: Request, res: Response) => {
   console.log('Received GET request to /sse (establishing SSE stream)');
 
   try {

--- a/src/examples/server/simpleSseServer.ts
+++ b/src/examples/server/simpleSseServer.ts
@@ -9,7 +9,7 @@ import { CallToolResult } from '../../types.js';
  * (protocol version 2024-11-05). It mainly used for testing backward compatible clients.
  * 
  * The server exposes two endpoints:
- * - /sse: For establishing the SSE stream (GET)
+ * - /mcp: For establishing the SSE stream (GET)
  * - /messages: For receiving client messages (POST)
  * 
  */

--- a/src/examples/server/simpleSseServer.ts
+++ b/src/examples/server/simpleSseServer.ts
@@ -1,5 +1,4 @@
 import express, { Request, Response } from 'express';
-import { randomUUID } from "node:crypto";
 import { McpServer } from '../../server/mcp.js';
 import { SSEServerTransport } from '../../server/sse.js';
 import { z } from 'zod';

--- a/src/examples/server/simpleStatelessStreamableHttp.ts
+++ b/src/examples/server/simpleStatelessStreamableHttp.ts
@@ -96,7 +96,11 @@ app.use(express.json());
 const transport: StreamableHTTPServerTransport = new StreamableHTTPServerTransport({
   sessionIdGenerator: undefined,
 });
-await server.connect(transport);
+
+// Setup routes for the server
+const setupServer = async () => {
+  await server.connect(transport);
+};
 
 app.post('/mcp', async (req: Request, res: Response) => {
   console.log('Received MCP request:', req.body);
@@ -143,8 +147,13 @@ app.delete('/mcp', async (req: Request, res: Response) => {
 
 // Start the server
 const PORT = 3000;
-app.listen(PORT, () => {
-  console.log(`MCP Streamable HTTP Server listening on port ${PORT}`);
+setupServer().then(() => {
+  app.listen(PORT, () => {
+    console.log(`MCP Streamable HTTP Server listening on port ${PORT}`);
+  });
+}).catch(error => {
+  console.error('Failed to set up the server:', error);
+  process.exit(1);
 });
 
 // Handle server shutdown

--- a/src/examples/server/simpleStatelessStreamableHttp.ts
+++ b/src/examples/server/simpleStatelessStreamableHttp.ts
@@ -1,0 +1,163 @@
+import express, { Request, Response } from 'express';
+import { McpServer } from '../../server/mcp.js';
+import { StreamableHTTPServerTransport } from '../../server/streamableHttp.js';
+import { z } from 'zod';
+import { CallToolResult, GetPromptResult, ReadResourceResult } from '../../types.js';
+
+// Create an MCP server with implementation details
+const server = new McpServer({
+  name: 'stateless-streamable-http-server',
+  version: '1.0.0',
+}, { capabilities: { logging: {} } });
+
+// Register a simple prompt
+server.prompt(
+  'greeting-template',
+  'A simple greeting prompt template',
+  {
+    name: z.string().describe('Name to include in greeting'),
+  },
+  async ({ name }): Promise<GetPromptResult> => {
+    return {
+      messages: [
+        {
+          role: 'user',
+          content: {
+            type: 'text',
+            text: `Please greet ${name} in a friendly manner.`,
+          },
+        },
+      ],
+    };
+  }
+);
+
+// Register a tool specifically for testing resumability
+server.tool(
+  'start-notification-stream',
+  'Starts sending periodic notifications for testing resumability',
+  {
+    interval: z.number().describe('Interval in milliseconds between notifications').default(100),
+    count: z.number().describe('Number of notifications to send (0 for 100)').default(10),
+  },
+  async ({ interval, count }, { sendNotification }): Promise<CallToolResult> => {
+    const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+    let counter = 0;
+
+    while (count === 0 || counter < count) {
+      counter++;
+      try {
+        await sendNotification({
+          method: "notifications/message",
+          params: {
+            level: "info",
+            data: `Periodic notification #${counter} at ${new Date().toISOString()}`
+          }
+        });
+      }
+      catch (error) {
+        console.error("Error sending notification:", error);
+      }
+      // Wait for the specified interval
+      await sleep(interval);
+    }
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `Started sending periodic notifications every ${interval}ms`,
+        }
+      ],
+    };
+  }
+);
+
+// Create a simple resource at a fixed URI
+server.resource(
+  'greeting-resource',
+  'https://example.com/greetings/default',
+  { mimeType: 'text/plain' },
+  async (): Promise<ReadResourceResult> => {
+    return {
+      contents: [
+        {
+          uri: 'https://example.com/greetings/default',
+          text: 'Hello, world!',
+        },
+      ],
+    };
+  }
+);
+
+const app = express();
+app.use(express.json());
+
+const transport: StreamableHTTPServerTransport = new StreamableHTTPServerTransport({
+  sessionIdGenerator: undefined,
+});
+await server.connect(transport);
+
+app.post('/mcp', async (req: Request, res: Response) => {
+  console.log('Received MCP request:', req.body);
+  try {
+      await transport.handleRequest(req, res, req.body);
+  } catch (error) {
+    console.error('Error handling MCP request:', error);
+    if (!res.headersSent) {
+      res.status(500).json({
+        jsonrpc: '2.0',
+        error: {
+          code: -32603,
+          message: 'Internal server error',
+        },
+        id: null,
+      });
+    }
+  }
+});
+
+app.get('/mcp', async (req: Request, res: Response) => {
+  console.log('Received GET MCP request');
+  res.writeHead(405).end(JSON.stringify({
+    jsonrpc: "2.0",
+    error: {
+      code: -32000,
+      message: "Method not allowed."
+    },
+    id: null
+  }));
+});
+
+app.delete('/mcp', async (req: Request, res: Response) => {
+  console.log('Received DELETE MCP request');
+  res.writeHead(405).end(JSON.stringify({
+    jsonrpc: "2.0",
+    error: {
+      code: -32000,
+      message: "Method not allowed."
+    },
+    id: null
+  }));
+});
+
+// Start the server
+const PORT = 3000;
+app.listen(PORT, () => {
+  console.log(`MCP Streamable HTTP Server listening on port ${PORT}`);
+});
+
+// Handle server shutdown
+process.on('SIGINT', async () => {
+  console.log('Shutting down server...');
+    try {
+      console.log(`Closing transport`);
+      await transport.close();
+    } catch (error) {
+      console.error(`Error closing transport:`, error);
+    }
+  
+  await server.close();
+  console.log('Server shutdown complete');
+  process.exit(0);
+});

--- a/src/examples/server/simpleStreamableHttp.ts
+++ b/src/examples/server/simpleStreamableHttp.ts
@@ -247,19 +247,19 @@ app.post('/mcp', async (req: Request, res: Response) => {
       transport = new StreamableHTTPServerTransport({
         sessionIdGenerator: () => randomUUID(),
         eventStore, // Enable resumability
+        onsessioninitialized: (sessionId) => {
+          // Store the transport by session ID when session is initialized
+          // This avoids race conditions where requests might come in before the session is stored
+          console.log(`Session initialized with ID: ${sessionId}`);
+          transports[sessionId] = transport;
+        }
       });
 
       // Connect the transport to the MCP server BEFORE handling the request
       // so responses can flow back through the same transport
       await server.connect(transport);
 
-      // After handling the request, if we get a session ID back, store the transport
       await transport.handleRequest(req, res, req.body);
-
-      // Store the transport by session ID for future requests
-      if (transport.sessionId) {
-        transports[transport.sessionId] = transport;
-      }
       return; // Already handled
     } else {
       // Invalid request - no session ID or not initialization request

--- a/src/examples/server/simpleStreamableHttp.ts
+++ b/src/examples/server/simpleStreamableHttp.ts
@@ -12,6 +12,21 @@ const server = new McpServer({
   version: '1.0.0',
 }, { capabilities: { logging: {} } });
 
+// Log the capability invocation details
+server.onCapabilityChange((event) => {
+  switch (event.action) {
+    case 'invoked':
+      console.log(`${event.capabilityType} invocation ${event.invocationIndex}: '${event.capabilityName}' started`);
+      break;
+    case 'completed':
+      console.log(`${event.capabilityType} invocation ${event.invocationIndex}: '${event.capabilityName}' completed in ${event.durationMs}ms`);
+      break;
+    case 'error':
+      console.log(`${event.capabilityType} invocation ${event.invocationIndex}: '${event.capabilityName}' failed in ${event.durationMs}ms: ${event.error}`);
+      break;
+  }
+});
+
 // Register a simple tool that returns a greeting
 server.tool(
   'greet',

--- a/src/examples/server/simpleStreamableHttp.ts
+++ b/src/examples/server/simpleStreamableHttp.ts
@@ -3,7 +3,7 @@ import { randomUUID } from 'node:crypto';
 import { McpServer } from '../../server/mcp.js';
 import { EventStore, StreamableHTTPServerTransport } from '../../server/streamableHttp.js';
 import { z } from 'zod';
-import { CallToolResult, GetPromptResult, JSONRPCMessage, ReadResourceResult } from '../../types.js';
+import { CallToolResult, GetPromptResult, isInitializeRequest, JSONRPCMessage, ReadResourceResult } from '../../types.js';
 
 // Create a simple in-memory EventStore for resumability
 class InMemoryEventStore implements EventStore {
@@ -36,7 +36,7 @@ class InMemoryEventStore implements EventStore {
    * Replays events that occurred after a specific event ID
    * Implements EventStore.replayEventsAfter
    */
-  async replayEventsAfter(lastEventId: string, 
+  async replayEventsAfter(lastEventId: string,
     { send }: { send: (eventId: string, message: JSONRPCMessage) => Promise<void> }
   ): Promise<string> {
     if (!lastEventId || !this.events.has(lastEventId)) {
@@ -311,14 +311,6 @@ app.get('/mcp', async (req: Request, res: Response) => {
   const transport = transports[sessionId];
   await transport.handleRequest(req, res);
 });
-
-// Helper function to detect initialize requests
-function isInitializeRequest(body: unknown): boolean {
-  if (Array.isArray(body)) {
-    return body.some(msg => typeof msg === 'object' && msg !== null && 'method' in msg && msg.method === 'initialize');
-  }
-  return typeof body === 'object' && body !== null && 'method' in body && body.method === 'initialize';
-}
 
 // Start the server
 const PORT = 3000;

--- a/src/examples/server/simpleStreamableHttp.ts
+++ b/src/examples/server/simpleStreamableHttp.ts
@@ -1,84 +1,10 @@
 import express, { Request, Response } from 'express';
 import { randomUUID } from 'node:crypto';
 import { McpServer } from '../../server/mcp.js';
-import { EventStore, StreamableHTTPServerTransport } from '../../server/streamableHttp.js';
+import { StreamableHTTPServerTransport } from '../../server/streamableHttp.js';
 import { z } from 'zod';
-import { CallToolResult, GetPromptResult, isInitializeRequest, JSONRPCMessage, ReadResourceResult } from '../../types.js';
-
-// Create a simple in-memory EventStore for resumability
-class InMemoryEventStore implements EventStore {
-  private events: Map<string, { streamId: string, message: JSONRPCMessage }> = new Map();
-
-  /**
-   * Generates a unique event ID for a given stream ID
-   */
-  private generateEventId(streamId: string): string {
-    return `${streamId}_${Date.now()}_${Math.random().toString(36).substring(2, 10)}`;
-  }
-
-  private getStreamIdFromEventId(eventId: string): string {
-    const parts = eventId.split('_');
-    return parts.length > 0 ? parts[0] : '';
-  }
-
-  /**
-   * Stores an event with a generated event ID
-   * Implements EventStore.storeEvent
-   */
-  async storeEvent(streamId: string, message: JSONRPCMessage): Promise<string> {
-    const eventId = this.generateEventId(streamId);
-    console.log(`Storing event ${eventId} for stream ${streamId}`);
-    this.events.set(eventId, { streamId, message });
-    return eventId;
-  }
-
-  /**
-   * Replays events that occurred after a specific event ID
-   * Implements EventStore.replayEventsAfter
-   */
-  async replayEventsAfter(lastEventId: string,
-    { send }: { send: (eventId: string, message: JSONRPCMessage) => Promise<void> }
-  ): Promise<string> {
-    if (!lastEventId || !this.events.has(lastEventId)) {
-      console.log(`No events found for lastEventId: ${lastEventId}`);
-      return '';
-    }
-
-    // Extract the stream ID from the event ID
-    const streamId = this.getStreamIdFromEventId(lastEventId);
-    if (!streamId) {
-      console.log(`Could not extract streamId from lastEventId: ${lastEventId}`);
-      return '';
-    }
-
-    let foundLastEvent = false;
-    let eventCount = 0;
-
-    // Sort events by eventId for chronological ordering
-    const sortedEvents = [...this.events.entries()].sort((a, b) => a[0].localeCompare(b[0]));
-
-    for (const [eventId, { streamId: eventStreamId, message }] of sortedEvents) {
-      // Only include events from the same stream
-      if (eventStreamId !== streamId) {
-        continue;
-      }
-
-      // Start sending events after we find the lastEventId
-      if (eventId === lastEventId) {
-        foundLastEvent = true;
-        continue;
-      }
-
-      if (foundLastEvent) {
-        await send(eventId, message);
-        eventCount++;
-      }
-    }
-
-    console.log(`Replayed ${eventCount} events after ${lastEventId} for stream ${streamId}`);
-    return streamId;
-  }
-}
+import { CallToolResult, GetPromptResult, isInitializeRequest, ReadResourceResult } from '../../types.js';
+import { InMemoryEventStore } from '../shared/inMemoryEventStore.js';
 
 // Create an MCP server with implementation details
 const server = new McpServer({

--- a/src/examples/server/simpleStreamableHttp.ts
+++ b/src/examples/server/simpleStreamableHttp.ts
@@ -272,28 +272,6 @@ app.delete('/mcp', async (req: Request, res: Response) => {
 const PORT = 3000;
 app.listen(PORT, () => {
   console.log(`MCP Streamable HTTP Server listening on port ${PORT}`);
-  console.log(`Initialize session with the command below id you are using curl for testing: 
-    -----------------------------
-    SESSION_ID=$(curl -X POST \
-    -H "Content-Type: application/json" \
-    -H "Accept: application/json" \
-    -H "Accept: text/event-stream" \
-    -d '{
-      "jsonrpc": "2.0",
-      "method": "initialize",
-      "params": {
-        "capabilities": {},
-        "protocolVersion": "2025-03-26", 
-        "clientInfo": {
-          "name": "test",
-          "version": "1.0.0"
-        }
-      },
-      "id": "1"
-    }' \
-    -i http://localhost:3000/mcp 2>&1 | grep -i "mcp-session-id" | cut -d' ' -f2 | tr -d '\\r')
-    echo "Session ID: $SESSION_ID"
-    -----------------------------`);
 });
 
 // Handle server shutdown

--- a/src/examples/server/sseAndStreamableHttpCompatibleServer.ts
+++ b/src/examples/server/sseAndStreamableHttpCompatibleServer.ts
@@ -1,10 +1,11 @@
 import express, { Request, Response } from 'express';
 import { randomUUID } from "node:crypto";
 import { McpServer } from '../../server/mcp.js';
-import { EventStore, StreamableHTTPServerTransport } from '../../server/streamableHttp.js';
+import { StreamableHTTPServerTransport } from '../../server/streamableHttp.js';
 import { SSEServerTransport } from '../../server/sse.js';
 import { z } from 'zod';
-import { CallToolResult, isInitializeRequest, JSONRPCMessage } from '../../types.js';
+import { CallToolResult, isInitializeRequest } from '../../types.js';
+import { InMemoryEventStore } from '../shared/inMemoryEventStore.js';
 
 /**
  * This example server demonstrates backwards compatibility with both:
@@ -17,81 +18,7 @@ import { CallToolResult, isInitializeRequest, JSONRPCMessage } from '../../types
  * - /messages: The deprecated POST endpoint for older clients (POST to send messages)
  */
 
-// Simple in-memory event store for resumability
-class InMemoryEventStore implements EventStore {
-  private events: Map<string, { streamId: string, message: JSONRPCMessage }> = new Map();
 
-  /**
-   * Generates a unique event ID for a given stream ID
-   */
-  private generateEventId(streamId: string): string {
-    return `${streamId}_${Date.now()}_${Math.random().toString(36).substring(2, 10)}`;
-  }
-
-  private getStreamIdFromEventId(eventId: string): string {
-    const parts = eventId.split('_');
-    return parts.length > 0 ? parts[0] : '';
-  }
-
-  /**
-   * Stores an event with a generated event ID
-   * Implements EventStore.storeEvent
-   */
-  async storeEvent(streamId: string, message: JSONRPCMessage): Promise<string> {
-    const eventId = this.generateEventId(streamId);
-    console.log(`Storing event ${eventId} for stream ${streamId}`);
-    this.events.set(eventId, { streamId, message });
-    return eventId;
-  }
-
-  /**
-   * Replays events that occurred after a specific event ID
-   * Implements EventStore.replayEventsAfter
-   */
-  async replayEventsAfter(lastEventId: string,
-    { send }: { send: (eventId: string, message: JSONRPCMessage) => Promise<void> }
-  ): Promise<string> {
-    if (!lastEventId || !this.events.has(lastEventId)) {
-      console.log(`No events found for lastEventId: ${lastEventId}`);
-      return '';
-    }
-
-    const streamId = this.getStreamIdFromEventId(lastEventId);
-    if (!streamId) {
-      console.log(`Could not extract streamId from lastEventId: ${lastEventId}`);
-      return '';
-    }
-
-    let foundLastEvent = false;
-    let eventCount = 0;
-
-    // Sort events by eventId for chronological ordering
-    const sortedEvents = [...this.events.entries()].sort((a, b) => a[0].localeCompare(b[0]));
-
-    for (const [eventId, { streamId: eventStreamId, message }] of sortedEvents) {
-      // Only include events from the same stream
-      if (eventStreamId !== streamId) {
-        continue;
-      }
-
-      // Start sending events after we find the lastEventId
-      if (eventId === lastEventId) {
-        foundLastEvent = true;
-        continue;
-      }
-
-      if (foundLastEvent) {
-        await send(eventId, message);
-        eventCount++;
-      }
-    }
-
-    console.log(`Replayed ${eventCount} events after ${lastEventId} for stream ${streamId}`);
-    return streamId;
-  }
-}
-
-// Create a shared MCP server instance
 const server = new McpServer({
   name: 'backwards-compatible-server',
   version: '1.0.0',

--- a/src/examples/server/sseAndStreamableHttpCompatibleServer.ts
+++ b/src/examples/server/sseAndStreamableHttpCompatibleServer.ts
@@ -1,0 +1,316 @@
+import express, { Request, Response } from 'express';
+import { randomUUID } from "node:crypto";
+import { McpServer } from '../../server/mcp.js';
+import { EventStore, StreamableHTTPServerTransport } from '../../server/streamableHttp.js';
+import { SSEServerTransport } from '../../server/sse.js';
+import { z } from 'zod';
+import { CallToolResult, isInitializeRequest, JSONRPCMessage } from '../../types.js';
+
+/**
+ * This example server demonstrates backwards compatibility with both:
+ * 1. The deprecated HTTP+SSE transport (protocol version 2024-11-05)
+ * 2. The Streamable HTTP transport (protocol version 2025-03-26)
+ * 
+ * It maintains a single MCP server instance but exposes two transport options:
+ * - /mcp: The new Streamable HTTP endpoint (supports GET/POST/DELETE)
+ * - /sse: The deprecated SSE endpoint for older clients (GET to establish stream)
+ * - /request: The deprecated POST endpoint for older clients (POST to send messages)
+ */
+
+// Simple in-memory event store for resumability
+class InMemoryEventStore implements EventStore {
+  private events: Map<string, { streamId: string, message: JSONRPCMessage }> = new Map();
+
+  /**
+   * Generates a unique event ID for a given stream ID
+   */
+  private generateEventId(streamId: string): string {
+    return `${streamId}_${Date.now()}_${Math.random().toString(36).substring(2, 10)}`;
+  }
+
+  private getStreamIdFromEventId(eventId: string): string {
+    const parts = eventId.split('_');
+    return parts.length > 0 ? parts[0] : '';
+  }
+
+  /**
+   * Stores an event with a generated event ID
+   * Implements EventStore.storeEvent
+   */
+  async storeEvent(streamId: string, message: JSONRPCMessage): Promise<string> {
+    const eventId = this.generateEventId(streamId);
+    console.log(`Storing event ${eventId} for stream ${streamId}`);
+    this.events.set(eventId, { streamId, message });
+    return eventId;
+  }
+
+  /**
+   * Replays events that occurred after a specific event ID
+   * Implements EventStore.replayEventsAfter
+   */
+  async replayEventsAfter(lastEventId: string,
+    { send }: { send: (eventId: string, message: JSONRPCMessage) => Promise<void> }
+  ): Promise<string> {
+    if (!lastEventId || !this.events.has(lastEventId)) {
+      console.log(`No events found for lastEventId: ${lastEventId}`);
+      return '';
+    }
+
+    const streamId = this.getStreamIdFromEventId(lastEventId);
+    if (!streamId) {
+      console.log(`Could not extract streamId from lastEventId: ${lastEventId}`);
+      return '';
+    }
+
+    let foundLastEvent = false;
+    let eventCount = 0;
+
+    // Sort events by eventId for chronological ordering
+    const sortedEvents = [...this.events.entries()].sort((a, b) => a[0].localeCompare(b[0]));
+
+    for (const [eventId, { streamId: eventStreamId, message }] of sortedEvents) {
+      // Only include events from the same stream
+      if (eventStreamId !== streamId) {
+        continue;
+      }
+
+      // Start sending events after we find the lastEventId
+      if (eventId === lastEventId) {
+        foundLastEvent = true;
+        continue;
+      }
+
+      if (foundLastEvent) {
+        await send(eventId, message);
+        eventCount++;
+      }
+    }
+
+    console.log(`Replayed ${eventCount} events after ${lastEventId} for stream ${streamId}`);
+    return streamId;
+  }
+}
+
+// Create a shared MCP server instance
+const server = new McpServer({
+  name: 'backwards-compatible-server',
+  version: '1.0.0',
+}, { capabilities: { logging: {} } });
+
+// Register a simple tool that sends notifications over time
+server.tool(
+  'start-notification-stream',
+  'Starts sending periodic notifications for testing resumability',
+  {
+    interval: z.number().describe('Interval in milliseconds between notifications').default(100),
+    count: z.number().describe('Number of notifications to send (0 for 100)').default(50),
+  },
+  async ({ interval, count }, { sendNotification }): Promise<CallToolResult> => {
+    const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+    let counter = 0;
+
+    while (count === 0 || counter < count) {
+      counter++;
+      try {
+        await sendNotification({
+          method: "notifications/message",
+          params: {
+            level: "info",
+            data: `Periodic notification #${counter} at ${new Date().toISOString()}`
+          }
+        });
+      }
+      catch (error) {
+        console.error("Error sending notification:", error);
+      }
+      // Wait for the specified interval
+      await sleep(interval);
+    }
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `Started sending periodic notifications every ${interval}ms`,
+        }
+      ],
+    };
+  }
+);
+
+// Create Express application
+const app = express();
+app.use(express.json());
+
+// Store transports by session ID
+const transports: Record<string, StreamableHTTPServerTransport | SSEServerTransport> = {};
+
+//=============================================================================
+// STREAMABLE HTTP TRANSPORT (PROTOCOL VERSION 2025-03-26)
+//=============================================================================
+
+// Handle all MCP Streamable HTTP requests (GET, POST, DELETE) on a single endpoint
+app.all('/mcp', async (req: Request, res: Response) => {
+  console.log(`Received ${req.method} request to /mcp`);
+
+  try {
+    // Check for existing session ID
+    const sessionId = req.headers['mcp-session-id'] as string | undefined;
+    let transport: StreamableHTTPServerTransport;
+
+    if (sessionId && transports[sessionId]) {
+      // Check if the transport is of the correct type
+      const existingTransport = transports[sessionId];
+      if (existingTransport instanceof StreamableHTTPServerTransport) {
+        // Reuse existing transport
+        transport = existingTransport;
+      } else {
+        // Transport exists but is not a StreamableHTTPServerTransport (could be SSEServerTransport)
+        res.status(400).json({
+          jsonrpc: '2.0',
+          error: {
+            code: -32000,
+            message: 'Bad Request: Session exists but uses a different transport protocol',
+          },
+          id: null,
+        });
+        return;
+      }
+    } else if (!sessionId && req.method === 'POST' && isInitializeRequest(req.body)) {
+      const eventStore = new InMemoryEventStore();
+      transport = new StreamableHTTPServerTransport({
+        sessionIdGenerator: () => randomUUID(),
+        eventStore, // Enable resumability
+        onsessioninitialized: (sessionId) => {
+          // Store the transport by session ID when session is initialized
+          console.log(`StreamableHTTP session initialized with ID: ${sessionId}`);
+          transports[sessionId] = transport;
+        }
+      });
+
+      // Set up onclose handler to clean up transport when closed
+      transport.onclose = () => {
+        const sid = transport.sessionId;
+        if (sid && transports[sid]) {
+          console.log(`Transport closed for session ${sid}, removing from transports map`);
+          delete transports[sid];
+        }
+      };
+
+      // Connect the transport to the MCP server
+      await server.connect(transport);
+    } else {
+      // Invalid request - no session ID or not initialization request
+      res.status(400).json({
+        jsonrpc: '2.0',
+        error: {
+          code: -32000,
+          message: 'Bad Request: No valid session ID provided',
+        },
+        id: null,
+      });
+      return;
+    }
+
+    // Handle the request with the transport
+    await transport.handleRequest(req, res, req.body);
+  } catch (error) {
+    console.error('Error handling MCP request:', error);
+    if (!res.headersSent) {
+      res.status(500).json({
+        jsonrpc: '2.0',
+        error: {
+          code: -32603,
+          message: 'Internal server error',
+        },
+        id: null,
+      });
+    }
+  }
+});
+
+//=============================================================================
+// DEPRECATED HTTP+SSE TRANSPORT (PROTOCOL VERSION 2024-11-05)
+//=============================================================================
+
+app.get('/sse', async (req: Request, res: Response) => {
+  console.log('Received GET request to /sse (deprecated SSE transport)');
+  const transport = new SSEServerTransport('/messages', res);
+  transports[transport.sessionId] = transport;
+  res.on("close", () => {
+    delete transports[transport.sessionId];
+  });
+  await server.connect(transport);
+});
+
+app.post("/messages", async (req: Request, res: Response) => {
+  const sessionId = req.query.sessionId as string;
+  let transport: SSEServerTransport;
+  const existingTransport = transports[sessionId];
+  if (existingTransport instanceof SSEServerTransport) {
+    // Reuse existing transport
+    transport = existingTransport;
+  } else {
+    // Transport exists but is not a SSEServerTransport (could be StreamableHTTPServerTransport)
+    res.status(400).json({
+      jsonrpc: '2.0',
+      error: {
+        code: -32000,
+        message: 'Bad Request: Session exists but uses a different transport protocol',
+      },
+      id: null,
+    });
+    return;
+  }
+  if (transport) {
+    await transport.handlePostMessage(req, res);
+  } else {
+    res.status(400).send('No transport found for sessionId');
+  }
+});
+
+
+// Start the server
+const PORT = 3000;
+app.listen(PORT, () => {
+  console.log(`Backwards compatible MCP server listening on port ${PORT}`);
+  console.log(`
+==============================================
+SUPPORTED TRANSPORT OPTIONS:
+
+1. Streamable Http(Protocol version: 2025-03-26)
+   Endpoint: /mcp
+   Methods: GET, POST, DELETE
+   Usage: 
+     - Initialize with POST to /mcp
+     - Establish SSE stream with GET to /mcp
+     - Send requests with POST to /mcp
+     - Terminate session with DELETE to /mcp
+
+2. Http + SSE (Protocol version: 2024-11-05)
+   Endpoints: /sse (GET) and /request (POST)
+   Usage:
+     - Establish SSE stream with GET to /sse
+     - Send requests with POST to /message?sessionId=<id>
+==============================================
+`);
+});
+
+// Handle server shutdown
+process.on('SIGINT', async () => {
+  console.log('Shutting down server...');
+
+  // Close all active transports to properly clean up resources
+  for (const sessionId in transports) {
+    try {
+      console.log(`Closing transport for session ${sessionId}`);
+      await transports[sessionId].close();
+      delete transports[sessionId];
+    } catch (error) {
+      console.error(`Error closing transport for session ${sessionId}:`, error);
+    }
+  }
+  await server.close();
+  console.log('Server shutdown complete');
+  process.exit(0);
+});

--- a/src/examples/server/sseAndStreamableHttpCompatibleServer.ts
+++ b/src/examples/server/sseAndStreamableHttpCompatibleServer.ts
@@ -14,7 +14,7 @@ import { CallToolResult, isInitializeRequest, JSONRPCMessage } from '../../types
  * It maintains a single MCP server instance but exposes two transport options:
  * - /mcp: The new Streamable HTTP endpoint (supports GET/POST/DELETE)
  * - /sse: The deprecated SSE endpoint for older clients (GET to establish stream)
- * - /request: The deprecated POST endpoint for older clients (POST to send messages)
+ * - /messages: The deprecated POST endpoint for older clients (POST to send messages)
  */
 
 // Simple in-memory event store for resumability
@@ -288,10 +288,10 @@ SUPPORTED TRANSPORT OPTIONS:
      - Terminate session with DELETE to /mcp
 
 2. Http + SSE (Protocol version: 2024-11-05)
-   Endpoints: /sse (GET) and /request (POST)
+   Endpoints: /sse (GET) and /messages (POST)
    Usage:
      - Establish SSE stream with GET to /sse
-     - Send requests with POST to /message?sessionId=<id>
+     - Send requests with POST to /messages?sessionId=<id>
 ==============================================
 `);
 });

--- a/src/examples/server/standaloneSseWithGetStreamableHttp.ts
+++ b/src/examples/server/standaloneSseWithGetStreamableHttp.ts
@@ -2,7 +2,7 @@ import express, { Request, Response } from 'express';
 import { randomUUID } from 'node:crypto';
 import { McpServer } from '../../server/mcp.js';
 import { StreamableHTTPServerTransport } from '../../server/streamableHttp.js';
-import { ReadResourceResult } from '../../types.js';
+import { isInitializeRequest, ReadResourceResult } from '../../types.js';
 
 // Create an MCP server with implementation details
 const server = new McpServer({
@@ -107,13 +107,6 @@ app.get('/mcp', async (req: Request, res: Response) => {
   await transport.handleRequest(req, res);
 });
 
-// Helper function to detect initialize requests
-function isInitializeRequest(body: unknown): boolean {
-  if (Array.isArray(body)) {
-    return body.some(msg => typeof msg === 'object' && msg !== null && 'method' in msg && msg.method === 'initialize');
-  }
-  return typeof body === 'object' && body !== null && 'method' in body && body.method === 'initialize';
-}
 
 // Start the server
 const PORT = 3000;

--- a/src/examples/shared/inMemoryEventStore.ts
+++ b/src/examples/shared/inMemoryEventStore.ts
@@ -1,0 +1,77 @@
+import { JSONRPCMessage } from '../../types.js';
+import { EventStore } from '../../server/streamableHttp.js';
+
+/**
+ * Simple in-memory implementation of the EventStore interface for resumability
+ * This is primarily intended for examples and testing, not for production use
+ * where a persistent storage solution would be more appropriate.
+ */
+export class InMemoryEventStore implements EventStore {
+  private events: Map<string, { streamId: string, message: JSONRPCMessage }> = new Map();
+
+  /**
+   * Generates a unique event ID for a given stream ID
+   */
+  private generateEventId(streamId: string): string {
+    return `${streamId}_${Date.now()}_${Math.random().toString(36).substring(2, 10)}`;
+  }
+
+  /**
+   * Extracts the stream ID from an event ID
+   */
+  private getStreamIdFromEventId(eventId: string): string {
+    const parts = eventId.split('_');
+    return parts.length > 0 ? parts[0] : '';
+  }
+
+  /**
+   * Stores an event with a generated event ID
+   * Implements EventStore.storeEvent
+   */
+  async storeEvent(streamId: string, message: JSONRPCMessage): Promise<string> {
+    const eventId = this.generateEventId(streamId);
+    this.events.set(eventId, { streamId, message });
+    return eventId;
+  }
+
+  /**
+   * Replays events that occurred after a specific event ID
+   * Implements EventStore.replayEventsAfter
+   */
+  async replayEventsAfter(lastEventId: string,
+    { send }: { send: (eventId: string, message: JSONRPCMessage) => Promise<void> }
+  ): Promise<string> {
+    if (!lastEventId || !this.events.has(lastEventId)) {
+      return '';
+    }
+
+    // Extract the stream ID from the event ID
+    const streamId = this.getStreamIdFromEventId(lastEventId);
+    if (!streamId) {
+      return '';
+    }
+
+    let foundLastEvent = false;
+
+    // Sort events by eventId for chronological ordering
+    const sortedEvents = [...this.events.entries()].sort((a, b) => a[0].localeCompare(b[0]));
+
+    for (const [eventId, { streamId: eventStreamId, message }] of sortedEvents) {
+      // Only include events from the same stream
+      if (eventStreamId !== streamId) {
+        continue;
+      }
+
+      // Start sending events after we find the lastEventId
+      if (eventId === lastEventId) {
+        foundLastEvent = true;
+        continue;
+      }
+
+      if (foundLastEvent) {
+        await send(eventId, message);
+      }
+    }
+    return streamId;
+  }
+}

--- a/src/integration-tests/stateManagementStreamableHttp.test.ts
+++ b/src/integration-tests/stateManagementStreamableHttp.test.ts
@@ -1,0 +1,265 @@
+import { createServer, type Server } from 'node:http';
+import { AddressInfo } from 'node:net';
+import { randomUUID } from 'node:crypto';
+import { Client } from '../client/index.js';
+import { StreamableHTTPClientTransport } from '../client/streamableHttp.js';
+import { McpServer } from '../server/mcp.js';
+import { StreamableHTTPServerTransport } from '../server/streamableHttp.js';
+import { CallToolResultSchema, ListToolsResultSchema, ListResourcesResultSchema, ListPromptsResultSchema } from '../types.js';
+import { z } from 'zod';
+
+describe('Streamable HTTP Transport Session Management', () => {
+  // Function to set up the server with optional session management
+  async function setupServer(withSessionManagement: boolean) {
+    const server: Server = createServer();
+    const mcpServer = new McpServer(
+      { name: 'test-server', version: '1.0.0' },
+      {
+        capabilities: {
+          logging: {},
+          tools: {},
+          resources: {},
+          prompts: {}
+        }
+      }
+    );
+
+    // Add a simple resource
+    mcpServer.resource(
+      'test-resource',
+      '/test',
+      { description: 'A test resource' },
+      async () => ({
+        contents: [{
+          uri: '/test',
+          text: 'This is a test resource content'
+        }]
+      })
+    );
+
+    mcpServer.prompt(
+      'test-prompt',
+      'A test prompt',
+      async () => ({
+        messages: [{
+          role: 'user',
+          content: {
+            type: 'text',
+            text: 'This is a test prompt'
+          }
+        }]
+      })
+    );
+
+    mcpServer.tool(
+      'greet',
+      'A simple greeting tool',
+      {
+        name: z.string().describe('Name to greet').default('World'),
+      },
+      async ({ name }) => {
+        return {
+          content: [{ type: 'text', text: `Hello, ${name}!` }]
+        };
+      }
+    );
+
+    // Create transport with or without session management
+    const serverTransport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: withSessionManagement
+        ? () => randomUUID()   // With session management, generate UUID
+        : () => undefined      // Without session management, return undefined
+    });
+
+    await mcpServer.connect(serverTransport);
+
+    server.on('request', async (req, res) => {
+      await serverTransport.handleRequest(req, res);
+    });
+
+    // Start the server on a random port
+    const baseUrl = await new Promise<URL>((resolve) => {
+      server.listen(0, '127.0.0.1', () => {
+        const addr = server.address() as AddressInfo;
+        resolve(new URL(`http://127.0.0.1:${addr.port}`));
+      });
+    });
+
+    return { server, mcpServer, serverTransport, baseUrl };
+  }
+
+  describe('Stateless Mode', () => {
+    let server: Server;
+    let mcpServer: McpServer;
+    let serverTransport: StreamableHTTPServerTransport;
+    let baseUrl: URL;
+
+    beforeEach(async () => {
+      const setup = await setupServer(false);
+      server = setup.server;
+      mcpServer = setup.mcpServer;
+      serverTransport = setup.serverTransport;
+      baseUrl = setup.baseUrl;
+    });
+
+    afterEach(async () => {
+      // Clean up resources
+      await mcpServer.close().catch(() => { });
+      await serverTransport.close().catch(() => { });
+      server.close();
+    });
+
+    it('should operate without session management', async () => {
+      // Create and connect a client
+      const client = new Client({
+        name: 'test-client',
+        version: '1.0.0'
+      });
+
+      const transport = new StreamableHTTPClientTransport(baseUrl);
+      await client.connect(transport);
+
+      // Verify that no session ID was set
+      expect(transport.sessionId).toBeUndefined();
+
+      // List available tools
+      const toolsResult = await client.request({
+        method: 'tools/list',
+        params: {}
+      }, ListToolsResultSchema);
+
+      // Verify tools are accessible
+      expect(toolsResult.tools).toContainEqual(expect.objectContaining({
+        name: 'greet'
+      }));
+
+      // List available resources
+      const resourcesResult = await client.request({
+        method: 'resources/list',
+        params: {}
+      }, ListResourcesResultSchema);
+
+      // Verify resources result structure
+      expect(resourcesResult).toHaveProperty('resources');
+
+      // List available prompts
+      const promptsResult = await client.request({
+        method: 'prompts/list',
+        params: {}
+      }, ListPromptsResultSchema);
+
+      // Verify prompts result structure
+      expect(promptsResult).toHaveProperty('prompts');
+      expect(promptsResult.prompts).toContainEqual(expect.objectContaining({
+        name: 'test-prompt'
+      }));
+
+      // Call the greeting tool
+      const greetingResult = await client.request({
+        method: 'tools/call',
+        params: {
+          name: 'greet',
+          arguments: {
+            name: 'Stateless Transport'
+          }
+        }
+      }, CallToolResultSchema);
+
+      // Verify tool result
+      expect(greetingResult.content).toEqual([
+        { type: 'text', text: 'Hello, Stateless Transport!' }
+      ]);
+
+      // Clean up
+      await transport.close();
+    });
+  });
+
+  describe('Stateful Mode', () => {
+    let server: Server;
+    let mcpServer: McpServer;
+    let serverTransport: StreamableHTTPServerTransport;
+    let baseUrl: URL;
+
+    beforeEach(async () => {
+      const setup = await setupServer(true);
+      server = setup.server;
+      mcpServer = setup.mcpServer;
+      serverTransport = setup.serverTransport;
+      baseUrl = setup.baseUrl;
+    });
+
+    afterEach(async () => {
+      // Clean up resources
+      await mcpServer.close().catch(() => { });
+      await serverTransport.close().catch(() => { });
+      server.close();
+    });
+
+    it('should operate with session management', async () => {
+      // Create and connect a client
+      const client = new Client({
+        name: 'test-client',
+        version: '1.0.0'
+      });
+
+      const transport = new StreamableHTTPClientTransport(baseUrl);
+      await client.connect(transport);
+
+      // Verify that a session ID was set
+      expect(transport.sessionId).toBeDefined();
+      expect(typeof transport.sessionId).toBe('string');
+
+      // List available tools
+      const toolsResult = await client.request({
+        method: 'tools/list',
+        params: {}
+      }, ListToolsResultSchema);
+
+      // Verify tools are accessible
+      expect(toolsResult.tools).toContainEqual(expect.objectContaining({
+        name: 'greet'
+      }));
+
+      // List available resources
+      const resourcesResult = await client.request({
+        method: 'resources/list',
+        params: {}
+      }, ListResourcesResultSchema);
+
+      // Verify resources result structure
+      expect(resourcesResult).toHaveProperty('resources');
+
+      // List available prompts
+      const promptsResult = await client.request({
+        method: 'prompts/list',
+        params: {}
+      }, ListPromptsResultSchema);
+
+      // Verify prompts result structure
+      expect(promptsResult).toHaveProperty('prompts');
+      expect(promptsResult.prompts).toContainEqual(expect.objectContaining({
+        name: 'test-prompt'
+      }));
+
+      // Call the greeting tool
+      const greetingResult = await client.request({
+        method: 'tools/call',
+        params: {
+          name: 'greet',
+          arguments: {
+            name: 'Stateful Transport'
+          }
+        }
+      }, CallToolResultSchema);
+
+      // Verify tool result
+      expect(greetingResult.content).toEqual([
+        { type: 'text', text: 'Hello, Stateful Transport!' }
+      ]);
+
+      // Clean up
+      await transport.close();
+    });
+  });
+});

--- a/src/integration-tests/stateManagementStreamableHttp.test.ts
+++ b/src/integration-tests/stateManagementStreamableHttp.test.ts
@@ -140,7 +140,7 @@ describe('Streamable HTTP Transport Session Management', () => {
       expect(transport2.sessionId).toBeUndefined();
 
       // List available tools
-      await client1.request({
+      await client2.request({
         method: 'tools/list',
         params: {}
       }, ListToolsResultSchema);

--- a/src/integration-tests/stateManagementStreamableHttp.test.ts
+++ b/src/integration-tests/stateManagementStreamableHttp.test.ts
@@ -68,7 +68,7 @@ describe('Streamable HTTP Transport Session Management', () => {
     const serverTransport = new StreamableHTTPServerTransport({
       sessionIdGenerator: withSessionManagement
         ? () => randomUUID()   // With session management, generate UUID
-        : () => undefined      // Without session management, return undefined
+        : undefined     // Without session management, return undefined
     });
 
     await mcpServer.connect(serverTransport);

--- a/src/integration-tests/stateManagementStreamableHttp.test.ts
+++ b/src/integration-tests/stateManagementStreamableHttp.test.ts
@@ -109,6 +109,44 @@ describe('Streamable HTTP Transport Session Management', () => {
       server.close();
     });
 
+    it('should support multiple client connections', async () => {
+      // Create and connect a client
+      const client1 = new Client({
+        name: 'test-client',
+        version: '1.0.0'
+      });
+
+      const transport1 = new StreamableHTTPClientTransport(baseUrl);
+      await client1.connect(transport1);
+
+      // Verify that no session ID was set
+      expect(transport1.sessionId).toBeUndefined();
+
+      // List available tools
+      await client1.request({
+        method: 'tools/list',
+        params: {}
+      }, ListToolsResultSchema);
+
+      const client2 = new Client({
+        name: 'test-client',
+        version: '1.0.0'
+      });
+
+      const transport2 = new StreamableHTTPClientTransport(baseUrl);
+      await client2.connect(transport2);
+
+      // Verify that no session ID was set
+      expect(transport2.sessionId).toBeUndefined();
+
+      // List available tools
+      await client1.request({
+        method: 'tools/list',
+        params: {}
+      }, ListToolsResultSchema);
+
+      
+    });
     it('should operate without session management', async () => {
       // Create and connect a client
       const client = new Client({

--- a/src/integration-tests/taskResumability.test.ts
+++ b/src/integration-tests/taskResumability.test.ts
@@ -4,68 +4,11 @@ import { randomUUID } from 'node:crypto';
 import { Client } from '../client/index.js';
 import { StreamableHTTPClientTransport } from '../client/streamableHttp.js';
 import { McpServer } from '../server/mcp.js';
-import { EventStore, StreamableHTTPServerTransport } from '../server/streamableHttp.js';
-import { CallToolResultSchema, JSONRPCMessage, LoggingMessageNotificationSchema } from '../types.js';
+import { StreamableHTTPServerTransport } from '../server/streamableHttp.js';
+import { CallToolResultSchema, LoggingMessageNotificationSchema } from '../types.js';
 import { z } from 'zod';
+import { InMemoryEventStore } from '../examples/shared/inMemoryEventStore.js';
 
-/**
- * Simple in-memory event store implementation for resumability
- */
-class InMemoryEventStore implements EventStore {
-  private events: Map<string, { streamId: string, message: JSONRPCMessage }> = new Map();
-
-  private generateEventId(streamId: string): string {
-    return `${streamId}_${Date.now()}_${Math.random().toString(36).substring(2, 10)}`;
-  }
-
-  private getStreamIdFromEventId(eventId: string): string {
-    const parts = eventId.split('_');
-    return parts.length > 0 ? parts[0] : '';
-  }
-
-  async storeEvent(streamId: string, message: JSONRPCMessage): Promise<string> {
-    const eventId = this.generateEventId(streamId);
-    this.events.set(eventId, { streamId, message });
-    return eventId;
-  }
-
-  async replayEventsAfter(lastEventId: string,
-    { send }: { send: (eventId: string, message: JSONRPCMessage) => Promise<void> }
-  ): Promise<string> {
-    if (!lastEventId || !this.events.has(lastEventId)) {
-      return '';
-    }
-
-    // Extract the stream ID from the event ID
-    const streamId = this.getStreamIdFromEventId(lastEventId);
-    if (!streamId) {
-      return '';
-    }
-    let foundLastEvent = false;
-
-    // Sort events by eventId for chronological ordering
-    const sortedEvents = [...this.events.entries()].sort((a, b) => a[0].localeCompare(b[0]));
-
-    for (const [eventId, { streamId: eventStreamId, message }] of sortedEvents) {
-      // Only include events from the same stream
-      if (eventStreamId !== streamId) {
-        continue;
-      }
-
-      // Start collecting events after we find the lastEventId
-      if (eventId === lastEventId) {
-        foundLastEvent = true;
-        continue;
-      }
-
-      if (foundLastEvent) {
-        await send(eventId, message);
-      }
-    }
-
-    return streamId;
-  }
-}
 
 
 describe('Transport resumability', () => {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -105,6 +105,13 @@ export class Server<
   }
 
   /**
+   * The server's name and version.
+   */
+  getVersion(): { readonly name: string; readonly version: string } {
+    return this._serverInfo;
+  }
+
+  /**
    * Registers new capabilities. This can only be called before connecting to a transport.
    *
    * The new capabilities will be merged with any existing capabilities previously given (e.g., at initialization).

--- a/src/server/mcp.test.ts
+++ b/src/server/mcp.test.ts
@@ -26,6 +26,10 @@ describe("McpServer", () => {
     });
 
     expect(mcpServer.server).toBeDefined();
+    expect(mcpServer.server.getVersion()).toEqual({
+      name: "test server",
+      version: "1.0",
+    });
   });
 
   test("should allow sending notifications via Server", async () => {

--- a/src/server/streamableHttp.test.ts
+++ b/src/server/streamableHttp.test.ts
@@ -187,15 +187,11 @@ describe("StreamableHTTPServerTransport", () => {
     expect(sessionId).toBeDefined();
 
     // Try second initialize
-    const secondInitMessage: JSONRPCMessage = {
-      jsonrpc: "2.0",
-      method: "initialize",
-      params: {
-        clientInfo: { name: "test-client-2", version: "1.0" },
-        protocolVersion: "2025-03-26",
-      },
-      id: "init-2",
+    const secondInitMessage = {
+      ...TEST_MESSAGES.initialize,
+      id: "second-init"
     };
+
     const response = await sendPostRequest(baseUrl, secondInitMessage);
 
     expect(response.status).toBe(400);
@@ -1092,14 +1088,7 @@ describe("StreamableHTTPServerTransport in stateless mode", () => {
   });
 
   it("should handle POST requests with various session IDs in stateless mode", async () => {
-    // Initialize the server first
-    await fetch(baseUrl, {
-      method: "POST",
-      headers: { "Content-Type": "application/json", Accept: "application/json, text/event-stream" },
-      body: JSON.stringify({
-        jsonrpc: "2.0", method: "initialize", params: { clientInfo: { name: "test-client", version: "1.0" }, protocolVersion: "2025-03-26" }, id: "init-1"
-      }),
-    });
+    await sendPostRequest(baseUrl, TEST_MESSAGES.initialize);
 
     // Try with a random session ID - should be accepted
     const response1 = await fetch(baseUrl, {
@@ -1131,13 +1120,7 @@ describe("StreamableHTTPServerTransport in stateless mode", () => {
     // one standalone SSE stream at a time
 
     // Initialize the server first
-    await fetch(baseUrl, {
-      method: "POST",
-      headers: { "Content-Type": "application/json", Accept: "application/json, text/event-stream" },
-      body: JSON.stringify({
-        jsonrpc: "2.0", method: "initialize", params: { clientInfo: { name: "test-client", version: "1.0" }, protocolVersion: "2025-03-26" }, id: "init-1"
-      }),
-    });
+    await sendPostRequest(baseUrl, TEST_MESSAGES.initialize);
 
     // Open first SSE stream
     const stream1 = await fetch(baseUrl, {

--- a/src/server/streamableHttp.ts
+++ b/src/server/streamableHttp.ts
@@ -343,7 +343,7 @@ export class StreamableHTTPServerTransport implements Transport {
       if (isInitializationRequest) {
         // If it's a server with session management and the session ID is already set we should reject the request
         // to avoid re-initialization.
-        if (this._initialized) {
+        if (this._initialized && this.sessionId !== undefined) {
           res.writeHead(400).end(JSON.stringify({
             jsonrpc: "2.0",
             error: {

--- a/src/server/streamableHttp.ts
+++ b/src/server/streamableHttp.ts
@@ -37,7 +37,7 @@ export interface StreamableHTTPServerTransportOptions {
    * 
    * Return undefined to disable session management.
    */
-  sessionIdGenerator: () => string | undefined;
+  sessionIdGenerator: (() => string) | undefined;
 
   /**
    * A callback for session initialization events
@@ -98,7 +98,7 @@ export interface StreamableHTTPServerTransportOptions {
  */
 export class StreamableHTTPServerTransport implements Transport {
   // when sessionId is not set (undefined), it means the transport is in stateless mode
-  private sessionIdGenerator: () => string | undefined;
+  private sessionIdGenerator: (() => string) | undefined;
   private _started: boolean = false;
   private _streamMapping: Map<string, ServerResponse> = new Map();
   private _requestToStreamMapping: Map<RequestId, string> = new Map();
@@ -365,7 +365,7 @@ export class StreamableHTTPServerTransport implements Transport {
           }));
           return;
         }
-        this.sessionId = this.sessionIdGenerator();
+        this.sessionId = this.sessionIdGenerator?.();
         this._initialized = true;
 
         // If we have a session ID and an onsessioninitialized handler, call it immediately

--- a/src/server/streamableHttp.ts
+++ b/src/server/streamableHttp.ts
@@ -42,7 +42,7 @@ export interface StreamableHTTPServerTransportOptions {
   /**
    * A callback for session initialization events
    * This is called when the server initializes a new session.
-   * Usefult in cases when you need to register multiple mcp sessions
+   * Useful in cases when you need to register multiple mcp sessions
    * and need to keep track of them.
    * @param sessionId The generated session ID
    */

--- a/src/shared/eventNotifier.test.ts
+++ b/src/shared/eventNotifier.test.ts
@@ -1,0 +1,145 @@
+import { createEventNotifier } from "./eventNotifier.js";
+
+describe("EventNotifier", () => {
+  let notifier: ReturnType<typeof createEventNotifier<string>>;
+
+  beforeEach(() => {
+    notifier = createEventNotifier<string>();
+  });
+
+  test("should notify listeners in registration order", () => {
+    const events: string[] = [];
+    notifier.onEvent((event) => events.push(`first: ${event}`));
+    notifier.onEvent((event) => events.push(`second: ${event}`));
+    notifier.onEvent((event) => events.push(`third: ${event}`));
+
+    notifier.notify("test event");
+
+    expect(events).toEqual([
+      "first: test event",
+      "second: test event",
+      "third: test event",
+    ]);
+  });
+
+  test("should not notify unsubscribed listeners", () => {
+    const events: string[] = [];
+    const subscription = notifier.onEvent((event) => events.push(event));
+
+    notifier.notify("first event");
+    subscription.close();
+    notifier.notify("second event");
+
+    expect(events).toEqual(["first event"]);
+  });
+
+  test("should handle function events", () => {
+    const events: string[] = [];
+    notifier.onEvent((event) => events.push(event));
+
+    notifier.notify(() => "dynamic event");
+
+    expect(events).toEqual(["dynamic event"]);
+  });
+
+  test("should handle errors through error handler", () => {
+    const errors: Error[] = [];
+    notifier.onError((error) => errors.push(error));
+
+    notifier.onEvent(() => {
+      throw new Error("test error");
+    });
+
+    notifier.notify("test event");
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toBeInstanceOf(Error);
+    expect(errors[0].message).toBe("test error");
+  });
+
+  test("should not notify after close", () => {
+    const events: string[] = [];
+    notifier.onEvent((event) => events.push(event));
+
+    notifier.notify("first event");
+    notifier.close();
+    notifier.notify("second event");
+
+    expect(events).toEqual(["first event"]);
+  });
+
+  test("should handle multiple subscriptions and unsubscriptions", () => {
+    const events: string[] = [];
+    const subscription1 = notifier.onEvent((event) =>
+      events.push(`1: ${event}`)
+    );
+    const subscription2 = notifier.onEvent((event) =>
+      events.push(`2: ${event}`)
+    );
+
+    notifier.notify("first event");
+    subscription1.close();
+    notifier.notify("second event");
+    subscription2.close();
+    notifier.notify("third event");
+
+    expect(events).toEqual([
+      "1: first event",
+      "2: first event",
+      "2: second event",
+    ]);
+  });
+
+  test("should handle error handler after close", () => {
+    const errors: Error[] = [];
+    notifier.onError((error) => errors.push(error));
+    notifier.close();
+
+    notifier.onEvent(() => {
+      throw new Error("test error");
+    });
+
+    notifier.notify("test event");
+
+    expect(errors).toHaveLength(0);
+  });
+
+  test("should clear error handler on close", () => {
+    const errors: Error[] = [];
+    notifier.onError((error) => errors.push(error));
+
+    // Close should clear the error handler
+    notifier.close();
+
+    // Setting up a new listener after close
+    notifier.onEvent(() => {
+      throw new Error("test error");
+    });
+
+    // This should not trigger the error handler since the notifier is closed
+    notifier.notify("test event");
+
+    expect(errors).toHaveLength(0);
+  });
+
+  test("should use the last set error handler", () => {
+    const errors1: Error[] = [];
+    const errors2: Error[] = [];
+
+    // First error handler
+    notifier.onError((error) => errors1.push(error));
+
+    // Second error handler should replace the first one
+    notifier.onError((error) => errors2.push(error));
+
+    notifier.onEvent(() => {
+      throw new Error("test error");
+    });
+
+    notifier.notify("test event");
+
+    expect(errors1).toHaveLength(0);
+    expect(errors2).toHaveLength(1);
+    expect(errors2[0].message).toBe("test error");
+  });
+});

--- a/src/shared/eventNotifier.ts
+++ b/src/shared/eventNotifier.ts
@@ -1,0 +1,149 @@
+/**
+ * Provides a simple, type-safe event notification implementation. This module allows components to implement the
+ * observer pattern with minimal boilerplate and proper type checking.
+ */
+
+/**
+ * A type-safe event notifier that manages event listeners and notifications.
+ *
+ * @template T The type of events this notifier will handle
+ * @template E The type of error that can be handled (defaults to Error)
+ *
+ *   EventNotifier provides:
+ *
+ *   - Type-safe event subscriptions via `onEvent`
+ *   - Synchronized event notifications via `notify`
+ *   - Automatic cleanup of resources via `close`
+ *   - Status tracking via `active` property
+ *   - Error handling via optional error callback
+ */
+export type EventNotifier<T, E = Error> = {
+  /**
+   * Registers a listener function to be called when events are notified. Listeners are notified in the order they
+   * were registered.
+   *
+   * @example
+   *
+   * ```ts
+   * const notifier = createEventNotifier<string>();
+   * const subscription = notifier.onEvent((message) => {
+   *   console.log(`Received message: ${message}`);
+   * });
+   *
+   * // Later, to stop listening:
+   * subscription.close();
+   * ```
+   *
+   * @param listener A function that will be called with the notified event
+   * @returns A SyncCloseable that, when closed, will unregister the listener
+   */
+  onEvent: (listener: (event: T) => unknown) => { close: () => void };
+
+  /**
+   * Notifies all registered listeners with the provided event.
+   *
+   * This method:
+   *
+   * - Calls all registered listeners with the event in their registration order
+   * - Ignores errors thrown by listeners (they won't affect other listeners)
+   * - Ignores returned promises (results are not awaited)
+   * - Does nothing if there are no listeners
+   * - If the event is a function, it will be called if there are listeners and its return value will be
+   *   used as the event.
+   *
+   * @example
+   *
+   * ```ts
+   * const notifier = createEventNotifier<{ type: string; data: unknown }>();
+   * notifier.onEvent((event) => {
+   *   console.log(`Received ${event.type} with data:`, event.data);
+   * });
+   *
+   * notifier.notify({ type: 'update', data: { id: 123, status: 'complete' } });
+   * ```
+   *
+   * @param event The event to send to all listeners or a function that returns such event.
+   */
+  notify: (event: T | (() => T)) => void;
+
+  /**
+   * Sets an error handler for the notifier. This handler will be called when a listener throws an error.
+   *
+   * @param handler A function that will be called with any errors thrown by listeners
+   */
+  onError: (handler: (error: E) => void) => void;
+
+  /**
+   * Closes the notifier and removes all listeners.
+   *
+   * @warning Failing to call close() on subscriptions or the notifier itself may lead to memory leaks.
+   */
+  close: () => void;
+};
+
+/**
+ * Creates a type-safe event notifier.
+ *
+ * @example
+ *
+ * ```ts
+ * // Simple string event notifier
+ * const stringNotifier = createEventNotifier<string>();
+ *
+ * // Complex object event notifier
+ * interface UserEvent {
+ *   type: 'created' | 'updated' | 'deleted';
+ *   userId: number;
+ *   data?: Record<string, unknown>;
+ * }
+ * const userNotifier = createEventNotifier<UserEvent>();
+ * ```
+ *
+ * @template T The type of events this notifier will handle
+ * @template E The type of error that can be handled (defaults to Error)
+ * @returns A new EventNotifier instance
+ */
+export const createEventNotifier = <T, E = Error>(): EventNotifier<T, E> => {
+  const listeners = new Set<(event: T) => unknown>();
+  let errorHandler: ((error: E) => void) | undefined;
+
+  return {
+    close: () => {
+      listeners.clear();
+      errorHandler = undefined;
+    },
+
+    onEvent: (listener) => {
+      listeners.add(listener);
+      return {
+        close: () => {
+          listeners.delete(listener);
+        },
+      };
+    },
+
+    notify: (event: T | (() => T)) => {
+      if (!listeners.size) {
+        return;
+      }
+
+      if (typeof event === "function") {
+        event = (event as () => T)();
+      }
+
+      for (const listener of listeners) {
+        try {
+          void listener(event);
+        } catch (error) {
+          if (errorHandler) {
+            errorHandler(error as E);
+          }
+        }
+      }
+    },
+
+    onError: (handler) => {
+      errorHandler = handler;
+    },
+  };
+};

--- a/src/shared/eventNotifier.ts
+++ b/src/shared/eventNotifier.ts
@@ -35,7 +35,7 @@ export type EventNotifier<T, E = Error> = {
    * ```
    *
    * @param listener A function that will be called with the notified event
-   * @returns A SyncCloseable that, when closed, will unregister the listener
+   * @returns A closeable to unregister the listener (all listeners are unregistered when the notifier is closed).
    */
   onEvent: (listener: (event: T) => unknown) => { close: () => void };
 
@@ -69,7 +69,7 @@ export type EventNotifier<T, E = Error> = {
   /**
    * Sets an error handler for the notifier. This handler will be called when a listener throws an error.
    *
-   * @param handler A function that will be called with any errors thrown by listeners
+   * @param handler A function that will be called with any errors thrown by listeners.
    */
   onError: (handler: (error: E) => void) => void;
 
@@ -101,7 +101,7 @@ export type EventNotifier<T, E = Error> = {
  *
  * @template T The type of events this notifier will handle
  * @template E The type of error that can be handled (defaults to Error)
- * @returns A new EventNotifier instance
+ * @returns A new EventNotifier instance.
  */
 export const createEventNotifier = <T, E = Error>(): EventNotifier<T, E> => {
   const listeners = new Set<(event: T) => unknown>();

--- a/src/shared/eventNotifier.ts
+++ b/src/shared/eventNotifier.ts
@@ -54,12 +54,12 @@ export type EventNotifier<T, E = Error> = {
    * @example
    *
    * ```ts
-   * const notifier = createEventNotifier<{ type: string; data: unknown }>();
+   * const notifier = createEventNotifier<{ type: string; value: number }>();
    * notifier.onEvent((event) => {
-   *   console.log(`Received ${event.type} with data:`, event.data);
+   *   console.log(`Received ${event.type} with value:`, event.value);
    * });
    *
-   * notifier.notify({ type: 'update', data: { id: 123, status: 'complete' } });
+   * notifier.notify({ type: 'progress', value: 75 });
    * ```
    *
    * @param event The event to send to all listeners or a function that returns such event.
@@ -91,12 +91,15 @@ export type EventNotifier<T, E = Error> = {
  * const stringNotifier = createEventNotifier<string>();
  *
  * // Complex object event notifier
- * interface UserEvent {
- *   type: 'created' | 'updated' | 'deleted';
- *   userId: number;
- *   data?: Record<string, unknown>;
+ * interface TaskEvent {
+ *   type: 'started' | 'completed' | 'failed';
+ *   taskId: number;
+ *   details: {
+ *     name: string;
+ *     duration?: number;
+ *   };
  * }
- * const userNotifier = createEventNotifier<UserEvent>();
+ * const taskNotifier = createEventNotifier<TaskEvent>();
  * ```
  *
  * @template T The type of events this notifier will handle

--- a/src/shared/stdio.ts
+++ b/src/shared/stdio.ts
@@ -1,5 +1,17 @@
 import { JSONRPCMessage, JSONRPCMessageSchema } from "../types.js";
 
+export class StdioParseError extends Error {
+  public readonly line: string;
+  constructor(message: string, line: string) {
+    super(message);
+    this.name = "StdioParseError";
+    this.line = line;
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, StdioParseError);
+    }
+  }
+}
+
 /**
  * Buffers a continuous stdio stream into discrete JSON-RPC messages.
  */
@@ -31,7 +43,11 @@ export class ReadBuffer {
 }
 
 export function deserializeMessage(line: string): JSONRPCMessage {
-  return JSONRPCMessageSchema.parse(JSON.parse(line));
+  try {
+    return JSONRPCMessageSchema.parse(JSON.parse(line));
+  } catch (error) {
+    throw new StdioParseError(error instanceof Error ? error.message : String(error), line);
+  }
 }
 
 export function serializeMessage(message: JSONRPCMessage): string {

--- a/src/types.ts
+++ b/src/types.ts
@@ -248,6 +248,10 @@ export const InitializeRequestSchema = RequestSchema.extend({
   }),
 });
 
+export const isInitializeRequest = (value: unknown): value is InitializeRequest =>
+  InitializeRequestSchema.safeParse(value).success;
+
+
 /**
  * Capabilities that a server may support. Known capabilities are defined here, in this schema, but this is not a closed set: any server can define its own, additional capabilities.
  */
@@ -336,6 +340,9 @@ export const InitializeResultSchema = ResultSchema.extend({
 export const InitializedNotificationSchema = NotificationSchema.extend({
   method: z.literal("notifications/initialized"),
 });
+
+export const isInitializedNotification = (value: unknown): value is InitializedNotification =>
+  InitializedNotificationSchema.safeParse(value).success;
 
 /* Ping */
 /**


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
Add StdioParseError for improved error handling in stdio stream processing
    
    - Introduced a custom error class, StdioParseError, to handle parsing errors with line context.
    - Updated the StdioClientTransport to log line messages for StdioParseError and continue processing, while delegating other errors to the existing error handler.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
In Node.js, console.log() writes output to the stdout stream, which is typically displayed in the terminal.
When using JSON.parse on stdout, it is necessary to check and ignore service log entries.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Yes, with https://github.com/modelcontextprotocol/inspector.git

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
inspector error will be like this

> @modelcontextprotocol/inspector@0.9.0 start
> node client/bin/start.js

Debugger attached.
Starting MCP inspector...
Debugger attached.
⚙️ Proxy server listening on port 6277
Debugger attached.
🔍 MCP Inspector is up and running at http://127.0.0.1:6274 🚀
New SSE connection
Query parameters: [Object: null prototype] {
  transportType: 'stdio',
  command: 'ts-node',
  args: '/Users/shun/Documents/project/github-repo/vscode-notebook/typescript/mcp/src/index.ts',
  env: '{}'
}
Stdio transport: command=/Users/shun/Documents/project/source-code/inspector/node_modules/.bin/ts-node, args=/Users/shun/Documents/project/github-repo/vscode-notebook/typescript/mcp/src/index.ts
Spawned stdio transport
Connected MCP client to backing server transport
Created web app transport
Created web app transport
Set up MCP proxy
Error from MCP server: SyntaxError: Unexpected token > in JSON at position 0
    at JSON.parse (<anonymous>)
    at deserializeMessage (file:///Users/shun/Documents/project/source-code/inspector/node_modules/@modelcontextprotocol/sdk/dist/esm/shared/stdio.js:26:44)
    at ReadBuffer.readMessage (file:///Users/shun/Documents/project/source-code/inspector/node_modules/@modelcontextprotocol/sdk/dist/esm/shared/stdio.js:19:16)
    at StdioClientTransport.processReadBuffer (file:///Users/shun/Documents/project/source-code/inspector/node_modules/@modelcontextprotocol/sdk/dist/esm/client/stdio.js:114:50)
    at Socket.<anonymous> (file:///Users/shun/Documents/project/source-code/inspector/node_modules/@modelcontextprotocol/sdk/dist/esm/client/stdio.js:93:22)
    at Socket.emit (node:events:517:28)
    at addChunk (node:internal/streams/readable:368:12)
    at readableAddChunk (node:internal/streams/readable:341:9)
    at Readable.push (node:internal/streams/readable:278:10)
    at Pipe.onStreamRead (node:internal/stream_base_commons:190:23) 

