### PR TITLE
Add missing _meta fields to match spec requirements

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -435,6 +435,10 @@ export const ResourceContentsSchema = z
      * The MIME type of this resource, if known.
      */
     mimeType: z.optional(z.string()),
+    /**
+     * Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.
+     */
+    _meta: z.optional(z.object({}).passthrough()),
   })
   .passthrough();
 
@@ -637,6 +641,10 @@ export const PromptSchema = BaseMetadataSchema.extend({
    * A list of arguments to use for templating the prompt.
    */
   arguments: z.optional(z.array(PromptArgumentSchema)),
+  /**
+   * Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.
+   */
+  _meta: z.optional(z.object({}).passthrough()),
 });
 
 /**
@@ -739,6 +747,10 @@ export const EmbeddedResourceSchema = z
   .object({
     type: z.literal("resource"),
     resource: z.union([TextResourceContentsSchema, BlobResourceContentsSchema]),
+    /**
+     * Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.
+     */
+    _meta: z.optional(z.object({}).passthrough()),
   })
   .passthrough();
 


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Added optional _meta field to ResourceContentsSchema, PromptSchema, and EmbeddedResourceSchema to align with spec change PR #710. These were the only schemas missing the _meta field that were required by the specification update.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
`npm run build`

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
N/A

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
