### PR TITLE
Add nonce support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@modelcontextprotocol/sdk",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@modelcontextprotocol/sdk",
-      "version": "1.15.0",
+      "version": "1.15.1",
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.6",

--- a/src/client/auth.test.ts
+++ b/src/client/auth.test.ts
@@ -728,6 +728,65 @@ describe("OAuth Authorization", () => {
       expect(authorizationUrl.searchParams.get("prompt")).toBe("consent");
     });
 
+    it("generates nonce automatically for OpenID Connect flows", async () => {
+      const { authorizationUrl, nonce } = await startAuthorization(
+          "https://auth.example.com",
+          {
+            clientInformation: validClientInfo,
+            redirectUrl: "http://localhost:3000/callback",
+            scope: "openid profile email",
+          }
+      );
+
+      expect(nonce).toBeDefined();
+      expect(authorizationUrl.searchParams.get("nonce")).toBe(nonce);
+      expect(nonce).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+    });
+
+    it("uses provided nonce for OpenID Connect flows", async () => {
+      const providedNonce = "test-nonce-123";
+      const { authorizationUrl, nonce } = await startAuthorization(
+          "https://auth.example.com",
+          {
+            clientInformation: validClientInfo,
+            redirectUrl: "http://localhost:3000/callback",
+            scope: "openid profile",
+            nonce: providedNonce,
+          }
+      );
+
+      expect(nonce).toBe(providedNonce);
+      expect(authorizationUrl.searchParams.get("nonce")).toBe(providedNonce);
+    });
+
+    it("does not include nonce for non-OpenID Connect flows", async () => {
+      const { authorizationUrl, nonce } = await startAuthorization(
+          "https://auth.example.com",
+          {
+            clientInformation: validClientInfo,
+            redirectUrl: "http://localhost:3000/callback",
+            scope: "read write",
+          }
+      );
+
+      expect(nonce).toBeUndefined();
+      expect(authorizationUrl.searchParams.has("nonce")).toBe(false);
+    });
+
+    it("generates nonce when openid scope is included with other scopes", async () => {
+      const { authorizationUrl, nonce } = await startAuthorization(
+          "https://auth.example.com",
+          {
+            clientInformation: validClientInfo,
+            redirectUrl: "http://localhost:3000/callback",
+            scope: "read openid write profile",
+          }
+      );
+
+      expect(nonce).toBeDefined();
+      expect(authorizationUrl.searchParams.get("nonce")).toBe(nonce);
+    });
+
     it("uses metadata authorization_endpoint when provided", async () => {
       const { authorizationUrl } = await startAuthorization(
         "https://auth.example.com",

--- a/src/server/auth/handlers/authorize.test.ts
+++ b/src/server/auth/handlers/authorize.test.ts
@@ -102,6 +102,10 @@ describe('Authorization Handler', () => {
     app.use('/authorize', handler);
   });
 
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   describe('HTTP method validation', () => {
     it('rejects non-GET/POST methods', async () => {
       const response = await supertest(app)
@@ -305,7 +309,6 @@ describe('Authorization Handler', () => {
 
     it('propagates nonce parameter for OpenID Connect flows', async () => {
       const mockProviderWithNonce = jest.spyOn(mockProvider, 'authorize');
-      mockProviderWithNonce.mockClear();
       
       const response = await supertest(app)
         .get('/authorize')
@@ -334,7 +337,6 @@ describe('Authorization Handler', () => {
 
     it('handles authorization without nonce parameter', async () => {
       const mockProviderWithoutNonce = jest.spyOn(mockProvider, 'authorize');
-      mockProviderWithoutNonce.mockClear();
       
       const response = await supertest(app)
         .get('/authorize')

--- a/src/server/auth/handlers/authorize.ts
+++ b/src/server/auth/handlers/authorize.ts
@@ -35,6 +35,7 @@ const RequestAuthorizationParamsSchema = z.object({
   code_challenge_method: z.literal("S256"),
   scope: z.string().optional(),
   state: z.string().optional(),
+  nonce: z.string().optional(),
   resource: z.string().url().optional(),
 });
 
@@ -115,7 +116,7 @@ export function authorizationHandler({ provider, rateLimit: rateLimitConfig }: A
         throw new InvalidRequestError(parseResult.error.message);
       }
 
-      const { scope, code_challenge, resource } = parseResult.data;
+      const { scope, code_challenge, nonce, resource } = parseResult.data;
       state = parseResult.data.state;
 
       // Validate scopes
@@ -138,6 +139,7 @@ export function authorizationHandler({ provider, rateLimit: rateLimitConfig }: A
         scopes: requestedScopes,
         redirectUri: redirect_uri,
         codeChallenge: code_challenge,
+        nonce,
         resource: resource ? new URL(resource) : undefined,
       }, res);
     } catch (error) {

--- a/src/server/auth/provider.ts
+++ b/src/server/auth/provider.ts
@@ -8,6 +8,7 @@ export type AuthorizationParams = {
   scopes?: string[];
   codeChallenge: string;
   redirectUri: string;
+  nonce?: string;
   resource?: URL;
 };
 


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
Adds nonce parameter support to OAuth/OIDC authorization flows to prevent replay attacks on ID tokens.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Supporting nonces are necessary for id_token flows to prevent replay attacks.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Just jest / automated tests. The changes are relatively minor, though.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
The return type of `startAuthorization()` now includes an optional `nonce` field. 

Hypothetically, someone could have provided explicit types on the return value like this:
`const result: { authorizationUrl: URL; codeVerifier: string } = await startAuthorization(...);`
Which would now be a type error, but I don't see why anyone would have an explicit type annotation there.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [X] I have added appropriate error handling
- [X] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
