### PR TITLE
docs: Add clarifying comments for stateless streamable HTTP endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,7 @@ app.post('/mcp', async (req: Request, res: Response) => {
   }
 });
 
+// SSE notifications not supported in stateless mode
 app.get('/mcp', async (req: Request, res: Response) => {
   console.log('Received GET MCP request');
   res.writeHead(405).end(JSON.stringify({
@@ -359,6 +360,7 @@ app.get('/mcp', async (req: Request, res: Response) => {
   }));
 });
 
+// Session termination not needed in stateless mode
 app.delete('/mcp', async (req: Request, res: Response) => {
   console.log('Received DELETE MCP request');
   res.writeHead(405).end(JSON.stringify({


### PR DESCRIPTION
This PR adds inline comments to clarify why GET and DELETE endpoints return 405 in stateless mode for streamable HTTP transport. As new StreamableHTTP user, I was still grasping the concepts, and at first thought those were to give useful errors for legacy SSE client connections.

## Motivation and Context
When reading the stateless streamable HTTP example, it's not immediately clear why these endpoints are not implemented. The comments help developers understand that:
- SSE notifications require session management to work properly
- Session termination is not applicable in stateless mode

## How Has This Been Tested?
Documentation change only - no code changes to test.

## Breaking Changes
None - documentation only.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
This change improves developer understanding of the stateless vs stateful streamable HTTP transport modes.