### PR TITLE
Add title to tools, resources, prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,10 +78,10 @@ server.registerResource(
     title: "Greeting Resource",      // Display name for UI
     description: "Dynamic greeting generator"
   },
-  async (uri, params) => ({
+  async (uri, { name }) => ({
     contents: [{
       uri: uri.href,
-      text: `Hello, ${params.name}!`
+      text: `Hello, ${name}!`
     }]
   })
 );
@@ -143,10 +143,10 @@ server.registerResource(
     title: "User Profile",
     description: "User profile information"
   },
-  async (uri, params) => ({
+  async (uri, { userId }) => ({
     contents: [{
       uri: uri.href,
-      text: `Profile data for user ${params.userId}`
+      text: `Profile data for user ${userId}`
     }]
   })
 );
@@ -479,10 +479,10 @@ server.registerResource(
     title: "Echo Resource",
     description: "Echoes back messages as resources"
   },
-  async (uri, params) => ({
+  async (uri, { message }) => ({
     contents: [{
       uri: uri.href,
-      text: `Resource echo: ${params.message}`
+      text: `Resource echo: ${message}`
     }]
   })
 );

--- a/README.md
+++ b/README.md
@@ -530,8 +530,7 @@ import { z } from "zod";
 
 const server = new McpServer({
   name: "sqlite-explorer",
-  version: "1.0.0",
-  title: "SQLite Explorer"
+  version: "1.0.0"
 });
 
 // Helper to create DB connection

--- a/README.md
+++ b/README.md
@@ -55,8 +55,7 @@ import { z } from "zod";
 // Create an MCP server
 const server = new McpServer({
   name: "demo-server",
-  version: "1.0.0",
-  title: "Demo Server"  // Optional display name
+  version: "1.0.0"
 });
 
 // Add an addition tool
@@ -109,9 +108,8 @@ The McpServer is your core interface to the MCP protocol. It handles connection 
 
 ```typescript
 const server = new McpServer({
-  name: "my-app",              // Unique identifier for your server
-  version: "1.0.0",            // Server version
-  title: "My Application"      // Optional display name for UI
+  name: "my-app",
+  version: "1.0.0"
 });
 ```
 
@@ -471,8 +469,7 @@ import { z } from "zod";
 
 const server = new McpServer({
   name: "echo-server",
-  version: "1.0.0",
-  title: "Echo Server"
+  version: "1.0.0"
 });
 
 server.registerResource(
@@ -507,7 +504,7 @@ server.registerPrompt(
   {
     title: "Echo Prompt",
     description: "Creates a prompt to process a message",
-    arguments: { message: z.string() }
+    argsSchema: { message: z.string() }
   },
   ({ message }) => ({
     messages: [{

--- a/README.md
+++ b/README.md
@@ -226,14 +226,36 @@ All resources, tools, and prompts support an optional `title` field for better U
 
 **Note:** The `register*` methods (`registerTool`, `registerPrompt`, `registerResource`) are the recommended approach for new code. The older methods (`tool`, `prompt`, `resource`) remain available for backwards compatibility.
 
+#### Title Precedence for Tools
+
+For tools specifically, there are two ways to specify a title:
+- `title` field in the tool configuration
+- `annotations.title` field (when using the older `tool()` method with annotations)
+
+The precedence order is: `title` → `annotations.title` → `name`
+
+```typescript
+// Using registerTool (recommended)
+server.registerTool("my_tool", {
+  title: "My Tool",              // This title takes precedence
+  annotations: {
+    title: "Annotation Title"    // This is ignored if title is set
+  }
+}, handler);
+
+// Using tool with annotations (older API)
+server.tool("my_tool", "description", {
+  title: "Annotation Title"      // This is used as title
+}, handler);
+```
 
 When building clients, use the provided utility to get the appropriate display name:
 
 ```typescript
 import { getDisplayName } from "@modelcontextprotocol/sdk/shared/metadataUtils.js";
 
-// Falls back to 'name' if 'title' is not provided
-const displayName = getDisplayName(tool);  // Returns title if available, otherwise name
+// Automatically handles the precedence: title → annotations.title → name
+const displayName = getDisplayName(tool);
 ```
 
 ## Running Your Server

--- a/src/examples/client/simpleStreamableHttp.ts
+++ b/src/examples/client/simpleStreamableHttp.ts
@@ -15,6 +15,7 @@ import {
   LoggingMessageNotificationSchema,
   ResourceListChangedNotificationSchema,
 } from '../../types.js';
+import { getDisplayName } from '../../shared/metadataUtils.js';
 
 // Create readline interface for user input
 const readline = createInterface({
@@ -317,7 +318,7 @@ async function listTools(): Promise<void> {
       console.log('  No tools available');
     } else {
       for (const tool of toolsResult.tools) {
-        console.log(`  - ${tool.name}: ${tool.description}`);
+        console.log(`  - ${getDisplayName(tool)}: ${tool.description}`);
       }
     }
   } catch (error) {
@@ -429,7 +430,7 @@ async function listPrompts(): Promise<void> {
       console.log('  No prompts available');
     } else {
       for (const prompt of promptsResult.prompts) {
-        console.log(`  - ${prompt.name}: ${prompt.description}`);
+        console.log(`  - ${getDisplayName(prompt)}: ${prompt.description}`);
       }
     }
   } catch (error) {
@@ -480,7 +481,7 @@ async function listResources(): Promise<void> {
       console.log('  No resources available');
     } else {
       for (const resource of resourcesResult.resources) {
-        console.log(`  - ${resource.name}: ${resource.uri}`);
+        console.log(`  - ${getDisplayName(resource)}: ${resource.uri}`);
       }
     }
   } catch (error) {

--- a/src/examples/client/simpleStreamableHttp.ts
+++ b/src/examples/client/simpleStreamableHttp.ts
@@ -318,7 +318,12 @@ async function listTools(): Promise<void> {
       console.log('  No tools available');
     } else {
       for (const tool of toolsResult.tools) {
-        console.log(`  - ${getDisplayName(tool)}: ${tool.description}`);
+        const displayName = getDisplayName(tool);
+        if (displayName !== tool.name) {
+          console.log(`  - ${tool.name} (${displayName}): ${tool.description}`);
+        } else {
+          console.log(`  - ${tool.name}: ${tool.description}`);
+        }
       }
     }
   } catch (error) {

--- a/src/examples/client/simpleStreamableHttp.ts
+++ b/src/examples/client/simpleStreamableHttp.ts
@@ -318,12 +318,7 @@ async function listTools(): Promise<void> {
       console.log('  No tools available');
     } else {
       for (const tool of toolsResult.tools) {
-        const displayName = getDisplayName(tool);
-        if (displayName !== tool.name) {
-          console.log(`  - ${tool.name} (${displayName}): ${tool.description}`);
-        } else {
-          console.log(`  - ${tool.name}: ${tool.description}`);
-        }
+        console.log(`  - id: ${tool.name}, name: ${getDisplayName(tool)}, description: ${tool.description}`);
       }
     }
   } catch (error) {
@@ -386,7 +381,7 @@ async function runNotificationsToolWithResumability(interval: number, count: num
   try {
     console.log(`Starting notification stream with resumability: interval=${interval}ms, count=${count || 'unlimited'}`);
     console.log(`Using resumption token: ${notificationsToolLastEventId || 'none'}`);
-    
+
     const request: CallToolRequest = {
       method: 'tools/call',
       params: {
@@ -399,7 +394,7 @@ async function runNotificationsToolWithResumability(interval: number, count: num
       notificationsToolLastEventId = event;
       console.log(`Updated resumption token: ${event}`);
     };
-    
+
     const result = await client.request(request, CallToolResultSchema, {
       resumptionToken: notificationsToolLastEventId,
       onresumptiontoken: onLastEventIdUpdate
@@ -435,7 +430,7 @@ async function listPrompts(): Promise<void> {
       console.log('  No prompts available');
     } else {
       for (const prompt of promptsResult.prompts) {
-        console.log(`  - ${getDisplayName(prompt)}: ${prompt.description}`);
+        console.log(`  - id: ${prompt.name}, name: ${getDisplayName(prompt)}, description: ${prompt.description}`);
       }
     }
   } catch (error) {
@@ -486,7 +481,7 @@ async function listResources(): Promise<void> {
       console.log('  No resources available');
     } else {
       for (const resource of resourcesResult.resources) {
-        console.log(`  - ${getDisplayName(resource)}: ${resource.uri}`);
+        console.log(`  - id: ${resource.name}, name: ${getDisplayName(resource)}, description: ${resource.uri}`);
       }
     }
   } catch (error) {

--- a/src/examples/server/simpleStreamableHttp.ts
+++ b/src/examples/server/simpleStreamableHttp.ts
@@ -17,8 +17,7 @@ const useOAuth = process.argv.includes('--oauth');
 const getServer = () => {
   const server = new McpServer({
     name: 'simple-streamable-http-server',
-    version: '1.0.0',
-    title: 'Simple Streamable HTTP Server',  // Display name for UI
+    version: '1.0.0'
   }, { capabilities: { logging: {} } });
 
   // Register a simple tool that returns a greeting
@@ -94,7 +93,7 @@ const getServer = () => {
     {
       title: 'Greeting Template',  // Display name for UI
       description: 'A simple greeting prompt template',
-      arguments: {
+      argsSchema: {
         name: z.string().describe('Name to include in greeting'),
       },
     },
@@ -158,10 +157,10 @@ const getServer = () => {
   server.registerResource(
     'greeting-resource',
     'https://example.com/greetings/default',
-    { 
+    {
       title: 'Default Greeting',  // Display name for UI
       description: 'A simple greeting resource',
-      mimeType: 'text/plain' 
+      mimeType: 'text/plain'
     },
     async (): Promise<ReadResourceResult> => {
       return {

--- a/src/examples/server/simpleStreamableHttp.ts
+++ b/src/examples/server/simpleStreamableHttp.ts
@@ -18,14 +18,18 @@ const getServer = () => {
   const server = new McpServer({
     name: 'simple-streamable-http-server',
     version: '1.0.0',
+    title: 'Simple Streamable HTTP Server',  // Display name for UI
   }, { capabilities: { logging: {} } });
 
   // Register a simple tool that returns a greeting
-  server.tool(
+  server.registerTool(
     'greet',
-    'A simple greeting tool',
     {
-      name: z.string().describe('Name to greet'),
+      title: 'Greeting Tool',  // Display name for UI
+      description: 'A simple greeting tool',
+      inputSchema: {
+        name: z.string().describe('Name to greet'),
+      },
     },
     async ({ name }): Promise<CallToolResult> => {
       return {
@@ -84,12 +88,15 @@ const getServer = () => {
     }
   );
 
-  // Register a simple prompt
-  server.prompt(
+  // Register a simple prompt with title
+  server.registerPrompt(
     'greeting-template',
-    'A simple greeting prompt template',
     {
-      name: z.string().describe('Name to include in greeting'),
+      title: 'Greeting Template',  // Display name for UI
+      description: 'A simple greeting prompt template',
+      arguments: {
+        name: z.string().describe('Name to include in greeting'),
+      },
     },
     async ({ name }): Promise<GetPromptResult> => {
       return {
@@ -148,10 +155,14 @@ const getServer = () => {
   );
 
   // Create a simple resource at a fixed URI
-  server.resource(
+  server.registerResource(
     'greeting-resource',
     'https://example.com/greetings/default',
-    { mimeType: 'text/plain' },
+    { 
+      title: 'Default Greeting',  // Display name for UI
+      description: 'A simple greeting resource',
+      mimeType: 'text/plain' 
+    },
     async (): Promise<ReadResourceResult> => {
       return {
         contents: [

--- a/src/server/mcp.ts
+++ b/src/server/mcp.ts
@@ -1011,7 +1011,7 @@ export class McpServer {
     config: {
       title?: string;
       description?: string;
-      arguments?: Args;
+      argsSchema?: Args;
     },
     cb: PromptCallback<Args>
   ): RegisteredPrompt {
@@ -1019,7 +1019,7 @@ export class McpServer {
       throw new Error(`Prompt ${name} is already registered`);
     }
 
-    const { title, description, arguments: argsSchema } = config;
+    const { title, description, argsSchema } = config;
 
     const registeredPrompt = this._createRegisteredPrompt(
       name,

--- a/src/server/mcp.ts
+++ b/src/server/mcp.ts
@@ -22,6 +22,7 @@ import {
   CompleteResult,
   PromptReference,
   ResourceTemplateReference,
+  BaseMetadata,
   Resource,
   ListResourcesResult,
   ListResourceTemplatesRequestSchema,
@@ -128,7 +129,7 @@ export class McpServer {
 
             if (tool.outputSchema) {
               toolDefinition.outputSchema = zodToJsonSchema(
-                tool.outputSchema, 
+                tool.outputSchema,
                 { strictUnions: true }
               ) as Tool["outputSchema"];
             }
@@ -586,27 +587,13 @@ export class McpServer {
         throw new Error(`Resource ${uriOrTemplate} is already registered`);
       }
 
-      const registeredResource: RegisteredResource = {
+      const registeredResource = this._createRegisteredResource(
         name,
+        undefined,
+        uriOrTemplate,
         metadata,
-        readCallback: readCallback as ReadResourceCallback,
-        enabled: true,
-        disable: () => registeredResource.update({ enabled: false }),
-        enable: () => registeredResource.update({ enabled: true }),
-        remove: () => registeredResource.update({ uri: null }),
-        update: (updates) => {
-          if (typeof updates.uri !== "undefined" && updates.uri !== uriOrTemplate) {
-            delete this._registeredResources[uriOrTemplate]
-            if (updates.uri) this._registeredResources[updates.uri] = registeredResource
-          }
-          if (typeof updates.name !== "undefined") registeredResource.name = updates.name
-          if (typeof updates.metadata !== "undefined") registeredResource.metadata = updates.metadata
-          if (typeof updates.callback !== "undefined") registeredResource.readCallback = updates.callback
-          if (typeof updates.enabled !== "undefined") registeredResource.enabled = updates.enabled
-          this.sendResourceListChanged()
-        },
-      };
-      this._registeredResources[uriOrTemplate] = registeredResource;
+        readCallback as ReadResourceCallback
+      );
 
       this.setResourceRequestHandlers();
       this.sendResourceListChanged();
@@ -616,27 +603,13 @@ export class McpServer {
         throw new Error(`Resource template ${name} is already registered`);
       }
 
-      const registeredResourceTemplate: RegisteredResourceTemplate = {
-        resourceTemplate: uriOrTemplate,
+      const registeredResourceTemplate = this._createRegisteredResourceTemplate(
+        name,
+        undefined,
+        uriOrTemplate,
         metadata,
-        readCallback: readCallback as ReadResourceTemplateCallback,
-        enabled: true,
-        disable: () => registeredResourceTemplate.update({ enabled: false }),
-        enable: () => registeredResourceTemplate.update({ enabled: true }),
-        remove: () => registeredResourceTemplate.update({ name: null }),
-        update: (updates) => {
-          if (typeof updates.name !== "undefined" && updates.name !== name) {
-            delete this._registeredResourceTemplates[name]
-            if (updates.name) this._registeredResourceTemplates[updates.name] = registeredResourceTemplate
-          }
-          if (typeof updates.template !== "undefined") registeredResourceTemplate.resourceTemplate = updates.template
-          if (typeof updates.metadata !== "undefined") registeredResourceTemplate.metadata = updates.metadata
-          if (typeof updates.callback !== "undefined") registeredResourceTemplate.readCallback = updates.callback
-          if (typeof updates.enabled !== "undefined") registeredResourceTemplate.enabled = updates.enabled
-          this.sendResourceListChanged()
-        },
-      };
-      this._registeredResourceTemplates[name] = registeredResourceTemplate;
+        readCallback as ReadResourceTemplateCallback
+      );
 
       this.setResourceRequestHandlers();
       this.sendResourceListChanged();
@@ -651,11 +624,7 @@ export class McpServer {
   registerResource(
     name: string,
     uriOrTemplate: string | ResourceTemplate,
-    config: ResourceMetadata & {
-      title?: string;
-      description?: string;
-      mimeType?: string;
-    },
+    config: ResourceMetadata,
     readCallback: ReadResourceCallback | ReadResourceTemplateCallback
   ): RegisteredResource | RegisteredResourceTemplate {
     if (typeof uriOrTemplate === "string") {
@@ -663,27 +632,13 @@ export class McpServer {
         throw new Error(`Resource ${uriOrTemplate} is already registered`);
       }
 
-      const registeredResource: RegisteredResource = {
+      const registeredResource = this._createRegisteredResource(
         name,
-        metadata: config,
-        readCallback: readCallback as ReadResourceCallback,
-        enabled: true,
-        disable: () => registeredResource.update({ enabled: false }),
-        enable: () => registeredResource.update({ enabled: true }),
-        remove: () => registeredResource.update({ uri: null }),
-        update: (updates) => {
-          if (typeof updates.uri !== "undefined" && updates.uri !== uriOrTemplate) {
-            delete this._registeredResources[uriOrTemplate]
-            if (updates.uri) this._registeredResources[updates.uri] = registeredResource
-          }
-          if (typeof updates.name !== "undefined") registeredResource.name = updates.name
-          if (typeof updates.metadata !== "undefined") registeredResource.metadata = updates.metadata
-          if (typeof updates.callback !== "undefined") registeredResource.readCallback = updates.callback
-          if (typeof updates.enabled !== "undefined") registeredResource.enabled = updates.enabled
-          this.sendResourceListChanged()
-        },
-      };
-      this._registeredResources[uriOrTemplate] = registeredResource;
+        (config as BaseMetadata).title,
+        uriOrTemplate,
+        config,
+        readCallback as ReadResourceCallback
+      );
 
       this.setResourceRequestHandlers();
       this.sendResourceListChanged();
@@ -693,27 +648,13 @@ export class McpServer {
         throw new Error(`Resource template ${name} is already registered`);
       }
 
-      const registeredResourceTemplate: RegisteredResourceTemplate = {
-        resourceTemplate: uriOrTemplate,
-        metadata: config,
-        readCallback: readCallback as ReadResourceTemplateCallback,
-        enabled: true,
-        disable: () => registeredResourceTemplate.update({ enabled: false }),
-        enable: () => registeredResourceTemplate.update({ enabled: true }),
-        remove: () => registeredResourceTemplate.update({ name: null }),
-        update: (updates) => {
-          if (typeof updates.name !== "undefined" && updates.name !== name) {
-            delete this._registeredResourceTemplates[name]
-            if (updates.name) this._registeredResourceTemplates[updates.name] = registeredResourceTemplate
-          }
-          if (typeof updates.template !== "undefined") registeredResourceTemplate.resourceTemplate = updates.template
-          if (typeof updates.metadata !== "undefined") registeredResourceTemplate.metadata = updates.metadata
-          if (typeof updates.callback !== "undefined") registeredResourceTemplate.readCallback = updates.callback
-          if (typeof updates.enabled !== "undefined") registeredResourceTemplate.enabled = updates.enabled
-          this.sendResourceListChanged()
-        },
-      };
-      this._registeredResourceTemplates[name] = registeredResourceTemplate;
+      const registeredResourceTemplate = this._createRegisteredResourceTemplate(
+        name,
+        (config as BaseMetadata).title,
+        uriOrTemplate,
+        config,
+        readCallback as ReadResourceTemplateCallback
+      );
 
       this.setResourceRequestHandlers();
       this.sendResourceListChanged();
@@ -721,8 +662,108 @@ export class McpServer {
     }
   }
 
+  private _createRegisteredResource(
+    name: string,
+    title: string | undefined,
+    uri: string,
+    metadata: ResourceMetadata | undefined,
+    readCallback: ReadResourceCallback
+  ): RegisteredResource {
+    const registeredResource: RegisteredResource = {
+      name,
+      title,
+      metadata,
+      readCallback,
+      enabled: true,
+      disable: () => registeredResource.update({ enabled: false }),
+      enable: () => registeredResource.update({ enabled: true }),
+      remove: () => registeredResource.update({ uri: null }),
+      update: (updates) => {
+        if (typeof updates.uri !== "undefined" && updates.uri !== uri) {
+          delete this._registeredResources[uri]
+          if (updates.uri) this._registeredResources[updates.uri] = registeredResource
+        }
+        if (typeof updates.name !== "undefined") registeredResource.name = updates.name
+        if (typeof updates.title !== "undefined") registeredResource.title = updates.title
+        if (typeof updates.metadata !== "undefined") registeredResource.metadata = updates.metadata
+        if (typeof updates.callback !== "undefined") registeredResource.readCallback = updates.callback
+        if (typeof updates.enabled !== "undefined") registeredResource.enabled = updates.enabled
+        this.sendResourceListChanged()
+      },
+    };
+    this._registeredResources[uri] = registeredResource;
+    return registeredResource;
+  }
+
+  private _createRegisteredResourceTemplate(
+    name: string,
+    title: string | undefined,
+    template: ResourceTemplate,
+    metadata: ResourceMetadata | undefined,
+    readCallback: ReadResourceTemplateCallback
+  ): RegisteredResourceTemplate {
+    const registeredResourceTemplate: RegisteredResourceTemplate = {
+      resourceTemplate: template,
+      title,
+      metadata,
+      readCallback,
+      enabled: true,
+      disable: () => registeredResourceTemplate.update({ enabled: false }),
+      enable: () => registeredResourceTemplate.update({ enabled: true }),
+      remove: () => registeredResourceTemplate.update({ name: null }),
+      update: (updates) => {
+        if (typeof updates.name !== "undefined" && updates.name !== name) {
+          delete this._registeredResourceTemplates[name]
+          if (updates.name) this._registeredResourceTemplates[updates.name] = registeredResourceTemplate
+        }
+        if (typeof updates.title !== "undefined") registeredResourceTemplate.title = updates.title
+        if (typeof updates.template !== "undefined") registeredResourceTemplate.resourceTemplate = updates.template
+        if (typeof updates.metadata !== "undefined") registeredResourceTemplate.metadata = updates.metadata
+        if (typeof updates.callback !== "undefined") registeredResourceTemplate.readCallback = updates.callback
+        if (typeof updates.enabled !== "undefined") registeredResourceTemplate.enabled = updates.enabled
+        this.sendResourceListChanged()
+      },
+    };
+    this._registeredResourceTemplates[name] = registeredResourceTemplate;
+    return registeredResourceTemplate;
+  }
+
+  private _createRegisteredPrompt(
+    name: string,
+    title: string | undefined,
+    description: string | undefined,
+    argsSchema: PromptArgsRawShape | undefined,
+    callback: PromptCallback<PromptArgsRawShape | undefined>
+  ): RegisteredPrompt {
+    const registeredPrompt: RegisteredPrompt = {
+      title,
+      description,
+      argsSchema: argsSchema === undefined ? undefined : z.object(argsSchema),
+      callback,
+      enabled: true,
+      disable: () => registeredPrompt.update({ enabled: false }),
+      enable: () => registeredPrompt.update({ enabled: true }),
+      remove: () => registeredPrompt.update({ name: null }),
+      update: (updates) => {
+        if (typeof updates.name !== "undefined" && updates.name !== name) {
+          delete this._registeredPrompts[name]
+          if (updates.name) this._registeredPrompts[updates.name] = registeredPrompt
+        }
+        if (typeof updates.title !== "undefined") registeredPrompt.title = updates.title
+        if (typeof updates.description !== "undefined") registeredPrompt.description = updates.description
+        if (typeof updates.argsSchema !== "undefined") registeredPrompt.argsSchema = z.object(updates.argsSchema)
+        if (typeof updates.callback !== "undefined") registeredPrompt.callback = updates.callback
+        if (typeof updates.enabled !== "undefined") registeredPrompt.enabled = updates.enabled
+        this.sendPromptListChanged()
+      },
+    };
+    this._registeredPrompts[name] = registeredPrompt;
+    return registeredPrompt;
+  }
+
   private _createRegisteredTool(
     name: string,
+    title: string | undefined,
     description: string | undefined,
     inputSchema: ZodRawShape | undefined,
     outputSchema: ZodRawShape | undefined,
@@ -730,6 +771,7 @@ export class McpServer {
     callback: ToolCallback<ZodRawShape | undefined>
   ): RegisteredTool {
     const registeredTool: RegisteredTool = {
+      title,
       description,
       inputSchema:
         inputSchema === undefined ? undefined : z.object(inputSchema),
@@ -868,7 +910,7 @@ export class McpServer {
     }
     const callback = rest[0] as ToolCallback<ZodRawShape | undefined>;
 
-    return this._createRegisteredTool(name, description, inputSchema, outputSchema, annotations, callback)
+    return this._createRegisteredTool(name, undefined, description, inputSchema, outputSchema, annotations, callback)
   }
 
   /**
@@ -891,21 +933,15 @@ export class McpServer {
 
     const { title, description, inputSchema, outputSchema, annotations } = config;
 
-    const registeredTool = this._createRegisteredTool(
+    return this._createRegisteredTool(
       name,
+      title,
       description,
       inputSchema,
       outputSchema,
       annotations,
       cb as ToolCallback<ZodRawShape | undefined>
     );
-
-    // Set title if provided
-    if (title !== undefined) {
-      registeredTool.title = title;
-    }
-
-    return registeredTool;
   }
 
   /**
@@ -953,28 +989,13 @@ export class McpServer {
     }
 
     const cb = rest[0] as PromptCallback<PromptArgsRawShape | undefined>;
-    const registeredPrompt: RegisteredPrompt = {
+    const registeredPrompt = this._createRegisteredPrompt(
+      name,
+      undefined,
       description,
-      argsSchema: argsSchema === undefined ? undefined : z.object(argsSchema),
-      callback: cb,
-      enabled: true,
-      disable: () => registeredPrompt.update({ enabled: false }),
-      enable: () => registeredPrompt.update({ enabled: true }),
-      remove: () => registeredPrompt.update({ name: null }),
-      update: (updates) => {
-        if (typeof updates.name !== "undefined" && updates.name !== name) {
-          delete this._registeredPrompts[name]
-          if (updates.name) this._registeredPrompts[updates.name] = registeredPrompt
-        }
-        if (typeof updates.title !== "undefined") registeredPrompt.title = updates.title
-        if (typeof updates.description !== "undefined") registeredPrompt.description = updates.description
-        if (typeof updates.argsSchema !== "undefined") registeredPrompt.argsSchema = z.object(updates.argsSchema)
-        if (typeof updates.callback !== "undefined") registeredPrompt.callback = updates.callback
-        if (typeof updates.enabled !== "undefined") registeredPrompt.enabled = updates.enabled
-        this.sendPromptListChanged()
-      },
-    };
-    this._registeredPrompts[name] = registeredPrompt;
+      argsSchema,
+      cb
+    );
 
     this.setPromptRequestHandlers();
     this.sendPromptListChanged()
@@ -1000,29 +1021,13 @@ export class McpServer {
 
     const { title, description, arguments: argsSchema } = config;
 
-    const registeredPrompt: RegisteredPrompt = {
+    const registeredPrompt = this._createRegisteredPrompt(
+      name,
       title,
       description,
-      argsSchema: argsSchema === undefined ? undefined : z.object(argsSchema),
-      callback: cb as PromptCallback<PromptArgsRawShape | undefined>,
-      enabled: true,
-      disable: () => registeredPrompt.update({ enabled: false }),
-      enable: () => registeredPrompt.update({ enabled: true }),
-      remove: () => registeredPrompt.update({ name: null }),
-      update: (updates) => {
-        if (typeof updates.name !== "undefined" && updates.name !== name) {
-          delete this._registeredPrompts[name]
-          if (updates.name) this._registeredPrompts[updates.name] = registeredPrompt
-        }
-        if (typeof updates.title !== "undefined") registeredPrompt.title = updates.title
-        if (typeof updates.description !== "undefined") registeredPrompt.description = updates.description
-        if (typeof updates.argsSchema !== "undefined") registeredPrompt.argsSchema = z.object(updates.argsSchema)
-        if (typeof updates.callback !== "undefined") registeredPrompt.callback = updates.callback
-        if (typeof updates.enabled !== "undefined") registeredPrompt.enabled = updates.enabled
-        this.sendPromptListChanged()
-      },
-    };
-    this._registeredPrompts[name] = registeredPrompt;
+      argsSchema,
+      cb as PromptCallback<PromptArgsRawShape | undefined>
+    );
 
     this.setPromptRequestHandlers();
     this.sendPromptListChanged()
@@ -1155,16 +1160,16 @@ export type RegisteredTool = {
   enable(): void;
   disable(): void;
   update<InputArgs extends ZodRawShape, OutputArgs extends ZodRawShape>(
-    updates: { 
-      name?: string | null, 
+    updates: {
+      name?: string | null,
       title?: string,
-      description?: string, 
-      paramsSchema?: InputArgs, 
-      outputSchema?: OutputArgs, 
-      annotations?: ToolAnnotations, 
-      callback?: ToolCallback<InputArgs>, 
-      enabled?: boolean 
-  }): void
+      description?: string,
+      paramsSchema?: InputArgs,
+      outputSchema?: OutputArgs,
+      annotations?: ToolAnnotations,
+      callback?: ToolCallback<InputArgs>,
+      enabled?: boolean
+    }): void
   remove(): void
 };
 
@@ -1212,12 +1217,13 @@ export type ReadResourceCallback = (
 
 export type RegisteredResource = {
   name: string;
+  title?: string;
   metadata?: ResourceMetadata;
   readCallback: ReadResourceCallback;
   enabled: boolean;
   enable(): void;
   disable(): void;
-  update(updates: { name?: string, uri?: string | null, metadata?: ResourceMetadata, callback?: ReadResourceCallback, enabled?: boolean }): void
+  update(updates: { name?: string, title?: string, uri?: string | null, metadata?: ResourceMetadata, callback?: ReadResourceCallback, enabled?: boolean }): void
   remove(): void
 };
 
@@ -1232,12 +1238,13 @@ export type ReadResourceTemplateCallback = (
 
 export type RegisteredResourceTemplate = {
   resourceTemplate: ResourceTemplate;
+  title?: string;
   metadata?: ResourceMetadata;
   readCallback: ReadResourceTemplateCallback;
   enabled: boolean;
   enable(): void;
   disable(): void;
-  update(updates: { name?: string | null, template?: ResourceTemplate, metadata?: ResourceMetadata, callback?: ReadResourceTemplateCallback, enabled?: boolean }): void
+  update(updates: { name?: string | null, title?: string, template?: ResourceTemplate, metadata?: ResourceMetadata, callback?: ReadResourceTemplateCallback, enabled?: boolean }): void
   remove(): void
 };
 

--- a/src/server/mcp.ts
+++ b/src/server/mcp.ts
@@ -114,6 +114,7 @@ export class McpServer {
           ([name, tool]): Tool => {
             const toolDefinition: Tool = {
               name,
+              title: tool.title,
               description: tool.description,
               inputSchema: tool.inputSchema
                 ? (zodToJsonSchema(tool.inputSchema, {
@@ -122,10 +123,6 @@ export class McpServer {
                 : EMPTY_OBJECT_JSON_SCHEMA,
               annotations: tool.annotations,
             };
-
-            if (tool.title !== undefined) {
-              toolDefinition.title = tool.title;
-            }
 
             if (tool.outputSchema) {
               toolDefinition.outputSchema = zodToJsonSchema(
@@ -472,19 +469,14 @@ export class McpServer {
           ([, prompt]) => prompt.enabled,
         ).map(
           ([name, prompt]): Prompt => {
-            const promptDefinition: Prompt = {
+            return {
               name,
+              title: prompt.title,
               description: prompt.description,
               arguments: prompt.argsSchema
                 ? promptArgumentsFromSchema(prompt.argsSchema)
                 : undefined,
             };
-
-            if (prompt.title !== undefined) {
-              promptDefinition.title = prompt.title;
-            }
-
-            return promptDefinition;
           },
         ),
       }),

--- a/src/server/title.test.ts
+++ b/src/server/title.test.ts
@@ -1,0 +1,194 @@
+import { Server } from "./index.js";
+import { Client } from "../client/index.js";
+import { InMemoryTransport } from "../inMemory.js";
+import { z } from "zod";
+import { McpServer } from "./mcp.js";
+
+describe("Title field backwards compatibility", () => {
+  it("should work with tools that have title", async () => {
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    
+    const server = new McpServer(
+      { name: "test-server", version: "1.0.0" },
+      { capabilities: {} }
+    );
+    
+    // Register tool with title
+    server.registerTool(
+      "test-tool",
+      {
+        title: "Test Tool Display Name",
+        description: "A test tool",
+        inputSchema: {
+          value: z.string()
+        }
+      },
+      async () => ({ content: [{ type: "text", text: "result" }] })
+    );
+    
+    const client = new Client({ name: "test-client", version: "1.0.0" });
+    
+    await server.server.connect(serverTransport);
+    await client.connect(clientTransport);
+    
+    const tools = await client.listTools();
+    expect(tools.tools).toHaveLength(1);
+    expect(tools.tools[0].name).toBe("test-tool");
+    expect(tools.tools[0].title).toBe("Test Tool Display Name");
+    expect(tools.tools[0].description).toBe("A test tool");
+  });
+
+  it("should work with tools without title", async () => {
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    
+    const server = new McpServer(
+      { name: "test-server", version: "1.0.0" },
+      { capabilities: {} }
+    );
+    
+    // Register tool without title
+    server.tool(
+      "test-tool",
+      "A test tool",
+      { value: z.string() },
+      async () => ({ content: [{ type: "text", text: "result" }] })
+    );
+    
+    const client = new Client({ name: "test-client", version: "1.0.0" });
+    
+    await server.server.connect(serverTransport);
+    await client.connect(clientTransport);
+    
+    const tools = await client.listTools();
+    expect(tools.tools).toHaveLength(1);
+    expect(tools.tools[0].name).toBe("test-tool");
+    expect(tools.tools[0].title).toBeUndefined();
+    expect(tools.tools[0].description).toBe("A test tool");
+  });
+
+  it("should work with prompts that have title using update", async () => {
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    
+    const server = new McpServer(
+      { name: "test-server", version: "1.0.0" },
+      { capabilities: {} }
+    );
+    
+    // Register prompt with title by updating after creation
+    const prompt = server.prompt(
+      "test-prompt",
+      "A test prompt",
+      async () => ({ messages: [{ role: "user", content: { type: "text", text: "test" } }] })
+    );
+    prompt.update({ title: "Test Prompt Display Name" });
+    
+    const client = new Client({ name: "test-client", version: "1.0.0" });
+    
+    await server.server.connect(serverTransport);
+    await client.connect(clientTransport);
+    
+    const prompts = await client.listPrompts();
+    expect(prompts.prompts).toHaveLength(1);
+    expect(prompts.prompts[0].name).toBe("test-prompt");
+    expect(prompts.prompts[0].title).toBe("Test Prompt Display Name");
+    expect(prompts.prompts[0].description).toBe("A test prompt");
+  });
+
+  it("should work with prompts using registerPrompt", async () => {
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    
+    const server = new McpServer(
+      { name: "test-server", version: "1.0.0" },
+      { capabilities: {} }
+    );
+    
+    // Register prompt with title using registerPrompt
+    server.registerPrompt(
+      "test-prompt",
+      {
+        title: "Test Prompt Display Name",
+        description: "A test prompt",
+        arguments: { input: z.string() }
+      },
+      async ({ input }) => ({ 
+        messages: [{ 
+          role: "user", 
+          content: { type: "text", text: `test: ${input}` } 
+        }] 
+      })
+    );
+    
+    const client = new Client({ name: "test-client", version: "1.0.0" });
+    
+    await server.server.connect(serverTransport);
+    await client.connect(clientTransport);
+    
+    const prompts = await client.listPrompts();
+    expect(prompts.prompts).toHaveLength(1);
+    expect(prompts.prompts[0].name).toBe("test-prompt");
+    expect(prompts.prompts[0].title).toBe("Test Prompt Display Name");
+    expect(prompts.prompts[0].description).toBe("A test prompt");
+    expect(prompts.prompts[0].arguments).toHaveLength(1);
+  });
+
+  it("should work with resources using registerResource", async () => {
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    
+    const server = new McpServer(
+      { name: "test-server", version: "1.0.0" },
+      { capabilities: {} }
+    );
+    
+    // Register resource with title using registerResource
+    server.registerResource(
+      "test-resource",
+      "https://example.com/test",
+      {
+        title: "Test Resource Display Name",
+        description: "A test resource",
+        mimeType: "text/plain"
+      },
+      async () => ({ 
+        contents: [{ 
+          uri: "https://example.com/test",
+          text: "test content" 
+        }] 
+      })
+    );
+    
+    const client = new Client({ name: "test-client", version: "1.0.0" });
+    
+    await server.server.connect(serverTransport);
+    await client.connect(clientTransport);
+    
+    const resources = await client.listResources();
+    expect(resources.resources).toHaveLength(1);
+    expect(resources.resources[0].name).toBe("test-resource");
+    expect(resources.resources[0].title).toBe("Test Resource Display Name");
+    expect(resources.resources[0].description).toBe("A test resource");
+    expect(resources.resources[0].mimeType).toBe("text/plain");
+  });
+
+  it("should support serverInfo with title", async () => {
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    
+    const server = new Server(
+      { 
+        name: "test-server",
+        version: "1.0.0",
+        title: "Test Server Display Name"
+      },
+      { capabilities: {} }
+    );
+    
+    const client = new Client({ name: "test-client", version: "1.0.0" });
+    
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+    
+    const serverInfo = client.getServerVersion();
+    expect(serverInfo?.name).toBe("test-server");
+    expect(serverInfo?.version).toBe("1.0.0");
+    expect(serverInfo?.title).toBe("Test Server Display Name");
+  });
+});

--- a/src/server/title.test.ts
+++ b/src/server/title.test.ts
@@ -185,7 +185,7 @@ describe("Title field backwards compatibility", () => {
         title: "User Profile",
         description: "User profile information"
       },
-      async (uri, { userId }, extra) => ({
+      async (uri, { userId }, _extra) => ({
         contents: [{
           uri: uri.href,
           text: `Profile data for user ${userId}`

--- a/src/server/title.test.ts
+++ b/src/server/title.test.ts
@@ -7,12 +7,12 @@ import { McpServer } from "./mcp.js";
 describe("Title field backwards compatibility", () => {
   it("should work with tools that have title", async () => {
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
-    
+
     const server = new McpServer(
       { name: "test-server", version: "1.0.0" },
       { capabilities: {} }
     );
-    
+
     // Register tool with title
     server.registerTool(
       "test-tool",
@@ -25,12 +25,12 @@ describe("Title field backwards compatibility", () => {
       },
       async () => ({ content: [{ type: "text", text: "result" }] })
     );
-    
+
     const client = new Client({ name: "test-client", version: "1.0.0" });
-    
+
     await server.server.connect(serverTransport);
     await client.connect(clientTransport);
-    
+
     const tools = await client.listTools();
     expect(tools.tools).toHaveLength(1);
     expect(tools.tools[0].name).toBe("test-tool");
@@ -40,12 +40,12 @@ describe("Title field backwards compatibility", () => {
 
   it("should work with tools without title", async () => {
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
-    
+
     const server = new McpServer(
       { name: "test-server", version: "1.0.0" },
       { capabilities: {} }
     );
-    
+
     // Register tool without title
     server.tool(
       "test-tool",
@@ -53,12 +53,12 @@ describe("Title field backwards compatibility", () => {
       { value: z.string() },
       async () => ({ content: [{ type: "text", text: "result" }] })
     );
-    
+
     const client = new Client({ name: "test-client", version: "1.0.0" });
-    
+
     await server.server.connect(serverTransport);
     await client.connect(clientTransport);
-    
+
     const tools = await client.listTools();
     expect(tools.tools).toHaveLength(1);
     expect(tools.tools[0].name).toBe("test-tool");
@@ -68,12 +68,12 @@ describe("Title field backwards compatibility", () => {
 
   it("should work with prompts that have title using update", async () => {
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
-    
+
     const server = new McpServer(
       { name: "test-server", version: "1.0.0" },
       { capabilities: {} }
     );
-    
+
     // Register prompt with title by updating after creation
     const prompt = server.prompt(
       "test-prompt",
@@ -81,12 +81,12 @@ describe("Title field backwards compatibility", () => {
       async () => ({ messages: [{ role: "user", content: { type: "text", text: "test" } }] })
     );
     prompt.update({ title: "Test Prompt Display Name" });
-    
+
     const client = new Client({ name: "test-client", version: "1.0.0" });
-    
+
     await server.server.connect(serverTransport);
     await client.connect(clientTransport);
-    
+
     const prompts = await client.listPrompts();
     expect(prompts.prompts).toHaveLength(1);
     expect(prompts.prompts[0].name).toBe("test-prompt");
@@ -96,33 +96,33 @@ describe("Title field backwards compatibility", () => {
 
   it("should work with prompts using registerPrompt", async () => {
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
-    
+
     const server = new McpServer(
       { name: "test-server", version: "1.0.0" },
       { capabilities: {} }
     );
-    
+
     // Register prompt with title using registerPrompt
     server.registerPrompt(
       "test-prompt",
       {
         title: "Test Prompt Display Name",
         description: "A test prompt",
-        arguments: { input: z.string() }
+        argsSchema: { input: z.string() }
       },
-      async ({ input }) => ({ 
-        messages: [{ 
-          role: "user", 
-          content: { type: "text", text: `test: ${input}` } 
-        }] 
+      async ({ input }) => ({
+        messages: [{
+          role: "user",
+          content: { type: "text", text: `test: ${input}` }
+        }]
       })
     );
-    
+
     const client = new Client({ name: "test-client", version: "1.0.0" });
-    
+
     await server.server.connect(serverTransport);
     await client.connect(clientTransport);
-    
+
     const prompts = await client.listPrompts();
     expect(prompts.prompts).toHaveLength(1);
     expect(prompts.prompts[0].name).toBe("test-prompt");
@@ -133,12 +133,12 @@ describe("Title field backwards compatibility", () => {
 
   it("should work with resources using registerResource", async () => {
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
-    
+
     const server = new McpServer(
       { name: "test-server", version: "1.0.0" },
       { capabilities: {} }
     );
-    
+
     // Register resource with title using registerResource
     server.registerResource(
       "test-resource",
@@ -148,19 +148,19 @@ describe("Title field backwards compatibility", () => {
         description: "A test resource",
         mimeType: "text/plain"
       },
-      async () => ({ 
-        contents: [{ 
+      async () => ({
+        contents: [{
           uri: "https://example.com/test",
-          text: "test content" 
-        }] 
+          text: "test content"
+        }]
       })
     );
-    
+
     const client = new Client({ name: "test-client", version: "1.0.0" });
-    
+
     await server.server.connect(serverTransport);
     await client.connect(clientTransport);
-    
+
     const resources = await client.listResources();
     expect(resources.resources).toHaveLength(1);
     expect(resources.resources[0].name).toBe("test-resource");
@@ -171,21 +171,21 @@ describe("Title field backwards compatibility", () => {
 
   it("should support serverInfo with title", async () => {
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
-    
+
     const server = new Server(
-      { 
+      {
         name: "test-server",
         version: "1.0.0",
         title: "Test Server Display Name"
       },
       { capabilities: {} }
     );
-    
+
     const client = new Client({ name: "test-client", version: "1.0.0" });
-    
+
     await server.connect(serverTransport);
     await client.connect(clientTransport);
-    
+
     const serverInfo = client.getServerVersion();
     expect(serverInfo?.name).toBe("test-server");
     expect(serverInfo?.version).toBe("1.0.0");

--- a/src/shared/metadataUtils.ts
+++ b/src/shared/metadataUtils.ts
@@ -6,11 +6,26 @@ import { BaseMetadata } from "../types.js";
 
 /**
  * Gets the display name for an object with BaseMetadata.
- * Returns the title if available, otherwise falls back to name.
+ * For tools, the precedence is: title → annotations.title → name
+ * For other objects: title → name
  * This implements the spec requirement: "if no title is provided, name should be used for display purposes"
  */
 export function getDisplayName(metadata: BaseMetadata): string {
-  return metadata.title ?? metadata.name;
+  // First check for title (not undefined and not empty string)
+  if (metadata.title !== undefined && metadata.title !== '') {
+    return metadata.title;
+  }
+  
+  // Then check for annotations.title (only present in Tool objects)
+  if ('annotations' in metadata) {
+    const metadataWithAnnotations = metadata as BaseMetadata & { annotations?: { title?: string } };
+    if (metadataWithAnnotations.annotations?.title) {
+      return metadataWithAnnotations.annotations.title;
+    }
+  }
+  
+  // Finally fall back to name
+  return metadata.name;
 }
 
 /**

--- a/src/shared/metadataUtils.ts
+++ b/src/shared/metadataUtils.ts
@@ -1,0 +1,21 @@
+import { BaseMetadata } from "../types.js";
+
+/**
+ * Utilities for working with BaseMetadata objects.
+ */
+
+/**
+ * Gets the display name for an object with BaseMetadata.
+ * Returns the title if available, otherwise falls back to name.
+ * This implements the spec requirement: "if no title is provided, name should be used for display purposes"
+ */
+export function getDisplayName(metadata: BaseMetadata): string {
+  return metadata.title ?? metadata.name;
+}
+
+/**
+ * Checks if an object has a custom title different from its name.
+ */
+export function hasCustomTitle(metadata: BaseMetadata): boolean {
+  return metadata.title !== undefined && metadata.title !== metadata.name;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -203,7 +203,14 @@ export const BaseMetadataSchema = z
   .object({
     /** Intended for programmatic or logical use, but used as a display name in past specs or fallback */
     name: z.string(),
-    /** Intended for UI and end-user contexts — optimized to be human-readable */
+    /**
+    * Intended for UI and end-user contexts — optimized to be human-readable and easily understood,
+    * even by those unfamiliar with domain-specific terminology.
+    *
+    * If not provided, the name should be used for display (except for Tool,
+    * where `annotations.title` should be given precedence over using `name`,
+    * if present).
+    */
     title: z.optional(z.string()),
   })
   .passthrough();

--- a/src/types.ts
+++ b/src/types.ts
@@ -195,16 +195,26 @@ export const CancelledNotificationSchema = NotificationSchema.extend({
   }),
 });
 
+/* Base Metadata */
+/**
+ * Base metadata interface for common properties across resources, tools, prompts, and implementations.
+ */
+export const BaseMetadataSchema = z
+  .object({
+    /** Intended for programmatic or logical use, but used as a display name in past specs or fallback */
+    name: z.string(),
+    /** Intended for UI and end-user contexts — optimized to be human-readable */
+    title: z.optional(z.string()),
+  })
+  .passthrough();
+
 /* Initialization */
 /**
  * Describes the name and version of an MCP implementation.
  */
-export const ImplementationSchema = z
-  .object({
-    name: z.string(),
-    version: z.string(),
-  })
-  .passthrough();
+export const ImplementationSchema = BaseMetadataSchema.extend({
+  version: z.string(),
+});
 
 /**
  * Capabilities a client may support. Known capabilities are defined here, in this schema, but this is not a closed set: any client can define its own, additional capabilities.
@@ -438,74 +448,56 @@ export const BlobResourceContentsSchema = ResourceContentsSchema.extend({
 /**
  * A known resource that the server is capable of reading.
  */
-export const ResourceSchema = z
-  .object({
-    /**
-     * The URI of this resource.
-     */
-    uri: z.string(),
+export const ResourceSchema = BaseMetadataSchema.extend({
+  /**
+   * The URI of this resource.
+   */
+  uri: z.string(),
 
-    /**
-     * A human-readable name for this resource.
-     *
-     * This can be used by clients to populate UI elements.
-     */
-    name: z.string(),
+  /**
+   * A description of what this resource represents.
+   *
+   * This can be used by clients to improve the LLM's understanding of available resources. It can be thought of like a "hint" to the model.
+   */
+  description: z.optional(z.string()),
 
-    /**
-     * A description of what this resource represents.
-     *
-     * This can be used by clients to improve the LLM's understanding of available resources. It can be thought of like a "hint" to the model.
-     */
-    description: z.optional(z.string()),
+  /**
+   * The MIME type of this resource, if known.
+   */
+  mimeType: z.optional(z.string()),
 
-    /**
-     * The MIME type of this resource, if known.
-     */
-    mimeType: z.optional(z.string()),
-
-    /**
-     * Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.
-    */
-    _meta: z.optional(z.object({}).passthrough()),
-  })
-  .passthrough();
+  /**
+   * Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.
+  */
+  _meta: z.optional(z.object({}).passthrough()),
+});
 
 /**
  * A template description for resources available on the server.
  */
-export const ResourceTemplateSchema = z
-  .object({
-    /**
-     * A URI template (according to RFC 6570) that can be used to construct resource URIs.
-     */
-    uriTemplate: z.string(),
+export const ResourceTemplateSchema = BaseMetadataSchema.extend({
+  /**
+   * A URI template (according to RFC 6570) that can be used to construct resource URIs.
+   */
+  uriTemplate: z.string(),
 
-    /**
-     * A human-readable name for the type of resource this template refers to.
-     *
-     * This can be used by clients to populate UI elements.
-     */
-    name: z.string(),
+  /**
+   * A description of what this template is for.
+   *
+   * This can be used by clients to improve the LLM's understanding of available resources. It can be thought of like a "hint" to the model.
+   */
+  description: z.optional(z.string()),
 
-    /**
-     * A description of what this template is for.
-     *
-     * This can be used by clients to improve the LLM's understanding of available resources. It can be thought of like a "hint" to the model.
-     */
-    description: z.optional(z.string()),
+  /**
+   * The MIME type for all resources that match this template. This should only be included if all resources matching this template have the same type.
+   */
+  mimeType: z.optional(z.string()),
 
-    /**
-     * The MIME type for all resources that match this template. This should only be included if all resources matching this template have the same type.
-     */
-    mimeType: z.optional(z.string()),
-
-    /**
-     * Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.
-    */
-    _meta: z.optional(z.object({}).passthrough()),
-  })
-  .passthrough();
+  /**
+   * Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.
+  */
+  _meta: z.optional(z.object({}).passthrough()),
+});
 
 /**
  * Sent from the client to request a list of resources the server has.
@@ -629,22 +621,16 @@ export const PromptArgumentSchema = z
 /**
  * A prompt or prompt template that the server offers.
  */
-export const PromptSchema = z
-  .object({
-    /**
-     * The name of the prompt or prompt template.
-     */
-    name: z.string(),
-    /**
-     * An optional description of what this prompt provides
-     */
-    description: z.optional(z.string()),
-    /**
-     * A list of arguments to use for templating the prompt.
-     */
-    arguments: z.optional(z.array(PromptArgumentSchema)),
-  })
-  .passthrough();
+export const PromptSchema = BaseMetadataSchema.extend({
+  /**
+   * An optional description of what this prompt provides
+   */
+  description: z.optional(z.string()),
+  /**
+   * A list of arguments to use for templating the prompt.
+   */
+  arguments: z.optional(z.array(PromptArgumentSchema)),
+});
 
 /**
  * Sent from the client to request a list of prompts and prompt templates the server has.
@@ -842,49 +828,43 @@ export const ToolAnnotationsSchema = z
 /**
  * Definition for a tool the client can call.
  */
-export const ToolSchema = z
-  .object({
-    /**
-     * The name of the tool.
-     */
-    name: z.string(),
-    /**
-     * A human-readable description of the tool.
-     */
-    description: z.optional(z.string()),
-    /**
-     * A JSON Schema object defining the expected parameters for the tool.
-     */
-    inputSchema: z
-      .object({
-        type: z.literal("object"),
-        properties: z.optional(z.object({}).passthrough()),
-        required: z.optional(z.array(z.string())),
-      })
-      .passthrough(),
-    /**
-     * An optional JSON Schema object defining the structure of the tool's output returned in 
-     * the structuredContent field of a CallToolResult.
-     */
-    outputSchema: z.optional(
-      z.object({
-        type: z.literal("object"),
-        properties: z.optional(z.object({}).passthrough()),
-        required: z.optional(z.array(z.string())),
-      })
-        .passthrough()
-    ),
-    /**
-     * Optional additional tool information.
-     */
-    annotations: z.optional(ToolAnnotationsSchema),
+export const ToolSchema = BaseMetadataSchema.extend({
+  /**
+   * A human-readable description of the tool.
+   */
+  description: z.optional(z.string()),
+  /**
+   * A JSON Schema object defining the expected parameters for the tool.
+   */
+  inputSchema: z
+    .object({
+      type: z.literal("object"),
+      properties: z.optional(z.object({}).passthrough()),
+      required: z.optional(z.array(z.string())),
+    })
+    .passthrough(),
+  /**
+   * An optional JSON Schema object defining the structure of the tool's output returned in 
+   * the structuredContent field of a CallToolResult.
+   */
+  outputSchema: z.optional(
+    z.object({
+      type: z.literal("object"),
+      properties: z.optional(z.object({}).passthrough()),
+      required: z.optional(z.array(z.string())),
+    })
+      .passthrough()
+  ),
+  /**
+   * Optional additional tool information.
+   */
+  annotations: z.optional(ToolAnnotationsSchema),
 
-    /**
-     * Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.
-    */
-    _meta: z.optional(z.object({}).passthrough()),
-  })
-  .passthrough();
+  /**
+   * Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.
+  */
+  _meta: z.optional(z.object({}).passthrough()),
+});
 
 /**
  * Sent from the client to request a list of tools the server has.
@@ -1346,6 +1326,9 @@ export type EmptyResult = Infer<typeof EmptyResultSchema>;
 
 /* Cancellation */
 export type CancelledNotification = Infer<typeof CancelledNotificationSchema>;
+
+/* Base Metadata */
+export type BaseMetadata = Infer<typeof BaseMetadataSchema>;
 
 /* Initialization */
 export type Implementation = Infer<typeof ImplementationSchema>;


### PR DESCRIPTION
Background: https://github.com/modelcontextprotocol/modelcontextprotocol/pull/663/files
Closes: https://github.com/modelcontextprotocol/typescript-sdk/issues/624

**Changes**

  - Added `BaseMetadata` interface with name (required) and title (optional) fields
  - Updated `Resource`, `Tool`, `Prompt`, and `Implementation` types to extend BaseMetadata
  - Added register* methods (`registerTool`, `registerPrompt`, `registerResource`) for consistent API patterns
  - Created metadataUtils with `getDisplayName()` helper function for title fallback logic
  - Updated server implementations to include title in list responses when defined
  - Added comprehensive tests for title functionality and backwards compatibility
  - Updated README documentation to showcase the new patterns
