### PR TITLE
Ensure JSONRPCError messages are sent for streamable http

### DIFF
--- a/src/server/streamableHttp.ts
+++ b/src/server/streamableHttp.ts
@@ -587,7 +587,7 @@ export class StreamableHTTPServerTransport implements Transport {
       }
     }
 
-    if (isJSONRPCResponse(message)) {
+    if (isJSONRPCResponse(message) || isJSONRPCError(message)) {
       this._requestResponseMap.set(requestId, message);
       const relatedIds = Array.from(this._requestToStreamMapping.entries())
         .filter(([_, streamId]) => this._streamMapping.get(streamId) === response)


### PR DESCRIPTION
Prior to this, any JSONRPCError message sent when `enableJsonResponse` is true would be ignored (and response.end() never called)

<!-- Provide a brief summary of your changes -->

## Motivation and Context

There's a bug when `enableJsonResponse` is true and an error is sent, say, by the protocol. The current logic will just ignore any message that isn't a JSONRPCResponse – and JSONRPCError is one of these.

## How Has This Been Tested?

I tested this by sending a message that would parse, but fail at the protocol layer due to no handler being found.

```
{"jsonrpc":"2.0","id":"0","method":"a"}
```

## Breaking Changes

No
## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
