### PR TITLE
Make ResourceTemplate list callback optional

### DIFF
--- a/src/server/mcp.ts
+++ b/src/server/mcp.ts
@@ -934,9 +934,9 @@ export class ResourceTemplate {
     uriTemplate: string | UriTemplate,
     private _callbacks: {
       /**
-       * A callback to list all resources matching this template. This is required to specified, even if `undefined`, to avoid accidentally forgetting resource listing.
+       * A callback to list all resources matching this template.
        */
-      list: ListResourcesCallback | undefined;
+      list?: ListResourcesCallback;
 
       /**
        * An optional callback to autocomplete variables within the URI template. Useful for clients and users to discover possible values.
@@ -944,7 +944,7 @@ export class ResourceTemplate {
       complete?: {
         [variable: string]: CompleteResourceTemplateCallback;
       };
-    },
+    } = {},
   ) {
     this._uriTemplate =
       typeof uriTemplate === "string"


### PR DESCRIPTION
This removes the `| undefined` in exchange for optional because forcing the inclusion of `list` is unnecessary and confusing.

## Motivation and Context

`list` is not a MUST in the spec and having to specify `list` is annoying. Sometimes listing all resources is not feasible or possible.

The note in the comment suggests it's here to help people not forget to include it, but I do not think this is sufficient reason to force its inclusion all the time. If people forget, then listing won't work and they'll figure out why.

## How Has This Been Tested?

In my [epicshop](https://github.com/epicweb-dev/epicshop/blob/main/packages/workshop-mcp) mcp server, I edited the type changes locally and it works as expected. All of these are typesafe:

```ts
new ResourceTemplate('epicshop://{workshopDirectory}/workshop-context')
new ResourceTemplate('epicshop://{workshopDirectory}/workshop-context', { list: undefined })
new ResourceTemplate('epicshop://{workshopDirectory}/workshop-context', { list: async () => { /* ... etc... */ } })
```

## Breaking Changes

No breaking changes

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->

Related discussion: https://github.com/modelcontextprotocol/modelcontextprotocol/discussions/586
