### PR TITLE
Modify Origin header validation in validateRequestHeaders (streamableHttp.ts and sse.ts) to allow requests without an Origin, as they are not relevant to server DNS rebinding protection.

### DIFF
--- a/src/server/sse.test.ts
+++ b/src/server/sse.test.ts
@@ -547,6 +547,27 @@ describe.each(zodTestMatrix)('$zodVersionLabel', (entry: ZodMatrixEntry) => {
                     expect(mockHandleRes.end).toHaveBeenCalledWith('Accepted');
                 });
 
+                it('should accept requests without origin headers', async () => {
+                    const mockRes = createMockResponse();
+                    const transport = new SSEServerTransport('/messages', mockRes, {
+                        allowedOrigins: ['http://localhost:3000', 'https://example.com'],
+                        enableDnsRebindingProtection: true
+                    });
+                    await transport.start();
+
+                    const mockReq = createMockRequest({
+                        headers: {
+                            'content-type': 'application/json'
+                        }
+                    });
+                    const mockHandleRes = createMockResponse();
+
+                    await transport.handlePostMessage(mockReq, mockHandleRes, { jsonrpc: '2.0', method: 'test' });
+
+                    expect(mockHandleRes.writeHead).toHaveBeenCalledWith(202);
+                    expect(mockHandleRes.end).toHaveBeenCalledWith('Accepted');
+                });
+
                 it('should reject requests with disallowed origin headers', async () => {
                     const mockRes = createMockResponse();
                     const transport = new SSEServerTransport('/messages', mockRes, {

--- a/src/server/sse.ts
+++ b/src/server/sse.ts
@@ -79,7 +79,7 @@ export class SSEServerTransport implements Transport {
         // Validate Origin header if allowedOrigins is configured
         if (this._options.allowedOrigins && this._options.allowedOrigins.length > 0) {
             const originHeader = req.headers.origin;
-            if (!originHeader || !this._options.allowedOrigins.includes(originHeader)) {
+            if (originHeader && !this._options.allowedOrigins.includes(originHeader)) {
                 return `Invalid Origin header: ${originHeader}`;
             }
         }

--- a/src/server/streamableHttp.test.ts
+++ b/src/server/streamableHttp.test.ts
@@ -2678,6 +2678,29 @@ describe.each(zodTestMatrix)('$zodVersionLabel', (entry: ZodMatrixEntry) => {
                 const body = await response.json();
                 expect(body.error.message).toBe('Invalid Origin header: http://evil.com');
             });
+
+            it('should accept requests without origin headers', async () => {
+                const result = await createTestServerWithDnsProtection({
+                    sessionIdGenerator: undefined,
+                    allowedOrigins: ['http://localhost:3000', 'https://example.com'],
+                    enableDnsRebindingProtection: true
+                });
+                server = result.server;
+                transport = result.transport;
+                baseUrl = result.baseUrl;
+
+                const response = await fetch(baseUrl, {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        Accept: 'application/json, text/event-stream'
+                    },
+                    body: JSON.stringify(TEST_MESSAGES.initialize)
+                });
+
+                // Should pass even with no Origin headers because requests that do not come from browsers may not have Origin and DNS rebinding attacks can only be performed via browsers
+                expect(response.status).toBe(200);
+            });
         });
 
         describe('enableDnsRebindingProtection option', () => {

--- a/src/server/streamableHttp.ts
+++ b/src/server/streamableHttp.ts
@@ -228,7 +228,7 @@ export class StreamableHTTPServerTransport implements Transport {
         // Validate Origin header if allowedOrigins is configured
         if (this._allowedOrigins && this._allowedOrigins.length > 0) {
             const originHeader = req.headers.origin;
-            if (!originHeader || !this._allowedOrigins.includes(originHeader)) {
+            if (originHeader && !this._allowedOrigins.includes(originHeader)) {
                 return `Invalid Origin header: ${originHeader}`;
             }
         }


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
In the context of DNS rebinding protection, the condition to validate the Origin header has been modified in validateRequestHeaders (in both streamableHttp.ts and sse.ts) in order to prevent the rejection of requests that do not include an Origin header, such as those not originating from browsers, since they are not related to DNS rebinding attacks against the server.

Moreover, before this change, the Origin validation condition in validateRequestHeaders, i.e.

```
if (!originHeader || !this._allowedOrigins.includes(originHeader)) {
    return `Invalid Origin header: ${originHeader}`;
}
```
was not compliant with the latest version (2025-11-25) of the MCP specification (Transports - 2.0.1 Security Warning) that states:

> If the `Origin` header **is** present **and** invalid, servers MUST respond with HTTP 403 Forbidden.

Instead, the updated Origin validation condition
```
if (originHeader && !this._allowedOrigins.includes(originHeader)) {
    return `Invalid Origin header: ${originHeader}`;
}
```
closely implements the specification.


## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Along with the modified condition, this pull request introduces two new tests to verify the acceptance of requests without an Origin header when DNS Rebinding protection is enabled.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No breaking changes have been introduced.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
