### PR TITLE
fix: change Icon.sizes from string to string[]

### DIFF
--- a/src/examples/server/simpleStreamableHttp.ts
+++ b/src/examples/server/simpleStreamableHttp.ts
@@ -22,7 +22,7 @@ const getServer = () => {
   const server = new McpServer({
     name: 'simple-streamable-http-server',
     version: '1.0.0',
-    icons: [{src: './mcp.svg', sizes: '512x512', mimeType: 'image/svg+xml'}],
+    icons: [{src: './mcp.svg', sizes: ['512x512'], mimeType: 'image/svg+xml'}],
     websiteUrl: 'https://github.com/modelcontextprotocol/typescript-sdk',
   }, { capabilities: { logging: {} } });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -214,9 +214,11 @@ export const IconSchema = z
      */
     mimeType: z.optional(z.string()),
     /**
-     * Optional string specifying icon dimensions (e.g., "48x48 96x96").
+     * Optional array of strings that specify sizes at which the icon can be used.
+     * Each string should be in WxH format (e.g., "48x48", "96x96") or "any" for scalable formats like SVG.
+     * If not provided, the client should assume that the icon can be used at any size.
      */
-    sizes: z.optional(z.string()),
+    sizes: z.optional(z.array(z.string())),
   })
   .passthrough();
 


### PR DESCRIPTION
Mainly to fix failing CI checks on main

---

## Summary

Updates the `Icon.sizes` property from `string` to `string[]` to match the MCP specification.

The spec defines `sizes` as an array of strings (e.g., `["48x48", "96x96"]` or `["any"]`) rather than a single string. This change:
- Updates the `IconSchema` in `src/types.ts` to use `z.array(z.string())` instead of `z.string()`
- Updates documentation to match the spec
- Fixes the example usage in `simpleStreamableHttp.ts`

This resolves type compatibility issues with the spec and allows icons to properly specify multiple size variants.