### PR TITLE
optimization: When using custom SSE request,`Authorization` header can still be automatically attached to the SSE request.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,6 +120,7 @@ out
 
 # Stores VSCode versions used for testing VSCode extensions
 .vscode-test
+.vscode/
 
 # yarn v2
 .yarn/cache

--- a/src/client/sse.ts
+++ b/src/client/sse.ts
@@ -35,11 +35,6 @@ export type SSEClientTransportOptions = {
 
   /**
    * Customizes the initial SSE request to the server (the request that begins the stream).
-   * 
-   * NOTE: Setting this property will prevent an `Authorization` header from
-   * being automatically attached to the SSE request, if an `authProvider` is
-   * also given. This can be worked around by setting the `Authorization` header
-   * manually.
    */
   eventSourceInit?: EventSourceInit;
 


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
When using the custom SSE request, the `Authorization` header can still be automatically attached to the SSE request.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
**Current:** 
When user customizes the initial SSE request, it will prevent an `Authorization` header from being automatically attached to the SSE request. It require user to fetch tokens from `authProvider` and set the `Authorization` header manually.
Ref:
https://github.com/modelcontextprotocol/typescript-sdk/blob/bced33d8bc57419c6d498ca9a26a284f3ccf6016/src/client/sse.ts#L36-L44

**Goal:**  
Simplify the code and reduce the risk of misuse.
There is an misused case: https://github.com/CherryHQ/cherry-studio/pull/5709



## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
`npm test -- src/client/sse.test.ts -t "refreshes expired token during SSE connection"`

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
