### PR TITLE
fix: Ensure _meta object is not lost when onprogress option is passed

### DIFF
--- a/src/shared/protocol.ts
+++ b/src/shared/protocol.ts
@@ -542,7 +542,7 @@ export abstract class Protocol<
         jsonrpcRequest.params = {
           ...request.params,
           _meta: {
-            ...(request.params._meta || {}),
+            ...(request.params?._meta || {}),
             progressToken: messageId
           },
         };


### PR DESCRIPTION
When the onprogress option is passed, the _meta object in the request params was being overwritten, causing any existing _meta content to be lost.

<!-- Provide a brief summary of your changes -->

## Motivation and Context
this is right，the _meta could be passed to the svr
```
client?.callTool({
        name: toolName,
        arguments: input as Record<string, unknown>,
        _meta: {
          __test: 'test',
        },
      }, CallToolResultSchema, {}})
```

however:
```
client?.callTool({
        name: toolName,
        arguments: input as Record<string, unknown>,
        _meta: {
          __test: 'test',
        },
      }, CallToolResultSchema, {

onprogress: (progress: any) => {
}
}})
```
_meta disappeared...


## How Has This Been Tested?
yes

## Breaking Changes
no

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
