### PR TITLE
Add type compatibility test between SDK and spec types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,9 @@ web_modules/
 # Output of 'npm pack'
 *.tgz
 
+# Output of 'npm run fetch:spec-types'
+src/spec.types.ts
+
 # Yarn Integrity file
 .yarn-integrity
 

--- a/.gitignore
+++ b/.gitignore
@@ -70,7 +70,7 @@ web_modules/
 *.tgz
 
 # Output of 'npm run fetch:spec-types'
-src/spec.types.ts
+spec.types.ts
 
 # Yarn Integrity file
 .yarn-integrity

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "dist"
   ],
   "scripts": {
+    "fetch:spec-types": "test -f src/spec.types.ts || curl -o src/spec.types.ts https://raw.githubusercontent.com/modelcontextprotocol/modelcontextprotocol/refs/heads/main/schema/draft/schema.ts",
     "build": "npm run build:esm && npm run build:cjs",
     "build:esm": "mkdir -p dist/esm && echo '{\"type\": \"module\"}' > dist/esm/package.json && tsc -p tsconfig.prod.json",
     "build:esm:w": "npm run build:esm -- -w",
@@ -43,7 +44,7 @@
     "examples:simple-server:w": "tsx --watch src/examples/server/simpleStreamableHttp.ts --oauth",
     "prepack": "npm run build:esm && npm run build:cjs",
     "lint": "eslint src/",
-    "test": "jest",
+    "test": "npm run fetch:spec-types && jest",
     "start": "npm run server",
     "server": "tsx watch --clear-screen=false src/cli.ts server",
     "client": "tsx src/cli.ts client"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "dist"
   ],
   "scripts": {
-    "fetch:spec-types": "curl -o src/spec.types.ts https://raw.githubusercontent.com/modelcontextprotocol/modelcontextprotocol/refs/heads/main/schema/draft/schema.ts",
+    "fetch:spec-types": "curl -o spec.types.ts https://raw.githubusercontent.com/modelcontextprotocol/modelcontextprotocol/refs/heads/main/schema/draft/schema.ts",
     "build": "npm run build:esm && npm run build:cjs",
     "build:esm": "mkdir -p dist/esm && echo '{\"type\": \"module\"}' > dist/esm/package.json && tsc -p tsconfig.prod.json",
     "build:esm:w": "npm run build:esm -- -w",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "dist"
   ],
   "scripts": {
-    "fetch:spec-types": "test -f src/spec.types.ts || curl -o src/spec.types.ts https://raw.githubusercontent.com/modelcontextprotocol/modelcontextprotocol/refs/heads/main/schema/draft/schema.ts",
+    "fetch:spec-types": "curl -o src/spec.types.ts https://raw.githubusercontent.com/modelcontextprotocol/modelcontextprotocol/refs/heads/main/schema/draft/schema.ts",
     "build": "npm run build:esm && npm run build:cjs",
     "build:esm": "mkdir -p dist/esm && echo '{\"type\": \"module\"}' > dist/esm/package.json && tsc -p tsconfig.prod.json",
     "build:esm:w": "npm run build:esm -- -w",

--- a/src/spec.types.test.ts
+++ b/src/spec.types.test.ts
@@ -1,0 +1,657 @@
+// import ts from 'typescript';
+
+import * as SDKTypes from "./types.js";
+import * as SpecTypes from "./spec.types.js";
+
+// Deep version that recursively removes index signatures (caused by ZodObject.passthrough()) and turns unknowns into `object | undefined`
+type DeepKnownKeys<T> = T extends object
+  ? T extends Array<infer U>
+    ? Array<DeepKnownKeys<U>>
+    : T extends Function
+    ? T
+    : {
+        [K in keyof T as string extends K ? never : number extends K ? never : K]: DeepKnownKeys<T[K]>;
+      }
+  : unknown extends T
+  ? (object | undefined)
+  : T;
+
+function checkCancelledNotification(
+  sdk: SDKTypes.CancelledNotification,
+  spec: SpecTypes.CancelledNotification
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkBaseMetadata(
+  sdk: SDKTypes.BaseMetadata,
+  spec: DeepKnownKeys<SpecTypes.BaseMetadata>
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkImplementation(
+  sdk: SDKTypes.Implementation,
+  spec: DeepKnownKeys<SpecTypes.Implementation>
+) {
+  sdk = spec;
+  spec = sdk;
+} 
+function checkProgressNotification(
+  sdk: SDKTypes.ProgressNotification,
+  spec: DeepKnownKeys<SpecTypes.ProgressNotification>
+) {
+  sdk = spec;
+  spec = sdk;
+}
+
+function checkSubscribeRequest(
+  sdk: SDKTypes.SubscribeRequest,
+  spec: SpecTypes.SubscribeRequest
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkUnsubscribeRequest(
+  sdk: SDKTypes.UnsubscribeRequest,
+  spec: SpecTypes.UnsubscribeRequest
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkPaginatedRequest(
+  sdk: SDKTypes.PaginatedRequest,
+  spec: SpecTypes.PaginatedRequest
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkPaginatedResult(
+  sdk: SDKTypes.PaginatedResult,
+  spec: SpecTypes.PaginatedResult
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkListRootsRequest(
+  sdk: SDKTypes.ListRootsRequest,
+  spec: SpecTypes.ListRootsRequest
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkListRootsResult(
+  sdk: SDKTypes.ListRootsResult,
+  spec: DeepKnownKeys<SpecTypes.ListRootsResult>
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkRoot(sdk: SDKTypes.Root, spec: DeepKnownKeys<SpecTypes.Root>) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkElicitRequest(sdk: SDKTypes.ElicitRequest, spec: DeepKnownKeys<SpecTypes.ElicitRequest>) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkElicitResult(sdk: SDKTypes.ElicitResult, spec: DeepKnownKeys<SpecTypes.ElicitResult>) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkCompleteRequest(sdk: SDKTypes.CompleteRequest, spec: DeepKnownKeys<SpecTypes.CompleteRequest>) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkCompleteResult(sdk: SDKTypes.CompleteResult, spec: SpecTypes.CompleteResult) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkProgressToken(
+  sdk: SDKTypes.ProgressToken,
+  spec: SpecTypes.ProgressToken
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkCursor(sdk: SDKTypes.Cursor, spec: SpecTypes.Cursor) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkRequest(
+  sdk: SDKTypes.Request,
+  spec: SpecTypes.Request
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkResult(
+  sdk: SDKTypes.Result,
+  spec: SpecTypes.Result
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkRequestId(
+  sdk: SDKTypes.RequestId,
+  spec: SpecTypes.RequestId
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkJSONRPCRequest(
+  sdk: SDKTypes.JSONRPCRequest,
+  spec: SpecTypes.JSONRPCRequest
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkJSONRPCNotification(
+  sdk: SDKTypes.JSONRPCNotification,
+  spec: SpecTypes.JSONRPCNotification
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkJSONRPCResponse(
+  sdk: SDKTypes.JSONRPCResponse,
+  spec: SpecTypes.JSONRPCResponse
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkEmptyResult(
+  sdk: SDKTypes.EmptyResult,
+  spec: SpecTypes.EmptyResult
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkNotification(
+  sdk: SDKTypes.Notification,
+  spec: SpecTypes.Notification
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkClientResult(
+  sdk: SDKTypes.ClientResult,
+  spec: SpecTypes.ClientResult
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkClientNotification(
+  sdk: SDKTypes.ClientNotification,
+  spec: SpecTypes.ClientNotification
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkServerResult(
+  sdk: SDKTypes.ServerResult,
+  spec: SpecTypes.ServerResult
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkResourceTemplateReference(
+  sdk: SDKTypes.ResourceTemplateReference,
+  spec: DeepKnownKeys<SpecTypes.ResourceTemplateReference>
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkPromptReference(
+  sdk: SDKTypes.PromptReference,
+  spec: DeepKnownKeys<SpecTypes.PromptReference>
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkResourceReference(
+  sdk: SDKTypes.ResourceReference,
+  spec: DeepKnownKeys<SpecTypes.ResourceTemplateReference>
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkToolAnnotations(
+  sdk: SDKTypes.ToolAnnotations,
+  spec: DeepKnownKeys<SpecTypes.ToolAnnotations>
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkTool(
+  sdk: SDKTypes.Tool,
+  spec: DeepKnownKeys<SpecTypes.Tool>
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkListToolsRequest(
+  sdk: SDKTypes.ListToolsRequest,
+  spec: SpecTypes.ListToolsRequest
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkListToolsResult(
+  sdk: SDKTypes.ListToolsResult,
+  spec: DeepKnownKeys<SpecTypes.ListToolsResult>
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkCallToolResult(
+  sdk: SDKTypes.CallToolResult,
+  spec: DeepKnownKeys<SpecTypes.CallToolResult>
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkCallToolRequest(
+  sdk: SDKTypes.CallToolRequest,
+  spec: SpecTypes.CallToolRequest
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkToolListChangedNotification(
+  sdk: SDKTypes.ToolListChangedNotification,
+  spec: SpecTypes.ToolListChangedNotification
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkResourceListChangedNotification(
+  sdk: SDKTypes.ResourceListChangedNotification,
+  spec: SpecTypes.ResourceListChangedNotification
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkPromptListChangedNotification(
+  sdk: SDKTypes.PromptListChangedNotification,
+  spec: SpecTypes.PromptListChangedNotification
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkRootsListChangedNotification(
+  sdk: SDKTypes.RootsListChangedNotification,
+  spec: SpecTypes.RootsListChangedNotification
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkResourceUpdatedNotification(
+  sdk: SDKTypes.ResourceUpdatedNotification,
+  spec: SpecTypes.ResourceUpdatedNotification
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkSamplingMessage(
+  sdk: SDKTypes.SamplingMessage,
+  spec: DeepKnownKeys<SpecTypes.SamplingMessage>
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkCreateMessageResult(
+  sdk: SDKTypes.CreateMessageResult,
+  spec: DeepKnownKeys<SpecTypes.CreateMessageResult>
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkSetLevelRequest(
+  sdk: SDKTypes.SetLevelRequest,
+  spec: SpecTypes.SetLevelRequest
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkPingRequest(
+  sdk: SDKTypes.PingRequest,
+  spec: SpecTypes.PingRequest
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkInitializedNotification(
+  sdk: SDKTypes.InitializedNotification,
+  spec: SpecTypes.InitializedNotification
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkListResourcesRequest(
+  sdk: SDKTypes.ListResourcesRequest,
+  spec: SpecTypes.ListResourcesRequest
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkListResourcesResult(
+  sdk: SDKTypes.ListResourcesResult,
+  spec: DeepKnownKeys<SpecTypes.ListResourcesResult>
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkListResourceTemplatesRequest(
+  sdk: SDKTypes.ListResourceTemplatesRequest,
+  spec: SpecTypes.ListResourceTemplatesRequest
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkListResourceTemplatesResult(
+  sdk: SDKTypes.ListResourceTemplatesResult,
+  spec: DeepKnownKeys<SpecTypes.ListResourceTemplatesResult>
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkReadResourceRequest(
+  sdk: SDKTypes.ReadResourceRequest,
+  spec: SpecTypes.ReadResourceRequest
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkReadResourceResult(
+  sdk: SDKTypes.ReadResourceResult,
+  spec: DeepKnownKeys<SpecTypes.ReadResourceResult>
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkResourceContents(
+  sdk: SDKTypes.ResourceContents,
+  spec: DeepKnownKeys<SpecTypes.ResourceContents>
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkTextResourceContents(
+  sdk: SDKTypes.TextResourceContents,
+  spec: DeepKnownKeys<SpecTypes.TextResourceContents>
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkBlobResourceContents(
+  sdk: SDKTypes.BlobResourceContents,
+  spec: DeepKnownKeys<SpecTypes.BlobResourceContents>
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkResource(
+  sdk: SDKTypes.Resource,
+  spec: DeepKnownKeys<SpecTypes.Resource>
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkResourceTemplate(
+  sdk: SDKTypes.ResourceTemplate,
+  spec: DeepKnownKeys<SpecTypes.ResourceTemplate>
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkPromptArgument(
+  sdk: SDKTypes.PromptArgument,
+  spec: DeepKnownKeys<SpecTypes.PromptArgument>
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkPrompt(
+  sdk: SDKTypes.Prompt,
+  spec: DeepKnownKeys<SpecTypes.Prompt>
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkListPromptsRequest(
+  sdk: SDKTypes.ListPromptsRequest,
+  spec: SpecTypes.ListPromptsRequest
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkListPromptsResult(
+  sdk: SDKTypes.ListPromptsResult,
+  spec: DeepKnownKeys<SpecTypes.ListPromptsResult>
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkGetPromptRequest(
+  sdk: SDKTypes.GetPromptRequest,
+  spec: SpecTypes.GetPromptRequest
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkTextContent(
+  sdk: SDKTypes.TextContent,
+  spec: DeepKnownKeys<SpecTypes.TextContent>
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkImageContent(
+  sdk: SDKTypes.ImageContent,
+  spec: DeepKnownKeys<SpecTypes.ImageContent>
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkAudioContent(
+  sdk: SDKTypes.AudioContent,
+  spec: DeepKnownKeys<SpecTypes.AudioContent>
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkEmbeddedResource(
+  sdk: SDKTypes.EmbeddedResource,
+  spec: DeepKnownKeys<SpecTypes.EmbeddedResource>
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkResourceLink(
+  sdk: SDKTypes.ResourceLink,
+  spec: DeepKnownKeys<SpecTypes.ResourceLink>
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkContentBlock(
+  sdk: SDKTypes.ContentBlock,
+  spec: DeepKnownKeys<SpecTypes.ContentBlock>
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkPromptMessage(
+  sdk: SDKTypes.PromptMessage,
+  spec: DeepKnownKeys<SpecTypes.PromptMessage>
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkGetPromptResult(
+  sdk: SDKTypes.GetPromptResult,
+  spec: DeepKnownKeys<SpecTypes.GetPromptResult>
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkBooleanSchema(
+  sdk: SDKTypes.BooleanSchema,
+  spec: DeepKnownKeys<SpecTypes.BooleanSchema>
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkStringSchema(
+  sdk: SDKTypes.StringSchema,
+  spec: DeepKnownKeys<SpecTypes.StringSchema>
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkNumberSchema(
+  sdk: SDKTypes.NumberSchema,
+  spec: DeepKnownKeys<SpecTypes.NumberSchema>
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkEnumSchema(
+  sdk: SDKTypes.EnumSchema,
+  spec: DeepKnownKeys<SpecTypes.EnumSchema>
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkPrimitiveSchemaDefinition(
+  sdk: SDKTypes.PrimitiveSchemaDefinition,
+  spec: DeepKnownKeys<SpecTypes.PrimitiveSchemaDefinition>
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkCreateMessageRequest(
+  sdk: DeepKnownKeys<SDKTypes.CreateMessageRequest>, // TODO(quirk): some {} type
+  spec: DeepKnownKeys<SpecTypes.CreateMessageRequest>
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkInitializeRequest(
+  sdk: DeepKnownKeys<SDKTypes.InitializeRequest>, // TODO(quirk): some {} type
+  spec: SpecTypes.InitializeRequest
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkInitializeResult(
+  sdk: DeepKnownKeys<SDKTypes.InitializeResult>, // TODO(quirk): some {} type
+  spec: SpecTypes.InitializeResult
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkClientCapabilities(
+  sdk: DeepKnownKeys<SDKTypes.ClientCapabilities>, // TODO(quirk): {}
+  spec: SpecTypes.ClientCapabilities
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkServerCapabilities(
+  sdk: DeepKnownKeys<SDKTypes.ServerCapabilities>, // TODO(quirk): {}
+  spec: SpecTypes.ServerCapabilities
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkJSONRPCError(
+  sdk: DeepKnownKeys<SDKTypes.JSONRPCError>, // TODO(quirk): error.data
+  spec: DeepKnownKeys<SpecTypes.JSONRPCError>
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkJSONRPCMessage(
+  sdk: DeepKnownKeys<SDKTypes.JSONRPCMessage>, // TODO(quirk): error.data
+  spec: DeepKnownKeys<SpecTypes.JSONRPCMessage>
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkClientRequest(
+  sdk: DeepKnownKeys<SDKTypes.ClientRequest>, // TODO(quirk): capabilities.logging is {}
+  spec: SpecTypes.ClientRequest
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkServerRequest(
+  sdk: DeepKnownKeys<SDKTypes.ServerRequest>, // TODO(quirk): some {} typ
+  spec: SpecTypes.ServerRequest
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkLoggingMessageNotification(
+  sdk: SDKTypes.LoggingMessageNotification,
+  spec: SpecTypes.LoggingMessageNotification
+) {
+  sdk = spec;
+  // spec = sdk; // TODO(bug): data is optional
+}
+function checkServerNotification(
+  sdk: SDKTypes.ServerNotification,
+  spec: SpecTypes.ServerNotification
+) {
+  sdk = spec;
+  // spec = sdk; // TODO(bug): data is optional
+}
+
+// TODO(bug): missing type in SDK
+// function checkModelHint(
+//   sdk: SDKTypes.ModelHint,
+//   spec: DeepKnownKeys<SpecTypes.ModelHint>
+// ) {
+//   sdk = spec;
+//   spec = sdk;
+// }
+
+// TODO(bug): missing type in SDK
+// function checkModelPreferences(
+//   sdk: SDKTypes.ModelPreferences,
+//   spec: DeepKnownKeys<SpecTypes.ModelPreferences>
+// ) {
+//   sdk = spec;
+//   spec = sdk;
+// }
+
+// TODO(bug): missing type in SDK
+// function checkAnnotations(
+//   sdk: SDKTypes.Annotations,
+//   spec: DeepKnownKeys<SpecTypes.Annotations>
+// ) {
+//   sdk = spec;
+//   spec = sdk;
+// }
+
+const SPEC_TYPES_FILE  = 'src/spec.types.ts';
+const THIS_SOURCE_FILE = 'src/spec.types.test.ts';
+
+describe('Spec Types', () => {
+    const specTypesContent = require('fs').readFileSync(SPEC_TYPES_FILE, 'utf-8');
+    const typeNames = [...specTypesContent.matchAll(/export\s+interface\s+(\w+)\b/g)].map(m => m[1]);
+    const testContent = require('fs').readFileSync(THIS_SOURCE_FILE, 'utf-8');
+    
+    it('should define some expected types', () => {
+        expect(typeNames).toContain('JSONRPCNotification');
+        expect(typeNames).toContain('ElicitResult');
+    });
+
+    for (const typeName of typeNames) {
+        it(`${typeName} should have a compatibility test`, () => {
+            expect(testContent).toContain(`function check${typeName}(`);
+        });
+    }
+});

--- a/src/spec.types.test.ts
+++ b/src/spec.types.test.ts
@@ -7,14 +7,14 @@ import * as SpecTypes from "./spec.types.js";
 
 // Deep version that recursively removes index signatures (caused by ZodObject.passthrough()) and turns unknowns into `object | undefined`
 // TODO: make string index mapping tighter
-// TODO: split into multiple transformations (e.g. RemovePassthrough) and only use the ones needed for each type.
-type DeepKnownKeys<T> = T extends object
+// TODO: split into multiple transformations if needed
+type RemovePassthrough<T> = T extends object
   ? T extends Array<infer U>
-    ? Array<DeepKnownKeys<U>>
+    ? Array<RemovePassthrough<U>>
     : T extends Function
     ? T
     : {
-        [K in keyof T as string extends K ? never : number extends K ? never : K]: DeepKnownKeys<T[K]>;
+        [K in keyof T as string extends K ? never : number extends K ? never : K]: RemovePassthrough<T[K]>;
       }
   : unknown extends T
   ? (object | undefined)
@@ -28,22 +28,22 @@ function checkCancelledNotification(
   spec = sdk;
 }
 function checkBaseMetadata(
-  sdk: SDKTypes.BaseMetadata,
-  spec: DeepKnownKeys<SpecTypes.BaseMetadata>
+  sdk: RemovePassthrough<SDKTypes.BaseMetadata>,
+  spec: SpecTypes.BaseMetadata
 ) {
   sdk = spec;
   spec = sdk;
 }
 function checkImplementation(
-  sdk: SDKTypes.Implementation,
-  spec: DeepKnownKeys<SpecTypes.Implementation>
+  sdk: RemovePassthrough<SDKTypes.Implementation>,
+  spec: SpecTypes.Implementation
 ) {
   sdk = spec;
   spec = sdk;
 } 
 function checkProgressNotification(
-  sdk: SDKTypes.ProgressNotification,
-  spec: DeepKnownKeys<SpecTypes.ProgressNotification>
+  sdk: RemovePassthrough<SDKTypes.ProgressNotification>,
+  spec: SpecTypes.ProgressNotification
 ) {
   sdk = spec;
   spec = sdk;
@@ -85,29 +85,44 @@ function checkListRootsRequest(
   spec = sdk;
 }
 function checkListRootsResult(
-  sdk: SDKTypes.ListRootsResult,
-  spec: DeepKnownKeys<SpecTypes.ListRootsResult>
+  sdk: RemovePassthrough<SDKTypes.ListRootsResult>,
+  spec: SpecTypes.ListRootsResult
 ) {
   sdk = spec;
   spec = sdk;
 }
-function checkRoot(sdk: SDKTypes.Root, spec: DeepKnownKeys<SpecTypes.Root>) {
+function checkRoot(
+  sdk: RemovePassthrough<SDKTypes.Root>,
+  spec: SpecTypes.Root
+) {
   sdk = spec;
   spec = sdk;
 }
-function checkElicitRequest(sdk: SDKTypes.ElicitRequest, spec: DeepKnownKeys<SpecTypes.ElicitRequest>) {
+function checkElicitRequest(
+  sdk: RemovePassthrough<SDKTypes.ElicitRequest>,
+  spec: SpecTypes.ElicitRequest
+) {
   sdk = spec;
   spec = sdk;
 }
-function checkElicitResult(sdk: SDKTypes.ElicitResult, spec: DeepKnownKeys<SpecTypes.ElicitResult>) {
+function checkElicitResult(
+  sdk: RemovePassthrough<SDKTypes.ElicitResult>,
+  spec: SpecTypes.ElicitResult
+) {
   sdk = spec;
   spec = sdk;
 }
-function checkCompleteRequest(sdk: SDKTypes.CompleteRequest, spec: DeepKnownKeys<SpecTypes.CompleteRequest>) {
+function checkCompleteRequest(
+  sdk: RemovePassthrough<SDKTypes.CompleteRequest>,
+  spec: SpecTypes.CompleteRequest
+) {
   sdk = spec;
   spec = sdk;
 }
-function checkCompleteResult(sdk: SDKTypes.CompleteResult, spec: SpecTypes.CompleteResult) {
+function checkCompleteResult(
+  sdk: SDKTypes.CompleteResult,
+  spec: SpecTypes.CompleteResult
+) {
   sdk = spec;
   spec = sdk;
 }
@@ -118,7 +133,10 @@ function checkProgressToken(
   sdk = spec;
   spec = sdk;
 }
-function checkCursor(sdk: SDKTypes.Cursor, spec: SpecTypes.Cursor) {
+function checkCursor(
+  sdk: SDKTypes.Cursor,
+  spec: SpecTypes.Cursor
+) {
   sdk = spec;
   spec = sdk;
 }
@@ -200,36 +218,36 @@ function checkServerResult(
   spec = sdk;
 }
 function checkResourceTemplateReference(
-  sdk: SDKTypes.ResourceTemplateReference,
-  spec: DeepKnownKeys<SpecTypes.ResourceTemplateReference>
+  sdk: RemovePassthrough<SDKTypes.ResourceTemplateReference>,
+  spec: SpecTypes.ResourceTemplateReference
 ) {
   sdk = spec;
   spec = sdk;
 }
 function checkPromptReference(
-  sdk: SDKTypes.PromptReference,
-  spec: DeepKnownKeys<SpecTypes.PromptReference>
+  sdk: RemovePassthrough<SDKTypes.PromptReference>,
+  spec: SpecTypes.PromptReference
 ) {
   sdk = spec;
   spec = sdk;
 }
 function checkResourceReference(
-  sdk: SDKTypes.ResourceReference,
-  spec: DeepKnownKeys<SpecTypes.ResourceTemplateReference>
+  sdk: RemovePassthrough<SDKTypes.ResourceReference>,
+  spec: SpecTypes.ResourceTemplateReference
 ) {
   sdk = spec;
   spec = sdk;
 }
 function checkToolAnnotations(
-  sdk: SDKTypes.ToolAnnotations,
-  spec: DeepKnownKeys<SpecTypes.ToolAnnotations>
+  sdk: RemovePassthrough<SDKTypes.ToolAnnotations>,
+  spec: SpecTypes.ToolAnnotations
 ) {
   sdk = spec;
   spec = sdk;
 }
 function checkTool(
-  sdk: SDKTypes.Tool,
-  spec: DeepKnownKeys<SpecTypes.Tool>
+  sdk: RemovePassthrough<SDKTypes.Tool>,
+  spec: SpecTypes.Tool
 ) {
   sdk = spec;
   spec = sdk;
@@ -242,15 +260,15 @@ function checkListToolsRequest(
   spec = sdk;
 }
 function checkListToolsResult(
-  sdk: SDKTypes.ListToolsResult,
-  spec: DeepKnownKeys<SpecTypes.ListToolsResult>
+  sdk: RemovePassthrough<SDKTypes.ListToolsResult>,
+  spec: SpecTypes.ListToolsResult
 ) {
   sdk = spec;
   spec = sdk;
 }
 function checkCallToolResult(
-  sdk: SDKTypes.CallToolResult,
-  spec: DeepKnownKeys<SpecTypes.CallToolResult>
+  sdk: RemovePassthrough<SDKTypes.CallToolResult>,
+  spec: SpecTypes.CallToolResult
 ) {
   sdk = spec;
   spec = sdk;
@@ -298,15 +316,15 @@ function checkResourceUpdatedNotification(
   spec = sdk;
 }
 function checkSamplingMessage(
-  sdk: SDKTypes.SamplingMessage,
-  spec: DeepKnownKeys<SpecTypes.SamplingMessage>
+  sdk: RemovePassthrough<SDKTypes.SamplingMessage>,
+  spec: SpecTypes.SamplingMessage
 ) {
   sdk = spec;
   spec = sdk;
 }
 function checkCreateMessageResult(
-  sdk: SDKTypes.CreateMessageResult,
-  spec: DeepKnownKeys<SpecTypes.CreateMessageResult>
+  sdk: RemovePassthrough<SDKTypes.CreateMessageResult>,
+  spec: SpecTypes.CreateMessageResult
 ) {
   sdk = spec;
   spec = sdk;
@@ -340,8 +358,8 @@ function checkListResourcesRequest(
   spec = sdk;
 }
 function checkListResourcesResult(
-  sdk: SDKTypes.ListResourcesResult,
-  spec: DeepKnownKeys<SpecTypes.ListResourcesResult>
+  sdk: RemovePassthrough<SDKTypes.ListResourcesResult>,
+  spec: SpecTypes.ListResourcesResult
 ) {
   sdk = spec;
   spec = sdk;
@@ -354,8 +372,8 @@ function checkListResourceTemplatesRequest(
   spec = sdk;
 }
 function checkListResourceTemplatesResult(
-  sdk: SDKTypes.ListResourceTemplatesResult,
-  spec: DeepKnownKeys<SpecTypes.ListResourceTemplatesResult>
+  sdk: RemovePassthrough<SDKTypes.ListResourceTemplatesResult>,
+  spec: SpecTypes.ListResourceTemplatesResult
 ) {
   sdk = spec;
   spec = sdk;
@@ -368,57 +386,57 @@ function checkReadResourceRequest(
   spec = sdk;
 }
 function checkReadResourceResult(
-  sdk: SDKTypes.ReadResourceResult,
-  spec: DeepKnownKeys<SpecTypes.ReadResourceResult>
+  sdk: RemovePassthrough<SDKTypes.ReadResourceResult>,
+  spec: SpecTypes.ReadResourceResult
 ) {
   sdk = spec;
   spec = sdk;
 }
 function checkResourceContents(
-  sdk: SDKTypes.ResourceContents,
-  spec: DeepKnownKeys<SpecTypes.ResourceContents>
+  sdk: RemovePassthrough<SDKTypes.ResourceContents>,
+  spec: SpecTypes.ResourceContents
 ) {
   sdk = spec;
   spec = sdk;
 }
 function checkTextResourceContents(
-  sdk: SDKTypes.TextResourceContents,
-  spec: DeepKnownKeys<SpecTypes.TextResourceContents>
+  sdk: RemovePassthrough<SDKTypes.TextResourceContents>,
+  spec: SpecTypes.TextResourceContents
 ) {
   sdk = spec;
   spec = sdk;
 }
 function checkBlobResourceContents(
-  sdk: SDKTypes.BlobResourceContents,
-  spec: DeepKnownKeys<SpecTypes.BlobResourceContents>
+  sdk: RemovePassthrough<SDKTypes.BlobResourceContents>,
+  spec: SpecTypes.BlobResourceContents
 ) {
   sdk = spec;
   spec = sdk;
 }
 function checkResource(
-  sdk: SDKTypes.Resource,
-  spec: DeepKnownKeys<SpecTypes.Resource>
+  sdk: RemovePassthrough<SDKTypes.Resource>,
+  spec: SpecTypes.Resource
 ) {
   sdk = spec;
   spec = sdk;
 }
 function checkResourceTemplate(
-  sdk: SDKTypes.ResourceTemplate,
-  spec: DeepKnownKeys<SpecTypes.ResourceTemplate>
+  sdk: RemovePassthrough<SDKTypes.ResourceTemplate>,
+  spec: SpecTypes.ResourceTemplate
 ) {
   sdk = spec;
   spec = sdk;
 }
 function checkPromptArgument(
-  sdk: SDKTypes.PromptArgument,
-  spec: DeepKnownKeys<SpecTypes.PromptArgument>
+  sdk: RemovePassthrough<SDKTypes.PromptArgument>,
+  spec: SpecTypes.PromptArgument
 ) {
   sdk = spec;
   spec = sdk;
 }
 function checkPrompt(
-  sdk: SDKTypes.Prompt,
-  spec: DeepKnownKeys<SpecTypes.Prompt>
+  sdk: RemovePassthrough<SDKTypes.Prompt>,
+  spec: SpecTypes.Prompt
 ) {
   sdk = spec;
   spec = sdk;
@@ -431,8 +449,8 @@ function checkListPromptsRequest(
   spec = sdk;
 }
 function checkListPromptsResult(
-  sdk: SDKTypes.ListPromptsResult,
-  spec: DeepKnownKeys<SpecTypes.ListPromptsResult>
+  sdk: RemovePassthrough<SDKTypes.ListPromptsResult>,
+  spec: SpecTypes.ListPromptsResult
 ) {
   sdk = spec;
   spec = sdk;
@@ -445,154 +463,154 @@ function checkGetPromptRequest(
   spec = sdk;
 }
 function checkTextContent(
-  sdk: SDKTypes.TextContent,
-  spec: DeepKnownKeys<SpecTypes.TextContent>
+  sdk: RemovePassthrough<SDKTypes.TextContent>,
+  spec: SpecTypes.TextContent
 ) {
   sdk = spec;
   spec = sdk;
 }
 function checkImageContent(
-  sdk: SDKTypes.ImageContent,
-  spec: DeepKnownKeys<SpecTypes.ImageContent>
+  sdk: RemovePassthrough<SDKTypes.ImageContent>,
+  spec: SpecTypes.ImageContent
 ) {
   sdk = spec;
   spec = sdk;
 }
 function checkAudioContent(
-  sdk: SDKTypes.AudioContent,
-  spec: DeepKnownKeys<SpecTypes.AudioContent>
+  sdk: RemovePassthrough<SDKTypes.AudioContent>,
+  spec: SpecTypes.AudioContent
 ) {
   sdk = spec;
   spec = sdk;
 }
 function checkEmbeddedResource(
-  sdk: SDKTypes.EmbeddedResource,
-  spec: DeepKnownKeys<SpecTypes.EmbeddedResource>
+  sdk: RemovePassthrough<SDKTypes.EmbeddedResource>,
+  spec: SpecTypes.EmbeddedResource
 ) {
   sdk = spec;
   spec = sdk;
 }
 function checkResourceLink(
-  sdk: SDKTypes.ResourceLink,
-  spec: DeepKnownKeys<SpecTypes.ResourceLink>
+  sdk: RemovePassthrough<SDKTypes.ResourceLink>,
+  spec: SpecTypes.ResourceLink
 ) {
   sdk = spec;
   spec = sdk;
 }
 function checkContentBlock(
-  sdk: SDKTypes.ContentBlock,
-  spec: DeepKnownKeys<SpecTypes.ContentBlock>
+  sdk: RemovePassthrough<SDKTypes.ContentBlock>,
+  spec: SpecTypes.ContentBlock
 ) {
   sdk = spec;
   spec = sdk;
 }
 function checkPromptMessage(
-  sdk: SDKTypes.PromptMessage,
-  spec: DeepKnownKeys<SpecTypes.PromptMessage>
+  sdk: RemovePassthrough<SDKTypes.PromptMessage>,
+  spec: SpecTypes.PromptMessage
 ) {
   sdk = spec;
   spec = sdk;
 }
 function checkGetPromptResult(
-  sdk: SDKTypes.GetPromptResult,
-  spec: DeepKnownKeys<SpecTypes.GetPromptResult>
+  sdk: RemovePassthrough<SDKTypes.GetPromptResult>,
+  spec: SpecTypes.GetPromptResult
 ) {
   sdk = spec;
   spec = sdk;
 }
 function checkBooleanSchema(
-  sdk: SDKTypes.BooleanSchema,
-  spec: DeepKnownKeys<SpecTypes.BooleanSchema>
+  sdk: RemovePassthrough<SDKTypes.BooleanSchema>,
+  spec: SpecTypes.BooleanSchema
 ) {
   sdk = spec;
   spec = sdk;
 }
 function checkStringSchema(
-  sdk: SDKTypes.StringSchema,
-  spec: DeepKnownKeys<SpecTypes.StringSchema>
+  sdk: RemovePassthrough<SDKTypes.StringSchema>,
+  spec: SpecTypes.StringSchema
 ) {
   sdk = spec;
   spec = sdk;
 }
 function checkNumberSchema(
-  sdk: SDKTypes.NumberSchema,
-  spec: DeepKnownKeys<SpecTypes.NumberSchema>
+  sdk: RemovePassthrough<SDKTypes.NumberSchema>,
+  spec: SpecTypes.NumberSchema
 ) {
   sdk = spec;
   spec = sdk;
 }
 function checkEnumSchema(
-  sdk: SDKTypes.EnumSchema,
-  spec: DeepKnownKeys<SpecTypes.EnumSchema>
+  sdk: RemovePassthrough<SDKTypes.EnumSchema>,
+  spec: SpecTypes.EnumSchema
 ) {
   sdk = spec;
   spec = sdk;
 }
 function checkPrimitiveSchemaDefinition(
-  sdk: SDKTypes.PrimitiveSchemaDefinition,
-  spec: DeepKnownKeys<SpecTypes.PrimitiveSchemaDefinition>
+  sdk: RemovePassthrough<SDKTypes.PrimitiveSchemaDefinition>,
+  spec: SpecTypes.PrimitiveSchemaDefinition
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkJSONRPCError(
+  sdk: SDKTypes.JSONRPCError,
+  spec: SpecTypes.JSONRPCError
+) {
+  sdk = spec;
+  spec = sdk;
+}
+function checkJSONRPCMessage(
+  sdk: SDKTypes.JSONRPCMessage,
+  spec: SpecTypes.JSONRPCMessage
 ) {
   sdk = spec;
   spec = sdk;
 }
 function checkCreateMessageRequest(
-  sdk: DeepKnownKeys<SDKTypes.CreateMessageRequest>, // TODO(quirk): some {} type
-  spec: DeepKnownKeys<SpecTypes.CreateMessageRequest>
+  sdk: RemovePassthrough<SDKTypes.CreateMessageRequest>, // TODO(quirk): some {} typ>e
+  spec: SpecTypes.CreateMessageRequest
 ) {
   sdk = spec;
   spec = sdk;
 }
 function checkInitializeRequest(
-  sdk: DeepKnownKeys<SDKTypes.InitializeRequest>, // TODO(quirk): some {} type
+  sdk: RemovePassthrough<SDKTypes.InitializeRequest>, // TODO(quirk): some {} type
   spec: SpecTypes.InitializeRequest
 ) {
   sdk = spec;
   spec = sdk;
 }
 function checkInitializeResult(
-  sdk: DeepKnownKeys<SDKTypes.InitializeResult>, // TODO(quirk): some {} type
+  sdk: RemovePassthrough<SDKTypes.InitializeResult>, // TODO(quirk): some {} type
   spec: SpecTypes.InitializeResult
 ) {
   sdk = spec;
   spec = sdk;
 }
 function checkClientCapabilities(
-  sdk: DeepKnownKeys<SDKTypes.ClientCapabilities>, // TODO(quirk): {}
+  sdk: RemovePassthrough<SDKTypes.ClientCapabilities>, // TODO(quirk): {}
   spec: SpecTypes.ClientCapabilities
 ) {
   sdk = spec;
   spec = sdk;
 }
 function checkServerCapabilities(
-  sdk: DeepKnownKeys<SDKTypes.ServerCapabilities>, // TODO(quirk): {}
+  sdk: RemovePassthrough<SDKTypes.ServerCapabilities>, // TODO(quirk): {}
   spec: SpecTypes.ServerCapabilities
 ) {
   sdk = spec;
   spec = sdk;
 }
-function checkJSONRPCError(
-  sdk: DeepKnownKeys<SDKTypes.JSONRPCError>, // TODO(quirk): error.data
-  spec: DeepKnownKeys<SpecTypes.JSONRPCError>
-) {
-  sdk = spec;
-  spec = sdk;
-}
-function checkJSONRPCMessage(
-  sdk: DeepKnownKeys<SDKTypes.JSONRPCMessage>, // TODO(quirk): error.data
-  spec: DeepKnownKeys<SpecTypes.JSONRPCMessage>
-) {
-  sdk = spec;
-  spec = sdk;
-}
 function checkClientRequest(
-  sdk: DeepKnownKeys<SDKTypes.ClientRequest>, // TODO(quirk): capabilities.logging is {}
+  sdk: RemovePassthrough<SDKTypes.ClientRequest>, // TODO(quirk): capabilities.logging is {}
   spec: SpecTypes.ClientRequest
 ) {
   sdk = spec;
   spec = sdk;
 }
 function checkServerRequest(
-  sdk: DeepKnownKeys<SDKTypes.ServerRequest>, // TODO(quirk): some {} typ
+  sdk: RemovePassthrough<SDKTypes.ServerRequest>, // TODO(quirk): some {} typ
   spec: SpecTypes.ServerRequest
 ) {
   sdk = spec;
@@ -615,8 +633,8 @@ function checkServerNotification(
 
 // TODO(bug): missing type in SDK
 // function checkModelHint(
-//   sdk: SDKTypes.ModelHint,
-//   spec: DeepKnownKeys<SpecTypes.ModelHint>
+//  RemovePassthrough< sdk: SDKTypes.ModelHint>,
+//   spec: SpecTypes.ModelHint
 // ) {
 //   sdk = spec;
 //   spec = sdk;
@@ -624,8 +642,8 @@ function checkServerNotification(
 
 // TODO(bug): missing type in SDK
 // function checkModelPreferences(
-//   sdk: SDKTypes.ModelPreferences,
-//   spec: DeepKnownKeys<SpecTypes.ModelPreferences>
+//  RemovePassthrough< sdk: SDKTypes.ModelPreferences>,
+//   spec: SpecTypes.ModelPreferences
 // ) {
 //   sdk = spec;
 //   spec = sdk;
@@ -633,8 +651,8 @@ function checkServerNotification(
 
 // TODO(bug): missing type in SDK
 // function checkAnnotations(
-//   sdk: SDKTypes.Annotations,
-//   spec: DeepKnownKeys<SpecTypes.Annotations>
+//  RemovePassthrough< sdk: SDKTypes.Annotations>,
+//   spec: SpecTypes.Annotations
 // ) {
 //   sdk = spec;
 //   spec = sdk;

--- a/src/spec.types.test.ts
+++ b/src/spec.types.test.ts
@@ -1,9 +1,13 @@
-// import ts from 'typescript';
-
 import * as SDKTypes from "./types.js";
 import * as SpecTypes from "./spec.types.js";
 
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/no-unsafe-function-type */
+/* eslint-disable @typescript-eslint/no-require-imports */
+
 // Deep version that recursively removes index signatures (caused by ZodObject.passthrough()) and turns unknowns into `object | undefined`
+// TODO: make string index mapping tighter
+// TODO: split into multiple transformations (e.g. RemovePassthrough) and only use the ones needed for each type.
 type DeepKnownKeys<T> = T extends object
   ? T extends Array<infer U>
     ? Array<DeepKnownKeys<U>>

--- a/src/spec.types.test.ts
+++ b/src/spec.types.test.ts
@@ -12,12 +12,8 @@ type RemovePassthrough<T> = T extends object
   ? T extends Array<infer U>
     ? Array<RemovePassthrough<U>>
     : T extends Function
-    ? T
-    : {
-        [K in keyof T as string extends K ? never : number extends K ? never : K]: RemovePassthrough<T[K]>;
-      }
-  : unknown extends T
-  ? (object | undefined)
+        ? T
+        : {[K in keyof T as string extends K ? never : K]: RemovePassthrough<T[K]>}
   : T;
 
 function checkCancelledNotification(

--- a/src/spec.types.test.ts
+++ b/src/spec.types.test.ts
@@ -42,7 +42,7 @@ function checkImplementation(
   spec = sdk;
 } 
 function checkProgressNotification(
-  sdk: RemovePassthrough<SDKTypes.ProgressNotification>,
+  sdk: SDKTypes.ProgressNotification,
   spec: SpecTypes.ProgressNotification
 ) {
   sdk = spec;

--- a/src/spec.types.test.ts
+++ b/src/spec.types.test.ts
@@ -676,9 +676,9 @@ const MISSING_SDK_TYPES = [
 
   // These aren't supported by the SDK yet:
   // TODO: Add definitions to the SDK
+  'Annotations',
   'ModelHint',
   'ModelPreferences',
-  'Annotations',
 ]
 
 function extractExportedTypes(source: string): string[] {
@@ -693,6 +693,7 @@ describe('Spec Types', () => {
   it('should define some expected types', () => {
     expect(specTypes).toContain('JSONRPCNotification');
     expect(specTypes).toContain('ElicitResult');
+    expect(specTypes).toHaveLength(91);
   });
 
   it('should have up to date list of missing sdk types', () => {

--- a/src/spec.types.test.ts
+++ b/src/spec.types.test.ts
@@ -6,7 +6,7 @@
  *   (note: a few don't have SDK types, see MISSING_SDK_TYPES below)
  */
 import * as SDKTypes from "./types.js";
-import * as SpecTypes from "./spec.types.js";
+import * as SpecTypes from "../spec.types.js";
 import fs from "node:fs";
 
 /* eslint-disable @typescript-eslint/no-unused-vars */
@@ -666,7 +666,7 @@ function checkLoggingLevel(
 }
 
 // This file is .gitignore'd, and fetched by `npm run fetch:spec-types` (called by `npm run test`)
-const SPEC_TYPES_FILE  = 'src/spec.types.ts';
+const SPEC_TYPES_FILE  = 'spec.types.ts';
 const SDK_TYPES_FILE  = 'src/types.ts';
 
 const MISSING_SDK_TYPES = [

--- a/src/spec.types.test.ts
+++ b/src/spec.types.test.ts
@@ -258,13 +258,6 @@ function checkPromptReference(
   sdk = spec;
   spec = sdk;
 }
-function checkResourceReference(
-  sdk: RemovePassthrough<SDKTypes.ResourceReference>,
-  spec: SpecTypes.ResourceTemplateReference
-) {
-  sdk = spec;
-  spec = sdk;
-}
 function checkToolAnnotations(
   sdk: RemovePassthrough<SDKTypes.ToolAnnotations>,
   spec: SpecTypes.ToolAnnotations

--- a/src/spec.types.test.ts
+++ b/src/spec.types.test.ts
@@ -7,6 +7,7 @@
  */
 import * as SDKTypes from "./types.js";
 import * as SpecTypes from "./spec.types.js";
+import fs from "node:fs";
 
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/no-unsafe-function-type */
@@ -690,18 +691,18 @@ const SPEC_TYPES_FILE  = 'src/spec.types.ts';
 const THIS_SOURCE_FILE = 'src/spec.types.test.ts';
 
 describe('Spec Types', () => {
-    const specTypesContent = require('fs').readFileSync(SPEC_TYPES_FILE, 'utf-8');
-    const typeNames = [...specTypesContent.matchAll(/export\s+interface\s+(\w+)\b/g)].map(m => m[1]);
-    const testContent = require('fs').readFileSync(THIS_SOURCE_FILE, 'utf-8');
+  const specTypesContent = fs.readFileSync(SPEC_TYPES_FILE, 'utf-8');
+  const typeNames = [...specTypesContent.matchAll(/export\s+interface\s+(\w+)\b/g)].map(m => m[1]);
+  const testContent = fs.readFileSync(THIS_SOURCE_FILE, 'utf-8');
 
-    it('should define some expected types', () => {
-        expect(typeNames).toContain('JSONRPCNotification');
-        expect(typeNames).toContain('ElicitResult');
+  it('should define some expected types', () => {
+    expect(typeNames).toContain('JSONRPCNotification');
+    expect(typeNames).toContain('ElicitResult');
+  });
+
+  for (const typeName of typeNames) {
+    it(`${typeName} should have a compatibility test`, () => {
+      expect(testContent).toContain(`function check${typeName}(`);
     });
-
-    for (const typeName of typeNames) {
-        it(`${typeName} should have a compatibility test`, () => {
-            expect(testContent).toContain(`function check${typeName}(`);
-        });
-    }
+  }
 });

--- a/src/spec.types.test.ts
+++ b/src/spec.types.test.ts
@@ -2,8 +2,8 @@
  * This contains:
  * - Static type checks to verify the Spec's types are compatible with the SDK's types
  *   (mutually assignable, w/ slight affordances to get rid of ZodObject.passthrough() index signatures, etc)
- * - Runtime checks to verify all Spec types have a static check
- *   (a few don't have SDK types, see TODOs in this file)
+ * - Runtime checks to verify each Spec type has a static check
+ *   (note: a few don't have SDK types, see TODOs in this file)
  */
 import * as SDKTypes from "./types.js";
 import * as SpecTypes from "./spec.types.js";
@@ -685,6 +685,7 @@ function checkServerNotification(
 //   spec = sdk;
 // }
 
+// This file is .gitignore'd, and fetched by `npm run fetch:spec-types` (called by `npm run test`)
 const SPEC_TYPES_FILE  = 'src/spec.types.ts';
 const THIS_SOURCE_FILE = 'src/spec.types.test.ts';
 

--- a/src/spec.types.test.ts
+++ b/src/spec.types.test.ts
@@ -11,7 +11,6 @@ import fs from "node:fs";
 
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/no-unsafe-function-type */
-/* eslint-disable @typescript-eslint/no-require-imports */
 
 // Removes index signatures added by ZodObject.passthrough().
 type RemovePassthrough<T> = T extends object

--- a/src/spec.types.test.ts
+++ b/src/spec.types.test.ts
@@ -3,7 +3,7 @@
  * - Static type checks to verify the Spec's types are compatible with the SDK's types
  *   (mutually assignable, w/ slight affordances to get rid of ZodObject.passthrough() index signatures, etc)
  * - Runtime checks to verify each Spec type has a static check
- *   (note: a few don't have SDK types, see TODOs in this file)
+ *   (note: a few don't have SDK types, see MISSING_SDK_TYPES below)
  */
 import * as SDKTypes from "./types.js";
 import * as SpecTypes from "./spec.types.js";


### PR DESCRIPTION
Test that the [TS SDK types](https://github.com/modelcontextprotocol/typescript-sdk/blob/main/src/types.ts) are in sync w/ the [Spec types](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/main/schema/draft/schema.ts)

Note: ModelHint, ModelPreferences, Annotations are not in the SDK yet, incubating them in https://github.com/modelcontextprotocol/typescript-sdk/commit/a63aeebde326bce271bd0acc31326bd8a3bb7235

## Motivation and Context

https://github.com/modelcontextprotocol/typescript-sdk/pull/727 cc/ @ihrpr 

## How Has This Been Tested?

- Checked that `npm run test` failes w/ human-readable message before https://github.com/modelcontextprotocol/typescript-sdk/pull/727

  ![CleanShot 2025-07-03 at 21 23 01@2x](https://github.com/user-attachments/assets/42ce0f0a-6769-42a3-b932-16368fd205bc)

- Did spot tests of editing either the sdk types or the spec types, e.g. switching fields between optional & required, renaming, altering strings

## Breaking Changes
None

## Types of changes
- [x] Test
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context

Types in the TS SDK are derived from Zod schemas, while the ones in the specs are written by hand. This causes a few type discrepancies, which are temptatively ironed out using ham-handed type mappings:
- `ZodObject.passthrough()` feature introduces `{[key: string]: unknown}` passthroughs: we undo this w/ `RemovePassthrough<T>`
- Fields w/ `z.unknown()` are treated as optional; we undo this w/ `MakeUnknownsNotOptional<T>`, with the exception of `_meta` fields
