### PR TITLE
restrict url schemes allowed in oauth metadata

### DIFF
--- a/src/shared/auth.test.ts
+++ b/src/shared/auth.test.ts
@@ -25,6 +25,10 @@ describe('SafeUrlSchema', () => {
     expect(() => SafeUrlSchema.parse('not-a-url')).toThrow();
     expect(() => SafeUrlSchema.parse('')).toThrow();
   });
+
+  it('works with safeParse', () => {
+    expect(() => SafeUrlSchema.safeParse('not-a-url')).not.toThrow();
+  });
 });
 
 describe('OAuthMetadataSchema', () => {

--- a/src/shared/auth.test.ts
+++ b/src/shared/auth.test.ts
@@ -3,7 +3,6 @@ import {
   SafeUrlSchema,
   OAuthMetadataSchema,
   OpenIdProviderMetadataSchema,
-  OAuthTokensSchema,
   OAuthClientMetadataSchema,
 } from './auth.js';
 
@@ -18,8 +17,8 @@ describe('SafeUrlSchema', () => {
   });
 
   it('rejects javascript: scheme URLs', () => {
-    expect(() => SafeUrlSchema.parse('javascript:alert(1)')).toThrow('URL cannot use javascript: scheme');
-    expect(() => SafeUrlSchema.parse('JAVASCRIPT:alert(1)')).toThrow('URL cannot use javascript: scheme');
+    expect(() => SafeUrlSchema.parse('javascript:alert(1)')).toThrow('URL cannot use javascript:, data:, or vbscript: scheme');
+    expect(() => SafeUrlSchema.parse('JAVASCRIPT:alert(1)')).toThrow('URL cannot use javascript:, data:, or vbscript: scheme');
   });
 
   it('rejects invalid URLs', () => {
@@ -49,7 +48,7 @@ describe('OAuthMetadataSchema', () => {
       response_types_supported: ['code'],
     };
 
-    expect(() => OAuthMetadataSchema.parse(metadata)).toThrow('URL cannot use javascript: scheme');
+    expect(() => OAuthMetadataSchema.parse(metadata)).toThrow('URL cannot use javascript:, data:, or vbscript: scheme');
   });
 
   it('requires mandatory fields', () => {
@@ -87,7 +86,7 @@ describe('OpenIdProviderMetadataSchema', () => {
       id_token_signing_alg_values_supported: ['RS256'],
     };
 
-    expect(() => OpenIdProviderMetadataSchema.parse(metadata)).toThrow('URL cannot use javascript: scheme');
+    expect(() => OpenIdProviderMetadataSchema.parse(metadata)).toThrow('URL cannot use javascript:, data:, or vbscript: scheme');
   });
 });
 
@@ -108,6 +107,6 @@ describe('OAuthClientMetadataSchema', () => {
       client_name: 'Test App',
     };
 
-    expect(() => OAuthClientMetadataSchema.parse(metadata)).toThrow('URL cannot use javascript: scheme');
+    expect(() => OAuthClientMetadataSchema.parse(metadata)).toThrow('URL cannot use javascript:, data:, or vbscript: scheme');
   });
 });

