### PR TITLE
update _meta usage guidance in `types.ts`

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -44,8 +44,9 @@ export const RequestSchema = z.object({
 const BaseNotificationParamsSchema = z
   .object({
     /**
-     * Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.
-    */
+     * See [MCP specification](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/47339c03c143bb4ec01a26e721a1b8fe66634ebe/docs/specification/draft/basic/index.mdx#general-fields)
+     * for notes on _meta usage.
+     */
     _meta: z.optional(z.object({}).passthrough()),
   })
   .passthrough();
@@ -58,8 +59,9 @@ export const NotificationSchema = z.object({
 export const ResultSchema = z
   .object({
     /**
-     * Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.
-    */
+     * See [MCP specification](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/47339c03c143bb4ec01a26e721a1b8fe66634ebe/docs/specification/draft/basic/index.mdx#general-fields)
+     * for notes on _meta usage.
+     */
     _meta: z.optional(z.object({}).passthrough()),
   })
   .passthrough();
@@ -436,7 +438,8 @@ export const ResourceContentsSchema = z
      */
     mimeType: z.optional(z.string()),
     /**
-     * Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.
+     * See [MCP specification](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/47339c03c143bb4ec01a26e721a1b8fe66634ebe/docs/specification/draft/basic/index.mdx#general-fields)
+     * for notes on _meta usage.
      */
     _meta: z.optional(z.object({}).passthrough()),
   })
@@ -478,8 +481,9 @@ export const ResourceSchema = BaseMetadataSchema.extend({
   mimeType: z.optional(z.string()),
 
   /**
-   * Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.
-  */
+   * See [MCP specification](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/47339c03c143bb4ec01a26e721a1b8fe66634ebe/docs/specification/draft/basic/index.mdx#general-fields)
+   * for notes on _meta usage.
+   */
   _meta: z.optional(z.object({}).passthrough()),
 });
 
@@ -505,8 +509,9 @@ export const ResourceTemplateSchema = BaseMetadataSchema.extend({
   mimeType: z.optional(z.string()),
 
   /**
-   * Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.
-  */
+   * See [MCP specification](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/47339c03c143bb4ec01a26e721a1b8fe66634ebe/docs/specification/draft/basic/index.mdx#general-fields)
+   * for notes on _meta usage.
+   */
   _meta: z.optional(z.object({}).passthrough()),
 });
 
@@ -642,7 +647,8 @@ export const PromptSchema = BaseMetadataSchema.extend({
    */
   arguments: z.optional(z.array(PromptArgumentSchema)),
   /**
-   * Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.
+   * See [MCP specification](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/47339c03c143bb4ec01a26e721a1b8fe66634ebe/docs/specification/draft/basic/index.mdx#general-fields)
+   * for notes on _meta usage.
    */
   _meta: z.optional(z.object({}).passthrough()),
 });
@@ -690,8 +696,9 @@ export const TextContentSchema = z
     text: z.string(),
 
     /**
-     * Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.
-    */
+     * See [MCP specification](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/47339c03c143bb4ec01a26e721a1b8fe66634ebe/docs/specification/draft/basic/index.mdx#general-fields)
+     * for notes on _meta usage.
+     */
     _meta: z.optional(z.object({}).passthrough()),
   })
   .passthrough();
@@ -712,8 +719,9 @@ export const ImageContentSchema = z
     mimeType: z.string(),
 
     /**
-     * Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.
-    */
+     * See [MCP specification](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/47339c03c143bb4ec01a26e721a1b8fe66634ebe/docs/specification/draft/basic/index.mdx#general-fields)
+     * for notes on _meta usage.
+     */
     _meta: z.optional(z.object({}).passthrough()),
   })
   .passthrough();
@@ -734,8 +742,9 @@ export const AudioContentSchema = z
     mimeType: z.string(),
 
     /**
-     * Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.
-    */
+     * See [MCP specification](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/47339c03c143bb4ec01a26e721a1b8fe66634ebe/docs/specification/draft/basic/index.mdx#general-fields)
+     * for notes on _meta usage.
+     */
     _meta: z.optional(z.object({}).passthrough()),
   })
   .passthrough();
@@ -748,7 +757,8 @@ export const EmbeddedResourceSchema = z
     type: z.literal("resource"),
     resource: z.union([TextResourceContentsSchema, BlobResourceContentsSchema]),
     /**
-     * Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.
+     * See [MCP specification](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/47339c03c143bb4ec01a26e721a1b8fe66634ebe/docs/specification/draft/basic/index.mdx#general-fields)
+     * for notes on _meta usage.
      */
     _meta: z.optional(z.object({}).passthrough()),
   })
@@ -895,8 +905,9 @@ export const ToolSchema = BaseMetadataSchema.extend({
   annotations: z.optional(ToolAnnotationsSchema),
 
   /**
-   * Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.
-  */
+   * See [MCP specification](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/47339c03c143bb4ec01a26e721a1b8fe66634ebe/docs/specification/draft/basic/index.mdx#general-fields)
+   * for notes on _meta usage.
+   */
   _meta: z.optional(z.object({}).passthrough()),
 });
 
@@ -1230,8 +1241,9 @@ export const RootSchema = z
     name: z.optional(z.string()),
 
     /**
-     * Reserved by MCP for protocol-level metadata; implementations must not make assumptions about its contents.
-    */
+     * See [MCP specification](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/47339c03c143bb4ec01a26e721a1b8fe66634ebe/docs/specification/draft/basic/index.mdx#general-fields)
+     * for notes on _meta usage.
+     */
     _meta: z.optional(z.object({}).passthrough()),
   })
   .passthrough();


### PR DESCRIPTION
Tracking spec change, comment no longer says "make no assumptions" but points to [spec guidance re key format and reserved names](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/47339c03c143bb4ec01a26e721a1b8fe66634ebe/docs/specification/draft/basic/index.mdx#general-fields). 

Note: link is to commit-hashed version of spec doc, so changes to this language in spec will require an update to TS SDK, but other changes to the page should not.