### PR TITLE
fix(stdio): ensure child process is killed on close to prevent orphan…

### DIFF
--- a/src/client/stdio.ts
+++ b/src/client/stdio.ts
@@ -187,7 +187,14 @@ export class StdioClientTransport implements Transport {
 
   async close(): Promise<void> {
     this._abortController.abort();
-    this._process = undefined;
+    if (this._process) {
+      try {
+        this._process.kill();
+      } catch (e) {
+        // Optionally log or ignore
+      }
+      this._process = undefined;
+    }
     this._readBuffer.clear();
   }
 


### PR DESCRIPTION

This PR updates the StdioClientTransport.close() method to explicitly call .kill() on the child process before clearing the process reference.

### Background & Motivation:

- Previously, when using stdio transports (e.g., with bunx, npx, or similar commands), the child process would not be terminated when the client disconnected.

- This could lead to orphaned subprocesses (such as lingering bunx or npx processes) after the parent agent/application exited, especially in environments where the agent is not running inside a disposable container.

### What’s changed:

- The close() method now checks if a child process exists and calls .kill() on it before setting the reference to undefined.

- This ensures all subprocesses are properly cleaned up when the client disconnects.

### Impact:

- Prevents resource leaks and phantom processes on the host system.

- No impact for users running everything inside short-lived containers, but improves robustness and hygiene for all environments.

### Testing:

Verified that after this change, no orphaned stdio subprocesses remain after agent exit, both in local and containerized environments.