### PR TITLE
fix client id issuance date should only be sent when generated

### DIFF
--- a/src/server/auth/clients.ts
+++ b/src/server/auth/clients.ts
@@ -16,5 +16,5 @@ export interface OAuthRegisteredClientsStore {
    * 
    * If unimplemented, dynamic client registration is unsupported.
    */
-  registerClient?(client: Omit<OAuthClientInformationFull, "client_id">): OAuthClientInformationFull | Promise<OAuthClientInformationFull>;
+  registerClient?(client: Omit<OAuthClientInformationFull, "client_id" | "client_id_issued_at">): OAuthClientInformationFull | Promise<OAuthClientInformationFull>;
 }

--- a/src/server/auth/handlers/register.test.ts
+++ b/src/server/auth/handlers/register.test.ts
@@ -236,6 +236,7 @@ describe('Client Registration Handler', () => {
 
       expect(response.status).toBe(201);
       expect(response.body.client_id).toBeUndefined();
+      expect(response.body.client_id_issued_at).toBeUndefined();
     });
 
     it('handles client with all metadata fields', async () => {

--- a/src/server/auth/handlers/register.ts
+++ b/src/server/auth/handlers/register.ts
@@ -99,12 +99,12 @@ export function clientRegistrationHandler({
       let clientInfo: Omit<OAuthClientInformationFull, "client_id"> & { client_id?: string } = {
         ...clientMetadata,
         client_secret: clientSecret,
-        client_id_issued_at: clientIdIssuedAt,
         client_secret_expires_at: clientSecretExpiresAt,
       };
 
       if (clientIdGeneration) {
         clientInfo.client_id = crypto.randomUUID();
+        clientInfo.client_id_issued_at = clientIdIssuedAt;
       }
 
       clientInfo = await clientsStore.registerClient!(clientInfo);


### PR DESCRIPTION
Sorry I missed this in https://github.com/modelcontextprotocol/typescript-sdk/pull/734.