### PR TITLE
fix: enable arrays and boolean data to be structured data.

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -892,7 +892,7 @@ export const CallToolResultSchema = ResultSchema.extend({
    *
    * If the Tool defines an outputSchema, this field MUST be present in the result, and contain a JSON object that matches the schema.
    */
-  structuredContent: z.object({}).passthrough().optional(),
+  structuredContent: z.any().optional(),
 
   /**
    * Whether the tool call ended in an error.


### PR DESCRIPTION
Replaces .object to .any on CallToolResultSchema to enable arrays and boolean on structuredContent

## Motivation and Context
Hi folks! I have some mcps and I'd love to migrate them to using the new structuredContent for mcp output. Turns out that when migrating these MCPs I've noticed some of my tools return either and array or a boolean value. When this is the case I currently get an error from zod schema validation. 

This PR addresses this issue by allowing .any() type on structuredContent

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
