### PR TITLE
Fix StreamableHTTPClientTransport instantiation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1701,13 +1701,13 @@ import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
 let client: Client | undefined = undefined;
 const baseUrl = new URL(url);
 try {
-  client = new Client({
-    name: 'streamable-http-client',
-    version: '1.0.0'
-  });
-  const transport = new StreamableHTTPClientTransport(baseUrl);
-  await client.connect(transport);
-  console.log("Connected using Streamable HTTP transport");
+    client = new Client({
+        name: 'streamable-http-client',
+        version: '1.0.0'
+    });
+    const transport = new StreamableHTTPClientTransport(baseUrl);
+    await client.connect(transport);
+    console.log('Connected using Streamable HTTP transport');
 } catch (error) {
     // If that fails with a 4xx error, try the older SSE transport
     console.log('Streamable HTTP connection failed, falling back to SSE transport');


### PR DESCRIPTION
The sample code has a problem to construct the URL object again. This is already construct  at [Line 1225](https://github.com/modelcontextprotocol/typescript-sdk/blob/b28c297184cb0cb64611a3357d6438dd1b0824c6/README.md?plain=1#L1225)

## Motivation and Context

The existing code snippet is not work

## How Has This Been Tested?
Tested by creating the client

## Breaking Changes
N/A

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [X] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
