### PR TITLE
feat: Add scope parameter to startAuthorization function

### DIFF
--- a/src/client/auth.test.ts
+++ b/src/client/auth.test.ts
@@ -177,6 +177,31 @@ describe("OAuth Authorization", () => {
       expect(codeVerifier).toBe("test_verifier");
     });
 
+    it("includes scope parameter when provided", async () => {
+      const { authorizationUrl } = await startAuthorization(
+        "https://auth.example.com",
+        {
+          clientInformation: validClientInfo,
+          redirectUrl: "http://localhost:3000/callback",
+          scope: "read write profile",
+        }
+      );
+
+      expect(authorizationUrl.searchParams.get("scope")).toBe("read write profile");
+    });
+
+    it("excludes scope parameter when not provided", async () => {
+      const { authorizationUrl } = await startAuthorization(
+        "https://auth.example.com",
+        {
+          clientInformation: validClientInfo,
+          redirectUrl: "http://localhost:3000/callback",
+        }
+      );
+
+      expect(authorizationUrl.searchParams.has("scope")).toBe(false);
+    });
+
     it("uses metadata authorization_endpoint when provided", async () => {
       const { authorizationUrl } = await startAuthorization(
         "https://auth.example.com",

--- a/src/client/auth.ts
+++ b/src/client/auth.ts
@@ -145,7 +145,8 @@ export async function auth(
   const { authorizationUrl, codeVerifier } = await startAuthorization(serverUrl, {
     metadata,
     clientInformation,
-    redirectUrl: provider.redirectUrl
+    redirectUrl: provider.redirectUrl,
+    scope: provider.clientMetadata.scope
   });
 
   await provider.saveCodeVerifier(codeVerifier);
@@ -202,10 +203,12 @@ export async function startAuthorization(
     metadata,
     clientInformation,
     redirectUrl,
+    scope,
   }: {
     metadata?: OAuthMetadata;
     clientInformation: OAuthClientInformation;
     redirectUrl: string | URL;
+    scope?: string;
   },
 ): Promise<{ authorizationUrl: URL; codeVerifier: string }> {
   const responseType = "code";
@@ -246,6 +249,10 @@ export async function startAuthorization(
     codeChallengeMethod,
   );
   authorizationUrl.searchParams.set("redirect_uri", String(redirectUrl));
+  
+  if (scope) {
+    authorizationUrl.searchParams.set("scope", scope);
+  }
 
   return { authorizationUrl, codeVerifier };
 }


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
- Add optional scope parameter to startAuthorization function signature
- Include scope in authorization URL query parameters when provided
- Update auth function to pass through scope from provider.clientMetadata
- Add tests to verify scope is correctly included/excluded from auth URL

I ran into this while testing a python example server in the inspector

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
