### PR TITLE
fix: expose ./dist/cjs/types.js in package.json exports for @modelcon…

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "./*": {
       "import": "./dist/esm/*",
       "require": "./dist/cjs/*"
-    }
+    },
+    "./types": "./dist/cjs/types.js"
   },
   "typesVersions": {
     "*": {


### PR DESCRIPTION
…textprotocol/sdk

- Add "./types": "./dist/cjs/types.js" to the "exports" field in package.json.
- Allows correct import of types from the MCP SDK in TypeScript projects using ts-node or internal paths.
- Fixes "Cannot find module .../dist/cjs/types" error when running custom MCP servers.
- Improves integration and extension of the SDK in modern Node.js environments.

<!-- Provide a brief summary of your changes -->

## Motivation and Context
- Fixes "Cannot find module .../dist/cjs/types" error when running custom MCP servers.

## How Has This Been Tested?
- tested reinstalling lib from fork and it solved the issue

## Breaking Changes
- nope

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed