### PR TITLE
Fix double onerror trigger on client.close() (Streamable HTTP)

### DIFF
--- a/src/client/streamableHttp.ts
+++ b/src/client/streamableHttp.ts
@@ -233,8 +233,7 @@ export class StreamableHTTPClientTransport implements Transport {
 
       this._handleSseStream(response.body, options, true);
     } catch (error) {
-      this.onerror?.(error as Error);
-      throw error;
+      throw error as Error;
     }
   }
 


### PR DESCRIPTION
### Summary
This PR fixes an issue where `onerror` was being triggered twice when
`client.close()` was executed.  
The duplicate call originated from `_startOrAuthSse`, where an extra 
`this.onerror?.(error as Error);` invocation existed in the `catch` block.  

Since the method already throws the error, the extra `onerror` call was redundant
and caused duplicate event firing.

### Motivation and Context
Fixes #868
When client.close() was executed, onerror was being triggered twice.
This happened because _startOrAuthSse had an extra this.onerror?.(error as Error); inside its catch block, even though the error was already propagated via throw error;.
By removing this line, the onerror event now fires only once, matching expected behavior.

### How Has This Been Tested?
Ran the provided reproduction script from Issue #868.
Verified that after the change, the output contains only one error: The operation was aborted. log.
Confirmed no side effects or missing error propagation in other scenarios.

### Breaking Changes
No breaking changes — this only removes redundant error event firing.

## Types of changes  
- [x] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to change)  
- [ ] Documentation update  

## Checklist  
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)  
- [x] My code follows the repository's style guidelines  
- [x] New and existing tests pass locally  
- [x] I have added appropriate error handling  
- [x] I have added or updated documentation as needed 