### PR TITLE
simpleStreamableHttp: fix example code

### DIFF
--- a/src/examples/server/demoInMemoryOAuthProvider.ts
+++ b/src/examples/server/demoInMemoryOAuthProvider.ts
@@ -151,7 +151,7 @@ export const setupAuthServer = ({authServerUrl, mcpServerUrl, strictResource}: {
   // server in the SDK. The SDK is not intended to be provide a standalone
   // authorization server.
 
-  const validateResource = strictResource ? resource => {
+  const validateResource = strictResource ? (resource?: URL) => {
     if (!resource) return false;
     const expectedResource = resourceUrlFromServerUrl(mcpServerUrl);
     return resource.toString() === expectedResource.toString();

--- a/src/examples/server/demoInMemoryOAuthProvider.ts
+++ b/src/examples/server/demoInMemoryOAuthProvider.ts
@@ -35,17 +35,8 @@ export class DemoInMemoryAuthProvider implements OAuthServerProvider {
     params: AuthorizationParams,
     client: OAuthClientInformationFull}>();
   private tokens = new Map<string, AuthInfo>();
-  private validateResource?: (resource?: URL) => boolean;
 
-  constructor({mcpServerUrl}: {mcpServerUrl?: URL} = {}) {
-    if (mcpServerUrl) {
-      const expectedResource = resourceUrlFromServerUrl(mcpServerUrl);
-      this.validateResource = (resource?: URL) => {
-        if (!resource) return false;
-        return resource.toString() === expectedResource.toString();
-      };
-    }
-  }
+  constructor(private validateResource?: (resource?: URL) => boolean) {}
 
   async authorize(
     client: OAuthClientInformationFull,
@@ -153,13 +144,20 @@ export class DemoInMemoryAuthProvider implements OAuthServerProvider {
 }
 
 
-export const setupAuthServer = (authServerUrl: URL, mcpServerUrl: URL): OAuthMetadata => {
+export const setupAuthServer = ({authServerUrl, mcpServerUrl, strictResource}: {authServerUrl: URL, mcpServerUrl: URL, strictResource: boolean}): OAuthMetadata => {
   // Create separate auth server app
   // NOTE: This is a separate app on a separate port to illustrate
   // how to separate an OAuth Authorization Server from a Resource
   // server in the SDK. The SDK is not intended to be provide a standalone
   // authorization server.
-  const provider = new DemoInMemoryAuthProvider({mcpServerUrl});
+
+  const validateResource = strictResource ? resource => {
+    if (!resource) return false;
+    const expectedResource = resourceUrlFromServerUrl(mcpServerUrl);
+    return resource.toString() === expectedResource.toString();
+  } : undefined;
+
+  const provider = new DemoInMemoryAuthProvider(validateResource);
   const authApp = express();
   authApp.use(express.json());
   // For introspection requests

--- a/src/examples/server/simpleStreamableHttp.ts
+++ b/src/examples/server/simpleStreamableHttp.ts
@@ -432,7 +432,7 @@ if (useOAuth) {
   const mcpServerUrl = new URL(`http://localhost:${MCP_PORT}/mcp`);
   const authServerUrl = new URL(`http://localhost:${AUTH_PORT}`);
 
-  const oauthMetadata: OAuthMetadata = setupAuthServer(authServerUrl, mcpServerUrl);
+  const oauthMetadata: OAuthMetadata = setupAuthServer({authServerUrl, mcpServerUrl, strictResource: strictOAuth});
 
   const tokenVerifier = {
     verifyAccessToken: async (token: string) => {


### PR DESCRIPTION
Update simpleStreamableHttp.ts example so its in-memory OAuth server isn't always strict (only make it strict if `--oauth-strict` isn't passed).

Follow up to https://github.com/modelcontextprotocol/typescript-sdk/pull/638 cc/ @pcarleton 

## Motivation and Context
While testing an old inspector's refresh flow w/ the new simpleStreamableHttp.ts, realized the in-memory oauth is too strict. This loosens it unless `--oauth-strict` is set.

## How Has This Been Tested?

Using a pre-resources inspector (before https://github.com/modelcontextprotocol/inspector/pull/526) + new typescript-sdk (after https://github.com/modelcontextprotocol/typescript-sdk/pull/638):

```
git clone https://github.com/modelcontextprotocol/typescript-sdk
( cd typescript-sdk && npx tsx src/examples/server/simpleStreamableHttp.ts  --oauth )& # no need for --oauth-strict here

git clone https://github.com/modelcontextprotocol/inspector
( cd inspector && npm run dev http://localhost:3000/mcp )

# Then:
# - Connect to the MCP server in the inspector (works),
# - Open the Auth panel
# - Click "Quick Refresh": fails!
# - Server console output says: "Invalid resource: undefined"
```

## Breaking Changes
None (just better example in main branch)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update (the example being a form of documentation)
