### PR TITLE
fix: do not use references in Zod to JSON Schema

### DIFF
--- a/src/server/mcp.ts
+++ b/src/server/mcp.ts
@@ -105,7 +105,8 @@ export class McpServer {
                             inputSchema: tool.inputSchema
                                 ? (zodToJsonSchema(tool.inputSchema, {
                                       strictUnions: true,
-                                      pipeStrategy: 'input'
+                                      pipeStrategy: 'input',
+                                      $refStrategy: 'none'
                                   }) as Tool['inputSchema'])
                                 : EMPTY_OBJECT_JSON_SCHEMA,
                             annotations: tool.annotations,
@@ -115,7 +116,8 @@ export class McpServer {
                         if (tool.outputSchema) {
                             toolDefinition.outputSchema = zodToJsonSchema(tool.outputSchema, {
                                 strictUnions: true,
-                                pipeStrategy: 'output'
+                                pipeStrategy: 'output',
+                                $refStrategy: 'none'
                             }) as Tool['outputSchema'];
                         }
 


### PR DESCRIPTION
Many LLMs do not support references in the JSON Schemas for tool inputs/outputs and if they do, they mostly only support root-level references. Schemas produced with Zod to JSON Schema do not comply with this restriction thus, if using strict tool calling (e.g. in OpenAI), the request fails. While this is not documented as a limitation in the MCP Specification, for convenience we should avoid triggering this issue.

<!-- Provide a brief summary of your changes -->

## Motivation and Context
When trying out the TypeScript SDK we have used nested definitions for a group of fields. While I cannot provide the exact schema, but here's a quick mock:
```typescript
export const locationSchema = z.object({
  testId: z.string().optional().describe("Test ID"),
  secondTestId: z.string().optional().describe("Second test ID")
});

export const searchParamsSchema = z.object({
  startLocation: locationSchema.describe("Test 1"),
  endLocation: locationSchema.describe("Test 2")
});
```

## How Has This Been Tested?
I have tested my code with the lines from this PR and without it. Without my change, strict tool calling ends up in:
```
OpenAIException - {\n  "error": {\n    "message": "Invalid schema for function \'search\': In context=(\'properties\', \'endLocation\', \'properties\', \'testId\'), reference can only point to definitions defined at the top level of the schema.",\n    "type": "invalid_request_error",\n    "param": "tools[3].parameters",\n    "code": "invalid_function_parameters"\n  }
```

With my changes, the code runs properly.

## Breaking Changes
No breaking changes and, to the best of my knowledge, no LLM providers charge extra for longer JSON Schemas, so this should not impact the users negatively.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
