### PR TITLE
Add prompt=consent for OIDC offline_access scope

### DIFF
--- a/src/client/auth.test.ts
+++ b/src/client/auth.test.ts
@@ -394,6 +394,20 @@ describe("OAuth Authorization", () => {
       expect(authorizationUrl.searchParams.has("state")).toBe(false);
     });
 
+    // OpenID Connect requires that the user is prompted for consent if the scope includes 'offline_access'
+    it("includes consent prompt parameter if scope includes 'offline_access'", async () => {
+      const { authorizationUrl } = await startAuthorization(
+          "https://auth.example.com",
+          {
+            clientInformation: validClientInfo,
+            redirectUrl: "http://localhost:3000/callback",
+            scope: "read write profile offline_access",
+          }
+      );
+
+      expect(authorizationUrl.searchParams.get("prompt")).toBe("consent");
+    });
+
     it("uses metadata authorization_endpoint when provided", async () => {
       const { authorizationUrl } = await startAuthorization(
         "https://auth.example.com",

--- a/src/client/auth.ts
+++ b/src/client/auth.ts
@@ -395,6 +395,13 @@ export async function startAuthorization(
     authorizationUrl.searchParams.set("scope", scope);
   }
 
+  if (scope?.includes("offline_access")) {
+    // if the request includes the OIDC-only "offline_access" scope,
+    // we need to set the prompt to "consent" to ensure the user is prompted to grant offline access
+    // https://openid.net/specs/openid-connect-core-1_0.html#OfflineAccess
+    authorizationUrl.searchParams.append("prompt", "consent");
+  }
+
   if (resource) {
     authorizationUrl.searchParams.set("resource", resource.href);
   }


### PR DESCRIPTION
<\!-- Provide a brief summary of your changes -->
Add automatic prompt=consent parameter when requesting offline_access scope in OpenID Connect flows. This ensures proper user consent for refresh token issuance as required by the OIDC specification.

## Motivation and Context
<\!-- Why is this change needed? What problem does it solve? -->
OpenID Connect specification requires that when requesting the "offline_access" scope (which grants refresh tokens), the authorization server must ensure the user explicitly consents to this access. By adding prompt=consent when offline_access is requested, we ensure OIDC-compliant authorization servers properly prompt users for consent.

Reference: https://openid.net/specs/openid-connect-core-1_0.html#OfflineAccess

## How Has This Been Tested?
<\!-- Have you tested this in a real application? Which scenarios were tested? -->
- Added unit test to verify prompt=consent is added when scope includes offline_access
- Verified existing authorization flows without offline_access are unaffected
- All existing tests pass

## Breaking Changes
<\!-- Will users need to update their code or configurations? -->
No breaking changes. This only affects flows that request the offline_access scope, and ensures they comply with OIDC requirements.

## Types of changes
<\!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<\!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<\!-- Add any other context, implementation notes, or design decisions -->
This change specifically checks if the requested scope includes "offline_access" and appends prompt=consent to the authorization URL. This is a minimal change that improves OIDC compliance without affecting existing OAuth 2.0 flows.