### PR TITLE
Preserve paths when building PRM URL, per specification.

### DIFF
--- a/src/server/auth/router.test.ts
+++ b/src/server/auth/router.test.ts
@@ -1,4 +1,4 @@
-import { mcpAuthRouter, AuthRouterOptions, mcpAuthMetadataRouter, AuthMetadataOptions } from './router.js';
+import { mcpAuthRouter, AuthRouterOptions, mcpAuthMetadataRouter, AuthMetadataOptions, getOAuthProtectedResourceMetadataUrl } from './router.js';
 import { OAuthServerProvider, AuthorizationParams } from './provider.js';
 import { OAuthRegisteredClientsStore } from './clients.js';
 import { OAuthClientInformationFull, OAuthMetadata, OAuthTokenRevocationRequest, OAuthTokens } from '../../shared/auth.js';
@@ -479,4 +479,46 @@ describe('MCP Auth Metadata Router', () => {
       expect(resourceResponse.body.resource_documentation).toBeUndefined();
     });
   });
+});
+
+describe('MCP Protected Resource Metadata URL', () => {
+
+  it('should insert well-known URI after host', () => {
+    const serverUrl = new URL('https://mcp.example.com')
+    expect(getOAuthProtectedResourceMetadataUrl(serverUrl)).toBe('https://mcp.example.com/.well-known/oauth-protected-resource');
+  });
+
+  // NOTE: There's some ambiguity in the specifications as to expected output.
+  // See discussion on OAuth WG mailing list for further details and rationale:
+  // https://mailarchive.ietf.org/arch/msg/oauth/LLoteOrAn0sd172dsll254oHGX4/
+  it('should insert well-known URI after host with path', () => {
+    const serverUrl = new URL('https://mcp.example.com/')
+    expect(getOAuthProtectedResourceMetadataUrl(serverUrl)).toBe('https://mcp.example.com/.well-known/oauth-protected-resource');
+  });
+
+  it('should insert well-known URI between host and path', () => {
+    const serverUrl = new URL('https://mcp.example.com/mcp')
+    expect(getOAuthProtectedResourceMetadataUrl(serverUrl)).toBe('https://mcp.example.com/.well-known/oauth-protected-resource/mcp');
+  });
+
+  it('should insert well-known URI between host and query', () => {
+    const serverUrl = new URL('https://mcp.example.com?k=v')
+    expect(getOAuthProtectedResourceMetadataUrl(serverUrl)).toBe('https://mcp.example.com/.well-known/oauth-protected-resource?k=v');
+  });
+
+  it('should insert well-known URI between host and path with query', () => {
+    const serverUrl = new URL('https://mcp.example.com/mcp?k=v')
+    expect(getOAuthProtectedResourceMetadataUrl(serverUrl)).toBe('https://mcp.example.com/.well-known/oauth-protected-resource/mcp?k=v');
+  });
+
+  it('should insert well-known URI between host and path while preserving trailing slash from path', () => {
+    const serverUrl = new URL('https://mcp.example.com/mcp/')
+    expect(getOAuthProtectedResourceMetadataUrl(serverUrl)).toBe('https://mcp.example.com/.well-known/oauth-protected-resource/mcp/');
+  });
+
+  it('should insert well-known URI between host and path with query while preserving trailing slash from path', () => {
+    const serverUrl = new URL('https://mcp.example.com/mcp/?k=v')
+    expect(getOAuthProtectedResourceMetadataUrl(serverUrl)).toBe('https://mcp.example.com/.well-known/oauth-protected-resource/mcp/?k=v');
+  });
+
 });

--- a/src/server/auth/router.ts
+++ b/src/server/auth/router.ts
@@ -218,8 +218,12 @@ export function mcpAuthMetadataRouter(options: AuthMetadataOptions) {
  * @returns The URL for the OAuth protected resource metadata endpoint
  *
  * @example
- * getOAuthProtectedResourceMetadataUrl(new URL('https://api.example.com/mcp'))
+ * getOAuthProtectedResourceMetadataUrl(new URL('https://api.example.com'))
  * // Returns: 'https://api.example.com/.well-known/oauth-protected-resource'
+ *
+ * @example
+ * getOAuthProtectedResourceMetadataUrl(new URL('https://api.example.com/mcp'))
+ * // Returns: 'https://api.example.com/.well-known/oauth-protected-resource/mcp'
  */
 export function getOAuthProtectedResourceMetadataUrl(serverUrl: URL): string {
   const wellKnownUrl = new URL(serverUrl);

--- a/src/server/auth/router.ts
+++ b/src/server/auth/router.ts
@@ -222,5 +222,12 @@ export function mcpAuthMetadataRouter(options: AuthMetadataOptions) {
  * // Returns: 'https://api.example.com/.well-known/oauth-protected-resource'
  */
 export function getOAuthProtectedResourceMetadataUrl(serverUrl: URL): string {
-  return new URL('/.well-known/oauth-protected-resource', serverUrl).href;
+  const wellKnownUrl = new URL(serverUrl);
+  let path = wellKnownUrl.pathname;
+  if (path === '/') {
+		path = path.slice(0, -1);
+	}
+
+  wellKnownUrl.pathname = `/.well-known/oauth-protected-resource${path}`
+  return wellKnownUrl.toString();
 }


### PR DESCRIPTION
Preserves paths and query parameters when making Protected Resource Metdata requests, per [section 3.1](https://datatracker.ietf.org/doc/html/rfc9728#section-3.1) of [RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728).

## Motivation and Context

This is important for security hardening of MCP, ensuring that clients can [validate](https://datatracker.ietf.org/doc/html/rfc9728#section-3.3) that the resource metadata they are using correlates with the resource they are accessing.

## How Has This Been Tested?

We (@KeycardLabs) are building an identity and access system for agents, and ensuring that SDKs are implementing the relevant OAuth bits in accordance with specifications.

Unit tests have been supplied.

## Breaking Changes

This returns PRM URLs that include path components, whereas before the `getOAuthProtectedResourceMetadataUrl()` function did not.  This may be considered a breaking change, but also brings it inline with the specifications.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

Either a bug fix or a breaking change (or both), depending on perspective.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->

There's a [discussion](https://mailarchive.ietf.org/arch/msg/oauth/LLoteOrAn0sd172dsll254oHGX4/) about expected behavior on the OAuth mailing list.

As far as I can see, proper validation of resource indicators is very lax in the MCP specification and implementations.   This is leading to a number of security vulnerabilities.   I've outlined this [here](https://github.com/oauth-wg/oauth-v2-1/issues/215#issuecomment-2978453131), and there's a related [issue](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/763) in the MCP specification.

I'm trying to work with both the specification authors and SDK implementers to improve the security posture of MCP.  This PR is part of that effort :).