### PR TITLE
Update `registerTool` function signature for proper typed `ToolCalback`

### DIFF
--- a/src/server/mcp.ts
+++ b/src/server/mcp.ts
@@ -788,7 +788,7 @@ export class McpServer {
     /**
      * Registers a tool with a config object and callback.
      */
-    registerTool<InputArgs extends undefined | ZodRawShape = undefined, OutputArgs extends ZodRawShape>(
+    registerTool<OutputArgs extends ZodRawShape, InputArgs extends undefined | ZodRawShape = undefined>(
         name: string,
         config: {
             title?: string;


### PR DESCRIPTION
* Updates `registerTool` signature to provide the accurate type for the `ToolCallback`

## Motivation and Context
* Currently, even though no `inputSchma` is provided, given the generic, it will assume the `ToolCallback` function will always be `cb(params, extra)` even though it should be `cb(extra)`
* In these cases, `params` will be typed as the `Record<string, any>` even though it should be typed `RequestHandlerExtra` and `extra` would be typed as `RequestHandlerExtra` but actually be `undefined`
* After the change, we have a properly typed `ToolCallback` where if `inputSchema` is `undefined`, the callback will be `cb(extra)` and if `inputSchema` is defined, it will be `cb(params, extra)`

## How Has This Been Tested?
* Local type check

## Breaking Changes
* Probably not, just removing typecasts + @ts-ignore

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
