### PR TITLE
[auth] OAuth protected-resource-metadata: fallback on 4xx not just 404

### DIFF
--- a/src/client/auth.test.ts
+++ b/src/client/auth.test.ts
@@ -212,11 +212,11 @@ describe("OAuth Authorization", () => {
       expect(url.toString()).toBe("https://resource.example.com/.well-known/oauth-protected-resource/path?param=value");
     });
 
-    it("falls back to root discovery when path-aware discovery returns 404", async () => {
-      // First call (path-aware) returns 404
+    it("falls back to root discovery when path-aware discovery fails", async () => {
+      // First call (path-aware) returns 4xx
       mockFetch.mockResolvedValueOnce({
         ok: false,
-        status: 404,
+        status: 401,
       });
 
       // Second call (root fallback) succeeds
@@ -907,7 +907,7 @@ describe("OAuth Authorization", () => {
       const metadata = await discoverAuthorizationServerMetadata("https://auth.example.com/tenant1");
 
       expect(metadata).toBeUndefined();
-      
+
       // Verify that all discovery URLs were attempted
       expect(mockFetch).toHaveBeenCalledTimes(8); // 4 URLs × 2 attempts each (with and without headers)
     });

--- a/src/client/auth.ts
+++ b/src/client/auth.ts
@@ -571,7 +571,7 @@ async function tryMetadataDiscovery(
  * Determines if fallback to root discovery should be attempted
  */
 function shouldAttemptFallback(response: Response | undefined, pathname: string): boolean {
-  return !response || response.status === 404 && pathname !== '/';
+  return !response || (response.status >= 400 && response.status < 500 ) && pathname !== '/';
 }
 
 /**

--- a/src/client/auth.ts
+++ b/src/client/auth.ts
@@ -571,7 +571,7 @@ async function tryMetadataDiscovery(
  * Determines if fallback to root discovery should be attempted
  */
 function shouldAttemptFallback(response: Response | undefined, pathname: string): boolean {
-  return !response || (response.status >= 400 && response.status < 500 ) && pathname !== '/';
+  return !response || (response.status >= 400 && response.status < 500) && pathname !== '/';
 }
 
 /**


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Some places will return a 401 or other 4xx status code when you probe for a metadata endpoint they don't support.  Prior to this, we'd only fallback specifically on a 404, but if it's unauthorized, you're not guaranteed to get a 404.

Without this change, clients will fail trying to get the path-aware version and never try the supported root PRM path.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Added tests

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
Unbreaks a change from introducing path-aware metadata 

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
