### PR TITLE
fix: Explicitly declare accpet type to json when exchanging oauth token

### DIFF
--- a/src/client/auth.ts
+++ b/src/client/auth.ts
@@ -774,6 +774,7 @@ export async function exchangeAuthorization(
   // Exchange code for tokens
   const headers = new Headers({
     "Content-Type": "application/x-www-form-urlencoded",
+    "Accept": "application/json",
   });
   const params = new URLSearchParams({
     grant_type: grantType,


### PR DESCRIPTION
When exchanging OAuth token, explicitly declare the accept type to JSON as it's potentially indicated

## Motivation and Context
When using [official github mcp server](https://github.com/github/github-mcp-server), the default response is not a valid json and causes json parse error. (Looks like `access_token=[some token]&scope=[some scope]&token_type=bearer`. So the type may need to be explicitly declared if it will be treated as json format.

## How Has This Been Tested?
Tested with the server

## Breaking Changes
No 

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

