### PR TITLE
[FEAT] added support for AuthInfo in extra for StreamableHTTPServerTransport

### DIFF
--- a/src/server/streamableHttp.ts
+++ b/src/server/streamableHttp.ts
@@ -136,7 +136,7 @@ export class StreamableHTTPServerTransport implements Transport {
   /**
    * Handles an incoming HTTP request, whether GET or POST
    */
-  async handleRequest(req: IncomingMessage, res: ServerResponse, parsedBody?: unknown): Promise<void> {
+  async handleRequest(req: IncomingMessage & { auth?: AuthInfo }, res: ServerResponse, parsedBody?: unknown): Promise<void> {
     if (req.method === "POST") {
       await this.handlePostRequest(req, res, parsedBody);
     } else if (req.method === "GET") {

--- a/src/server/streamableHttp.ts
+++ b/src/server/streamableHttp.ts
@@ -4,6 +4,7 @@ import { isInitializeRequest, isJSONRPCError, isJSONRPCRequest, isJSONRPCRespons
 import getRawBody from "raw-body";
 import contentType from "content-type";
 import { randomUUID } from "node:crypto";
+import { AuthInfo } from "./auth/types.js";
 
 const MAXIMUM_MESSAGE_SIZE = "4mb";
 
@@ -112,7 +113,7 @@ export class StreamableHTTPServerTransport implements Transport {
   sessionId?: string | undefined;
   onclose?: () => void;
   onerror?: (error: Error) => void;
-  onmessage?: (message: JSONRPCMessage) => void;
+  onmessage?: (message: JSONRPCMessage, extra?: { authInfo?: AuthInfo }) => void;
 
   constructor(options: StreamableHTTPServerTransportOptions) {
     this.sessionIdGenerator = options.sessionIdGenerator;
@@ -286,7 +287,7 @@ export class StreamableHTTPServerTransport implements Transport {
   /**
    * Handles POST requests containing JSON-RPC messages
    */
-  private async handlePostRequest(req: IncomingMessage, res: ServerResponse, parsedBody?: unknown): Promise<void> {
+  private async handlePostRequest(req: IncomingMessage & { auth?: AuthInfo }, res: ServerResponse, parsedBody?: unknown): Promise<void> {
     try {
       // Validate the Accept header
       const acceptHeader = req.headers.accept;
@@ -315,6 +316,8 @@ export class StreamableHTTPServerTransport implements Transport {
         }));
         return;
       }
+
+      const authInfo: AuthInfo | undefined = req.auth;
 
       let rawMessage;
       if (parsedBody !== undefined) {
@@ -392,7 +395,7 @@ export class StreamableHTTPServerTransport implements Transport {
 
         // handle each message
         for (const message of messages) {
-          this.onmessage?.(message);
+          this.onmessage?.(message, { authInfo });
         }
       } else if (hasRequests) {
         // The default behavior is to use SSE streaming
@@ -427,7 +430,7 @@ export class StreamableHTTPServerTransport implements Transport {
 
         // handle each message
         for (const message of messages) {
-          this.onmessage?.(message);
+          this.onmessage?.(message, { authInfo });
         }
         // The server SHOULD NOT close the SSE stream before sending all JSON-RPC responses
         // This will be handled by the send() method when responses are ready


### PR DESCRIPTION
Includes the `req.auth` AuthInfo that's set by the MCP Server bearer auth middleware in the server request handler via Streamable HTTP Transport, allowing for distinguishing of users in requests (eg. tool use).

## Motivation and Context
Authorisation token passed through the client (MCP inspector) needs to be used by tools implemented by the server to make sure that they can get user specific data.
Implementation has been inspired from SSE Transport - https://github.com/modelcontextprotocol/typescript-sdk/pull/166

## How Has This Been Tested?
Added unit tests ensuring:
- AuthInfo is passed down to tool call
- Validate AutoInfo to be optional

## Breaking Changes
None

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
Fixes https://github.com/modelcontextprotocol/typescript-sdk/issues/398
