### PR TITLE
add server error if tool declares outputSchema but returns no structuredContent 

### DIFF
--- a/src/server/mcp.ts
+++ b/src/server/mcp.ts
@@ -198,7 +198,14 @@ export class McpServer {
           }
         }
 
-        if (tool.outputSchema && result.structuredContent) {
+        if (tool.outputSchema) {
+          if (!result.structuredContent) {
+            throw new McpError(
+              ErrorCode.InvalidParams,
+              `Tool ${request.params.name} has an output schema but no structured content was provided`,
+            );
+          }
+
           // if the tool has an output schema, validate structured content
           const parseResult = await tool.outputSchema.safeParseAsync(
             result.structuredContent,


### PR DESCRIPTION
## Motivation and Context
Update server tool call request handler to match draft spec language more precisely: if a tool declares an outputSchema, it must return valid structuredContent.

## How Has This Been Tested?
Added test

## Breaking Changes
None

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [X] I have added appropriate error handling
- [X] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
