### PR TITLE
fix: Add Accept header to auth metadata request

### DIFF
--- a/src/client/auth.test.ts
+++ b/src/client/auth.test.ts
@@ -863,7 +863,8 @@ describe('OAuth Authorization', () => {
             const calls = mockFetch.mock.calls;
             const [, options] = calls[0];
             expect(options.headers).toEqual({
-                'MCP-Protocol-Version': '2025-01-01'
+                'MCP-Protocol-Version': '2025-01-01',
+                Accept: 'application/json'
             });
         });
 

--- a/src/client/auth.ts
+++ b/src/client/auth.ts
@@ -738,7 +738,10 @@ export async function discoverAuthorizationServerMetadata(
         protocolVersion?: string;
     } = {}
 ): Promise<AuthorizationServerMetadata | undefined> {
-    const headers = { 'MCP-Protocol-Version': protocolVersion };
+    const headers = {
+        'MCP-Protocol-Version': protocolVersion,
+        Accept: 'application/json'
+    };
 
     // Get the list of URLs to try
     const urlsToTry = buildDiscoveryUrls(authorizationServerUrl);


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
Adds the Accept header of 'application/json' to the auth metadata request for the MCP client. 
Reason for this being that in some cases, particularly in the SAP ecosystem, auth services have a default of going to a login page/IDP selection screen if the Accept is '*/*'. 

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Recently I've been working on getting MCP into the ERP world, particularly the SAP sphere. All apps used in this area are typically deployed to the Business Technology Platform (BTP) where auth systems like XSUAA are used. 

Unfortunately with the current implementation of the auth metadata fetcher for the client side, the default logic of the XSUAA service comes into play, as it defaults to a login page when a query against the metadata endpoint is made, unless the requester explicitly asks for the JSON content. 

Therefore by asking specifically for the metadata as JSON this problem can be avoided, and seeing as the subsequent logic in the client library also depends on the data received being of JSON format, it would make sense.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
I tested this using our internal implementation and the client returned the metadata as expected.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
Not to my knowledge.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
