### PR TITLE
Fix Table of Contents in README and markdown linter warnings.

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,8 @@
 # MCP TypeScript SDK Guide
 
 ## Build & Test Commands
-```
+
+```sh
 npm run build        # Build ESM and CJS versions
 npm run lint         # Run ESLint
 npm test             # Run all tests
@@ -10,6 +11,7 @@ npx jest -t "test name"        # Run tests matching pattern
 ```
 
 ## Code Style Guidelines
+
 - **TypeScript**: Strict type checking, ES modules, explicit return types
 - **Naming**: PascalCase for classes/types, camelCase for functions/variables
 - **Files**: Lowercase with hyphens, test files with `.test.ts` suffix
@@ -20,6 +22,7 @@ npx jest -t "test name"        # Run tests matching pattern
 - **Comments**: JSDoc for public APIs, inline comments for complex logic
 
 ## Project Structure
+
 - `/src`: Source code with client, server, and shared modules
 - Tests alongside source files with `.test.ts` suffix
 - Node.js >= 18 required

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-mcp-coc@anthropic.com.
+<mcp-coc@anthropic.com>.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the
@@ -116,7 +116,7 @@ the community.
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage],
 version 2.0, available at
-https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+<https://www.contributor-covenant.org/version/2/0/code_of_conduct.html>.
 
 Community Impact Guidelines were inspired by [Mozilla's code of conduct
 enforcement ladder](https://github.com/mozilla/diversity).
@@ -124,5 +124,5 @@ enforcement ladder](https://github.com/mozilla/diversity).
 [homepage]: https://www.contributor-covenant.org
 
 For answers to common questions about this code of conduct, see the FAQ at
-https://www.contributor-covenant.org/faq. Translations are available at
-https://www.contributor-covenant.org/translations.
+<https://www.contributor-covenant.org/faq>. Translations are available at
+<https://www.contributor-covenant.org/translations>.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # MCP TypeScript SDK ![NPM Version](https://img.shields.io/npm/v/%40modelcontextprotocol%2Fsdk) ![MIT licensed](https://img.shields.io/npm/l/%40modelcontextprotocol%2Fsdk)
 
 ## Table of Contents
+
 - [Overview](#overview)
 - [Installation](#installation)
-- [Quickstart](#quickstart)
+- [Quickstart](#quick-start)
 - [What is MCP?](#what-is-mcp)
 - [Core Concepts](#core-concepts)
   - [Server](#server)
@@ -18,11 +19,14 @@
   - [Echo Server](#echo-server)
   - [SQLite Explorer](#sqlite-explorer)
 - [Advanced Usage](#advanced-usage)
+  - [Dynamic Servers](#dynamic-servers)
   - [Low-Level Server](#low-level-server)
   - [Writing MCP Clients](#writing-mcp-clients)
-  - [Server Capabilities](#server-capabilities)
-  - [Proxy OAuth Server](#proxy-authorization-requests-upstream)
+  - [Proxy Authorization Requests Upstream](#proxy-authorization-requests-upstream)
   - [Backwards Compatibility](#backwards-compatibility)
+- [Documentation](#documentation)
+- [Contributing](#contributing)
+- [License](#license)
 
 ## Overview
 
@@ -377,6 +381,7 @@ app.listen(PORT, () => {
 ```
 
 This stateless approach is useful for:
+
 - Simple API wrappers
 - RESTful scenarios where each request is independent
 - Horizontally scaled deployments without shared session state
@@ -720,6 +725,7 @@ app.use(mcpAuthRouter({
 ```
 
 This setup allows you to:
+
 - Forward OAuth requests to an external provider
 - Add custom token validation logic
 - Manage client registrations
@@ -833,7 +839,7 @@ app.listen(3000);
 
 ## Contributing
 
-Issues and pull requests are welcome on GitHub at https://github.com/modelcontextprotocol/typescript-sdk.
+Issues and pull requests are welcome on GitHub at <https://github.com/modelcontextprotocol/typescript-sdk>.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,4 +1,5 @@
 # Security Policy
+
 Thank you for helping us keep the SDKs and systems they interact with secure.
 
 ## Reporting Security Issues


### PR DESCRIPTION
The Table of Contents of the README was outdated => fixed
Also fixed Markdown linter warnings.

## Motivation and Context

Small contribution to improve the documentation.

## How Has This Been Tested?

[x] I visually inspected the updated Markdown in the Github site.
[x] I clicked the corrected ToC links, they all work.

## Breaking Changes

None.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed