### PR TITLE
Pr/protocol overwriting transport hooks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@modelcontextprotocol/sdk",
-  "version": "1.9.0",
+  "version": "1.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@modelcontextprotocol/sdk",
-      "version": "1.9.0",
+      "version": "1.11.1",
       "license": "MIT",
       "dependencies": {
         "content-type": "^1.0.5",

--- a/src/shared/protocol.test.ts
+++ b/src/shared/protocol.test.ts
@@ -63,6 +63,22 @@ describe("protocol tests", () => {
     expect(oncloseMock).toHaveBeenCalled();
   });
 
+  it("should not overwrite existing hooks when connecting transports", async () => {
+    const oncloseMock = jest.fn();
+    const onerrorMock = jest.fn();
+    const onmessageMock = jest.fn();
+    transport.onclose = oncloseMock;
+    transport.onerror = onerrorMock;
+    transport.onmessage = onmessageMock;
+    await protocol.connect(transport);
+    transport.onclose();
+    transport.onerror(new Error());
+    transport.onmessage("");
+    expect(oncloseMock).toHaveBeenCalled();
+    expect(onerrorMock).toHaveBeenCalled();
+    expect(onmessageMock).toHaveBeenCalled();
+  });
+
   describe("progress notification timeout behavior", () => {
     beforeEach(() => {
       jest.useFakeTimers();

--- a/src/shared/protocol.ts
+++ b/src/shared/protocol.ts
@@ -279,15 +279,21 @@ export abstract class Protocol<
    */
   async connect(transport: Transport): Promise<void> {
     this._transport = transport;
+    const _onclose = this.transport?.onclose;
     this._transport.onclose = () => {
+      _onclose?.();
       this._onclose();
     };
 
+    const _onerror = this.transport?.onerror;
     this._transport.onerror = (error: Error) => {
+      _onerror?.(error);
       this._onerror(error);
     };
 
+    const _onmessage = this._transport?.onmessage;
     this._transport.onmessage = (message, extra) => {
+      _onmessage?.(message, extra);
       if (isJSONRPCResponse(message) || isJSONRPCError(message)) {
         this._onresponse(message);
       } else if (isJSONRPCRequest(message)) {
@@ -295,7 +301,9 @@ export abstract class Protocol<
       } else if (isJSONRPCNotification(message)) {
         this._onnotification(message);
       } else {
-        this._onerror(new Error(`Unknown message type: ${JSON.stringify(message)}`));
+        this._onerror(
+          new Error(`Unknown message type: ${JSON.stringify(message)}`),
+        );
       }
     };
 


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
`Protocol` class currently hooks onto transports by completely overwriting them, which causes the originally hooked functions to be lost and not executed. 

For example this code snippet in the README.md wouldn't be executed.
https://github.com/modelcontextprotocol/typescript-sdk/blob/main/README.md?plain=1#L254-L258

## How Has This Been Tested?

<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
