### PR TITLE
Allow boolean and enum in registerPrompt argsSchema

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ server.registerPrompt(
   {
     title: "Code Review",
     description: "Review code for best practices and potential issues",
+    // can use string, boolean or enum
     argsSchema: { code: z.string() }
   },
   ({ code }) => ({

--- a/src/server/mcp.ts
+++ b/src/server/mcp.ts
@@ -10,6 +10,9 @@ import {
   ZodType,
   ZodTypeDef,
   ZodOptional,
+  ZodDefault,
+  ZodEnum,
+  ZodBoolean,
 } from "zod";
 import {
   Implementation,
@@ -1246,7 +1249,14 @@ export type RegisteredResourceTemplate = {
 type PromptArgsRawShape = {
   [k: string]:
   | ZodType<string, ZodTypeDef, string>
-  | ZodOptional<ZodType<string, ZodTypeDef, string>>;
+  | ZodBoolean
+  | ZodDefault<ZodBoolean>
+  | ZodDefault<ZodOptional<ZodBoolean>>
+  | ZodEnum<[string, ...string[]]>
+  | ZodDefault<ZodEnum<[string, ...string[]]>>
+  | ZodDefault<ZodOptional<ZodEnum<[string, ...string[]]>>>
+  | ZodOptional<ZodType<string, ZodTypeDef, string>>
+  | ZodDefault<ZodOptional<ZodType<string, ZodTypeDef, string>>>;
 };
 
 export type PromptCallback<

--- a/src/types.ts
+++ b/src/types.ts
@@ -685,7 +685,11 @@ export const GetPromptRequestSchema = RequestSchema.extend({
     /**
      * Arguments to use for templating the prompt.
      */
-    arguments: z.optional(z.record(z.string())),
+    arguments: z.optional(z.record(z.union([
+      z.string(),
+      z.boolean(),
+      z.object({ type: z.literal("enum"), enum: z.array(z.string()) })
+    ]))),
   }),
 });
 


### PR DESCRIPTION
## Motivation and Context
Being able to take user input that is boolean or enumerated values is useful when creating prompt callback functions and allows deeper prompt argument validation than strings only.

## How Has This Been Tested?
Unit test coverage added

## Breaking Changes
No breaking changes, backwards compatibility is maintained

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
Other Zod types, such as number, could be supported  as well
