### PR TITLE
test(server): add more tests for `SSEServerTransport` class

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@modelcontextprotocol/sdk",
-  "version": "1.9.0",
+  "version": "1.10.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@modelcontextprotocol/sdk",
-      "version": "1.9.0",
+      "version": "1.10.2",
       "license": "MIT",
       "dependencies": {
         "content-type": "^1.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,12 @@
 {
   "name": "@modelcontextprotocol/sdk",
-<<<<<<< cb/sse-tests -- Incoming Change
-  "version": "1.10.2",
-=======
   "version": "1.13.1",
->>>>>>> main -- Current Change
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@modelcontextprotocol/sdk",
-<<<<<<< cb/sse-tests -- Incoming Change
-      "version": "1.10.2",
-=======
       "version": "1.13.1",
->>>>>>> main -- Current Change
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.6",

--- a/src/server/sse.test.ts
+++ b/src/server/sse.test.ts
@@ -7,11 +7,42 @@ const createMockResponse = () => {
     writeHead: jest.fn<http.ServerResponse['writeHead']>(),
     write: jest.fn<http.ServerResponse['write']>().mockReturnValue(true),
     on: jest.fn<http.ServerResponse['on']>(),
+    end: jest.fn<http.ServerResponse['end']>(),
   };
   res.writeHead.mockReturnThis();
   res.on.mockReturnThis();
   
   return res as unknown as http.ServerResponse;
+};
+
+const createMockRequest = ({ headers = {}, body }: { headers?: Record<string, string>, body?: string } = {}) => {
+  const mockReq = {
+    headers,
+    body: body ? body : undefined,
+    auth: {
+      token: 'test-token',
+    },
+    on: jest.fn<http.IncomingMessage['on']>().mockImplementation((event, listener) => {
+      const mockListener = listener as unknown as (...args: unknown[]) => void;
+      if (event === 'data') {
+        mockListener(Buffer.from(body || '') as unknown as Error);
+      }
+      if (event === 'error') {
+        mockListener(new Error('test'));
+      }
+      if (event === 'end') {
+        mockListener();
+      }
+      if (event === 'close') {
+        setTimeout(listener, 100);
+      }
+      return mockReq;
+    }),
+    listeners: jest.fn<http.IncomingMessage['listeners']>(),
+    removeListener: jest.fn<http.IncomingMessage['removeListener']>(),
+  } as unknown as http.IncomingMessage;
+
+  return mockReq;
 };
 
 describe('SSEServerTransport', () => {
@@ -104,6 +135,126 @@ describe('SSEServerTransport', () => {
       expect(mockRes.write).toHaveBeenCalledWith(
         `event: endpoint\ndata: /?sessionId=${expectedSessionId}\n\n`
       );
+    });
+  });
+
+  describe('handlePostMessage method', () => {
+    it('should return 500 if server has not started', async () => {
+      const mockReq = createMockRequest();
+      const mockRes = createMockResponse();
+      const endpoint = '/messages';
+      const transport = new SSEServerTransport(endpoint, mockRes);
+
+      const error = 'SSE connection not established';
+      await expect(transport.handlePostMessage(mockReq, mockRes))
+        .rejects.toThrow(error);
+      expect(mockRes.writeHead).toHaveBeenCalledWith(500);
+      expect(mockRes.end).toHaveBeenCalledWith(error);
+    });
+
+    it('should return 400 if content-type is not application/json', async () => {
+      const mockReq = createMockRequest({ headers: { 'content-type': 'text/plain' } });
+      const mockRes = createMockResponse();
+      const endpoint = '/messages';
+      const transport = new SSEServerTransport(endpoint, mockRes);
+      await transport.start();
+
+      transport.onerror = jest.fn();
+      const error = 'Unsupported content-type: text/plain';
+      await expect(transport.handlePostMessage(mockReq, mockRes))
+        .resolves.toBe(undefined);
+      expect(mockRes.writeHead).toHaveBeenCalledWith(400);
+      expect(mockRes.end).toHaveBeenCalledWith(expect.stringContaining(error));
+      expect(transport.onerror).toHaveBeenCalledWith(new Error(error));
+    });
+
+    it('should return 400 if message has not a valid schema', async () => {
+      const invalidMessage = JSON.stringify({
+        // missing jsonrpc field
+        method: 'call',
+        params: [1, 2, 3],
+        id: 1,
+      })
+      const mockReq = createMockRequest({
+        headers: { 'content-type': 'application/json' },
+        body: invalidMessage,
+      });
+      const mockRes = createMockResponse();
+      const endpoint = '/messages';
+      const transport = new SSEServerTransport(endpoint, mockRes);
+      await transport.start();
+
+      transport.onmessage = jest.fn();
+      await transport.handlePostMessage(mockReq, mockRes);
+      expect(mockRes.writeHead).toHaveBeenCalledWith(400);
+      expect(transport.onmessage).not.toHaveBeenCalled();
+      expect(mockRes.end).toHaveBeenCalledWith(`Invalid message: ${invalidMessage}`);
+    });
+
+    it('should return 202 if message has a valid schema', async () => {
+      const validMessage = JSON.stringify({
+        jsonrpc: "2.0",
+        method: 'call',
+        params: {
+          a: 1,
+          b: 2,
+          c: 3,
+        },
+        id: 1
+      })
+      const mockReq = createMockRequest({
+        headers: { 'content-type': 'application/json' },
+        body: validMessage,
+      });
+      const mockRes = createMockResponse();
+      const endpoint = '/messages';
+      const transport = new SSEServerTransport(endpoint, mockRes);
+      await transport.start();
+
+      transport.onmessage = jest.fn();
+      await transport.handlePostMessage(mockReq, mockRes);
+      expect(mockRes.writeHead).toHaveBeenCalledWith(202);
+      expect(mockRes.end).toHaveBeenCalledWith('Accepted');
+      expect(transport.onmessage).toHaveBeenCalledWith({
+        jsonrpc: "2.0",
+        method: 'call',
+        params: {
+          a: 1,
+          b: 2,
+          c: 3,
+        },
+        id: 1
+      }, {
+        authInfo: {
+          token: 'test-token',
+        }
+      });
+    });
+  });
+
+  describe('close method', () => {
+    it('should call onclose', async () => {
+      const mockRes = createMockResponse();
+      const endpoint = '/messages';
+      const transport = new SSEServerTransport(endpoint, mockRes);
+      await transport.start();
+      transport.onclose = jest.fn();
+      await transport.close();
+      expect(transport.onclose).toHaveBeenCalled();
+    });
+  });
+
+  describe('send method', () => {
+    it('should call onsend', async () => {
+      const mockRes = createMockResponse();
+      const endpoint = '/messages';
+      const transport = new SSEServerTransport(endpoint, mockRes);
+      await transport.start();
+      expect(mockRes.write).toHaveBeenCalledTimes(1);
+      expect(mockRes.write).toHaveBeenCalledWith(
+        expect.stringContaining('event: endpoint'));
+      expect(mockRes.write).toHaveBeenCalledWith(
+        expect.stringContaining(`data: /messages?sessionId=${transport.sessionId}`));
     });
   });
 });

--- a/src/server/sse.test.ts
+++ b/src/server/sse.test.ts
@@ -418,7 +418,12 @@ describe('SSEServerTransport', () => {
       }, {
         authInfo: {
           token: 'test-token',
-        }
+        },
+        requestInfo: {
+          headers: {
+            'content-type': 'application/json',
+          },
+        },
       });
     });
   });

--- a/src/server/sse.ts
+++ b/src/server/sse.ts
@@ -92,7 +92,7 @@ export class SSEServerTransport implements Transport {
     try {
       const ct = contentType.parse(req.headers["content-type"] ?? "");
       if (ct.type !== "application/json") {
-        throw new Error(`Unsupported content-type: ${ct}`);
+        throw new Error(`Unsupported content-type: ${ct.type}`);
       }
 
       body = parsedBody ?? await getRawBody(req, {


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
I've been skimming through the code and discovered that there is an opportunity to add more tests to the `SSEServerTransport` class. That's it!

Note: the `package-lock.json` change is not intended but it seems to be missing the recent update. Happy to revert though.

## How Has This Been Tested?
I added unit tests.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
