### PR TITLE
ignore icons for now

### DIFF
--- a/src/spec.types.test.ts
+++ b/src/spec.types.test.ts
@@ -685,6 +685,7 @@ const MISSING_SDK_TYPES = [
   'Annotations',
   'ModelHint',
   'ModelPreferences',
+  'Icons',
 ]
 
 function extractExportedTypes(source: string): string[] {
@@ -699,7 +700,7 @@ describe('Spec Types', () => {
   it('should define some expected types', () => {
     expect(specTypes).toContain('JSONRPCNotification');
     expect(specTypes).toContain('ElicitResult');
-    expect(specTypes).toHaveLength(93);
+    expect(specTypes).toHaveLength(94);
   });
 
   it('should have up to date list of missing sdk types', () => {


### PR DESCRIPTION
Icons were added in https://github.com/modelcontextprotocol/modelcontextprotocol/pull/1451/files, for now, for the release, adding them to the types test to ignore