### PR TITLE
fix: ProxyOAuthServerProvider: redirect_uri missing in token request

### DIFF
--- a/src/server/auth/handlers/token.ts
+++ b/src/server/auth/handlers/token.ts
@@ -31,6 +31,7 @@ const TokenRequestSchema = z.object({
 const AuthorizationCodeGrantSchema = z.object({
   code: z.string(),
   code_verifier: z.string(),
+  redirect_uri: z.string().optional(),
 });
 
 const RefreshTokenGrantSchema = z.object({
@@ -88,7 +89,7 @@ export function tokenHandler({ provider, rateLimit: rateLimitConfig }: TokenHand
             throw new InvalidRequestError(parseResult.error.message);
           }
 
-          const { code, code_verifier } = parseResult.data;
+          const { code, code_verifier, redirect_uri } = parseResult.data;
 
           const skipLocalPkceValidation = provider.skipLocalPkceValidation;
 
@@ -102,7 +103,12 @@ export function tokenHandler({ provider, rateLimit: rateLimitConfig }: TokenHand
           }
 
           // Passes the code_verifier to the provider if PKCE validation didn't occur locally
-          const tokens = await provider.exchangeAuthorizationCode(client, code, skipLocalPkceValidation ? code_verifier : undefined);
+          const tokens = await provider.exchangeAuthorizationCode(
+            client, 
+            code, 
+            skipLocalPkceValidation ? code_verifier : undefined,
+            redirect_uri
+          );
           res.status(200).json(tokens);
           break;
         }

--- a/src/server/auth/provider.ts
+++ b/src/server/auth/provider.ts
@@ -36,7 +36,12 @@ export interface OAuthServerProvider {
   /**
    * Exchanges an authorization code for an access token.
    */
-  exchangeAuthorizationCode(client: OAuthClientInformationFull, authorizationCode: string, codeVerifier?: string): Promise<OAuthTokens>;
+  exchangeAuthorizationCode(
+    client: OAuthClientInformationFull, 
+    authorizationCode: string, 
+    codeVerifier?: string,
+    redirectUri?: string
+  ): Promise<OAuthTokens>;
 
   /**
    * Exchanges a refresh token for an access token.

--- a/src/server/auth/providers/proxyProvider.test.ts
+++ b/src/server/auth/providers/proxyProvider.test.ts
@@ -142,6 +142,28 @@ describe("Proxy OAuth Server Provider", () => {
       expect(tokens).toEqual(mockTokenResponse);
     });
 
+    it("includes redirect_uri in token request when provided", async () => {
+      const redirectUri = "https://example.com/callback";
+      const tokens = await provider.exchangeAuthorizationCode(
+        validClient,
+        "test-code",
+        "test-verifier",
+        redirectUri
+      );
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        "https://auth.example.com/token",
+        expect.objectContaining({
+          method: "POST",
+          headers: {
+            "Content-Type": "application/x-www-form-urlencoded",
+          },
+          body: expect.stringContaining(`redirect_uri=${encodeURIComponent(redirectUri)}`)
+        })
+      );
+      expect(tokens).toEqual(mockTokenResponse);
+    });
+
     it("exchanges refresh token for new tokens", async () => {
       const tokens = await provider.exchangeRefreshToken(
         validClient,

--- a/src/server/auth/providers/proxyProvider.ts
+++ b/src/server/auth/providers/proxyProvider.ts
@@ -151,7 +151,8 @@ export class ProxyOAuthServerProvider implements OAuthServerProvider {
   async exchangeAuthorizationCode(
     client: OAuthClientInformationFull,
     authorizationCode: string,
-    codeVerifier?: string
+    codeVerifier?: string,
+    redirectUri?: string
   ): Promise<OAuthTokens> {
     const params = new URLSearchParams({
       grant_type: "authorization_code",
@@ -165,6 +166,10 @@ export class ProxyOAuthServerProvider implements OAuthServerProvider {
 
     if (codeVerifier) {
       params.append("code_verifier", codeVerifier);
+    }
+
+    if (redirectUri) {
+      params.append("redirect_uri", redirectUri);
     }
 
     const response = await fetch(this._endpoints.tokenUrl, {


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
Fixes #479: a critical issue in ProxyOAuthServerProvider where the redirect_uri parameter was missing from the token exchange request, causing token endpoints (like Amazon Cognito) to return 400/500 errors. 

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Issue: The ProxyOAuthServerProvider did not include the redirect_uri parameter in the /token request, violating the OAuth 2.0 spec.
Impact: This caused token endpoints to fail, preventing successful token exchanges.
Why Fix: The redirect_uri is required by the OAuth 2.0 spec and must match the one used during the /authorize request.
## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Unit Tests: Added tests to verify that the redirect_uri is included in the token request.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
None: This is a bug fix that does not change the public API or behavior of the ProxyOAuthServerProvider.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
Implementation Notes: The fix updates the exchangeAuthorizationCode method to include the redirect_uri parameter in the token request.
Design Decisions: Ensured the fix adheres to the OAuth 2.0 spec and maintains backward compatibility.