### PR TITLE
docs: Fix import paths for ProxyOAuthServerProvider in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -686,7 +686,8 @@ You can proxy OAuth requests to an external authorization provider:
 
 ```typescript
 import express from 'express';
-import { ProxyOAuthServerProvider, mcpAuthRouter } from '@modelcontextprotocol/sdk';
+import { ProxyOAuthServerProvider } from '@modelcontextprotocol/sdk/server/auth/providers/proxyProvider.js';
+import { mcpAuthRouter } from '@modelcontextprotocol/sdk/server/auth/router.js';
 
 const app = express();
 


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

The current README example shows incorrect import paths for the OAuth components. Updated the example to use the correct paths:

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

This is a documentation fix only. Verified that the corrected import paths work by manually importing the components using the specified paths in a test project.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
