### PR TITLE
Allow enum in registerPrompt argsSchema

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ server.registerPrompt(
   {
     title: "Code Review",
     description: "Review code for best practices and potential issues",
+    // can use string, boolean or enum
     argsSchema: { code: z.string() }
   },
   ({ code }) => ({

--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ server.registerPrompt(
   {
     title: "Code Review",
     description: "Review code for best practices and potential issues",
-    // can use string, boolean or enum
+    // can use string or enum
     argsSchema: { code: z.string() }
   },
   ({ code }) => ({

--- a/src/server/mcp.test.ts
+++ b/src/server/mcp.test.ts
@@ -4010,7 +4010,7 @@ describe("Tool title precedence", () => {
   });
 });
 
-  test("registerPrompt schema should support strings, booleans and enums", async () => {
+  test("registerPrompt schema should support strings and enums", async () => {
     const mcpServer = new McpServer({
       name: "test server",
       version: "1.0",
@@ -4028,17 +4028,16 @@ describe("Tool title precedence", () => {
         description: "Generate a greeting for team members",
         argsSchema: {
           name: z.string(),
-          initialize: z.boolean().optional().default(false),
           visibility: z.enum(["public", "private"]).optional().default("private"),
         }
       },
-      async ({ initialize, name, visibility }) => ({
+      async ({ name, visibility }) => ({
         messages: [
           {
             role: "assistant",
             content: {
               type: "text",
-              text: `Creating${initialize ? " and initializing" : ""} a new project named ${name} with visibility ${visibility}.`,
+              text: `Creating a new project named ${name} with visibility ${visibility}.`,
             },
           },
         ],
@@ -4057,12 +4056,21 @@ describe("Tool title precedence", () => {
       name: "test-prompt",
       arguments: {
         name: "Test Project",
-        initialize: true,
         visibility: "public"
       }
     });
 
-    expect(result1.messages[0].content.text).toBe("Creating and initializing a new project named Test Project with visibility public.");
+    expect(result1.messages[0].content.text).toBe("Creating a new project named Test Project with visibility public.");
+
+    await expect(
+      client.getPrompt({
+        name: "test-prompt",
+        arguments: {
+          name: "Test Project",
+          visibility: "foo"
+        }
+      }),
+    ).rejects.toThrow();
 });
 
 describe("elicitInput()", () => {

--- a/src/server/mcp.ts
+++ b/src/server/mcp.ts
@@ -12,7 +12,6 @@ import {
   ZodOptional,
   ZodDefault,
   ZodEnum,
-  ZodBoolean,
 } from "zod";
 import {
   Implementation,
@@ -1249,9 +1248,6 @@ export type RegisteredResourceTemplate = {
 type PromptArgsRawShape = {
   [k: string]:
   | ZodType<string, ZodTypeDef, string>
-  | ZodBoolean
-  | ZodDefault<ZodBoolean>
-  | ZodDefault<ZodOptional<ZodBoolean>>
   | ZodEnum<[string, ...string[]]>
   | ZodDefault<ZodEnum<[string, ...string[]]>>
   | ZodDefault<ZodOptional<ZodEnum<[string, ...string[]]>>>

--- a/src/server/mcp.ts
+++ b/src/server/mcp.ts
@@ -10,6 +10,9 @@ import {
   ZodType,
   ZodTypeDef,
   ZodOptional,
+  ZodDefault,
+  ZodEnum,
+  ZodBoolean,
 } from "zod";
 import {
   Implementation,
@@ -1246,7 +1249,14 @@ export type RegisteredResourceTemplate = {
 type PromptArgsRawShape = {
   [k: string]:
   | ZodType<string, ZodTypeDef, string>
-  | ZodOptional<ZodType<string, ZodTypeDef, string>>;
+  | ZodBoolean
+  | ZodDefault<ZodBoolean>
+  | ZodDefault<ZodOptional<ZodBoolean>>
+  | ZodEnum<[string, ...string[]]>
+  | ZodDefault<ZodEnum<[string, ...string[]]>>
+  | ZodDefault<ZodOptional<ZodEnum<[string, ...string[]]>>>
+  | ZodOptional<ZodType<string, ZodTypeDef, string>>
+  | ZodDefault<ZodOptional<ZodType<string, ZodTypeDef, string>>>;
 };
 
 export type PromptCallback<

--- a/src/types.ts
+++ b/src/types.ts
@@ -687,7 +687,6 @@ export const GetPromptRequestSchema = RequestSchema.extend({
      */
     arguments: z.optional(z.record(z.union([
       z.string(),
-      z.boolean(),
       z.object({ type: z.literal("enum"), enum: z.array(z.string()) })
     ]))),
   }),

--- a/src/types.ts
+++ b/src/types.ts
@@ -685,7 +685,11 @@ export const GetPromptRequestSchema = RequestSchema.extend({
     /**
      * Arguments to use for templating the prompt.
      */
-    arguments: z.optional(z.record(z.string())),
+    arguments: z.optional(z.record(z.union([
+      z.string(),
+      z.boolean(),
+      z.object({ type: z.literal("enum"), enum: z.array(z.string()) })
+    ]))),
   }),
 });
 


### PR DESCRIPTION
## Motivation and Context
Being able to take user input that is enumerated values is useful when creating prompt callback functions and allows deeper prompt argument validation. [Zod enum](https://zod.dev/api?id=enums) enforce a fixed set of strings at the SDK layer while still sending strings to the spec.

## How Has This Been Tested?
Unit test coverage added

## Breaking Changes
No breaking changes, backwards compatibility is maintained

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
Follow up to #691 with enum only. Spec changes will be needed to support other Zod schema types, such as boolean, as the spec currently only supports strings.