### PR TITLE
docs: add error handling when it fails to start HTTP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,7 +367,11 @@ app.delete('/mcp', async (req: Request, res: Response) => {
 // Start the server
 const PORT = 3000;
 setupServer().then(() => {
-  app.listen(PORT, () => {
+  app.listen(PORT, (error) => {
+    if (error) {
+      console.error('Failed to start server:', error);
+      process.exit(1);
+    }
     console.log(`MCP Streamable HTTP Server listening on port ${PORT}`);
   });
 }).catch(error => {


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
In sample code of Streamable HTTP, it may fail to start HTTP server. e.g. Port 3000 is already in use.
So, add error handling when it fails to start HTTP server

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

Test code in my Code Runner MCP Server: https://github.com/formulahendry/mcp-server-code-runner/blob/main/src/streamableHttp.ts

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
