### PR TITLE
Revert "fix: add type safety for tool output schemas in ToolCallback"

### DIFF
--- a/src/examples/server/mcpServerOutputSchema.ts
+++ b/src/examples/server/mcpServerOutputSchema.ts
@@ -43,14 +43,7 @@ server.registerTool(
     void country;
     // Simulate weather API call
     const temp_c = Math.round((Math.random() * 35 - 5) * 10) / 10;
-    const conditionCandidates = [
-      "sunny",
-      "cloudy",
-      "rainy",
-      "stormy",
-      "snowy",
-    ] as const;
-    const conditions = conditionCandidates[Math.floor(Math.random() * conditionCandidates.length)];
+    const conditions = ["sunny", "cloudy", "rainy", "stormy", "snowy"][Math.floor(Math.random() * 5)];
 
     const structuredContent = {
       temperature: {

--- a/src/server/mcp.test.ts
+++ b/src/server/mcp.test.ts
@@ -1312,7 +1312,7 @@ describe("tool()", () => {
           resultType: "structured",
           // Missing required 'timestamp' field
           someExtraField: "unexpected" // Extra field not in schema
-        } as unknown as { processedInput: string; resultType: string; timestamp: string }, // Type assertion to bypass TypeScript validation for testing purposes
+        },
       })
     );
 


### PR DESCRIPTION
Reverts modelcontextprotocol/typescript-sdk#670

Addressing this issue: https://github.com/modelcontextprotocol/typescript-sdk/pull/670#issuecomment-3028894658
Forcibly casting a type onto `CallToolResult` was a bad modification.