### PR TITLE
fix: Prefer the `token_endpoint_auth_method` response from DCR registration

### DIFF
--- a/src/client/auth.test.ts
+++ b/src/client/auth.test.ts
@@ -1635,6 +1635,7 @@ describe("OAuth Authorization", () => {
       (mockProvider.clientInformation as jest.Mock).mockResolvedValue({
         client_id: "test-client",
         client_secret: "test-secret",
+        redirect_uris: ["http://localhost:3000/callback"],
       });
       (mockProvider.tokens as jest.Mock).mockResolvedValue(undefined);
       (mockProvider.saveCodeVerifier as jest.Mock).mockResolvedValue(undefined);
@@ -1705,6 +1706,7 @@ describe("OAuth Authorization", () => {
       (mockProvider.clientInformation as jest.Mock).mockResolvedValue({
         client_id: "test-client",
         client_secret: "test-secret",
+        redirect_uris: ["http://localhost:3000/callback"],
       });
       (mockProvider.codeVerifier as jest.Mock).mockResolvedValue("test-verifier");
       (mockProvider.saveTokens as jest.Mock).mockResolvedValue(undefined);
@@ -1773,6 +1775,7 @@ describe("OAuth Authorization", () => {
       (mockProvider.clientInformation as jest.Mock).mockResolvedValue({
         client_id: "test-client",
         client_secret: "test-secret",
+        redirect_uris: ["http://localhost:3000/callback"],
       });
       (mockProvider.tokens as jest.Mock).mockResolvedValue({
         access_token: "old-access",
@@ -1841,6 +1844,7 @@ describe("OAuth Authorization", () => {
       (providerWithCustomValidation.clientInformation as jest.Mock).mockResolvedValue({
         client_id: "test-client",
         client_secret: "test-secret",
+        redirect_uris: ["http://localhost:3000/callback"],
       });
       (providerWithCustomValidation.tokens as jest.Mock).mockResolvedValue(undefined);
       (providerWithCustomValidation.saveCodeVerifier as jest.Mock).mockResolvedValue(undefined);
@@ -1896,6 +1900,7 @@ describe("OAuth Authorization", () => {
       (mockProvider.clientInformation as jest.Mock).mockResolvedValue({
         client_id: "test-client",
         client_secret: "test-secret",
+        redirect_uris: ["http://localhost:3000/callback"],
       });
       (mockProvider.tokens as jest.Mock).mockResolvedValue(undefined);
       (mockProvider.saveCodeVerifier as jest.Mock).mockResolvedValue(undefined);
@@ -1954,6 +1959,7 @@ describe("OAuth Authorization", () => {
       (mockProvider.clientInformation as jest.Mock).mockResolvedValue({
         client_id: "test-client",
         client_secret: "test-secret",
+        redirect_uris: ["http://localhost:3000/callback"],
       });
       (mockProvider.tokens as jest.Mock).mockResolvedValue(undefined);
       (mockProvider.saveCodeVerifier as jest.Mock).mockResolvedValue(undefined);
@@ -2021,6 +2027,7 @@ describe("OAuth Authorization", () => {
       (mockProvider.clientInformation as jest.Mock).mockResolvedValue({
         client_id: "test-client",
         client_secret: "test-secret",
+        redirect_uris: ["http://localhost:3000/callback"],
       });
       (mockProvider.codeVerifier as jest.Mock).mockResolvedValue("test-verifier");
       (mockProvider.saveTokens as jest.Mock).mockResolvedValue(undefined);
@@ -2086,6 +2093,7 @@ describe("OAuth Authorization", () => {
       (mockProvider.clientInformation as jest.Mock).mockResolvedValue({
         client_id: "test-client",
         client_secret: "test-secret",
+        redirect_uris: ["http://localhost:3000/callback"],
       });
       (mockProvider.tokens as jest.Mock).mockResolvedValue({
         access_token: "old-access",
@@ -2149,6 +2157,7 @@ describe("OAuth Authorization", () => {
       (mockProvider.clientInformation as jest.Mock).mockResolvedValue({
         client_id: "test-client",
         client_secret: "test-secret",
+        redirect_uris: ["http://localhost:3000/callback"],
       });
       (mockProvider.tokens as jest.Mock).mockResolvedValue(undefined);
       (mockProvider.saveCodeVerifier as jest.Mock).mockResolvedValue(undefined);
@@ -2209,6 +2218,7 @@ describe("OAuth Authorization", () => {
         clientInformation: jest.fn().mockResolvedValue({
           client_id: "client123",
           client_secret: "secret123",
+          redirect_uris: ["http://localhost:3000/callback"],
         }),
         tokens: jest.fn().mockResolvedValue(undefined),
         saveTokens: jest.fn(),

--- a/src/client/auth.ts
+++ b/src/client/auth.ts
@@ -2,7 +2,6 @@ import pkceChallenge from "pkce-challenge";
 import { LATEST_PROTOCOL_VERSION } from "../types.js";
 import {
   OAuthClientMetadata,
-  OAuthClientInformation,
   OAuthTokens,
   OAuthMetadata,
   OAuthClientInformationFull,
@@ -51,7 +50,7 @@ export interface OAuthClientProvider {
    * server, or returns `undefined` if the client is not registered with the
    * server.
    */
-  clientInformation(): OAuthClientInformation | undefined | Promise<OAuthClientInformation | undefined>;
+  clientInformation(): OAuthClientInformationFull | undefined | Promise<OAuthClientInformationFull | undefined>;
 
   /**
    * If implemented, this permits the OAuth client to dynamically register with
@@ -139,6 +138,10 @@ export class UnauthorizedError extends Error {
 
 type ClientAuthMethod = 'client_secret_basic' | 'client_secret_post' | 'none';
 
+function isClientAuthMethod(method: string): method is ClientAuthMethod {
+  return ["client_secret_basic", "client_secret_post", "none"].includes(method);
+}
+
 /**
  * Determines the best client authentication method to use based on server support and client configuration.
  *
@@ -152,7 +155,7 @@ type ClientAuthMethod = 'client_secret_basic' | 'client_secret_post' | 'none';
  * @returns The selected authentication method
  */
 function selectClientAuthMethod(
-  clientInformation: OAuthClientInformation,
+  clientInformation: OAuthClientInformationFull,
   supportedMethods: string[]
 ): ClientAuthMethod {
   const hasClientSecret = clientInformation.client_secret !== undefined;
@@ -160,6 +163,15 @@ function selectClientAuthMethod(
   // If server doesn't specify supported methods, use RFC 6749 defaults
   if (supportedMethods.length === 0) {
     return hasClientSecret ? "client_secret_post" : "none";
+  }
+
+  // Prefer the method returned by the server during client registration if valid and supported
+  if (
+    clientInformation.token_endpoint_auth_method &&
+    isClientAuthMethod(clientInformation.token_endpoint_auth_method) &&
+    supportedMethods.includes(clientInformation.token_endpoint_auth_method)
+  ) {
+    return clientInformation.token_endpoint_auth_method;
   }
 
   // Try methods in priority order (most secure first)
@@ -195,7 +207,7 @@ function selectClientAuthMethod(
  */
 function applyClientAuthentication(
   method: ClientAuthMethod,
-  clientInformation: OAuthClientInformation,
+  clientInformation: OAuthClientInformationFull,
   headers: Headers,
   params: URLSearchParams
 ): void {
@@ -809,7 +821,7 @@ export async function startAuthorization(
     resource,
   }: {
     metadata?: AuthorizationServerMetadata;
-    clientInformation: OAuthClientInformation;
+    clientInformation: OAuthClientInformationFull;
     redirectUrl: string | URL;
     scope?: string;
     state?: string;
@@ -902,7 +914,7 @@ export async function exchangeAuthorization(
     fetchFn,
   }: {
     metadata?: AuthorizationServerMetadata;
-    clientInformation: OAuthClientInformation;
+    clientInformation: OAuthClientInformationFull;
     authorizationCode: string;
     codeVerifier: string;
     redirectUri: string | URL;
@@ -988,7 +1000,7 @@ export async function refreshAuthorization(
     fetchFn,
   }: {
     metadata?: AuthorizationServerMetadata;
-    clientInformation: OAuthClientInformation;
+    clientInformation: OAuthClientInformationFull;
     refreshToken: string;
     resource?: URL;
     addClientAuthentication?: OAuthClientProvider["addClientAuthentication"];

--- a/src/client/sse.test.ts
+++ b/src/client/sse.test.ts
@@ -363,7 +363,7 @@ describe("SSEClientTransport", () => {
       mockAuthProvider = {
         get redirectUrl() { return "http://localhost/callback"; },
         get clientMetadata() { return { redirect_uris: ["http://localhost/callback"] }; },
-        clientInformation: jest.fn(() => ({ client_id: "test-client-id", client_secret: "test-client-secret" })),
+        clientInformation: jest.fn(() => ({ client_id: "test-client-id", client_secret: "test-client-secret", redirect_uris: ["http://localhost/callback"] })),
         tokens: jest.fn(),
         saveTokens: jest.fn(),
         redirectToAuthorization: jest.fn(),
@@ -1140,7 +1140,8 @@ describe("SSEClientTransport", () => {
 
       const clientInfo = config.clientRegistered ? {
         client_id: "test-client-id",
-        client_secret: "test-client-secret"
+        client_secret: "test-client-secret",
+        redirect_uris: ["http://localhost/callback"],
       } : undefined;
 
       return {

--- a/src/client/streamableHttp.test.ts
+++ b/src/client/streamableHttp.test.ts
@@ -12,7 +12,7 @@ describe("StreamableHTTPClientTransport", () => {
     mockAuthProvider = {
       get redirectUrl() { return "http://localhost/callback"; },
       get clientMetadata() { return { redirect_uris: ["http://localhost/callback"] }; },
-      clientInformation: jest.fn(() => ({ client_id: "test-client-id", client_secret: "test-client-secret" })),
+      clientInformation: jest.fn(() => ({ client_id: "test-client-id", client_secret: "test-client-secret", redirect_uris: ["http://localhost/callback"] })),
       tokens: jest.fn(),
       saveTokens: jest.fn(),
       redirectToAuthorization: jest.fn(),

--- a/src/examples/client/simpleOAuthClient.ts
+++ b/src/examples/client/simpleOAuthClient.ts
@@ -6,7 +6,7 @@ import { URL } from 'node:url';
 import { exec } from 'node:child_process';
 import { Client } from '../../client/index.js';
 import { StreamableHTTPClientTransport } from '../../client/streamableHttp.js';
-import { OAuthClientInformation, OAuthClientInformationFull, OAuthClientMetadata, OAuthTokens } from '../../shared/auth.js';
+import { OAuthClientInformationFull, OAuthClientMetadata, OAuthTokens } from '../../shared/auth.js';
 import {
   CallToolRequest,
   ListToolsRequest,
@@ -49,7 +49,7 @@ class InMemoryOAuthClientProvider implements OAuthClientProvider {
     return this._clientMetadata;
   }
 
-  clientInformation(): OAuthClientInformation | undefined {
+  clientInformation(): OAuthClientInformationFull | undefined {
     return this._clientInformation;
   }
 


### PR DESCRIPTION
Updates the OAuth authorization flow to prefer to use the `token_endpoint_auth_method` result from the Dynamic Client Registration endpoint, if provided.

> Fixes #951 

## Motivation and Context
When using dynamic client registration, the registration endpoint may return the `token_endpoint_auth_method` value to be used when exchanging tokens for access tokens. The current oauth implementation ignores this field and only uses the methods from the oauth authorization server metadata.

## How Has This Been Tested?
This has not been tested in a real application.

## Breaking Changes
No breaking changes.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
This is my first stab at a PR for this project. Go easy on me xD.
