### PR TITLE
feat(protocol): Debounce notifications to improve network efficiancy

### DIFF
--- a/README.md
+++ b/README.md
@@ -902,6 +902,40 @@ const transport = new StdioServerTransport();
 await server.connect(transport);
 ```
 
+### Improving Network Efficiency with Notification Debouncing
+
+When performing bulk updates that trigger notifications (e.g., enabling or disabling multiple tools in a loop), the SDK can send a large number of messages in a short period. To improve performance and reduce network traffic, you can enable notification debouncing.
+
+This feature coalesces multiple, rapid calls for the same notification type into a single message. For example, if you disable five tools in a row, only one `notifications/tools/list_changed` message will be sent instead of five.
+
+This is an opt-in feature configured during server initialization.
+
+```typescript
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+const server = new McpServer(
+  {
+    name: "efficient-server",
+    version: "1.0.0"
+  },
+  {
+    // Enable notification debouncing for specific methods
+    debouncedNotificationMethods: [
+      'notifications/tools/list_changed',
+      'notifications/resources/list_changed',
+      'notifications/prompts/list_changed'
+    ]
+  }
+);
+
+// Now, any rapid changes to tools, resources, or prompts will result
+// in a single, consolidated notification for each type.
+server.registerTool("tool1", ...).disable();
+server.registerTool("tool2", ...).disable();
+server.registerTool("tool3", ...).disable();
+// Only one 'notifications/tools/list_changed' is sent.
+```
+
 ### Low-Level Server
 
 For more control, you can use the low-level Server class directly:


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
This PR introduces a micro-batching mechanism for notifications within the protocol layer to improve network efficiency by coalescing rapid, successive notifications into a single message.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Currently, SDK methods that trigger notifications (e.g., `tool.enable()`) do so immediately. When an application performs bulk operations, such as enabling and disabling multiple tools during a state transition, this results in a "flood" of individual notifications being sent to the client.

For instance, consider the following state management code from a benchmark application:

```ts
export class IdleState extends AbstractBenchmarkState {
  async enter(context: BenchmarkContext): Promise<void> {
    console.log(`[State] Entering IdleState for session ${context.sessionId}`);
    // Enable the 'start' tool and disable others
    context.mcpEntities.startBenchmarkTool?.enable();
    context.mcpEntities.chooseCategoryTool?.disable();
    context.mcpEntities.selectMenuTool?.disable();
    context.mcpEntities.submitDetailsTool?.disable();
    context.mcpEntities.getConfirmationEmailTool?.disable();
  }
  // ...
}
```

Without this change, the `enter()` method would trigger **five separate `notifications/tools/list_changed` messages** to be sent to the client, one for each call to `.enable()` or `.disable()`.

This PR solves this inefficiency by debouncing these notifications. With this change, the entire block of five calls results in only **a single, coalesced `notifications/tools/list_changed` message**, significantly reducing network traffic and server load.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
This feature has been validated with a new suite of unit tests and verified in the real-world application that uses the state machine shown above.

**Unit Tests:**
- A test confirms that multiple synchronous calls for a debounced notification method are correctly coalesced into a single network `send`.
- A test verifies that notifications *not* configured for debouncing are sent immediately, ensuring no regressions in existing behavior.
- The tests use microtask flushing (`setImmediate` or `Promise.resolve().then()`) to reliably test the asynchronous debouncing logic.

**Application Testing:**
- The change was tested in the client/server application that uses the `IdleState` class.
- After enabling the feature, server logs confirmed that the five method calls in `IdleState.enter()` now result in a single, consolidated `tools/list_changed` notification, as expected.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No. This is a non-breaking, opt-in feature. Existing code will continue to function without any changes. To enable the new behavior, users must explicitly provide the new `debouncedNotificationMethods` configuration option.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
The implementation uses a microtask-based debouncing strategy within the `Protocol.notification()` method. When a notification designated for debouncing is called, it schedules the actual network send for the next microtask using `Promise.resolve().then()`. This allows all other synchronous calls within the same event-loop tick to be captured and coalesced into that single scheduled send.

This design was chosen specifically to avoid altering the public-facing SDK API. No new methods like `server.batchedUpdates()` are required, making the feature transparent to the end-user's application code once configured.