### PR TITLE
[auth] Fix march spec fallback for metadata discovery 

### DIFF
--- a/src/client/auth.test.ts
+++ b/src/client/auth.test.ts
@@ -1654,7 +1654,7 @@ describe('OAuth Authorization', () => {
             // Verify that the oauth-authorization-server call uses the base URL
             // This proves the fix: using new URL("/", serverUrl) instead of serverUrl
             const authServerCall = mockFetch.mock.calls.find(call =>
-              call[0].toString().includes('/.well-known/oauth-authorization-server')
+                call[0].toString().includes('/.well-known/oauth-authorization-server')
             );
             expect(authServerCall).toBeDefined();
             expect(authServerCall[0].toString()).toBe('https://resource.example.com/.well-known/oauth-authorization-server');

--- a/src/client/auth.ts
+++ b/src/client/auth.ts
@@ -363,7 +363,7 @@ async function authInternal(
      * fallback to the legacy MCP spec's implementation (version 2025-03-26): MCP server base URL acts as the Authorization server.
      */
     if (!authorizationServerUrl) {
-        authorizationServerUrl = new URL("/", serverUrl);
+        authorizationServerUrl = new URL('/', serverUrl);
     }
 
     const resource: URL | undefined = await selectResourceURL(serverUrl, provider, resourceMetadata);


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
fixes https://github.com/modelcontextprotocol/typescript-sdk/issues/1103

In https://github.com/modelcontextprotocol/typescript-sdk/pull/1070 we switched to only doing path or root based URLs, but this broke legacy servers because we were using the wrong "auth server url" for that scenario.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Added unit tests.
Also checked against JIRA and Linear via:
```
MCP_SERVER_URL=https://mcp.linear.app/sse  npx tsx ./src/examples/client/simpleOAuthClient.ts
MCP_SERVER_URL=https://mcp.atlassian.com/v1/sse  npx tsx ./src/examples/client/simpleOAuthClient.ts
```


## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No, unbreaks main

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
I also tested this against new conformance tests in this PR:
https://github.com/modelcontextprotocol/conformance/pull/28