### PR TITLE
feat: add controlled client-side logging that respects NODE_ENV

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -15,5 +15,12 @@ export default tseslint.config(
                 { "argsIgnorePattern": "^_" }
             ]
         }
+    },
+    {
+        files: ["src/client/**/*.ts"],
+        ignores: ["src/client/logging.ts"],
+        rules: {
+            "no-console": "error"
+        }
     }
 );

--- a/src/client/auth.ts
+++ b/src/client/auth.ts
@@ -3,6 +3,7 @@ import { LATEST_PROTOCOL_VERSION } from "../types.js";
 import type { OAuthClientMetadata, OAuthClientInformation, OAuthTokens, OAuthMetadata, OAuthClientInformationFull, OAuthProtectedResourceMetadata } from "../shared/auth.js";
 import { OAuthClientInformationFullSchema, OAuthMetadataSchema, OAuthProtectedResourceMetadataSchema, OAuthTokensSchema } from "../shared/auth.js";
 import { resourceUrlFromServerUrl } from "../shared/auth-utils.js";
+import { logger } from "./logging.js";
 
 /**
  * Implements an end-to-end OAuth client to be used with one MCP server.
@@ -117,7 +118,7 @@ export async function auth(
       authorizationServerUrl = resourceMetadata.authorization_servers[0];
     }
   } catch (error) {
-    console.warn("Could not load OAuth Protected Resource metadata, falling back to /.well-known/oauth-authorization-server", error)
+    logger.warn("Could not load OAuth Protected Resource metadata, falling back to /.well-known/oauth-authorization-server", error)
   }
 
   const resource: URL | undefined = await selectResourceURL(serverUrl, provider, resourceMetadata);
@@ -176,7 +177,7 @@ export async function auth(
       await provider.saveTokens(newTokens);
       return "AUTHORIZED";
     } catch (error) {
-      console.error("Could not refresh OAuth tokens:", error);
+      logger.error("Could not refresh OAuth tokens:", error);
     }
   }
 
@@ -222,7 +223,7 @@ export function extractResourceMetadataUrl(res: Response): URL | undefined {
 
   const [type, scheme] = authenticateHeader.split(' ');
   if (type.toLowerCase() !== 'bearer' || !scheme) {
-    console.log("Invalid WWW-Authenticate header format, expected 'Bearer'");
+    logger.log("Invalid WWW-Authenticate header format, expected 'Bearer'");
     return undefined;
   }
   const regex = /resource_metadata="([^"]*)"/;
@@ -235,7 +236,7 @@ export function extractResourceMetadataUrl(res: Response): URL | undefined {
   try {
     return new URL(match[1]);
   } catch {
-    console.log("Invalid resource metadata url: ", match[1]);
+    logger.log("Invalid resource metadata url: ", match[1]);
     return undefined;
   }
 }

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -45,6 +45,7 @@ import {
 } from "../types.js";
 import Ajv from "ajv";
 import type { ValidateFunction } from "ajv";
+import { logger } from "./logging.js";
 
 export type ClientOptions = ProtocolOptions & {
   /**
@@ -487,7 +488,7 @@ export class Client<
           const validator = this._ajv.compile(tool.outputSchema);
           this._cachedToolOutputValidators.set(tool.name, validator);
         } catch (error) {
-          console.warn(`Failed to compile output schema for tool ${tool.name}: ${error}`);
+          logger.warn(`Failed to compile output schema for tool ${tool.name}: ${error}`);
         }
       }
     }

--- a/src/client/logging.ts
+++ b/src/client/logging.ts
@@ -1,0 +1,41 @@
+/**
+ * Client-side logging utility that suppresses console output in production environments.
+ * Logs are shown when NODE_ENV is not set to 'production'.
+ */
+
+const isDebugEnabled = (): boolean => {
+  // Allow logging unless explicitly in production
+  if (typeof process !== "undefined" && process.env) {
+    return process.env.NODE_ENV !== "production";
+  }
+  // If process.env is not available, default to allowing logs
+  return true;
+};
+
+const debugEnabled = isDebugEnabled();
+
+export const logger = {
+  log: (...args: unknown[]): void => {
+    if (debugEnabled) {
+      console.log(...args);
+    }
+  },
+
+  warn: (...args: unknown[]): void => {
+    if (debugEnabled) {
+      console.warn(...args);
+    }
+  },
+
+  error: (...args: unknown[]): void => {
+    if (debugEnabled) {
+      console.error(...args);
+    }
+  },
+
+  debug: (...args: unknown[]): void => {
+    if (debugEnabled) {
+      console.debug(...args);
+    }
+  },
+};


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

- Add logging utility that suppresses output when NODE_ENV=production
- Replace all console usage in client code with logger
- Add ESLint no-console rule for client code (except logging.ts)

Fixes https://github.com/modelcontextprotocol/typescript-sdk/issues/615

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

This prevents unwanted console output in production environments like Claude Code while still allowing debugging in development. Otherwise the `console.warn` appears in the terminal output.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

Tested locally against Claude Code build

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
