### PR TITLE
chore: drop `raw-body` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "express": "^5.0.1",
         "express-rate-limit": "^7.5.0",
         "pkce-challenge": "^5.0.0",
-        "raw-body": "^3.0.0",
         "zod": "^3.23.8",
         "zod-to-json-schema": "^3.24.1"
       },

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "express": "^5.0.1",
     "express-rate-limit": "^7.5.0",
     "pkce-challenge": "^5.0.0",
-    "raw-body": "^3.0.0",
     "zod": "^3.23.8",
     "zod-to-json-schema": "^3.24.1"
   },


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context

`raw-body` depends on `iconv-lite` for charset support, which is quite hefty. Since the MCP spec states "JSON-RPC messages MUST be UTF-8 encoded", I don't think we need that. This PR replaces `raw-body`.

## How Has This Been Tested?

Unit tests still pass, no tests added.

## Breaking Changes

Technically, this drops support for charsets other than the ones listed in https://nodejs.org/api/buffer.html#buffers-and-character-encodings. This is unlikely to be noticed by anyone.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

I'll open a second PR to remove `express`. cc @cliffhall for review.