### PR TITLE
fix: Expose the MCP child process PID as an accessible property in StdioClientTransport

### DIFF
--- a/src/client/stdio.test.ts
+++ b/src/client/stdio.test.ts
@@ -64,7 +64,7 @@ test("should return child process pid", async () => {
   const client = new StdioClientTransport(serverParameters);
 
   await client.start();
-  expect(client.pid).toBeDefined();
+  expect(client.pid).not.toBeNull();
   await client.close();
-  expect(client.pid).toBeUndefined();
+  expect(client.pid).toBeNull();
 });

--- a/src/client/stdio.test.ts
+++ b/src/client/stdio.test.ts
@@ -59,3 +59,12 @@ test("should read messages", async () => {
 
   await client.close();
 });
+
+test("should return child process pid", async () => {
+  const client = new StdioClientTransport(serverParameters);
+
+  await client.start();
+  expect(client.pid).toBeDefined();
+  await client.close();
+  expect(client.pid).toBeUndefined();
+});

--- a/src/client/stdio.ts
+++ b/src/client/stdio.ts
@@ -184,6 +184,10 @@ export class StdioClientTransport implements Transport {
     return this._process?.stderr ?? null;
   }
 
+  get pid(): number | undefined {
+    return this._process?.pid;
+  }
+
   private processReadBuffer() {
     while (true) {
       try {

--- a/src/client/stdio.ts
+++ b/src/client/stdio.ts
@@ -184,8 +184,13 @@ export class StdioClientTransport implements Transport {
     return this._process?.stderr ?? null;
   }
 
-  get pid(): number | undefined {
-    return this._process?.pid;
+  /**
+   * The child process pid spawned by this transport.
+   *
+   * This is only available after the transport has been started.
+   */
+  get pid(): number | null {
+    return this._process?.pid ?? null;
   }
 
   private processReadBuffer() {


### PR DESCRIPTION
Expose the MCP child process PID as an accessible property in `StdioClientTransport`

## Motivation and Context
The stdio transport connects to servers by spawning a process and communicating over stdin/stdout. When debugging a server running via this transport, IDE debuggers require the child process PID to properly attach to the server's Node process. 

This change exposes the child process PID through the MCP client SDK, enabling direct debugger attachment without requiring manual PID lookup or additional tooling. This improves the developer debugging experience when working with stdio-based server connections.

## How Has This Been Tested?
Added UT and used in sample MCP template

## Breaking Changes
No breaking changes

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

