### PR TITLE
fix: restore extensibility for ToolAnnotations schema

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -944,49 +944,51 @@ export const PromptListChangedNotificationSchema = NotificationSchema.extend({
  * Clients should never make tool use decisions based on ToolAnnotations
  * received from untrusted servers.
  */
-export const ToolAnnotationsSchema = z.object({
-    /**
-     * A human-readable title for the tool.
-     */
-    title: z.string().optional(),
+export const ToolAnnotationsSchema = z
+    .object({
+        /**
+         * A human-readable title for the tool.
+         */
+        title: z.string().optional(),
 
-    /**
-     * If true, the tool does not modify its environment.
-     *
-     * Default: false
-     */
-    readOnlyHint: z.boolean().optional(),
+        /**
+         * If true, the tool does not modify its environment.
+         *
+         * Default: false
+         */
+        readOnlyHint: z.boolean().optional(),
 
-    /**
-     * If true, the tool may perform destructive updates to its environment.
-     * If false, the tool performs only additive updates.
-     *
-     * (This property is meaningful only when `readOnlyHint == false`)
-     *
-     * Default: true
-     */
-    destructiveHint: z.boolean().optional(),
+        /**
+         * If true, the tool may perform destructive updates to its environment.
+         * If false, the tool performs only additive updates.
+         *
+         * (This property is meaningful only when `readOnlyHint == false`)
+         *
+         * Default: true
+         */
+        destructiveHint: z.boolean().optional(),
 
-    /**
-     * If true, calling the tool repeatedly with the same arguments
-     * will have no additional effect on the its environment.
-     *
-     * (This property is meaningful only when `readOnlyHint == false`)
-     *
-     * Default: false
-     */
-    idempotentHint: z.boolean().optional(),
+        /**
+         * If true, calling the tool repeatedly with the same arguments
+         * will have no additional effect on the its environment.
+         *
+         * (This property is meaningful only when `readOnlyHint == false`)
+         *
+         * Default: false
+         */
+        idempotentHint: z.boolean().optional(),
 
-    /**
-     * If true, this tool may interact with an "open world" of external
-     * entities. If false, the tool's domain of interaction is closed.
-     * For example, the world of a web search tool is open, whereas that
-     * of a memory tool is not.
-     *
-     * Default: true
-     */
-    openWorldHint: z.boolean().optional()
-});
+        /**
+         * If true, this tool may interact with an "open world" of external
+         * entities. If false, the tool's domain of interaction is closed.
+         * For example, the world of a web search tool is open, whereas that
+         * of a memory tool is not.
+         *
+         * Default: true
+         */
+        openWorldHint: z.boolean().optional()
+    })
+    .catchall(z.unknown());
 
 /**
  * Definition for a tool the client can call.


### PR DESCRIPTION
## Summary

Restores the ability for `ToolAnnotations` to accept additional properties beyond the standard fields.

## Problem

In SDK v1.22.0, the `.passthrough()` modifier was accidentally removed from `ToolAnnotationsSchema` during the SEP-1319 cleanup (commit f59996a). This broke consumers like [Cloudflare's x402 integration](https://github.com/cloudflare/agents/pull/659) that rely on extending annotations with custom fields (e.g., `paymentHint`, `paymentPriceUSD`).

## Justification from Spec

The MCP specification **allows** additional properties on `ToolAnnotations`. Looking at the [JSON Schema for ToolAnnotations](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/main/schema/draft/schema.json):

```json
{
  "description": "Additional properties describing a Tool to clients...",
  "properties": {
    "title": { ... },
    "readOnlyHint": { ... },
    "destructiveHint": { ... },
    "idempotentHint": { ... },
    "openWorldHint": { ... },
    "taskHint": { ... }
  },
  "type": "object"
}
```

**Note: No `"additionalProperties": false`** is specified, which per JSON Schema semantics means additional properties ARE allowed.

## Solution

Add `.catchall(z.unknown())` to `ToolAnnotationsSchema` to match the spec's extensibility. Using `.catchall(z.unknown())` rather than `.passthrough()` for consistency with other schemas per commit 913ca2a.

## Test Plan

- [x] All existing tests pass (1092 tests)
- [x] Lint passes
- [x] Build passes