### PR TITLE
Fix oauth-protected-resource to also be path aware

### DIFF
--- a/src/client/auth.ts
+++ b/src/client/auth.ts
@@ -261,7 +261,9 @@ export async function discoverOAuthProtectedResourceMetadata(
   if (opts?.resourceMetadataUrl) {
     url = new URL(opts?.resourceMetadataUrl);
   } else {
-    url = new URL("/.well-known/oauth-protected-resource", serverUrl);
+    const issuer = new URL(serverUrl);
+    const wellKnownPath = buildWellKnownPath('oauth-protected-resource', issuer.pathname);
+    url = new URL(wellKnownPath, issuer);
   }
 
   let response: Response;
@@ -318,8 +320,8 @@ async function fetchWithCorsRetry(
 /**
  * Constructs the well-known path for OAuth metadata discovery
  */
-function buildWellKnownPath(pathname: string): string {
-  let wellKnownPath = `/.well-known/oauth-authorization-server${pathname}`;
+function buildWellKnownPath(wellKnownPath: string, pathname: string): string {
+  let wellKnownPath = `/.well-known/${wellKnownPath}${pathname}`;
   if (pathname.endsWith('/')) {
     // Strip trailing slash from pathname to avoid double slashes
     wellKnownPath = wellKnownPath.slice(0, -1);
@@ -361,7 +363,7 @@ export async function discoverOAuthMetadata(
   const protocolVersion = opts?.protocolVersion ?? LATEST_PROTOCOL_VERSION;
 
   // Try path-aware discovery first (RFC 8414 compliant)
-  const wellKnownPath = buildWellKnownPath(issuer.pathname);
+  const wellKnownPath = buildWellKnownPath('oauth-authorization-server', issuer.pathname);
   const pathAwareUrl = new URL(wellKnownPath, issuer);
   let response = await tryMetadataDiscovery(pathAwareUrl, protocolVersion);
 


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
This change is the same as https://github.com/modelcontextprotocol/typescript-sdk/pull/687 but applied to the protected resource well known path as well.

This should be spec compliant, as per RFC 9728:

Different applications utilizing OAuth protected resources in  application-specific ways MAY define and register different well-  known URI path suffixes for publishing protected resource metadata  used by those applications.  For instance, if the Example application  uses an OAuth protected resource in an Example-specific way and there  are Example-specific metadata values that it needs to publish, then  it might register and use the example-protected-resource URI path  suffix and publish the metadata document at the URL formed by  inserting /.well-known/example-protected-resource between the host  and path and/or query components of the protected resource's resource  identifier.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
