### PR TITLE
feat(shared/auth): support software_statement in OAuthClientMetadata

### DIFF
--- a/src/shared/auth.ts
+++ b/src/shared/auth.ts
@@ -98,6 +98,7 @@ export const OAuthClientMetadataSchema = z.object({
   jwks: z.any().optional(),
   software_id: z.string().optional(),
   software_version: z.string().optional(),
+  software_statement: z.string().optional(),
 }).strip();
 
 /**


### PR DESCRIPTION
Per [Section 3.1.1][ref], `software_statement` is an OPTIONAL member of the client creation request, which may contain a JWT encoding claims about client software.

[ref]: https://datatracker.ietf.org/doc/html/rfc7591#section-3.1.1

## Motivation and Context

This allows clients to "pre-register" applications with authorization servers without having to distribute confidential client secret information. Allowing this to be specified will allow SDK users to specify a JWT if they've been issued one.

## How Has This Been Tested?

This ran through the local tests.

## Breaking Changes

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed