### PR TITLE
fix: client initial GET sse include requestInit (modelcontextprotocol#895)

### DIFF
--- a/src/client/streamableHttp.test.ts
+++ b/src/client/streamableHttp.test.ts
@@ -502,6 +502,30 @@ describe("StreamableHTTPClientTransport", () => {
     expect(global.fetch).toHaveBeenCalledTimes(2);
   });
 
+  it("should always include requestInit options for initial connection in SSE", async () => {
+    const requestInit: RequestInit = {
+      credentials: 'include'
+    };
+
+    transport = new StreamableHTTPClientTransport(new URL("http://localhost:1234/mcp"), {
+      requestInit: requestInit
+    });
+
+    let actualReqInit: RequestInit = {};
+
+    ((global.fetch as jest.Mock)).mockImplementation(
+      async (_url, reqInit) => {
+        actualReqInit = reqInit;
+        return new Response(null, { status: 200, headers: { "content-type": "text/event-stream" } });
+      }
+    );
+
+    await transport.start();
+
+    await transport["_startOrAuthSse"]({});
+    expect(actualReqInit.credentials).toBe("include");
+  });
+
   it("should always send specified custom headers (Headers class)", async () => {
     const requestInit = {
       headers: new Headers({

--- a/src/client/streamableHttp.ts
+++ b/src/client/streamableHttp.ts
@@ -208,6 +208,7 @@ export class StreamableHTTPClientTransport implements Transport {
       }
 
       const response = await (this._fetch ?? fetch)(this._url, {
+        ...this._requestInit,
         method: "GET",
         headers,
         signal: this._abortController?.signal,
@@ -301,7 +302,7 @@ export class StreamableHTTPClientTransport implements Transport {
   }
 
   private _handleSseStream(
-    stream: ReadableStream<Uint8Array> | null, 
+    stream: ReadableStream<Uint8Array> | null,
     options: StartSSEOptions,
     isReconnectable: boolean,
   ): void {
@@ -352,8 +353,8 @@ export class StreamableHTTPClientTransport implements Transport {
 
         // Attempt to reconnect if the stream disconnects unexpectedly and we aren't closing
         if (
-          isReconnectable && 
-          this._abortController && 
+          isReconnectable &&
+          this._abortController &&
           !this._abortController.signal.aborted
         ) {
           // Use the exponential backoff reconnection strategy


### PR DESCRIPTION
Updated the  `_startOrAuthSse` method of `StreamableHTTPClientTransport` to include the `requestInit` parameters that were provided in the constructor.

## Motivation and Context

To include credentials in HTTP calls you need to configure options like `credentials` and `mode` in the `requestInit` options. Currently the  `requestInit` options are included in all the requests except the initial GET request when setting up SSE. Since this request uses `Accept: text/eventsource` it will not include the credentials without settings `credentials: "include"`. 

## How Has This Been Tested?

Added unit tests and updated this in our application that uses the client to connect to an MCP server that is where we noticed it was not including the headers. Since I could not include the change without an official release in our system I had to test is by implementing a workaround that overrides fetch:

```typescript
    const requestInit =  { credentials: 'include', redirect: 'manual', mode: 'cors' };
    this.transport = new StreamableHTTPClientTransport("https://some-mcp-server", requestInit,
      fetch: (input: RequestInfo | URL, _: RequestInit): Promise<Response> => {
         return fetch(input,  requestInit).
        })
    });
```

## Breaking Changes

No, it is possible that users may have implemented a similar workaround but their workaround will still override the default init options in that case.

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [X] I have added appropriate error handling
- [X] I have added or updated documentation as needed
  
## Additional context

None
