### PR TITLE
fix: prevent streamable http wite after end from crashing the node process

### DIFF
--- a/src/server/streamableHttp.ts
+++ b/src/server/streamableHttp.ts
@@ -303,6 +303,15 @@ export class StreamableHTTPServerTransport implements Transport {
     res.on("close", () => {
       this._streamMapping.delete(this._standaloneSseStreamId);
     });
+
+    // Add error handler for standalone SSE stream
+    res.on("error", (error) => {
+      if ((error as NodeJS.ErrnoException).code === 'ERR_STREAM_WRITE_AFTER_END') {
+        this._streamMapping.delete(this._standaloneSseStreamId);
+      } else {
+        this.onerror?.(error as Error);
+      }
+    });
   }
 
   /**
@@ -327,6 +336,11 @@ export class StreamableHTTPServerTransport implements Transport {
 
       const streamId = await this._eventStore?.replayEventsAfter(lastEventId, {
         send: async (eventId: string, message: JSONRPCMessage) => {
+          // Check stream state before writing
+          if (res.destroyed || res.writableEnded || !res.writable) {
+            res.end();
+            return;
+          }
           if (!this.writeSSEEvent(res, message, eventId)) {
             this.onerror?.(new Error("Failed replay events"));
             res.end();
@@ -334,6 +348,15 @@ export class StreamableHTTPServerTransport implements Transport {
         }
       });
       this._streamMapping.set(streamId, res);
+
+      // Add error handler for replay stream
+      res.on("error", (error) => {
+        if ((error as NodeJS.ErrnoException).code === 'ERR_STREAM_WRITE_AFTER_END') {
+          this._streamMapping.delete(streamId);
+        } else {
+          this.onerror?.(error as Error);
+        }
+      });
     } catch (error) {
       this.onerror?.(error as Error);
     }
@@ -343,6 +366,11 @@ export class StreamableHTTPServerTransport implements Transport {
    * Writes an event to the SSE stream with proper formatting
    */
   private writeSSEEvent(res: ServerResponse, message: JSONRPCMessage, eventId?: string): boolean {
+    // Check if stream is still writable to prevent ERR_STREAM_WRITE_AFTER_END
+    if (res.destroyed || res.writableEnded || !res.writable) {
+      return false;
+    }
+
     let eventData = `event: message\n`;
     // Include event ID if provided - this is important for resumability
     if (eventId) {
@@ -350,7 +378,14 @@ export class StreamableHTTPServerTransport implements Transport {
     }
     eventData += `data: ${JSON.stringify(message)}\n\n`;
 
-    return res.write(eventData);
+    try {
+      return res.write(eventData);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ERR_STREAM_WRITE_AFTER_END') {
+        return false;
+      }
+      throw error;
+    }
   }
 
   /**
@@ -509,15 +544,30 @@ export class StreamableHTTPServerTransport implements Transport {
         }
         // Store the response for this request to send messages back through this connection
         // We need to track by request ID to maintain the connection
+        const requestIds: RequestId[] = [];
         for (const message of messages) {
           if (isJSONRPCRequest(message)) {
             this._streamMapping.set(streamId, res);
             this._requestToStreamMapping.set(message.id, streamId);
+            requestIds.push(message.id);
           }
         }
         // Set up close handler for client disconnects
         res.on("close", () => {
           this._streamMapping.delete(streamId);
+        });
+
+        // Add error handler for stream write errors
+        res.on("error", (error) => {
+          if ((error as NodeJS.ErrnoException).code === 'ERR_STREAM_WRITE_AFTER_END') {
+            this._streamMapping.delete(streamId);
+            // Clean up all request mappings for this stream
+            for (const reqId of requestIds) {
+              this._requestToStreamMapping.delete(reqId);
+            }
+          } else {
+            this.onerror?.(error as Error);
+          }
         });
 
         // handle each message
@@ -681,7 +731,11 @@ export class StreamableHTTPServerTransport implements Transport {
       }
 
       // Send the message to the standalone SSE stream
-      this.writeSSEEvent(standaloneSse, message, eventId);
+      const writeSuccess = this.writeSSEEvent(standaloneSse, message, eventId);
+      if (!writeSuccess) {
+        // Clean up if write failed
+        this._streamMapping.delete(this._standaloneSseStreamId);
+      }
       return;
     }
 
@@ -692,6 +746,14 @@ export class StreamableHTTPServerTransport implements Transport {
       throw new Error(`No connection established for request ID: ${String(requestId)}`);
     }
 
+    // Check if response stream is still valid and writable
+    if (!response || response.destroyed || response.writableEnded || !response.writable) {
+      // Clean up mappings for ended streams
+      this._streamMapping.delete(streamId);
+      this._requestToStreamMapping.delete(requestId);
+      return;
+    }
+
     if (!this._enableJsonResponse) {
       // For SSE responses, generate event ID if event store is provided
       let eventId: string | undefined;
@@ -699,9 +761,12 @@ export class StreamableHTTPServerTransport implements Transport {
       if (this._eventStore) {
         eventId = await this._eventStore.storeEvent(streamId, message);
       }
-      if (response) {
-        // Write the event to the response stream
-        this.writeSSEEvent(response, message, eventId);
+      // Write the event to the response stream (now safe due to validation above)
+      const writeSuccess = this.writeSSEEvent(response, message, eventId);
+      if (!writeSuccess) {
+        // Clean up if write failed
+        this._streamMapping.delete(streamId);
+        this._requestToStreamMapping.delete(requestId);
       }
     }
 


### PR DESCRIPTION
A critical production bug was identified in the [Apify MCP Server](https://github.com/apify/apify-mcp-server) causing server crashes due to the `ERR_STREAM_WRITE_AFTER_END` error. This error occurred when multiple concurrent HTTP requests with the same ID were processed simultaneously, leading to race conditions in the `StreamableHTTPServerTransport`.

## Motivation and Context
To prevent the `ERR_STREAM_WRITE_AFTER_END` from crashing the node process.

## How Has This Been Tested?
Manually replicated using script that triggered the crash, fixed in the SDK and then verified that the script no longer crashes the server.

## Breaking Changes
No.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
This error was almost always triggered by the Claude.ai MCP connectors and crashed the server:
```
Sep 10 02:47:49 apify-mcp-server-56dd9854bf-cxxc4 apify-mcp-server INFO {"time":"2025-09-10T00:47:49.054Z","level":"INFO","msg":"MCP API","mth":"POST","rt":"/","tr":"HTTP","ip":"xxx","userAgent":"Claude-User","body":"{\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2025-06-18\",\"capabilities\":{},\"clientInfo\":{\"name\":\"Anthropic/ClaudeAI\",\"version\":\"1.0.0\"}},\"jsonrpc\":\"2.0\",\"id\":0}"}
Sep 10 02:47:49 apify-mcp-server-56dd9854bf-cxxc4 apify-mcp-server INFO {"time":"2025-09-10T00:47:49.154Z","level":"INFO","msg":"Session initialized","sessionId":"a14f0708-fcfe-4788-9afb-78b5cca580d8","clientsCount":178,"tr":"HTTP"}
Sep 10 02:47:49 apify-mcp-server-56dd9854bf-cxxc4 apify-mcp-server INFO {"time":"2025-09-10T00:47:49.248Z","level":"INFO","msg":"MCP API","mth":"POST","rt":"/","tr":"HTTP","ip":"xxx","userAgent":"Claude-User","body":"{\"method\":\"notifications/initialized\",\"jsonrpc\":\"2.0\"}"}
Sep 10 02:47:49 apify-mcp-server-56dd9854bf-cxxc4 apify-mcp-server INFO {"time":"2025-09-10T00:47:49.330Z","level":"INFO","msg":"MCP API","mth":"POST","rt":"/","tr":"HTTP","ip":"xxx","userAgent":"Claude-User","body":"{\"method\":\"prompts/list\",\"jsonrpc\":\"2.0\",\"id\":1}"}
Sep 10 02:47:49 apify-mcp-server-56dd9854bf-cxxc4 apify-mcp-server INFO {"time":"2025-09-10T00:47:49.331Z","level":"INFO","msg":"MCP API","mth":"POST","rt":"/","tr":"HTTP","ip":"xxx","userAgent":"Claude-User","body":"{\"method\":\"tools/list\",\"jsonrpc\":\"2.0\",\"id\":3}"}
Sep 10 02:47:49 apify-mcp-server-56dd9854bf-cxxc4 apify-mcp-server INFO {"time":"2025-09-10T00:47:49.332Z","level":"INFO","msg":"MCP API","mth":"POST","rt":"/","tr":"HTTP","ip":"xxx","userAgent":"Claude-User","body":"{\"method\":\"prompts/list\",\"jsonrpc\":\"2.0\",\"id\":1}"}
Wednesday, Sep 10th 2025, 2:47am
Sep 10 02:47:49 apify-mcp-server-56dd9854bf-cxxc4 apify-mcp-server err node:events:502
      throw er; // Unhandled 'error' event
      ^
Sep 10 02:47:49 apify-mcp-server-56dd9854bf-cxxc4 apify-mcp-server Error Error [ERR_STREAM_WRITE_AFTER_END]: write after end
    at write_ (node:_http_outgoing:955:11)
    at ServerResponse.write (node:_http_outgoing:904:15)
    at StreamableHTTPServerTransport.writeSSEEvent (file:///home/node/node_modules/@modelcontextprotocol/sdk/dist/esm/server/streamableHttp.js:238:20)
    at StreamableHTTPServerTransport.send (file:///home/node/node_modules/@modelcontextprotocol/sdk/dist/esm/server/streamableHttp.js:565:22)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
Sep 10 02:47:49 apify-mcp-server-56dd9854bf-cxxc4 apify-mcp-server err Emitted 'error' event on ServerResponse instance at:
    at emitErrorNt (node:_http_outgoing:927:9)
    at process.processTicksAndRejections (node:internal/process/task_queues:91:21) {
  code: 'ERR_STREAM_WRITE_AFTER_END'
}
Sep 10 02:47:49 apify-mcp-server-56dd9854bf-cxxc4 apify-mcp-server Node.js v22.13.1
```

After patch is applied the server prints errors and continues to run:
```
DEBUG Processing request {"sessionId":"03190050-dd9e-44b6-802c-6bbbce839904","tr":"HTTP","body":"{\"jsonrpc\":\"2.0\",\"id\":9,\"method\":\"prompts/list\"}"}
[MCP Error] Error: Failed to send response: Error: No connection established for request ID: 2
    at <anonymous> (/home/mq/workdir/apify/mcp.apify.com/typescript-sdk/src/shared/protocol.ts:444:23)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
[MCP Error] Error: Failed to send response: Error: No connection established for request ID: 3
    at <anonymous> (/home/mq/workdir/apify/mcp.apify.com/typescript-sdk/src/shared/protocol.ts:444:23)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
[MCP Error] Error: Failed to send response: Error: No connection established for request ID: 4
    at <anonymous> (/home/mq/workdir/apify/mcp.apify.com/typescript-sdk/src/shared/protocol.ts:444:23)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
[MCP Error] Error: Failed to send response: Error: No connection established for request ID: 5
    at <anonymous> (/home/mq/workdir/apify/mcp.apify.com/typescript-sdk/src/shared/protocol.ts:444:23)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
[MCP Error] Error: Failed to send response: Error: No connection established for request ID: 7
    at <anonymous> (/home/mq/workdir/apify/mcp.apify.com/typescript-sdk/src/shared/protocol.ts:444:23)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
[MCP Error] Error: Failed to send response: Error: No connection established for request ID: 8
    at <anonymous> (/home/mq/workdir/apify/mcp.apify.com/typescript-sdk/src/shared/protocol.ts:444:23)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
```