### PR TITLE
fix: consistently use consumer-provided fetch function

### DIFF
--- a/src/client/auth.ts
+++ b/src/client/auth.ts
@@ -19,6 +19,7 @@ import {
   ServerError,
   UnauthorizedClientError
 } from "../server/auth/errors.js";
+import { FetchLike } from "src/shared/transport.js";
 
 /**
  * Implements an end-to-end OAuth client to be used with one MCP server.
@@ -281,8 +282,9 @@ export async function auth(
     serverUrl: string | URL;
     authorizationCode?: string;
     scope?: string;
-    resourceMetadataUrl?: URL }): Promise<AuthResult> {
-
+    resourceMetadataUrl?: URL;
+    fetchFn?: FetchLike;
+}): Promise<AuthResult> {
   try {
     return await authInternal(provider, options);
   } catch (error) {
@@ -305,18 +307,21 @@ async function authInternal(
   { serverUrl,
     authorizationCode,
     scope,
-    resourceMetadataUrl
+    resourceMetadataUrl,
+    fetchFn,
   }: {
     serverUrl: string | URL;
     authorizationCode?: string;
     scope?: string;
-    resourceMetadataUrl?: URL
-  }): Promise<AuthResult> {
+    resourceMetadataUrl?: URL;
+    fetchFn?: FetchLike;
+  },
+): Promise<AuthResult> {
 
   let resourceMetadata: OAuthProtectedResourceMetadata | undefined;
   let authorizationServerUrl = serverUrl;
   try {
-    resourceMetadata = await discoverOAuthProtectedResourceMetadata(serverUrl, { resourceMetadataUrl });
+    resourceMetadata = await discoverOAuthProtectedResourceMetadata(serverUrl, { resourceMetadataUrl }, fetchFn);
     if (resourceMetadata.authorization_servers && resourceMetadata.authorization_servers.length > 0) {
       authorizationServerUrl = resourceMetadata.authorization_servers[0];
     }
@@ -328,7 +333,7 @@ async function authInternal(
 
   const metadata = await discoverOAuthMetadata(serverUrl, {
     authorizationServerUrl
-  });
+  }, fetchFn);
 
   // Handle client registration if needed
   let clientInformation = await Promise.resolve(provider.clientInformation());
@@ -469,10 +474,12 @@ export function extractResourceMetadataUrl(res: Response): URL | undefined {
 export async function discoverOAuthProtectedResourceMetadata(
   serverUrl: string | URL,
   opts?: { protocolVersion?: string, resourceMetadataUrl?: string | URL },
+  fetchFn: FetchLike = fetch,
 ): Promise<OAuthProtectedResourceMetadata> {
   const response = await discoverMetadataWithFallback(
     serverUrl,
     'oauth-protected-resource',
+    fetchFn,
     {
       protocolVersion: opts?.protocolVersion,
       metadataUrl: opts?.resourceMetadataUrl,
@@ -497,14 +504,15 @@ export async function discoverOAuthProtectedResourceMetadata(
 async function fetchWithCorsRetry(
   url: URL,
   headers?: Record<string, string>,
+  fetchFn: FetchLike = fetch,
 ): Promise<Response | undefined> {
   try {
-    return await fetch(url, { headers });
+    return await fetchFn(url, { headers });
   } catch (error) {
     if (error instanceof TypeError) {
       if (headers) {
         // CORS errors come back as TypeError, retry without headers
-        return fetchWithCorsRetry(url)
+        return fetchWithCorsRetry(url, undefined, fetchFn)
       } else {
         // We're getting CORS errors on retry too, return undefined
         return undefined
@@ -532,11 +540,12 @@ function buildWellKnownPath(wellKnownPrefix: string, pathname: string): string {
 async function tryMetadataDiscovery(
   url: URL,
   protocolVersion: string,
+  fetchFn: FetchLike = fetch,
 ): Promise<Response | undefined> {
   const headers = {
     "MCP-Protocol-Version": protocolVersion
   };
-  return await fetchWithCorsRetry(url, headers);
+  return await fetchWithCorsRetry(url, headers, fetchFn);
 }
 
 /**
@@ -552,6 +561,7 @@ function shouldAttemptFallback(response: Response | undefined, pathname: string)
 async function discoverMetadataWithFallback(
   serverUrl: string | URL,
   wellKnownType: 'oauth-authorization-server' | 'oauth-protected-resource',
+  fetchFn: FetchLike,
   opts?: { protocolVersion?: string; metadataUrl?: string | URL, metadataServerUrl?: string | URL },
 ): Promise<Response | undefined> {
   const issuer = new URL(serverUrl);
@@ -567,12 +577,12 @@ async function discoverMetadataWithFallback(
     url.search = issuer.search;
   }
 
-  let response = await tryMetadataDiscovery(url, protocolVersion);
+  let response = await tryMetadataDiscovery(url, protocolVersion, fetchFn);
 
   // If path-aware discovery fails with 404 and we're not already at root, try fallback to root discovery
   if (!opts?.metadataUrl && shouldAttemptFallback(response, issuer.pathname)) {
     const rootUrl = new URL(`/.well-known/${wellKnownType}`, issuer);
-    response = await tryMetadataDiscovery(rootUrl, protocolVersion);
+    response = await tryMetadataDiscovery(rootUrl, protocolVersion, fetchFn);
   }
 
   return response;
@@ -593,6 +603,7 @@ export async function discoverOAuthMetadata(
     authorizationServerUrl?: string | URL,
     protocolVersion?: string,
   } = {},
+  fetchFn: FetchLike = fetch,
 ): Promise<OAuthMetadata | undefined> {
   if (typeof issuer === 'string') {
     issuer = new URL(issuer);
@@ -608,6 +619,7 @@ export async function discoverOAuthMetadata(
   const response = await discoverMetadataWithFallback(
     authorizationServerUrl,
     'oauth-authorization-server',
+    fetchFn,
     {
       protocolVersion,
       metadataServerUrl: authorizationServerUrl,
@@ -730,7 +742,8 @@ export async function exchangeAuthorization(
     codeVerifier,
     redirectUri,
     resource,
-    addClientAuthentication
+    addClientAuthentication,
+    fetchFn,
   }: {
     metadata?: OAuthMetadata;
     clientInformation: OAuthClientInformation;
@@ -739,6 +752,7 @@ export async function exchangeAuthorization(
     redirectUri: string | URL;
     resource?: URL;
     addClientAuthentication?: OAuthClientProvider["addClientAuthentication"];
+    fetchFn?: FetchLike;
   },
 ): Promise<OAuthTokens> {
   const grantType = "authorization_code";
@@ -781,7 +795,7 @@ export async function exchangeAuthorization(
     params.set("resource", resource.href);
   }
 
-  const response = await fetch(tokenUrl, {
+  const response = await (fetchFn ?? fetch)(tokenUrl, {
     method: "POST",
     headers,
     body: params,
@@ -814,12 +828,14 @@ export async function refreshAuthorization(
     refreshToken,
     resource,
     addClientAuthentication,
+    fetchFn,
   }: {
     metadata?: OAuthMetadata;
     clientInformation: OAuthClientInformation;
     refreshToken: string;
     resource?: URL;
     addClientAuthentication?: OAuthClientProvider["addClientAuthentication"];
+    fetchFn?: FetchLike;
   }
 ): Promise<OAuthTokens> {
   const grantType = "refresh_token";
@@ -863,7 +879,7 @@ export async function refreshAuthorization(
     params.set("resource", resource.href);
   }
 
-  const response = await fetch(tokenUrl, {
+  const response = await (fetchFn ?? fetch)(tokenUrl, {
     method: "POST",
     headers,
     body: params,
@@ -883,9 +899,11 @@ export async function registerClient(
   {
     metadata,
     clientMetadata,
+    fetchFn,
   }: {
     metadata?: OAuthMetadata;
     clientMetadata: OAuthClientMetadata;
+    fetchFn?: FetchLike;
   },
 ): Promise<OAuthClientInformationFull> {
   let registrationUrl: URL;
@@ -900,7 +918,7 @@ export async function registerClient(
     registrationUrl = new URL("/register", authorizationServerUrl);
   }
 
-  const response = await fetch(registrationUrl, {
+  const response = await (fetchFn ?? fetch)(registrationUrl, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",

--- a/src/client/sse.ts
+++ b/src/client/sse.ts
@@ -93,7 +93,7 @@ export class SSEClientTransport implements Transport {
 
     let result: AuthResult;
     try {
-      result = await auth(this._authProvider, { serverUrl: this._url, resourceMetadataUrl: this._resourceMetadataUrl });
+      result = await auth(this._authProvider, { serverUrl: this._url, resourceMetadataUrl: this._resourceMetadataUrl, fetchFn: this._fetch });
     } catch (error) {
       this.onerror?.(error as Error);
       throw error;
@@ -218,7 +218,7 @@ export class SSEClientTransport implements Transport {
       throw new UnauthorizedError("No auth provider");
     }
 
-    const result = await auth(this._authProvider, { serverUrl: this._url, authorizationCode, resourceMetadataUrl: this._resourceMetadataUrl });
+    const result = await auth(this._authProvider, { serverUrl: this._url, authorizationCode, resourceMetadataUrl: this._resourceMetadataUrl, fetchFn: this._fetch });
     if (result !== "AUTHORIZED") {
       throw new UnauthorizedError("Failed to authorize");
     }
@@ -246,13 +246,13 @@ export class SSEClientTransport implements Transport {
         signal: this._abortController?.signal,
       };
 
-const response = await (this._fetch ?? fetch)(this._endpoint, init);
+      const response = await (this._fetch ?? fetch)(this._endpoint, init);
       if (!response.ok) {
         if (response.status === 401 && this._authProvider) {
 
           this._resourceMetadataUrl = extractResourceMetadataUrl(response);
 
-          const result = await auth(this._authProvider, { serverUrl: this._url, resourceMetadataUrl: this._resourceMetadataUrl });
+          const result = await auth(this._authProvider, { serverUrl: this._url, resourceMetadataUrl: this._resourceMetadataUrl, fetchFn: this._fetch });
           if (result !== "AUTHORIZED") {
             throw new UnauthorizedError();
           }

--- a/src/client/streamableHttp.ts
+++ b/src/client/streamableHttp.ts
@@ -156,7 +156,7 @@ export class StreamableHTTPClientTransport implements Transport {
 
     let result: AuthResult;
     try {
-      result = await auth(this._authProvider, { serverUrl: this._url, resourceMetadataUrl: this._resourceMetadataUrl });
+      result = await auth(this._authProvider, { serverUrl: this._url, resourceMetadataUrl: this._resourceMetadataUrl, fetchFn: this._fetch });
     } catch (error) {
       this.onerror?.(error as Error);
       throw error;
@@ -386,7 +386,7 @@ const response = await (this._fetch ?? fetch)(this._url, {
       throw new UnauthorizedError("No auth provider");
     }
 
-    const result = await auth(this._authProvider, { serverUrl: this._url, authorizationCode, resourceMetadataUrl: this._resourceMetadataUrl });
+    const result = await auth(this._authProvider, { serverUrl: this._url, authorizationCode, resourceMetadataUrl: this._resourceMetadataUrl, fetchFn: this._fetch });
     if (result !== "AUTHORIZED") {
       throw new UnauthorizedError("Failed to authorize");
     }
@@ -434,7 +434,7 @@ const response = await (this._fetch ?? fetch)(this._url, init);
 
           this._resourceMetadataUrl = extractResourceMetadataUrl(response);
 
-          const result = await auth(this._authProvider, { serverUrl: this._url, resourceMetadataUrl: this._resourceMetadataUrl });
+          const result = await auth(this._authProvider, { serverUrl: this._url, resourceMetadataUrl: this._resourceMetadataUrl, fetchFn: this._fetch });
           if (result !== "AUTHORIZED") {
             throw new UnauthorizedError();
           }

--- a/src/server/auth/providers/proxyProvider.ts
+++ b/src/server/auth/providers/proxyProvider.ts
@@ -10,6 +10,7 @@ import {
 import { AuthInfo } from "../types.js";
 import { AuthorizationParams, OAuthServerProvider } from "../provider.js";
 import { ServerError } from "../errors.js";
+import { FetchLike } from "src/shared/transport.js";
 
 export type ProxyEndpoints = {
   authorizationUrl: string;
@@ -34,6 +35,10 @@ export type ProxyOptions = {
   */
   getClient: (clientId: string) => Promise<OAuthClientInformationFull | undefined>;
 
