### PR TITLE
feat: Add CORS configuration for browser-based MCP clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -570,18 +570,7 @@ app.listen(3000);
 ```
 
 > [!TIP]
-> When using this in a remote environment, make sure to allow the header parameter `mcp-session-id` in CORS. Otherwise, it may result in a `Bad Request: No valid session ID provided` error. 
-> 
-> For example, in Node.js you can configure it like this:
-> 
-> ```ts
-> app.use(
->   cors({
->     origin: ['https://your-remote-domain.com, https://your-other-remote-domain.com'],
->     exposedHeaders: ['mcp-session-id'],
->     allowedHeaders: ['Content-Type', 'mcp-session-id'],
->   })
-> );
+> When using this in a remote environment, make sure to allow the header parameter `mcp-session-id` in CORS. Otherwise, it may result in a `Bad Request: No valid session ID provided` error. Read the following section for examples.
 > ```
 
 
@@ -594,8 +583,10 @@ import cors from 'cors';
 
 // Add CORS middleware before your MCP routes
 app.use(cors({
-  origin: '*', // Configure appropriately for production
+  origin: '*', // Configure appropriately for production, for example:
+  // origin: ['https://your-remote-domain.com, https://your-other-remote-domain.com'],
   exposedHeaders: ['Mcp-Session-Id']
+  allowedHeaders: ['Content-Type', 'mcp-session-id'],
 }));
 ```
 

