### PR TITLE
Add missing app.listen error handling to server examples

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -102,7 +102,11 @@ async function runServer(port: number | null) {
       await transport.handlePostMessage(req, res);
     });
 
-    app.listen(port, () => {
+    app.listen(port, (error) => {
+      if (error) {
+        console.error('Failed to start server:', error);
+        process.exit(1);
+      }
       console.log(`Server running on http://localhost:${port}/sse`);
     });
   } else {

--- a/src/examples/server/demoInMemoryOAuthProvider.ts
+++ b/src/examples/server/demoInMemoryOAuthProvider.ts
@@ -200,7 +200,11 @@ export const setupAuthServer = ({authServerUrl, mcpServerUrl, strictResource}: {
 
   const auth_port = authServerUrl.port;
   // Start the auth server
-  authApp.listen(auth_port, () => {
+  authApp.listen(auth_port, (error) => {
+    if (error) {
+      console.error('Failed to start server:', error);
+      process.exit(1);
+    }
     console.log(`OAuth Authorization Server listening on port ${auth_port}`);
   });
 

--- a/src/examples/server/jsonResponseStreamableHttp.ts
+++ b/src/examples/server/jsonResponseStreamableHttp.ts
@@ -158,7 +158,11 @@ app.get('/mcp', async (req: Request, res: Response) => {
 
 // Start the server
 const PORT = 3000;
-app.listen(PORT, () => {
+app.listen(PORT, (error) => {
+  if (error) {
+    console.error('Failed to start server:', error);
+    process.exit(1);
+  }
   console.log(`MCP Streamable HTTP Server listening on port ${PORT}`);
 });
 

--- a/src/examples/server/simpleSseServer.ts
+++ b/src/examples/server/simpleSseServer.ts
@@ -145,7 +145,11 @@ app.post('/messages', async (req: Request, res: Response) => {
 
 // Start the server
 const PORT = 3000;
-app.listen(PORT, () => {
+app.listen(PORT, (error) => {
+  if (error) {
+    console.error('Failed to start server:', error);
+    process.exit(1);
+  }
   console.log(`Simple SSE Server (deprecated protocol version 2024-11-05) listening on port ${PORT}`);
 });
 

--- a/src/examples/server/simpleStatelessStreamableHttp.ts
+++ b/src/examples/server/simpleStatelessStreamableHttp.ts
@@ -158,7 +158,11 @@ app.delete('/mcp', async (req: Request, res: Response) => {
 
 // Start the server
 const PORT = 3000;
-app.listen(PORT, () => {
+app.listen(PORT, (error) => {
+  if (error) {
+    console.error('Failed to start server:', error);
+    process.exit(1);
+  }
   console.log(`MCP Stateless Streamable HTTP Server listening on port ${PORT}`);
 });
 

--- a/src/examples/server/simpleStreamableHttp.ts
+++ b/src/examples/server/simpleStreamableHttp.ts
@@ -648,7 +648,11 @@ if (useOAuth && authMiddleware) {
   app.delete('/mcp', mcpDeleteHandler);
 }
 
-app.listen(MCP_PORT, () => {
+app.listen(MCP_PORT, (error) => {
+  if (error) {
+    console.error('Failed to start server:', error);
+    process.exit(1);
+  }
   console.log(`MCP Streamable HTTP Server listening on port ${MCP_PORT}`);
 });
 

--- a/src/examples/server/sseAndStreamableHttpCompatibleServer.ts
+++ b/src/examples/server/sseAndStreamableHttpCompatibleServer.ts
@@ -210,7 +210,11 @@ app.post("/messages", async (req: Request, res: Response) => {
 
 // Start the server
 const PORT = 3000;
-app.listen(PORT, () => {
+app.listen(PORT, (error) => {
+  if (error) {
+    console.error('Failed to start server:', error);
+    process.exit(1);
+  }
   console.log(`Backwards compatible MCP server listening on port ${PORT}`);
   console.log(`
 ==============================================

--- a/src/examples/server/standaloneSseWithGetStreamableHttp.ts
+++ b/src/examples/server/standaloneSseWithGetStreamableHttp.ts
@@ -112,7 +112,11 @@ app.get('/mcp', async (req: Request, res: Response) => {
 
 // Start the server
 const PORT = 3000;
-app.listen(PORT, () => {
+app.listen(PORT, (error) => {
+  if (error) {
+    console.error('Failed to start server:', error);
+    process.exit(1);
+  }
   console.log(`Server listening on port ${PORT}`);
 });
 


### PR DESCRIPTION
Express `app.listen`'s callback accepts an optional error argument, which needs checking to avoid surprising behaviour.

## Motivation and Context
When one of the ports used by the examples is already in use, users will unknowingly hit the previously running server instead of being notified of an error.

## How Has This Been Tested?
Concurrent runs of `npx -y tsx src/examples/server/simpleStreamableHttp.ts` and its sibling examples.

## Breaking Changes
None

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed
