### PR TITLE
fix: missing "properties" property in empty schema

### DIFF
--- a/src/server/mcp.test.ts
+++ b/src/server/mcp.test.ts
@@ -265,6 +265,7 @@ describe("tool()", () => {
     expect(result.tools[0].name).toBe("test");
     expect(result.tools[0].inputSchema).toEqual({
       type: "object",
+      properties: {},
     });
 
     // Adding the tool before the connection was established means no notification was sent

--- a/src/server/mcp.ts
+++ b/src/server/mcp.ts
@@ -1018,6 +1018,7 @@ export type RegisteredTool = {
 
 const EMPTY_OBJECT_JSON_SCHEMA = {
   type: "object" as const,
+  properties: {},
 };
 
 // Helper to check if an object is a Zod schema (ZodRawShape)


### PR DESCRIPTION
## Motivation and Context
This PR fixes a behaviour difference between the TS and Python SDK in regards to how MCP tools with no parameters are handled.

## How Has This Been Tested?
Yes, this has been both unit-tested and e2e tested in a real world scenario.

## Breaking Changes
No breaking changes here.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
This issue was found while fixing a downstream related issue in the LangChain.js package, see this comment here (unfold) for details: https://github.com/langchain-ai/langchainjs/pull/8222/files/d3999743ef9beff7a667601ba10aa4d04a245027#diff-837f7946011257a2651ecd961d544e72da8192f0fa3c2a04b6a17a2024ed31bb

We found out that TS and Python MCP SDKs were handling the case of MCP tools with no parameters differently. In some cases, the PY server even enforce the `additionalProperties: false` attribute in the JSON schema, however due to how this is handled in the TS SDK, I could not also add it here without the risk of breaking stuff as the empty schema is used as a fallback.
