### PR TITLE
chore: update protocol version to 2025-11-25

### DIFF
--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -20,15 +20,16 @@ import {
 describe('Types', () => {
     test('should have correct latest protocol version', () => {
         expect(LATEST_PROTOCOL_VERSION).toBeDefined();
-        expect(LATEST_PROTOCOL_VERSION).toBe('2025-06-18');
+        expect(LATEST_PROTOCOL_VERSION).toBe('2025-11-25');
     });
     test('should have correct supported protocol versions', () => {
         expect(SUPPORTED_PROTOCOL_VERSIONS).toBeDefined();
         expect(SUPPORTED_PROTOCOL_VERSIONS).toBeInstanceOf(Array);
         expect(SUPPORTED_PROTOCOL_VERSIONS).toContain(LATEST_PROTOCOL_VERSION);
+        expect(SUPPORTED_PROTOCOL_VERSIONS).toContain('2025-06-18');
+        expect(SUPPORTED_PROTOCOL_VERSIONS).toContain('2025-03-26');
         expect(SUPPORTED_PROTOCOL_VERSIONS).toContain('2024-11-05');
         expect(SUPPORTED_PROTOCOL_VERSIONS).toContain('2024-10-07');
-        expect(SUPPORTED_PROTOCOL_VERSIONS).toContain('2025-03-26');
     });
 
     describe('ResourceLink', () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,9 @@
 import * as z from 'zod/v4';
 import { AuthInfo } from './server/auth/types.js';
 
-export const LATEST_PROTOCOL_VERSION = '2025-06-18';
+export const LATEST_PROTOCOL_VERSION = '2025-11-25';
 export const DEFAULT_NEGOTIATED_PROTOCOL_VERSION = '2025-03-26';
-export const SUPPORTED_PROTOCOL_VERSIONS = [LATEST_PROTOCOL_VERSION, '2025-03-26', '2024-11-05', '2024-10-07'];
+export const SUPPORTED_PROTOCOL_VERSIONS = [LATEST_PROTOCOL_VERSION, '2025-06-18', '2025-03-26', '2024-11-05', '2024-10-07'];
 
 export const RELATED_TASK_META_KEY = 'io.modelcontextprotocol/related-task';
 


### PR DESCRIPTION
## Summary
- Update `LATEST_PROTOCOL_VERSION` from `2025-06-18` to `2025-11-25`
- Add `2025-06-18` to `SUPPORTED_PROTOCOL_VERSIONS` for backward compatibility
- Update tests to reflect the new version constants

## Test plan
- [x] Run `npm test -- src/types.test.ts` to verify version constants are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)