### PR TITLE
add stdio-http proxy example

### DIFF
--- a/src/examples/proxy/stdio-wrapper.ts
+++ b/src/examples/proxy/stdio-wrapper.ts
@@ -1,4 +1,32 @@
 #!/usr/bin/env npx -y tsx
+/*
+    This allows exposing a local stdio MCP server as a Streamable HTTP endpoint.
+    The --cloudflare flag exposes the endpoint over the web using a reverse tunnel (requires installing cloudflared).
+    The --auth-key option allows some level of security (defaults to random, use empty to disable - dangerous if exposing on the web)
+
+    Prerequisites:
+    - cloudflared: https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads
+    - Node.js with `npx`
+
+    Usage example:
+    
+        export PATH=$PWD:$PATH # Put the script's parent folder in your PATH
+
+        stdio-wrapper.ts --cloudflare \
+            docker run --rm -i \
+                --network=none --cap-drop=ALL --security-opt=no-new-privileges:true \
+                -v claude-memory:/app/dist \
+                node:latest \
+                npx -y @modelcontextprotocol/server-memory
+        
+        PORT=3001 stdio-wrapper.ts --cloudflare \
+            docker run --rm -i \
+                --cap-drop=ALL --security-opt=no-new-privileges:true \
+                ghcr.io/astral-sh/uv:debian \
+                uvx mcp-server-fetch                
+
+    Note that you should not drop the `--network=none` flag unless you fully trust the MCP server, as it will have full access to the internet *and* localhost (any unprotected local server can then pose high risks).
+*/
 import { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import { CancelledNotification, CancelledNotificationSchema, isJSONRPCError, isJSONRPCResponse, Tool } from "@modelcontextprotocol/sdk/types.js";
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';


### PR DESCRIPTION
Example proxy wrapper around an stdio MCP server that expose it as a Streamable HTTP endpoint *on the web* (+ gives example usage guidelines w/ the Claude API)

This shows how to do transport-level proxying. A subsequent example will delve into higher-level proxying (w/ support for augmentations / filtering / etc).

## Motivation and Context

Provide canonical code for simple transport-level proxying (lots of options on the web), and simple, preliminary security guidelines.

This is the full code of the upcoming tutorial in https://github.com/modelcontextprotocol/modelcontextprotocol/pull/918

## How Has This Been Tested?
Local testing + Claude API testing

## Breaking Changes
None

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed
