### PR TITLE
Pass `requestId` to handlers via metadata

### DIFF
--- a/src/shared/protocol.ts
+++ b/src/shared/protocol.ts
@@ -116,6 +116,12 @@ export type RequestHandlerExtra<SendRequestT extends Request,
     sessionId?: string;
 
     /**
+     * The JSON-RPC ID of the request being handled.
+     * This can be useful for tracking or logging purposes.
+     */
+    requestId: RequestId;
+
+    /**
      * Sends a notification that relates to the current request being handled.
      * 
      * This is used by certain transports to correctly associate related messages.
@@ -361,6 +367,7 @@ export abstract class Protocol<
       sendRequest: (r, resultSchema, options?) =>
         this.request(r, resultSchema, { ...options, relatedRequestId: request.id }),
       authInfo: extra?.authInfo,
+      requestId: request.id,
     };
 
     // Starting with Promise.resolve() puts any synchronous errors into the monad as well.


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

This PR passes the JSON RPC request ID to the `resource`, `tool`, and `prompt` handlers via the `RequestHandlerExtra` (`extra`) argument.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

I am maintaining the Sentry SDK and to provide observability into MCP servers we would like to be tracing requests to the MCP server.
As it stands, the tool, resource and prompt handlers live in the context of the SSE request handler, which makes it impossible to resort to `AsyncLocalStorage` to associate messages to the server with the handlers.

Passing the message's request ID along to the handlers allows us to correlate the POST message to the handler execution (allowing us to show users traces where the handlers are connected to the POST request). This would be great for error correlation, and also performance monitoring.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

I ran an MCP server locally and verified that the data is useful. Also added some tests.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

No. I don't think the `RequestHandlerExtra` is part of any user-facing "implementations".

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
  - Not sure if this requires an update somewhere...
