### PR TITLE
#547 kill the child process if it's not properly terminated by stdio.…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/sdk",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "description": "Model Context Protocol implementation for TypeScript",
   "license": "MIT",
   "author": "Anthropic, PBC (https://anthropic.com)",

--- a/src/shared/protocol.ts
+++ b/src/shared/protocol.ts
@@ -541,7 +541,10 @@ export abstract class Protocol<
         this._progressHandlers.set(messageId, options.onprogress);
         jsonrpcRequest.params = {
           ...request.params,
-          _meta: { progressToken: messageId },
+          _meta: {
+            ...(request.params?._meta || {}),
+            progressToken: messageId
+          },
         };
       }
 


### PR DESCRIPTION
The `StdioClientTransport.close()` is not properly terminating tools that use a Docker container (e.g. `docker -i ...`), if you build a CLI tool that handles a single prompt that will interact with the MCP tool and then gracefully terminate. It won't terminate the process. It will be hanging because the child process that executed the Docker container will still be running idle.

## Motivation and Context
This is a fix for the bug [Running MCP tools from Docker doesn't properly terminate the container #547](https://github.com/modelcontextprotocol/typescript-sdk/issues/547).

## How Has This Been Tested?
Running MCP tools using `docker -i`. The example is described in the bug.

## Breaking Changes
No breaking changes, but possibly a delay in closing the `StdioClientTransport`.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
This was the best solution I found. I understand if you do not agree with the timeout in the close. I am open to any changes you propose since the problem needs to be fixed as soon as possible.

The execution of close() may be slower depending on how long it takes to terminate the child process. We can remove the `await` from there and let it handle the termination in the background.

