### PR TITLE
fix: normalize headers in sse transport

### DIFF
--- a/src/client/streamableHttp.ts
+++ b/src/client/streamableHttp.ts
@@ -2,6 +2,7 @@ import { Transport, FetchLike } from "../shared/transport.js";
 import { isInitializedNotification, isJSONRPCRequest, isJSONRPCResponse, JSONRPCMessage, JSONRPCMessageSchema } from "../types.js";
 import { auth, AuthResult, extractResourceMetadataUrl, OAuthClientProvider, UnauthorizedError } from "./auth.js";
 import { EventSourceParserStream } from "eventsource-parser/stream";
+import { normalizeHeaders } from "../shared/headers.js";
 
 // Default reconnection options for StreamableHTTP connections
 const DEFAULT_STREAMABLE_HTTP_RECONNECTION_OPTIONS: StreamableHTTPReconnectionOptions = {
@@ -185,7 +186,7 @@ export class StreamableHTTPClientTransport implements Transport {
       headers["mcp-protocol-version"] = this._protocolVersion;
     }
 
-    const extraHeaders = this._normalizeHeaders(this._requestInit?.headers);
+    const extraHeaders = normalizeHeaders(this._requestInit?.headers);
 
     return new Headers({
       ...headers,
@@ -254,20 +255,6 @@ export class StreamableHTTPClientTransport implements Transport {
     // Cap at maximum delay
     return Math.min(initialDelay * Math.pow(growFactor, attempt), maxDelay);
 
-  }
-
-    private _normalizeHeaders(headers: HeadersInit | undefined): Record<string, string> {
-    if (!headers) return {};
-
-    if (headers instanceof Headers) {
-      return Object.fromEntries(headers.entries());
-    }
-
-    if (Array.isArray(headers)) {
-      return Object.fromEntries(headers);
-    }
-
-    return { ...headers as Record<string, string> };
   }
 
   /**

--- a/src/shared/headers.ts
+++ b/src/shared/headers.ts
@@ -1,0 +1,15 @@
+export function normalizeHeaders(
+  headers: HeadersInit | undefined
+): Record<string, string> {
+  if (!headers) return {};
+
+  if (headers instanceof Headers) {
+    return Object.fromEntries(headers.entries());
+  }
+
+  if (Array.isArray(headers)) {
+    return Object.fromEntries(headers);
+  }
+
+  return { ...headers };
+}


### PR DESCRIPTION
The SSE transport does not properly forward custom headers that are provided as a `Headers` object or as a `[string, string][]`.

The Streamable HTTP transport already implements the correct solution to this problem, so I moved the solution into a common helper function, used it from both transports, and added a test to the SSE transport that exercises this.

## Motivation and Context
Bug

## How Has This Been Tested?
I have an internal application that passes custom headers `[["Authorization", "Bearer XYZ"]]` to the client. Before this change, this was getting forwarded to the server as a header `{0: "Authorization,Bearer XYZ"}`. After this change, it is correctly forwarded as `{Authorization: "Bearer XYZ"}`.

## Breaking Changes
None

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling (N/A: doesn't add new error possibilities)
- [ ] I have added or updated documentation as needed (N/A: just a fix to existing functionality)

## Additional context
None