### PR TITLE
fix: add type safety for tool output schemas in ToolCallback

### DIFF
--- a/src/examples/server/mcpServerOutputSchema.ts
+++ b/src/examples/server/mcpServerOutputSchema.ts
@@ -43,7 +43,14 @@ server.registerTool(
     void country;
     // Simulate weather API call
     const temp_c = Math.round((Math.random() * 35 - 5) * 10) / 10;
-    const conditions = ["sunny", "cloudy", "rainy", "stormy", "snowy"][Math.floor(Math.random() * 5)] as unknown as "sunny" | "cloudy" | "rainy" | "stormy" | "snowy";
+    const conditionCandidates = [
+      "sunny",
+      "cloudy",
+      "rainy",
+      "stormy",
+      "snowy",
+    ] as const;
+    const conditions = conditionCandidates[Math.floor(Math.random() * conditionCandidates.length)];
 
     const structuredContent = {
       temperature: {

--- a/src/examples/server/mcpServerOutputSchema.ts
+++ b/src/examples/server/mcpServerOutputSchema.ts
@@ -43,7 +43,7 @@ server.registerTool(
     void country;
     // Simulate weather API call
     const temp_c = Math.round((Math.random() * 35 - 5) * 10) / 10;
-    const conditions = ["sunny", "cloudy", "rainy", "stormy", "snowy"][Math.floor(Math.random() * 5)];
+    const conditions = ["sunny", "cloudy", "rainy", "stormy", "snowy"][Math.floor(Math.random() * 5)] as unknown as "sunny" | "cloudy" | "rainy" | "stormy" | "snowy";
 
     const structuredContent = {
       temperature: {

--- a/src/server/mcp.test.ts
+++ b/src/server/mcp.test.ts
@@ -1248,8 +1248,7 @@ describe("tool()", () => {
           processedInput: input,
           resultType: "structured",
           // Missing required 'timestamp' field
-          someExtraField: "unexpected" // Extra field not in schema
-        },
+        } as unknown as { processedInput: string; resultType: string; timestamp: string }, // Type assertion to bypass TypeScript validation for testing purposes
       })
     );
 

--- a/src/server/mcp.test.ts
+++ b/src/server/mcp.test.ts
@@ -1248,6 +1248,7 @@ describe("tool()", () => {
           processedInput: input,
           resultType: "structured",
           // Missing required 'timestamp' field
+          someExtraField: "unexpected" // Extra field not in schema
         } as unknown as { processedInput: string; resultType: string; timestamp: string }, // Type assertion to bypass TypeScript validation for testing purposes
       })
     );


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context

Enhances `ToolCallback` to support type-safe structured outputs
by introducing a second generic parameter for the output schema.
fixes: https://github.com/modelcontextprotocol/typescript-sdk/issues/669
<!-- Why is this change needed? What problem does it solve? -->

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Passing all existing tests.
No need for adding new tests as no change for runtime behavior.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
None.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
