### PR TITLE
Allow empty string as valid URL in DCR workflow

### DIFF
--- a/src/shared/auth.test.ts
+++ b/src/shared/auth.test.ts
@@ -23,11 +23,14 @@ describe('SafeUrlSchema', () => {
 
   it('rejects invalid URLs', () => {
     expect(() => SafeUrlSchema.parse('not-a-url')).toThrow();
-    expect(() => SafeUrlSchema.parse('')).toThrow();
   });
 
   it('works with safeParse', () => {
     expect(() => SafeUrlSchema.safeParse('not-a-url')).not.toThrow();
+  });
+
+  it('works with empty string', () => {
+    expect(() => SafeUrlSchema.parse('')).not.toThrow();
   });
 });
 

--- a/src/shared/auth.ts
+++ b/src/shared/auth.ts
@@ -20,7 +20,7 @@ export const SafeUrlSchema = z.string().url()
       return u.protocol !== 'javascript:' && u.protocol !== 'data:' && u.protocol !== 'vbscript:';
     },
     { message: "URL cannot use javascript:, data:, or vbscript: scheme" }
-);
+).or(z.literal(""));
 
 
 /**


### PR DESCRIPTION
Fixes #940

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Allow empty URL as valid URL in DCR payload

## How Has This Been Tested?
Added a specific test case for empty string

## Breaking Changes
None, this actually reverts breaking change introduced by #877 

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
