### PR TITLE
Fix quit command in Example client with OAuth

### DIFF
--- a/src/examples/client/simpleOAuthClient.ts
+++ b/src/examples/client/simpleOAuthClient.ts
@@ -270,7 +270,9 @@ class InteractiveOAuthClient {
         }
 
         if (command === 'quit') {
-          break;
+          console.log('\n👋 Goodbye!');
+          this.close();
+          process.exit(0);
         } else if (command === 'list') {
           await this.listTools();
         } else if (command.startsWith('call ')) {


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context

The `quit` command does not exit the example client with OAuth.

## How Has This Been Tested?

- Before

<img width="1092" height="1094" alt="2025-08-11 at 14 04 03" src="https://github.com/user-attachments/assets/4aeded90-f73e-4e4b-bb31-80cc0e49b520" />

- After

<img width="1304" height="1072" alt="2025-08-11 at 14 03 18" src="https://github.com/user-attachments/assets/570223bc-2289-452c-8260-d1fe955a5ca6" />

## Breaking Changes

This only changes the example client.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

Thank you!
