### PR TITLE
fix sse endpoint path preservation

### DIFF
--- a/src/client/sse.test.ts
+++ b/src/client/sse.test.ts
@@ -87,7 +87,7 @@ describe("SSEClientTransport", () => {
       await transport.send(message);
 
       // Verify the POST request maintains the custom path
-      expect(lastServerRequest.url).toBe("/custom/path/messages");
+      expect(lastServerRequest.url).toBe("/custom/path/sse");
     });
 
     it("handles multiple levels of custom paths", async () => {
@@ -107,7 +107,7 @@ describe("SSEClientTransport", () => {
       await transport.send(message);
 
       // Verify the POST request maintains the full custom path
-      expect(lastServerRequest.url).toBe("/api/v1/custom/deep/path/messages");
+      expect(lastServerRequest.url).toBe("/api/v1/custom/deep/path/sse");
     });
 
     it("maintains custom path for SSE connection", async () => {
@@ -130,7 +130,7 @@ describe("SSEClientTransport", () => {
       };
       
       await transport.send(message);
-      expect(lastServerRequest.url).toBe("/custom/path/messages");
+      expect(lastServerRequest.url).toBe("/custom/path/sse");
     });
 
     it("establishes SSE connection and receives endpoint", async () => {

--- a/src/client/sse.ts
+++ b/src/client/sse.ts
@@ -147,13 +147,7 @@ export class SSEClientTransport implements Transport {
           this._endpoint = new URL(messageEvent.data, this._url);
           
           // If the original URL had a custom path, preserve it in the endpoint URL
-          const originalPath = this._url.pathname;
-          if (originalPath && originalPath !== '/' && originalPath !== '/sse') {
-            // Extract the base path from the original URL (everything before the /sse suffix)
-            const basePath = originalPath.replace(/\/sse$/, '');
-            // The endpoint should use the same base path but with /messages instead of /sse
-            this._endpoint.pathname = basePath + '/messages';
-          }
+          this._endpoint.pathname = this._url.pathname;
           
           if (this._endpoint.origin !== this._url.origin) {
             throw new Error(


### PR DESCRIPTION
Fix for the fix in #466, which was arbitrarily converting an "sse" endpoint suffix to a "messages" endpoint suffix.

## Motivation and Context
bugfix

## How Has This Been Tested?
updated erroneous existing test

## Breaking Changes
no

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
