### PR TITLE
PoC: Simulating Code Execution via MCP Meta-Tools

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,8 @@
         "test:watch": "vitest",
         "start": "npm run server",
         "server": "tsx watch --clear-screen=false scripts/cli.ts server",
-        "client": "tsx scripts/cli.ts client"
+        "client": "tsx scripts/cli.ts client",
+        "code-mode": "tsx scripts/code-mode.ts"
     },
     "dependencies": {
         "ajv": "^8.17.1",

--- a/scripts/code-mode.ts
+++ b/scripts/code-mode.ts
@@ -1,0 +1,119 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { CodeModeWrapper } from '../src/code-mode/index.js';
+import type { DownstreamConfig } from '../src/code-mode/downstream.js';
+import { StdioServerTransport } from '../src/server/stdio.js';
+import type { Implementation } from '../src/types.js';
+
+type CodeModeConfig = {
+    server?: Implementation;
+    downstreams: DownstreamConfig[];
+};
+
+function parseArgs(argv: string[]): string | undefined {
+    for (let i = 0; i < argv.length; i += 1) {
+        const current = argv[i];
+        if (current === '--config' || current === '-c') {
+            return argv[i + 1];
+        }
+
+        if (current?.startsWith('--config=')) {
+            return current.split('=')[1];
+        }
+    }
+
+    return undefined;
+}
+
+function assertDownstreamConfig(value: unknown): asserts value is DownstreamConfig[] {
+    if (!Array.isArray(value) || value.length === 0) {
+        throw new Error('Config must include a non-empty "downstreams" array.');
+    }
+
+    for (const entry of value) {
+        if (!entry || typeof entry !== 'object') {
+            throw new Error('Invalid downstream entry.');
+        }
+
+        const { id, command, args, env, cwd } = entry as DownstreamConfig;
+        if (!id || typeof id !== 'string') {
+            throw new Error('Each downstream requires a string "id".');
+        }
+
+        if (!command || typeof command !== 'string') {
+            throw new Error(`Downstream "${id}" is missing a "command".`);
+        }
+
+        if (args && !Array.isArray(args)) {
+            throw new Error(`Downstream "${id}" has invalid "args"; expected an array.`);
+        }
+
+        if (env && typeof env !== 'object') {
+            throw new Error(`Downstream "${id}" has invalid "env"; expected an object.`);
+        }
+
+        if (cwd && typeof cwd !== 'string') {
+            throw new Error(`Downstream "${id}" has invalid "cwd"; expected a string.`);
+        }
+    }
+}
+
+async function readConfig(configPath: string): Promise<CodeModeConfig> {
+    const resolved = path.resolve(process.cwd(), configPath);
+    const raw = await readFile(resolved, 'utf8');
+    const parsed = JSON.parse(raw);
+
+    assertDownstreamConfig(parsed.downstreams);
+
+    return {
+        server: parsed.server,
+        downstreams: parsed.downstreams
+    };
+}
+
+function printUsage(): void {
+    console.log('Usage: npm run code-mode -- --config ./code-mode.config.json');
+}
+
+async function main(): Promise<void> {
+    const configPath = parseArgs(process.argv.slice(2));
+    if (!configPath) {
+        printUsage();
+        process.exitCode = 1;
+        return;
+    }
+
+    const config = await readConfig(configPath);
+    const wrapper = new CodeModeWrapper({
+        serverInfo: config.server,
+        downstreams: config.downstreams
+    });
+
+    const transport = new StdioServerTransport();
+    await wrapper.connect(transport);
+    console.log('Code Mode wrapper is running on stdio.');
+
+    let shuttingDown = false;
+    const shutdown = async () => {
+        if (shuttingDown) {
+            return;
+        }
+
+        shuttingDown = true;
+        await wrapper.close();
+    };
+
+    process.on('SIGINT', () => {
+        void shutdown().finally(() => process.exit(0));
+    });
+
+    process.on('SIGTERM', () => {
+        void shutdown().finally(() => process.exit(0));
+    });
+}
+
+main().catch(error => {
+    console.error(error);
+    process.exit(1);
+});

--- a/src/code-mode/downstream.ts
+++ b/src/code-mode/downstream.ts
@@ -1,0 +1,112 @@
+import { Client } from '../client/index.js';
+import { StdioClientTransport, getDefaultEnvironment } from '../client/stdio.js';
+import { CallToolResultSchema, ToolListChangedNotificationSchema } from '../types.js';
+import type { CallToolResult, Implementation, Tool } from '../types.js';
+
+export type DownstreamConfig = {
+    id: string;
+    command: string;
+    args?: string[];
+    env?: Record<string, string>;
+    cwd?: string;
+    description?: string;
+};
+
+export interface DownstreamHandle {
+    readonly config: DownstreamConfig;
+    listTools(): Promise<Tool[]>;
+    getTool(toolName: string): Promise<Tool | undefined>;
+    callTool(toolName: string, args?: Record<string, unknown>): Promise<CallToolResult>;
+    close(): Promise<void>;
+}
+
+export class DefaultDownstreamHandle implements DownstreamHandle {
+    private readonly _clientInfo: Implementation;
+    private _client?: Client;
+    private _toolsCache?: Tool[];
+    private _listPromise?: Promise<Tool[]>;
+
+    constructor(
+        private readonly _config: DownstreamConfig,
+        clientInfo: Implementation
+    ) {
+        this._clientInfo = clientInfo;
+    }
+
+    get config(): DownstreamConfig {
+        return this._config;
+    }
+
+    async listTools(): Promise<Tool[]> {
+        if (this._toolsCache) {
+            return this._toolsCache;
+        }
+
+        if (this._listPromise) {
+            return this._listPromise;
+        }
+
+        this._listPromise = this._ensureClient()
+            .then(async client => {
+                const result = await client.listTools();
+                this._toolsCache = result.tools;
+                return this._toolsCache;
+            })
+            .finally(() => {
+                this._listPromise = undefined;
+            });
+
+        return this._listPromise;
+    }
+
+    async getTool(toolName: string): Promise<Tool | undefined> {
+        const tools = await this.listTools();
+        return tools.find(tool => tool.name === toolName);
+    }
+
+    async callTool(toolName: string, args?: Record<string, unknown>): Promise<CallToolResult> {
+        const client = await this._ensureClient();
+        return client.callTool(
+            {
+                name: toolName,
+                arguments: args
+            },
+            CallToolResultSchema
+        ) as Promise<CallToolResult>;
+    }
+
+    async close(): Promise<void> {
+        await this._client?.close();
+        this._client = undefined;
+        this._toolsCache = undefined;
+    }
+
+    private async _ensureClient(): Promise<Client> {
+        if (this._client) {
+            return this._client;
+        }
+
+        const transport = new StdioClientTransport({
+            command: this._config.command,
+            args: this._config.args,
+            env: {
+                ...getDefaultEnvironment(),
+                ...this._config.env
+            },
+            cwd: this._config.cwd
+        });
+
+        const client = new Client({
+            name: `code-mode:${this._config.id}`,
+            version: '0.1.0'
+        });
+
+        await client.connect(transport);
+        client.setNotificationHandler(ToolListChangedNotificationSchema, () => {
+            this._toolsCache = undefined;
+        });
+
+        this._client = client;
+        return client;
+    }
+}

--- a/src/code-mode/index.ts
+++ b/src/code-mode/index.ts
@@ -1,0 +1,13 @@
+export { CodeModeWrapper, type CodeModeWrapperOptions } from './wrapper.js';
+export type { DownstreamConfig, DownstreamHandle } from './downstream.js';
+export {
+    ListToolNamesInputSchema,
+    ListToolNamesOutputSchema,
+    type ListToolNamesResult,
+    type ToolSummary,
+    GetToolImplementationInputSchema,
+    GetToolImplementationOutputSchema,
+    type GetToolImplementationResult,
+    CallToolInputSchema,
+    type CallToolInput
+} from './metaTools.js';

--- a/src/code-mode/metaTools.ts
+++ b/src/code-mode/metaTools.ts
@@ -1,0 +1,54 @@
+import { z } from 'zod';
+
+export const ServerSummarySchema = z.object({
+    serverId: z.string(),
+    description: z.string().optional()
+});
+
+export const ListMcpServersOutputSchema = z.object({
+    servers: z.array(ServerSummarySchema)
+});
+
+export type ListMcpServersResult = z.infer<typeof ListMcpServersOutputSchema>;
+
+export const ToolSummarySchema = z.object({
+    serverId: z.string(),
+    toolName: z.string(),
+    description: z.string().optional()
+});
+
+export const ListToolNamesInputSchema = z.object({
+    serverId: z.string()
+});
+
+export const ListToolNamesOutputSchema = z.object({
+    tools: z.array(ToolSummarySchema)
+});
+
+export type ToolSummary = z.infer<typeof ToolSummarySchema>;
+export type ListToolNamesResult = z.infer<typeof ListToolNamesOutputSchema>;
+
+export const GetToolImplementationInputSchema = z.object({
+    serverId: z.string(),
+    toolName: z.string()
+});
+
+export const GetToolImplementationOutputSchema = z.object({
+    serverId: z.string(),
+    toolName: z.string(),
+    signature: z.string(),
+    description: z.string().optional(),
+    annotations: z.record(z.unknown()).optional(),
+    inputSchema: z.record(z.unknown()).optional(),
+    outputSchema: z.record(z.unknown()).optional()
+});
+
+export type GetToolImplementationResult = z.infer<typeof GetToolImplementationOutputSchema>;
+
+export const CallToolInputSchema = z.object({
+    serverId: z.string(),
+    toolName: z.string(),
+    arguments: z.record(z.unknown()).optional()
+});
+
+export type CallToolInput = z.infer<typeof CallToolInputSchema>;

--- a/src/code-mode/wrapper.test.ts
+++ b/src/code-mode/wrapper.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { CallToolResult, Tool } from '../types.js';
+import type { DownstreamConfig, DownstreamHandle } from './downstream.js';
+import { CodeModeWrapper } from './wrapper.js';
+
+class FakeHandle implements DownstreamHandle {
+    public listTools: () => Promise<Tool[]>;
+    public getTool: (name: string) => Promise<Tool | undefined>;
+    public callTool: (toolName: string, args?: Record<string, unknown>) => Promise<CallToolResult>;
+    public close: () => Promise<void>;
+
+    constructor(
+        public readonly config: DownstreamConfig,
+        tools: Tool[],
+        callResult: CallToolResult
+    ) {
+        this.listTools = vi.fn(async () => tools);
+        this.getTool = vi.fn(async (name: string) => tools.find(tool => tool.name === name));
+        this.callTool = vi.fn(async () => callResult);
+        this.close = vi.fn(async () => undefined);
+    }
+}
+
+const SAMPLE_TOOL: Tool = {
+    name: 'demo-tool',
+    description: 'Demo tool',
+    inputSchema: {
+        type: 'object',
+        properties: {
+            message: {
+                type: 'string'
+            }
+        }
+    },
+    annotations: undefined
+};
+
+const SAMPLE_RESULT: CallToolResult = {
+    content: [
+        {
+            type: 'text',
+            text: 'ok'
+        }
+    ],
+    isError: false
+};
+
+describe('CodeModeWrapper', () => {
+    const downstreamConfig: DownstreamConfig = {
+        id: 'alpha',
+        description: 'Demo downstream',
+        command: 'node',
+        args: ['noop.js']
+    };
+
+    it('lists tool summaries from downstream servers', async () => {
+        const handle = new FakeHandle(downstreamConfig, [SAMPLE_TOOL], SAMPLE_RESULT);
+        const wrapper = new CodeModeWrapper({
+            downstreams: [downstreamConfig],
+            downstreamFactory: () => handle
+        });
+
+        const summaries = await wrapper.listToolSummaries('alpha');
+        expect(summaries).toEqual([
+            expect.objectContaining({
+                serverId: 'alpha',
+                toolName: 'demo-tool',
+                description: 'Demo tool'
+            })
+        ]);
+    });
+
+    it('returns implementation summaries with generated signatures', async () => {
+        const handle = new FakeHandle(downstreamConfig, [SAMPLE_TOOL], SAMPLE_RESULT);
+        const wrapper = new CodeModeWrapper({
+            downstreams: [downstreamConfig],
+            downstreamFactory: () => handle
+        });
+
+        const implementation = await wrapper.getToolImplementationSummary('alpha', 'demo-tool');
+        expect(implementation.signature).toContain('export async function demo_tool');
+    });
+
+    it('proxies tool calls to the downstream handle', async () => {
+        const handle = new FakeHandle(downstreamConfig, [SAMPLE_TOOL], SAMPLE_RESULT);
+        const wrapper = new CodeModeWrapper({
+            downstreams: [downstreamConfig],
+            downstreamFactory: () => handle
+        });
+
+        const result = await wrapper.callDownstreamTool('alpha', 'demo-tool', { message: 'hello' });
+        expect(result).toEqual(SAMPLE_RESULT);
+        expect(handle.callTool).toHaveBeenCalledWith('demo-tool', { message: 'hello' });
+    });
+
+    it('lists configured MCP servers', async () => {
+        const handle = new FakeHandle(downstreamConfig, [SAMPLE_TOOL], SAMPLE_RESULT);
+        const wrapper = new CodeModeWrapper({
+            downstreams: [downstreamConfig],
+            downstreamFactory: () => handle
+        });
+
+        const servers = await wrapper.listMcpServers();
+        expect(servers).toEqual([
+            expect.objectContaining({
+                serverId: 'alpha',
+                description: 'Demo downstream'
+            })
+        ]);
+    });
+});

--- a/src/code-mode/wrapper.ts
+++ b/src/code-mode/wrapper.ts
@@ -1,0 +1,267 @@
+import { McpServer } from '../server/mcp.js';
+import type { Transport } from '../shared/transport.js';
+import { ErrorCode, McpError, type CallToolResult, type Implementation, type Tool } from '../types.js';
+import {
+    CallToolInputSchema,
+    GetToolImplementationInputSchema,
+    GetToolImplementationOutputSchema,
+    ListMcpServersOutputSchema,
+    type ListMcpServersResult,
+    type GetToolImplementationResult,
+    ListToolNamesInputSchema,
+    ListToolNamesOutputSchema,
+    type ListToolNamesResult,
+    type ToolSummary
+} from './metaTools.js';
+import { DefaultDownstreamHandle, type DownstreamConfig, type DownstreamHandle } from './downstream.js';
+
+type DownstreamFactory = (config: DownstreamConfig, clientInfo: Implementation) => DownstreamHandle;
+
+export type CodeModeWrapperOptions = {
+    /**
+     * Downstream MCP servers that should be exposed through code-mode.
+     */
+    downstreams: DownstreamConfig[];
+
+    /**
+     * Info advertised for the wrapper server itself.
+     */
+    serverInfo?: Implementation;
+
+    /**
+     * Info advertised when the wrapper connects to downstream servers.
+     */
+    downstreamClientInfo?: Implementation;
+
+    /**
+     * Used for testing to override how downstream handles are created.
+     */
+    downstreamFactory?: DownstreamFactory;
+};
+
+const DEFAULT_SERVER_INFO: Implementation = {
+    name: 'code-mode-wrapper',
+    version: '0.1.0'
+};
+
+const DEFAULT_DOWNSTREAM_CLIENT_INFO: Implementation = {
+    name: 'code-mode-wrapper-client',
+    version: '0.1.0'
+};
+
+export class CodeModeWrapper {
+    public readonly server: McpServer;
+
+    private readonly _handles: Map<string, DownstreamHandle>;
+    private readonly _downstreamFactory: DownstreamFactory;
+    private readonly _downstreamClientInfo: Implementation;
+
+    constructor(private readonly _options: CodeModeWrapperOptions) {
+        if (!_options.downstreams.length) {
+            throw new Error('At least one downstream server must be configured.');
+        }
+
+        const serverInfo = _options.serverInfo ?? DEFAULT_SERVER_INFO;
+        this.server = new McpServer(serverInfo, {
+            capabilities: {
+                tools: {}
+            }
+        });
+
+        this._downstreamClientInfo = _options.downstreamClientInfo ?? DEFAULT_DOWNSTREAM_CLIENT_INFO;
+        this._downstreamFactory =
+            _options.downstreamFactory ??
+            ((config: DownstreamConfig, clientInfo: Implementation) => new DefaultDownstreamHandle(config, clientInfo));
+
+        this._handles = new Map(
+            _options.downstreams.map(config => [config.id, this._downstreamFactory(config, this._downstreamClientInfo)])
+        );
+
+        this.registerMetaTools();
+    }
+
+    async connect(transport: Transport): Promise<void> {
+        await this.server.connect(transport);
+    }
+
+    async close(): Promise<void> {
+        await Promise.all([...this._handles.values()].map(handle => handle.close()));
+        await this.server.close();
+    }
+
+    /**
+     * Internal helper exposed for easier testing.
+     */
+    async listToolSummaries(serverId?: string): Promise<ToolSummary[]> {
+        if (!serverId) {
+            throw new McpError(ErrorCode.InvalidParams, 'serverId is required');
+        }
+
+        const handle = this.getHandle(serverId);
+        const tools = await handle.listTools();
+        return tools.map(tool => ({
+            serverId: handle.config.id,
+            toolName: tool.name,
+            description: tool.description
+        }));
+    }
+
+    async listMcpServers(): Promise<ListMcpServersResult['servers']> {
+        return this._options.downstreams.map(config => ({
+            serverId: config.id,
+            description: config.description
+        }));
+    }
+
+    /**
+     * Internal helper exposed for easier testing.
+     */
+    async getToolImplementationSummary(serverId: string, toolName: string): Promise<GetToolImplementationResult> {
+        const handle = this.getHandle(serverId);
+        const tool = await handle.getTool(toolName);
+        if (!tool) {
+            throw new McpError(ErrorCode.InvalidParams, `Tool ${toolName} not found on server ${serverId}`);
+        }
+
+        return {
+            serverId,
+            toolName,
+            description: tool.description,
+            annotations: tool.annotations,
+            inputSchema: tool.inputSchema as Record<string, unknown> | undefined,
+            outputSchema: tool.outputSchema as Record<string, unknown> | undefined,
+            signature: generateToolSignature(tool)
+        };
+    }
+
+    /**
+     * Internal helper exposed for easier testing.
+     */
+    async callDownstreamTool(serverId: string, toolName: string, args?: Record<string, unknown>): Promise<CallToolResult> {
+        const handle = this.getHandle(serverId);
+        return handle.callTool(toolName, args);
+    }
+
+    private registerMetaTools() {
+        this.server.registerTool(
+            'list_mcp_servers',
+            {
+                description: 'List the available downstream MCP servers.',
+                outputSchema: ListMcpServersOutputSchema
+            },
+            async () => {
+                const servers = await this.listMcpServers();
+                const structuredContent: ListMcpServersResult = { servers };
+                return {
+                    content: [
+                        {
+                            type: 'text' as const,
+                            text: JSON.stringify(structuredContent, null, 2)
+                        }
+                    ],
+                    structuredContent
+                };
+            }
+        );
+
+        this.server.registerTool(
+            'list_tool_names',
+            {
+                description: 'List tools exposed by a specific downstream MCP server.',
+                inputSchema: ListToolNamesInputSchema,
+                outputSchema: ListToolNamesOutputSchema
+            },
+            async ({ serverId }) => {
+                const tools = await this.listToolSummaries(serverId);
+                const structuredContent: ListToolNamesResult = { tools };
+                return {
+                    content: [
+                        {
+                            type: 'text' as const,
+                            text: JSON.stringify(structuredContent, null, 2)
+                        }
+                    ],
+                    structuredContent
+                };
+            }
+        );
+
+        this.server.registerTool(
+            'get_tool_implementation',
+            {
+                description: 'Inspect an individual downstream tool and generate a TypeScript stub.',
+                inputSchema: GetToolImplementationInputSchema,
+                outputSchema: GetToolImplementationOutputSchema
+            },
+            async ({ serverId, toolName }) => {
+                const structuredContent = await this.getToolImplementationSummary(serverId, toolName);
+                return {
+                    content: [
+                        {
+                            type: 'text' as const,
+                            text: structuredContent.signature
+                        }
+                    ],
+                    structuredContent
+                };
+            }
+        );
+
+        this.server.registerTool(
+            'call_tool',
+            {
+                description: 'Invoke a downstream tool directly through the wrapper.',
+                inputSchema: CallToolInputSchema
+            },
+            async ({ serverId, toolName, arguments: args }) => {
+                return this.callDownstreamTool(serverId, toolName, args);
+            }
+        );
+    }
+
+    private getHandle(serverId: string): DownstreamHandle {
+        const handle = this._handles.get(serverId);
+        if (!handle) {
+            throw new McpError(ErrorCode.InvalidParams, `Unknown server: ${serverId}`);
+        }
+
+        return handle;
+    }
+}
+
+function generateToolSignature(tool: Tool): string {
+    const lines = [
+        `import { Client } from '@modelcontextprotocol/sdk/client';`,
+        '',
+        tool.description ? `// ${tool.description}` : undefined,
+        formatSchemaComment('inputSchema', tool.inputSchema),
+        formatSchemaComment('outputSchema', tool.outputSchema),
+        `export async function ${sanitizeIdentifier(tool.name)}(client: Client, args?: Record<string, unknown>) {`,
+        `  return client.callTool({ name: '${tool.name}', arguments: args });`,
+        `}`
+    ].filter(Boolean) as string[];
+
+    return lines.join('\n');
+}
+
+function formatSchemaComment(label: string, schema: Record<string, unknown> | undefined): string {
+    if (!schema) {
+        return `// ${label}: none`;
+    }
+
+    const serialized = JSON.stringify(schema, null, 2)
+        .split('\n')
+        .map(line => `// ${line}`)
+        .join('\n');
+
+    return `// ${label}:\n${serialized}`;
+}
+
+function sanitizeIdentifier(name: string): string {
+    const cleaned = name.replace(/[^a-zA-Z0-9_$]/g, '_');
+    if (!cleaned.length) {
+        return 'tool';
+    }
+
+    return /^[0-9]/.test(cleaned) ? `_${cleaned}` : cleaned;
+}


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

Adds an opt-in “code-mode” wrapper that fronts multiple downstream MCP servers via three meta-tools (`list_mcp_servers`, `list_tool_names`, `get_tool_implementation`, plus `call_tool`). Agents progressively disclose server → tool → schema, so they only load what they need.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

Per [Anthropic's recent article on code execution providing massive token savings over MCP servers](https://www.anthropic.com/engineering/code-execution-with-mcp), I was curious to explore whether we might imagine emulating this file-system based code execution (listing directories & reading files to execute scripts) with MCP meta-tools (one config stores many MCP servers, and so the agent can list MCP servers, list tools, and call tools).

With the wrapper in place, linking Playwright through the MCP server drops a simple “open a site” run from 17 k tokens down to 13.7 k. **Given Cursor’s 11.1 k base prompt, that’s 5.9 k tokens of overhead without the wrapper versus 2.6 k with it—a 56 % reduction (about 3.3 k tokens) while still keeping all downstream tools available**. The LLM does spend a couple of extra tool calls on discovery, but the workflow mirrors “explore files → read file,” so even with many servers the prompt stays slim.

Please note: I open this PR to hear what you all think of this sort of setup. I did this fairly quickly, so there's likely cleaner approaches to accomplishing this setup. I would love to hear your thoughts and hunches around this, and whether building this out further might be worthwhile! Thanks for your thoughts :). 

## How Has This Been Tested?

<!-- Have you tested this in a real application? Which scenarios were tested? -->

- `npm run typecheck`
- `npm run test`
- Manual end-to-end test in Cursor with the wrapper configured via `code-config.mcp-servers.json`, Playwright MCP linked to the local SDK, and the client invoking `list_mcp_servers → list_tool_names(serverId=playwright) → get_tool_implementation → call_tool`. 

This is how I set it up: 
In `~/.cursor/code-config.mcp-servers.json`: 
```
{
    "downstreams": [
        {
            "id": "playwright",
            "description": "Browser automation via Playwright",
            "command": "node",
            "args": ["/Users/yannbonzom/Desktop/projects/playwright-mcp/cli.js", "--headless", "--browser=chromium"]
        }
    ]
}
```
In `~/.cursor/mcp.json`: 
```
{
  "mcpServers": {
    "code-mode-mcp-servers": {
      "command": "npm",
      "args": [
        "--prefix",
        "/Users/yannbonzom/Desktop/projects/typescript-sdk",
        "run",
        "code-mode",
        "--",
        "--config",
        "/Users/yannbonzom/.cursor/code-mode.mcp-servers.json"
      ]
    }
  }
}
```

## Breaking Changes

<!-- Will users need to update their code or configurations? -->

No breaking changes. The wrapper is opt-in and runs as its own CLI (`npm run code-mode -- --config ...`). Existing SDK usage is untouched.

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

<!-- Add any other context, implementation notes, or design decisions -->

- The config file is named `code-config.mcp-servers.json` to underline that it lists multiple downstream MCP servers.
- Meta-tools are hierarchical to keep token usage predictable: `list_mcp_servers` returns server summaries; `list_tool_names` requires `serverId` and returns just name + short description; `get_tool_implementation` is the only call that returns full schemas/stubs.
- This gives agents a code-execution-like exploration experience without needing a real filesystem view, and lets users keep many MCP servers active simultaneously while still saving tokens. I realize there's the risk of too-many-MCP-servers (similar to the too-many-tools problem causing agents to get confused), so it will need experimentation to see if we encounter similar problems. My hunch is that it's a lot easier for an agent to discern across, say, [notion, playwright, jira] than having many similar-sounding tool names. 
- Sample chat to show how it's able to dynamically retrieve what it needs: 

<img width="505" height="1319" alt="Screenshot 2025-11-15 at 5 21 20 PM" src="https://github.com/user-attachments/assets/0338d519-37eb-49e6-b873-886462cf9d06" />

- Sample chat showing how it figures out to explore its tools first to then determine what to use

<img width="501" height="921" alt="Screenshot 2025-11-15 at 5 25 21 PM" src="https://github.com/user-attachments/assets/e428df94-49cf-49eb-97f9-ebf157b43f02" />
