### PR TITLE
Show session id per request in simpleStreamableHttp example server

### DIFF
--- a/src/examples/server/simpleStreamableHttp.ts
+++ b/src/examples/server/simpleStreamableHttp.ts
@@ -178,10 +178,10 @@ const getServer = () => {
   server.registerResource(
     'example-file-1',
     'file:///example/file1.txt',
-    { 
+    {
       title: 'Example File 1',
       description: 'First example file for ResourceLink demonstration',
-      mimeType: 'text/plain' 
+      mimeType: 'text/plain'
     },
     async (): Promise<ReadResourceResult> => {
       return {
@@ -198,10 +198,10 @@ const getServer = () => {
   server.registerResource(
     'example-file-2',
     'file:///example/file2.txt',
-    { 
+    {
       title: 'Example File 2',
       description: 'Second example file for ResourceLink demonstration',
-      mimeType: 'text/plain' 
+      mimeType: 'text/plain'
     },
     async (): Promise<ReadResourceResult> => {
       return {
@@ -338,15 +338,13 @@ const transports: { [sessionId: string]: StreamableHTTPServerTransport } = {};
 
 // MCP POST endpoint with optional auth
 const mcpPostHandler = async (req: Request, res: Response) => {
-  console.log('Received MCP request:', req.body);
+  const sessionId = req.headers['mcp-session-id'] as string | undefined;
+  console.log(sessionId? `Received MCP request for session: ${sessionId}`: 'Received MCP request:', req.body);
   if (useOAuth && req.auth) {
     console.log('Authenticated user:', req.auth);
   }
   try {
-    // Check for existing session ID
-    const sessionId = req.headers['mcp-session-id'] as string | undefined;
     let transport: StreamableHTTPServerTransport;
-
     if (sessionId && transports[sessionId]) {
       // Reuse existing transport
       transport = transports[sessionId];


### PR DESCRIPTION
- In src/examples/server/simpleStreamableHttp.ts
  - In  mcpPostHandler,
    - Get `mcp-session-id` header early so that it can be reported in every incoming request.
    - Helpful for troubleshooting Inspector's ability to retain the session id for the Proxy <-> Server leg
  - Linter fixed a few small whitespace foibles.
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
* A recent issue in the Inspector repo questioned the its proxy's ability to retain and send the appropriate `mcp-session-id` header to the server. 
* In order to demonstrate that each request following the `initialize` request carried this header with the appropriate id.
* This is a go-to, in-project server that we frequently test simple streamable connections as well as OAuth.
* The only problem was that this server did not report the session id for each incoming request, because it did not extract the header before reporting the request and its contents.
* This change simply gets the header as soon as the request comes in and if the sessionId is present, it includes it in its log output.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
* See: https://github.com/modelcontextprotocol/inspector/issues/492#issuecomment-2977083160 

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
Nope. 

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
