### PR TITLE
fix: retry next endpoint on CORS error during auth server discovery

### DIFF
--- a/src/client/auth.test.ts
+++ b/src/client/auth.test.ts
@@ -899,6 +899,18 @@ describe("OAuth Authorization", () => {
         "MCP-Protocol-Version": "2025-01-01"
       });
     });
+
+    it("returns undefined when all URLs fail with CORS errors", async () => {
+      // All fetch attempts fail with CORS errors (TypeError)
+      mockFetch.mockImplementation(() => Promise.reject(new TypeError("CORS error")));
+
+      const metadata = await discoverAuthorizationServerMetadata("https://auth.example.com/tenant1");
+
+      expect(metadata).toBeUndefined();
+      
+      // Verify that all discovery URLs were attempted
+      expect(mockFetch).toHaveBeenCalledTimes(8); // 4 URLs × 2 attempts each (with and without headers)
+    });
   });
 
   describe("startAuthorization", () => {

--- a/src/client/auth.ts
+++ b/src/client/auth.ts
@@ -758,7 +758,11 @@ export async function discoverAuthorizationServerMetadata(
     const response = await fetchWithCorsRetry(endpointUrl, headers, fetchFn);
 
     if (!response) {
-      throw new Error(`CORS error trying to load ${type === 'oauth' ? 'OAuth' : 'OpenID provider'} metadata from ${endpointUrl}`);
+      /**
+       * CORS error occurred - don't throw as the endpoint may not allow CORS,
+       * continue trying other possible endpoints
+       */
+      continue;
     }
 
     if (!response.ok) {


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
Continue trying other discovery endpoints when CORS errors occur instead of failing immediately.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

Authorization servers don't always allow CORS requests for all potential metadata discovery endpoints, especially for non-public information. The client tries multiple well-known endpoints, and CORS failures are common and expected. Previously, a CORS error on any endpoint would cause the entire discovery process to fail immediately, even though other endpoints might work.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

- Unit test added
- Tested implementation manually in MCP Inspector

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

None.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->

Changed `discoverAuthorizationServerMetadata` to use `continue` instead of throwing when CORS errors occur, allowing the function to try all available discovery URLs before giving up.