### PR TITLE
Incoming request headers in passed to callbacks via RequestHandlerExtra<ServerRequest, ServerNotification>

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@modelcontextprotocol/sdk",
-  "version": "1.11.4",
+  "version": "1.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@modelcontextprotocol/sdk",
-      "version": "1.11.4",
+      "version": "1.12.0",
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.6",

--- a/src/server/sse.ts
+++ b/src/server/sse.ts
@@ -118,7 +118,7 @@ export class SSEServerTransport implements Transport {
   /**
    * Handle a client message, regardless of how it arrived. This can be used to inform the server of messages that arrive via a means different than HTTP POST.
    */
-  async handleMessage(message: unknown, extra?: { authInfo?: AuthInfo, requestHeaders?: IncomingHttpHeaders }): Promise<void> {
+  async handleMessage(message: unknown, extra?: { authInfo?: AuthInfo, requestHeaders: IncomingHttpHeaders }): Promise<void> {
     let parsedMessage: JSONRPCMessage;
     try {
       parsedMessage = JSONRPCMessageSchema.parse(message);

--- a/src/server/streamableHttp.ts
+++ b/src/server/streamableHttp.ts
@@ -1,4 +1,4 @@
-import { IncomingMessage, ServerResponse } from "node:http";
+import { IncomingHttpHeaders, IncomingMessage, ServerResponse } from "node:http";
 import { Transport } from "../shared/transport.js";
 import { isInitializeRequest, isJSONRPCError, isJSONRPCRequest, isJSONRPCResponse, JSONRPCMessage, JSONRPCMessageSchema, RequestId } from "../types.js";
 import getRawBody from "raw-body";
@@ -113,7 +113,7 @@ export class StreamableHTTPServerTransport implements Transport {
   sessionId?: string | undefined;
   onclose?: () => void;
   onerror?: (error: Error) => void;
-  onmessage?: (message: JSONRPCMessage, extra?: { authInfo?: AuthInfo }) => void;
+  onmessage?: (message: JSONRPCMessage, extra?: { authInfo?: AuthInfo, requestHeaders?: IncomingHttpHeaders }) => void;
 
   constructor(options: StreamableHTTPServerTransportOptions) {
     this.sessionIdGenerator = options.sessionIdGenerator;
@@ -395,7 +395,7 @@ export class StreamableHTTPServerTransport implements Transport {
 
         // handle each message
         for (const message of messages) {
-          this.onmessage?.(message, { authInfo });
+          this.onmessage?.(message, { authInfo, requestHeaders: req.headers });
         }
       } else if (hasRequests) {
         // The default behavior is to use SSE streaming
@@ -430,7 +430,7 @@ export class StreamableHTTPServerTransport implements Transport {
 
         // handle each message
         for (const message of messages) {
-          this.onmessage?.(message, { authInfo });
+          this.onmessage?.(message, { authInfo, requestHeaders: req.headers });
         }
         // The server SHOULD NOT close the SSE stream before sending all JSON-RPC responses
         // This will be handled by the send() method when responses are ready

--- a/src/shared/protocol.ts
+++ b/src/shared/protocol.ts
@@ -131,7 +131,7 @@ export type RequestHandlerExtra<SendRequestT extends Request,
     /**
      * The headers from the original request.
      */
-    requestHeaders?: IncomingHttpHeaders;
+    requestHeaders: IncomingHttpHeaders;
 
     /**
      * Sends a notification that relates to the current request being handled.
@@ -381,7 +381,7 @@ export abstract class Protocol<
         this.request(r, resultSchema, { ...options, relatedRequestId: request.id }),
       authInfo: extra?.authInfo,
       requestId: request.id,
-      requestHeaders: extra?.requestHeaders,
+      requestHeaders: extra?.requestHeaders ?? {},
     };
 
     // Starting with Promise.resolve() puts any synchronous errors into the monad as well.

--- a/src/shared/protocol.ts
+++ b/src/shared/protocol.ts
@@ -25,6 +25,7 @@ import {
 } from "../types.js";
 import { Transport, TransportSendOptions } from "./transport.js";
 import { AuthInfo } from "../server/auth/types.js";
+import { IncomingHttpHeaders } from "node:http";
 
 /**
  * Callback for progress notifications.
@@ -126,6 +127,11 @@ export type RequestHandlerExtra<SendRequestT extends Request,
      * This can be useful for tracking or logging purposes.
      */
     requestId: RequestId;
+
+    /**
+     * The headers from the original request.
+     */
+    requestHeaders?: IncomingHttpHeaders;
 
     /**
      * Sends a notification that relates to the current request being handled.
@@ -339,7 +345,7 @@ export abstract class Protocol<
       );
   }
 
-  private _onrequest(request: JSONRPCRequest, extra?: { authInfo?: AuthInfo }): void {
+  private _onrequest(request: JSONRPCRequest, extra?: { authInfo?: AuthInfo, requestHeaders?: IncomingHttpHeaders }): void {
     const handler =
       this._requestHandlers.get(request.method) ?? this.fallbackRequestHandler;
 
@@ -375,6 +381,7 @@ export abstract class Protocol<
         this.request(r, resultSchema, { ...options, relatedRequestId: request.id }),
       authInfo: extra?.authInfo,
       requestId: request.id,
+      requestHeaders: extra?.requestHeaders,
     };
 
     // Starting with Promise.resolve() puts any synchronous errors into the monad as well.

--- a/src/shared/transport.ts
+++ b/src/shared/transport.ts
@@ -1,3 +1,4 @@
+import { IncomingHttpHeaders } from "http";
 import { AuthInfo } from "../server/auth/types.js";
 import { JSONRPCMessage, RequestId } from "../types.js";
 
@@ -69,7 +70,7 @@ export interface Transport {
    * Includes the authInfo if the transport is authenticated.
    * 
    */
-  onmessage?: (message: JSONRPCMessage, extra?: { authInfo?: AuthInfo }) => void;
+  onmessage?: (message: JSONRPCMessage, extra?: { authInfo?: AuthInfo, requestHeaders?: IncomingHttpHeaders }) => void;
 
   /**
    * The session ID generated for this connection.


### PR DESCRIPTION
Incoming Request headers passed down to callbacks via RequestHandlerExtra

## Motivation and Context
An application often times needs access to the original request headers, for example, whenever it is sitting behind a reverse proxy, and the reverse proxy is setting some headers itself. 

One practical example: A trace ID / correlation header is generated at the API gateway / reverse proxy later, then passed to the actual remote MCP server. The MCP server needs to utilize the traceparent to store it in logs, etc.

## How Has This Been Tested?
SSE and Streamable transport - resources and tools.

## Breaking Changes
No breaking changes.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
Adding the headers as "requestHeaders" inside RequestHandlerExtra appears the appropriate place to put this, since it contributes to a non-breaking change.
