### PR TITLE
handle async onmessage hook

### DIFF
--- a/src/server/sse.ts
+++ b/src/server/sse.ts
@@ -191,7 +191,7 @@ export class SSEServerTransport implements Transport {
       throw error;
     }
 
-    this.onmessage?.(parsedMessage, extra);
+    await this.onmessage?.(parsedMessage, extra);
   }
 
   async close(): Promise<void> {


### PR DESCRIPTION
## Motivation and Context

Using the example code from README:
```
// Legacy message endpoint for older clients
app.post('/messages', async (req, res) => {
  const sessionId = req.query.sessionId as string;
  const transport = transports.sse[sessionId];
  if (transport) {
    await transport.handlePostMessage(req, res, req.body);
  } else {
    res.status(400).send('No transport found for sessionId');
  }
});
```

I notice that "await" is not respected
```
    await transport.handlePostMessage(req, res, req.body);
```

The reason is a missing await in `handlePostMessage` 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [ x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed
