### PR TITLE
Allow OAuth client provider to implement token endpoint authentication methods

### DIFF
--- a/src/client/auth.test.ts
+++ b/src/client/auth.test.ts
@@ -480,9 +480,10 @@ describe("OAuth Authorization", () => {
     });
 
     it("exchanges code for tokens with auth", async () => {
-      mockProvider.authToTokenEndpoint = function(headers: Headers, params: URLSearchParams) {
+      mockProvider.authToTokenEndpoint = function(url: URL, headers: Headers, params: URLSearchParams) {
         headers.set("Authorization", "Basic " + btoa(validClientInfo.client_id + ":" + validClientInfo.client_secret));
-        params.set("example_param", "example_value")
+        params.set("example_url", url.toString());
+        params.set("example_param", "example_value");
       };
 
       mockFetch.mockResolvedValueOnce({
@@ -517,6 +518,7 @@ describe("OAuth Authorization", () => {
       expect(body.get("code_verifier")).toBe("verifier123");
       expect(body.get("client_id")).toBe("client123");
       expect(body.get("redirect_uri")).toBe("http://localhost:3000/callback");
+      expect(body.get("example_url")).toBe("https://auth.example.com/token");
       expect(body.get("example_param")).toBe("example_value");
       expect(body.get("client_secret")).toBeUndefined;
     });
@@ -624,9 +626,10 @@ describe("OAuth Authorization", () => {
     });
 
     it("exchanges refresh token for new tokens with auth", async () => {
-      mockProvider.authToTokenEndpoint = function(headers: Headers, params: URLSearchParams) {
+      mockProvider.authToTokenEndpoint = function(url: URL, headers: Headers, params: URLSearchParams) {
         headers.set("Authorization", "Basic " + btoa(validClientInfo.client_id + ":" + validClientInfo.client_secret));
-        params.set("example_param", "example_value")
+        params.set("example_url", url.toString());
+        params.set("example_param", "example_value");
       };
 
       mockFetch.mockResolvedValueOnce({
@@ -657,6 +660,7 @@ describe("OAuth Authorization", () => {
       expect(body.get("grant_type")).toBe("refresh_token");
       expect(body.get("refresh_token")).toBe("refresh123");
       expect(body.get("client_id")).toBe("client123");
+      expect(body.get("example_url")).toBe("https://auth.example.com/token");
       expect(body.get("example_param")).toBe("example_value");
       expect(body.get("client_secret")).toBeUndefined;
     });

--- a/src/client/auth.test.ts
+++ b/src/client/auth.test.ts
@@ -451,7 +451,7 @@ describe("OAuth Authorization", () => {
         json: async () => validTokens,
       });
 
-      const tokens = await exchangeAuthorization("https://auth.example.com", mockProvider, {
+      const tokens = await exchangeAuthorization("https://auth.example.com", {
         clientInformation: validClientInfo,
         authorizationCode: "code123",
         codeVerifier: "verifier123",
@@ -491,12 +491,12 @@ describe("OAuth Authorization", () => {
         json: async () => validTokens,
       });
 
-      const tokens = await exchangeAuthorization("https://auth.example.com", mockProvider, {
+      const tokens = await exchangeAuthorization("https://auth.example.com", {
         clientInformation: validClientInfo,
         authorizationCode: "code123",
         codeVerifier: "verifier123",
         redirectUri: "http://localhost:3000/callback",
-      });
+      }, mockProvider);
 
       expect(tokens).toEqual(validTokens);
       expect(mockFetch).toHaveBeenCalledWith(
@@ -532,7 +532,7 @@ describe("OAuth Authorization", () => {
       });
 
       await expect(
-        exchangeAuthorization("https://auth.example.com", mockProvider, {
+        exchangeAuthorization("https://auth.example.com", {
           clientInformation: validClientInfo,
           authorizationCode: "code123",
           codeVerifier: "verifier123",
@@ -548,7 +548,7 @@ describe("OAuth Authorization", () => {
       });
 
       await expect(
-        exchangeAuthorization("https://auth.example.com", mockProvider, {
+        exchangeAuthorization("https://auth.example.com", {
           clientInformation: validClientInfo,
           authorizationCode: "code123",
           codeVerifier: "verifier123",
@@ -599,7 +599,7 @@ describe("OAuth Authorization", () => {
         json: async () => validTokensWithNewRefreshToken,
       });
 
-      const tokens = await refreshAuthorization("https://auth.example.com", mockProvider, {
+      const tokens = await refreshAuthorization("https://auth.example.com", {
         clientInformation: validClientInfo,
         refreshToken: "refresh123",
       });
@@ -635,10 +635,10 @@ describe("OAuth Authorization", () => {
         json: async () => validTokensWithNewRefreshToken,
       });
 
-      const tokens = await refreshAuthorization("https://auth.example.com", mockProvider, {
+      const tokens = await refreshAuthorization("https://auth.example.com", {
         clientInformation: validClientInfo,
         refreshToken: "refresh123",
-      });
+      }, mockProvider);
 
       expect(tokens).toEqual(validTokensWithNewRefreshToken);
       expect(mockFetch).toHaveBeenCalledWith(
@@ -669,7 +669,7 @@ describe("OAuth Authorization", () => {
       });
 
       const refreshToken = "refresh123";
-      const tokens = await refreshAuthorization("https://auth.example.com", mockProvider, {
+      const tokens = await refreshAuthorization("https://auth.example.com", {
         clientInformation: validClientInfo,
         refreshToken,
       });
@@ -688,7 +688,7 @@ describe("OAuth Authorization", () => {
       });
 
       await expect(
-        refreshAuthorization("https://auth.example.com", mockProvider, {
+        refreshAuthorization("https://auth.example.com", {
           clientInformation: validClientInfo,
           refreshToken: "refresh123",
         })
@@ -702,7 +702,7 @@ describe("OAuth Authorization", () => {
       });
 
       await expect(
-        refreshAuthorization("https://auth.example.com", mockProvider, {
+        refreshAuthorization("https://auth.example.com", {
           clientInformation: validClientInfo,
           refreshToken: "refresh123",
         })

--- a/src/client/auth.test.ts
+++ b/src/client/auth.test.ts
@@ -414,6 +414,22 @@ describe("OAuth Authorization", () => {
   });
 
   describe("exchangeAuthorization", () => {
+    const mockProvider: OAuthClientProvider = {
+      get redirectUrl() { return "http://localhost:3000/callback"; },
+      get clientMetadata() {
+        return {
+          redirect_uris: ["http://localhost:3000/callback"],
+          client_name: "Test Client",
+        };
+      },
+      clientInformation: jest.fn(),
+      tokens: jest.fn(),
+      saveTokens: jest.fn(),
+      redirectToAuthorization: jest.fn(),
+      saveCodeVerifier: jest.fn(),
+      codeVerifier: jest.fn(),
+    };
+    
     const validTokens = {
       access_token: "access123",
       token_type: "Bearer",
@@ -435,7 +451,7 @@ describe("OAuth Authorization", () => {
         json: async () => validTokens,
       });
 
-      const tokens = await exchangeAuthorization("https://auth.example.com", {
+      const tokens = await exchangeAuthorization("https://auth.example.com", mockProvider, {
         clientInformation: validClientInfo,
         authorizationCode: "code123",
         codeVerifier: "verifier123",
@@ -449,9 +465,9 @@ describe("OAuth Authorization", () => {
         }),
         expect.objectContaining({
           method: "POST",
-          headers: {
+          headers: new Headers({
             "Content-Type": "application/x-www-form-urlencoded",
-          },
+          }),
         })
       );
 
@@ -475,7 +491,7 @@ describe("OAuth Authorization", () => {
       });
 
       await expect(
-        exchangeAuthorization("https://auth.example.com", {
+        exchangeAuthorization("https://auth.example.com", mockProvider, {
           clientInformation: validClientInfo,
           authorizationCode: "code123",
           codeVerifier: "verifier123",
@@ -491,7 +507,7 @@ describe("OAuth Authorization", () => {
       });
 
       await expect(
-        exchangeAuthorization("https://auth.example.com", {
+        exchangeAuthorization("https://auth.example.com", mockProvider, {
           clientInformation: validClientInfo,
           authorizationCode: "code123",
           codeVerifier: "verifier123",

--- a/src/client/auth.ts
+++ b/src/client/auth.ts
@@ -67,7 +67,7 @@ export interface OAuthClientProvider {
    */
   codeVerifier(): string | Promise<string>;
   
-  authToTokenEndpoint?(headers: Headers, params: URLSearchParams): void | Promise<void>;
+  authToTokenEndpoint?(url: URL, headers: Headers, params: URLSearchParams): void | Promise<void>;
 }
 
 export type AuthResult = "AUTHORIZED" | "REDIRECT";
@@ -407,7 +407,7 @@ export async function exchangeAuthorization(
   });
 
   if (provider?.authToTokenEndpoint) {
-    provider.authToTokenEndpoint(headers, params);
+    provider.authToTokenEndpoint(tokenUrl, headers, params);
   } else if (clientInformation.client_secret) {
     params.set("client_secret", clientInformation.client_secret);
   }
@@ -470,7 +470,7 @@ export async function refreshAuthorization(
   });
 
   if (provider?.authToTokenEndpoint) {
-    provider.authToTokenEndpoint(headers, params);
+    provider.authToTokenEndpoint(tokenUrl, headers, params);
   } else if (clientInformation.client_secret) {
     params.set("client_secret", clientInformation.client_secret);
   }

--- a/src/client/auth.ts
+++ b/src/client/auth.ts
@@ -133,13 +133,13 @@ export async function auth(
   // Exchange authorization code for tokens
   if (authorizationCode !== undefined) {
     const codeVerifier = await provider.codeVerifier();
-    const tokens = await exchangeAuthorization(authorizationServerUrl, provider, {
+    const tokens = await exchangeAuthorization(authorizationServerUrl, {
       metadata,
       clientInformation,
       authorizationCode,
       codeVerifier,
       redirectUri: provider.redirectUrl,
-    });
+    }, provider);
 
     await provider.saveTokens(tokens);
     return "AUTHORIZED";
@@ -151,11 +151,11 @@ export async function auth(
   if (tokens?.refresh_token) {
     try {
       // Attempt to refresh the token
-      const newTokens = await refreshAuthorization(authorizationServerUrl, provider, {
+      const newTokens = await refreshAuthorization(authorizationServerUrl, {
         metadata,
         clientInformation,
         refreshToken: tokens.refresh_token,
-      });
+      }, provider);
 
       await provider.saveTokens(newTokens);
       return "AUTHORIZED";
@@ -361,7 +361,6 @@ export async function startAuthorization(
  */
 export async function exchangeAuthorization(
   authorizationServerUrl: string | URL,
-  provider: OAuthClientProvider,
   {
     metadata,
     clientInformation,
@@ -375,6 +374,7 @@ export async function exchangeAuthorization(
     codeVerifier: string;
     redirectUri: string | URL;
   },
+  provider?: OAuthClientProvider
 ): Promise<OAuthTokens> {
   const grantType = "authorization_code";
 
@@ -406,7 +406,7 @@ export async function exchangeAuthorization(
     redirect_uri: String(redirectUri),
   });
 
-  if (provider.authToTokenEndpoint) {
+  if (provider?.authToTokenEndpoint) {
     provider.authToTokenEndpoint(headers, params);
   } else if (clientInformation.client_secret) {
     params.set("client_secret", clientInformation.client_secret);
@@ -430,7 +430,6 @@ export async function exchangeAuthorization(
  */
 export async function refreshAuthorization(
   authorizationServerUrl: string | URL,
-  provider: OAuthClientProvider,
   {
     metadata,
     clientInformation,
@@ -440,6 +439,7 @@ export async function refreshAuthorization(
     clientInformation: OAuthClientInformation;
     refreshToken: string;
   },
+  provider?: OAuthClientProvider,
 ): Promise<OAuthTokens> {
   const grantType = "refresh_token";
 
@@ -469,7 +469,7 @@ export async function refreshAuthorization(
     refresh_token: refreshToken,
   });
 
-  if (provider.authToTokenEndpoint) {
+  if (provider?.authToTokenEndpoint) {
     provider.authToTokenEndpoint(headers, params);
   } else if (clientInformation.client_secret) {
     params.set("client_secret", clientInformation.client_secret);


### PR DESCRIPTION
Adds an optional `authToTokenEndpoint` function to the `OAuthClientProvider` interface.  This allows client providers implement other [token endpoint authentication methods](https://www.iana.org/assignments/oauth-parameters/oauth-parameters.xhtml#token-endpoint-auth-method) such as `private_key_jwt` that are more secure than `client_secret_post` and `none`, which are implemented by default currently.

## Motivation and Context

Allows implementation of other methods for authenticating to the token endpoint.

## How Has This Been Tested?

This is being tested in a real agent that I'm currently developing, which is using key pairs for authentication.

## Breaking Changes

This adds a required `provider` parameter to `exchangeAuthorization` and `refreshAuthorization` which are exported from `@modelcontextprotocol/sdk/client/auth`.  In that sense it is a breaking change.  However, these functions seem to be used only internally to this package, which limits the impact.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

NOTE: This could be considered breaking, per description above, but it seems low probability at this point.

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
