### PR TITLE
feat: add optional resource annotations

### DIFF
--- a/src/server/mcp.test.ts
+++ b/src/server/mcp.test.ts
@@ -2111,6 +2111,11 @@ describe("resource()", () => {
       {
         description: "Test resource",
         mimeType: "text/plain",
+        annotations: {
+          audience: ["assistant"],
+          priority: 0.42,
+          lastModified: "2025-01-12T15:00:58Z"
+        }
       },
       async () => ({
         contents: [
@@ -2140,6 +2145,11 @@ describe("resource()", () => {
     expect(result.resources).toHaveLength(1);
     expect(result.resources[0].description).toBe("Test resource");
     expect(result.resources[0].mimeType).toBe("text/plain");
+    expect(result.resources[0].annotations).toEqual({
+      audience: ["assistant"],
+      priority: 0.42,
+      lastModified: "2025-01-12T15:00:58Z"
+    });
   });
 
   /***

--- a/src/spec.types.test.ts
+++ b/src/spec.types.test.ts
@@ -439,6 +439,13 @@ function checkBlobResourceContents(
   sdk = spec;
   spec = sdk;
 }
+function checkResourceAnnotations(
+  sdk: RemovePassthrough<SDKTypes.ResourceAnnotations>,
+  spec: SpecTypes.Annotations
+) {
+  sdk = spec;
+  spec = sdk;
+}
 function checkResource(
   sdk: RemovePassthrough<SDKTypes.Resource>,
   spec: SpecTypes.Resource

--- a/src/types.ts
+++ b/src/types.ts
@@ -519,6 +519,28 @@ export const BlobResourceContentsSchema = ResourceContentsSchema.extend({
 });
 
 /**
+ * Optional annotations providing clients additional context about a resource.
+ */
+export const ResourceAnnotationsSchema = z
+  .object({
+    /**
+     * Intended audience(s) for the resource.
+     */
+    audience: z.optional(z.array(z.enum(["user", "assistant"]))),
+
+    /**
+     * Importance hint for the resource, from 0 (least) to 1 (most).
+     */
+    priority: z.optional(z.number().min(0).max(1)),
+
+    /**
+     * ISO 8601 timestamp for the most recent modification.
+     */
+    lastModified: z.optional(z.string().datetime({ offset: true })),
+  })
+  .passthrough();
+
+/**
  * A known resource that the server is capable of reading.
  */
 export const ResourceSchema = BaseMetadataSchema.extend({
@@ -538,6 +560,11 @@ export const ResourceSchema = BaseMetadataSchema.extend({
    * The MIME type of this resource, if known.
    */
   mimeType: z.optional(z.string()),
+
+  /**
+   * Optional annotations for the client.
+   */
+  annotations: z.optional(ResourceAnnotationsSchema),
 
   /**
    * An optional list of icons for this resource.
@@ -1608,6 +1635,7 @@ export type PaginatedResult = Infer<typeof PaginatedResultSchema>;
 export type ResourceContents = Infer<typeof ResourceContentsSchema>;
 export type TextResourceContents = Infer<typeof TextResourceContentsSchema>;
 export type BlobResourceContents = Infer<typeof BlobResourceContentsSchema>;
+export type ResourceAnnotations = Infer<typeof ResourceAnnotationsSchema>;
 export type Resource = Infer<typeof ResourceSchema>;
 export type ResourceTemplate = Infer<typeof ResourceTemplateSchema>;
 export type ListResourcesRequest = Infer<typeof ListResourcesRequestSchema>;


### PR DESCRIPTION
Solves https://github.com/modelcontextprotocol/typescript-sdk/issues/946 by adding type definitions for the optional [annotations](https://modelcontextprotocol.io/specification/2025-06-18/server/resources#annotations) attribute for resources.