### PR TITLE
SEP-1456: add allowCustom option for enum fields to support custom values

### DIFF
--- a/src/examples/client/simpleStreamableHttp.ts
+++ b/src/examples/client/simpleStreamableHttp.ts
@@ -260,6 +260,7 @@ async function connect(url?: string): Promise<void> {
                         description?: string;
                         default?: unknown;
                         enum?: string[];
+                        allowCustom?: boolean;
                         minimum?: number;
                         maximum?: number;
                         minLength?: number;
@@ -276,6 +277,9 @@ async function connect(url?: string): Promise<void> {
                     }
                     if (field.enum) {
                         prompt += ` [options: ${field.enum.join(', ')}]`;
+                        if (field.allowCustom) {
+                            prompt += ' (custom allowed)';
+                        }
                     }
                     if (field.type === 'number' || field.type === 'integer') {
                         if (field.minimum !== undefined && field.maximum !== undefined) {
@@ -337,7 +341,9 @@ async function connect(url?: string): Promise<void> {
                                 }
                             } else if (field.enum) {
                                 if (!field.enum.includes(answer)) {
-                                    throw new Error(`${fieldName} must be one of: ${field.enum.join(', ')}`);
+                                    if (!field.allowCustom) {
+                                        throw new Error(`${fieldName} must be one of: ${field.enum.join(', ')}`);
+                                    }
                                 }
                                 parsedValue = answer;
                             } else {

--- a/src/examples/server/simpleStreamableHttp.ts
+++ b/src/examples/server/simpleStreamableHttp.ts
@@ -163,7 +163,8 @@ const getServer = () => {
                                 title: 'Theme',
                                 description: 'Choose your preferred theme',
                                 enum: ['light', 'dark', 'auto'],
-                                enumNames: ['Light', 'Dark', 'Auto']
+                                enumNames: ['Light', 'Dark', 'Auto'],
+                                allowCustom: true
                             },
                             notifications: {
                                 type: 'boolean',
@@ -176,7 +177,8 @@ const getServer = () => {
                                 title: 'Notification Frequency',
                                 description: 'How often would you like notifications?',
                                 enum: ['daily', 'weekly', 'monthly'],
-                                enumNames: ['Daily', 'Weekly', 'Monthly']
+                                enumNames: ['Daily', 'Weekly', 'Monthly'],
+                                allowCustom: true
                             }
                         },
                         required: ['theme']

--- a/src/types.ts
+++ b/src/types.ts
@@ -1224,7 +1224,8 @@ export const EnumSchemaSchema = z
         title: z.optional(z.string()),
         description: z.optional(z.string()),
         enum: z.array(z.string()),
-        enumNames: z.optional(z.array(z.string()))
+        enumNames: z.optional(z.array(z.string())),
+        allowCustom: z.optional(z.boolean())
     })
     .passthrough();
 


### PR DESCRIPTION
SEP description: https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1456

## Motivation and Context
Existing implementations face two significant issues:

1. Guidance vs Flexibility – Developers want to provide commonly used options while still allowing custom entries that fall outside predefined values.

2. Inconsistent Workarounds – Current approaches, such as adding an “Other” option and triggering additional elicitation requests, lead to complex, fragmented user experiences. Refer: https://github.com/modelcontextprotocol/typescript-sdk/issues/932#issue-3403764551

The lack of a declarative, schema-driven solution for this use case leads to repetitive development patterns and diverging UX across tools.

This proposal is based on real implementation challenges and has been validated through prototypes built in MCP Server workflows. It avoids speculative enhancements and follows MCP’s principles of simplicity, minimalism, and concrete problem-solving.

## How Has This Been Tested?
Added tests for allowCustom enabled and without allowCustom to evaluate fallback flow.

## Breaking Changes
- None.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context

### Behavior

- If `allowCustom` is `true`, users see predefined options but can also enter custom input.
- If unspecified or `false`, users are limited to selecting from `enum` options.
- Validation may be extended via other schema properties (e.g., `pattern`, `maxLength`).

### UI Rendering expectation 

- Suggest predefined options.
- Allow free-text input when `allowCustom` is enabled.
- Display validation feedback if the input violates additional constraints.

### Why this approach?

- **Declarative** – Developers specify their intent via schema, avoiding imperative UI hacks.
- **Minimal** – Adds only one property without altering existing semantics.
- **Concrete** – Addresses a widely encountered problem validated by prototypes.
- **Backward Compatible** – Existing schemas remain valid without changes.

### Considered alternatives

| Alternative       | Reason rejected |
|-----------------|----------------|
| Free-text only   | No guidance leads to user errors and inconsistent experiences |
| Multi-step prompting | Adds complexity and interrupts conversational flow |