+  /**
+   * Custom fetch implementation used for all network requests.
+   */
+  fetch?: FetchLike;
 };
 
 /**
@@ -43,6 +48,7 @@ export class ProxyOAuthServerProvider implements OAuthServerProvider {
   protected readonly _endpoints: ProxyEndpoints;
   protected readonly _verifyAccessToken: (token: string) => Promise<AuthInfo>;
   protected readonly _getClient: (clientId: string) => Promise<OAuthClientInformationFull | undefined>;
+  protected readonly _fetch?: FetchLike;
   
   skipLocalPkceValidation = true;
 
@@ -55,6 +61,7 @@ export class ProxyOAuthServerProvider implements OAuthServerProvider {
     this._endpoints = options.endpoints;
     this._verifyAccessToken = options.verifyAccessToken;
     this._getClient = options.getClient;
+    this._fetch = options.fetch;
     if (options.endpoints?.revocationUrl) {
       this.revokeToken = async (
         client: OAuthClientInformationFull,
@@ -76,7 +83,7 @@ export class ProxyOAuthServerProvider implements OAuthServerProvider {
           params.set("token_type_hint", request.token_type_hint);
         }
 
-        const response = await fetch(revocationUrl, {
+        const response = await (this._fetch ?? fetch)(revocationUrl, {
           method: "POST",
           headers: {
             "Content-Type": "application/x-www-form-urlencoded",
@@ -97,7 +104,7 @@ export class ProxyOAuthServerProvider implements OAuthServerProvider {
       getClient: this._getClient,
       ...(registrationUrl && {
         registerClient: async (client: OAuthClientInformationFull) => {
-          const response = await fetch(registrationUrl, {
+          const response = await (this._fetch ?? fetch)(registrationUrl, {
             method: "POST",
             headers: {
               "Content-Type": "application/json",
@@ -178,7 +185,7 @@ export class ProxyOAuthServerProvider implements OAuthServerProvider {
       params.append("resource", resource.href);
     }
 
-    const response = await fetch(this._endpoints.tokenUrl, {
+    const response = await (this._fetch ?? fetch)(this._endpoints.tokenUrl, {
       method: "POST",
       headers: {
         "Content-Type": "application/x-www-form-urlencoded",
@@ -220,7 +227,7 @@ export class ProxyOAuthServerProvider implements OAuthServerProvider {
       params.set("resource", resource.href);
     }
 
-    const response = await fetch(this._endpoints.tokenUrl, {
+    const response = await (this._fetch ?? fetch)(this._endpoints.tokenUrl, {
       method: "POST",
       headers: {
         "Content-Type": "application/x-www-form-urlencoded",


### PR DESCRIPTION
Updates the transports and auth to consistently use the consumer-provided fetch function, if provided.

## Motivation and Context
Enables usage in environments with non-conformant fetch globals, and assists in debugging. I was passing a custom fetch function to check the request order in the auth flow, and wasn't seeing everything due to this issue.

## How Has This Been Tested?
Existing unit tests plus a spot check in my debug setup.

## Breaking Changes
None.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
- I left the `?? fetch` fallbacks in the code to avoid needing to change the unit tests. The unit tests currently rely on the fact that the global fetch is always looked up at call-time due to mocking the global `fetch` function.