### PR TITLE
SEP-1330: Update EnumSchema and extend Elicitation result

### DIFF
--- a/src/server/elicitation.test.ts
+++ b/src/server/elicitation.test.ts
@@ -159,6 +159,7 @@ function testElicitationFlow(validatorProvider: typeof ajvProvider | typeof cfWo
                     age: { type: 'integer', minimum: 0, maximum: 150 },
                     street: { type: 'string' },
                     city: { type: 'string' },
+                    // @ts-expect-error - pattern is not a valid property by MCP spec, however it is making use of the Ajv validator
                     zipCode: { type: 'string', pattern: '^[0-9]{5}$' },
                     newsletter: { type: 'boolean' },
                     notifications: { type: 'boolean' }
@@ -273,6 +274,7 @@ function testElicitationFlow(validatorProvider: typeof ajvProvider | typeof cfWo
                 requestedSchema: {
                     type: 'object',
                     properties: {
+                        // @ts-expect-error - pattern is not a valid property by MCP spec, however it is making use of the Ajv validator
                         zipCode: { type: 'string', pattern: '^[0-9]{5}$' }
                     },
                     required: ['zipCode']

--- a/src/spec.types.test.ts
+++ b/src/spec.types.test.ts
@@ -464,6 +464,34 @@ const sdkTypeChecks = {
         sdk = spec;
         spec = sdk;
     },
+    UntitledSingleSelectEnumSchema: (sdk: SDKTypes.UntitledSingleSelectEnumSchema, spec: SpecTypes.UntitledSingleSelectEnumSchema) => {
+        sdk = spec;
+        spec = sdk;
+    },
+    TitledSingleSelectEnumSchema: (sdk: SDKTypes.TitledSingleSelectEnumSchema, spec: SpecTypes.TitledSingleSelectEnumSchema) => {
+        sdk = spec;
+        spec = sdk;
+    },
+    SingleSelectEnumSchema: (sdk: SDKTypes.SingleSelectEnumSchema, spec: SpecTypes.SingleSelectEnumSchema) => {
+        sdk = spec;
+        spec = sdk;
+    },
+    UntitledMultiSelectEnumSchema: (sdk: SDKTypes.UntitledMultiSelectEnumSchema, spec: SpecTypes.UntitledMultiSelectEnumSchema) => {
+        sdk = spec;
+        spec = sdk;
+    },
+    TitledMultiSelectEnumSchema: (sdk: SDKTypes.TitledMultiSelectEnumSchema, spec: SpecTypes.TitledMultiSelectEnumSchema) => {
+        sdk = spec;
+        spec = sdk;
+    },
+    MultiSelectEnumSchema: (sdk: SDKTypes.MultiSelectEnumSchema, spec: SpecTypes.MultiSelectEnumSchema) => {
+        sdk = spec;
+        spec = sdk;
+    },
+    LegacyTitledEnumSchema: (sdk: SDKTypes.LegacyTitledEnumSchema, spec: SpecTypes.LegacyTitledEnumSchema) => {
+        sdk = spec;
+        spec = sdk;
+    },
     PrimitiveSchemaDefinition: (sdk: SDKTypes.PrimitiveSchemaDefinition, spec: SpecTypes.PrimitiveSchemaDefinition) => {
         sdk = spec;
         spec = sdk;
@@ -565,7 +593,7 @@ describe('Spec Types', () => {
     it('should define some expected types', () => {
         expect(specTypes).toContain('JSONRPCNotification');
         expect(specTypes).toContain('ElicitResult');
-        expect(specTypes).toHaveLength(112);
+        expect(specTypes).toHaveLength(119);
     });
 
     it('should have up to date list of missing sdk types', () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1229,21 +1229,18 @@ export const NumberSchemaSchema = z.object({
 /**
  * Schema for single-selection enumeration without display titles for options.
  */
-export const UntitledSingleSelectEnumSchema = z
-    .object({
-        type: z.literal('string'),
-        title: z.optional(z.string()),
-        description: z.optional(z.string()),
-        enum: z.array(z.string()),
-        default: z.string().optional()
-    })
-    .passthrough();
-
+export const UntitledSingleSelectEnumSchemaSchema = z.object({
+    type: z.literal('string'),
+    title: z.string().optional(),
+    description: z.string().optional(),
+    enum: z.array(z.string()),
+    default: z.string().optional()
+});
 
 /**
  * Schema for single-selection enumeration with display titles for each option.
  */
-export const TitledSingleSelectEnumSchema = z.object({
+export const TitledSingleSelectEnumSchemaSchema = z.object({
     type: z.literal('string'),
     title: z.string().optional(),
     description: z.string().optional(),
@@ -1260,7 +1257,7 @@ export const TitledSingleSelectEnumSchema = z.object({
  * Use TitledSingleSelectEnumSchema instead.
  * This interface will be removed in a future version.
  */
-export const LegacyTitledEnumSchema = z.object({
+export const LegacyTitledEnumSchemaSchema = z.object({
     type: z.literal('string'),
     title: z.string().optional(),
     description: z.string().optional(),
@@ -1270,12 +1267,16 @@ export const LegacyTitledEnumSchema = z.object({
 });
 
 // Combined single selection enumeration
-export const SingleSelectEnumSchema = z.union([UntitledSingleSelectEnumSchema, TitledSingleSelectEnumSchema, LegacyTitledEnumSchema]);
+export const SingleSelectEnumSchemaSchema = z.union([
+    UntitledSingleSelectEnumSchemaSchema,
+    TitledSingleSelectEnumSchemaSchema,
+    LegacyTitledEnumSchemaSchema
+]);
 
 /**
  * Schema for multiple-selection enumeration without display titles for options.
  */
-export const UntitledMultiSelectEnumSchema = z.object({
+export const UntitledMultiSelectEnumSchemaSchema = z.object({
     type: z.literal('array'),
     title: z.string().optional(),
     description: z.string().optional(),
@@ -1291,7 +1292,7 @@ export const UntitledMultiSelectEnumSchema = z.object({
 /**
  * Schema for multiple-selection enumeration with display titles for each option.
  */
-export const TitledMultiSelectEnumSchema = z.object({
+export const TitledMultiSelectEnumSchemaSchema = z.object({
     type: z.literal('array'),
     title: z.string().optional(),
     description: z.string().optional(),
@@ -1311,12 +1312,12 @@ export const TitledMultiSelectEnumSchema = z.object({
 /**
  * Combined schema for multiple-selection enumeration
  */
-export const MultiSelectEnumSchema = z.union([UntitledMultiSelectEnumSchema, TitledMultiSelectEnumSchema]);
+export const MultiSelectEnumSchemaSchema = z.union([UntitledMultiSelectEnumSchemaSchema, TitledMultiSelectEnumSchemaSchema]);
 
 /**
  * Primitive schema definition for enum fields.
  */
-export const EnumSchemaSchema = z.union([SingleSelectEnumSchema, MultiSelectEnumSchema]);
+export const EnumSchemaSchema = z.union([SingleSelectEnumSchemaSchema, MultiSelectEnumSchemaSchema]);
 
 /**
  * Union of all primitive schema definitions.
@@ -1735,7 +1736,16 @@ export type CreateMessageResult = Infer<typeof CreateMessageResultSchema>;
 export type BooleanSchema = Infer<typeof BooleanSchemaSchema>;
 export type StringSchema = Infer<typeof StringSchemaSchema>;
 export type NumberSchema = Infer<typeof NumberSchemaSchema>;
+
 export type EnumSchema = Infer<typeof EnumSchemaSchema>;
+export type UntitledSingleSelectEnumSchema = Infer<typeof UntitledSingleSelectEnumSchemaSchema>;
+export type TitledSingleSelectEnumSchema = Infer<typeof TitledSingleSelectEnumSchemaSchema>;
+export type LegacyTitledEnumSchema = Infer<typeof LegacyTitledEnumSchemaSchema>;
+export type UntitledMultiSelectEnumSchema = Infer<typeof UntitledMultiSelectEnumSchemaSchema>;
+export type TitledMultiSelectEnumSchema = Infer<typeof TitledMultiSelectEnumSchemaSchema>;
+export type SingleSelectEnumSchema = Infer<typeof SingleSelectEnumSchemaSchema>;
+export type MultiSelectEnumSchema = Infer<typeof MultiSelectEnumSchemaSchema>;
+
 export type PrimitiveSchemaDefinition = Infer<typeof PrimitiveSchemaDefinitionSchema>;
 export type ElicitRequestParams = Infer<typeof ElicitRequestParamsSchema>;
 export type ElicitRequest = Infer<typeof ElicitRequestSchema>;


### PR DESCRIPTION
* In `types.ts`
  - add `UntitledSingleSelectEnumSchema`, `TitledSingleSelectEnumSchema`, and `LegacyTitledEnumSchema`
    - add `SingleSelectEnumSchema` that is a union of these three
  - add `UntitledMultiSelectEnumSchema` and `TitledMultiSelectEnumSchema`
    - add `MultiSelectEnumSchema` that is a union of these two
  - refactor `EnumSchemaSchema` to be a union of `SingleSelectEnumSchema` and `MultiSelectEnumSchema`
  - In `ElicitResultSchema` - add string array as possible return type

* In `elicitation.test.ts`
  - simplify tests by extracting the duplicated client and server creation and connection logic into a beforeEach block, run in the describe block for each flow
  - add positive/negative tests for all enum permutations (single-select, multi-select, titled, untitled, and legacy)
    - "should succeed with valid selection in single-select untitled enum"
    - "should succeed with valid selection in single-select titled enum"
    - "should succeed with valid selection in single-select titled legacy enum"
    - "should succeed with valid selection in multi-select untitled enum"
    - "should succeed with valid selection in multi-select titled enum"
    - "should reject invalid selection in single-select untitled enum"
    - "should reject invalid selection in single-select titled enum"
    - "should reject invalid selection in single-select titled legacy enum"
    - "should reject invalid selection in multi-select untitled enum"
    - "should reject invalid selection in multi-select titled enum"

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Update `EnumSchema` and extend Elicitation result to support string array return type. See [SEP-1330](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1330)

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Locally, all tests pass. New tests added.

CURRENTLY: spec.types test is failing because the spec changes aren't merged.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
Nope. 

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
