### PR TITLE
feat(auth): support custom scope in authorization requests

### DIFF
--- a/src/client/auth.ts
+++ b/src/client/auth.ts
@@ -84,7 +84,14 @@ export class UnauthorizedError extends Error {
  */
 export async function auth(
   provider: OAuthClientProvider,
-  { serverUrl, authorizationCode }: { serverUrl: string | URL, authorizationCode?: string }): Promise<AuthResult> {
+  { serverUrl,
+    authorizationCode,
+    scope,
+  }: {
+    serverUrl: string | URL;
+    authorizationCode?: string;
+    scope?: string;
+  }): Promise<AuthResult> {
   const metadata = await discoverOAuthMetadata(serverUrl);
 
   // Handle client registration if needed
@@ -146,7 +153,7 @@ export async function auth(
     metadata,
     clientInformation,
     redirectUrl: provider.redirectUrl,
-    scope: provider.clientMetadata.scope
+    scope,
   });
 
   await provider.saveCodeVerifier(codeVerifier);

--- a/src/client/auth.ts
+++ b/src/client/auth.ts
@@ -153,7 +153,7 @@ export async function auth(
     metadata,
     clientInformation,
     redirectUrl: provider.redirectUrl,
-    scope,
+    scope: scope || provider.clientMetadata.scope,
   });
 
   await provider.saveCodeVerifier(codeVerifier);


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
Add support for specifying custom OAuth scopes during authorization requests, separating client registration metadata from authorization request parameters.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Previously, the authorization request was hardcoded to use the scope from client metadata (`clientMetadata.scope`)(in https://github.com/modelcontextprotocol/typescript-sdk/pull/464), which incorrectly mixed two different OAuth 2.0 concepts:
1. Client Registration Metadata: defines the maximum scope capabilities a client is registered for
2. Authorization Request Parameters: specific scope requested during an individual authorization flow

This change properly separates these concerns by:
- Making the scope in authorization requests configurable
- Allowing different scopes for different authorization flows
- Maintaining the original client metadata scope for registration purposes

This better aligns with OAuth 2.0 specification where authorization request scopes and client registration metadata serve different purposes.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Existing unit tests passed.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No. If the scope is not provided, it will fallback to `clientMetadata.scope`.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
This change focuses on architectural correctness in OAuth 2.0 implementation by properly separating client registration metadata from authorization request parameters. While this is a breaking change, it enforces better OAuth 2.0 practices by making scope requirements explicit in authorization requests.

Migration guide:
```typescript
// Old code
await auth(provider, { serverUrl });

// New code
await auth(provider, { 
  serverUrl,
  scope: "your-required-scope" // Explicitly specify the scope
});
```