### PR TITLE
MCP SDK: Draft - Context Utility + Request Context & Lifespan context

### DIFF
--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -1,0 +1,204 @@
+import {
+    CreateMessageRequest,
+    CreateMessageResultSchema,
+    ElicitRequest,
+    ElicitResultSchema,
+    LoggingMessageNotification,
+    Notification,
+    Request,
+    RequestId,
+    RequestInfo,
+    RequestMeta,
+    Result,
+    ServerNotification,
+    ServerRequest,
+    ServerResult
+} from '../types.js';
+import { RequestHandlerExtra, RequestOptions } from '../shared/protocol.js';
+import { ZodType } from 'zod';
+import type { z } from 'zod';
+import { Server } from './index.js';
+import { LifespanContext, RequestContext } from '../shared/requestContext.js';
+import { AuthInfo } from './auth/types.js';
+
+/**
+ * A context object that is passed to request handlers.
+ *
+ * Implements the RequestHandlerExtra interface for backwards compatibility.
+ * Notes:
+ * Keeps this backwards compatible with the old RequestHandlerExtra interface and provides getter methods for backwards compatibility.
+ * In a breaking change, this can be removed and the RequestContext can be used directly via ctx.requestContext.
+ *
+ * TODO(Konstantin): Could be restructured better when breaking changes are allowed. More
+ */
+export class Context<
+    LifespanContextT extends LifespanContext | undefined = undefined,
+    RequestT extends Request = Request,
+    NotificationT extends Notification = Notification,
+    ResultT extends Result = Result
+> implements RequestHandlerExtra<ServerRequest | RequestT, ServerNotification | NotificationT>
+{
+    private readonly server: Server<RequestT, NotificationT, ResultT, LifespanContextT>;
+
+    /**
+     * The request context.
+     * A type-safe context that is passed to request handlers.
+     */
+    public readonly requestCtx: RequestContext<
+        LifespanContextT,
+        RequestT | ServerRequest,
+        NotificationT | ServerNotification,
+        ResultT | ServerResult
+    >;
+
+    constructor(args: {
+        server: Server<RequestT, NotificationT, ResultT, LifespanContextT>;
+        requestCtx: RequestContext<LifespanContextT, RequestT | ServerRequest, NotificationT | ServerNotification, ResultT | ServerResult>;
+    }) {
+        this.server = args.server;
+        this.requestCtx = args.requestCtx;
+    }
+
+    public get requestId(): RequestId {
+        return this.requestCtx.requestId;
+    }
+
+    public get signal(): AbortSignal {
+        return this.requestCtx.signal;
+    }
+
+    public get authInfo(): AuthInfo | undefined {
+        return this.requestCtx.authInfo;
+    }
+
+    public get requestInfo(): RequestInfo | undefined {
+        return this.requestCtx.requestInfo;
+    }
+
+    public get _meta(): RequestMeta | undefined {
+        return this.requestCtx._meta;
+    }
+
+    public get sessionId(): string | undefined {
+        return this.requestCtx.sessionId;
+    }
+
+    /**
+     * Sends a notification that relates to the current request being handled.
+     *
+     * This is used by certain transports to correctly associate related messages.
+     */
+    public sendNotification = (notification: NotificationT | ServerNotification): Promise<void> => {
+        return this.requestCtx.sendNotification(notification);
+    };
+
+    /**
+     * Sends a request that relates to the current request being handled.
+     *
+     * This is used by certain transports to correctly associate related messages.
+     */
+    public sendRequest = <U extends ZodType<object>>(
+        request: RequestT | ServerRequest,
+        resultSchema: U,
+        options?: RequestOptions
+    ): Promise<z.infer<U>> => {
+        return this.requestCtx.sendRequest(request, resultSchema, { ...options, relatedRequestId: this.requestId });
+    };
+
+    /**
+     * Sends a request to sample an LLM via the client.
+     */
+    public requestSampling(params: CreateMessageRequest['params'], options?: RequestOptions) {
+        const request: CreateMessageRequest = {
+            method: 'sampling/createMessage',
+            params
+        };
+        return this.server.request(request, CreateMessageResultSchema, { ...options, relatedRequestId: this.requestId });
+    }
+
+    /**
+     * Sends an elicitation request to the client.
+     */
+    public elicit(params: ElicitRequest['params'], options?: RequestOptions) {
+        const request: ElicitRequest = {
+            method: 'elicitation/create',
+            params
+        };
+        return this.server.request(request, ElicitResultSchema, { ...options, relatedRequestId: this.requestId });
+    }
+
+    /**
+     * Sends a logging message.
+     */
+    public async log(params: LoggingMessageNotification['params'], sessionId?: string) {
+        await this.server.sendLoggingMessage(params, sessionId);
+    }
+
+    /**
+     * Sends a debug log message.
+     */
+    public async debug(message: string, extraLogData?: Record<string, unknown>, sessionId?: string) {
+        await this.log(
+            {
+                level: 'debug',
+                data: {
+                    ...extraLogData,
+                    message
+                },
+                logger: 'server'
+            },
+            sessionId
+        );
+    }
+
+    /**
+     * Sends an info log message.
+     */
+    public async info(message: string, extraLogData?: Record<string, unknown>, sessionId?: string) {
+        await this.log(
+            {
+                level: 'info',
+                data: {
+                    ...extraLogData,
+                    message
+                },
+                logger: 'server'
+            },
+            sessionId
+        );
+    }
+
+    /**
+     * Sends a warning log message.
+     */
+    public async warning(message: string, extraLogData?: Record<string, unknown>, sessionId?: string) {
+        await this.log(
+            {
+                level: 'warning',
+                data: {
+                    ...extraLogData,
+                    message
+                },
+                logger: 'server'
+            },
+            sessionId
+        );
+    }
+
+    /**
+     * Sends an error log message.
+     */
+    public async error(message: string, extraLogData?: Record<string, unknown>, sessionId?: string) {
+        await this.log(
+            {
+                level: 'error',
+                data: {
+                    ...extraLogData,
+                    message
+                },
+                logger: 'server'
+            },
+            sessionId
+        );
+    }
+}