--- a/src/shared/auth.test.ts
+++ b/src/shared/auth.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from '@jest/globals';
+import {
+  SafeUrlSchema,
+  OAuthMetadataSchema,
+  OpenIdProviderMetadataSchema,
+  OAuthTokensSchema,
+  OAuthClientMetadataSchema,
+} from './auth.js';
+
+describe('SafeUrlSchema', () => {
+  it('accepts valid HTTPS URLs', () => {
+    expect(SafeUrlSchema.parse('https://example.com')).toBe('https://example.com');
+    expect(SafeUrlSchema.parse('https://auth.example.com/oauth/authorize')).toBe('https://auth.example.com/oauth/authorize');
+  });
+
+  it('accepts valid HTTP URLs', () => {
+    expect(SafeUrlSchema.parse('http://localhost:3000')).toBe('http://localhost:3000');
+  });
+
+  it('rejects javascript: scheme URLs', () => {
+    expect(() => SafeUrlSchema.parse('javascript:alert(1)')).toThrow('URL cannot use javascript: scheme');
+    expect(() => SafeUrlSchema.parse('JAVASCRIPT:alert(1)')).toThrow('URL cannot use javascript: scheme');
+  });
+
+  it('rejects invalid URLs', () => {
+    expect(() => SafeUrlSchema.parse('not-a-url')).toThrow();
+    expect(() => SafeUrlSchema.parse('')).toThrow();
+  });
+});
+
+describe('OAuthMetadataSchema', () => {
+  it('validates complete OAuth metadata', () => {
+    const metadata = {
+      issuer: 'https://auth.example.com',
+      authorization_endpoint: 'https://auth.example.com/oauth/authorize',
+      token_endpoint: 'https://auth.example.com/oauth/token',
+      response_types_supported: ['code'],
+      scopes_supported: ['read', 'write'],
+    };
+
+    expect(() => OAuthMetadataSchema.parse(metadata)).not.toThrow();
+  });
+
+  it('rejects metadata with javascript: URLs', () => {
+    const metadata = {
+      issuer: 'https://auth.example.com',
+      authorization_endpoint: 'javascript:alert(1)',
+      token_endpoint: 'https://auth.example.com/oauth/token',
+      response_types_supported: ['code'],
+    };
+
+    expect(() => OAuthMetadataSchema.parse(metadata)).toThrow('URL cannot use javascript: scheme');
+  });
+
+  it('requires mandatory fields', () => {
+    const incompleteMetadata = {
+      issuer: 'https://auth.example.com',
+    };
+
+    expect(() => OAuthMetadataSchema.parse(incompleteMetadata)).toThrow();
+  });
+});
+
+describe('OpenIdProviderMetadataSchema', () => {
+  it('validates complete OpenID Provider metadata', () => {
+    const metadata = {
+      issuer: 'https://auth.example.com',
+      authorization_endpoint: 'https://auth.example.com/oauth/authorize',
+      token_endpoint: 'https://auth.example.com/oauth/token',
+      jwks_uri: 'https://auth.example.com/.well-known/jwks.json',
+      response_types_supported: ['code'],
+      subject_types_supported: ['public'],
+      id_token_signing_alg_values_supported: ['RS256'],
+    };
+
+    expect(() => OpenIdProviderMetadataSchema.parse(metadata)).not.toThrow();
+  });
+
+  it('rejects metadata with javascript: in jwks_uri', () => {
+    const metadata = {
+      issuer: 'https://auth.example.com',
+      authorization_endpoint: 'https://auth.example.com/oauth/authorize',
+      token_endpoint: 'https://auth.example.com/oauth/token',
+      jwks_uri: 'javascript:alert(1)',
+      response_types_supported: ['code'],
+      subject_types_supported: ['public'],
+      id_token_signing_alg_values_supported: ['RS256'],
+    };
+
+    expect(() => OpenIdProviderMetadataSchema.parse(metadata)).toThrow('URL cannot use javascript: scheme');
+  });
+});
+
+describe('OAuthClientMetadataSchema', () => {
+  it('validates client metadata with safe URLs', () => {
+    const metadata = {
+      redirect_uris: ['https://app.example.com/callback'],
+      client_name: 'Test App',
+      client_uri: 'https://app.example.com',
+    };
+
+    expect(() => OAuthClientMetadataSchema.parse(metadata)).not.toThrow();
+  });
+
+  it('rejects client metadata with javascript: redirect URIs', () => {
+    const metadata = {
+      redirect_uris: ['javascript:alert(1)'],
+      client_name: 'Test App',
+    };
+
+    expect(() => OAuthClientMetadataSchema.parse(metadata)).toThrow('URL cannot use javascript: scheme');
+  });
+});

--- a/src/shared/auth.ts
+++ b/src/shared/auth.ts
@@ -8,8 +8,15 @@ export const SafeUrlSchema = z.string().url()
     (url) => URL.canParse(url),
     {message: "URL must be parseable"}
   ).refine(
-    (url) =>  !url.toLowerCase().startsWith('javascript:'),
-    { message: "URL cannot use javascript: scheme" }
+    (url) => {
+      const u = url.trim().toLowerCase();
+      return !(
+        u.startsWith('javascript:') ||
+        u.startsWith('data:') ||
+        u.startsWith('vbscript:')
+      );
+    },
+    { message: "URL cannot use javascript:, data:, or vbscript: scheme" }
 );
 
 

--- a/src/shared/auth.ts
+++ b/src/shared/auth.ts
@@ -4,10 +4,17 @@ import { z } from "zod";
  * Reusable URL validation that disallows javascript: scheme
  */
 export const SafeUrlSchema = z.string().url()
