### PR TITLE
test: use toStrictEqual instead of toEqual in InMemoryTransport tests

### DIFF
--- a/src/inMemory.test.ts
+++ b/src/inMemory.test.ts
@@ -33,7 +33,7 @@ describe('InMemoryTransport', () => {
         };
 
         await clientTransport.send(message);
-        expect(receivedMessage).toEqual(message);
+        expect(receivedMessage).toStrictEqual(message);
     });
 
     test('should send message with auth info from client to server', async () => {
@@ -58,8 +58,8 @@ describe('InMemoryTransport', () => {
         };
 
         await clientTransport.send(message, { authInfo });
-        expect(receivedMessage).toEqual(message);
-        expect(receivedAuthInfo).toEqual(authInfo);
+        expect(receivedMessage).toStrictEqual(message);
+        expect(receivedAuthInfo).toStrictEqual(authInfo);
     });
 
     test('should send message from server to client', async () => {
@@ -75,7 +75,7 @@ describe('InMemoryTransport', () => {
         };
 
         await serverTransport.send(message);
-        expect(receivedMessage).toEqual(message);
+        expect(receivedMessage).toStrictEqual(message);
     });
 
     test('should handle close', async () => {
@@ -114,6 +114,6 @@ describe('InMemoryTransport', () => {
 
         await clientTransport.send(message);
         await serverTransport.start();
-        expect(receivedMessage).toEqual(message);
+        expect(receivedMessage).toStrictEqual(message);
     });
 });


### PR DESCRIPTION
## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
- Replace `toEqual` with `toStrictEqual` for more precise type checking in InMemoryTransport test assertions
- Improves test accuracy by ensuring strict equality checks
    - https://vitest.dev/api/expect.html#tostrictequal

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
- Run existing tests to verify behavior remains correct

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
- none

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
