### PR TITLE
Add request init headers defined on the sse transport on the start phase

### DIFF
--- a/src/client/sse.ts
+++ b/src/client/sse.ts
@@ -99,11 +99,11 @@ export class SSEClientTransport implements Transport {
   }
 
   private async _commonHeaders(): Promise<HeadersInit> {
-    const headers: HeadersInit = {};
+    const headers: HeadersInit = { ...this._requestInit?.headers };
     if (this._authProvider) {
       const tokens = await this._authProvider.tokens();
       if (tokens) {
-        headers["Authorization"] = `Bearer ${tokens.access_token}`;
+        (headers as Record<string, string>)["Authorization"] = `Bearer ${tokens.access_token}`;
       }
     }
 


### PR DESCRIPTION
This pr adds the headers from the transport instantiation into the start procedure to on sse(this already happens on the httpstream transport)

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
If i want to use sse transport and send a token for the authentication i need to have the token on the start phase

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
This has been tested in a real application

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
I don't think there is breaking changes 

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