-  .refine(
-    (url) => URL.canParse(url),
-    {message: "URL must be parseable"}
-  ).refine(
+  .superRefine((val, ctx) => {
+    if (!URL.canParse(val)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "URL must be parseable",
+        fatal: true,
+      });
+
+      return z.NEVER;
+    }
+  }).refine(
     (url) => {
       const u = new URL(url);
       return u.protocol !== 'javascript:' && u.protocol !== 'data:' && u.protocol !== 'vbscript:';

--- a/src/shared/auth.ts
+++ b/src/shared/auth.ts
@@ -1,12 +1,25 @@
 import { z } from "zod";
 
 /**
+ * Reusable URL validation that disallows javascript: scheme
+ */
+export const SafeUrlSchema = z.string().url()
+  .refine(
+    (url) => URL.canParse(url),
+    {message: "URL must be parseable"}
+  ).refine(
+    (url) =>  !url.toLowerCase().startsWith('javascript:'),
+    { message: "URL cannot use javascript: scheme" }
+);
+
+
+/**
  * RFC 9728 OAuth Protected Resource Metadata
  */
 export const OAuthProtectedResourceMetadataSchema = z
   .object({
     resource: z.string().url(),
-    authorization_servers: z.array(z.string().url()).optional(),
+    authorization_servers: z.array(SafeUrlSchema).optional(),
     jwks_uri: z.string().url().optional(),
     scopes_supported: z.array(z.string()).optional(),
     bearer_methods_supported: z.array(z.string()).optional(),
@@ -28,9 +41,9 @@ export const OAuthProtectedResourceMetadataSchema = z
 export const OAuthMetadataSchema = z
   .object({
     issuer: z.string(),
-    authorization_endpoint: z.string(),
-    token_endpoint: z.string(),
-    registration_endpoint: z.string().optional(),
+    authorization_endpoint: SafeUrlSchema,
+    token_endpoint: SafeUrlSchema,
+    registration_endpoint: SafeUrlSchema.optional(),
     scopes_supported: z.array(z.string()).optional(),
     response_types_supported: z.array(z.string()),
     response_modes_supported: z.array(z.string()).optional(),
@@ -39,8 +52,8 @@ export const OAuthMetadataSchema = z
     token_endpoint_auth_signing_alg_values_supported: z
       .array(z.string())
       .optional(),
-    service_documentation: z.string().optional(),
-    revocation_endpoint: z.string().optional(),
+    service_documentation: SafeUrlSchema.optional(),
+    revocation_endpoint: SafeUrlSchema.optional(),
     revocation_endpoint_auth_methods_supported: z.array(z.string()).optional(),
     revocation_endpoint_auth_signing_alg_values_supported: z
       .array(z.string())
@@ -63,11 +76,11 @@ export const OAuthMetadataSchema = z
 export const OpenIdProviderMetadataSchema = z
   .object({
     issuer: z.string(),
-    authorization_endpoint: z.string(),
-    token_endpoint: z.string(),
-    userinfo_endpoint: z.string().optional(),
-    jwks_uri: z.string(),
-    registration_endpoint: z.string().optional(),
+    authorization_endpoint: SafeUrlSchema,
+    token_endpoint: SafeUrlSchema,
+    userinfo_endpoint: SafeUrlSchema.optional(),
+    jwks_uri: SafeUrlSchema,
+    registration_endpoint: SafeUrlSchema.optional(),
     scopes_supported: z.array(z.string()).optional(),
     response_types_supported: z.array(z.string()),
     response_modes_supported: z.array(z.string()).optional(),
@@ -101,8 +114,8 @@ export const OpenIdProviderMetadataSchema = z
     request_parameter_supported: z.boolean().optional(),
     request_uri_parameter_supported: z.boolean().optional(),
     require_request_uri_registration: z.boolean().optional(),
-    op_policy_uri: z.string().optional(),
-    op_tos_uri: z.string().optional(),
+    op_policy_uri: SafeUrlSchema.optional(),
+    op_tos_uri: SafeUrlSchema.optional(),
   })
   .passthrough();
 
@@ -146,18 +159,18 @@ export const OAuthErrorResponseSchema = z
  * RFC 7591 OAuth 2.0 Dynamic Client Registration metadata
  */
 export const OAuthClientMetadataSchema = z.object({
-  redirect_uris: z.array(z.string()).refine((uris) => uris.every((uri) => URL.canParse(uri)), { message: "redirect_uris must contain valid URLs" }),
+  redirect_uris: z.array(SafeUrlSchema),
   token_endpoint_auth_method: z.string().optional(),
   grant_types: z.array(z.string()).optional(),
   response_types: z.array(z.string()).optional(),
   client_name: z.string().optional(),
-  client_uri: z.string().optional(),
-  logo_uri: z.string().optional(),
+  client_uri: SafeUrlSchema.optional(),
+  logo_uri: SafeUrlSchema.optional(),
   scope: z.string().optional(),
   contacts: z.array(z.string()).optional(),
-  tos_uri: z.string().optional(),
+  tos_uri: SafeUrlSchema.optional(),
   policy_uri: z.string().optional(),
-  jwks_uri: z.string().optional(),
+  jwks_uri: SafeUrlSchema.optional(),
   jwks: z.any().optional(),
   software_id: z.string().optional(),
   software_version: z.string().optional(),

--- a/src/shared/auth.ts
+++ b/src/shared/auth.ts
@@ -9,12 +9,8 @@ export const SafeUrlSchema = z.string().url()
     {message: "URL must be parseable"}
   ).refine(
     (url) => {
-      const u = url.trim().toLowerCase();
-      return !(
-        u.startsWith('javascript:') ||
-        u.startsWith('data:') ||
-        u.startsWith('vbscript:')
-      );
+      const u = new URL(url);
+      return u.protocol !== 'javascript:' && u.protocol !== 'data:' && u.protocol !== 'vbscript:';
     },
     { message: "URL cannot use javascript:, data:, or vbscript: scheme" }
 );


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
See https://github.com/modelcontextprotocol/typescript-sdk/pull/841 (cc @arjunkmrm )

Since authorization_url is often opened in a browser, we don't want it to be javascript.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Added tests

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
