### PR TITLE
fix: prevent TS2589 type instantiation error in ToolCallback

### DIFF
--- a/src/server/mcp.ts
+++ b/src/server/mcp.ts
@@ -1088,7 +1088,7 @@ export class ResourceTemplate {
  */
 export type ToolCallback<Args extends undefined | ZodRawShapeCompat | AnySchema = undefined> = Args extends ZodRawShapeCompat
     ? (args: ShapeOutput<Args>, extra: RequestHandlerExtra<ServerRequest, ServerNotification>) => CallToolResult | Promise<CallToolResult>
-    : Args extends AnySchema
+    : [Args] extends [AnySchema]
       ? (
             args: SchemaOutput<Args>,
             extra: RequestHandlerExtra<ServerRequest, ServerNotification>


### PR DESCRIPTION
Use [T] extends [U] pattern on the AnySchema check to prevent distributive conditional types.

## Motivation and Context
Fixes #1180. After upgrading from v1.22.0 to v1.23.0, users get `TS2589: Type instantiation is excessively deep and possibly infinite` when using `registerTool`. The issue was that `AnySchema` (`z3.ZodTypeAny | z4.$ZodType`) as a union caused TypeScript to distribute the conditional type check, leading to exponential type instantiation.

## How Has This Been Tested?
- `npm run build` passes
- `npm test` passes (1129 tests)
- `npm run lint` passes

## Breaking Changes
None. This is a type-level fix only.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed