### PR TITLE
make client side client_id generation configurable in the oauth router

### DIFF
--- a/src/server/auth/clients.ts
+++ b/src/server/auth/clients.ts
@@ -16,5 +16,5 @@ export interface OAuthRegisteredClientsStore {
    * 
    * If unimplemented, dynamic client registration is unsupported.
    */
-  registerClient?(client: OAuthClientInformationFull): OAuthClientInformationFull | Promise<OAuthClientInformationFull>;
+  registerClient?(client: Omit<OAuthClientInformationFull, "client_id">): OAuthClientInformationFull | Promise<OAuthClientInformationFull>;
 }

--- a/src/server/auth/handlers/register.test.ts
+++ b/src/server/auth/handlers/register.test.ts
@@ -218,6 +218,26 @@ describe('Client Registration Handler', () => {
       expect(response.body.client_secret_expires_at).toBe(0);
     });
 
+    it('sets no client_id when clientIdGeneration=false', async () => {
+      // Create handler with no expiry
+      const customApp = express();
+      const options: ClientRegistrationHandlerOptions = {
+        clientsStore: mockClientStoreWithRegistration,
+        clientIdGeneration: false
+      };
+
+      customApp.use('/register', clientRegistrationHandler(options));
+
+      const response = await supertest(customApp)
+        .post('/register')
+        .send({
+          redirect_uris: ['https://example.com/callback']
+        });
+
+      expect(response.status).toBe(201);
+      expect(response.body.client_id).toBeUndefined();
+    });
+
     it('handles client with all metadata fields', async () => {
       const fullClientMetadata: OAuthClientMetadata = {
         redirect_uris: ['https://example.com/callback'],

--- a/src/server/auth/router.ts
+++ b/src/server/auth/router.ts
@@ -142,7 +142,7 @@ export function mcpAuthRouter(options: AuthRouterOptions): RequestHandler {
       new URL(oauthMetadata.registration_endpoint).pathname,
       clientRegistrationHandler({
         clientsStore: options.provider.clientsStore,
-        ...options,
+        ...options.clientRegistrationOptions,
       })
     );
   }


### PR DESCRIPTION
Add the ability to toggle client side `client_id` generation during the registration process.

## Motivation and Context
Some oauth servers will not let the client provide a `client_id` during registration and generate it themselves (eg. keycloak).
Fixes https://github.com/modelcontextprotocol/typescript-sdk/issues/724

## How Has This Been Tested?

I tested the entire flow with the MCP inspector and a production keycloak instance.

## Breaking Changes
None.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
None.
