### PR TITLE
Add OIDC ID token support

### DIFF
--- a/src/shared/auth.ts
+++ b/src/shared/auth.ts
@@ -62,6 +62,7 @@ export const OAuthMetadataSchema = z
 export const OAuthTokensSchema = z
   .object({
     access_token: z.string(),
+    id_token: z.string().optional(), // Optional for OAuth 2.1, but necessary in OpenID Connect
     token_type: z.string(),
     expires_in: z.number().optional(),
     scope: z.string().optional(),


### PR DESCRIPTION
<\!-- Provide a brief summary of your changes -->
Add support for OpenID Connect ID tokens in OAuth responses. When an auth server returns an ID token (typically when the scope includes "openid"), it will now be preserved and passed through to the client.

## Motivation and Context
<\!-- Why is this change needed? What problem does it solve? -->
This change enables MCP SDK to work with OpenID Connect providers that return ID tokens. Previously, the SDK would discard ID tokens even when they were provided by the auth server. This is needed for full OIDC compliance and to support auth providers that require ID token validation.

## How Has This Been Tested?
<\!-- Have you tested this in a real application? Which scenarios were tested? -->
- Added unit test to verify ID token is preserved when returned by auth server
- Tested that existing OAuth flows without ID tokens continue to work unchanged
- All existing tests pass

## Breaking Changes
<\!-- Will users need to update their code or configurations? -->
No breaking changes. The ID token field is optional and existing code will continue to work without modification.

## Types of changes
<\!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<\!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<\!-- Add any other context, implementation notes, or design decisions -->
This change is minimal and non-invasive - it simply adds an optional `id_token` field to the `OAuthTokensSchema`. The field is marked as optional to maintain backward compatibility. No additional validation or processing of the ID token is performed at this time.