### PR TITLE
Update protocol version

### DIFF
--- a/src/client/auth.test.ts
+++ b/src/client/auth.test.ts
@@ -39,7 +39,7 @@ describe("OAuth Authorization", () => {
       const [url, options] = calls[0];
       expect(url.toString()).toBe("https://auth.example.com/.well-known/oauth-authorization-server");
       expect(options.headers).toEqual({
-        "MCP-Protocol-Version": "2024-11-05"
+        "MCP-Protocol-Version": "2025-03-26"
       });
     });
 

--- a/src/client/index.test.ts
+++ b/src/client/index.test.ts
@@ -222,8 +222,6 @@ test("should connect new client to old, supported server version", async () => {
     server.connect(serverTransport),
   ]);
 
-  // These should work
-  // Connection should succeed with the older version
   expect(client.getServerVersion()).toEqual({
     name: "old server",
     version: "1.0",
@@ -287,8 +285,6 @@ test("should negotiate version when client is old, and newer server supports its
     server.connect(serverTransport),
   ]);
 
-  // These should work
-  // Connection should succeed with the older version
   expect(client.getServerVersion()).toEqual({
     name: "new server",
     version: "1.0",
@@ -347,9 +343,6 @@ test("should throw when client is old, and server doesn't support its version", 
         enforceStrictCapabilities: true,
       },
   );
-
-  let closed = false;
-  clientTransport.onerror = () => {closed = true};
 
   await Promise.all([
     expect(client.connect(clientTransport)).rejects.toThrow(

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -1,4 +1,4 @@
-import { LATEST_PROTOCOL_VERSION, SUPPORTED_PROTOCOL_VERSIONS} from "./types.js";
+import { LATEST_PROTOCOL_VERSION, SUPPORTED_PROTOCOL_VERSIONS } from "./types.js";
 
 describe("Types", () => {
 

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -1,0 +1,17 @@
+import { LATEST_PROTOCOL_VERSION, SUPPORTED_PROTOCOL_VERSIONS} from "./types.js";
+
+describe("Types", () => {
+
+    test("should have correct latest protocol version", () => {
+        expect(LATEST_PROTOCOL_VERSION).toBeDefined();
+        expect(LATEST_PROTOCOL_VERSION).toBe("2025-03-26");
+    });
+    test("should have correct supported protocol versions", () => {
+        expect(SUPPORTED_PROTOCOL_VERSIONS).toBeDefined();
+        expect(SUPPORTED_PROTOCOL_VERSIONS).toBeInstanceOf(Array);
+        expect(SUPPORTED_PROTOCOL_VERSIONS).toContain(LATEST_PROTOCOL_VERSION);
+        expect(SUPPORTED_PROTOCOL_VERSIONS).toContain("2024-11-05");
+        expect(SUPPORTED_PROTOCOL_VERSIONS).toContain("2024-10-07");
+    });
+
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,9 @@
 import { z, ZodTypeAny } from "zod";
 
-export const LATEST_PROTOCOL_VERSION = "2024-11-05";
+export const LATEST_PROTOCOL_VERSION = "2025-03-26";
 export const SUPPORTED_PROTOCOL_VERSIONS = [
   LATEST_PROTOCOL_VERSION,
+  "2024-11-05",
   "2024-10-07",
 ];
 
@@ -754,11 +755,11 @@ export const PromptListChangedNotificationSchema = NotificationSchema.extend({
 /* Tools */
 /**
  * Additional properties describing a Tool to clients.
- * 
- * NOTE: all properties in ToolAnnotations are **hints**. 
- * They are not guaranteed to provide a faithful description of 
+ *
+ * NOTE: all properties in ToolAnnotations are **hints**.
+ * They are not guaranteed to provide a faithful description of
  * tool behavior (including descriptive properties like `title`).
- * 
+ *
  * Clients should never make tool use decisions based on ToolAnnotations
  * received from untrusted servers.
  */
@@ -771,7 +772,7 @@ export const ToolAnnotationsSchema = z
 
     /**
      * If true, the tool does not modify its environment.
-     * 
+     *
      * Default: false
      */
     readOnlyHint: z.optional(z.boolean()),
@@ -779,19 +780,19 @@ export const ToolAnnotationsSchema = z
     /**
      * If true, the tool may perform destructive updates to its environment.
      * If false, the tool performs only additive updates.
-     * 
+     *
      * (This property is meaningful only when `readOnlyHint == false`)
-     * 
+     *
      * Default: true
      */
     destructiveHint: z.optional(z.boolean()),
 
     /**
-     * If true, calling the tool repeatedly with the same arguments 
+     * If true, calling the tool repeatedly with the same arguments
      * will have no additional effect on the its environment.
-     * 
+     *
      * (This property is meaningful only when `readOnlyHint == false`)
-     * 
+     *
      * Default: false
      */
     idempotentHint: z.optional(z.boolean()),
@@ -801,7 +802,7 @@ export const ToolAnnotationsSchema = z
      * entities. If false, the tool's domain of interaction is closed.
      * For example, the world of a web search tool is open, whereas that
      * of a memory tool is not.
-     * 
+     *
      * Default: true
      */
     openWorldHint: z.optional(z.boolean()),


### PR DESCRIPTION
* This fixes #378
* In types.ts
  - set LATEST_PROTOCOL_VERSION to "2025-03-26"
  - add "2025-03-26" to SUPPORTED_PROTOCOL_VERSIONS
* In auth.test.ts
  - in test "returns metadata when discovery succeeds"
    - expect "MCP-Protocol-Version" to be "2025-03-26"
* Added types.test.ts
  - "should have correct latest protocol version"
  - "should have correct supported protocol versions"

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
StreamableHttp is available in the current release of the SDK and [people are finding](https://github.com/modelcontextprotocol/inspector/pull/227#issuecomment-2828386614) that returning the newest protocol version from their servers can cause a failure to connect.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Unit and integration tests pass. Lint has no errors.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
Nope.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
