### PR TITLE
Support beta releases by publishing with --tag beta

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,6 +63,16 @@ jobs:
 
             - run: npm ci
 
-            - run: npm publish --provenance --access public
+            - name: Determine npm tag
+              id: npm-tag
+              run: |
+                  VERSION=$(node -p "require('./package.json').version")
+                  if [[ "$VERSION" == *"-beta"* ]]; then
+                    echo "tag=--tag beta" >> $GITHUB_OUTPUT
+                  else
+                    echo "tag=" >> $GITHUB_OUTPUT
+                  fi
+
+            - run: npm publish --provenance --access public ${{ steps.npm-tag.outputs.tag }}
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds a step to the publish workflow that detects if the version contains `-beta`
- When a beta version is detected, publishes with `--tag beta` instead of the default `latest`
- Stable releases remain unchanged (no `--tag` argument)

## How to use
1. Update `package.json` version to e.g., `1.23.0-beta.0`
2. Create PR, approve, merge to `main`
3. Create a GitHub Release with tag matching the version `1.23.0-beta.0`
4. Workflow publishes to npm `beta` tag
5. Users install via `npm install @modelcontextprotocol/sdk@beta`

## Test plan
- [ ] Create a test release with a beta version to verify the workflow correctly adds `--tag beta`