--- a/README.md
+++ b/README.md
@@ -584,6 +584,26 @@ app.listen(3000);
 > );
 > ```
 
+
+#### CORS Configuration for Browser-Based Clients
+
+If you'd like your server to be accessible by browser-based MCP clients, you'll need to configure CORS headers. The `Mcp-Session-Id` header must be exposed for browser clients to access it:
+
+```typescript
+import cors from 'cors';
+
+// Add CORS middleware before your MCP routes
+app.use(cors({
+  origin: '*', // Configure appropriately for production
+  exposedHeaders: ['Mcp-Session-Id']
+}));
+```
+
+This configuration is necessary because:
+- The MCP streamable HTTP transport uses the `Mcp-Session-Id` header for session management
+- Browsers restrict access to response headers unless explicitly exposed via CORS
+- Without this configuration, browser-based clients won't be able to read the session ID from initialization responses
+
 #### Without Session Management (Stateless)
 
 For simpler use cases where session management isn't needed:

--- a/src/examples/server/jsonResponseStreamableHttp.ts
+++ b/src/examples/server/jsonResponseStreamableHttp.ts
@@ -4,6 +4,7 @@ import { McpServer } from '../../server/mcp.js';
 import { StreamableHTTPServerTransport } from '../../server/streamableHttp.js';
 import { z } from 'zod';
 import { CallToolResult, isInitializeRequest } from '../../types.js';
+import cors from 'cors';
 
 
 // Create an MCP server with implementation details
@@ -80,6 +81,12 @@ const getServer = () => {
 
 const app = express();
 app.use(express.json());
+
+// Configure CORS to expose Mcp-Session-Id header for browser-based clients
+app.use(cors({
+  origin: '*', // Allow all origins - adjust as needed for production
+  exposedHeaders: ['Mcp-Session-Id']
+}));
 
 // Map to store transports by session ID
 const transports: { [sessionId: string]: StreamableHTTPServerTransport } = {};

--- a/src/examples/server/simpleStatelessStreamableHttp.ts
+++ b/src/examples/server/simpleStatelessStreamableHttp.ts
@@ -3,6 +3,7 @@ import { McpServer } from '../../server/mcp.js';
 import { StreamableHTTPServerTransport } from '../../server/streamableHttp.js';
 import { z } from 'zod';
 import { CallToolResult, GetPromptResult, ReadResourceResult } from '../../types.js';
+import cors from 'cors';
 
 const getServer = () => {
   // Create an MCP server with implementation details
@@ -95,6 +96,12 @@ const getServer = () => {
 
 const app = express();
 app.use(express.json());
+
+// Configure CORS to expose Mcp-Session-Id header for browser-based clients
+app.use(cors({
+  origin: '*', // Allow all origins - adjust as needed for production
+  exposedHeaders: ['Mcp-Session-Id']
+}));
 
 app.post('/mcp', async (req: Request, res: Response) => {
   const server = getServer();

--- a/src/examples/server/simpleStreamableHttp.ts
+++ b/src/examples/server/simpleStreamableHttp.ts
@@ -11,6 +11,8 @@ import { setupAuthServer } from './demoInMemoryOAuthProvider.js';
 import { OAuthMetadata } from 'src/shared/auth.js';
 import { checkResourceAllowed } from 'src/shared/auth-utils.js';
 
+import cors from 'cors';
+
 // Check for OAuth flag
 const useOAuth = process.argv.includes('--oauth');
 const strictOAuth = process.argv.includes('--oauth-strict');
@@ -420,11 +422,17 @@ const getServer = () => {
   return server;
 };
 
-const MCP_PORT = 3000;
-const AUTH_PORT = 3001;
+const MCP_PORT = process.env.MCP_PORT ? parseInt(process.env.MCP_PORT, 10) : 3000;
+const AUTH_PORT = process.env.MCP_AUTH_PORT ? parseInt(process.env.MCP_AUTH_PORT, 10) : 3001;
 
 const app = express();
 app.use(express.json());
+
+// Allow CORS all domains, expose the Mcp-Session-Id header
+app.use(cors({
+  origin: '*', // Allow all origins
+  exposedHeaders: ["Mcp-Session-Id"]
+}));
 
 // Set up OAuth if enabled
 let authMiddleware = null;

--- a/src/examples/server/sseAndStreamableHttpCompatibleServer.ts
+++ b/src/examples/server/sseAndStreamableHttpCompatibleServer.ts
@@ -6,6 +6,7 @@ import { SSEServerTransport } from '../../server/sse.js';
 import { z } from 'zod';
 import { CallToolResult, isInitializeRequest } from '../../types.js';
 import { InMemoryEventStore } from '../shared/inMemoryEventStore.js';
+import cors from 'cors';
 
 /**
  * This example server demonstrates backwards compatibility with both:
@@ -70,6 +71,12 @@ const getServer = () => {
 // Create Express application
 const app = express();
 app.use(express.json());
+
+// Configure CORS to expose Mcp-Session-Id header for browser-based clients
+app.use(cors({
+  origin: '*', // Allow all origins - adjust as needed for production
+  exposedHeaders: ['Mcp-Session-Id']
+}));
 
 // Store transports by session ID
 const transports: Record<string, StreamableHTTPServerTransport | SSEServerTransport> = {};


### PR DESCRIPTION
## Summary
- Add CORS middleware to example servers to expose the `Mcp-Session-Id` header
- Add documentation for CORS configuration in the README
- Use minimal CORS settings (only expose required headers and methods)

## Problem
Browser-based MCP clients cannot access the `Mcp-Session-Id` header from initialization responses due to CORS restrictions. Without this header, they cannot establish sessions with MCP servers.

## Solution
This PR adds the `cors` npm package to example servers and configures it to expose the `Mcp-Session-Id` header via `Access-Control-Expose-Headers`. The configuration is minimal, only exposing what's necessary for MCP protocol operation.

## Changes
- Add `cors` import and middleware to:
  - `sseAndStreamableHttpCompatibleServer.ts`
  - `simpleStatelessStreamableHttp.ts`
  - `jsonResponseStreamableHttp.ts`
- Add CORS configuration section to README explaining when and how to configure CORS for browser clients

## Test plan
- [ ] Example servers start successfully with CORS configured
- [ ] Browser-based clients can read the `Mcp-Session-Id` header from responses
- [ ] CORS headers are properly set on responses

Reported-by: Jerome