### PR TITLE
fix: Return 401 instead of 400 for missing authentication

### DIFF
--- a/src/server/streamableHttp.test.ts
+++ b/src/server/streamableHttp.test.ts
@@ -435,9 +435,9 @@ describe("StreamableHTTPServerTransport", () => {
   it("should reject requests without a valid session ID", async () => {
     const response = await sendPostRequest(baseUrl, TEST_MESSAGES.toolsList);
 
-    expect(response.status).toBe(400);
+    expect(response.status).toBe(401);
     const errorData = await response.json();
-    expectErrorResponse(errorData, -32000, /Bad Request/);
+    expectErrorResponse(errorData, -32000, /Unauthorized/);
     expect(errorData.id).toBeNull();
   });
 

--- a/src/server/streamableHttp.ts
+++ b/src/server/streamableHttp.ts
@@ -120,7 +120,7 @@ export interface StreamableHTTPServerTransportOptions {
  * - Session ID is generated and included in response headers
  * - Session ID is always included in initialization responses
  * - Requests with invalid session IDs are rejected with 404 Not Found
- * - Non-initialization requests without a session ID are rejected with 400 Bad Request
+ * - Non-initialization requests without a session ID are rejected with 401 Unauthorized
  * - State is maintained in-memory (connections, message history)
  * 
  * In stateless mode:
@@ -598,12 +598,12 @@ export class StreamableHTTPServerTransport implements Transport {
     const sessionId = req.headers["mcp-session-id"];
 
     if (!sessionId) {
-      // Non-initialization requests without a session ID should return 400 Bad Request
-      res.writeHead(400).end(JSON.stringify({
+      // Non-initialization requests without a session ID should return 401 Unauthorized
+      res.writeHead(401).end(JSON.stringify({
         jsonrpc: "2.0",
         error: {
           code: -32000,
-          message: "Bad Request: Mcp-Session-Id header is required"
+          message: "Unauthorized: Mcp-Session-Id header is required"
         },
         id: null
       }));


### PR DESCRIPTION
## Summary

This PR fixes an issue where the server returns 400 Bad Request when the session ID header is missing, when it should return 401 Unauthorized according to HTTP standards.

## Problem

When a request is made without the `Mcp-Session-Id` header, the server currently returns:
- **Status**: 400 Bad Request  
- **Message**: "Bad Request: Mcp-Session-Id header is required"

According to HTTP semantics:
- **400 Bad Request**: The request is syntactically invalid or malformed
- **401 Unauthorized**: Authentication credentials are missing or invalid

Missing authentication headers should result in 401, not 400.

## Solution

Changed the status code from 400 to 401 for missing session ID headers, making the API behavior semantically correct and helping clients properly distinguish between authentication errors and request format errors.

## Changes

- Changed status code from 400 to 401 in `streamableHttp.ts` when `Mcp-Session-Id` header is missing
- Updated error message from "Bad Request" to "Unauthorized"  
- Updated documentation comments to reflect the change
- Fixed test expectations in `streamableHttp.test.ts` to match new behavior

## Testing

- Updated existing test to expect 401 instead of 400
- All tests pass with the new behavior

## Related Issues

- Originally reported as punkpeye/fastmcp#180 but the issue is actually in the MCP SDK

## Breaking Change Consideration

This is technically a breaking change as it changes the status code returned by the API. However:
1. It fixes incorrect HTTP semantics
2. Clients should already be handling 401 for authentication failures
3. The error message and code remain similar, just with correct HTTP status