### PR TITLE
Add stderr access before start

### DIFF
--- a/src/client/stdio.ts
+++ b/src/client/stdio.ts
@@ -1,7 +1,7 @@
 import { ChildProcess, IOType } from "node:child_process";
 import spawn from "cross-spawn";
 import process from "node:process";
-import { Stream } from "node:stream";
+import { Stream, PassThrough } from "node:stream";
 import { ReadBuffer, serializeMessage } from "../shared/stdio.js";
 import { Transport } from "../shared/transport.js";
 import { JSONRPCMessage } from "../types.js";
@@ -93,6 +93,7 @@ export class StdioClientTransport implements Transport {
   private _abortController: AbortController = new AbortController();
   private _readBuffer: ReadBuffer = new ReadBuffer();
   private _serverParams: StdioServerParameters;
+  private _stderrStream: PassThrough | null = null;
 
   onclose?: () => void;
   onerror?: (error: Error) => void;
@@ -100,6 +101,9 @@ export class StdioClientTransport implements Transport {
 
   constructor(server: StdioServerParameters) {
     this._serverParams = server;
+    if (server.stderr === "pipe" || server.stderr === "overlapped") {
+      this._stderrStream = new PassThrough();
+    }
   }
 
   /**
@@ -158,15 +162,25 @@ export class StdioClientTransport implements Transport {
       this._process.stdout?.on("error", (error) => {
         this.onerror?.(error);
       });
+
+      if (this._stderrStream && this._process.stderr) {
+        this._process.stderr.pipe(this._stderrStream);
+      }
     });
   }
 
   /**
    * The stderr stream of the child process, if `StdioServerParameters.stderr` was set to "pipe" or "overlapped".
    *
-   * This is only available after the process has been started.
+   * If stderr piping was requested, a PassThrough stream is returned _immediately_, allowing callers to
+   * attach listeners before the start method is invoked. This prevents loss of any early
+   * error output emitted by the child process.
    */
   get stderr(): Stream | null {
+    if (this._stderrStream) {
+      return this._stderrStream;
+    }
+
     return this._process?.stderr ?? null;
   }
 


### PR DESCRIPTION
Currently, when using StdioClientTransport with stderr set to "pipe", the stderr stream is not available until after start() is called. This means that any error output from the child process during startup is lost if the caller wants to capture it.

## Motivation and Context
The current implementation has a race condition:
1. User creates StdioClientTransport with stderr: "pipe"
2. User wants to attach stderr listeners
3. But stderr is only available after start() is called
4. By the time start() is called and stderr becomes available, early error output may have already been lost

This forces users to implement workarounds like:
```typescript
let stderrOutput = '';
const transport = new StdioClientTransport({...});
const connectionPromise = client.connect(transport);
transport?.stderr?.on('data', (chunk) => {
  stderrOutput += chunk.toString();
});
await connectionPromise;
```

## How Has This Been Tested?
The changes maintain backward compatibility while fixing the race condition. No existing behavior is changed - we just make the stderr stream available earlier.

## Breaking Changes
No, purely additive

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
