### PR TITLE
Only use path-based discovery URLs from the authorization server to discover metadata

### DIFF
--- a/src/client/auth.test.ts
+++ b/src/client/auth.test.ts
@@ -712,14 +712,10 @@ describe('OAuth Authorization', () => {
         it('generates correct URLs for server with path', () => {
             const urls = buildDiscoveryUrls('https://auth.example.com/tenant1');
 
-            expect(urls).toHaveLength(5);
+            expect(urls).toHaveLength(3);
             expect(urls.map(u => ({ url: u.url.toString(), type: u.type }))).toEqual([
                 {
                     url: 'https://auth.example.com/.well-known/oauth-authorization-server/tenant1',
-                    type: 'oauth'
-                },
-                {
-                    url: 'https://auth.example.com/tenant1/.well-known/oauth-authorization-server',
                     type: 'oauth'
                 },
                 {
@@ -729,10 +725,6 @@ describe('OAuth Authorization', () => {
                 {
                     url: 'https://auth.example.com/tenant1/.well-known/openid-configuration',
                     type: 'oidc'
-                },
-                {
-                    url: 'https://auth.example.com/.well-known/oauth-authorization-server',
-                    type: 'oauth'
                 }
             ]);
         });
@@ -740,7 +732,7 @@ describe('OAuth Authorization', () => {
         it('handles URL object input', () => {
             const urls = buildDiscoveryUrls(new URL('https://auth.example.com/tenant1'));
 
-            expect(urls).toHaveLength(5);
+            expect(urls).toHaveLength(3);
             expect(urls[0].url.toString()).toBe('https://auth.example.com/.well-known/oauth-authorization-server/tenant1');
         });
     });
@@ -773,22 +765,22 @@ describe('OAuth Authorization', () => {
                 status: 404
             });
 
-            // Second OAuth URL (path after well-known) succeeds
+            // Second OIDC URL (path before well-known) succeeds
             mockFetch.mockResolvedValueOnce({
                 ok: true,
                 status: 200,
-                json: async () => validOAuthMetadata
+                json: async () => validOpenIdMetadata
             });
 
             const metadata = await discoverAuthorizationServerMetadata('https://auth.example.com/tenant1');
 
-            expect(metadata).toEqual(validOAuthMetadata);
+            expect(metadata).toEqual(validOpenIdMetadata);
 
             // Verify it tried the URLs in the correct order
             const calls = mockFetch.mock.calls;
             expect(calls.length).toBe(2);
             expect(calls[0][0].toString()).toBe('https://auth.example.com/.well-known/oauth-authorization-server/tenant1');
-            expect(calls[1][0].toString()).toBe('https://auth.example.com/tenant1/.well-known/oauth-authorization-server');
+            expect(calls[1][0].toString()).toBe('https://auth.example.com/.well-known/openid-configuration/tenant1');
         });
 
         it('continues on 4xx errors', async () => {
@@ -882,7 +874,7 @@ describe('OAuth Authorization', () => {
             expect(metadata).toBeUndefined();
 
             // Verify that all discovery URLs were attempted
-            expect(mockFetch).toHaveBeenCalledTimes(10); // 5 URLs × 2 attempts each (with and without headers)
+            expect(mockFetch).toHaveBeenCalledTimes(6); // 3 URLs × 2 attempts each (with and without headers)
         });
     });
 

--- a/src/client/auth.ts
+++ b/src/client/auth.ts
@@ -670,7 +670,6 @@ export async function discoverOAuthMetadata(
  * URLs are returned in priority order:
  * 1. OAuth metadata at the given URL
  * 2. OIDC metadata endpoints at the given URL
- * 3. OAuth metadata at root (if URL has path)
  */
 export function buildDiscoveryUrls(authorizationServerUrl: string | URL): { url: URL; type: 'oauth' | 'oidc' }[] {
     const url = typeof authorizationServerUrl === 'string' ? new URL(authorizationServerUrl) : authorizationServerUrl;
@@ -706,12 +705,6 @@ export function buildDiscoveryUrls(authorizationServerUrl: string | URL): { url:
         type: 'oauth'
     });
 
-    // Insert well-known after the path: https://example.com/tenant1/.well-known/oauth-authorization-server
-    urlsToTry.push({
-        url: new URL(`${pathname}/.well-known/oauth-authorization-server`, url.origin),
-        type: 'oauth'
-    });
-
     // 2. OIDC metadata endpoints
     // RFC 8414 style: Insert /.well-known/openid-configuration before the path
     urlsToTry.push({
@@ -723,13 +716,6 @@ export function buildDiscoveryUrls(authorizationServerUrl: string | URL): { url:
     urlsToTry.push({
         url: new URL(`${pathname}/.well-known/openid-configuration`, url.origin),
         type: 'oidc'
-    });
-
-    // 3. OAuth metadata at root
-    // Root path: https://example.com/.well-known/oauth-authorization-server
-    urlsToTry.push({
-        url: new URL('/.well-known/oauth-authorization-server', url.origin),
-        type: 'oauth'
     });
 
     return urlsToTry;


### PR DESCRIPTION
Use path-based discovery URLs from an authorization server discovered from `/.well-known/oauth-protected-resource`'s `authorization_servers` value.

1. https://auth.example.com/.well-known/oauth-authorization-server/oauth
2. https://auth.example.com/oauth/.well-known/oauth-authorization-server
3. https://auth.example.com/.well-known/openid-configuration/oauth
4. https://auth.example.com/oauth/.well-known/openid-configuration
5. https://auth.example.com/.well-known/oauth-authorization-server

## Motivation and Context
See #1069.
If the root URL contains an OAuth authorization server in addition to the path-based URL supplied from `/.well-known/oauth-protected-resource`, the incorrect authorization server is relied upon to continue the OAuth flow.

## How Has This Been Tested?
Updated unit tests.

## Breaking Changes
I do not believe so as the first choice has not been changed which means if no path is set, reading from `https://auth.example.com/.well-known/oauth-authorization-server` should work as expected.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [X] I have added appropriate error handling
- [X] I have added or updated documentation as needed

## Additional context
Is this behavior documented anywhere else?
