### PR TITLE
fix: add missing eventsource-parser dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,19 @@
 {
   "name": "@modelcontextprotocol/sdk",
-  "version": "1.9.0",
+  "version": "1.10.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@modelcontextprotocol/sdk",
-      "version": "1.9.0",
+      "version": "1.10.2",
       "license": "MIT",
       "dependencies": {
         "content-type": "^1.0.5",
         "cors": "^2.8.5",
         "cross-spawn": "^7.0.3",
         "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
         "express": "^5.0.1",
         "express-rate-limit": "^7.5.0",
         "pkce-challenge": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "cors": "^2.8.5",
     "cross-spawn": "^7.0.3",
     "eventsource": "^3.0.2",
+    "eventsource-parser": "^3.0.0",
     "express": "^5.0.1",
     "express-rate-limit": "^7.5.0",
     "pkce-challenge": "^5.0.0",


### PR DESCRIPTION
Adds missing dependency on `eventsource-parser`.

## Motivation and Context

`src/client/streamableHttp.ts` imports from `eventsource-parser` but the package was not listed in `package.json`.

## How Has This Been Tested?

Fixed the build in a test client application.

## Breaking Changes

None

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
