### PR TITLE
use client info scope

### DIFF
--- a/src/client/auth.ts
+++ b/src/client/auth.ts
@@ -175,7 +175,7 @@ export async function auth(
     clientInformation,
     state,
     redirectUrl: provider.redirectUrl,
-    scope: scope || provider.clientMetadata.scope,
+    scope: scope || provider.clientMetadata.scope || (clientInformation as OAuthClientInformationFull).scope,
   });
 
   await provider.saveCodeVerifier(codeVerifier);


### PR DESCRIPTION
Fallback to client information scope when it is provided during client registration.

## Motivation and Context
The supported scopes are being passed into DCR but not being used yet in the authorization flow.  I believe this is the root cause of https://github.com/modelcontextprotocol/inspector/issues/454 

## How Has This Been Tested?
Unit test and validated that it fixes the inspector oauth flow when connecting.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
