### PR TITLE
fix: add windows env PROGRAMFILES, avoid some exe can not be found

### DIFF
--- a/src/client/stdio.ts
+++ b/src/client/stdio.ts
@@ -56,6 +56,7 @@ export const DEFAULT_INHERITED_ENV_VARS =
         "TEMP",
         "USERNAME",
         "USERPROFILE",
+        "PROGRAMFILES",
       ]
     : /* list inspired by the default env inheritance of sudo */
       ["HOME", "LOGNAME", "PATH", "SHELL", "TERM", "USER"];


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

add windows env PROGRAMFILES, avoid some exe can not be found.


## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

Some libs, [such as puppeteer](https://github.com/puppeteer/puppeteer/blob/98fe5581cb679b3018a296700e635abad7a2c88a/packages/browsers/src/browser-data/chrome.ts#L162-L173), use env PROGRAMFILES in Windows.

Adding default environment variable settings can make it easier to configure mcp based on these libs.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
