### PR TITLE
Support for multi-instance shttp MCP server deployments

### DIFF
--- a/src/server/streamableHttp.ts
+++ b/src/server/streamableHttp.ts
@@ -83,7 +83,7 @@ export interface StreamableHTTPServerTransportOptions {
   /**
    * Enables support for multiple instances of the transport.
    */
-  multiInstance?: boolean;
+  throwOnMissingStream?: boolean;
 }
 
 /**
@@ -135,7 +135,7 @@ export class StreamableHTTPServerTransport implements Transport {
   private _allowedHosts?: string[];
   private _allowedOrigins?: string[];
   private _enableDnsRebindingProtection: boolean;
-  private _multiInstance: boolean;
+  private _throwOnMissingStream: boolean;
 
   sessionId?: string;
   onclose?: () => void;
@@ -150,7 +150,7 @@ export class StreamableHTTPServerTransport implements Transport {
     this._allowedHosts = options.allowedHosts;
     this._allowedOrigins = options.allowedOrigins;
     this._enableDnsRebindingProtection = options.enableDnsRebindingProtection ?? false;
-    this._multiInstance = options.multiInstance ?? false;
+    this._throwOnMissingStream = options.throwOnMissingStream ?? false;
   }
 
   /**
@@ -681,8 +681,8 @@ export class StreamableHTTPServerTransport implements Transport {
     const streamId = this._requestToStreamMapping.get(requestId);
     const response = this._streamMapping.get(streamId!);
     if (!streamId) {
-      if (this._multiInstance) {
-        return; // If multi-instance is enabled, we can ignore messages without a stream
+      if (this._throwOnMissingStream) {
+        return; // If throwOnMissingStream is enabled, we can ignore messages without a stream
       }
       throw new Error(`No connection established for request ID: ${String(requestId)}`);
     }
@@ -711,8 +711,8 @@ export class StreamableHTTPServerTransport implements Transport {
 
       if (allResponsesReady) {
         if (!response) {
-          if (this._multiInstance) {
-            // If multi-instance is enabled, we can ignore messages without a stream
+          if (this._throwOnMissingStream) {
+            // If throwOnMissingStream is enabled, we can ignore messages without a stream
             return;
           }
           throw new Error(`No connection established for request ID: ${String(requestId)}`);


### PR DESCRIPTION
Adding support for multiple instances of streamable http tracking the same MCP server. Needed for a multi-instance deployment of MCP using this transport

<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
