### PR TITLE
[v1.x] fix: Update UriTemplate implementation to handle optional/omitted, out-of-order, and encoded query parameters

### DIFF
--- a/.changeset/fix-uri-template-query-params.md
+++ b/.changeset/fix-uri-template-query-params.md
@@ -1,0 +1,6 @@
+---
+'@modelcontextprotocol/core': patch
+---
+
+Fix `UriTemplate.match()` to correctly handle optional, out-of-order, and URL-encoded query parameters. Previously, query parameters had to appear in the exact order specified in the template and omitted parameters would cause match failures. Omitted query parameters are now
+absent from the result (rather than set to `''`), so callers can use `vars.param ?? defaultValue`.

--- a/src/shared/uriTemplate.ts
+++ b/src/shared/uriTemplate.ts
@@ -247,38 +247,91 @@ export class UriTemplate {
 
     match(uri: string): Variables | null {
         UriTemplate.validateLength(uri, MAX_TEMPLATE_LENGTH, 'URI');
+
+        // Split URI into path and query parts
+        const queryIndex = uri.indexOf('?');
+        const pathPart = queryIndex === -1 ? uri : uri.slice(0, queryIndex);
+        const queryPart = queryIndex === -1 ? '' : uri.slice(queryIndex + 1);
+
+        // Build regex pattern for path (non-query) parts
         let pattern = '^';
-        const names: Array<{ name: string; exploded: boolean }> = [];
+        const names: Array<{ name: string; exploded: boolean; isQuery: boolean }> = [];
+        const queryParts: Array<{ name: string; exploded: boolean }> = [];
 
         for (const part of this.parts) {
             if (typeof part === 'string') {
                 pattern += this.escapeRegExp(part);
             } else {
-                const patterns = this.partToRegExp(part);
-                for (const { pattern: partPattern, name } of patterns) {
-                    pattern += partPattern;
-                    names.push({ name, exploded: part.exploded });
+                if (part.operator === '?' || part.operator === '&') {
+                    // Collect query parameter names for later extraction
+                    for (const name of part.names) {
+                        queryParts.push({ name, exploded: part.exploded });
+                    }
+                } else {
+                    // Handle non-query parts normally
+                    const patterns = this.partToRegExp(part);
+                    for (const { pattern: partPattern, name } of patterns) {
+                        pattern += partPattern;
+                        names.push({ name, exploded: part.exploded, isQuery: false });
+                    }
                 }
             }
         }
 
-        pattern += '$';
+        // Match the path part (without query parameters)
+        pattern += '(?:\\?.*)?$'; // Allow optional query string at the end
         UriTemplate.validateLength(pattern, MAX_REGEX_LENGTH, 'Generated regex pattern');
         const regex = new RegExp(pattern);
-        const match = uri.match(regex);
+        const match = pathPart.match(regex);
 
         if (!match) return null;
 
         const result: Variables = {};
-        for (let i = 0; i < names.length; i++) {
-            const { name, exploded } = names[i];
-            const value = match[i + 1];
-            const cleanName = name.replace('*', '');
 
-            if (exploded && value.includes(',')) {
-                result[cleanName] = value.split(',');
-            } else {
-                result[cleanName] = value;
+        // Extract non-query parameters
+        let matchIndex = 0;
+        for (const { name, exploded, isQuery } of names) {
+            if (!isQuery) {
+                const value = match[matchIndex + 1];
+                const cleanName = name.replace('*', '');
+
+                if (exploded && value && value.includes(',')) {
+                    result[cleanName] = value.split(',');
+                } else {
+                    result[cleanName] = value;
+                }
+                matchIndex++;
+            }
+        }
+
+        // Extract query parameters from query string
+        if (queryParts.length > 0) {
+            const queryParams = new Map<string, string>();
+            if (queryPart) {
+                // Parse query string
+                const pairs = queryPart.split('&');
+                for (const pair of pairs) {
+                    const equalIndex = pair.indexOf('=');
+                    if (equalIndex !== -1) {
+                        const key = decodeURIComponent(pair.slice(0, equalIndex));
+                        const value = decodeURIComponent(pair.slice(equalIndex + 1));
+                        queryParams.set(key, value);
+                    }
+                }
+            }
+
+            // Extract values for each expected query parameter
+            for (const { name, exploded } of queryParts) {
+                const cleanName = name.replace('*', '');
+                const value = queryParams.get(cleanName);
+
+                if (value === undefined) {
+                    result[cleanName] = '';
+                } else if (exploded && value.includes(',')) {
+                    result[cleanName] = value.split(',');
+                } else {
+                    result[cleanName] = value;
+                }
             }
         }
 

--- a/src/shared/uriTemplate.ts
+++ b/src/shared/uriTemplate.ts
@@ -43,19 +43,6 @@ export class UriTemplate {
         UriTemplate.validateLength(template, MAX_TEMPLATE_LENGTH, 'Template');
         this.template = template;
         this.parts = this.parse(template);
-
-        // Templates with a literal '?' in a string segment are incompatible
-        // with match()'s split-at-'?' query parsing — the path regex would
-        // include the escaped '?' but the URI is split before matching.
-        // Supporting this requires a fragile two-code-path implementation
-        // that has proven bug-prone, so reject at construction time.
-        const literalQueryPart = this.parts.find(part => typeof part === 'string' && part.includes('?'));
-        if (literalQueryPart !== undefined) {
-            throw new Error(
-                `UriTemplate: literal '?' in template string is not supported. ` +
-                    `Use {?param} to introduce query parameters instead. Template: "${template}"`
-            );
-        }
     }
 
     toString(): string {
@@ -290,14 +277,27 @@ export class UriTemplate {
             }
         }
 
-        // Strip any URI fragment before splitting path/query.
-        const hashIndex = uri.indexOf('#');
-        const uriNoFrag = hashIndex === -1 ? uri : uri.slice(0, hashIndex);
+        // Only strip the URI fragment when the template has no {#var} operator;
+        // otherwise the fragment is part of what the path regex must capture.
+        const hasHashOperator = this.parts.some(p => typeof p !== 'string' && p.operator === '#');
+        let working = uri;
+        if (!hasHashOperator) {
+            const hashIndex = working.indexOf('#');
+            if (hashIndex !== -1) working = working.slice(0, hashIndex);
+        }
 
-        // Split URI into path and query parts at the first '?'
-        const queryIndex = uriNoFrag.indexOf('?');
-        const pathPart = queryIndex === -1 ? uriNoFrag : uriNoFrag.slice(0, queryIndex);
-        const queryPart = queryIndex === -1 ? '' : uriNoFrag.slice(queryIndex + 1);
+        // Only split path/query when the template actually has {?..}/{&..}
+        // operators. Otherwise match the path regex against the full URI so
+        // {+var} can capture across '?' as it did before query-param support.
+        let pathPart = working;
+        let queryPart = '';
+        if (queryParts.length > 0) {
+            const queryIndex = working.indexOf('?');
+            if (queryIndex !== -1) {
+                pathPart = working.slice(0, queryIndex);
+                queryPart = working.slice(queryIndex + 1);
+            }
+        }
 
         pattern += '$';
         UriTemplate.validateLength(pattern, MAX_REGEX_LENGTH, 'Generated regex pattern');

--- a/src/shared/uriTemplate.ts
+++ b/src/shared/uriTemplate.ts
@@ -105,7 +105,7 @@ export class UriTemplate {
         return expr
             .slice(operator.length)
             .split(',')
-            .map(name => name.replace('*', '').trim())
+            .map(name => name.replace(/\*/g, '').trim())
             .filter(name => name.length > 0);
     }
 
@@ -256,10 +256,11 @@ export class UriTemplate {
     match(uri: string): Variables | null {
         UriTemplate.validateLength(uri, MAX_TEMPLATE_LENGTH, 'URI');
 
-        // Split URI into path and query parts
-        const queryIndex = uri.indexOf('?');
-        const pathPart = queryIndex === -1 ? uri : uri.slice(0, queryIndex);
-        const queryPart = queryIndex === -1 ? '' : uri.slice(queryIndex + 1);
+        // Check whether any literal string segment in the template contains a
+        // '?'. If so, the template author has written a manual query-string
+        // prefix (e.g. `/path?fixed=1{&var}`) and we cannot simply split the
+        // URI at its first '?' — the path regex itself needs to consume past it.
+        const hasLiteralQuery = this.parts.some(part => typeof part === 'string' && part.includes('?'));
 
         // Build regex pattern for path (non-query) parts
         let pattern = '^';
@@ -282,18 +283,36 @@ export class UriTemplate {
             }
         }
 
-        pattern += '$';
-        UriTemplate.validateLength(pattern, MAX_REGEX_LENGTH, 'Generated regex pattern');
-        const regex = new RegExp(pattern);
-        const match = pathPart.match(regex);
+        let match: RegExpMatchArray | null;
+        let queryPart: string;
 
-        if (!match) return null;
+        if (hasLiteralQuery) {
+            // Match the path regex against the full URI without a trailing
+            // anchor, then treat everything after the match as the remaining
+            // query string to parse for {?...}/{&...} expressions.
+            UriTemplate.validateLength(pattern, MAX_REGEX_LENGTH, 'Generated regex pattern');
+            const regex = new RegExp(pattern);
+            match = uri.match(regex);
+            if (!match) return null;
+            queryPart = uri.slice(match[0].length).replace(/^&/, '');
+        } else {
+            // Split URI into path and query parts at the first '?'
+            const queryIndex = uri.indexOf('?');
+            const pathPart = queryIndex === -1 ? uri : uri.slice(0, queryIndex);
+            queryPart = queryIndex === -1 ? '' : uri.slice(queryIndex + 1);
+
+            pattern += '$';
+            UriTemplate.validateLength(pattern, MAX_REGEX_LENGTH, 'Generated regex pattern');
+            const regex = new RegExp(pattern);
+            match = pathPart.match(regex);
+            if (!match) return null;
+        }
 
         const result: Variables = {};
 
         for (const [i, { name, exploded }] of names.entries()) {
             const value = match[i + 1]!;
-            const cleanName = name.replace('*', '');
+            const cleanName = name.replace(/\*/g, '');
             result[cleanName] = exploded && value.includes(',') ? value.split(',') : value;
         }
 
@@ -311,7 +330,7 @@ export class UriTemplate {
             }
 
             for (const { name, exploded } of queryParts) {
-                const cleanName = name.replace('*', '');
+                const cleanName = name.replace(/\*/g, '');
                 const value = queryParams.get(cleanName);
 
                 if (value === undefined) continue;

--- a/src/shared/uriTemplate.ts
+++ b/src/shared/uriTemplate.ts
@@ -287,14 +287,23 @@ export class UriTemplate {
         let queryPart: string;
 
         if (hasLiteralQuery) {
-            // Match the path regex against the full URI without a trailing
-            // anchor, then treat everything after the match as the remaining
-            // query string to parse for {?...}/{&...} expressions.
+            // Match the path regex against the full URI. The lookahead
+            // assertion ensures the literal portion ends exactly at a
+            // query-param separator, fragment, or end-of-string, so a
+            // template like `?id=1` does not spuriously prefix-match
+            // `?id=100`.
+            pattern += '(?=[&#]|$)';
             UriTemplate.validateLength(pattern, MAX_REGEX_LENGTH, 'Generated regex pattern');
             const regex = new RegExp(pattern);
             match = uri.match(regex);
             if (!match) return null;
-            queryPart = uri.slice(match[0].length).replace(/^&/, '');
+            // Everything after the match is the remaining query string to
+            // parse for {?...}/{&...} expressions. Strip any fragment and
+            // the leading `&` separator first.
+            let rest = uri.slice(match[0].length);
+            const hashIndex = rest.indexOf('#');
+            if (hashIndex !== -1) rest = rest.slice(0, hashIndex);
+            queryPart = rest.replace(/^&/, '');
         } else {
             // Split URI into path and query parts at the first '?'
             const queryIndex = uri.indexOf('?');

--- a/src/shared/uriTemplate.ts
+++ b/src/shared/uriTemplate.ts
@@ -255,31 +255,26 @@ export class UriTemplate {
 
         // Build regex pattern for path (non-query) parts
         let pattern = '^';
-        const names: Array<{ name: string; exploded: boolean; isQuery: boolean }> = [];
+        const names: Array<{ name: string; exploded: boolean }> = [];
         const queryParts: Array<{ name: string; exploded: boolean }> = [];
 
         for (const part of this.parts) {
             if (typeof part === 'string') {
                 pattern += this.escapeRegExp(part);
+            } else if (part.operator === '?' || part.operator === '&') {
+                for (const name of part.names) {
+                    queryParts.push({ name, exploded: part.exploded });
+                }
             } else {
-                if (part.operator === '?' || part.operator === '&') {
-                    // Collect query parameter names for later extraction
-                    for (const name of part.names) {
-                        queryParts.push({ name, exploded: part.exploded });
-                    }
-                } else {
-                    // Handle non-query parts normally
-                    const patterns = this.partToRegExp(part);
-                    for (const { pattern: partPattern, name } of patterns) {
-                        pattern += partPattern;
-                        names.push({ name, exploded: part.exploded, isQuery: false });
-                    }
+                const patterns = this.partToRegExp(part);
+                for (const { pattern: partPattern, name } of patterns) {
+                    pattern += partPattern;
+                    names.push({ name, exploded: part.exploded });
                 }
             }
         }
 
-        // Match the path part (without query parameters)
-        pattern += '(?:\\?.*)?$'; // Allow optional query string at the end
+        pattern += '$';
         UriTemplate.validateLength(pattern, MAX_REGEX_LENGTH, 'Generated regex pattern');
         const regex = new RegExp(pattern);
         const match = pathPart.match(regex);
@@ -288,29 +283,16 @@ export class UriTemplate {
 
         const result: Variables = {};
 
-        // Extract non-query parameters
-        let matchIndex = 0;
-        for (const { name, exploded, isQuery } of names) {
-            if (!isQuery) {
-                const value = match[matchIndex + 1];
-                const cleanName = name.replace('*', '');
-
-                if (exploded && value && value.includes(',')) {
-                    result[cleanName] = value.split(',');
-                } else {
-                    result[cleanName] = value;
-                }
-                matchIndex++;
-            }
+        for (const [i, { name, exploded }] of names.entries()) {
+            const value = match[i + 1]!;
+            const cleanName = name.replace('*', '');
+            result[cleanName] = exploded && value.includes(',') ? value.split(',') : value;
         }
 
-        // Extract query parameters from query string
         if (queryParts.length > 0) {
             const queryParams = new Map<string, string>();
             if (queryPart) {
-                // Parse query string
-                const pairs = queryPart.split('&');
-                for (const pair of pairs) {
+                for (const pair of queryPart.split('&')) {
                     const equalIndex = pair.indexOf('=');
                     if (equalIndex !== -1) {
                         const key = decodeURIComponent(pair.slice(0, equalIndex));
@@ -320,18 +302,12 @@ export class UriTemplate {
                 }
             }
 
-            // Extract values for each expected query parameter
             for (const { name, exploded } of queryParts) {
                 const cleanName = name.replace('*', '');
                 const value = queryParams.get(cleanName);
 
-                if (value === undefined) {
-                    result[cleanName] = '';
-                } else if (exploded && value.includes(',')) {
-                    result[cleanName] = value.split(',');
-                } else {
-                    result[cleanName] = value;
-                }
+                if (value === undefined) continue;
+                result[cleanName] = exploded && value.includes(',') ? value.split(',') : value;
             }
         }
 

--- a/src/shared/uriTemplate.ts
+++ b/src/shared/uriTemplate.ts
@@ -7,6 +7,14 @@ const MAX_VARIABLE_LENGTH = 1000000; // 1MB
 const MAX_TEMPLATE_EXPRESSIONS = 10000;
 const MAX_REGEX_LENGTH = 1000000; // 1MB
 
+function safeDecode(s: string): string {
+    try {
+        return decodeURIComponent(s);
+    } catch {
+        return s;
+    }
+}
+
 export class UriTemplate {
     /**
      * Returns true if the given string contains any URI template expressions.
@@ -295,8 +303,8 @@ export class UriTemplate {
                 for (const pair of queryPart.split('&')) {
                     const equalIndex = pair.indexOf('=');
                     if (equalIndex !== -1) {
-                        const key = decodeURIComponent(pair.slice(0, equalIndex));
-                        const value = decodeURIComponent(pair.slice(equalIndex + 1));
+                        const key = safeDecode(pair.slice(0, equalIndex));
+                        const value = safeDecode(pair.slice(equalIndex + 1));
                         queryParams.set(key, value);
                     }
                 }

--- a/src/shared/uriTemplate.ts
+++ b/src/shared/uriTemplate.ts
@@ -43,6 +43,19 @@ export class UriTemplate {
         UriTemplate.validateLength(template, MAX_TEMPLATE_LENGTH, 'Template');
         this.template = template;
         this.parts = this.parse(template);
+
+        // Templates with a literal '?' in a string segment are incompatible
+        // with match()'s split-at-'?' query parsing — the path regex would
+        // include the escaped '?' but the URI is split before matching.
+        // Supporting this requires a fragile two-code-path implementation
+        // that has proven bug-prone, so reject at construction time.
+        const literalQueryPart = this.parts.find(part => typeof part === 'string' && part.includes('?'));
+        if (literalQueryPart !== undefined) {
+            throw new Error(
+                `UriTemplate: literal '?' in template string is not supported. ` +
+                    `Use {?param} to introduce query parameters instead. Template: "${template}"`
+            );
+        }
     }
 
     toString(): string {
@@ -256,12 +269,6 @@ export class UriTemplate {
     match(uri: string): Variables | null {
         UriTemplate.validateLength(uri, MAX_TEMPLATE_LENGTH, 'URI');
 
-        // Check whether any literal string segment in the template contains a
-        // '?'. If so, the template author has written a manual query-string
-        // prefix (e.g. `/path?fixed=1{&var}`) and we cannot simply split the
-        // URI at its first '?' — the path regex itself needs to consume past it.
-        const hasLiteralQuery = this.parts.some(part => typeof part === 'string' && part.includes('?'));
-
         // Build regex pattern for path (non-query) parts
         let pattern = '^';
         const names: Array<{ name: string; exploded: boolean }> = [];
@@ -283,39 +290,20 @@ export class UriTemplate {
             }
         }
 
-        let match: RegExpMatchArray | null;
-        let queryPart: string;
+        // Strip any URI fragment before splitting path/query.
+        const hashIndex = uri.indexOf('#');
+        const uriNoFrag = hashIndex === -1 ? uri : uri.slice(0, hashIndex);
 
-        if (hasLiteralQuery) {
-            // Match the path regex against the full URI. The lookahead
-            // assertion ensures the literal portion ends exactly at a
-            // query-param separator, fragment, or end-of-string, so a
-            // template like `?id=1` does not spuriously prefix-match
-            // `?id=100`.
-            pattern += '(?=[&#]|$)';
-            UriTemplate.validateLength(pattern, MAX_REGEX_LENGTH, 'Generated regex pattern');
-            const regex = new RegExp(pattern);
-            match = uri.match(regex);
-            if (!match) return null;
-            // Everything after the match is the remaining query string to
-            // parse for {?...}/{&...} expressions. Strip any fragment and
-            // the leading `&` separator first.
-            let rest = uri.slice(match[0].length);
-            const hashIndex = rest.indexOf('#');
-            if (hashIndex !== -1) rest = rest.slice(0, hashIndex);
-            queryPart = rest.replace(/^&/, '');
-        } else {
-            // Split URI into path and query parts at the first '?'
-            const queryIndex = uri.indexOf('?');
-            const pathPart = queryIndex === -1 ? uri : uri.slice(0, queryIndex);
-            queryPart = queryIndex === -1 ? '' : uri.slice(queryIndex + 1);
+        // Split URI into path and query parts at the first '?'
+        const queryIndex = uriNoFrag.indexOf('?');
+        const pathPart = queryIndex === -1 ? uriNoFrag : uriNoFrag.slice(0, queryIndex);
+        const queryPart = queryIndex === -1 ? '' : uriNoFrag.slice(queryIndex + 1);
 
-            pattern += '$';
-            UriTemplate.validateLength(pattern, MAX_REGEX_LENGTH, 'Generated regex pattern');
-            const regex = new RegExp(pattern);
-            match = pathPart.match(regex);
-            if (!match) return null;
-        }
+        pattern += '$';
+        UriTemplate.validateLength(pattern, MAX_REGEX_LENGTH, 'Generated regex pattern');
+        const regex = new RegExp(pattern);
+        const match = pathPart.match(regex);
+        if (!match) return null;
 
         const result: Variables = {};
 

--- a/test/shared/uriTemplate.test.ts
+++ b/test/shared/uriTemplate.test.ts
@@ -191,10 +191,59 @@ describe('UriTemplate', () => {
             expect(template.variableNames).toEqual(['q', 'page']);
         });
 
+        it('should handle partial query parameter matches correctly', () => {
+            const template = new UriTemplate('/search{?q,page}');
+            const match = template.match('/search?q=test');
+            expect(match).toEqual({ q: 'test', page: '' });
+            expect(template.variableNames).toEqual(['q', 'page']);
+        });
+
+        it('should match multiple query parameters if provided in a different order', () => {
+            const template = new UriTemplate('/search{?q,page}');
+            const match = template.match('/search?page=1&q=test');
+            expect(match).toEqual({ q: 'test', page: '1' });
+            expect(template.variableNames).toEqual(['q', 'page']);
+        });
+
+        it('should still match if additional query parameters are provided', () => {
+            const template = new UriTemplate('/search{?q,page}');
+            const match = template.match('/search?q=test&page=1&sort=desc');
+            expect(match).toEqual({ q: 'test', page: '1' });
+            expect(template.variableNames).toEqual(['q', 'page']);
+        });
+
+        it('should match omitted query parameters', () => {
+            const template = new UriTemplate('/search{?q,page}');
+            const match = template.match('/search');
+            expect(match).toEqual({ q: '', page: '' });
+            expect(template.variableNames).toEqual(['q', 'page']);
+        });
+
+        it('should match nested path segments with query parameters', () => {
+            const template = new UriTemplate('/api/{version}/{resource}{?apiKey,q,p,sort}');
+            const match = template.match('/api/v1/users?apiKey=testkey&q=user');
+            expect(match).toEqual({
+                version: 'v1',
+                resource: 'users',
+                apiKey: 'testkey',
+                q: 'user',
+                p: '',
+                sort: ''
+            });
+            expect(template.variableNames).toEqual(['version', 'resource', 'apiKey', 'q', 'p', 'sort']);
+        });
+
         it('should handle partial matches correctly', () => {
             const template = new UriTemplate('/users/{id}');
             expect(template.match('/users/123/extra')).toBeNull();
             expect(template.match('/users')).toBeNull();
+        });
+
+        it('should handle encoded query parameters', () => {
+            const template = new UriTemplate('/search{?q}');
+            const match = template.match('/search?q=hello%20world');
+            expect(match).toEqual({ q: 'hello world' });
+            expect(template.variableNames).toEqual(['q']);
         });
     });
 

--- a/test/shared/uriTemplate.test.ts
+++ b/test/shared/uriTemplate.test.ts
@@ -256,12 +256,20 @@ describe('UriTemplate', () => {
             expect(template.match('/search?q=%ZZ')).toEqual({ q: '%ZZ' });
         });
 
-        it('should reject templates with literal ? in a string segment', () => {
-            expect(() => new UriTemplate('/path?fixed=1')).toThrow(/literal '\?'/);
-            expect(() => new UriTemplate('/path?static=1{?dynamic}')).toThrow(/literal '\?'/);
-            expect(() => new UriTemplate('/path?static=1{&dynamic}')).toThrow(/literal '\?'/);
-            expect(() => new UriTemplate('/api?v=2{&key,page}')).toThrow(/literal '\?'/);
-            expect(() => new UriTemplate('/api/{version}?format=json{&key}')).toThrow(/literal '\?'/);
+        it('should not throw on literal ? in a string segment (expand-only usage)', () => {
+            expect(() => new UriTemplate('/path?fixed=1')).not.toThrow();
+            expect(() => new UriTemplate('http://e.com/?literal').expand({})).not.toThrow();
+            expect(new UriTemplate('http://e.com/?literal').expand({})).toBe('http://e.com/?literal');
+        });
+
+        it('should let {+var} capture across ? when template has no query operators', () => {
+            const template = new UriTemplate('http://e.com{+rest}');
+            expect(template.match('http://e.com/search?q=hello')).toEqual({ rest: '/search?q=hello' });
+        });
+
+        it('should let {#var} capture the fragment', () => {
+            const template = new UriTemplate('/page{#section}');
+            expect(template.match('/page#intro')).toEqual({ section: '#intro' });
         });
 
         it('should accept templates using {?param} for query parameters', () => {

--- a/test/shared/uriTemplate.test.ts
+++ b/test/shared/uriTemplate.test.ts
@@ -256,49 +256,31 @@ describe('UriTemplate', () => {
             expect(template.match('/search?q=%ZZ')).toEqual({ q: '%ZZ' });
         });
 
-        it('should match templates with a literal ? followed by {&...} continuation', () => {
-            const template = new UriTemplate('/path?static=1{&dynamic}');
-            const match = template.match('/path?static=1&dynamic=hello');
-            expect(match).toEqual({ dynamic: 'hello' });
-            expect(template.variableNames).toEqual(['dynamic']);
+        it('should reject templates with literal ? in a string segment', () => {
+            expect(() => new UriTemplate('/path?fixed=1')).toThrow(/literal '\?'/);
+            expect(() => new UriTemplate('/path?static=1{?dynamic}')).toThrow(/literal '\?'/);
+            expect(() => new UriTemplate('/path?static=1{&dynamic}')).toThrow(/literal '\?'/);
+            expect(() => new UriTemplate('/api?v=2{&key,page}')).toThrow(/literal '\?'/);
+            expect(() => new UriTemplate('/api/{version}?format=json{&key}')).toThrow(/literal '\?'/);
         });
 
-        it('should match templates with literal ? when continuation param is absent', () => {
-            const template = new UriTemplate('/path?static=1{&dynamic}');
-            const match = template.match('/path?static=1');
-            expect(match).toEqual({});
+        it('should accept templates using {?param} for query parameters', () => {
+            // The supported way to express query parameters
+            const template = new UriTemplate('/path{?fixed}');
+            expect(template.match('/path?fixed=1')).toEqual({ fixed: '1' });
+            expect(template.match('/path')).toEqual({});
         });
 
-        it('should match templates with literal ? and multiple continuation params', () => {
-            const template = new UriTemplate('/api?v=2{&key,page}');
-            const match = template.match('/api?v=2&page=3&key=abc');
-            expect(match).toEqual({ key: 'abc', page: '3' });
+        it('should strip fragments before matching query parameters', () => {
+            const template = new UriTemplate('/path{?a}');
+            expect(template.match('/path?a=1#frag')).toEqual({ a: '1' });
+            expect(template.match('/path?a=1&b=2#frag')).toEqual({ a: '1' });
         });
 
-        it('should match path variables combined with literal ? and {&...}', () => {
-            const template = new UriTemplate('/api/{version}?format=json{&key}');
-            const match = template.match('/api/v1?format=json&key=secret');
-            expect(match).toEqual({ version: 'v1', key: 'secret' });
-        });
-
-        it('should not prefix-match literal query values with literal ?', () => {
-            // `?id=1` must not match `?id=100`
-            const template = new UriTemplate('/path?id=1{&extra}');
-            expect(template.match('/path?id=100')).toBeNull();
-            expect(template.match('/path?id=1')).toEqual({});
-            expect(template.match('/path?id=1&extra=x')).toEqual({ extra: 'x' });
-        });
-
-        it('should require a proper separator after the literal ? portion', () => {
-            // malformed URI missing `&` between params must not match
-            const template = new UriTemplate('/path?a=1{&b}');
-            expect(template.match('/path?a=1b=2')).toBeNull();
-        });
-
-        it('should ignore fragments after the literal ? portion', () => {
-            const template = new UriTemplate('/path?a=1{&b}');
-            expect(template.match('/path?a=1#section')).toEqual({});
-            expect(template.match('/path?a=1&b=foo#section')).toEqual({ b: 'foo' });
+        it('should strip fragments when the URI has no query string', () => {
+            const template = new UriTemplate('/path{?a}');
+            expect(template.match('/path#frag')).toEqual({});
+            expect(template.match('/path')).toEqual({});
         });
     });
 

--- a/test/shared/uriTemplate.test.ts
+++ b/test/shared/uriTemplate.test.ts
@@ -194,7 +194,7 @@ describe('UriTemplate', () => {
         it('should handle partial query parameter matches correctly', () => {
             const template = new UriTemplate('/search{?q,page}');
             const match = template.match('/search?q=test');
-            expect(match).toEqual({ q: 'test', page: '' });
+            expect(match).toEqual({ q: 'test' });
             expect(template.variableNames).toEqual(['q', 'page']);
         });
 
@@ -215,8 +215,14 @@ describe('UriTemplate', () => {
         it('should match omitted query parameters', () => {
             const template = new UriTemplate('/search{?q,page}');
             const match = template.match('/search');
-            expect(match).toEqual({ q: '', page: '' });
+            expect(match).toEqual({});
             expect(template.variableNames).toEqual(['q', 'page']);
+        });
+
+        it('should distinguish absent from empty query parameters', () => {
+            const template = new UriTemplate('/search{?q,page}');
+            const match = template.match('/search?q=');
+            expect(match).toEqual({ q: '' });
         });
 
         it('should match nested path segments with query parameters', () => {
@@ -227,8 +233,6 @@ describe('UriTemplate', () => {
                 resource: 'users',
                 apiKey: 'testkey',
                 q: 'user',
-                p: '',
-                sort: ''
             });
             expect(template.variableNames).toEqual(['version', 'resource', 'apiKey', 'q', 'p', 'sort']);
         });

--- a/test/shared/uriTemplate.test.ts
+++ b/test/shared/uriTemplate.test.ts
@@ -249,6 +249,37 @@ describe('UriTemplate', () => {
             expect(match).toEqual({ q: 'hello world' });
             expect(template.variableNames).toEqual(['q']);
         });
+
+        it('should not throw on malformed percent-encoding in query parameters', () => {
+            const template = new UriTemplate('/search{?q}');
+            expect(template.match('/search?q=100%')).toEqual({ q: '100%' });
+            expect(template.match('/search?q=%ZZ')).toEqual({ q: '%ZZ' });
+        });
+
+        it('should match templates with a literal ? followed by {&...} continuation', () => {
+            const template = new UriTemplate('/path?static=1{&dynamic}');
+            const match = template.match('/path?static=1&dynamic=hello');
+            expect(match).toEqual({ dynamic: 'hello' });
+            expect(template.variableNames).toEqual(['dynamic']);
+        });
+
+        it('should match templates with literal ? when continuation param is absent', () => {
+            const template = new UriTemplate('/path?static=1{&dynamic}');
+            const match = template.match('/path?static=1');
+            expect(match).toEqual({});
+        });
+
+        it('should match templates with literal ? and multiple continuation params', () => {
+            const template = new UriTemplate('/api?v=2{&key,page}');
+            const match = template.match('/api?v=2&page=3&key=abc');
+            expect(match).toEqual({ key: 'abc', page: '3' });
+        });
+
+        it('should match path variables combined with literal ? and {&...}', () => {
+            const template = new UriTemplate('/api/{version}?format=json{&key}');
+            const match = template.match('/api/v1?format=json&key=secret');
+            expect(match).toEqual({ version: 'v1', key: 'secret' });
+        });
     });
 
     describe('security and edge cases', () => {

--- a/test/shared/uriTemplate.test.ts
+++ b/test/shared/uriTemplate.test.ts
@@ -280,6 +280,26 @@ describe('UriTemplate', () => {
             const match = template.match('/api/v1?format=json&key=secret');
             expect(match).toEqual({ version: 'v1', key: 'secret' });
         });
+
+        it('should not prefix-match literal query values with literal ?', () => {
+            // `?id=1` must not match `?id=100`
+            const template = new UriTemplate('/path?id=1{&extra}');
+            expect(template.match('/path?id=100')).toBeNull();
+            expect(template.match('/path?id=1')).toEqual({});
+            expect(template.match('/path?id=1&extra=x')).toEqual({ extra: 'x' });
+        });
+
+        it('should require a proper separator after the literal ? portion', () => {
+            // malformed URI missing `&` between params must not match
+            const template = new UriTemplate('/path?a=1{&b}');
+            expect(template.match('/path?a=1b=2')).toBeNull();
+        });
+
+        it('should ignore fragments after the literal ? portion', () => {
+            const template = new UriTemplate('/path?a=1{&b}');
+            expect(template.match('/path?a=1#section')).toEqual({});
+            expect(template.match('/path?a=1&b=foo#section')).toEqual({ b: 'foo' });
+        });
     });
 
     describe('security and edge cases', () => {

--- a/test/shared/uriTemplate.test.ts
+++ b/test/shared/uriTemplate.test.ts
@@ -232,7 +232,7 @@ describe('UriTemplate', () => {
                 version: 'v1',
                 resource: 'users',
                 apiKey: 'testkey',
-                q: 'user',
+                q: 'user'
             });
             expect(template.variableNames).toEqual(['version', 'resource', 'apiKey', 'q', 'p', 'sort']);
         });


### PR DESCRIPTION
**Note:** This is the v1.x backport of https://github.com/modelcontextprotocol/typescript-sdk/pull/1396.

This PR addresses several limitations of the current `UriTemplate#match` implementation:

- template matching fails when optional query parameters are not provided
- template matching fails when query parameters are provided out of order from the sequence specified in the template
- template matching does not decode uri-encoded query parameters

Omitted query parameters are parsed as an empty string per guidance of [RFC 6570 Section 2.3](https://www.rfc-editor.org/rfc/rfc6570.html#section-2.3).

## Motivation and Context
Fixes https://github.com/modelcontextprotocol/typescript-sdk/issues/1079
Fixes https://github.com/modelcontextprotocol/typescript-sdk/issues/149

## How Has This Been Tested?
New test additions cover all of the cases mentioned in https://github.com/modelcontextprotocol/typescript-sdk/issues/1079 and https://github.com/modelcontextprotocol/typescript-sdk/issues/149 as well as a few additional potential edge cases I could come up with.

## Breaking Changes
n/a

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
