### PR TITLE
chore: update package.json exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
   ],
   "exports": {
     "./*": {
-      "import": "./dist/esm/*",
-      "require": "./dist/cjs/*"
+      "import": "./dist/esm/*.js",
+      "require": "./dist/cjs/*.js"
     }
   },
   "typesVersions": {


### PR DESCRIPTION
## Motivation and Context
current exports field is not friendly to typescript. User must import file with `.js`.
