### PR TITLE
Fix `isZodRawShape` return false on empty object and add test

### DIFF
--- a/src/server/mcp.ts
+++ b/src/server/mcp.ts
@@ -663,8 +663,11 @@ export class McpServer {
     // Helper to check if an object is a Zod schema (ZodRawShape)
     const isZodRawShape = (obj: unknown): obj is ZodRawShape => {
       if (typeof obj !== "object" || obj === null) return false;
-      // Check that at least one property is a ZodType instance
-      return Object.values(obj as object).some(v => v instanceof ZodType);
+
+      const isEmptyObject = z.object({}).strict().safeParse(obj).success;
+
+      // Check if object is empty or at least one property is a ZodType instance
+      return isEmptyObject || Object.values(obj as object).some(v => v instanceof ZodType);
     };
 
     let description: string | undefined;


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
Fix `isZodRawShape` implementation to properly handle the empty object and add the test.

Close #453 

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
The `isZodRawShape` type guard function was incorrectly returning false for the empty object. This caused issues when trying to register tools with empty parameters. The fix ensures that empty objects are correctly identified as valid ZodRawShape instances, which allows for proper tool registration with empty parameter schemas.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Added a new test case in `mcp.test.ts` that specifically tests registering a tool with an empty parameters object. The test verifies that the tool is correctly registered with an empty object schema and that the proper annotations are applied. 

Additionally, manual testing regarding types accept by `ZodRawShape` was done with a simple test snippet:
```typescript
import { type ZodRawShape } from 'zod';

class Test {
  zodRawShape(input: ZodRawShape) {
    console.log(input);
  }
}

const test = new Test();
test.zodRawShape({}); // type check succeed - now works correctly on our type guard
test.zodRawShape(null); // type check failed as expected
```

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
None. This is a bug fix that maintains backward compatibility.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
The fix modifies the `isZodRawShape` type guard to explicitly handle empty objects as valid ZodRawShape instances. This is done by using Zod's own validation to check if the object is an empty object. If it is, we consider it a valid ZodRawShape. Otherwise, we fall back to the original check which verifies if any property is a ZodType instance.

The issue was particularly important for tools that don't require any parameters but still need to be properly registered with the MCP server.