### PR TITLE
Update tools/call input validation errors to be tool execution errors

### DIFF
--- a/src/server/mcp.test.ts
+++ b/src/server/mcp.test.ts
@@ -937,24 +937,6 @@ describe("tool()", () => {
       }),
     );
 
-    mcpServer.registerTool(
-      "test (new api)",
-      {
-        inputSchema: {
-          name: z.string(),
-          value: z.number(),
-        },
-      },
-      async ({ name, value }) => ({
-        content: [
-          {
-            type: "text",
-            text: `${name}: ${value}`,
-          },
-        ],
-      })
-    );
-
     const [clientTransport, serverTransport] =
       InMemoryTransport.createLinkedPair();
 
@@ -977,23 +959,15 @@ describe("tool()", () => {
         },
         CallToolResultSchema,
       ),
-    ).rejects.toThrow(/Invalid arguments/);
-
-    await expect(
-      client.request(
+    ).resolves.toStrictEqual({
+      content: [
         {
-          method: "tools/call",
-          params: {
-            name: "test (new api)",
-            arguments: {
-              name: "test",
-              value: "not a number",
-            },
-          },
+          type: "text",
+          text: expect.stringMatching(/Invalid arguments for tool test/),
         },
-        CallToolResultSchema,
-      ),
-    ).rejects.toThrow(/Invalid arguments/);
+      ],
+      isError: true,
+    });
   });
 
   /***

--- a/src/server/mcp.ts
+++ b/src/server/mcp.ts
@@ -162,10 +162,15 @@ export class McpServer {
             request.params.arguments,
           );
           if (!parseResult.success) {
-            throw new McpError(
-              ErrorCode.InvalidParams,
-              `Invalid arguments for tool ${request.params.name}: ${parseResult.error.message}`,
-            );
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: `Invalid arguments for tool ${request.params.name}: ${parseResult.error.message}`,
+                },
+              ],
+              isError: true,
+            };
           }
 
           const args = parseResult.data;


### PR DESCRIPTION
Reporting input validation errors as **Tool Execution Errors** instead of **Protocol Errors** in order to increase model self-recovery success rate.

## Motivation and Context

The [tools error handling specs](https://modelcontextprotocol.io/specification/2025-06-18/server/tools#error-handling) is quite vague on wether input validation errors shall be treated as Protocol Errors (following the _Invalid arguments_ exemple) or as Tool Execution Errors (following the _Invalid input data_ exemple).

Only Tool Execution Errors are injected back into the LLM context window, just like successful responses. Input validation error messages can be leveraged by the model as much as any other prompt, giving it a chance to recover from the error without human intervention.

## How Has This Been Tested?

The `should validate tool args` test suite in `src/server/mcp.test.ts` has been updated to reflect the new error reponse format.

## Breaking Changes

None

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
I am the author of the following article on MCP tool execution errors : [Better MCP tools/call Error Responses: Help Your AI Recover Gracefully](https://dev.to/alpic/better-mcp-toolscall-error-responses-help-your-ai-recover-gracefully-15c7)
