### PR TITLE
Introduce throwErrors property on OAuth server middlewares and handlers

### DIFF
--- a/src/server/auth/handlers/register.ts
+++ b/src/server/auth/handlers/register.ts
@@ -33,6 +33,11 @@ export type ClientRegistrationHandlerOptions = {
      * If not set, defaults to true.
      */
     clientIdGeneration?: boolean;
+
+    /**
+     * Set to true to throw errors to the express error handler
+     */
+    throwErrors?: boolean;
 };
 
 const DEFAULT_CLIENT_SECRET_EXPIRY_SECONDS = 30 * 24 * 60 * 60; // 30 days
@@ -41,7 +46,8 @@ export function clientRegistrationHandler({
     clientsStore,
     clientSecretExpirySeconds = DEFAULT_CLIENT_SECRET_EXPIRY_SECONDS,
     rateLimit: rateLimitConfig,
-    clientIdGeneration = true
+    clientIdGeneration = true,
+    throwErrors
 }: ClientRegistrationHandlerOptions): RequestHandler {
     if (!clientsStore.registerClient) {
         throw new Error('Client registration store does not support registering clients');
@@ -111,6 +117,10 @@ export function clientRegistrationHandler({
             } else {
                 const serverError = new ServerError('Internal Server Error');
                 res.status(500).json(serverError.toResponseObject());
+            }
+
+            if (throwErrors) {
+                throw error;
             }
         }
     });

--- a/src/server/auth/handlers/revoke.ts
+++ b/src/server/auth/handlers/revoke.ts
@@ -14,9 +14,11 @@ export type RevocationHandlerOptions = {
      * Set to false to disable rate limiting for this endpoint.
      */
     rateLimit?: Partial<RateLimitOptions> | false;
+
+    throwErrors?: boolean;
 };
 
-export function revocationHandler({ provider, rateLimit: rateLimitConfig }: RevocationHandlerOptions): RequestHandler {
+export function revocationHandler({ provider, rateLimit: rateLimitConfig, throwErrors }: RevocationHandlerOptions): RequestHandler {
     if (!provider.revokeToken) {
         throw new Error('Auth provider does not support revoking tokens');
     }
@@ -71,6 +73,10 @@ export function revocationHandler({ provider, rateLimit: rateLimitConfig }: Revo
             } else {
                 const serverError = new ServerError('Internal Server Error');
                 res.status(500).json(serverError.toResponseObject());
+            }
+
+            if (throwErrors) {
+                throw error;
             }
         }
     });

--- a/src/server/auth/middleware/bearerAuth.ts
+++ b/src/server/auth/middleware/bearerAuth.ts
@@ -18,6 +18,11 @@ export type BearerAuthMiddlewareOptions = {
      * Optional resource metadata URL to include in WWW-Authenticate header.
      */
     resourceMetadataUrl?: string;
+
+    /**
+     * Set to true to throw errors to the express error handler
+     */
+    throwErrors?: boolean;
 };
 
 declare module 'express-serve-static-core' {
@@ -37,7 +42,12 @@ declare module 'express-serve-static-core' {
  * If resourceMetadataUrl is provided, it will be included in the WWW-Authenticate header
  * for 401 responses as per the OAuth 2.0 Protected Resource Metadata spec.
  */
-export function requireBearerAuth({ verifier, requiredScopes = [], resourceMetadataUrl }: BearerAuthMiddlewareOptions): RequestHandler {
+export function requireBearerAuth({
+    verifier,
+    requiredScopes = [],
+    resourceMetadataUrl,
+    throwErrors
+}: BearerAuthMiddlewareOptions): RequestHandler {
     return async (req, res, next) => {
         try {
             const authHeader = req.headers.authorization;
@@ -90,6 +100,10 @@ export function requireBearerAuth({ verifier, requiredScopes = [], resourceMetad
             } else {
                 const serverError = new ServerError('Internal Server Error');
                 res.status(500).json(serverError.toResponseObject());
+            }
+
+            if (throwErrors) {
+                throw error;
             }
         }
     };

--- a/src/server/auth/middleware/clientAuth.ts
+++ b/src/server/auth/middleware/clientAuth.ts
@@ -9,6 +9,11 @@ export type ClientAuthenticationMiddlewareOptions = {
      * A store used to read information about registered OAuth clients.
      */
     clientsStore: OAuthRegisteredClientsStore;
+
+    /**
+     * Set to true to throw errors to the express error handler
+     */
+    throwErrors?: boolean;
 };
 
 const ClientAuthenticatedRequestSchema = z.object({
@@ -25,7 +30,7 @@ declare module 'express-serve-static-core' {
     }
 }
 
-export function authenticateClient({ clientsStore }: ClientAuthenticationMiddlewareOptions): RequestHandler {
+export function authenticateClient({ clientsStore, throwErrors }: ClientAuthenticationMiddlewareOptions): RequestHandler {
     return async (req, res, next) => {
         try {
             const result = ClientAuthenticatedRequestSchema.safeParse(req.body);
@@ -66,6 +71,10 @@ export function authenticateClient({ clientsStore }: ClientAuthenticationMiddlew
             } else {
                 const serverError = new ServerError('Internal Server Error');
                 res.status(500).json(serverError.toResponseObject());
+            }
+
+            if (throwErrors) {
+                throw error;
             }
         }
     };


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
Any errors in route handles or middlewares like errors in a user provided `clientStore` or user provided `OAuthServerProvider` will quietly be swallowed, stopping users of this library from properly debugging their implementation and stopping users from debugging mcp clients and implementing their own error handling. 

It's unlikely that the user wants to do provide their own error responses so I'm not modifying that, this change solely throws errors to be picked up by the express error handler

## How Has This Been Tested?
I'm doing a lot of MCP related OAuth stuff right now and this is the biggest blocker from me using this library.

## Breaking Changes
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
