### PR TITLE
Temporarily omit test that is breaking CI

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -12,5 +12,11 @@ export default {
   transformIgnorePatterns: [
     "/node_modules/(?!eventsource)/"
   ],
-  testPathIgnorePatterns: ["/node_modules/", "/dist/"],
+  /*
+   *  Omit spec.types.test.ts for now until we can figure out how to make it work
+   *  Changes in the spec file are causing it to fail vis-à-vis
+   *  JSONRPCNotification vs Notification.
+   *  See: https://github.com/modelcontextprotocol/modelcontextprotocol/pull/1026
+   */
+  testPathIgnorePatterns: ["/node_modules/", "/dist/", "<rootDir>/src/spec.types.test.ts"],
 };


### PR DESCRIPTION
## Description
<!-- Provide a brief summary of your changes -->
* In jest.config.js,
  - Omit spec.types.test.ts for now unti we can figure out how to make it work.
  - Changes in the spec file are causing it to fail vis-à-vis JSONRPCNotification vs Notification
  - see https://github.com/modelcontextprotocol/modelcontextprotocol/pull/1026

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
### Tl;dr
A recent [set of changes](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/1026) to the `schema.ts` file in the specification repo has broken a test in this repo which checks that our types all match the spec. This causes CI to fail and no further PRs can be merged until we fix this problem. Unfortunately, it's not a simple fix (do we need to change the test or the types?), so omitting the test temporarily will let us move ahead while we figure out how to fix the problem.

### Here's what happened:
* I noticed that when the author of Typescript SDK [PR 819](https://github.com/modelcontextprotocol/typescript-sdk/pull/819) merged main into his PR, the tests failed when they were not failing previously. 
* I saw a [ton of errors](https://github.com/modelcontextprotocol/typescript-sdk/pull/819/checks) in the test file: `src/spec.types.test.ts` similar to:
<img width="2440" height="350" alt="image" src="https://github.com/user-attachments/assets/170d3529-783c-48f5-8b16-0fdbdfde39ca" />

* I looked at that test file and it hasn't changed in a month. However, I see that it is fetching the actual [spec.types.ts](https://raw.githubusercontent.com/modelcontextprotocol/modelcontextprotocol/refs/heads/main/schema/draft/schema.ts)  file from the specification repo prior to the tests.

<img width="2174" height="478" alt="image" src="https://github.com/user-attachments/assets/d0df82fe-6c7a-467f-b82a-5933ed832c04" />

* Now certain that the problem is with the `src/spec.types.tst.ts` file, I replaced my version of it from local history removed the `npm run fetch:spec-types `from the `test` npm script and ran it. All passed.
<img width="584" height="288" alt="image" src="https://github.com/user-attachments/assets/b53b091d-ccd9-4b17-bc31-b4214bb91c87" />

* After further sleuthing with @felixweinberger in this [Discord thread](https://discord.com/channels/1358869848138059966/1410729215417909248), we narrowed it down to [this PR](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/1026) in the specification repo.

* The author of the spec repo PR, @hesreallyhim did some looking into it last night and his response was:

> ok so this is a little nuanced - the type change from the mcp types is breaking the tests but is not affecting the behavior of the library at all because internally the messages are treated as missing the jsonrpc field, and then it gets added when the message gets sent over the wire. so basically the internal types are not JSONRPC messages. but that wasn't being enforced or caught before because the MCP schema had the same defect.
> 
> i think another way to put it might be that the Protocol class handles the obligatory JSONRPC fields like jsonrpc (kind of wrapper or "framing"),  but then the sepc.types.test is comparing the non-wrapped internal types, which are no actually typed as JSONRPC messages, but this was not caught until the fix above.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
All tests now run.
<img width="315" height="169" alt="Screenshot 2025-08-29 at 10 15 49 AM" src="https://github.com/user-attachments/assets/dd11ce8f-2a54-4e4f-b314-f4448f829961" />

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
Nope.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
