### PR TITLE
auth: fetch AS metadata in well-known subpath from serverUrl even when PRM returns external AS

### DIFF
--- a/src/client/auth.test.ts
+++ b/src/client/auth.test.ts
@@ -1753,7 +1753,7 @@ describe("OAuth Authorization", () => {
       mockFetch.mockImplementation((url) => {
         const urlString = url.toString();
 
-        if (urlString === "https://my.resource.com/.well-known/oauth-protected-resource") {
+        if (urlString === "https://my.resource.com/.well-known/oauth-protected-resource/path/name") {
           return Promise.resolve({
             ok: true,
             status: 200,
@@ -1800,7 +1800,7 @@ describe("OAuth Authorization", () => {
       const calls = mockFetch.mock.calls;
       
       // First call should be to PRM
-      expect(calls[0][0].toString()).toBe("https://my.resource.com/.well-known/oauth-protected-resource");
+      expect(calls[0][0].toString()).toBe("https://my.resource.com/.well-known/oauth-protected-resource/path/name");
       
       // Second call should be to AS metadata with the path from serverUrl
       expect(calls[1][0].toString()).toBe("https://auth.example.com/.well-known/oauth-authorization-server/path/name");

--- a/src/client/auth.ts
+++ b/src/client/auth.ts
@@ -358,9 +358,9 @@ function shouldAttemptFallback(response: Response | undefined, pathname: string)
 export async function discoverOAuthMetadata(
   issuer: string | URL,
   {
-    authorizationServerUrl
+    authorizationServerUrl,
   }: {
-    authorizationServerUrl?: string | URL
+    authorizationServerUrl?: string | URL,
   } = {},
 ): Promise<OAuthMetadata | undefined> {
   if (typeof issuer === 'string') {

--- a/src/client/auth.ts
+++ b/src/client/auth.ts
@@ -471,7 +471,7 @@ function shouldAttemptFallback(response: Response | undefined, pathname: string)
 async function discoverMetadataWithFallback(
   serverUrl: string | URL,
   wellKnownType: 'oauth-authorization-server' | 'oauth-protected-resource',
-  opts?: { protocolVersion?: string; metadataUrl?: string | URL },
+  opts?: { protocolVersion?: string; metadataUrl?: string | URL, metadataServerUrl?: string | URL },
 ): Promise<Response | undefined> {
   const issuer = new URL(serverUrl);
   const protocolVersion = opts?.protocolVersion ?? LATEST_PROTOCOL_VERSION;
@@ -482,7 +482,7 @@ async function discoverMetadataWithFallback(
   } else {
     // Try path-aware discovery first
     const wellKnownPath = buildWellKnownPath(wellKnownType, issuer.pathname);
-    url = new URL(wellKnownPath, issuer);
+    url = new URL(wellKnownPath, opts?.metadataServerUrl ?? issuer);
     url.search = issuer.search;
   }
 
@@ -525,9 +525,13 @@ export async function discoverOAuthMetadata(
   protocolVersion ??= LATEST_PROTOCOL_VERSION;
 
   const response = await discoverMetadataWithFallback(
-    authorizationServerUrl,
+    issuer,
+    // authorizationServerUrl,
     'oauth-authorization-server',
-    {protocolVersion},
+    {
+      protocolVersion,
+      metadataServerUrl: authorizationServerUrl,
+    },
   );
 
   if (!response || response.status === 404) {

--- a/src/client/auth.ts
+++ b/src/client/auth.ts
@@ -526,7 +526,6 @@ export async function discoverOAuthMetadata(
 
   const response = await discoverMetadataWithFallback(
     issuer,
-    // authorizationServerUrl,
     'oauth-authorization-server',
     {
       protocolVersion,

--- a/src/client/auth.ts
+++ b/src/client/auth.ts
@@ -489,8 +489,10 @@ export async function discoverOAuthMetadata(
   issuer: string | URL,
   {
     authorizationServerUrl,
+    protocolVersion,
   }: {
     authorizationServerUrl?: string | URL,
+    protocolVersion?: string,
   } = {},
 ): Promise<OAuthMetadata | undefined> {
   if (typeof issuer === 'string') {


### PR DESCRIPTION
When hitting a protected endpoint `https://foo.com/mcp`, we now query the integrated AS at `https://foo.com/.well-known/oauth-authorization-server/mcp` (w/ a fallback to just `https://foo.com/.well-known/oauth-authorization-server`).

BUT if there's an external AS defined in the PRM (e.g. if `https://foo.com/.well-known/oauth-protected-resource` returns `{"authorization_servers":["https://some-auth.com"]...}`), we currently sidestep the subpath logic and only hit `https://some-auth.com/.well-known/oauth-authorization-server`.

This change passes the auth server URL to `discoverOAuthMetadata` separately from the issuer URL (from which the subpath is to be fetched), and adds a test on `auth` itself that fails before the change.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
