### PR TITLE
Allow custom fetch

### DIFF
--- a/src/client/streamableHttp.test.ts
+++ b/src/client/streamableHttp.test.ts
@@ -1,4 +1,4 @@
-import { StreamableHTTPClientTransport, StreamableHTTPReconnectionOptions } from "./streamableHttp.js";
+import { StreamableHTTPClientTransport, StreamableHTTPReconnectionOptions, StartSSEOptions } from "./streamableHttp.js";
 import { OAuthClientProvider, UnauthorizedError } from "./auth.js";
 import { JSONRPCMessage } from "../types.js";
 
@@ -443,6 +443,35 @@ describe("StreamableHTTPClientTransport", () => {
     expect(errorSpy).toHaveBeenCalled();
   });
 
+  it("uses custom fetch implementation", async () => {
+    const authToken = "Bearer custom-token";
+
+    const fetchWithAuth = jest.fn((url: string | URL, init?: RequestInit) => {
+      const headers = new Headers(init?.headers);
+      headers.set("Authorization", authToken);
+      return (global.fetch as jest.Mock)(url, { ...init, headers });
+    });
+
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce(
+        new Response(null, { status: 200, headers: { "content-type": "text/event-stream" } })
+      )
+      .mockResolvedValueOnce(new Response(null, { status: 202 }));
+
+    transport = new StreamableHTTPClientTransport(new URL("http://localhost:1234/mcp"), { fetch: fetchWithAuth });
+
+    await transport.start();
+    await (transport as unknown as { _startOrAuthSse: (opts: StartSSEOptions) => Promise<void> })._startOrAuthSse({});
+
+    await transport.send({ jsonrpc: "2.0", method: "test", params: {}, id: "1" } as JSONRPCMessage);
+
+    expect(fetchWithAuth).toHaveBeenCalled();
+    for (const call of (global.fetch as jest.Mock).mock.calls) {
+      const headers = call[1].headers as Headers;
+      expect(headers.get("Authorization")).toBe(authToken);
+    }
+  });
+
 
   it("should always send specified custom headers", async () => {
     const requestInit = {
@@ -530,7 +559,7 @@ describe("StreamableHTTPClientTransport", () => {
     // Second retry - should double (2^1 * 100 = 200)
     expect(getDelay(1)).toBe(200);
 
-    // Third retry - should double again (2^2 * 100 = 400) 
+    // Third retry - should double again (2^2 * 100 = 400)
     expect(getDelay(2)).toBe(400);
 
     // Fourth retry - should double again (2^3 * 100 = 800)

--- a/src/shared/transport.ts
+++ b/src/shared/transport.ts
@@ -1,10 +1,12 @@
 import { JSONRPCMessage, MessageExtraInfo, RequestId } from "../types.js";
 
+export type FetchLike = (url: string | URL, init?: RequestInit) => Promise<Response>;
+
 /**
  * Options for sending a JSON-RPC message.
  */
 export type TransportSendOptions = {
-  /** 
+  /**
    * If present, `relatedRequestId` is used to indicate to the transport which incoming request to associate this outgoing message with.
    */
   relatedRequestId?: RequestId;
@@ -38,7 +40,7 @@ export interface Transport {
 
   /**
    * Sends a JSON-RPC message (request or response).
-   * 
+   *
    * If present, `relatedRequestId` is used to indicate to the transport which incoming request to associate this outgoing message with.
    */
   send(message: JSONRPCMessage, options?: TransportSendOptions): Promise<void>;
@@ -64,9 +66,9 @@ export interface Transport {
 
   /**
    * Callback for when a message (request or response) is received over the connection.
-   * 
+   *
    * Includes the requestInfo and authInfo if the transport is authenticated.
-   * 
+   *
    * The requestInfo can be used to get the original request information (headers, etc.)
    */
   onmessage?: (message: JSONRPCMessage, extra?: MessageExtraInfo) => void;


### PR DESCRIPTION
## Summary of Changes

This pull request significantly enhances the flexibility of the `SSEClientTransport` and `StreamableHTTPClientTransport` classes by enabling the injection of a custom `fetch` implementation. This change empowers users to exert fine-grained control over network requests, facilitating advanced use cases such as custom authentication flows or specialized request handling, thereby improving the adaptability of the transport layer.

### Highlights

* **Custom Fetch Support**: Added a `fetch` option to `SSEClientTransport` and `StreamableHTTPClientTransport` constructors, allowing consumers to provide their own custom `fetch` implementation for network requests.
* **Comprehensive Integration**: The custom `fetch` implementation is now utilized for all internal network operations within these transports, including initial SSE connections (GET), sending messages (POST), and session termination (DELETE).
* **Type Standardization**: Introduced a shared `FetchLike` type definition in `src/shared/transport.ts` to ensure consistent typing for custom `fetch` functions across the codebase.
* **Enhanced Test Coverage**: New test cases were added to verify the correct usage and behavior of the custom `fetch` implementation, specifically ensuring proper authentication header propagation for various request types.

<details>
<summary><b>Changelog</b></summary>

* **src/client/sse.test.ts**
    * Added a new test case to verify that `SSEClientTransport` correctly utilizes a custom `fetch` implementation for both initial connection and subsequent POST requests, ensuring proper header propagation.
* **src/client/sse.ts**
    * Imported the new `FetchLike` type from `src/shared/transport.ts`.
    * Added a `fetch` option to `SSEClientTransportOptions` and a corresponding private `_fetch` property.
    * Updated internal `fetch` calls within `_startOrAuth()` and `send()` methods to use the provided custom `fetch` or fall back to the global `fetch`.
    * Applied nullish coalescing operator (`??`) for `fetch` fallback logic as per review suggestions.
* **src/client/streamableHttp.test.ts**
    * Imported the `StartSSEOptions` interface for improved type safety in tests.
    * Added a new test case to confirm `StreamableHTTPClientTransport` uses the custom `fetch` implementation for all its network operations, including authentication.
    * Minor formatting adjustments.
* **src/client/streamableHttp.ts**
    * Imported the new `FetchLike` type from `src/shared/transport.ts`.
    * Exported the `StartSSEOptions` interface.
    * Added a `fetch` option to `StreamableHTTPClientTransportOptions` and a corresponding private `_fetch` property.
    * Modified `_startOrAuthSse()`, `send()`, and `terminate()` methods to use the custom `fetch` implementation for their respective network requests.
    * Applied nullish coalescing operator (`??`) for `fetch` fallback logic as per review suggestions.
    * Minor formatting adjustments.
* **src/shared/transport.ts**
    * Defined and exported the `FetchLike` type, standardizing the signature for custom `fetch` functions across the codebase.
    * Minor formatting adjustments to comments.
</details>

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Picks up on the work started in abandoned PR #296, refining the implementation, extending it to include StreamableHttp in addition to SSE,  and adds tests for both.

The ultimate motivation is in the requirement by a[ pending PR](https://github.com/modelcontextprotocol/inspector/pull/402) in the Inspector project, which seeks to bridge the WWW-Authenticate header returned by an MCP server back to the Inspector client within the Inspector proxy. This makes use of the custom fetch function to capture the header.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
New unit tests.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
Nope.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [X] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
Fixes #476 