### PR TITLE
fix: pass fetchfn parameter to registerClient and refreshAuthorizatio…

### DIFF
--- a/src/client/auth.ts
+++ b/src/client/auth.ts
@@ -359,6 +359,7 @@ async function authInternal(
     const fullInformation = await registerClient(authorizationServerUrl, {
       metadata,
       clientMetadata: provider.clientMetadata,
+      fetchFn,
     });
 
     await provider.saveClientInformation(fullInformation);
@@ -395,6 +396,7 @@ async function authInternal(
         refreshToken: tokens.refresh_token,
         resource,
         addClientAuthentication: provider.addClientAuthentication,
+        fetchFn,
       });
 
       await provider.saveTokens(newTokens);


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
Fixed missing `fetchFn` parameter in `registerClient` and `refreshAuthorization` function calls in the auth flow

## Motivation and Context
The `authInternal` function accepts a `fetchFn` parameter and correctly passes it to most HTTP calls (`discoverOAuthProtectedResourceMetadata`, `discoverAuthorizationServerMetadata`, `exchangeAuthorization`), but was missing it in calls to `registerClient` and `refreshAuthorization`. This caused these functions to fall back to the global `fetch` instead of using any custom `fetchFn` provided, creating inconsistent behavior in scenarios requiring custom network configurations, testing with mock fetch functions, or environments where global fetch might not be available.

## How Has This Been Tested?
Tested in our application at Smithery (https://smithery.ai)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
