### PR TITLE
comment: fix stateless comments that no session-id is included in any responses

### DIFF
--- a/src/server/streamableHttp.ts
+++ b/src/server/streamableHttp.ts
@@ -93,7 +93,7 @@ export interface StreamableHTTPServerTransportOptions {
  * - State is maintained in-memory (connections, message history)
  * 
  * In stateless mode:
- * - Session ID is only included in initialization responses
+ * - No Session ID is included in any responses
  * - No session validation is performed
  */
 export class StreamableHTTPServerTransport implements Transport {


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

Fixed the comments for stateless mode.
CMIIR - My understanding of the stateless mode in the code, the sessionIdGenerator is not defined, and then there will be no session id for any response.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
No need to test.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
