### PR TITLE
fix: clean up event listeners in StdioClientTransport.close()

### DIFF
--- a/src/client/stdio.ts
+++ b/src/client/stdio.ts
@@ -215,6 +215,14 @@ export class StdioClientTransport implements Transport {
 
   async close(): Promise<void> {
     this._abortController.abort();
+
+    if (this._process) {
+      this._process.removeAllListeners();
+      this._process.stdin?.removeAllListeners();
+      this._process.stdout?.removeAllListeners();
+      this._process.stderr?.removeAllListeners();
+    }
+
     this._process = undefined;
     this._readBuffer.clear();
   }


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
Added logic to clean up residual listeners after calling `transport.close()`.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
see https://github.com/modelcontextprotocol/typescript-sdk/issues/780

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
After making this modification, residual listeners will not be triggered after closing the transport, and only "close" will be printed in the console.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No breaking changes

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

