### PR TITLE
Feat: Separate authorization server and resource server on client auth flow

### DIFF
--- a/src/client/auth.test.ts
+++ b/src/client/auth.test.ts
@@ -758,10 +758,10 @@ describe("OAuth Authorization", () => {
         "https://resource.example.com/.well-known/oauth-protected-resource"
       );
 
-      // Since protected resource metadata failed, it should fallback to discovering
-      // the auth server metadata from the default location (but the auth function
-      // expects authorization_servers from the resource metadata, so this test
-      // needs to be updated to handle that case properly)
+      // Second call should be to oauth metadata
+      expect(mockFetch.mock.calls[1][0].toString()).toBe(
+        "https://resource.example.com/.well-known/oauth-authorization-server"
+      );
     });
   });
 });

--- a/src/client/auth.test.ts
+++ b/src/client/auth.test.ts
@@ -381,7 +381,6 @@ describe("OAuth Authorization", () => {
 
       await expect(
         startAuthorization("https://auth.example.com", {
-          resource: "https://resource.example.com",
           metadata,
           clientInformation: validClientInfo,
           redirectUrl: "http://localhost:3000/callback",

--- a/src/client/auth.test.ts
+++ b/src/client/auth.test.ts
@@ -320,9 +320,10 @@ describe("OAuth Authorization", () => {
 
     it("generates authorization URL with PKCE challenge", async () => {
       const { authorizationUrl, codeVerifier } = await startAuthorization(
-        "https://resource.example.com",
         "https://auth.example.com",
         {
+          resource: "https://resource.example.com",
+          metadata: undefined,
           clientInformation: validClientInfo,
           redirectUrl: "http://localhost:3000/callback",
         }
@@ -345,9 +346,9 @@ describe("OAuth Authorization", () => {
 
     it("uses metadata authorization_endpoint when provided", async () => {
       const { authorizationUrl } = await startAuthorization(
-        "https://resource.example.com",
         "https://auth.example.com",
         {
+          resource: "https://resource.example.com",
           metadata: validMetadata,
           clientInformation: validClientInfo,
           redirectUrl: "http://localhost:3000/callback",
@@ -366,7 +367,8 @@ describe("OAuth Authorization", () => {
       };
 
       await expect(
-        startAuthorization("https://resource.example.com", "https://auth.example.com", {
+        startAuthorization("https://auth.example.com", {
+          resource: "https://resource.example.com",
           metadata,
           clientInformation: validClientInfo,
           redirectUrl: "http://localhost:3000/callback",
@@ -382,7 +384,8 @@ describe("OAuth Authorization", () => {
       };
 
       await expect(
-        startAuthorization("https://resource.example.com", "https://auth.example.com", {
+        startAuthorization("https://auth.example.com", {
+          resource: "https://resource.example.com",
           metadata,
           clientInformation: validClientInfo,
           redirectUrl: "http://localhost:3000/callback",

--- a/src/client/auth.test.ts
+++ b/src/client/auth.test.ts
@@ -368,7 +368,6 @@ describe("OAuth Authorization", () => {
 
       await expect(
         startAuthorization("https://auth.example.com", {
-          resource: "https://resource.example.com",
           metadata,
           clientInformation: validClientInfo,
           redirectUrl: "http://localhost:3000/callback",

--- a/src/client/auth.test.ts
+++ b/src/client/auth.test.ts
@@ -346,7 +346,6 @@ describe("OAuth Authorization", () => {
       const { authorizationUrl } = await startAuthorization(
         "https://auth.example.com",
         {
-          resource: "https://resource.example.com",
           metadata: validMetadata,
           clientInformation: validClientInfo,
           redirectUrl: "http://localhost:3000/callback",

--- a/src/client/auth.test.ts
+++ b/src/client/auth.test.ts
@@ -331,7 +331,6 @@ describe("OAuth Authorization", () => {
       expect(authorizationUrl.toString()).toMatch(
         /^https:\/\/auth\.example\.com\/authorize\?/
       );
-      expect(authorizationUrl.searchParams.get("resource")).toBe("https://resource.example.com");
       expect(authorizationUrl.searchParams.get("response_type")).toBe("code");
       expect(authorizationUrl.searchParams.get("code_challenge")).toBe("test_challenge");
       expect(authorizationUrl.searchParams.get("code_challenge_method")).toBe(

--- a/src/client/auth.test.ts
+++ b/src/client/auth.test.ts
@@ -744,7 +744,7 @@ describe("OAuth Authorization", () => {
 
       // Call the auth function
       const result = await auth(mockProvider, {
-        resourceServerUrl: "https://resource.example.com",
+        serverUrl: "https://resource.example.com",
       });
 
       // Verify the result

--- a/src/client/auth.test.ts
+++ b/src/client/auth.test.ts
@@ -322,7 +322,6 @@ describe("OAuth Authorization", () => {
       const { authorizationUrl, codeVerifier } = await startAuthorization(
         "https://auth.example.com",
         {
-          resource: "https://resource.example.com",
           metadata: undefined,
           clientInformation: validClientInfo,
           redirectUrl: "http://localhost:3000/callback",

--- a/src/client/auth.test.ts
+++ b/src/client/auth.test.ts
@@ -320,6 +320,7 @@ describe("OAuth Authorization", () => {
 
     it("generates authorization URL with PKCE challenge", async () => {
       const { authorizationUrl, codeVerifier } = await startAuthorization(
+        "https://resource.example.com",
         "https://auth.example.com",
         {
           clientInformation: validClientInfo,
@@ -330,6 +331,7 @@ describe("OAuth Authorization", () => {
       expect(authorizationUrl.toString()).toMatch(
         /^https:\/\/auth\.example\.com\/authorize\?/
       );
+      expect(authorizationUrl.searchParams.get("resource")).toBe("https://resource.example.com");
       expect(authorizationUrl.searchParams.get("response_type")).toBe("code");
       expect(authorizationUrl.searchParams.get("code_challenge")).toBe("test_challenge");
       expect(authorizationUrl.searchParams.get("code_challenge_method")).toBe(
@@ -343,6 +345,7 @@ describe("OAuth Authorization", () => {
 
     it("uses metadata authorization_endpoint when provided", async () => {
       const { authorizationUrl } = await startAuthorization(
+        "https://resource.example.com",
         "https://auth.example.com",
         {
           metadata: validMetadata,
@@ -363,7 +366,7 @@ describe("OAuth Authorization", () => {
       };
 
       await expect(
-        startAuthorization("https://auth.example.com", {
+        startAuthorization("https://resource.example.com", "https://auth.example.com", {
           metadata,
           clientInformation: validClientInfo,
           redirectUrl: "http://localhost:3000/callback",
@@ -379,7 +382,7 @@ describe("OAuth Authorization", () => {
       };
 
       await expect(
-        startAuthorization("https://auth.example.com", {
+        startAuthorization("https://resource.example.com", "https://auth.example.com", {
           metadata,
           clientInformation: validClientInfo,
           redirectUrl: "http://localhost:3000/callback",

--- a/src/client/auth.ts
+++ b/src/client/auth.ts
@@ -86,7 +86,7 @@ export async function auth(
   provider: OAuthClientProvider,
   { resourceServerUrl, authorizationCode, authServerUrl }: { resourceServerUrl: string | URL, authorizationCode?: string, authServerUrl?: string | URL }): Promise<AuthResult> {
 
-    let authorizationServerUrl = authServerUrl
+  let authorizationServerUrl = authServerUrl
 
   if (!authorizationServerUrl) {
     const protectedResourceMetadata = await discoverOAuthProtectedResourceMetadata(resourceServerUrl);
@@ -157,7 +157,7 @@ export async function auth(
   }
 
   // Start new authorization flow
-  const { authorizationUrl, codeVerifier } = await startAuthorization(authorizationServerUrl, {
+  const { authorizationUrl, codeVerifier } = await startAuthorization(resourceServerUrl, authorizationServerUrl, {
     metadata,
     clientInformation,
     redirectUrl: provider.redirectUrl
@@ -288,6 +288,7 @@ export async function discoverOAuthMetadata(
  * Begins the authorization flow with the given server, by generating a PKCE challenge and constructing the authorization URL.
  */
 export async function startAuthorization(
+  resourceServerUrl: string | URL,
   authorizationServerUrl: string | URL,
   {
     metadata,
@@ -337,6 +338,10 @@ export async function startAuthorization(
     codeChallengeMethod,
   );
   authorizationUrl.searchParams.set("redirect_uri", String(redirectUrl));
+
+  const serverURL = new URL(resourceServerUrl)
+  const baseURL = `${serverURL.protocol}//${serverURL.host}`
+  authorizationUrl.searchParams.set("resource", String(baseURL));
 
   return { authorizationUrl, codeVerifier };
 }

--- a/src/client/auth.ts
+++ b/src/client/auth.ts
@@ -331,7 +331,6 @@ export async function startAuthorization(
     codeChallengeMethod,
   );
   authorizationUrl.searchParams.set("redirect_uri", String(redirectUrl));
-  authorizationUrl.searchParams.set("resource", String(resource));
 
   return { authorizationUrl, codeVerifier };
 }

--- a/src/client/auth.ts
+++ b/src/client/auth.ts
@@ -288,7 +288,6 @@ export async function startAuthorization(
     clientInformation,
     redirectUrl,
   }: {
-    resource: string | URL;
     metadata?: OAuthMetadata;
     clientInformation: OAuthClientInformation;
     redirectUrl: string | URL;

--- a/src/client/auth.ts
+++ b/src/client/auth.ts
@@ -84,20 +84,20 @@ export class UnauthorizedError extends Error {
  */
 export async function auth(
   provider: OAuthClientProvider,
-  { resourceServerUrl,
+  { serverUrl,
     authorizationCode,
     scope,
     resourceMetadataUrl
   }: {
-    resourceServerUrl: string | URL;
+    serverUrl: string | URL;
     authorizationCode?: string;
     scope?: string;
     resourceMetadataUrl?: URL }): Promise<AuthResult> {
 
-  let authorizationServerUrl = resourceServerUrl;
+  let authorizationServerUrl = serverUrl;
   try {
     const resourceMetadata = await discoverOAuthProtectedResourceMetadata(
-      resourceMetadataUrl || resourceServerUrl);
+      resourceMetadataUrl || serverUrl);
 
     if (resourceMetadata.authorization_servers && resourceMetadata.authorization_servers.length > 0) {
       authorizationServerUrl = resourceMetadata.authorization_servers[0];
@@ -212,7 +212,7 @@ export function extractResourceMetadataUrl(res: Response): URL | undefined {
  * return `undefined`. Any other errors will be thrown as exceptions.
  */
 export async function discoverOAuthProtectedResourceMetadata(
-  resourceServerUrl: string | URL,
+  serverUrl: string | URL,
   opts?: { protocolVersion?: string, resourceMetadataUrl?: string | URL },
 ): Promise<OAuthProtectedResourceMetadata> {
 
@@ -220,7 +220,7 @@ export async function discoverOAuthProtectedResourceMetadata(
   if (opts?.resourceMetadataUrl) {
     url = new URL(opts?.resourceMetadataUrl);
   } else {
-    url = new URL("/.well-known/oauth-protected-resource", resourceServerUrl);
+    url = new URL("/.well-known/oauth-protected-resource", serverUrl);
   }
 
   let response: Response;

--- a/src/client/auth.ts
+++ b/src/client/auth.ts
@@ -1,11 +1,11 @@
 import pkceChallenge from "pkce-challenge";
 import { LATEST_PROTOCOL_VERSION } from "../types.js";
-import type { OAuthClientMetadata, OAuthClientInformation, OAuthTokens, OAuthMetadata, OAuthClientInformationFull } from "../shared/auth.js";
-import { OAuthClientInformationFullSchema, OAuthMetadataSchema, OAuthTokensSchema } from "../shared/auth.js";
+import type { OAuthClientMetadata, OAuthClientInformation, OAuthTokens, OAuthMetadata, OAuthClientInformationFull, OAuthProtectedResourceMetadata } from "../shared/auth.js";
+import { OAuthClientInformationFullSchema, OAuthMetadataSchema, OAuthProtectedResourceMetadataSchema, OAuthTokensSchema } from "../shared/auth.js";
 
 /**
  * Implements an end-to-end OAuth client to be used with one MCP server.
- * 
+ *
  * This client relies upon a concept of an authorized "session," the exact
  * meaning of which is application-defined. Tokens, authorization codes, and
  * code verifiers should not cross different sessions.
@@ -32,7 +32,7 @@ export interface OAuthClientProvider {
    * If implemented, this permits the OAuth client to dynamically register with
    * the server. Client information saved this way should later be read via
    * `clientInformation()`.
-   * 
+   *
    * This method is not required to be implemented if client information is
    * statically known (e.g., pre-registered).
    */
@@ -78,14 +78,29 @@ export class UnauthorizedError extends Error {
 
 /**
  * Orchestrates the full auth flow with a server.
- * 
+ *
  * This can be used as a single entry point for all authorization functionality,
  * instead of linking together the other lower-level functions in this module.
  */
 export async function auth(
   provider: OAuthClientProvider,
-  { serverUrl, authorizationCode }: { serverUrl: string | URL, authorizationCode?: string }): Promise<AuthResult> {
-  const metadata = await discoverOAuthMetadata(serverUrl);
+  { resourceServerUrl, authorizationCode, authServerUrl }: { resourceServerUrl: string | URL, authorizationCode?: string, authServerUrl?: string | URL }): Promise<AuthResult> {
+
+    let authorizationServerUrl = authServerUrl
+
+  if (!authorizationServerUrl) {
+    const protectedResourceMetadata = await discoverOAuthProtectedResourceMetadata(resourceServerUrl);
+    if (protectedResourceMetadata.authorization_servers === undefined || protectedResourceMetadata.authorization_servers.length === 0) {
+      throw new Error("Server does not speicify any authorization servers.");
+    }
+    authorizationServerUrl = protectedResourceMetadata.authorization_servers[0];
+  }
+
+  if (!authorizationServerUrl) {
+    throw new Error("Server does not speicify any authorization servers.");
+  }
+
+  const metadata = await discoverOAuthMetadata(authorizationServerUrl);
 
   // Handle client registration if needed
   let clientInformation = await Promise.resolve(provider.clientInformation());
@@ -98,7 +113,7 @@ export async function auth(
       throw new Error("OAuth client information must be saveable for dynamic registration");
     }
 
-    const fullInformation = await registerClient(serverUrl, {
+    const fullInformation = await registerClient(authorizationServerUrl, {
       metadata,
       clientMetadata: provider.clientMetadata,
     });
@@ -110,7 +125,7 @@ export async function auth(
   // Exchange authorization code for tokens
   if (authorizationCode !== undefined) {
     const codeVerifier = await provider.codeVerifier();
-    const tokens = await exchangeAuthorization(serverUrl, {
+    const tokens = await exchangeAuthorization(authorizationServerUrl, {
       metadata,
       clientInformation,
       authorizationCode,
@@ -128,7 +143,7 @@ export async function auth(
   if (tokens?.refresh_token) {
     try {
       // Attempt to refresh the token
-      const newTokens = await refreshAuthorization(serverUrl, {
+      const newTokens = await refreshAuthorization(authorizationServerUrl, {
         metadata,
         clientInformation,
         refreshToken: tokens.refresh_token,
@@ -142,7 +157,7 @@ export async function auth(
   }
 
   // Start new authorization flow
-  const { authorizationUrl, codeVerifier } = await startAuthorization(serverUrl, {
+  const { authorizationUrl, codeVerifier } = await startAuthorization(authorizationServerUrl, {
     metadata,
     clientInformation,
     redirectUrl: provider.redirectUrl
@@ -154,16 +169,92 @@ export async function auth(
 }
 
 /**
+ * Extract resource_metadata from response header.
+ */
+export function extractResourceMetadataUrl(res: Response): URL | undefined {
+
+  const authenticateHeader = res.headers.get("WWW-Authenticate");
+  if (!authenticateHeader) {
+    return undefined;
+  }
+
+  const [type, scheme] = authenticateHeader.split(' ');
+  if (type.toLowerCase() !== 'bearer' || !scheme) {
+    console.log("Invalid WWW-Authenticate header format, expected 'Bearer'");
+    return undefined;
+  }
+  const regex = /resource_metadata="([^"]*)"/;
+  const match = regex.exec(authenticateHeader);
+
+  if (!match) {
+    return undefined;
+  }
+
+  try {
+    return new URL(match[1]);
+  } catch(error) {
+    console.log("Invalid resource metadata url.");
+    return undefined;
+  }
+}
+
+/**
+ * Looks up RFC 9728 OAuth 2.0 Protected Resource Metadata.
+ *
+ * If the server returns a 404 for the well-known endpoint, this function will
+ * return `undefined`. Any other errors will be thrown as exceptions.
+ */
+export async function discoverOAuthProtectedResourceMetadata(
+  resourceServerUrl: string | URL,
+  opts?: { protocolVersion?: string, resourceMetadataUrl?: string | URL },
+): Promise<OAuthProtectedResourceMetadata> {
+
+  let url: URL
+  if (opts?.resourceMetadataUrl) {
+    url = new URL(opts?.resourceMetadataUrl);
+  } else {
+    url = new URL("/.well-known/oauth-protected-resource", resourceServerUrl);
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      headers: {
+        "MCP-Protocol-Version": opts?.protocolVersion ?? LATEST_PROTOCOL_VERSION
+      }
+    });
+  } catch (error) {
+    // CORS errors come back as TypeError
+    if (error instanceof TypeError) {
+      response = await fetch(url);
+    } else {
+      throw error;
+    }
+  }
+
+  if (response.status === 404) {
+    throw new Error(`Resource server does not implement OAuth 2.0 Protected Resource Metadata.`);
+  }
+
+  if (!response.ok) {
+    throw new Error(
+      `HTTP ${response.status} trying to load well-known OAuth protected resource metadata.`,
+    );
+  }
+  return OAuthProtectedResourceMetadataSchema.parse(await response.json());
+}
+
+/**
  * Looks up RFC 8414 OAuth 2.0 Authorization Server Metadata.
  *
  * If the server returns a 404 for the well-known endpoint, this function will
  * return `undefined`. Any other errors will be thrown as exceptions.
  */
 export async function discoverOAuthMetadata(
-  serverUrl: string | URL,
+  authorizationServerUrl: string | URL,
   opts?: { protocolVersion?: string },
 ): Promise<OAuthMetadata | undefined> {
-  const url = new URL("/.well-known/oauth-authorization-server", serverUrl);
+  const url = new URL("/.well-known/oauth-authorization-server", authorizationServerUrl);
   let response: Response;
   try {
     response = await fetch(url, {
@@ -197,7 +288,7 @@ export async function discoverOAuthMetadata(
  * Begins the authorization flow with the given server, by generating a PKCE challenge and constructing the authorization URL.
  */
 export async function startAuthorization(
-  serverUrl: string | URL,
+  authorizationServerUrl: string | URL,
   {
     metadata,
     clientInformation,
@@ -230,7 +321,7 @@ export async function startAuthorization(
       );
     }
   } else {
-    authorizationUrl = new URL("/authorize", serverUrl);
+    authorizationUrl = new URL("/authorize", authorizationServerUrl);
   }
 
   // Generate PKCE challenge
@@ -254,7 +345,7 @@ export async function startAuthorization(
  * Exchanges an authorization code for an access token with the given server.
  */
 export async function exchangeAuthorization(
-  serverUrl: string | URL,
+  authorizationServerUrl: string | URL,
   {
     metadata,
     clientInformation,
@@ -284,7 +375,7 @@ export async function exchangeAuthorization(
       );
     }
   } else {
-    tokenUrl = new URL("/token", serverUrl);
+    tokenUrl = new URL("/token", authorizationServerUrl);
   }
 
   // Exchange code for tokens
@@ -319,7 +410,7 @@ export async function exchangeAuthorization(
  * Exchange a refresh token for an updated access token.
  */
 export async function refreshAuthorization(
-  serverUrl: string | URL,
+  authorizationServerUrl: string | URL,
   {
     metadata,
     clientInformation,
@@ -345,7 +436,7 @@ export async function refreshAuthorization(
       );
     }
   } else {
-    tokenUrl = new URL("/token", serverUrl);
+    tokenUrl = new URL("/token", authorizationServerUrl);
   }
 
   // Exchange refresh token
@@ -366,7 +457,7 @@ export async function refreshAuthorization(
     },
     body: params,
   });
-
+console.log(response)
   if (!response.ok) {
     throw new Error(`Token refresh failed: HTTP ${response.status}`);
   }
@@ -378,7 +469,7 @@ export async function refreshAuthorization(
  * Performs OAuth 2.0 Dynamic Client Registration according to RFC 7591.
  */
 export async function registerClient(
-  serverUrl: string | URL,
+  authorizationServerUrl: string | URL,
   {
     metadata,
     clientMetadata,
@@ -396,7 +487,7 @@ export async function registerClient(
 
     registrationUrl = new URL(metadata.registration_endpoint);
   } else {
-    registrationUrl = new URL("/register", serverUrl);
+    registrationUrl = new URL("/register", authorizationServerUrl);
   }
 
   const response = await fetch(registrationUrl, {

--- a/src/client/auth.ts
+++ b/src/client/auth.ts
@@ -454,7 +454,6 @@ export async function refreshAuthorization(
     },
     body: params,
   });
-console.log(response)
   if (!response.ok) {
     throw new Error(`Token refresh failed: HTTP ${response.status}`);
   }

--- a/src/client/auth.ts
+++ b/src/client/auth.ts
@@ -151,7 +151,6 @@ export async function auth(
 
   // Start new authorization flow
   const { authorizationUrl, codeVerifier } = await startAuthorization(authorizationServerUrl, {
-    resource: resourceMetadata.resource,
     metadata,
     clientInformation,
     redirectUrl: provider.redirectUrl

--- a/src/client/auth.ts
+++ b/src/client/auth.ts
@@ -89,7 +89,7 @@ export async function auth(
   let resourceMetadata = protectedResourceMetadata ?? await discoverOAuthProtectedResourceMetadata(resourceServerUrl);
 
   if (resourceMetadata.authorization_servers === undefined || resourceMetadata.authorization_servers.length === 0) {
-    throw new Error("Server does not speicify any authorization servers.");
+    throw new Error("Server does not specify any authorization servers.");
   }
   const authorizationServerUrl = resourceMetadata.authorization_servers[0];
 

--- a/src/client/auth.ts
+++ b/src/client/auth.ts
@@ -192,8 +192,8 @@ export function extractResourceMetadataUrl(res: Response): URL | undefined {
 
   try {
     return new URL(match[1]);
-  } catch(error) {
-    console.log("Invalid resource metadata url.");
+  } catch {
+    console.log("Invalid resource metadata url: ", match[1]);
     return undefined;
   }
 }

--- a/src/client/auth.ts
+++ b/src/client/auth.ts
@@ -284,7 +284,6 @@ export async function discoverOAuthMetadata(
 export async function startAuthorization(
   authorizationServerUrl: string | URL,
   {
-    resource,
     metadata,
     clientInformation,
     redirectUrl,

--- a/src/client/sse.test.ts
+++ b/src/client/sse.test.ts
@@ -668,9 +668,6 @@ describe("SSEClientTransport", () => {
         currentTokens = tokens;
       });
 
-      // Create server that accepts SSE but returns 401 on POST with expired token
-      resourceServer.close();
-
       // Create server that returns 401 for expired token, then accepts new token
       resourceServer.close();
       authServer.close();

--- a/src/client/sse.test.ts
+++ b/src/client/sse.test.ts
@@ -557,7 +557,6 @@ describe("SSEClientTransport", () => {
         }
 
         if (req.url === "/token" && req.method === "POST") {
-          console.log("token here")
           // Handle token refresh request
           let body = "";
           req.on("data", chunk => { body += chunk; });

--- a/src/client/sse.test.ts
+++ b/src/client/sse.test.ts
@@ -6,9 +6,11 @@ import { OAuthClientProvider, UnauthorizedError } from "./auth.js";
 import { OAuthTokens } from "../shared/auth.js";
 
 describe("SSEClientTransport", () => {
-  let server: Server;
+  let resourceServer: Server;
+  let authServer: Server;
   let transport: SSEClientTransport;
-  let baseUrl: URL;
+  let resourceBaseUrl: URL;
+  let authBaseUrl: URL;
   let lastServerRequest: IncomingMessage;
   let sendServerMessage: ((message: string) => void) | null = null;
 
@@ -17,8 +19,26 @@ describe("SSEClientTransport", () => {
     lastServerRequest = null as unknown as IncomingMessage;
     sendServerMessage = null;
 
+    authServer = createServer((req, res) => {
+      if (req.url === "/.well-known/oauth-authorization-server") {
+        res.writeHead(200, {
+          "Content-Type": "application/json"
+        });
+        res.end(JSON.stringify({
+          issuer: "https://auth.example.com",
+          authorization_endpoint: "https://auth.example.com/authorize",
+          token_endpoint: "https://auth.example.com/token",
+          registration_endpoint: "https://auth.example.com/register",
+          response_types_supported: ["code"],
+          code_challenge_methods_supported: ["S256"],
+        }));
+        return;
+      }
+      res.writeHead(401).end();
+    });
+
     // Create a test server that will receive the EventSource connection
-    server = createServer((req, res) => {
+    resourceServer = createServer((req, res) => {
       lastServerRequest = req;
 
       // Send SSE headers
@@ -30,7 +50,7 @@ describe("SSEClientTransport", () => {
 
       // Send the endpoint event
       res.write("event: endpoint\n");
-      res.write(`data: ${baseUrl.href}\n\n`);
+      res.write(`data: ${resourceBaseUrl.href}\n\n`);
 
       // Store reference to send function for tests
       sendServerMessage = (message: string) => {
@@ -51,9 +71,9 @@ describe("SSEClientTransport", () => {
     });
 
     // Start server on random port
-    server.listen(0, "127.0.0.1", () => {
-      const addr = server.address() as AddressInfo;
-      baseUrl = new URL(`http://127.0.0.1:${addr.port}`);
+    resourceServer.listen(0, "127.0.0.1", () => {
+      const addr = resourceServer.address() as AddressInfo;
+      resourceBaseUrl = new URL(`http://127.0.0.1:${addr.port}`);
       done();
     });
 
@@ -62,14 +82,15 @@ describe("SSEClientTransport", () => {
 
   afterEach(async () => {
     await transport.close();
-    await server.close();
+    await resourceServer.close();
+    await authServer.close();
 
     jest.clearAllMocks();
   });
 
   describe("connection handling", () => {
     it("establishes SSE connection and receives endpoint", async () => {
-      transport = new SSEClientTransport(baseUrl);
+      transport = new SSEClientTransport(resourceBaseUrl);
       await transport.start();
 
       expect(lastServerRequest.headers.accept).toBe("text/event-stream");
@@ -78,27 +99,27 @@ describe("SSEClientTransport", () => {
 
     it("rejects if server returns non-200 status", async () => {
       // Create a server that returns 403
-      await server.close();
+      await resourceServer.close();
 
-      server = createServer((req, res) => {
+      resourceServer = createServer((req, res) => {
         res.writeHead(403);
         res.end();
       });
 
       await new Promise<void>((resolve) => {
-        server.listen(0, "127.0.0.1", () => {
-          const addr = server.address() as AddressInfo;
-          baseUrl = new URL(`http://127.0.0.1:${addr.port}`);
+        resourceServer.listen(0, "127.0.0.1", () => {
+          const addr = resourceServer.address() as AddressInfo;
+          resourceBaseUrl = new URL(`http://127.0.0.1:${addr.port}`);
           resolve();
         });
       });
 
-      transport = new SSEClientTransport(baseUrl);
+      transport = new SSEClientTransport(resourceBaseUrl);
       await expect(transport.start()).rejects.toThrow();
     });
 
     it("closes EventSource connection on close()", async () => {
-      transport = new SSEClientTransport(baseUrl);
+      transport = new SSEClientTransport(resourceBaseUrl);
       await transport.start();
 
       const closePromise = new Promise((resolve) => {
@@ -113,7 +134,7 @@ describe("SSEClientTransport", () => {
   describe("message handling", () => {
     it("receives and parses JSON-RPC messages", async () => {
       const receivedMessages: JSONRPCMessage[] = [];
-      transport = new SSEClientTransport(baseUrl);
+      transport = new SSEClientTransport(resourceBaseUrl);
       transport.onmessage = (msg) => receivedMessages.push(msg);
 
       await transport.start();
@@ -136,7 +157,7 @@ describe("SSEClientTransport", () => {
 
     it("handles malformed JSON messages", async () => {
       const errors: Error[] = [];
-      transport = new SSEClientTransport(baseUrl);
+      transport = new SSEClientTransport(resourceBaseUrl);
       transport.onerror = (err) => errors.push(err);
 
       await transport.start();
@@ -151,7 +172,7 @@ describe("SSEClientTransport", () => {
     });
 
     it("handles messages via POST requests", async () => {
-      transport = new SSEClientTransport(baseUrl);
+      transport = new SSEClientTransport(resourceBaseUrl);
       await transport.start();
 
       const testMessage: JSONRPCMessage = {
@@ -179,9 +200,9 @@ describe("SSEClientTransport", () => {
 
     it("handles POST request failures", async () => {
       // Create a server that returns 500 for POST
-      await server.close();
+      await resourceServer.close();
 
-      server = createServer((req, res) => {
+      resourceServer = createServer((req, res) => {
         if (req.method === "GET") {
           res.writeHead(200, {
             "Content-Type": "text/event-stream",
@@ -189,7 +210,7 @@ describe("SSEClientTransport", () => {
             Connection: "keep-alive",
           });
           res.write("event: endpoint\n");
-          res.write(`data: ${baseUrl.href}\n\n`);
+          res.write(`data: ${resourceBaseUrl.href}\n\n`);
         } else {
           res.writeHead(500);
           res.end("Internal error");
@@ -197,14 +218,14 @@ describe("SSEClientTransport", () => {
       });
 
       await new Promise<void>((resolve) => {
-        server.listen(0, "127.0.0.1", () => {
-          const addr = server.address() as AddressInfo;
-          baseUrl = new URL(`http://127.0.0.1:${addr.port}`);
+        resourceServer.listen(0, "127.0.0.1", () => {
+          const addr = resourceServer.address() as AddressInfo;
+          resourceBaseUrl = new URL(`http://127.0.0.1:${addr.port}`);
           resolve();
         });
       });
 
-      transport = new SSEClientTransport(baseUrl);
+      transport = new SSEClientTransport(resourceBaseUrl);
       await transport.start();
 
       const testMessage: JSONRPCMessage = {
@@ -229,7 +250,7 @@ describe("SSEClientTransport", () => {
         return fetch(url.toString(), { ...init, headers });
       };
 
-      transport = new SSEClientTransport(baseUrl, {
+      transport = new SSEClientTransport(resourceBaseUrl, {
         eventSourceInit: {
           fetch: fetchWithAuth,
         },
@@ -247,7 +268,7 @@ describe("SSEClientTransport", () => {
         "X-Custom-Header": "custom-value",
       };
 
-      transport = new SSEClientTransport(baseUrl, {
+      transport = new SSEClientTransport(resourceBaseUrl, {
         requestInit: {
           headers: customHeaders,
         },
@@ -319,7 +340,7 @@ describe("SSEClientTransport", () => {
         token_type: "Bearer"
       });
 
-      transport = new SSEClientTransport(baseUrl, {
+      transport = new SSEClientTransport(resourceBaseUrl, {
         authProvider: mockAuthProvider,
       });
 
@@ -335,7 +356,7 @@ describe("SSEClientTransport", () => {
         token_type: "Bearer"
       });
 
-      transport = new SSEClientTransport(baseUrl, {
+      transport = new SSEClientTransport(resourceBaseUrl, {
         authProvider: mockAuthProvider,
       });
 
@@ -355,27 +376,50 @@ describe("SSEClientTransport", () => {
     });
 
     it("attempts auth flow on 401 during SSE connection", async () => {
-      // Create server that returns 401s
-      await server.close();
 
-      server = createServer((req, res) => {
+      // Create server that returns 401s
+      resourceServer.close();
+      authServer.close();
+
+      // Start auth server on random port
+      await new Promise<void>(resolve => {
+        authServer.listen(0, "127.0.0.1", () => {
+          const addr = authServer.address() as AddressInfo;
+          authBaseUrl = new URL(`http://127.0.0.1:${addr.port}`);
+          resolve();
+        });
+      });
+
+      resourceServer = createServer((req, res) => {
         lastServerRequest = req;
+
+        if (req.url === "/.well-known/oauth-protected-resource") {
+          res.writeHead(200, {
+            'Content-Type': 'application/json',
+          })
+          .end(JSON.stringify({
+            resource: "https://resource.example.com",
+            authorization_servers: [`${authBaseUrl}`],
+          }));
+          return;
+        }
+
         if (req.url !== "/") {
-          res.writeHead(404).end();
+            res.writeHead(404).end();
         } else {
           res.writeHead(401).end();
         }
       });
 
       await new Promise<void>(resolve => {
-        server.listen(0, "127.0.0.1", () => {
-          const addr = server.address() as AddressInfo;
-          baseUrl = new URL(`http://127.0.0.1:${addr.port}`);
+        resourceServer.listen(0, "127.0.0.1", () => {
+          const addr = resourceServer.address() as AddressInfo;
+          resourceBaseUrl = new URL(`http://127.0.0.1:${addr.port}`);
           resolve();
         });
       });
 
-      transport = new SSEClientTransport(baseUrl, {
+      transport = new SSEClientTransport(resourceBaseUrl, {
         authProvider: mockAuthProvider,
       });
 
@@ -385,13 +429,33 @@ describe("SSEClientTransport", () => {
 
     it("attempts auth flow on 401 during POST request", async () => {
       // Create server that accepts SSE but returns 401 on POST
-      await server.close();
+      resourceServer.close();
+      authServer.close();
 
-      server = createServer((req, res) => {
+      await new Promise<void>(resolve => {
+        authServer.listen(0, "127.0.0.1", () => {
+          const addr = authServer.address() as AddressInfo;
+          authBaseUrl = new URL(`http://127.0.0.1:${addr.port}`);
+          resolve();
+        });
+      });
+
+      resourceServer = createServer((req, res) => {
         lastServerRequest = req;
 
         switch (req.method) {
           case "GET":
+            if (req.url === "/.well-known/oauth-protected-resource") {
+              res.writeHead(200, {
+                'Content-Type': 'application/json',
+              })
+              .end(JSON.stringify({
+                resource: "https://resource.example.com",
+                authorization_servers: [`${authBaseUrl}`],
+              }));
+              return;
+            }
+
             if (req.url !== "/") {
               res.writeHead(404).end();
               return;
@@ -403,7 +467,7 @@ describe("SSEClientTransport", () => {
               Connection: "keep-alive",
             });
             res.write("event: endpoint\n");
-            res.write(`data: ${baseUrl.href}\n\n`);
+            res.write(`data: ${resourceBaseUrl.href}\n\n`);
             break;
 
           case "POST":
@@ -414,14 +478,14 @@ describe("SSEClientTransport", () => {
       });
 
       await new Promise<void>(resolve => {
-        server.listen(0, "127.0.0.1", () => {
-          const addr = server.address() as AddressInfo;
-          baseUrl = new URL(`http://127.0.0.1:${addr.port}`);
+        resourceServer.listen(0, "127.0.0.1", () => {
+          const addr = resourceServer.address() as AddressInfo;
+          resourceBaseUrl = new URL(`http://127.0.0.1:${addr.port}`);
           resolve();
         });
       });
 
-      transport = new SSEClientTransport(baseUrl, {
+      transport = new SSEClientTransport(resourceBaseUrl, {
         authProvider: mockAuthProvider,
       });
 
@@ -448,7 +512,7 @@ describe("SSEClientTransport", () => {
         "X-Custom-Header": "custom-value",
       };
 
-      transport = new SSEClientTransport(baseUrl, {
+      transport = new SSEClientTransport(resourceBaseUrl, {
         authProvider: mockAuthProvider,
         requestInit: {
           headers: customHeaders,
@@ -483,13 +547,17 @@ describe("SSEClientTransport", () => {
       });
 
       // Create server that returns 401 for expired token, then accepts new token
-      await server.close();
+      resourceServer.close();
+      authServer.close();
 
-      let connectionAttempts = 0;
-      server = createServer((req, res) => {
-        lastServerRequest = req;
+      authServer = createServer((req, res) => {
+        if (req.url === "/.well-known/oauth-authorization-server") {
+          res.writeHead(404).end();
+          return;
+        }
 
         if (req.url === "/token" && req.method === "POST") {
+          console.log("token here")
           // Handle token refresh request
           let body = "";
           req.on("data", chunk => { body += chunk; });
@@ -512,6 +580,34 @@ describe("SSEClientTransport", () => {
           return;
         }
 
+        res.writeHead(401).end();
+
+      });
+
+      // Start auth server on random port
+      await new Promise<void>(resolve => {
+        authServer.listen(0, "127.0.0.1", () => {
+          const addr = authServer.address() as AddressInfo;
+          authBaseUrl = new URL(`http://127.0.0.1:${addr.port}`);
+          resolve();
+        });
+      });
+
+      let connectionAttempts = 0;
+      resourceServer = createServer((req, res) => {
+        lastServerRequest = req;
+
+        if (req.url === "/.well-known/oauth-protected-resource") {
+          res.writeHead(200, {
+            'Content-Type': 'application/json',
+          })
+          .end(JSON.stringify({
+            resource: "https://resource.example.com",
+            authorization_servers: [`${authBaseUrl}`],
+          }));
+          return;
+        }
+
         if (req.url !== "/") {
           res.writeHead(404).end();
           return;
@@ -530,7 +626,7 @@ describe("SSEClientTransport", () => {
             Connection: "keep-alive",
           });
           res.write("event: endpoint\n");
-          res.write(`data: ${baseUrl.href}\n\n`);
+          res.write(`data: ${resourceBaseUrl.href}\n\n`);
           connectionAttempts++;
           return;
         }
@@ -539,14 +635,14 @@ describe("SSEClientTransport", () => {
       });
 
       await new Promise<void>(resolve => {
-        server.listen(0, "127.0.0.1", () => {
-          const addr = server.address() as AddressInfo;
-          baseUrl = new URL(`http://127.0.0.1:${addr.port}`);
+        resourceServer.listen(0, "127.0.0.1", () => {
+          const addr = resourceServer.address() as AddressInfo;
+          resourceBaseUrl = new URL(`http://127.0.0.1:${addr.port}`);
           resolve();
         });
       });
 
-      transport = new SSEClientTransport(baseUrl, {
+      transport = new SSEClientTransport(resourceBaseUrl, {
         authProvider: mockAuthProvider,
       });
 
@@ -574,11 +670,17 @@ describe("SSEClientTransport", () => {
       });
 
       // Create server that accepts SSE but returns 401 on POST with expired token
-      await server.close();
+      resourceServer.close();
 
-      let postAttempts = 0;
-      server = createServer((req, res) => {
-        lastServerRequest = req;
+      // Create server that returns 401 for expired token, then accepts new token
+      resourceServer.close();
+      authServer.close();
+
+      authServer = createServer((req, res) => {
+        if (req.url === "/.well-known/oauth-authorization-server") {
+          res.writeHead(404).end();
+          return;
+        }
 
         if (req.url === "/token" && req.method === "POST") {
           // Handle token refresh request
@@ -603,6 +705,34 @@ describe("SSEClientTransport", () => {
           return;
         }
 
+        res.writeHead(401).end();
+
+      });
+
+      // Start auth server on random port
+      await new Promise<void>(resolve => {
+        authServer.listen(0, "127.0.0.1", () => {
+          const addr = authServer.address() as AddressInfo;
+          authBaseUrl = new URL(`http://127.0.0.1:${addr.port}`);
+          resolve();
+        });
+      });
+
+      let postAttempts = 0;
+      resourceServer = createServer((req, res) => {
+        lastServerRequest = req;
+
+        if (req.url === "/.well-known/oauth-protected-resource") {
+          res.writeHead(200, {
+            'Content-Type': 'application/json',
+          })
+          .end(JSON.stringify({
+            resource: "https://resource.example.com",
+            authorization_servers: [`${authBaseUrl}`],
+          }));
+          return;
+        }
+
         switch (req.method) {
           case "GET":
             if (req.url !== "/") {
@@ -616,7 +746,7 @@ describe("SSEClientTransport", () => {
               Connection: "keep-alive",
             });
             res.write("event: endpoint\n");
-            res.write(`data: ${baseUrl.href}\n\n`);
+            res.write(`data: ${resourceBaseUrl.href}\n\n`);
             break;
 
           case "POST": {
@@ -644,14 +774,14 @@ describe("SSEClientTransport", () => {
       });
 
       await new Promise<void>(resolve => {
-        server.listen(0, "127.0.0.1", () => {
-          const addr = server.address() as AddressInfo;
-          baseUrl = new URL(`http://127.0.0.1:${addr.port}`);
+        resourceServer.listen(0, "127.0.0.1", () => {
+          const addr = resourceServer.address() as AddressInfo;
+          resourceBaseUrl = new URL(`http://127.0.0.1:${addr.port}`);
           resolve();
         });
       });
 
-      transport = new SSEClientTransport(baseUrl, {
+      transport = new SSEClientTransport(resourceBaseUrl, {
         authProvider: mockAuthProvider,
       });
 
@@ -688,14 +818,46 @@ describe("SSEClientTransport", () => {
       });
 
       // Create server that returns 401 for all tokens
-      await server.close();
+      resourceServer.close();
+      authServer.close();
 
-      server = createServer((req, res) => {
-        lastServerRequest = req;
+      authServer = createServer((req, res) => {
+        if (req.url === "/.well-known/oauth-authorization-server") {
+          res.writeHead(404).end();
+          return;
+        }
 
         if (req.url === "/token" && req.method === "POST") {
           // Handle token refresh request - always fail
           res.writeHead(400).end();
+          return;
+        }
+
+        res.writeHead(401).end();
+
+      });
+
+
+      // Start auth server on random port
+      await new Promise<void>(resolve => {
+        authServer.listen(0, "127.0.0.1", () => {
+          const addr = authServer.address() as AddressInfo;
+          authBaseUrl = new URL(`http://127.0.0.1:${addr.port}`);
+          resolve();
+        });
+      });
+
+      resourceServer = createServer((req, res) => {
+        lastServerRequest = req;
+
+        if (req.url === "/.well-known/oauth-protected-resource") {
+          res.writeHead(200, {
+            'Content-Type': 'application/json',
+          })
+          .end(JSON.stringify({
+            resource: "https://resource.example.com",
+            authorization_servers: [`${authBaseUrl}`],
+          }));
           return;
         }
 
@@ -707,14 +869,14 @@ describe("SSEClientTransport", () => {
       });
 
       await new Promise<void>(resolve => {
-        server.listen(0, "127.0.0.1", () => {
-          const addr = server.address() as AddressInfo;
-          baseUrl = new URL(`http://127.0.0.1:${addr.port}`);
+        resourceServer.listen(0, "127.0.0.1", () => {
+          const addr = resourceServer.address() as AddressInfo;
+          resourceBaseUrl = new URL(`http://127.0.0.1:${addr.port}`);
           resolve();
         });
       });
 
-      transport = new SSEClientTransport(baseUrl, {
+      transport = new SSEClientTransport(resourceBaseUrl, {
         authProvider: mockAuthProvider,
       });
 

--- a/src/client/sse.ts
+++ b/src/client/sse.ts
@@ -1,8 +1,7 @@
 import { EventSource, type ErrorEvent, type EventSourceInit } from "eventsource";
 import { Transport } from "../shared/transport.js";
 import { JSONRPCMessage, JSONRPCMessageSchema } from "../types.js";
-import { auth, AuthResult, discoverOAuthProtectedResourceMetadata, extractResourceMetadataUrl, OAuthClientProvider, UnauthorizedError } from "./auth.js";
-import { OAuthProtectedResourceMetadata } from "../shared/auth.js";
+import { auth, AuthResult, extractResourceMetadataUrl, OAuthClientProvider, UnauthorizedError } from "./auth.js";
 
 export class SseError extends Error {
   constructor(
@@ -59,7 +58,7 @@ export class SSEClientTransport implements Transport {
   private _endpoint?: URL;
   private _abortController?: AbortController;
   private _url: URL;
-  private _protectedResourceMetadata: OAuthProtectedResourceMetadata | undefined;
+  private _resourceMetadataUrl?: URL;
   private _eventSourceInit?: EventSourceInit;
   private _requestInit?: RequestInit;
   private _authProvider?: OAuthClientProvider;
@@ -73,7 +72,7 @@ export class SSEClientTransport implements Transport {
     opts?: SSEClientTransportOptions,
   ) {
     this._url = url;
-    this._protectedResourceMetadata = undefined;
+    this._resourceMetadataUrl = undefined;
     this._eventSourceInit = opts?.eventSourceInit;
     this._requestInit = opts?.requestInit;
     this._authProvider = opts?.authProvider;
@@ -86,7 +85,7 @@ export class SSEClientTransport implements Transport {
 
     let result: AuthResult;
     try {
-      result = await auth(this._authProvider, { resourceServerUrl: this._url, protectedResourceMetadata: this._protectedResourceMetadata });
+      result = await auth(this._authProvider, { resourceServerUrl: this._url, resourceMetadataUrl: this._resourceMetadataUrl });
     } catch (error) {
       this.onerror?.(error as Error);
       throw error;
@@ -196,7 +195,7 @@ export class SSEClientTransport implements Transport {
       throw new UnauthorizedError("No auth provider");
     }
 
-    const result = await auth(this._authProvider, { resourceServerUrl: this._url, authorizationCode, protectedResourceMetadata: this._protectedResourceMetadata });
+    const result = await auth(this._authProvider, { resourceServerUrl: this._url, authorizationCode, resourceMetadataUrl: this._resourceMetadataUrl });
     if (result !== "AUTHORIZED") {
       throw new UnauthorizedError("Failed to authorize");
     }
@@ -229,12 +228,9 @@ export class SSEClientTransport implements Transport {
       if (!response.ok) {
         if (response.status === 401 && this._authProvider) {
 
-          const resourceMetadataUrl = extractResourceMetadataUrl(response);
-          this._protectedResourceMetadata = await discoverOAuthProtectedResourceMetadata(this._url, {
-            resourceMetadataUrl: resourceMetadataUrl
-          })
+          this._resourceMetadataUrl = extractResourceMetadataUrl(response);
 
-          const result = await auth(this._authProvider, { resourceServerUrl: this._url, protectedResourceMetadata: this._protectedResourceMetadata });
+          const result = await auth(this._authProvider, { resourceServerUrl: this._url, resourceMetadataUrl: this._resourceMetadataUrl });
           if (result !== "AUTHORIZED") {
             throw new UnauthorizedError();
           }

--- a/src/client/sse.ts
+++ b/src/client/sse.ts
@@ -2,7 +2,7 @@ import { EventSource, type ErrorEvent, type EventSourceInit } from "eventsource"
 import { Transport } from "../shared/transport.js";
 import { JSONRPCMessage, JSONRPCMessageSchema } from "../types.js";
 import { auth, AuthResult, discoverOAuthProtectedResourceMetadata, extractResourceMetadataUrl, OAuthClientProvider, UnauthorizedError } from "./auth.js";
-import { OAuthProtectedResourceMetadata } from "src/shared/auth.js";
+import { OAuthProtectedResourceMetadata } from "../shared/auth.js";
 
 export class SseError extends Error {
   constructor(

--- a/src/client/sse.ts
+++ b/src/client/sse.ts
@@ -1,7 +1,7 @@
 import { EventSource, type ErrorEvent, type EventSourceInit } from "eventsource";
 import { Transport } from "../shared/transport.js";
 import { JSONRPCMessage, JSONRPCMessageSchema } from "../types.js";
-import { auth, AuthResult, OAuthClientProvider, UnauthorizedError } from "./auth.js";
+import { auth, AuthResult, discoverOAuthProtectedResourceMetadata, extractResourceMetadataUrl, OAuthClientProvider, UnauthorizedError } from "./auth.js";
 
 export class SseError extends Error {
   constructor(
@@ -19,23 +19,23 @@ export class SseError extends Error {
 export type SSEClientTransportOptions = {
   /**
    * An OAuth client provider to use for authentication.
-   * 
+   *
    * When an `authProvider` is specified and the SSE connection is started:
    * 1. The connection is attempted with any existing access token from the `authProvider`.
    * 2. If the access token has expired, the `authProvider` is used to refresh the token.
    * 3. If token refresh fails or no access token exists, and auth is required, `OAuthClientProvider.redirectToAuthorization` is called, and an `UnauthorizedError` will be thrown from `connect`/`start`.
-   * 
+   *
    * After the user has finished authorizing via their user agent, and is redirected back to the MCP client application, call `SSEClientTransport.finishAuth` with the authorization code before retrying the connection.
-   * 
+   *
    * If an `authProvider` is not provided, and auth is required, an `UnauthorizedError` will be thrown.
-   * 
+   *
    * `UnauthorizedError` might also be thrown when sending any message over the SSE transport, indicating that the session has expired, and needs to be re-authed and reconnected.
    */
   authProvider?: OAuthClientProvider;
 
   /**
    * Customizes the initial SSE request to the server (the request that begins the stream).
-   * 
+   *
    * NOTE: Setting this property will prevent an `Authorization` header from
    * being automatically attached to the SSE request, if an `authProvider` is
    * also given. This can be worked around by setting the `Authorization` header
@@ -58,6 +58,7 @@ export class SSEClientTransport implements Transport {
   private _endpoint?: URL;
   private _abortController?: AbortController;
   private _url: URL;
+  private _authServerUrl: URL | undefined;
   private _eventSourceInit?: EventSourceInit;
   private _requestInit?: RequestInit;
   private _authProvider?: OAuthClientProvider;
@@ -71,6 +72,7 @@ export class SSEClientTransport implements Transport {
     opts?: SSEClientTransportOptions,
   ) {
     this._url = url;
+    this._authServerUrl = undefined;
     this._eventSourceInit = opts?.eventSourceInit;
     this._requestInit = opts?.requestInit;
     this._authProvider = opts?.authProvider;
@@ -83,7 +85,7 @@ export class SSEClientTransport implements Transport {
 
     let result: AuthResult;
     try {
-      result = await auth(this._authProvider, { serverUrl: this._url });
+      result = await auth(this._authProvider, { resourceServerUrl: this._url, authServerUrl: this._authServerUrl });
     } catch (error) {
       this.onerror?.(error as Error);
       throw error;
@@ -193,7 +195,7 @@ export class SSEClientTransport implements Transport {
       throw new UnauthorizedError("No auth provider");
     }
 
-    const result = await auth(this._authProvider, { serverUrl: this._url, authorizationCode });
+    const result = await auth(this._authProvider, { resourceServerUrl: this._url, authorizationCode, authServerUrl: this._authServerUrl });
     if (result !== "AUTHORIZED") {
       throw new UnauthorizedError("Failed to authorize");
     }
@@ -225,7 +227,18 @@ export class SSEClientTransport implements Transport {
       const response = await fetch(this._endpoint, init);
       if (!response.ok) {
         if (response.status === 401 && this._authProvider) {
-          const result = await auth(this._authProvider, { serverUrl: this._url });
+
+          const resourceMetadataUrl = extractResourceMetadataUrl(response);
+          const protectedResourceMetadata = await discoverOAuthProtectedResourceMetadata(this._url, {
+            resourceMetadataUrl: resourceMetadataUrl
+          })
+          if (protectedResourceMetadata.authorization_servers === undefined || protectedResourceMetadata.authorization_servers.length === 0) {
+            throw new Error("Server does not speicify any authorization servers.");
+          }
+          this._authServerUrl = new URL(protectedResourceMetadata.authorization_servers[0]);
+
+          const result = await auth(this._authProvider, { resourceServerUrl: this._url, authServerUrl: this._authServerUrl });
+
           if (result !== "AUTHORIZED") {
             throw new UnauthorizedError();
           }

--- a/src/client/sse.ts
+++ b/src/client/sse.ts
@@ -85,7 +85,7 @@ export class SSEClientTransport implements Transport {
 
     let result: AuthResult;
     try {
-      result = await auth(this._authProvider, { resourceServerUrl: this._url, resourceMetadataUrl: this._resourceMetadataUrl });
+      result = await auth(this._authProvider, { serverUrl: this._url, resourceMetadataUrl: this._resourceMetadataUrl });
     } catch (error) {
       this.onerror?.(error as Error);
       throw error;
@@ -195,7 +195,7 @@ export class SSEClientTransport implements Transport {
       throw new UnauthorizedError("No auth provider");
     }
 
-    const result = await auth(this._authProvider, { resourceServerUrl: this._url, authorizationCode, resourceMetadataUrl: this._resourceMetadataUrl });
+    const result = await auth(this._authProvider, { serverUrl: this._url, authorizationCode, resourceMetadataUrl: this._resourceMetadataUrl });
     if (result !== "AUTHORIZED") {
       throw new UnauthorizedError("Failed to authorize");
     }
@@ -230,7 +230,7 @@ export class SSEClientTransport implements Transport {
 
           this._resourceMetadataUrl = extractResourceMetadataUrl(response);
 
-          const result = await auth(this._authProvider, { resourceServerUrl: this._url, resourceMetadataUrl: this._resourceMetadataUrl });
+          const result = await auth(this._authProvider, { serverUrl: this._url, resourceMetadataUrl: this._resourceMetadataUrl });
           if (result !== "AUTHORIZED") {
             throw new UnauthorizedError();
           }

--- a/src/client/streamableHttp.ts
+++ b/src/client/streamableHttp.ts
@@ -148,7 +148,7 @@ export class StreamableHTTPClientTransport implements Transport {
 
     let result: AuthResult;
     try {
-      result = await auth(this._authProvider, { resourceServerUrl: this._url, resourceMetadataUrl: this._resourceMetadataUrl });
+      result = await auth(this._authProvider, { serverUrl: this._url, resourceMetadataUrl: this._resourceMetadataUrl });
     } catch (error) {
       this.onerror?.(error as Error);
       throw error;
@@ -358,7 +358,7 @@ export class StreamableHTTPClientTransport implements Transport {
       throw new UnauthorizedError("No auth provider");
     }
 
-    const result = await auth(this._authProvider, { resourceServerUrl: this._url, authorizationCode, resourceMetadataUrl: this._resourceMetadataUrl });
+    const result = await auth(this._authProvider, { serverUrl: this._url, authorizationCode, resourceMetadataUrl: this._resourceMetadataUrl });
     if (result !== "AUTHORIZED") {
       throw new UnauthorizedError("Failed to authorize");
     }
@@ -406,7 +406,7 @@ export class StreamableHTTPClientTransport implements Transport {
 
           this._resourceMetadataUrl = extractResourceMetadataUrl(response);
 
-          const result = await auth(this._authProvider, { resourceServerUrl: this._url, resourceMetadataUrl: this._resourceMetadataUrl });
+          const result = await auth(this._authProvider, { serverUrl: this._url, resourceMetadataUrl: this._resourceMetadataUrl });
           if (result !== "AUTHORIZED") {
             throw new UnauthorizedError();
           }

--- a/src/shared/auth.ts
+++ b/src/shared/auth.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 /**
- * RFC 8414 OAuth 2.0 Authorization Server Metadata
+ * RFC 9728 OAuth Protected Resource Metadata
  */
 export const OAuthProtectedResourceMetadataSchema = z
   .object({

--- a/src/shared/auth.ts
+++ b/src/shared/auth.ts
@@ -3,6 +3,28 @@ import { z } from "zod";
 /**
  * RFC 8414 OAuth 2.0 Authorization Server Metadata
  */
+export const OAuthProtectedResourceMetadataSchema = z
+  .object({
+    resource: z.string(),
+    authorization_servers: z.array(z.string()).optional(),
+    jwks_uri: z.string().optional(),
+    scopes_supported: z.array(z.string()).optional(),
+    bearer_methods_supported: z.array(z.string()).optional(),
+    resource_signing_alg_values_supported: z.array(z.string()).optional(),
+    resource_name: z.string().optional(),
+    resource_documentation: z.string().optional(),
+    resource_policy_uri: z.string().optional(),
+    resource_tos_uri: z.string().optional(),
+    tls_client_certificate_bound_access_tokens: z.boolean().optional(),
+    authorization_details_types_supported: z.array(z.string()).optional(),
+    dpop_signing_alg_values_supported: z.array(z.string()).optional(),
+    dpop_bound_access_tokens_required: z.boolean().optional(),
+  })
+  .passthrough();
+
+/**
+ * RFC 8414 OAuth 2.0 Authorization Server Metadata
+ */
 export const OAuthMetadataSchema = z
   .object({
     issuer: z.string(),
@@ -109,6 +131,7 @@ export const OAuthTokenRevocationRequestSchema = z.object({
   token_type_hint: z.string().optional(),
 }).strip();
 
+export type OAuthProtectedResourceMetadata = z.infer<typeof OAuthProtectedResourceMetadataSchema>;
 export type OAuthMetadata = z.infer<typeof OAuthMetadataSchema>;
 export type OAuthTokens = z.infer<typeof OAuthTokensSchema>;
 export type OAuthErrorResponse = z.infer<typeof OAuthErrorResponseSchema>;


### PR DESCRIPTION
Conform to the new authentication protocol by separating authorization server and resource server.
- add function to discover protected resource metadata
- use the discovered authorization server url for the auth flow

## Motivation and Context
Ensure the sdk functionality conforms to the [protocol specification](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/44f3de53dc3b5c3752cc01f60b18615379e42a6f/docs/specification/draft/basic/authorization.mdx).

## How Has This Been Tested?
`npm test`
- Modifying Existing tests to make sure they all past
- Add couple new tests for the authorization-related functions 

## Breaking Changes
Yes.
1. The functions arguments in auth.ts other than the auth() function requires authorization server url instead of resource server url.
2. The flow requires the server to implement [OAuth 2.0 Protected Resource Metadata](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-resource-metadata-13) as specified in the [authorization section](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/44f3de53dc3b5c3752cc01f60b18615379e42a6f/docs/specification/draft/basic/authorization.mdx) of the protocol.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
None.