### PR TITLE
Implement DNS Rebinding Protections per spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ app.post('/mcp', async (req, res) => {
       },
       // DNS rebinding protection is disabled by default for backwards compatibility. If you are running this server
       // locally, make sure to set:
-      // disableDnsRebindingProtection: true,
+      // enableDnsRebindingProtection: true,
       // allowedHosts: ['127.0.0.1'],
     });
 
@@ -399,7 +399,7 @@ The Streamable HTTP transport includes DNS rebinding protection to prevent secur
 ```typescript
 const transport = new StreamableHTTPServerTransport({
   sessionIdGenerator: () => randomUUID(),
-  disableDnsRebindingProtection: false,
+  enableDnsRebindingProtection: true,
 
   allowedHosts: ['127.0.0.1', ...],
   allowedOrigins: ['https://yourdomain.com', 'https://www.yourdomain.com']

--- a/README.md
+++ b/README.md
@@ -251,7 +251,11 @@ app.post('/mcp', async (req, res) => {
       onsessioninitialized: (sessionId) => {
         // Store the transport by session ID
         transports[sessionId] = transport;
-      }
+      },
+      // DNS rebinding protection is disabled by default for backwards compatibility. If you are running this server
+      // locally, make sure to set:
+      // disableDnsRebindingProtection: true,
+      // allowedHosts: ['127.0.0.1'],
     });
 
     // Clean up transport when closed
@@ -385,6 +389,22 @@ This stateless approach is useful for:
 - Simple API wrappers
 - RESTful scenarios where each request is independent
 - Horizontally scaled deployments without shared session state
+
+#### DNS Rebinding Protection
+
+The Streamable HTTP transport includes DNS rebinding protection to prevent security vulnerabilities. By default, this protection is **disabled** for backwards compatibility.
+
+**Important**: If you are running this server locally, enable DNS rebinding protection:
+
+```typescript
+const transport = new StreamableHTTPServerTransport({
+  sessionIdGenerator: () => randomUUID(),
+  disableDnsRebindingProtection: false,
+
+  allowedHosts: ['127.0.0.1', ...],
+  allowedOrigins: ['https://yourdomain.com', 'https://www.yourdomain.com']
+});
+```
 
 ### Testing and Debugging
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@modelcontextprotocol/sdk",
-  "version": "1.11.4",
+  "version": "1.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@modelcontextprotocol/sdk",
-      "version": "1.11.4",
+      "version": "1.12.1",
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@modelcontextprotocol/sdk",
-  "version": "1.12.1",
+  "version": "1.11.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@modelcontextprotocol/sdk",
-      "version": "1.12.1",
+      "version": "1.11.4",
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.6",

--- a/src/server/sse.test.ts
+++ b/src/server/sse.test.ts
@@ -469,8 +469,10 @@ describe('SSEServerTransport', () => {
         await transport.start();
 
         const mockReq = createMockRequest({
-          host: 'localhost:3000',
-          'content-type': 'application/json',
+          headers: {
+            host: 'localhost:3000',
+            'content-type': 'application/json',
+          }
         });
         const mockHandleRes = createMockResponse();
 
@@ -489,8 +491,10 @@ describe('SSEServerTransport', () => {
         await transport.start();
 
         const mockReq = createMockRequest({
-          host: 'evil.com',
-          'content-type': 'application/json',
+          headers: {
+            host: 'evil.com',
+            'content-type': 'application/json',
+          }
         });
         const mockHandleRes = createMockResponse();
 
@@ -509,7 +513,9 @@ describe('SSEServerTransport', () => {
         await transport.start();
 
         const mockReq = createMockRequest({
-          'content-type': 'application/json',
+          headers: {
+            'content-type': 'application/json',
+          }
         });
         const mockHandleRes = createMockResponse();
 
@@ -530,8 +536,10 @@ describe('SSEServerTransport', () => {
         await transport.start();
 
         const mockReq = createMockRequest({
-          origin: 'http://localhost:3000',
-          'content-type': 'application/json',
+          headers: {
+            origin: 'http://localhost:3000',
+            'content-type': 'application/json',
+          }
         });
         const mockHandleRes = createMockResponse();
 
@@ -550,8 +558,10 @@ describe('SSEServerTransport', () => {
         await transport.start();
 
         const mockReq = createMockRequest({
-          origin: 'http://evil.com',
-          'content-type': 'application/json',
+          headers: {
+            origin: 'http://evil.com',
+            'content-type': 'application/json',
+          }
         });
         const mockHandleRes = createMockResponse();
 
@@ -569,7 +579,9 @@ describe('SSEServerTransport', () => {
         await transport.start();
 
         const mockReq = createMockRequest({
-          'content-type': 'application/json',
+          headers: {
+            'content-type': 'application/json',
+          }
         });
         const mockHandleRes = createMockResponse();
 
@@ -585,7 +597,9 @@ describe('SSEServerTransport', () => {
         await transport.start();
 
         const mockReq = createMockRequest({
-          'content-type': 'application/json; charset=utf-8',
+          headers: {
+            'content-type': 'application/json; charset=utf-8',
+          }
         });
         const mockHandleRes = createMockResponse();
 
@@ -601,7 +615,9 @@ describe('SSEServerTransport', () => {
         await transport.start();
 
         const mockReq = createMockRequest({
-          'content-type': 'text/plain',
+          headers: {
+            'content-type': 'text/plain',
+          }
         });
         const mockHandleRes = createMockResponse();
 
@@ -623,9 +639,11 @@ describe('SSEServerTransport', () => {
         await transport.start();
 
         const mockReq = createMockRequest({
-          host: 'evil.com',
-          origin: 'http://evil.com',
-          'content-type': 'text/plain',
+          headers: {
+            host: 'evil.com',
+            origin: 'http://evil.com',
+            'content-type': 'text/plain',
+          }
         });
         const mockHandleRes = createMockResponse();
 
@@ -650,9 +668,11 @@ describe('SSEServerTransport', () => {
 
         // Valid host, invalid origin
         const mockReq1 = createMockRequest({
-          host: 'localhost:3000',
-          origin: 'http://evil.com',
-          'content-type': 'application/json',
+          headers: {
+            host: 'localhost:3000',
+            origin: 'http://evil.com',
+            'content-type': 'application/json',
+          }
         });
         const mockHandleRes1 = createMockResponse();
 
@@ -663,9 +683,11 @@ describe('SSEServerTransport', () => {
 
         // Invalid host, valid origin
         const mockReq2 = createMockRequest({
-          host: 'evil.com',
-          origin: 'http://localhost:3000',
-          'content-type': 'application/json',
+          headers: {
+            host: 'evil.com',
+            origin: 'http://localhost:3000',
+            'content-type': 'application/json',
+          }
         });
         const mockHandleRes2 = createMockResponse();
 
@@ -676,9 +698,11 @@ describe('SSEServerTransport', () => {
 
         // Both valid
         const mockReq3 = createMockRequest({
-          host: 'localhost:3000',
-          origin: 'http://localhost:3000',
-          'content-type': 'application/json',
+          headers: {
+            host: 'localhost:3000',
+            origin: 'http://localhost:3000',
+            'content-type': 'application/json',
+          }
         });
         const mockHandleRes3 = createMockResponse();
 

--- a/src/server/sse.test.ts
+++ b/src/server/sse.test.ts
@@ -125,6 +125,7 @@ describe('SSEServerTransport', () => {
         const mockRes = createMockResponse();
         const transport = new SSEServerTransport('/messages', mockRes, {
           allowedHosts: ['localhost:3000', 'example.com'],
+          enableDnsRebindingProtection: true,
         });
         await transport.start();
 
@@ -144,6 +145,7 @@ describe('SSEServerTransport', () => {
         const mockRes = createMockResponse();
         const transport = new SSEServerTransport('/messages', mockRes, {
           allowedHosts: ['localhost:3000'],
+          enableDnsRebindingProtection: true,
         });
         await transport.start();
 
@@ -163,6 +165,7 @@ describe('SSEServerTransport', () => {
         const mockRes = createMockResponse();
         const transport = new SSEServerTransport('/messages', mockRes, {
           allowedHosts: ['localhost:3000'],
+          enableDnsRebindingProtection: true,
         });
         await transport.start();
 
@@ -183,6 +186,7 @@ describe('SSEServerTransport', () => {
         const mockRes = createMockResponse();
         const transport = new SSEServerTransport('/messages', mockRes, {
           allowedOrigins: ['http://localhost:3000', 'https://example.com'],
+          enableDnsRebindingProtection: true,
         });
         await transport.start();
 
@@ -202,6 +206,7 @@ describe('SSEServerTransport', () => {
         const mockRes = createMockResponse();
         const transport = new SSEServerTransport('/messages', mockRes, {
           allowedOrigins: ['http://localhost:3000'],
+          enableDnsRebindingProtection: true,
         });
         await transport.start();
 
@@ -268,13 +273,13 @@ describe('SSEServerTransport', () => {
       });
     });
 
-    describe('disableDnsRebindingProtection option', () => {
-      it('should skip all validations when disableDnsRebindingProtection is true', async () => {
+    describe('enableDnsRebindingProtection option', () => {
+      it('should skip all validations when enableDnsRebindingProtection is false', async () => {
         const mockRes = createMockResponse();
         const transport = new SSEServerTransport('/messages', mockRes, {
           allowedHosts: ['localhost:3000'],
           allowedOrigins: ['http://localhost:3000'],
-          disableDnsRebindingProtection: true,
+          enableDnsRebindingProtection: false,
         });
         await transport.start();
 
@@ -300,6 +305,7 @@ describe('SSEServerTransport', () => {
         const transport = new SSEServerTransport('/messages', mockRes, {
           allowedHosts: ['localhost:3000'],
           allowedOrigins: ['http://localhost:3000'],
+          enableDnsRebindingProtection: true,
         });
         await transport.start();
 

--- a/src/server/sse.test.ts
+++ b/src/server/sse.test.ts
@@ -264,7 +264,7 @@ describe('SSEServerTransport', () => {
         await transport.handlePostMessage(mockReq, mockHandleRes, { jsonrpc: '2.0', method: 'test' });
 
         expect(mockHandleRes.writeHead).toHaveBeenCalledWith(400);
-        expect(mockHandleRes.end).toHaveBeenCalledWith('Error: Content-Type must start with application/json, got: text/plain');
+        expect(mockHandleRes.end).toHaveBeenCalledWith('Error: Unsupported content-type: text/plain');
       });
     });
 

--- a/src/server/sse.test.ts
+++ b/src/server/sse.test.ts
@@ -1,17 +1,25 @@
 import http from 'http'; 
 import { jest } from '@jest/globals';
-import { SSEServerTransport } from './sse.js'; 
+import { SSEServerTransport } from './sse.js';
+import { AuthInfo } from './auth/types.js'; 
 
 const createMockResponse = () => {
   const res = {
     writeHead: jest.fn<http.ServerResponse['writeHead']>(),
     write: jest.fn<http.ServerResponse['write']>().mockReturnValue(true),
     on: jest.fn<http.ServerResponse['on']>(),
+    end: jest.fn<http.ServerResponse['end']>().mockReturnThis(),
   };
   res.writeHead.mockReturnThis();
   res.on.mockReturnThis();
   
   return res as unknown as http.ServerResponse;
+};
+
+const createMockRequest = (headers: Record<string, string> = {}) => {
+  return {
+    headers,
+  } as unknown as http.IncomingMessage & { auth?: AuthInfo };
 };
 
 describe('SSEServerTransport', () => {
@@ -104,6 +112,236 @@ describe('SSEServerTransport', () => {
       expect(mockRes.write).toHaveBeenCalledWith(
         `event: endpoint\ndata: /?sessionId=${expectedSessionId}\n\n`
       );
+    });
+  });
+
+  describe('DNS rebinding protection', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    describe('Host header validation', () => {
+      it('should accept requests with allowed host headers', async () => {
+        const mockRes = createMockResponse();
+        const transport = new SSEServerTransport('/messages', mockRes, {
+          allowedHosts: ['localhost:3000', 'example.com'],
+        });
+        await transport.start();
+
+        const mockReq = createMockRequest({
+          host: 'localhost:3000',
+          'content-type': 'application/json',
+        });
+        const mockHandleRes = createMockResponse();
+
+        await transport.handlePostMessage(mockReq, mockHandleRes, { jsonrpc: '2.0', method: 'test' });
+
+        expect(mockHandleRes.writeHead).toHaveBeenCalledWith(202);
+        expect(mockHandleRes.end).toHaveBeenCalledWith('Accepted');
+      });
+
+      it('should reject requests with disallowed host headers', async () => {
+        const mockRes = createMockResponse();
+        const transport = new SSEServerTransport('/messages', mockRes, {
+          allowedHosts: ['localhost:3000'],
+        });
+        await transport.start();
+
+        const mockReq = createMockRequest({
+          host: 'evil.com',
+          'content-type': 'application/json',
+        });
+        const mockHandleRes = createMockResponse();
+
+        await transport.handlePostMessage(mockReq, mockHandleRes, { jsonrpc: '2.0', method: 'test' });
+
+        expect(mockHandleRes.writeHead).toHaveBeenCalledWith(403);
+        expect(mockHandleRes.end).toHaveBeenCalledWith('Invalid Host header: evil.com');
+      });
+
+      it('should reject requests without host header when allowedHosts is configured', async () => {
+        const mockRes = createMockResponse();
+        const transport = new SSEServerTransport('/messages', mockRes, {
+          allowedHosts: ['localhost:3000'],
+        });
+        await transport.start();
+
+        const mockReq = createMockRequest({
+          'content-type': 'application/json',
+        });
+        const mockHandleRes = createMockResponse();
+
+        await transport.handlePostMessage(mockReq, mockHandleRes, { jsonrpc: '2.0', method: 'test' });
+
+        expect(mockHandleRes.writeHead).toHaveBeenCalledWith(403);
+        expect(mockHandleRes.end).toHaveBeenCalledWith('Invalid Host header: undefined');
+      });
+    });
+
+    describe('Origin header validation', () => {
+      it('should accept requests with allowed origin headers', async () => {
+        const mockRes = createMockResponse();
+        const transport = new SSEServerTransport('/messages', mockRes, {
+          allowedOrigins: ['http://localhost:3000', 'https://example.com'],
+        });
+        await transport.start();
+
+        const mockReq = createMockRequest({
+          origin: 'http://localhost:3000',
+          'content-type': 'application/json',
+        });
+        const mockHandleRes = createMockResponse();
+
+        await transport.handlePostMessage(mockReq, mockHandleRes, { jsonrpc: '2.0', method: 'test' });
+
+        expect(mockHandleRes.writeHead).toHaveBeenCalledWith(202);
+        expect(mockHandleRes.end).toHaveBeenCalledWith('Accepted');
+      });
+
+      it('should reject requests with disallowed origin headers', async () => {
+        const mockRes = createMockResponse();
+        const transport = new SSEServerTransport('/messages', mockRes, {
+          allowedOrigins: ['http://localhost:3000'],
+        });
+        await transport.start();
+
+        const mockReq = createMockRequest({
+          origin: 'http://evil.com',
+          'content-type': 'application/json',
+        });
+        const mockHandleRes = createMockResponse();
+
+        await transport.handlePostMessage(mockReq, mockHandleRes, { jsonrpc: '2.0', method: 'test' });
+
+        expect(mockHandleRes.writeHead).toHaveBeenCalledWith(403);
+        expect(mockHandleRes.end).toHaveBeenCalledWith('Invalid Origin header: http://evil.com');
+      });
+    });
+
+    describe('Content-Type validation', () => {
+      it('should accept requests with application/json content-type', async () => {
+        const mockRes = createMockResponse();
+        const transport = new SSEServerTransport('/messages', mockRes);
+        await transport.start();
+
+        const mockReq = createMockRequest({
+          'content-type': 'application/json',
+        });
+        const mockHandleRes = createMockResponse();
+
+        await transport.handlePostMessage(mockReq, mockHandleRes, { jsonrpc: '2.0', method: 'test' });
+
+        expect(mockHandleRes.writeHead).toHaveBeenCalledWith(202);
+        expect(mockHandleRes.end).toHaveBeenCalledWith('Accepted');
+      });
+
+      it('should accept requests with application/json with charset', async () => {
+        const mockRes = createMockResponse();
+        const transport = new SSEServerTransport('/messages', mockRes);
+        await transport.start();
+
+        const mockReq = createMockRequest({
+          'content-type': 'application/json; charset=utf-8',
+        });
+        const mockHandleRes = createMockResponse();
+
+        await transport.handlePostMessage(mockReq, mockHandleRes, { jsonrpc: '2.0', method: 'test' });
+
+        expect(mockHandleRes.writeHead).toHaveBeenCalledWith(202);
+        expect(mockHandleRes.end).toHaveBeenCalledWith('Accepted');
+      });
+
+      it('should reject requests with non-application/json content-type when protection is enabled', async () => {
+        const mockRes = createMockResponse();
+        const transport = new SSEServerTransport('/messages', mockRes);
+        await transport.start();
+
+        const mockReq = createMockRequest({
+          'content-type': 'text/plain',
+        });
+        const mockHandleRes = createMockResponse();
+
+        await transport.handlePostMessage(mockReq, mockHandleRes, { jsonrpc: '2.0', method: 'test' });
+
+        expect(mockHandleRes.writeHead).toHaveBeenCalledWith(400);
+        expect(mockHandleRes.end).toHaveBeenCalledWith('Error: Content-Type must start with application/json, got: text/plain');
+      });
+    });
+
+    describe('disableDnsRebindingProtection option', () => {
+      it('should skip all validations when disableDnsRebindingProtection is true', async () => {
+        const mockRes = createMockResponse();
+        const transport = new SSEServerTransport('/messages', mockRes, {
+          allowedHosts: ['localhost:3000'],
+          allowedOrigins: ['http://localhost:3000'],
+          disableDnsRebindingProtection: true,
+        });
+        await transport.start();
+
+        const mockReq = createMockRequest({
+          host: 'evil.com',
+          origin: 'http://evil.com',
+          'content-type': 'text/plain',
+        });
+        const mockHandleRes = createMockResponse();
+
+        await transport.handlePostMessage(mockReq, mockHandleRes, { jsonrpc: '2.0', method: 'test' });
+
+        // Should pass even with invalid headers because protection is disabled
+        expect(mockHandleRes.writeHead).toHaveBeenCalledWith(400);
+        // The error should be from content-type parsing, not DNS rebinding protection
+        expect(mockHandleRes.end).toHaveBeenCalledWith('Error: Unsupported content-type: text/plain');
+      });
+    });
+
+    describe('Combined validations', () => {
+      it('should validate both host and origin when both are configured', async () => {
+        const mockRes = createMockResponse();
+        const transport = new SSEServerTransport('/messages', mockRes, {
+          allowedHosts: ['localhost:3000'],
+          allowedOrigins: ['http://localhost:3000'],
+        });
+        await transport.start();
+
+        // Valid host, invalid origin
+        const mockReq1 = createMockRequest({
+          host: 'localhost:3000',
+          origin: 'http://evil.com',
+          'content-type': 'application/json',
+        });
+        const mockHandleRes1 = createMockResponse();
+
+        await transport.handlePostMessage(mockReq1, mockHandleRes1, { jsonrpc: '2.0', method: 'test' });
+
+        expect(mockHandleRes1.writeHead).toHaveBeenCalledWith(403);
+        expect(mockHandleRes1.end).toHaveBeenCalledWith('Invalid Origin header: http://evil.com');
+
+        // Invalid host, valid origin
+        const mockReq2 = createMockRequest({
+          host: 'evil.com',
+          origin: 'http://localhost:3000',
+          'content-type': 'application/json',
+        });
+        const mockHandleRes2 = createMockResponse();
+
+        await transport.handlePostMessage(mockReq2, mockHandleRes2, { jsonrpc: '2.0', method: 'test' });
+
+        expect(mockHandleRes2.writeHead).toHaveBeenCalledWith(403);
+        expect(mockHandleRes2.end).toHaveBeenCalledWith('Invalid Host header: evil.com');
+
+        // Both valid
+        const mockReq3 = createMockRequest({
+          host: 'localhost:3000',
+          origin: 'http://localhost:3000',
+          'content-type': 'application/json',
+        });
+        const mockHandleRes3 = createMockResponse();
+
+        await transport.handlePostMessage(mockReq3, mockHandleRes3, { jsonrpc: '2.0', method: 'test' });
+
+        expect(mockHandleRes3.writeHead).toHaveBeenCalledWith(202);
+        expect(mockHandleRes3.end).toHaveBeenCalledWith('Accepted');
+      });
     });
   });
 });

--- a/src/server/sse.ts
+++ b/src/server/sse.ts
@@ -27,7 +27,6 @@ export interface SSEServerTransportOptions {
   
   /**
    * Disable DNS rebinding protection entirely (overrides allowedHosts and allowedOrigins).
-   * Default is false.
    */
   disableDnsRebindingProtection?: boolean;
 }
@@ -156,7 +155,7 @@ export class SSEServerTransport implements Transport {
     try {
       const ct = contentType.parse(req.headers["content-type"] ?? "");
       if (ct.type !== "application/json") {
-        throw new Error(`Unsupported content-type: ${ct.type}`);
+        throw new Error(`Unsupported content-type: ${ct}`);
       }
 
       body = parsedBody ?? await getRawBody(req, {

--- a/src/server/sse.ts
+++ b/src/server/sse.ts
@@ -155,7 +155,7 @@ export class SSEServerTransport implements Transport {
     try {
       const ct = contentType.parse(req.headers["content-type"] ?? "");
       if (ct.type !== "application/json") {
-        throw new Error(`Unsupported content-type: ${ct}`);
+        throw new Error(`Unsupported content-type: ${ct.type}`);
       }
 
       body = parsedBody ?? await getRawBody(req, {

--- a/src/server/sse.ts
+++ b/src/server/sse.ts
@@ -10,6 +10,29 @@ import { URL } from 'url';
 const MAXIMUM_MESSAGE_SIZE = "4mb";
 
 /**
+ * Configuration options for SSEServerTransport.
+ */
+export interface SSEServerTransportOptions {
+  /**
+   * List of allowed host header values for DNS rebinding protection.
+   * If not specified, host validation is disabled.
+   */
+  allowedHosts?: string[];
+  
+  /**
+   * List of allowed origin header values for DNS rebinding protection.
+   * If not specified, origin validation is disabled.
+   */
+  allowedOrigins?: string[];
+  
+  /**
+   * Disable DNS rebinding protection entirely (overrides allowedHosts and allowedOrigins).
+   * Default is false.
+   */
+  disableDnsRebindingProtection?: boolean;
+}
+
+/**
  * Server transport for SSE: this will send messages over an SSE connection and receive messages from HTTP POST requests.
  *
  * This transport is only available in Node.js environments.
@@ -17,6 +40,7 @@ const MAXIMUM_MESSAGE_SIZE = "4mb";
 export class SSEServerTransport implements Transport {
   private _sseResponse?: ServerResponse;
   private _sessionId: string;
+  private _options: SSEServerTransportOptions;
 
   onclose?: () => void;
   onerror?: (error: Error) => void;
@@ -28,8 +52,39 @@ export class SSEServerTransport implements Transport {
   constructor(
     private _endpoint: string,
     private res: ServerResponse,
+    options?: SSEServerTransportOptions,
   ) {
     this._sessionId = randomUUID();
+    this._options = options || {disableDnsRebindingProtection: true};
+  }
+
+  /**
+   * Validates request headers for DNS rebinding protection.
+   * @returns Error message if validation fails, undefined if validation passes.
+   */
+  private validateRequestHeaders(req: IncomingMessage): string | undefined {
+    // Skip validation if protection is disabled
+    if (this._options.disableDnsRebindingProtection) {
+      return undefined;
+    }
+
+    // Validate Host header if allowedHosts is configured
+    if (this._options.allowedHosts && this._options.allowedHosts.length > 0) {
+      const hostHeader = req.headers.host;
+      if (!hostHeader || !this._options.allowedHosts.includes(hostHeader)) {
+        return `Invalid Host header: ${hostHeader}`;
+      }
+    }
+
+    // Validate Origin header if allowedOrigins is configured
+    if (this._options.allowedOrigins && this._options.allowedOrigins.length > 0) {
+      const originHeader = req.headers.origin;
+      if (!originHeader || !this._options.allowedOrigins.includes(originHeader)) {
+        return `Invalid Origin header: ${originHeader}`;
+      }
+    }
+
+    return undefined;
   }
 
   /**
@@ -86,13 +141,22 @@ export class SSEServerTransport implements Transport {
       res.writeHead(500).end(message);
       throw new Error(message);
     }
+
+    // Validate request headers for DNS rebinding protection
+    const validationError = this.validateRequestHeaders(req);
+    if (validationError) {
+      res.writeHead(403).end(validationError);
+      this.onerror?.(new Error(validationError));
+      return;
+    }
+
     const authInfo: AuthInfo | undefined = req.auth;
 
     let body: string | unknown;
     try {
       const ct = contentType.parse(req.headers["content-type"] ?? "");
       if (ct.type !== "application/json") {
-        throw new Error(`Unsupported content-type: ${ct}`);
+        throw new Error(`Unsupported content-type: ${ct.type}`);
       }
 
       body = parsedBody ?? await getRawBody(req, {

--- a/src/server/sse.ts
+++ b/src/server/sse.ts
@@ -26,9 +26,10 @@ export interface SSEServerTransportOptions {
   allowedOrigins?: string[];
   
   /**
-   * Disable DNS rebinding protection entirely (overrides allowedHosts and allowedOrigins).
+   * Enable DNS rebinding protection (requires allowedHosts and/or allowedOrigins to be configured).
+   * Default is false for backwards compatibility.
    */
-  disableDnsRebindingProtection?: boolean;
+  enableDnsRebindingProtection?: boolean;
 }
 
 /**
@@ -54,7 +55,7 @@ export class SSEServerTransport implements Transport {
     options?: SSEServerTransportOptions,
   ) {
     this._sessionId = randomUUID();
-    this._options = options || {disableDnsRebindingProtection: true};
+    this._options = options || {enableDnsRebindingProtection: false};
   }
 
   /**
@@ -62,8 +63,8 @@ export class SSEServerTransport implements Transport {
    * @returns Error message if validation fails, undefined if validation passes.
    */
   private validateRequestHeaders(req: IncomingMessage): string | undefined {
-    // Skip validation if protection is disabled
-    if (this._options.disableDnsRebindingProtection) {
+    // Skip validation if protection is not enabled
+    if (!this._options.enableDnsRebindingProtection) {
       return undefined;
     }
 

--- a/src/server/streamableHttp.test.ts
+++ b/src/server/streamableHttp.test.ts
@@ -1294,3 +1294,264 @@ describe("StreamableHTTPServerTransport in stateless mode", () => {
     expect(stream2.status).toBe(409); // Conflict - only one stream allowed
   });
 });
+
+// Test DNS rebinding protection
+describe("StreamableHTTPServerTransport DNS rebinding protection", () => {
+  let server: Server;
+  let transport: StreamableHTTPServerTransport;
+  let baseUrl: URL;
+
+  afterEach(async () => {
+    if (server && transport) {
+      await stopTestServer({ server, transport });
+    }
+  });
+
+  describe("Host header validation", () => {
+    it("should accept requests with allowed host headers", async () => {
+      const result = await createTestServerWithDnsProtection({
+        sessionIdGenerator: undefined,
+        allowedHosts: ['localhost:3001'],
+        disableDnsRebindingProtection: false,
+      });
+      server = result.server;
+      transport = result.transport;
+      baseUrl = result.baseUrl;
+
+      // Note: fetch() automatically sets Host header to match the URL
+      // Since we're connecting to localhost:3001 and that's in allowedHosts, this should work
+      const response = await fetch(baseUrl, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json, text/event-stream",
+        },
+        body: JSON.stringify(TEST_MESSAGES.initialize),
+      });
+
+      expect(response.status).toBe(200);
+    });
+
+    it("should reject requests with disallowed host headers", async () => {
+      // Test DNS rebinding protection by creating a server that only allows example.com
+      // but we're connecting via localhost, so it should be rejected
+      const result = await createTestServerWithDnsProtection({
+        sessionIdGenerator: undefined,
+        allowedHosts: ['example.com:3001'],
+        disableDnsRebindingProtection: false,
+      });
+      server = result.server;
+      transport = result.transport;
+      baseUrl = result.baseUrl;
+
+      const response = await fetch(baseUrl, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json, text/event-stream",
+        },
+        body: JSON.stringify(TEST_MESSAGES.initialize),
+      });
+
+      expect(response.status).toBe(403);
+      const body = await response.json();
+      expect(body.error.message).toContain("Invalid Host header:");
+    });
+
+    it("should reject GET requests with disallowed host headers", async () => {
+      const result = await createTestServerWithDnsProtection({
+        sessionIdGenerator: undefined,
+        allowedHosts: ['example.com:3001'],
+        disableDnsRebindingProtection: false,
+      });
+      server = result.server;
+      transport = result.transport;
+      baseUrl = result.baseUrl;
+
+      const response = await fetch(baseUrl, {
+        method: "GET",
+        headers: {
+          Accept: "text/event-stream",
+        },
+      });
+
+      expect(response.status).toBe(403);
+    });
+  });
+
+  describe("Origin header validation", () => {
+    it("should accept requests with allowed origin headers", async () => {
+      const result = await createTestServerWithDnsProtection({
+        sessionIdGenerator: undefined,
+        allowedOrigins: ['http://localhost:3000', 'https://example.com'],
+        disableDnsRebindingProtection: false,
+      });
+      server = result.server;
+      transport = result.transport;
+      baseUrl = result.baseUrl;
+
+      const response = await fetch(baseUrl, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json, text/event-stream",
+          Origin: "http://localhost:3000",
+        },
+        body: JSON.stringify(TEST_MESSAGES.initialize),
+      });
+
+      expect(response.status).toBe(200);
+    });
+
+    it("should reject requests with disallowed origin headers", async () => {
+      const result = await createTestServerWithDnsProtection({
+        sessionIdGenerator: undefined,
+        allowedOrigins: ['http://localhost:3000'],
+        disableDnsRebindingProtection: false,
+      });
+      server = result.server;
+      transport = result.transport;
+      baseUrl = result.baseUrl;
+
+      const response = await fetch(baseUrl, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json, text/event-stream",
+          Origin: "http://evil.com",
+        },
+        body: JSON.stringify(TEST_MESSAGES.initialize),
+      });
+
+      expect(response.status).toBe(403);
+      const body = await response.json();
+      expect(body.error.message).toBe("Invalid Origin header: http://evil.com");
+    });
+  });
+
+  describe("disableDnsRebindingProtection option", () => {
+    it("should skip all validations when disableDnsRebindingProtection is true", async () => {
+      const result = await createTestServerWithDnsProtection({
+        sessionIdGenerator: undefined,
+        allowedHosts: ['localhost:3001'],
+        allowedOrigins: ['http://localhost:3000'],
+        disableDnsRebindingProtection: true,
+      });
+      server = result.server;
+      transport = result.transport;
+      baseUrl = result.baseUrl;
+
+      const response = await fetch(baseUrl, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json, text/event-stream",
+          Host: "evil.com",
+          Origin: "http://evil.com",
+        },
+        body: JSON.stringify(TEST_MESSAGES.initialize),
+      });
+
+      // Should pass even with invalid headers because protection is disabled
+      expect(response.status).toBe(200);
+    });
+  });
+
+  describe("Combined validations", () => {
+    it("should validate both host and origin when both are configured", async () => {
+      const result = await createTestServerWithDnsProtection({
+        sessionIdGenerator: undefined,
+        allowedHosts: ['localhost:3001'],
+        allowedOrigins: ['http://localhost:3001'],
+        disableDnsRebindingProtection: false,
+      });
+      server = result.server;
+      transport = result.transport;
+      baseUrl = result.baseUrl;
+
+      // Test with invalid origin (host will be automatically correct via fetch)
+      const response1 = await fetch(baseUrl, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json, text/event-stream",
+          Origin: "http://evil.com",
+        },
+        body: JSON.stringify(TEST_MESSAGES.initialize),
+      });
+
+      expect(response1.status).toBe(403);
+      const body1 = await response1.json();
+      expect(body1.error.message).toBe("Invalid Origin header: http://evil.com");
+
+      // Test with valid origin
+      const response2 = await fetch(baseUrl, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json, text/event-stream",
+          Origin: "http://localhost:3001",
+        },
+        body: JSON.stringify(TEST_MESSAGES.initialize),
+      });
+
+      expect(response2.status).toBe(200);
+    });
+  });
+});
+
+/**
+ * Helper to create test server with DNS rebinding protection options
+ */
+async function createTestServerWithDnsProtection(config: {
+  sessionIdGenerator: (() => string) | undefined;
+  allowedHosts?: string[];
+  allowedOrigins?: string[];
+  disableDnsRebindingProtection?: boolean;
+}): Promise<{
+  server: Server;
+  transport: StreamableHTTPServerTransport;
+  mcpServer: McpServer;
+  baseUrl: URL;
+}> {
+  const mcpServer = new McpServer(
+    { name: "test-server", version: "1.0.0" },
+    { capabilities: { logging: {} } }
+  );
+
+  const transport = new StreamableHTTPServerTransport({
+    sessionIdGenerator: config.sessionIdGenerator,
+    allowedHosts: config.allowedHosts,
+    allowedOrigins: config.allowedOrigins,
+    disableDnsRebindingProtection: config.disableDnsRebindingProtection,
+  });
+
+  await mcpServer.connect(transport);
+
+  const httpServer = createServer(async (req, res) => {
+    if (req.method === "POST") {
+      let body = "";
+      req.on("data", (chunk) => (body += chunk));
+      req.on("end", async () => {
+        const parsedBody = JSON.parse(body);
+        await transport.handleRequest(req as IncomingMessage & { auth?: AuthInfo }, res, parsedBody);
+      });
+    } else {
+      await transport.handleRequest(req as IncomingMessage & { auth?: AuthInfo }, res);
+    }
+  });
+
+  await new Promise<void>((resolve) => {
+    httpServer.listen(3001, () => resolve());
+  });
+
+  const port = (httpServer.address() as AddressInfo).port;
+  const serverUrl = new URL(`http://localhost:${port}/`);
+
+  return {
+    server: httpServer,
+    transport,
+    mcpServer,
+    baseUrl: serverUrl,
+  };
+}

--- a/src/server/streamableHttp.test.ts
+++ b/src/server/streamableHttp.test.ts
@@ -1312,7 +1312,7 @@ describe("StreamableHTTPServerTransport DNS rebinding protection", () => {
       const result = await createTestServerWithDnsProtection({
         sessionIdGenerator: undefined,
         allowedHosts: ['localhost:3001'],
-        disableDnsRebindingProtection: false,
+        enableDnsRebindingProtection: true,
       });
       server = result.server;
       transport = result.transport;
@@ -1338,7 +1338,7 @@ describe("StreamableHTTPServerTransport DNS rebinding protection", () => {
       const result = await createTestServerWithDnsProtection({
         sessionIdGenerator: undefined,
         allowedHosts: ['example.com:3001'],
-        disableDnsRebindingProtection: false,
+        enableDnsRebindingProtection: true,
       });
       server = result.server;
       transport = result.transport;
@@ -1362,7 +1362,7 @@ describe("StreamableHTTPServerTransport DNS rebinding protection", () => {
       const result = await createTestServerWithDnsProtection({
         sessionIdGenerator: undefined,
         allowedHosts: ['example.com:3001'],
-        disableDnsRebindingProtection: false,
+        enableDnsRebindingProtection: true,
       });
       server = result.server;
       transport = result.transport;
@@ -1384,7 +1384,7 @@ describe("StreamableHTTPServerTransport DNS rebinding protection", () => {
       const result = await createTestServerWithDnsProtection({
         sessionIdGenerator: undefined,
         allowedOrigins: ['http://localhost:3000', 'https://example.com'],
-        disableDnsRebindingProtection: false,
+        enableDnsRebindingProtection: true,
       });
       server = result.server;
       transport = result.transport;
@@ -1407,7 +1407,7 @@ describe("StreamableHTTPServerTransport DNS rebinding protection", () => {
       const result = await createTestServerWithDnsProtection({
         sessionIdGenerator: undefined,
         allowedOrigins: ['http://localhost:3000'],
-        disableDnsRebindingProtection: false,
+        enableDnsRebindingProtection: true,
       });
       server = result.server;
       transport = result.transport;
@@ -1429,13 +1429,13 @@ describe("StreamableHTTPServerTransport DNS rebinding protection", () => {
     });
   });
 
-  describe("disableDnsRebindingProtection option", () => {
-    it("should skip all validations when disableDnsRebindingProtection is true", async () => {
+  describe("enableDnsRebindingProtection option", () => {
+    it("should skip all validations when enableDnsRebindingProtection is false", async () => {
       const result = await createTestServerWithDnsProtection({
         sessionIdGenerator: undefined,
         allowedHosts: ['localhost:3001'],
         allowedOrigins: ['http://localhost:3000'],
-        disableDnsRebindingProtection: true,
+        enableDnsRebindingProtection: false,
       });
       server = result.server;
       transport = result.transport;
@@ -1463,7 +1463,7 @@ describe("StreamableHTTPServerTransport DNS rebinding protection", () => {
         sessionIdGenerator: undefined,
         allowedHosts: ['localhost:3001'],
         allowedOrigins: ['http://localhost:3001'],
-        disableDnsRebindingProtection: false,
+        enableDnsRebindingProtection: true,
       });
       server = result.server;
       transport = result.transport;
@@ -1507,7 +1507,7 @@ async function createTestServerWithDnsProtection(config: {
   sessionIdGenerator: (() => string) | undefined;
   allowedHosts?: string[];
   allowedOrigins?: string[];
-  disableDnsRebindingProtection?: boolean;
+  enableDnsRebindingProtection?: boolean;
 }): Promise<{
   server: Server;
   transport: StreamableHTTPServerTransport;
@@ -1523,7 +1523,7 @@ async function createTestServerWithDnsProtection(config: {
     sessionIdGenerator: config.sessionIdGenerator,
     allowedHosts: config.allowedHosts,
     allowedOrigins: config.allowedOrigins,
-    disableDnsRebindingProtection: config.disableDnsRebindingProtection,
+    enableDnsRebindingProtection: config.enableDnsRebindingProtection,
   });
 
   await mcpServer.connect(transport);

--- a/src/server/streamableHttp.ts
+++ b/src/server/streamableHttp.ts
@@ -75,10 +75,10 @@ export interface StreamableHTTPServerTransportOptions {
   allowedOrigins?: string[];
   
   /**
-   * Disable DNS rebinding protection entirely (overrides allowedHosts and allowedOrigins).
-   * Default is true for backwards compatibility.
+   * Enable DNS rebinding protection (requires allowedHosts and/or allowedOrigins to be configured).
+   * Default is false for backwards compatibility.
    */
-  disableDnsRebindingProtection?: boolean;
+  enableDnsRebindingProtection?: boolean;
 }
 
 /**
@@ -129,7 +129,7 @@ export class StreamableHTTPServerTransport implements Transport {
   private _onsessioninitialized?: (sessionId: string) => void;
   private _allowedHosts?: string[];
   private _allowedOrigins?: string[];
-  private _disableDnsRebindingProtection: boolean;
+  private _enableDnsRebindingProtection: boolean;
 
   sessionId?: string | undefined;
   onclose?: () => void;
@@ -143,7 +143,7 @@ export class StreamableHTTPServerTransport implements Transport {
     this._onsessioninitialized = options.onsessioninitialized;
     this._allowedHosts = options.allowedHosts;
     this._allowedOrigins = options.allowedOrigins;
-    this._disableDnsRebindingProtection = options.disableDnsRebindingProtection ?? true;
+    this._enableDnsRebindingProtection = options.enableDnsRebindingProtection ?? false;
   }
 
   /**
@@ -162,8 +162,8 @@ export class StreamableHTTPServerTransport implements Transport {
    * @returns Error message if validation fails, undefined if validation passes.
    */
   private validateRequestHeaders(req: IncomingMessage): string | undefined {
-    // Skip validation if protection is disabled
-    if (this._disableDnsRebindingProtection) {
+    // Skip validation if protection is not enabled
+    if (!this._enableDnsRebindingProtection) {
       return undefined;
     }
 

--- a/src/server/streamableHttp.ts
+++ b/src/server/streamableHttp.ts
@@ -61,6 +61,24 @@ export interface StreamableHTTPServerTransportOptions {
    * If provided, resumability will be enabled, allowing clients to reconnect and resume messages
    */
   eventStore?: EventStore;
+
+  /**
+   * List of allowed host header values for DNS rebinding protection.
+   * If not specified, host validation is disabled.
+   */
+  allowedHosts?: string[];
+  
+  /**
+   * List of allowed origin header values for DNS rebinding protection.
+   * If not specified, origin validation is disabled.
+   */
+  allowedOrigins?: string[];
+  
+  /**
+   * Disable DNS rebinding protection entirely (overrides allowedHosts and allowedOrigins).
+   * Default is true for backwards compatibility.
+   */
+  disableDnsRebindingProtection?: boolean;
 }
 
 /**
@@ -109,6 +127,9 @@ export class StreamableHTTPServerTransport implements Transport {
   private _standaloneSseStreamId: string = '_GET_stream';
   private _eventStore?: EventStore;
   private _onsessioninitialized?: (sessionId: string) => void;
+  private _allowedHosts?: string[];
+  private _allowedOrigins?: string[];
+  private _disableDnsRebindingProtection: boolean;
 
   sessionId?: string | undefined;
   onclose?: () => void;
@@ -120,6 +141,9 @@ export class StreamableHTTPServerTransport implements Transport {
     this._enableJsonResponse = options.enableJsonResponse ?? false;
     this._eventStore = options.eventStore;
     this._onsessioninitialized = options.onsessioninitialized;
+    this._allowedHosts = options.allowedHosts;
+    this._allowedOrigins = options.allowedOrigins;
+    this._disableDnsRebindingProtection = options.disableDnsRebindingProtection ?? true;
   }
 
   /**
@@ -134,9 +158,53 @@ export class StreamableHTTPServerTransport implements Transport {
   }
 
   /**
+   * Validates request headers for DNS rebinding protection.
+   * @returns Error message if validation fails, undefined if validation passes.
+   */
+  private validateRequestHeaders(req: IncomingMessage): string | undefined {
+    // Skip validation if protection is disabled
+    if (this._disableDnsRebindingProtection) {
+      return undefined;
+    }
+
+    // Validate Host header if allowedHosts is configured
+    if (this._allowedHosts && this._allowedHosts.length > 0) {
+      const hostHeader = req.headers.host;
+      if (!hostHeader || !this._allowedHosts.includes(hostHeader)) {
+        return `Invalid Host header: ${hostHeader}`;
+      }
+    }
+
+    // Validate Origin header if allowedOrigins is configured
+    if (this._allowedOrigins && this._allowedOrigins.length > 0) {
+      const originHeader = req.headers.origin;
+      if (!originHeader || !this._allowedOrigins.includes(originHeader)) {
+        return `Invalid Origin header: ${originHeader}`;
+      }
+    }
+
+    return undefined;
+  }
+
+  /**
    * Handles an incoming HTTP request, whether GET or POST
    */
   async handleRequest(req: IncomingMessage & { auth?: AuthInfo }, res: ServerResponse, parsedBody?: unknown): Promise<void> {
+    // Validate request headers for DNS rebinding protection
+    const validationError = this.validateRequestHeaders(req);
+    if (validationError) {
+      res.writeHead(403).end(JSON.stringify({
+        jsonrpc: "2.0",
+        error: {
+          code: -32000,
+          message: validationError
+        },
+        id: null
+      }));
+      this.onerror?.(new Error(validationError));
+      return;
+    }
+
     if (req.method === "POST") {
       await this.handlePostRequest(req, res, parsedBody);
     } else if (req.method === "GET") {


### PR DESCRIPTION
## Motivation and Context
This implements the mitigations described [here](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#security-warning). To avoid breaking existing applications this doesn't enable any changes by-default, but enabling this feature is heavily encouraged for any local MCP servers using the SSE transport. 

## How Has This Been Tested?
Tested via unit tests. 

## Breaking Changes
To avoid introducing any breaking changes, the DNS rebinding protections are disabled by default. Ideally we should find a way to enable them by default. But for now, adding them as disabled is a good first step. 

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
