### PR TITLE
Fix type error when using interface types for structuredContent

### DIFF
--- a/src/examples/server/mcpServerOutputSchema.ts
+++ b/src/examples/server/mcpServerOutputSchema.ts
@@ -41,7 +41,12 @@ server.registerTool(
         void country;
         // Simulate weather API call
         const temp_c = Math.round((Math.random() * 35 - 5) * 10) / 10;
-        const conditions = ['sunny', 'cloudy', 'rainy', 'stormy', 'snowy'][Math.floor(Math.random() * 5)] as 'sunny' | 'cloudy' | 'rainy' | 'stormy' | 'snowy';
+        const conditions = ['sunny', 'cloudy', 'rainy', 'stormy', 'snowy'][Math.floor(Math.random() * 5)] as
+            | 'sunny'
+            | 'cloudy'
+            | 'rainy'
+            | 'stormy'
+            | 'snowy';
 
         const structuredContent = {
             temperature: {

--- a/src/server/mcp.test.ts
+++ b/src/server/mcp.test.ts
@@ -1283,25 +1283,27 @@ describe.each(zodTestMatrix)('$zodVersionLabel', (entry: ZodMatrixEntry) => {
                         timestamp: z.string()
                     }
                 },
-                async ({ input }) => ({
-                    content: [
-                        {
-                            type: 'text',
-                            text: JSON.stringify({
-                                processedInput: input,
-                                resultType: 'structured',
-                                // Missing required 'timestamp' field
-                                someExtraField: 'unexpected' // Extra field not in schema
-                            })
+                async ({ input }) =>
+                    // @ts-expect-error - Intentionally returning invalid data to test runtime validation
+                    ({
+                        content: [
+                            {
+                                type: 'text',
+                                text: JSON.stringify({
+                                    processedInput: input,
+                                    resultType: 'structured',
+                                    // Missing required 'timestamp' field
+                                    someExtraField: 'unexpected' // Extra field not in schema
+                                })
+                            }
+                        ],
+                        structuredContent: {
+                            processedInput: input,
+                            resultType: 'structured',
+                            // Missing required 'timestamp' field
+                            someExtraField: 'unexpected' // Extra field not in schema
                         }
-                    ],
-                    structuredContent: {
-                        processedInput: input,
-                        resultType: 'structured',
-                        // Missing required 'timestamp' field
-                        someExtraField: 'unexpected' // Extra field not in schema
-                    }
-                })
+                    })
             );
 
             const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();

--- a/src/server/mcp.ts
+++ b/src/server/mcp.ts
@@ -61,13 +61,13 @@ import { validateAndWarnToolName } from '../shared/toolNameValidation.js';
  */
 export type CallToolResult<T extends ZodRawShapeCompat | AnySchema | undefined = undefined> = T extends ZodRawShapeCompat
     ? Omit<BaseCallToolResult, 'structuredContent'> & {
-        structuredContent?: ShapeOutput<T>;
-    }
+          structuredContent?: ShapeOutput<T>;
+      }
     : T extends AnySchema
-    ? Omit<BaseCallToolResult, 'structuredContent'> & {
-        structuredContent?: SchemaOutput<T>;
-    }
-    : BaseCallToolResult;
+      ? Omit<BaseCallToolResult, 'structuredContent'> & {
+            structuredContent?: SchemaOutput<T>;
+        }
+      : BaseCallToolResult;
 
 /**
  * High-level MCP server that provides a simpler API for working with resources, tools, and prompts.
@@ -137,9 +137,9 @@ export class McpServer {
                                 const obj = normalizeObjectSchema(tool.inputSchema);
                                 return obj
                                     ? (toJsonSchemaCompat(obj, {
-                                        strictUnions: true,
-                                        pipeStrategy: 'input'
-                                    }) as Tool['inputSchema'])
+                                          strictUnions: true,
+                                          pipeStrategy: 'input'
+                                      }) as Tool['inputSchema'])
                                     : EMPTY_OBJECT_JSON_SCHEMA;
                             })(),
                             annotations: tool.annotations,
@@ -1104,15 +1104,15 @@ export type ToolCallback<
     OutputArgs extends undefined | ZodRawShapeCompat | AnySchema = undefined
 > = InputArgs extends ZodRawShapeCompat
     ? (
-        args: ShapeOutput<InputArgs>,
-        extra: RequestHandlerExtra<ServerRequest, ServerNotification>
-    ) => CallToolResult<OutputArgs> | Promise<CallToolResult<OutputArgs>>
+          args: ShapeOutput<InputArgs>,
+          extra: RequestHandlerExtra<ServerRequest, ServerNotification>
+      ) => CallToolResult<OutputArgs> | Promise<CallToolResult<OutputArgs>>
     : InputArgs extends AnySchema
-    ? (
-        args: SchemaOutput<InputArgs>,
-        extra: RequestHandlerExtra<ServerRequest, ServerNotification>
-    ) => CallToolResult<OutputArgs> | Promise<CallToolResult<OutputArgs>>
-    : (extra: RequestHandlerExtra<ServerRequest, ServerNotification>) => CallToolResult<OutputArgs> | Promise<CallToolResult<OutputArgs>>;
+      ? (
+            args: SchemaOutput<InputArgs>,
+            extra: RequestHandlerExtra<ServerRequest, ServerNotification>
+        ) => CallToolResult<OutputArgs> | Promise<CallToolResult<OutputArgs>>
+      : (extra: RequestHandlerExtra<ServerRequest, ServerNotification>) => CallToolResult<OutputArgs> | Promise<CallToolResult<OutputArgs>>;
 
 export type RegisteredTool = {
     title?: string;


### PR DESCRIPTION
Parameterized ToolCallback() and CallToolResult() types to enable type-safe structured tool outputs.

## Motivation and Context
fixes #563 

## How Has This Been Tested?
- All existing tests pass 
- Type checking validates that structuredContent now properly infers types from outputSchema

## Breaking Changes
None

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

