### PR TITLE
updates listed resources from resource templates to favor their own metadata

### DIFF
--- a/src/server/mcp.ts
+++ b/src/server/mcp.ts
@@ -369,8 +369,9 @@ export class McpServer {
           const result = await template.resourceTemplate.listCallback(extra);
           for (const resource of result.resources) {
             templateResources.push({
-              ...resource,
               ...template.metadata,
+              // the defined resource metadata should override the template metadata if present
+              ...resource,
             });
           }
         }


### PR DESCRIPTION
This updates the way metadata is assigned to resources that are defined by the list property of a ResourceTemplate so that they favor their own metadata over that of the ResourceTemplate. 

## Motivation and Context
https://github.com/modelcontextprotocol/typescript-sdk/issues/573

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
This shouldn't result in breaking changes unless a listed resource was misconfigured and relying on inheriting the correct metadata from the ResourceTemplate. 

## Types of changes
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed


