### PR TITLE
Added Sampling Examples to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,7 +393,7 @@ import {CreateMessageResult} from "@modelcontextprotocol/sdk/types.js";
 
 // Async Function to send a sampling request to the LLM at top-level
 async function samplingExample(server: McpServer): Promise<CreateMessageResult> {	
-  const samplingText = "Text prompt to send to LLM";
+  const samplingText = "Example Sampling Prompt";
   const result = await McpServer.server.createMessage(
     {
       messages : [{

--- a/README.md
+++ b/README.md
@@ -393,20 +393,20 @@ import {CreateMessageResult} from "@modelcontextprotocol/sdk/types.js";
 
 // Async Function to send a sampling request to the LLM at top-level
 async function samplingExample(server: McpServer): Promise<CreateMessageResult> {	
-	const samplingText = "Text prompt to send to LLM";
-	const result = await McpServer.server.createMessage(
-		{
-			messages : [{
-				role: "user",
-				content: {
-					text: samplingText,
-				type: "text"
-				}
-			}],
-			maxTokens: 1000
-		}
-	);
-	return result;
+  const samplingText = "Text prompt to send to LLM";
+  const result = await McpServer.server.createMessage(
+    {
+      messages : [{
+        role: "user",
+        content: {
+          text: samplingText,
+          type: "text"
+        }
+      }],
+      maxTokens: 1000
+    }
+  );
+  return result;
 }
 
 // Sampling request just after connecting to MCP Client

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
   - [Tools](#tools)
   - [Prompts](#prompts)
   - [Completions](#completions)
+  - [Sampling](#sampling)
 - [Running Your Server](#running-your-server)
   - [stdio](#stdio)
   - [Streamable HTTP](#streamable-http)
@@ -380,6 +381,37 @@ import { getDisplayName } from "@modelcontextprotocol/sdk/shared/metadataUtils.j
 
 // Automatically handles the precedence: title → annotations.title → name
 const displayName = getDisplayName(tool);
+```
+
+### Sampling
+
+MCP servers can also request MCP client LLMs for responses. Below is an example of a sampling request sent just after connecting to the Client
+
+```typescript
+// Result sent back from LLM follow the CreateMessageSchema
+import {CreateMessageResult} from "@modelcontextprotocol/sdk/types.js";
+
+// Async Function to send a sampling request to the LLM at top-level
+async function samplingExample(server: McpServer): Promise<CreateMessageResult> {	
+	const samplingText = "Text prompt to send to LLM";
+	const result = await McpServer.server.createMessage(
+		{
+			messages : [{
+				role: "user",
+				content: {
+					text: samplingText,
+				type: "text"
+				}
+			}],
+			maxTokens: 1000
+		}
+	);
+	return result;
+}
+
+// Sampling request just after connecting to MCP Client
+server.connect(transport);
+samplingExample(server);
 ```
 
 ## Running Your Server


### PR DESCRIPTION
## Motivation and Context

I had opened #697 earlier today when I was trying to find out how to send sampling requests to MCP Clients from an MCP Server made using our SDK. There is no explicit mention of "Sampling" in the README while the SDK supports this function.

## How Has This Been Tested?
I have tested this example to work. The received result in the attached example is of the below format when used with VS Code's Github Co-Pilot as the client:

```json
{
    "model" : "github.copilot-chat/gpt-4.1",
    "role" : "assistant",
    "content": {
        "type" : "text",
        "text" : "text response"
    }
}
```

## Breaking Changes
No Breakages

## Types of changes
- [ x ] Documentation update

## Checklist
- [ x ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ x ] My code follows the repository's style guidelines
- [ NA ] New and existing tests pass locally
- [ NA ] I have added appropriate error handling
- [ x ] I have added or updated documentation as needed

