### PR TITLE
Add client_secret_basic and none authentication methods

### DIFF
--- a/src/client/auth.test.ts
+++ b/src/client/auth.test.ts
@@ -808,4 +808,232 @@ describe("OAuth Authorization", () => {
       );
     });
   });
+
+  describe("exchangeAuthorization with multiple client authentication methods", () => {
+    const validTokens = {
+      access_token: "access123",
+      token_type: "Bearer",
+      expires_in: 3600,
+      refresh_token: "refresh123",
+    };
+
+    const validClientInfo = {
+      client_id: "client123",
+      client_secret: "secret123",
+      redirect_uris: ["http://localhost:3000/callback"],
+      client_name: "Test Client",
+    };
+
+    const metadataWithBasicOnly = {
+      issuer: "https://auth.example.com",
+      authorization_endpoint: "https://auth.example.com/auth",
+      token_endpoint: "https://auth.example.com/token",
+      response_types_supported: ["code"],
+      code_challenge_methods_supported: ["S256"],
+      token_endpoint_auth_methods_supported: ["client_secret_basic"],
+    };
+
+    const metadataWithPostOnly = {
+      ...metadataWithBasicOnly,
+      token_endpoint_auth_methods_supported: ["client_secret_post"],
+    };
+
+    const metadataWithNoneOnly = {
+      ...metadataWithBasicOnly,
+      token_endpoint_auth_methods_supported: ["none"],
+    };
+
+    it("uses HTTP Basic authentication when client_secret_basic is supported", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => validTokens,
+      });
+
+      const tokens = await exchangeAuthorization("https://auth.example.com", {
+        metadata: metadataWithBasicOnly,
+        clientInformation: validClientInfo,
+        authorizationCode: "code123",
+        codeVerifier: "verifier123",
+        redirectUri: "http://localhost:3000/callback",
+      });
+
+      expect(tokens).toEqual(validTokens);
+      const request = mockFetch.mock.calls[0][1];
+
+      // Check Authorization header
+      const authHeader = request.headers["Authorization"];
+      const expected = "Basic " + btoa("client123:secret123");
+      expect(authHeader).toBe(expected);
+
+      const body = request.body as URLSearchParams;
+      expect(body.get("client_id")).toBeNull();     // should not be in body
+      expect(body.get("client_secret")).toBeNull(); // should not be in body
+    });
+
+    it("includes credentials in request body when client_secret_post is supported", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => validTokens,
+      });
+
+      const tokens = await exchangeAuthorization("https://auth.example.com", {
+        metadata: metadataWithPostOnly,
+        clientInformation: validClientInfo,
+        authorizationCode: "code123",
+        codeVerifier: "verifier123",
+        redirectUri: "http://localhost:3000/callback",
+      });
+
+      expect(tokens).toEqual(validTokens);
+      const request = mockFetch.mock.calls[0][1];
+
+      // Check no Authorization header
+      expect(request.headers["Authorization"]).toBeUndefined();
+
+      const body = request.body as URLSearchParams;
+      expect(body.get("client_id")).toBe("client123");
+      expect(body.get("client_secret")).toBe("secret123");
+    });
+
+    it("uses public client authentication when none method is specified", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => validTokens,
+      });
+
+      const clientInfoWithoutSecret = {
+        client_id: "client123",
+        redirect_uris: ["http://localhost:3000/callback"],
+        client_name: "Test Client",
+      };
+
+      const tokens = await exchangeAuthorization("https://auth.example.com", {
+        metadata: metadataWithNoneOnly,
+        clientInformation: clientInfoWithoutSecret,
+        authorizationCode: "code123",
+        codeVerifier: "verifier123",
+        redirectUri: "http://localhost:3000/callback",
+      });
+
+      expect(tokens).toEqual(validTokens);
+      const request = mockFetch.mock.calls[0][1];
+
+      // Check no Authorization header
+      expect(request.headers["Authorization"]).toBeUndefined();
+
+      const body = request.body as URLSearchParams;
+      expect(body.get("client_id")).toBe("client123");
+      expect(body.get("client_secret")).toBeNull();
+    });
+
+    it("defaults to client_secret_post when no auth methods specified", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => validTokens,
+      });
+
+      const tokens = await exchangeAuthorization("https://auth.example.com", {
+        clientInformation: validClientInfo,
+        authorizationCode: "code123",
+        codeVerifier: "verifier123",
+        redirectUri: "http://localhost:3000/callback",
+      });
+
+      expect(tokens).toEqual(validTokens);
+      const request = mockFetch.mock.calls[0][1];
+
+      // Check no Authorization header
+      expect(request.headers["Authorization"]).toBeUndefined();
+
+      const body = request.body as URLSearchParams;
+      expect(body.get("client_id")).toBe("client123");
+      expect(body.get("client_secret")).toBe("secret123");
+    });
+  });
+
+  describe("refreshAuthorization with multiple client authentication methods", () => {
+    const validTokens = {
+      access_token: "newaccess123",
+      token_type: "Bearer",
+      expires_in: 3600,
+      refresh_token: "newrefresh123",
+    };
+
+    const validClientInfo = {
+      client_id: "client123",
+      client_secret: "secret123",
+      redirect_uris: ["http://localhost:3000/callback"],
+      client_name: "Test Client",
+    };
+
+    const metadataWithBasicOnly = {
+      issuer: "https://auth.example.com",
+      authorization_endpoint: "https://auth.example.com/auth",
+      token_endpoint: "https://auth.example.com/token",
+      response_types_supported: ["code"],
+      token_endpoint_auth_methods_supported: ["client_secret_basic"],
+    };
+
+    const metadataWithPostOnly = {
+      ...metadataWithBasicOnly,
+      token_endpoint_auth_methods_supported: ["client_secret_post"],
+    };
+
+    it("uses client_secret_basic for refresh token", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => validTokens,
+      });
+
+      const tokens = await refreshAuthorization("https://auth.example.com", {
+        metadata: metadataWithBasicOnly,
+        clientInformation: validClientInfo,
+        refreshToken: "refresh123",
+      });
+
+      expect(tokens).toEqual(validTokens);
+      const request = mockFetch.mock.calls[0][1];
+
+      // Check Authorization header
+      const authHeader = request.headers["Authorization"];
+      const expected = "Basic " + btoa("client123:secret123");
+      expect(authHeader).toBe(expected);
+
+      const body = request.body as URLSearchParams;
+      expect(body.get("client_id")).toBeNull();     // should not be in body
+      expect(body.get("client_secret")).toBeNull(); // should not be in body
+      expect(body.get("refresh_token")).toBe("refresh123");
+    });
+
+    it("uses client_secret_post for refresh token", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => validTokens,
+      });
+
+      const tokens = await refreshAuthorization("https://auth.example.com", {
+        metadata: metadataWithPostOnly,
+        clientInformation: validClientInfo,
+        refreshToken: "refresh123",
+      });
+
+      expect(tokens).toEqual(validTokens);
+      const request = mockFetch.mock.calls[0][1];
+
+      // Check no Authorization header
+      expect(request.headers["Authorization"]).toBeUndefined();
+
+      const body = request.body as URLSearchParams;
+      expect(body.get("client_id")).toBe("client123");
+      expect(body.get("client_secret")).toBe("secret123");
+      expect(body.get("refresh_token")).toBe("refresh123");
+    });
+  });
+
 });


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
Add support for ```client_secret_basic``` and ```none``` OAuth client authentication methods to complement the existing **client_secret_post** method.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Currently, the TypeScript SDK only supports `client_secret_post` authentication method for OAuth token exchanges. However, OAuth 2.1 specification defines multiple client authentication methods, and many authorization servers prefer or require `client_secret_basic` (HTTP Basic authentication) for better security practices.

This change adds built-in support for:
- `client_secret_basic`: HTTP Basic authentication (RFC 6749 Section [2.3.1](https://datatracker.ietf.org/doc/html/rfc6749#section-2.3.1))
- `none`: Public client authentication (RFC 6749 Section [2.1](https://datatracker.ietf.org/doc/html/rfc6749#section-2.1))

The implementation automatically selects the best authentication method based on server capabilities and client credentials, following OAuth 2.1 best practices.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
- All existing tests continue to pass (403 tests)
- Added 6 new comprehensive test cases covering:
  - `client_secret_basic` authentication in both `exchangeAuthorization` and `refreshAuthorization`
  - `client_secret_post` authentication (existing behavior)
  - `none` authentication for public clients
  - Automatic method selection based on server metadata
  - Fallback behavior when server metadata is unavailable

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
**No breaking changes.** This is fully backward compatible:
- Existing code using `client_secret_post` continues to work unchanged
- New authentication methods are automatically selected when appropriate
- All existing APIs maintain the same signatures

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->

### Design Philosophy: Built-in vs External Implementation

This PR takes a different approach from [PR #531](https://github.com/modelcontextprotocol/typescript-sdk/pull/531), which delegates authentication to external providers via an `authToTokenEndpoint` callback. 

While that approach offers maximum flexibility,
But I  believe that standard OAuth authentication methods should be built into the SDK for the following reasons:

1. **Simplicity**: Standard methods like `client_secret_basic` and `none` are well-defined in RFC 6749 and don't require custom implementation
2. **Reduced Complexity**: Users don't need to implement standard authentication methods themselves
3. **Consistency**: All OAuth 2.1 implementations should handle these basic methods uniformly

The external delegation approach in PR #531 is better suited for advanced/custom authentication methods like `private_key_jwt` that require specialized cryptographic operations and key management.