### PR TITLE
fix SSE transport server  examples

### DIFF
--- a/src/examples/server/simpleSseServer.ts
+++ b/src/examples/server/simpleSseServer.ts
@@ -102,10 +102,6 @@ app.get('/mcp', async (req: Request, res: Response) => {
     const server = getServer();
     await server.connect(transport);
 
-    // Start the SSE transport to begin streaming
-    // This sends an initial 'endpoint' event with the session ID in the URL
-    await transport.start();
-
     console.log(`Established SSE stream with session ID: ${sessionId}`);
   } catch (error) {
     console.error('Error establishing SSE stream:', error);

--- a/src/examples/server/sseAndStreamableHttpCompatibleServer.ts
+++ b/src/examples/server/sseAndStreamableHttpCompatibleServer.ts
@@ -194,7 +194,7 @@ app.post("/messages", async (req: Request, res: Response) => {
     return;
   }
   if (transport) {
-    await transport.handlePostMessage(req, res);
+    await transport.handlePostMessage(req, res, req.body);
   } else {
     res.status(400).send('No transport found for sessionId');
   }


### PR DESCRIPTION
Reported in https://github.com/modelcontextprotocol/typescript-sdk/issues/376, [sseAndStreamableHttpCompatibleServer.ts](https://github.com/modelcontextprotocol/typescript-sdk/blob/main/src/examples/server/sseAndStreamableHttpCompatibleServer.ts) example had an error on POST when testing with inspector. 

After the change:
<img width="324" alt="image" src="https://github.com/user-attachments/assets/a8896772-7df1-4eba-8d49-250431b744eb" />


Also removing `await transport.start();` from sseServer, it's not needed as connect is already doing it 