### PR TITLE
fix: allow any JSON Schema type for outputSchema

### DIFF
--- a/src/spec.types.ts
+++ b/src/spec.types.ts
@@ -1166,11 +1166,7 @@ export interface Tool extends BaseMetadata, Icons {
    * An optional JSON Schema object defining the structure of the tool's output returned in
    * the structuredContent field of a CallToolResult.
    */
-  outputSchema?: {
-    type: "object";
-    properties?: { [key: string]: object };
-    required?: string[];
-  };
+  outputSchema?: { [key: string]: unknown };
 
   /**
    * Optional additional tool information.

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -420,16 +420,17 @@ describe('Types', () => {
             expect(result.success).toBe(false);
         });
 
-        test('should still require type: object at root for outputSchema', () => {
+        test('should accept outputSchema with type: array', () => {
             const tool = {
                 name: 'test',
                 inputSchema: { type: 'object' },
                 outputSchema: {
-                    type: 'array'
+                    type: 'array',
+                    items: { type: 'string' }
                 }
             };
             const result = ToolSchema.safeParse(tool);
-            expect(result.success).toBe(false);
+            expect(result.success).toBe(true);
         });
 
         test('should accept simple minimal schema (backward compatibility)', () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1012,16 +1012,8 @@ export const ToolSchema = z.object({
     /**
      * An optional JSON Schema 2020-12 object defining the structure of the tool's output
      * returned in the structuredContent field of a CallToolResult.
-     * Must have type: 'object' at the root level per MCP spec.
      */
-    outputSchema: z
-        .object({
-            type: z.literal('object'),
-            properties: z.record(z.string(), AssertObjectSchema).optional(),
-            required: z.array(z.string()).optional()
-        })
-        .catchall(z.unknown())
-        .optional(),
+    outputSchema: z.record(z.string(), z.unknown()).optional(),
     /**
      * Optional additional tool information.
      */


### PR DESCRIPTION
The MCP spec does not require `outputSchema` to have `type: 'object'` at the root level - it can be any valid JSON Schema. This allows tools to return arrays, primitives, or other structures for list/batch responses.

`inputSchema` still correctly requires `type: 'object'` since tool inputs are always named parameters.

Fixes #1149