### PR TITLE
SEP: Allow non-file URI schemes for Roots

### DIFF
--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -341,5 +341,15 @@ describe('Types', () => {
                 expect(result.data.name).toBe('GitHub Repo');
             }
         });
+
+        test('should reject invalid URIs', () => {
+            const invalidRoot = {
+                uri: '/home/modelcontextprotocol/project',
+                name: 'Invalid Root'
+            };
+
+            const result = RootSchema.safeParse(invalidRoot);
+            expect(result.success).toBe(false);
+        });
     });
 });

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -5,7 +5,8 @@ import {
     ContentBlockSchema,
     PromptMessageSchema,
     CallToolResultSchema,
-    CompleteRequestSchema
+    CompleteRequestSchema,
+    RootSchema
 } from './types.js';
 
 describe('Types', () => {
@@ -308,6 +309,36 @@ describe('Types', () => {
                     '{tenant}': 'acme-corp',
                     '{resource}': 'users'
                 });
+            }
+        });
+    });
+
+    describe('Root', () => {
+        test('should validate roots with file:// URIs', () => {
+            const root = {
+                uri: 'file:///users/test/project',
+                name: 'Test Root'
+            };
+
+            const result = RootSchema.safeParse(root);
+            expect(result.success).toBe(true);
+            if (result.success) {
+                expect(result.data.uri).toBe('file:///users/test/project');
+                expect(result.data.name).toBe('Test Root');
+            }
+        });
+
+        test('should validate roots with non-file URI schemes', () => {
+            const root = {
+                uri: 'https://github.com/owner/repo',
+                name: 'GitHub Repo'
+            };
+
+            const result = RootSchema.safeParse(root);
+            expect(result.success).toBe(true);
+            if (result.success) {
+                expect(result.data.uri).toBe('https://github.com/owner/repo');
+                expect(result.data.name).toBe('GitHub Repo');
             }
         });
     });

--- a/src/types.ts
+++ b/src/types.ts
@@ -1368,7 +1368,7 @@ export const RootSchema = z
          * The URI identifying the root. Can be any valid URI scheme (e.g., file://, https://, s3://, git://).
          * Servers should document which URI schemes they support and handle unsupported schemes gracefully.
          */
-        uri: z.string(),
+        uri: z.string().url(),
         /**
          * An optional name for the root.
          */

--- a/src/types.ts
+++ b/src/types.ts
@@ -1365,9 +1365,10 @@ export const CompleteResultSchema = ResultSchema.extend({
 export const RootSchema = z
     .object({
         /**
-         * The URI identifying the root. This *must* start with file:// for now.
+         * The URI identifying the root. Can be any valid URI scheme (e.g., file://, https://, s3://, git://).
+         * Servers should document which URI schemes they support and handle unsupported schemes gracefully.
          */
-        uri: z.string().startsWith('file://'),
+        uri: z.string(),
         /**
          * An optional name for the root.
          */


### PR DESCRIPTION
Reference implementation for [SEP-1573](https://www.github.com/modelcontextprotocol/modelcontextprotocol/issues/1573) to enable Roots with any URI scheme (https://, s3://, git://, etc.) instead of only file:// URIs. 

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

This allows servers to work with remote resources while maintaining full backward compatibility.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

All new and existing tests pass

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [X] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
