### PR TITLE
Jerome/fix/dev oauth server required scopes change

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@modelcontextprotocol/sdk",
-  "version": "1.11.4",
+  "version": "1.12.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@modelcontextprotocol/sdk",
-      "version": "1.11.4",
+      "version": "1.12.3",
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.6",

--- a/src/examples/server/simpleStreamableHttp.ts
+++ b/src/examples/server/simpleStreamableHttp.ts
@@ -225,7 +225,7 @@ if (useOAuth) {
 
   authMiddleware = requireBearerAuth({
     verifier: tokenVerifier,
-    requiredScopes: ['mcp:tools'],
+    requiredScopes: [],
     resourceMetadataUrl: getOAuthProtectedResourceMetadataUrl(mcpServerUrl),
   });
 }


### PR DESCRIPTION
Removing required scope from the shttp dev oauth server. admittedly I don't know the best behaviour here:
* Should the MCP client already know about the mcp:tools scope, and be requesting it?
* Should the MCP client discover all available scopes and request all of them?
  * Should the user filter down the scopes to what they're comfortable (from the list of all available scopes) - is this something that should be handled MCP client side, or MCP server (& auth server) side

As it currently stands, the inspector does both - guided flow requests all scopes, quick flow requests no scopes. I'm using this to test the inspector, and confused as to whether this oauth server is configured poorly (having required scopes for the MCP connection to function at all), or if the inspector quick flow is not functioning correctly (i.e. it should be requesting all available scopes)

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
