### PR TITLE
(fix): Update fallbackRequestHandler type to match _requestHandlers leaves type

### DIFF
--- a/src/shared/protocol.ts
+++ b/src/shared/protocol.ts
@@ -217,7 +217,10 @@ export abstract class Protocol<
   /**
    * A handler to invoke for any request types that do not have their own handler installed.
    */
-  fallbackRequestHandler?: (request: Request) => Promise<SendResultT>;
+  fallbackRequestHandler?: (
+    request: JSONRPCRequest,
+    extra: RequestHandlerExtra<SendRequestT, SendNotificationT>
+  ) => Promise<SendResultT>;
 
   /**
    * A handler to invoke for any notification types that do not have their own handler installed.


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
**This PR only updates type definition**

`fallbackRequestHandler` current type is not matching the type of what it is a fallback for, i.e. the type of each request handler on the `Server`.

The following code snippet is the only location where `fallbackRequestHandler` is used

https://github.com/modelcontextprotocol/typescript-sdk/blob/0d545176f9ba852c97a18a40037abff40cd086c2/src/shared/protocol.ts#L367-L368

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
`fallbackRequestHandler` current type lacks the request id, the jsonrpc version (while being actually forwarded) and the extra param altogether. Updating the type avoid having the rely on type casting where fallback must be defined. The new type is exacly the one defined for `_requestHandlers` leaves:

https://github.com/modelcontextprotocol/typescript-sdk/blob/0d545176f9ba852c97a18a40037abff40cd086c2/src/shared/protocol.ts#L182-L188

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Locally on my project

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
Non breaking, `JSONRPCRequest` is actually narrower than `Request` 

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
