### PR TITLE
Add `pathVariableNames` and `queryVariableNames` getters in `UriTemplate`

### DIFF
--- a/src/shared/uriTemplate.test.ts
+++ b/src/shared/uriTemplate.test.ts
@@ -273,4 +273,52 @@ describe("UriTemplate", () => {
       expect(() => template.expand(vars)).not.toThrow();
     });
   });
+
+  describe("variable classification", () => {
+    it("should identify path variables", () => {
+      const template = new UriTemplate(
+        "/users/{id}/posts/{postId}{?limit,offset}"
+      );
+      expect(template.pathVariableNames).toEqual(["id", "postId"]);
+    });
+
+    it("should identify query variables", () => {
+      const template = new UriTemplate(
+        "/users/{id}/posts/{postId}{?limit,offset}"
+      );
+      expect(template.queryVariableNames).toEqual(["limit", "offset"]);
+    });
+
+    it("should classify different operators correctly", () => {
+      const template = new UriTemplate(
+        "{base}{+path}{#fragment}{.ext}{/segments}{?query}{&more}"
+      );
+      expect(template.pathVariableNames).toEqual([
+        "base",
+        "path",
+        "fragment",
+        "ext",
+        "segments",
+      ]);
+      expect(template.queryVariableNames).toEqual(["query", "more"]);
+    });
+
+    it("should handle templates with only path variables", () => {
+      const template = new UriTemplate("/users/{id}/profile");
+      expect(template.pathVariableNames).toEqual(["id"]);
+      expect(template.queryVariableNames).toEqual([]);
+    });
+
+    it("should handle templates with only query variables", () => {
+      const template = new UriTemplate("/search{?q,limit,offset}");
+      expect(template.pathVariableNames).toEqual([]);
+      expect(template.queryVariableNames).toEqual(["q", "limit", "offset"]);
+    });
+
+    it("should handle templates with no variables", () => {
+      const template = new UriTemplate("/static/path");
+      expect(template.pathVariableNames).toEqual([]);
+      expect(template.queryVariableNames).toEqual([]);
+    });
+  });
 });

--- a/src/shared/uriTemplate.ts
+++ b/src/shared/uriTemplate.ts
@@ -40,6 +40,41 @@ export class UriTemplate {
     return this.parts.flatMap((part) => typeof part === 'string' ? [] : part.names);
   }
 
+  /**
+   * Returns variable names used in path-like expansions.
+   * These include simple expansion, reserved expansion, fragment expansion,
+   * label expansion, and path segment expansion.
+   */
+  get pathVariableNames(): string[] {
+    return this.parts
+      .filter((part) => typeof part !== "string")
+      .filter((part) => {
+        // Path-like expansions: simple, reserved, fragment, label, path segments
+        return (
+          part.operator === "" ||
+          part.operator === "+" ||
+          part.operator === "#" ||
+          part.operator === "." ||
+          part.operator === "/"
+        );
+      })
+      .flatMap((part) => part.names);
+  }
+  
+  /**
+   * Returns variable names used in query-like expansions.
+   * These include form-style query and query continuation expansions.
+   */
+  get queryVariableNames(): string[] {
+    return this.parts
+      .filter((part) => typeof part !== "string")
+      .filter((part) => {
+        // Query-like expansions: form-style query and continuation
+        return part.operator === "?" || part.operator === "&";
+      })
+      .flatMap((part) => part.names);
+  }
+
   constructor(template: string) {
     UriTemplate.validateLength(template, MAX_TEMPLATE_LENGTH, "Template");
     this.template = template;


### PR DESCRIPTION
This PR adds two new getter methods to the `UriTemplate` class that distinguish between path-like variables (which identify core resources) and query-like variables (which are optional parameters). This will enable the MCP Inspector to allow resource browsing with only essential path variables filled, while treating query parameters as optional filters.

## Motivation and Context

The MCP Inspector currently requires all URI template variables to be filled before allowing reading of resources from resource templates, which makes it difficult to explore available resources and understand what variables are needed. Some query parameters MAY be optional. This change enables better resource discovery by distinguishing between path-like variables (which identify the core resource) and query-like variables (which are optional filters/parameters).

This addresses the need for more intuitive resource browsing in MCP Inspector, where users should be able to access resources with only essential path variables while treating query parameters as optional enhancements.

## How Has This Been Tested?

- Added comprehensive test suite covering all RFC 6570 expansion operators
- Tests for edge cases (templates with no variables, only path variables, only query variables)
- Validated correct classification of mixed templates with both path and query variables
- All existing tests continue to pass, ensuring backward compatibility
- Tested with real MCP resource templates like `database://users/{id}{?limit,offset}`

## Breaking Changes

No breaking changes. This is a purely additive feature that maintains full backward compatibility with existing code.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

**Implementation Details:**
- `pathVariableNames`: Returns variables from path-like expansions (`""`, `"+"`, `"#"`, `"."`, `"/"` operators)
- `queryVariableNames`: Returns variables from query-like expansions (`"?"`, `"&"` operators)
- Classification based on RFC 6570 expansion operators, not semantic assumptions
- Maintains existing `variableNames` getter for full compatibility

**Use Case Example:**
```typescript
const template = new UriTemplate("database://users/{id}/posts{?limit,offset}");
template.pathVariableNames;  // ["id"] - structurally required
template.queryVariableNames; // ["limit", "offset"] - optional parameters
```

This  change will enable MCP Inspector to allow browsing `database://users/123/posts` without requiring query parameters, while still showing what optional filters are available.

**RFC 6570 Compliance:**
- Path-like variables affect URI structure when omitted
- Query-like variables only affect query parameters when omitted  
- Both types are technically optional per RFC 6570, but have different structural implications
- Implementation follows RFC 6570 expansion mechanics precisely