### PR TITLE
Remove zod inference and use explicit TypeScript types

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,7 +12,10 @@ export default tseslint.config(
         },
         rules: {
             "@typescript-eslint/no-unused-vars": ["error",
-                { "argsIgnorePattern": "^_" }
+                { 
+                    "argsIgnorePattern": "^_",
+                    "varsIgnorePattern": "^_Assert"
+                }
             ]
         }
     }


### PR DESCRIPTION
Fixes #119, wherein more context on why these types are bad for users, but in short, this makes things readable by humans, and also probably improves TS perf and even in some cases correctness.

To do so, I replaced all the `zod.infer` stuff, which is a mess as described in the issue, with explicit types. I moved the JSDoc to the new types, since that's where humans will read now -- and indeed they will actually be able to read! Type assertions ensure they match the schemas. (There are no runtime changes.)

This is a bit more annoying to maintain, of course -- the ideal would be to generate the schemas from the types and I assume there are packages to do so although I haven't explored the Zod universe lately. But in practice, Claude did all the work, so he can probably keep doing it as the types evolve.

🤖 Generated with [Claude Code](https://claude.ai/code)

## Breaking Changes
This may fail users' TS builds when they upgrade, if the bad types were hiding bugs (as, in our codebase, they were). Those are already bugs for them, just ones TS couldn't catch. There are no runtime changes.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling (n/a)
- [x] I have added or updated documentation as needed (n/a)

