### PR TITLE
feat(auth): support resource indicators in auth flow

### DIFF
--- a/src/client/auth.test.ts
+++ b/src/client/auth.test.ts
@@ -391,6 +391,50 @@ describe("OAuth Authorization", () => {
       expect(authorizationUrl.searchParams.has("state")).toBe(false);
     });
 
+
+    it("includes resource parameter when provided", async () => {
+      const { authorizationUrl } = await startAuthorization(
+        "https://auth.example.com",
+        {
+          clientInformation: validClientInfo,
+          redirectUrl: "http://localhost:3000/callback",
+          resources: ["https://api.example.com/resource"],
+        }
+      );
+
+      expect(authorizationUrl.searchParams.get("resource")).toBe(
+        "https://api.example.com/resource"
+      );
+    });
+
+    it("includes multiple resource parameters when provided", async () => {
+      const { authorizationUrl } = await startAuthorization(
+        "https://auth.example.com",
+        {
+          clientInformation: validClientInfo,
+          redirectUrl: "http://localhost:3000/callback",
+          resources: ["https://api.example.com/resource1", "https://api.example.com/resource2"],
+        }
+      );
+
+      expect(authorizationUrl.searchParams.getAll("resource")).toEqual([
+        "https://api.example.com/resource1",
+        "https://api.example.com/resource2",
+      ]);
+    });
+
+    it("excludes resource parameter when not provided", async () => {
+      const { authorizationUrl } = await startAuthorization(
+        "https://auth.example.com",
+        {
+          clientInformation: validClientInfo,
+          redirectUrl: "http://localhost:3000/callback",
+        }
+      );
+
+      expect(authorizationUrl.searchParams.has("resource")).toBe(false);
+    });
+
     it("uses metadata authorization_endpoint when provided", async () => {
       const { authorizationUrl } = await startAuthorization(
         "https://auth.example.com",


### PR DESCRIPTION
# Support Resource Indicators in OAuth Flow

## Motivation and Context
This PR adds support for Resource Indicators as specified in [RFC 8707](https://datatracker.ietf.org/doc/html/rfc8707), which allows OAuth clients to specify the target resource for access tokens. Many modern OAuth servers (like Auth0 and Logto) implement this specification to enable more granular access control and token audience restrictions.

While RFC 8707 supports specifying multiple resources during authorization and selecting specific resources during token exchange, this implementation intentionally handles only a single resource per authorization session. This design decision aligns with our current auth flow architecture where:
1. Each auth session corresponds to one token
2. Each token is bound to exactly one resource
3. The resource-token binding is maintained throughout the authorization session

## How Has This Been Tested?
- Added unit tests in `auth.test.ts` verifying:
  - Resource parameter inclusion in authorization URL when only one resource is provided
  - Resource parameters inclusion in authrization URL when more than one resource is provided
  - Resource parameter exclusion when not provided
- Tested integration with OAuth servers that support RFC 8707

## Breaking Changes
No breaking changes. The resource support is implemented as an optional feature through:
- Optional `resource()` method in `OAuthClientProvider` interface
- Optional `resource` parameter in auth flow functions

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
The implementation follows RFC 8707 specifications while maintaining simplicity in the auth flow. The resource parameter is consistently propagated through all relevant auth operations:
- Initial authorization request
- Token exchange
- Token refresh

This ensures that tokens are always bound to their intended resources throughout the entire authorization lifecycle.