### PR TITLE
add overloads for registerResource method in McpServer class

### DIFF
--- a/src/server/mcp.ts
+++ b/src/server/mcp.ts
@@ -615,6 +615,18 @@ export class McpServer {
    */
   registerResource(
     name: string,
+    uriOrTemplate: string,
+    config: ResourceMetadata,
+    readCallback: ReadResourceCallback
+  ): RegisteredResource;
+  registerResource(
+    name: string,
+    uriOrTemplate: ResourceTemplate,
+    config: ResourceMetadata,
+    readCallback: ReadResourceTemplateCallback
+  ): RegisteredResourceTemplate;
+  registerResource(
+    name: string,
     uriOrTemplate: string | ResourceTemplate,
     config: ResourceMetadata,
     readCallback: ReadResourceCallback | ReadResourceTemplateCallback


### PR DESCRIPTION
## Motivation and Context

Without the overload, TypeScript struggles to distinguish between `ReadResourceCallback` and `ReadResourceTemplateCallback`.

## How Has This Been Tested?

Locally modified the sdk and verified the typings work as expected with this change.

## Breaking Changes

None.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->

Here's a real-world example that has issues without this change:

```ts

	agent.server.registerResource(
		'entry',
		new ResourceTemplate('epicme://entries/{id}', {
			complete: {
				async id(value) {
					const user = await agent.requireUser()
					const entries = await agent.db.getEntries(user.id)
					return entries
						.map((entry) => entry.id.toString())
						.filter((id) => id.includes(value))
				},
			},
			list: async () => {
				const user = await agent.requireUser()
				const entries = await agent.db.getEntries(user.id)
				return {
					resources: entries.map((entry) => ({
						name: entry.title,
						uri: `epicme://entries/${entry.id}`,
						mimeType: 'application/json',
					})),
				}
			},
		}),
		{ description: 'A journal entry' },
		async (uri: URL, { id }) => {
			const user = await agent.requireUser()
			const entry = await agent.db.getEntry(user.id, Number(id))
			invariant(entry, `Entry with ID "${id}" not found`)
			return {
				contents: [
					{
						mimeType: 'application/json',
						uri: uri.toString(),
						text: JSON.stringify(entry),
					},
				],
			}
		},
	)
```

Here's the type error:

```
Argument of type '(uri: URL, { id }: { id: any; }) => Promise<{ contents: { mimeType: string; uri: string; text: string; }[]; }>' is not assignable to parameter of type 'ReadResourceCallback | ReadResourceTemplateCallback'.
  Type '(uri: URL, { id }: { id: any; }) => Promise<{ contents: { mimeType: string; uri: string; text: string; }[]; }>' is not assignable to type 'ReadResourceCallback'.
    Types of parameters '__1' and 'extra' are incompatible.
      Property 'id' is missing in type 'RequestHandlerExtra<ServerRequest, ServerNotification>' but required in type '{ id: any; }'.ts(2345)
```

I can manually add `satisfies ReadResourceTemplateCallback` to the callback, but that should not be necessary and this change removes the issue entirely.