### PR TITLE
Fixed Streamable HTTP Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,8 @@ import express from "express";
 import { randomUUID } from "node:crypto";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
-import { InMemoryEventStore } from "@modelcontextprotocol/sdk/inMemory.js";
+import { InMemoryEventStore } from "@modelcontextprotocol/sdk/examples/shared/inMemoryEventStore.js";
+import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js"
 
 
 const app = express();


### PR DESCRIPTION
I tried copying the Streamable HTTP example and it didn't work until I updated these imports.

## Motivation and Context
If someone wants to get going with the streaming http server code right away, they'll get errors and need to do the same as me.

## How Has This Been Tested?
copied the sample code, made these changes, built the mcp server, got no errors. connected to inspector, appears to be working. it wasn't building before. inspector needed to be running off of main, not the released version, because the released version doesn't yet support the streamable-http server

![Screenshot from 2025-04-21 00-03-13](https://github.com/user-attachments/assets/08afa6c1-1c73-4378-ba4c-04e77a80f77b)


## Breaking Changes
None!

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
Not comprehensive, not sure where else this issue exists.
