### PR TITLE
Include supported scopes in authorization url

### DIFF
--- a/src/client/auth.ts
+++ b/src/client/auth.ts
@@ -169,6 +169,12 @@ export async function auth(
 
   const state = provider.state ? await provider.state() : undefined;
 
+  if (scope === undefined) {
+    if (metadata?.scopes_supported) {
+      scope = metadata.scopes_supported.join(" ");
+    }
+  }
+
   // Start new authorization flow
   const { authorizationUrl, codeVerifier } = await startAuthorization(authorizationServerUrl, {
     metadata,


### PR DESCRIPTION
Scope parameter missing in oauth authorize endpoint when using the quick oauth flow in MCP Inspector.

## Motivation and Context
https://github.com/modelcontextprotocol/inspector/issues/465
In the MCP Inspector, during guided oauth flow, a correct auth url is formed which includes scope parameter. This behavior is achieved by [this line](https://github.com/modelcontextprotocol/inspector/blob/90517273a4ce055df1f9f97d9fe44a097f88bd71/client/src/lib/oauth-state-machine.ts#L106). It makes sense to have the same logic in SDK.

## How Has This Been Tested?
Suggested change has been executed in DevTools, and authentication was successful.

## Breaking Changes
Possible breaking changes - previously if scope hasn't been provided, a fallback would be clientMetadata's `scope`. Now the first fallback is metadata's `supported_scopes`.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
The "should read messages" test is not passing locally on this branch, however it doesn't pass on main as well. All other tests are passing.