### PR TITLE
 Introduced utility methods to check if a tool, resource, or prompt is registered

### DIFF
--- a/src/server/mcp.test.ts
+++ b/src/server/mcp.test.ts
@@ -484,8 +484,7 @@ describe("tool()", () => {
       ],
     }));
 
-    const [clientTransport, serverTransport] =
-      InMemoryTransport.createLinkedPair();
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
 
     await Promise.all([
       client.connect(clientTransport),
@@ -2937,7 +2936,7 @@ describe("prompt()", () => {
     result = await client.request(
       { method: "prompts/list" },
       ListPromptsResultSchema,
-    );
+       );
 
     expect(result.prompts).toHaveLength(1);
     expect(result.prompts[0].name).toBe("prompt2");
@@ -3498,5 +3497,38 @@ describe("prompt()", () => {
     expect(receivedRequestId).toBeDefined();
     expect(typeof receivedRequestId === 'string' || typeof receivedRequestId === 'number').toBe(true);
     expect(result.messages[0].content.text).toContain("Received request ID:");
+  });
+});
+
+describe("registration checks", () => {
+  /**
+   * Test: hasTool, hasResource, hasPrompt
+   */
+  test("should check tool/resource/prompt registration", () => {
+    const mcpServer = new McpServer({
+      name: "test server",
+      version: "1.0",
+    });
+
+    // Register tool, resource, prompt
+    mcpServer.tool("tool1", async () => ({ content: [] }));
+    mcpServer.resource("resource1", "test://resource1", async () => ({ contents: [] }));
+    // For prompt, return a valid prompt result (with messages)
+    mcpServer.prompt("prompt1", async () => ({
+      messages: [
+        {
+          role: "assistant",
+          content: { type: "text", text: "dummy" },
+        },
+      ],
+    }));
+
+    // Check registration
+    expect(mcpServer.hasTool("tool1")).toBe(true);
+    expect(mcpServer.hasTool("not-exist")).toBe(false);
+    expect(mcpServer.hasResource("test://resource1")).toBe(true);
+    expect(mcpServer.hasResource("not-exist://uri")).toBe(false);
+    expect(mcpServer.hasPrompt("prompt1")).toBe(true);
+    expect(mcpServer.hasPrompt("not-exist")).toBe(false);
   });
 });

--- a/src/server/mcp.ts
+++ b/src/server/mcp.ts
@@ -881,6 +881,33 @@ export class McpServer {
   }
 
   /**
+   * Checks if a tool with the given name is registered.
+   * @param name Tool name
+   * @returns True if the tool is registered
+   */
+  hasTool(name: string): boolean {
+    return !!this._registeredTools[name];
+  }
+
+  /**
+   * Checks if a resource with the given URI is registered.
+   * @param uri Resource URI
+   * @returns True if the resource is registered
+   */
+  hasResource(uri: string): boolean {
+    return !!this._registeredResources[uri];
+  }
+
+  /**
+   * Checks if a prompt with the given name is registered.
+   * @param name Prompt name
+   * @returns True if the prompt is registered
+   */
+  hasPrompt(name: string): boolean {
+    return !!this._registeredPrompts[name];
+  }
+
+  /**
    * Checks if the server is connected to a transport.
    * @returns True if the server is connected
    */


### PR DESCRIPTION
## Summary

Add utility methods and corresponding tests to check registration status of tools, resources, and prompts in `McpServer`.

## Motivation and Context

Previously, there was no way to introspect whether a specific tool, resource, or prompt was registered in the server.  
This change introduces `hasTool`, `hasResource`, and `hasPrompt` methods to fill that gap, improving reliability and debuggability for consumers and test cases.

## How Has This Been Tested?

- Unit tests were added under a new `describe("registration checks", ...)` block in `mcp.test.ts`.
- Verified that the server correctly returns `true` or `false` depending on whether the name/URI is registered.

## Breaking Changes

None. This is a non-breaking addition of utility methods.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context

These methods may be useful for tooling or plugin systems that want to conditionally register behavior or inspect the server's current state without risking overwrites or duplication.
