### PR TITLE
Save existing refresh_token in store if no new refresh_token is returned

### DIFF
--- a/src/client/auth.test.ts
+++ b/src/client/auth.test.ts
@@ -342,6 +342,9 @@ describe("OAuth Authorization", () => {
       access_token: "newaccess123",
       token_type: "Bearer",
       expires_in: 3600,
+    }
+    const validTokensWithNewRefreshToken = {
+      ...validTokens,
       refresh_token: "newrefresh123",
     };
 
@@ -356,7 +359,7 @@ describe("OAuth Authorization", () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
         status: 200,
-        json: async () => validTokens,
+        json: async () => validTokensWithNewRefreshToken,
       });
 
       const tokens = await refreshAuthorization("https://auth.example.com", {
@@ -364,7 +367,7 @@ describe("OAuth Authorization", () => {
         refreshToken: "refresh123",
       });
 
-      expect(tokens).toEqual(validTokens);
+      expect(tokens).toEqual(validTokensWithNewRefreshToken);
       expect(mockFetch).toHaveBeenCalledWith(
         expect.objectContaining({
           href: "https://auth.example.com/token",
@@ -382,6 +385,22 @@ describe("OAuth Authorization", () => {
       expect(body.get("refresh_token")).toBe("refresh123");
       expect(body.get("client_id")).toBe("client123");
       expect(body.get("client_secret")).toBe("secret123");
+    });
+
+    it("exchanges refresh token for new tokens and keep existing refresh token if none is returned", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => validTokens,
+      });
+
+      const refreshToken = "refresh123";
+      const tokens = await refreshAuthorization("https://auth.example.com", {
+        clientInformation: validClientInfo,
+        refreshToken,
+      });
+
+      expect(tokens).toEqual({ refresh_token: refreshToken, ...validTokens });
     });
 
     it("validates token response schema", async () => {

--- a/src/client/auth.ts
+++ b/src/client/auth.ts
@@ -378,7 +378,7 @@ export async function refreshAuthorization(
     throw new Error(`Token refresh failed: HTTP ${response.status}`);
   }
 
-  return OAuthTokensSchema.parse(await response.json());
+  return OAuthTokensSchema.parse({ refresh_token: refreshToken, ...(await response.json()) });
 }
 
 /**


### PR DESCRIPTION
As described in [OAuth 2.1 specs on refresh token response](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-12#name-refresh-token-response), server MAY return a new refresh_token. In case it doesn't, current implementation discards initially obtained refresh_token even if it is still valid.

<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Ensure refresh_token can be used more than once to generate a new access_token

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Added a test case to `auth.test.ts` to simulate the case where no `refresh_token` is returned in response from `/token` request with `refresh_token` grant.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
None

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [X] I have added appropriate error handling
- [X] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
