### PR TITLE
Add CODEOWNERS file for sdk

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# TypeScript SDK Code Owners
+
+# Default owners for everything in the repo
+* @modelcontextprotocol/typescript-sdk-maintainers
+
+# Auth team owns all auth-related code
+/src/server/auth/ @modelcontextprotocol/typescript-sdk-auth
+/src/client/auth* @modelcontextprotocol/typescript-sdk-auth
+/src/shared/auth* @modelcontextprotocol/typescript-sdk-auth
+/src/examples/client/simpleOAuthClient.ts @modelcontextprotocol/typescript-sdk-auth
+/src/examples/server/demoInMemoryOAuthProvider.ts @modelcontextprotocol/typescript-sdk-auth


### PR DESCRIPTION
This PR adds a CODEOWNERS file to define code ownership for the TypeScript SDK repository
 
Changes:
  - Creates .github/CODEOWNERS with two ownership levels:
    - @modelcontextprotocol/typescript-sdk-maintainers - default owners for the entire repository
    - @modelcontextprotocol/typescript-sdk-auth - owners for all auth-related code including:
        - /src/server/auth/ directory
      - /src/client/auth* files
      - /src/shared/auth* files
      - Auth-related examples