### PR TITLE
Improve Oauth Authorization Server fallback logic

### DIFF
--- a/src/client/auth.ts
+++ b/src/client/auth.ts
@@ -107,12 +107,13 @@ export async function auth(
     serverUrl: string | URL;
     authorizationCode?: string;
     scope?: string;
-    resourceMetadataUrl?: URL }): Promise<AuthResult> {
+    resourceMetadataUrl?: URL
+  }): Promise<AuthResult> {
 
   let resourceMetadata: OAuthProtectedResourceMetadata | undefined;
   let authorizationServerUrl = serverUrl;
   try {
-    resourceMetadata = await discoverOAuthProtectedResourceMetadata(serverUrl, {resourceMetadataUrl});
+    resourceMetadata = await discoverOAuthProtectedResourceMetadata(serverUrl, { resourceMetadataUrl });
     if (resourceMetadata.authorization_servers && resourceMetadata.authorization_servers.length > 0) {
       authorizationServerUrl = resourceMetadata.authorization_servers[0];
     }
@@ -197,7 +198,7 @@ export async function auth(
   return "REDIRECT";
 }
 
-export async function selectResourceURL(serverUrl: string| URL, provider: OAuthClientProvider, resourceMetadata?: OAuthProtectedResourceMetadata): Promise<URL | undefined> {
+export async function selectResourceURL(serverUrl: string | URL, provider: OAuthClientProvider, resourceMetadata?: OAuthProtectedResourceMetadata): Promise<URL | undefined> {
   const defaultResource = resourceUrlFromServerUrl(serverUrl);
 
   // If provider has custom validation, delegate to it
@@ -363,7 +364,13 @@ export async function discoverOAuthMetadata(
   // Try path-aware discovery first (RFC 8414 compliant)
   const wellKnownPath = buildWellKnownPath(issuer.pathname);
   const pathAwareUrl = new URL(wellKnownPath, issuer);
-  let response = await tryMetadataDiscovery(pathAwareUrl, protocolVersion);
+  let response;
+  try {
+    response = await tryMetadataDiscovery(pathAwareUrl, protocolVersion);
+  } catch (error) {
+    // If fetch fails, we assume the server does not support path-aware discovery
+    response = undefined;
+  }
 
   // If path-aware discovery fails with 404, try fallback to root discovery
   if (shouldAttemptFallback(response, issuer.pathname)) {


### PR DESCRIPTION
I'm dealing with the [Atlassian MCP
Server](https://mcp.atlassian.com/v1/sse). This server hosts the `/.well-known/oauth-authorization-sever` without the path aware support With the current version of the SDK, this will never hit the case where we try the wellknown path without the pathname because it fails cors both times due to how this server is configured. This throws an error instead of returning undefined and letting the fallthrough logic work.

This updates the logic so that we always fallback on using the well known server path without the pathname.

## Motivation and Context
Atlassian serves the well-know url without path aware support. It also returns a cors error for unknown paths. This fails the try/catch, but throws the error up and is not caught.

## How Has This Been Tested?
We are seeing this behavior in our react app using the latest `use-mcp` hook. I stepped through the code and verified that it still works if we remove the `/v1/sse` from the well-known path that is created.

## Breaking Changes
No, this is not a breaking change

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
