### PR TITLE
fix: typo in comment in ResourceTemplate class

### DIFF
--- a/src/server/mcp.ts
+++ b/src/server/mcp.ts
@@ -1096,7 +1096,7 @@ export class ResourceTemplate {
     uriTemplate: string | UriTemplate,
     private _callbacks: {
       /**
-       * A callback to list all resources matching this template. This is required to specified, even if `undefined`, to avoid accidentally forgetting resource listing.
+       * A callback to list all resources matching this template. This is required to be specified, even if `undefined`, to avoid accidentally forgetting resource listing.
        */
       list: ListResourcesCallback | undefined;
 


### PR DESCRIPTION
Typo in ResourceTemplate class comment

## Motivation and Context
N/A

## How Has This Been Tested?
N/A

## Breaking Changes
N/A

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
N/A