--- a/src/shared/requestContext.ts
+++ b/src/shared/requestContext.ts
@@ -1,0 +1,98 @@
+import { AuthInfo } from 'src/server/auth/types.js';
+import { Notification, Request, RequestId, RequestInfo, RequestMeta, Result } from 'src/types.js';
+import { Protocol, RequestHandlerExtra, RequestOptions } from './protocol.js';
+import { ZodType } from 'zod';
+import type { z } from 'zod';
+
+export type LifespanContext = {
+    [key: string]: unknown | undefined;
+};
+/**
+ * A context object that is passed to request handlers.
+ *
+ * Implements the RequestHandlerExtra interface for backwards compatibility.
+ *
+ * TODO(Konstantin): Could be restructured better when breaking changes are allowed.
+ */
+export class RequestContext<
+    LifespanContextT extends LifespanContext | undefined,
+    RequestT extends Request = Request,
+    NotificationT extends Notification = Notification,
+    ResultT extends Result = Result
+> implements RequestHandlerExtra<RequestT, NotificationT>
+{
+    /**
+     * An abort signal used to communicate if the request was cancelled from the sender's side.
+     */
+    public readonly signal: AbortSignal;
+
+    /**
+     * Information about a validated access token, provided to request handlers.
+     */
+    public readonly authInfo?: AuthInfo;
+
+    /**
+     * The original HTTP request.
+     */
+    public readonly requestInfo?: RequestInfo;
+
+    /**
+     * The JSON-RPC ID of the request being handled.
+     * This can be useful for tracking or logging purposes.
+     */
+    public readonly requestId: RequestId;
+
+    /**
+     * Metadata from the original request.
+     */
+    public readonly _meta?: RequestMeta;
+
+    /**
+     * The session ID from the transport, if available.
+     */
+    public readonly sessionId?: string;
+
+    /**
+     * The lifespan context. A type-safe context that is passed to request handlers.
+     */
+    public readonly lifespanContext: LifespanContextT;
+
+    private readonly protocol: Protocol<RequestT, NotificationT, ResultT>;
+    constructor(args: {
+        signal: AbortSignal;
+        authInfo?: AuthInfo;
+        requestInfo?: RequestInfo;
+        requestId: RequestId;
+        _meta?: RequestMeta;
+        sessionId?: string;
+        lifespanContext: LifespanContextT;
+        protocol: Protocol<RequestT, NotificationT, ResultT>;
+    }) {
+        this.signal = args.signal;
+        this.authInfo = args.authInfo;
+        this.requestInfo = args.requestInfo;
+        this.requestId = args.requestId;
+        this._meta = args._meta;
+        this.sessionId = args.sessionId;
+        this.lifespanContext = args.lifespanContext;
+        this.protocol = args.protocol;
+    }
+
+    /**
+     * Sends a notification that relates to the current request being handled.
+     *
+     * This is used by certain transports to correctly associate related messages.
+     */
+    public sendNotification = (notification: NotificationT): Promise<void> => {
+        return this.protocol.notification(notification, { relatedRequestId: this.requestId });
+    };
+
+    /**
+     * Sends a request that relates to the current request being handled.
+     *
+     * This is used by certain transports to correctly associate related messages.
+     */
+    public sendRequest = <U extends ZodType<object>>(request: RequestT, resultSchema: U, options?: RequestOptions): Promise<z.infer<U>> => {
+        return this.protocol.request(request, resultSchema, { ...options, relatedRequestId: this.requestId });
+    };
+}


### PR DESCRIPTION
This is a **draft** PR which aims to introduce convenience / quality of life improvements to the Typescript SDK and also bring it closer to the Python SDK, which already has implemented this, in a similar fashion.

This is a draft PR, feedback is more than welcome.

It adds a `Context` utility (with the aim to be backwards-compatible, so anyone using RequestHandlerExtra will not have breaking changes), which exposes extra convenience methods and could be extended further down the line.

## Motivation and Context
It aims to explore the concept of a backwards-compatible `Context` **utility class** being passed in callbacks on the server-side. The `Context` utility class provides convenience methods and can be further extended in the future. It provides access to methods like logging, sampling, elicitation (and others could be added) and one can call them from the callbacks without having access to the `Server` or `McpServer` instances.

It mimics to a large extent on how Python SDK works.

Additionally, `Context` has a composed class inside it, `RequestContext` (again, similar to how PythonSDK), which holds all the metadata, and adds on top of it the `lifespanContext` data. `lifespanContext` is a convenience / quality of life utility as implemented in the PythonSDK, which allows to pass any data to the `McpServer`, and access it back from the callback, by doing `extra.requestContext.lifespanContext` - this could be database connections or anything that the user wants to live through the whole lifespan of the server. This feature required some type generics to be added so that the `.lifespanContext` can have type safety when used from the callbacks.

TBD. Once any discussions have been had and if this gets accepted, documentation needs to be updated additionally in this PR to reflect the changes.

## How Has This Been Tested?
Additional unit tests have been added.
Existing unit tests work with no changes.
Tests when callback is tied to RequestHandlerExtra.

## Breaking Changes
No breaking changes. More tests could be added to ensure it.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
The changes follow existing concepts of the PythonSDK, applied in a similar fashion (to the extent that the libraries differ or similar in various parts of them) to Typescript.

