### PR TITLE
Add configurable JSON Schema target specification for OpenAI

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,27 @@ const server = new McpServer({
 });
 ```
 
+#### JSON Schema Specification
+
+You can configure the JSON Schema target specification for better compatibility with different systems, particularly OpenAI endpoints:
+
+```typescript
+const server = new McpServer({
+  name: "my-app",
+  version: "1.0.0"
+}, {
+  jsonSchemaSpec: 'openApi3'  // For OpenAI compatibility
+});
+```
+
+Supported values include:
+- `'jsonSchema7'` (default) - JSON Schema Draft 7
+- `'openApi3'` - OpenAPI 3.0 specification (recommended for OpenAI compatibility)
+- `'jsonSchema4'` - JSON Schema Draft 4
+- `'jsonSchema2019-09'` - JSON Schema Draft 2019-09
+
+This setting affects how tool input schemas are generated from Zod schemas, ensuring they match the expected format for your target system.
+
 ### Resources
 
 Resources are how you expose data to LLMs. They're similar to GET endpoints in a REST API - they provide data but shouldn't perform significant computation or have side effects:

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -37,6 +37,7 @@ import {
   LoggingLevelSchema
 } from "../types.js";
 import Ajv from "ajv";
+import type { Target } from "zod-to-json-schema";
 
 export type ServerOptions = ProtocolOptions & {
   /**
@@ -48,6 +49,11 @@ export type ServerOptions = ProtocolOptions & {
    * Optional instructions describing how to use the server and its features.
    */
   instructions?: string;
+
+  /**
+   * Optional spec for JSON Schema to allow fully compatible use with OpenAI endpoints.
+   */
+  jsonSchemaSpec?: Target;
 };
 
 /**
@@ -88,6 +94,7 @@ export class Server<
   private _clientVersion?: Implementation;
   private _capabilities: ServerCapabilities;
   private _instructions?: string;
+  public _jsonSchemaSpec?: Target = 'jsonSchema7';
 
   /**
    * Callback for when initialization has fully completed (i.e., the client has sent an `initialized` notification).
@@ -104,6 +111,7 @@ export class Server<
     super(options);
     this._capabilities = options?.capabilities ?? {};
     this._instructions = options?.instructions;
+    this._jsonSchemaSpec = options?.jsonSchemaSpec;
 
     this.setRequestHandler(InitializeRequestSchema, (request) =>
       this._oninitialize(request),

--- a/src/server/mcp.ts
+++ b/src/server/mcp.ts
@@ -119,6 +119,7 @@ export class McpServer {
               description: tool.description,
               inputSchema: tool.inputSchema
                 ? (zodToJsonSchema(tool.inputSchema, {
+                  target: this.server._jsonSchemaSpec,
                   strictUnions: true,
                 }) as Tool["inputSchema"])
                 : EMPTY_OBJECT_JSON_SCHEMA,


### PR DESCRIPTION
## Summary
This PR adds support for configurable JSON Schema target specification to improve compatibility with OpenAI endpoints and other systems that require specific JSON Schema versions.

## Changes Made
- Added `jsonSchemaSpec` option to `ServerOptions` interface
- Added `_jsonSchemaSpec` property to `Server` class with default value of `'jsonSchema7'`
- Updated `McpServer` to use the configured target in `zodToJsonSchema` calls
- Imported `Target` type from `zod-to-json-schema` for type safety

## Benefits
- **OpenAI Compatibility**: Allows servers to generate JSON schemas compatible with OpenAI endpoints
- **Flexibility**: Developers can choose the appropriate JSON Schema specification for their use case
- **Backward Compatibility**: Defaults to `'jsonSchema7'` to maintain existing behavior

## Usage Example
```typescript
const server = new McpServer({
  name: "my-server",
  version: "1.0.0"
}, {
  jsonSchemaSpec: 'openApi3' // For OpenAI compatibility
});
```

## Files Changed
- `src/server/index.ts`: Added `jsonSchemaSpec` option and property
- `src/server/mcp.ts`: Updated to use configured target in schema generation

## Motivation and Context
- Many people will be using MCP with OpenAI endpoints. OpenAI only works with a specific subset of JSON Schema. It would be useful to be able to retain other schema functionality when creating servers that are sometimes consumed by OpenAI, sometimes by other providers.

## How Has This Been Tested?
I made a non-OpenAI compliant schema and used them consumed it with the OpenAI responses API

## Breaking Changes
Nope

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
Nope - does what it says on the tin
