### PR TITLE
build: add watching script targets for build & simple streamable http server

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "build:esm:w": "npm run build:esm -- -w",
     "build:cjs": "mkdir -p dist/cjs && echo '{\"type\": \"commonjs\"}' > dist/cjs/package.json && tsc -p tsconfig.cjs.json",
     "build:cjs:w": "npm run build:cjs -- -w",
+    "examples:simple-server": "tsx src/examples/server/simpleStreamableHttp.ts --oauth",
     "prepack": "npm run build:esm && npm run build:cjs",
     "lint": "eslint src/",
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "build:esm:w": "npm run build:esm -- -w",
     "build:cjs": "mkdir -p dist/cjs && echo '{\"type\": \"commonjs\"}' > dist/cjs/package.json && tsc -p tsconfig.cjs.json",
     "build:cjs:w": "npm run build:cjs -- -w",
-    "examples:simple-server": "tsx src/examples/server/simpleStreamableHttp.ts --oauth",
+    "examples:simple-server:w": "tsx --watch src/examples/server/simpleStreamableHttp.ts --oauth",
     "prepack": "npm run build:esm && npm run build:cjs",
     "lint": "eslint src/",
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -36,8 +36,10 @@
   ],
   "scripts": {
     "build": "npm run build:esm && npm run build:cjs",
-    "build:esm": "tsc -p tsconfig.prod.json && echo '{\"type\": \"module\"}' > dist/esm/package.json",
-    "build:cjs": "tsc -p tsconfig.cjs.json && echo '{\"type\": \"commonjs\"}' > dist/cjs/package.json",
+    "build:esm": "mkdir -p dist/esm && echo '{\"type\": \"module\"}' > dist/esm/package.json && tsc -p tsconfig.prod.json",
+    "build:esm:w": "npm run build:esm -- -w",
+    "build:cjs": "mkdir -p dist/cjs && echo '{\"type\": \"commonjs\"}' > dist/cjs/package.json && tsc -p tsconfig.cjs.json",
+    "build:cjs:w": "npm run build:cjs -- -w",
     "prepack": "npm run build:esm && npm run build:cjs",
     "lint": "eslint src/",
     "test": "jest",


### PR DESCRIPTION
Add "watching" scripts build:esm:w / build:cjs:w / examples:simple-server:w

## Motivation and Context

This is to prepare a better DX for co-development of the SDK + inspector (goal = any edit in either codebases, for any client or server code, should be reflected live in the inspector), which is being added in <...>

## How Has This Been Tested?

See <...>