### PR TITLE
Fix automatic log level handling for sessionless connections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,9 +124,6 @@ out
 # Stores VSCode versions used for testing VSCode extensions
 .vscode-test
 
-# Jetbrains IDEs
-.idea/
-
 # yarn v2
 .yarn/cache
 .yarn/unplugged

--- a/.gitignore
+++ b/.gitignore
@@ -124,6 +124,9 @@ out
 # Stores VSCode versions used for testing VSCode extensions
 .vscode-test
 
+# Jetbrains IDEs
+.idea/
+
 # yarn v2
 .yarn/cache
 .yarn/unplugged

--- a/src/server/index.test.ts
+++ b/src/server/index.test.ts
@@ -21,7 +21,6 @@ import {
 import { Transport } from "../shared/transport.js";
 import { InMemoryTransport } from "../inMemory.js";
 import { Client } from "../client/index.js";
-import {AuthInfo} from "./auth/types.js";
 
 test("should accept latest protocol version", async () => {
   let sendPromiseResolve: (value: unknown) => void;

--- a/src/server/index.test.ts
+++ b/src/server/index.test.ts
@@ -4,18 +4,19 @@
 import { Server } from "./index.js";
 import { z } from "zod";
 import {
-    RequestSchema,
-    NotificationSchema,
-    ResultSchema,
-    LATEST_PROTOCOL_VERSION,
-    SUPPORTED_PROTOCOL_VERSIONS,
-    CreateMessageRequestSchema,
-    ElicitRequestSchema,
-    ListPromptsRequestSchema,
-    ListResourcesRequestSchema,
-    ListToolsRequestSchema,
-    SetLevelRequestSchema,
-    ErrorCode, LoggingMessageNotificationSchema, JSONRPCMessage, LoggingMessageNotification
+  RequestSchema,
+  NotificationSchema,
+  ResultSchema,
+  LATEST_PROTOCOL_VERSION,
+  SUPPORTED_PROTOCOL_VERSIONS,
+  CreateMessageRequestSchema,
+  ElicitRequestSchema,
+  ListPromptsRequestSchema,
+  ListResourcesRequestSchema,
+  ListToolsRequestSchema,
+  SetLevelRequestSchema,
+  ErrorCode,
+  LoggingMessageNotification
 } from "../types.js";
 import { Transport } from "../shared/transport.js";
 import { InMemoryTransport } from "../inMemory.js";

--- a/src/server/index.test.ts
+++ b/src/server/index.test.ts
@@ -4,22 +4,23 @@
 import { Server } from "./index.js";
 import { z } from "zod";
 import {
-  RequestSchema,
-  NotificationSchema,
-  ResultSchema,
-  LATEST_PROTOCOL_VERSION,
-  SUPPORTED_PROTOCOL_VERSIONS,
-  CreateMessageRequestSchema,
-  ElicitRequestSchema,
-  ListPromptsRequestSchema,
-  ListResourcesRequestSchema,
-  ListToolsRequestSchema,
-  SetLevelRequestSchema,
-  ErrorCode
+    RequestSchema,
+    NotificationSchema,
+    ResultSchema,
+    LATEST_PROTOCOL_VERSION,
+    SUPPORTED_PROTOCOL_VERSIONS,
+    CreateMessageRequestSchema,
+    ElicitRequestSchema,
+    ListPromptsRequestSchema,
+    ListResourcesRequestSchema,
+    ListToolsRequestSchema,
+    SetLevelRequestSchema,
+    ErrorCode, LoggingMessageNotificationSchema, JSONRPCMessage, LoggingMessageNotification
 } from "../types.js";
 import { Transport } from "../shared/transport.js";
 import { InMemoryTransport } from "../inMemory.js";
 import { Client } from "../client/index.js";
+import {AuthInfo} from "./auth/types.js";
 
 test("should accept latest protocol version", async () => {
   let sendPromiseResolve: (value: unknown) => void;
@@ -569,7 +570,7 @@ test("should allow elicitation reject and cancel without validation", async () =
     action: "decline",
   });
 
-  // Test cancel - should not validate  
+  // Test cancel - should not validate
   await expect(
     server.elicitInput({
       message: "Please provide your name",
@@ -861,3 +862,154 @@ test("should handle request timeout", async () => {
     code: ErrorCode.RequestTimeout,
   });
 });
+
+/*
+  Test automatic log level handling for transports with and without sessionId
+ */
+test("should respect log level for transport without sessionId", async () => {
+
+    const server = new Server(
+        {
+            name: "test server",
+            version: "1.0",
+        },
+        {
+            capabilities: {
+                prompts: {},
+                resources: {},
+                tools: {},
+                logging: {},
+            },
+            enforceStrictCapabilities: true,
+        },
+    );
+
+    const client = new Client(
+        {
+            name: "test client",
+            version: "1.0",
+        },
+    );
+
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+    await Promise.all([
+        client.connect(clientTransport),
+        server.connect(serverTransport),
+    ]);
+
+    expect(clientTransport.sessionId).toEqual(undefined);
+
+    // Client sets logging level to warning
+    await client.setLoggingLevel("warning");
+
+    // This one will make it through
+    const warningParams: LoggingMessageNotification["params"] = {
+        level: "warning",
+        logger: "test server",
+        data: "Warning message",
+    };
+
+    // This one will not
+    const debugParams: LoggingMessageNotification["params"] = {
+        level: "debug",
+        logger: "test server",
+        data: "Debug message",
+    };
+
+    // Test the one that makes it through
+    clientTransport.onmessage = jest.fn().mockImplementation((message) => {
+        expect(message).toEqual({
+            jsonrpc: "2.0",
+            method: "notifications/message",
+            params: warningParams
+        });
+    });
+
+    // This one will not make it through
+    await server.sendLoggingMessage(debugParams);
+    expect(clientTransport.onmessage).not.toHaveBeenCalled();
+
+    // This one will, triggering the above test in clientTransport.onmessage
+    await server.sendLoggingMessage(warningParams);
+    expect(clientTransport.onmessage).toHaveBeenCalled();
+
+});
+
+test("should respect log level for transport with sessionId", async () => {
+
+    const server = new Server(
+        {
+            name: "test server",
+            version: "1.0",
+        },
+        {
+            capabilities: {
+                prompts: {},
+                resources: {},
+                tools: {},
+                logging: {},
+            },
+            enforceStrictCapabilities: true,
+        },
+    );
+
+    const client = new Client(
+        {
+            name: "test client",
+            version: "1.0",
+        },
+    );
+
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+    // Add a session id to the transports
+    const SESSION_ID = "test-session-id";
+    clientTransport.sessionId = SESSION_ID;
+    serverTransport.sessionId = SESSION_ID;
+
+    expect(clientTransport.sessionId).toBeDefined();
+    expect(serverTransport.sessionId).toBeDefined();
+
+    await Promise.all([
+        client.connect(clientTransport),
+        server.connect(serverTransport),
+    ]);
+
+
+    // Client sets logging level to warning
+    await client.setLoggingLevel("warning");
+
+    // This one will make it through
+    const warningParams: LoggingMessageNotification["params"] = {
+        level: "warning",
+        logger: "test server",
+        data: "Warning message",
+    };
+
+    // This one will not
+    const debugParams: LoggingMessageNotification["params"] = {
+        level: "debug",
+        logger: "test server",
+        data: "Debug message",
+    };
+
+    // Test the one that makes it through
+    clientTransport.onmessage = jest.fn().mockImplementation((message) => {
+        expect(message).toEqual({
+            jsonrpc: "2.0",
+            method: "notifications/message",
+            params: warningParams
+        });
+    });
+
+    // This one will not make it through
+    await server.sendLoggingMessage(debugParams, SESSION_ID);
+    expect(clientTransport.onmessage).not.toHaveBeenCalled();
+
+    // This one will, triggering the above test in clientTransport.onmessage
+    await server.sendLoggingMessage(warningParams, SESSION_ID);
+    expect(clientTransport.onmessage).toHaveBeenCalled();
+
+});
+

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -114,10 +114,10 @@ export class Server<
 
     if (this._capabilities.logging) {
         this.setRequestHandler(SetLevelRequestSchema, async (request, extra) => {
-            const transportSessionId: string | undefined = extra.sessionId || extra.requestInfo?.headers['mcp-session-id'] as string || "NO_SESSION";
+            const transportSessionId: string | undefined = extra.sessionId || extra.requestInfo?.headers['mcp-session-id'] as string;
             const { level } = request.params;
             const parseResult = LoggingLevelSchema.safeParse(level);
-            if (transportSessionId && parseResult.success) {
+            if (parseResult.success) {
                 this._loggingLevels.set(transportSessionId, parseResult.data);
             }
             return {};
@@ -126,7 +126,7 @@ export class Server<
   }
 
   // Map log levels by session id
-  private _loggingLevels = new Map<string, LoggingLevel>();
+  private _loggingLevels = new Map<string | undefined, LoggingLevel>();
 
   // Map LogLevelSchema to severity index
   private readonly LOG_LEVEL_SEVERITY = new Map(
@@ -134,7 +134,7 @@ export class Server<
   );
 
   // Is a message with the given level ignored in the log level set for the given session id?
-  private isMessageIgnored = (level: LoggingLevel, sessionId: string = "NO_SESSION"): boolean => {
+  private isMessageIgnored = (level: LoggingLevel, sessionId?: string): boolean => {
     const currentLevel = this._loggingLevels.get(sessionId);
     return (currentLevel)
         ? this.LOG_LEVEL_SEVERITY.get(level)! < this.LOG_LEVEL_SEVERITY.get(currentLevel)!

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -114,7 +114,7 @@ export class Server<
 
     if (this._capabilities.logging) {
         this.setRequestHandler(SetLevelRequestSchema, async (request, extra) => {
-            const transportSessionId: string | undefined = extra.sessionId || extra.requestInfo?.headers['mcp-session-id'] as string || undefined;
+            const transportSessionId: string | undefined = extra.sessionId || extra.requestInfo?.headers['mcp-session-id'] as string || "NO_SESSION";
             const { level } = request.params;
             const parseResult = LoggingLevelSchema.safeParse(level);
             if (transportSessionId && parseResult.success) {
@@ -134,7 +134,7 @@ export class Server<
   );
 
   // Is a message with the given level ignored in the log level set for the given session id?
-  private isMessageIgnored = (level: LoggingLevel, sessionId: string): boolean => {
+  private isMessageIgnored = (level: LoggingLevel, sessionId: string = "NO_SESSION"): boolean => {
     const currentLevel = this._loggingLevels.get(sessionId);
     return (currentLevel)
         ? this.LOG_LEVEL_SEVERITY.get(level)! < this.LOG_LEVEL_SEVERITY.get(currentLevel)!
@@ -398,7 +398,7 @@ export class Server<
      */
     async sendLoggingMessage(params: LoggingMessageNotification["params"], sessionId?: string) {
       if (this._capabilities.logging) {
-          if (!sessionId || !this.isMessageIgnored(params.level, sessionId)) {
+          if (!this.isMessageIgnored(params.level, sessionId)) {
               return this.notification({method: "notifications/message", params})
           }
       }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -114,7 +114,7 @@ export class Server<
 
     if (this._capabilities.logging) {
         this.setRequestHandler(SetLevelRequestSchema, async (request, extra) => {
-            const transportSessionId: string | undefined = extra.sessionId || extra.requestInfo?.headers['mcp-session-id'] as string;
+            const transportSessionId: string | undefined = extra.sessionId || extra.requestInfo?.headers['mcp-session-id'] as string || undefined;
             const { level } = request.params;
             const parseResult = LoggingLevelSchema.safeParse(level);
             if (parseResult.success) {


### PR DESCRIPTION
## Description
<!-- Provide a brief summary of your changes -->

* In `src/server/index.ts`
  - In `Server` class
    - In constructor, when setting request handler for `SetLevelRequestSchema`
      - Remove check for `transportSessionId` when in condition wrapping call to `_loggingLevels.set`
      - Allows `undefined` `sessionId` to be a map key
    - Change `_loggingLevels` Map to allow `string` or `undefined` as a key. 
      - Allows an STDIO server to have automatic log filtering if `sendLoggingMessage` is used.
    - In `isMessageIgnored` method
      - Made `sessionId` argument optional. 
      - Will result in `undefined` for sessionless / STDIO servers 
    - In `sendLoggingMessage` method, 
      - Remove `sessionId` check from condition wrapping call to `notification`
      - Allows STDIO servers to have automatic log filtering

* In `src/server/index.test.ts`
  - Added tests
    - "should respect log level for transport without sessionId"
    - "should respect log level for transport with sessionId"
    
## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
While [refactoring the Everything server](https://github.com/modelcontextprotocol/servers/pull/2669) to demonstrate how servers can avail themselves of the SDK's recent addition of [Automatic handling of logging level](https://github.com/modelcontextprotocol/typescript-sdk/pull/882), I discovered a wrinkle that needs ironing out. 

STDIO server connections (which do not have a `sessionId`) would no longer throw a "Method not found" error if they advertised logging but did not set a listener for `SetLevelRequestSchema` messages, which is good. However, they would not respect the level that was set in subsequent calls to `sendLoggingMessage`. This is because the log levels are tracked by `sessionId`, to allow for multiple clients connecting to a server and each setting their own level. 

This PR fixes that and tests the entire process, both with and without a `sessionId`.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
New unit tests for both cases.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
Nope. 

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
