### PR TITLE
feature: add configuration option for shell of stdio client

### DIFF
--- a/src/client/stdio.ts
+++ b/src/client/stdio.ts
@@ -18,6 +18,13 @@ export type StdioServerParameters = {
     args?: string[];
 
     /**
+     * Whether to use a shell to execute the command, or the shell to use.
+     *
+     * If not specified, the default is false.
+     */
+    shell?: string | boolean;
+
+    /**
      * The environment to use when spawning the process.
      *
      * If not specified, the result of getDefaultEnvironment() will be used.
@@ -125,7 +132,7 @@ export class StdioClientTransport implements Transport {
                     ...this._serverParams.env
                 },
                 stdio: ['pipe', 'pipe', this._serverParams.stderr ?? 'inherit'],
-                shell: false,
+                shell: this._serverParams.shell ?? false,
                 signal: this._abortController.signal,
                 windowsHide: process.platform === 'win32' && isElectron(),
                 cwd: this._serverParams.cwd


### PR DESCRIPTION
This PR adds to `StdioClientTransport` a `shell` configuration option whose type match the `spawn` function parameter with the same name. The current value for this parameter is not configurable and always false. This default behavior is preserved.

Making this option configurable enables spawning MCP clients with shell execution capabilities. This is particularly useful for command chaining without having to rely on workarounds like `/bin/sh -c 'cd myDirectory && npm run start'`.

## Motivation and Context

This change provides a clean, cross-platform way to enable shell execution by adding a shell parameter that accepts either a boolean (to use the default system shell) or a string (to specify a custom shell path).

For exemple, this current configuration:

```ts
const transport = new StdioClientTransport({
  command: "/bin/sh",
  args: ["-c", "npm i && npm run start"],
});
```

can be replaced with:

```ts
const transport = new StdioClientTransport({
  command: "npm i && npm run start",
  shell: true
});
```

which is cross-platform compatible

## How Has This Been Tested?

No additional tests, the default behavior is preserved

## Breaking Changes

No breaking changes. The shell parameter is optional and defaults to false, maintaining backward compatibility with existing implementations.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed