### PR TITLE
ci: add workflow_dispatch trigger for manual CI runs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,7 @@ on:
         branches:
             - main
     pull_request:
+    workflow_dispatch:
     release:
         types: [published]
 


### PR DESCRIPTION
Adds manual triggering capability for the main CI workflow.

## Motivation and Context
PRs created by the spec update bot (using GITHUB_TOKEN) don't automatically trigger CI due to GitHub's security restrictions. This adds workflow_dispatch to allow manual CI triggering from the Actions UI.

## How Has This Been Tested?
- Verified YAML syntax is valid
- No functional changes to existing CI behavior

## Breaking Changes
None.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed