### PR TITLE
fix: use authorization_server_url as issuer when fetching metadata

### DIFF
--- a/src/client/auth.test.ts
+++ b/src/client/auth.test.ts
@@ -1759,7 +1759,7 @@ describe("OAuth Authorization", () => {
             status: 200,
             json: async () => ({
               resource: "https://my.resource.com/",
-              authorization_servers: ["https://auth.example.com/"],
+              authorization_servers: ["https://auth.example.com/oauth"],
             }),
           });
         } else if (urlString === "https://auth.example.com/.well-known/oauth-authorization-server/path/name") {
@@ -1802,8 +1802,8 @@ describe("OAuth Authorization", () => {
       // First call should be to PRM
       expect(calls[0][0].toString()).toBe("https://my.resource.com/.well-known/oauth-protected-resource/path/name");
       
-      // Second call should be to AS metadata with the path from serverUrl
-      expect(calls[1][0].toString()).toBe("https://auth.example.com/.well-known/oauth-authorization-server/path/name");
+      // Second call should be to AS metadata with the path from authorization server
+      expect(calls[1][0].toString()).toBe("https://auth.example.com/.well-known/oauth-authorization-server/oauth");
     });
   });
 

--- a/src/client/auth.ts
+++ b/src/client/auth.ts
@@ -525,7 +525,7 @@ export async function discoverOAuthMetadata(
   protocolVersion ??= LATEST_PROTOCOL_VERSION;
 
   const response = await discoverMetadataWithFallback(
-    issuer,
+    authorizationServerUrl,
     'oauth-authorization-server',
     {
       protocolVersion,


### PR DESCRIPTION
This pr resolves #762, build the well-known url with authorization_server_url rather than mcp server url when discovering metadata

## Motivation and Context
See #762 

## How Has This Been Tested?
Tested with [official github mcp server](https://github.com/github/github-mcp-server)

## Breaking Changes
No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
