### PR TITLE
Setting up pkg.pr.new

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,23 @@
+name: Publish Any Commit
+on:
+  pull_request:
+  push:
+    branches:
+      - '**'
+    tags:
+      - '!**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: npm
+
+      - run: npm ci
+      - run: npm run build
+      - run: npx pkg-pr-new publish --compact


### PR DESCRIPTION
This publishes NPM-compatible URLs for each commit on the repo:

![image](https://github.com/user-attachments/assets/f378aaf0-4d75-4518-a28e-ee5850091f34)

![image](https://github.com/user-attachments/assets/f0e3d2f0-eedd-4f19-89f9-3af4d0d4b542)

This makes it possible for people (like myself!) to build against the SDK before it goes through a release, to validate that everything's working with the downstream packages.

It requires installing this GH app on the main repo: https://github.com/apps/pkg-pr-new

Tested this on the `geelen` fork (see screenshots) but this code really needs to be added as a branch to the main repo, then someone can iterate until they're happy with the output. Instructions for customisation are [here](https://github.com/stackblitz-labs/pkg.pr.new?tab=readme-ov-file#custom-github-messages-and-comments), but I find the default look pretty much fine.