### PR TITLE
refactor: make Server class framework-agnostic by moving express to separate module

### DIFF
--- a/docs/server.md
+++ b/docs/server.md
@@ -71,7 +71,7 @@ For more detailed patterns (stateless vs stateful, JSON response mode, CORS, DNS
 MCP servers running on localhost are vulnerable to DNS rebinding attacks. Use `createMcpExpressApp()` to create an Express app with DNS rebinding protection enabled by default:
 
 ```typescript
-import { createMcpExpressApp } from '@modelcontextprotocol/sdk/server/index.js';
+import { createMcpExpressApp } from '@modelcontextprotocol/sdk/server/express.js';
 
 // Protection auto-enabled (default host is 127.0.0.1)
 const app = createMcpExpressApp();

--- a/src/examples/server/elicitationFormExample.ts
+++ b/src/examples/server/elicitationFormExample.ts
@@ -12,7 +12,7 @@ import { type Request, type Response } from 'express';
 import { McpServer } from '../../server/mcp.js';
 import { StreamableHTTPServerTransport } from '../../server/streamableHttp.js';
 import { isInitializeRequest } from '../../types.js';
-import { createMcpExpressApp } from '../../server/index.js';
+import { createMcpExpressApp } from '../../server/express.js';
 
 // Create MCP server - it will automatically use AjvJsonSchemaValidator with sensible defaults
 // The validator supports format validation (email, date, etc.) if ajv-formats is installed

--- a/src/examples/server/elicitationUrlExample.ts
+++ b/src/examples/server/elicitationUrlExample.ts
@@ -11,7 +11,7 @@ import express, { Request, Response } from 'express';
 import { randomUUID } from 'node:crypto';
 import { z } from 'zod';
 import { McpServer } from '../../server/mcp.js';
-import { createMcpExpressApp } from '../../server/index.js';
+import { createMcpExpressApp } from '../../server/express.js';
 import { StreamableHTTPServerTransport } from '../../server/streamableHttp.js';
 import { getOAuthProtectedResourceMetadataUrl, mcpAuthMetadataRouter } from '../../server/auth/router.js';
 import { requireBearerAuth } from '../../server/auth/middleware/bearerAuth.js';

--- a/src/examples/server/jsonResponseStreamableHttp.ts
+++ b/src/examples/server/jsonResponseStreamableHttp.ts
@@ -4,7 +4,7 @@ import { McpServer } from '../../server/mcp.js';
 import { StreamableHTTPServerTransport } from '../../server/streamableHttp.js';
 import * as z from 'zod/v4';
 import { CallToolResult, isInitializeRequest } from '../../types.js';
-import { createMcpExpressApp } from '../../server/index.js';
+import { createMcpExpressApp } from '../../server/express.js';
 
 // Create an MCP server with implementation details
 const getServer = () => {

--- a/src/examples/server/simpleSseServer.ts
+++ b/src/examples/server/simpleSseServer.ts
@@ -3,7 +3,7 @@ import { McpServer } from '../../server/mcp.js';
 import { SSEServerTransport } from '../../server/sse.js';
 import * as z from 'zod/v4';
 import { CallToolResult } from '../../types.js';
-import { createMcpExpressApp } from '../../server/index.js';
+import { createMcpExpressApp } from '../../server/express.js';
 
 /**
  * This example server demonstrates the deprecated HTTP+SSE transport

--- a/src/examples/server/simpleStatelessStreamableHttp.ts
+++ b/src/examples/server/simpleStatelessStreamableHttp.ts
@@ -3,7 +3,7 @@ import { McpServer } from '../../server/mcp.js';
 import { StreamableHTTPServerTransport } from '../../server/streamableHttp.js';
 import * as z from 'zod/v4';
 import { CallToolResult, GetPromptResult, ReadResourceResult } from '../../types.js';
-import { createMcpExpressApp } from '../../server/index.js';
+import { createMcpExpressApp } from '../../server/express.js';
 
 const getServer = () => {
     // Create an MCP server with implementation details

--- a/src/examples/server/simpleStreamableHttp.ts
+++ b/src/examples/server/simpleStreamableHttp.ts
@@ -5,7 +5,7 @@ import { McpServer } from '../../server/mcp.js';
 import { StreamableHTTPServerTransport } from '../../server/streamableHttp.js';
 import { getOAuthProtectedResourceMetadataUrl, mcpAuthMetadataRouter } from '../../server/auth/router.js';
 import { requireBearerAuth } from '../../server/auth/middleware/bearerAuth.js';
-import { createMcpExpressApp } from '../../server/index.js';
+import { createMcpExpressApp } from '../../server/express.js';
 import {
     CallToolResult,
     ElicitResultSchema,

--- a/src/examples/server/simpleTaskInteractive.ts
+++ b/src/examples/server/simpleTaskInteractive.ts
@@ -11,7 +11,8 @@
 
 import { Request, Response } from 'express';
 import { randomUUID } from 'node:crypto';
-import { createMcpExpressApp, Server } from '../../server/index.js';
+import { Server } from '../../server/index.js';
+import { createMcpExpressApp } from '../../server/express.js';
 import { StreamableHTTPServerTransport } from '../../server/streamableHttp.js';
 import {
     CallToolResult,

--- a/src/examples/server/sseAndStreamableHttpCompatibleServer.ts
+++ b/src/examples/server/sseAndStreamableHttpCompatibleServer.ts
@@ -6,7 +6,7 @@ import { SSEServerTransport } from '../../server/sse.js';
 import * as z from 'zod/v4';
 import { CallToolResult, isInitializeRequest } from '../../types.js';
 import { InMemoryEventStore } from '../shared/inMemoryEventStore.js';
-import { createMcpExpressApp } from '../../server/index.js';
+import { createMcpExpressApp } from '../../server/express.js';
 
 /**
  * This example server demonstrates backwards compatibility with both:

--- a/src/examples/server/ssePollingExample.ts
+++ b/src/examples/server/ssePollingExample.ts
@@ -15,7 +15,7 @@
 import { Request, Response } from 'express';
 import { randomUUID } from 'node:crypto';
 import { McpServer } from '../../server/mcp.js';
-import { createMcpExpressApp } from '../../server/index.js';
+import { createMcpExpressApp } from '../../server/express.js';
 import { StreamableHTTPServerTransport } from '../../server/streamableHttp.js';
 import { CallToolResult } from '../../types.js';
 import { InMemoryEventStore } from '../shared/inMemoryEventStore.js';

--- a/src/examples/server/standaloneSseWithGetStreamableHttp.ts
+++ b/src/examples/server/standaloneSseWithGetStreamableHttp.ts
@@ -3,7 +3,7 @@ import { randomUUID } from 'node:crypto';
 import { McpServer } from '../../server/mcp.js';
 import { StreamableHTTPServerTransport } from '../../server/streamableHttp.js';
 import { isInitializeRequest, ReadResourceResult } from '../../types.js';
-import { createMcpExpressApp } from '../../server/index.js';
+import { createMcpExpressApp } from '../../server/express.js';
 
 // Create an MCP server with implementation details
 const server = new McpServer({

--- a/src/server/express.ts
+++ b/src/server/express.ts
@@ -1,0 +1,74 @@
+import express, { Express } from 'express';
+import { hostHeaderValidation, localhostHostValidation } from './middleware/hostHeaderValidation.js';
+
+/**
+ * Options for creating an MCP Express application.
+ */
+export interface CreateMcpExpressAppOptions {
+    /**
+     * The hostname to bind to. Defaults to '127.0.0.1'.
+     * When set to '127.0.0.1', 'localhost', or '::1', DNS rebinding protection is automatically enabled.
+     */
+    host?: string;
+
+    /**
+     * List of allowed hostnames for DNS rebinding protection.
+     * If provided, host header validation will be applied using this list.
+     * For IPv6, provide addresses with brackets (e.g., '[::1]').
+     *
+     * This is useful when binding to '0.0.0.0' or '::' but still wanting
+     * to restrict which hostnames are allowed.
+     */
+    allowedHosts?: string[];
+}
+
+/**
+ * Creates an Express application pre-configured for MCP servers.
+ *
+ * When the host is '127.0.0.1', 'localhost', or '::1' (the default is '127.0.0.1'),
+ * DNS rebinding protection middleware is automatically applied to protect against
+ * DNS rebinding attacks on localhost servers.
+ *
+ * @param options - Configuration options
+ * @returns A configured Express application
+ *
+ * @example
+ * ```typescript
+ * // Basic usage - defaults to 127.0.0.1 with DNS rebinding protection
+ * const app = createMcpExpressApp();
+ *
+ * // Custom host - DNS rebinding protection only applied for localhost hosts
+ * const app = createMcpExpressApp({ host: '0.0.0.0' }); // No automatic DNS rebinding protection
+ * const app = createMcpExpressApp({ host: 'localhost' }); // DNS rebinding protection enabled
+ *
+ * // Custom allowed hosts for non-localhost binding
+ * const app = createMcpExpressApp({ host: '0.0.0.0', allowedHosts: ['myapp.local', 'localhost'] });
+ * ```
+ */
+export function createMcpExpressApp(options: CreateMcpExpressAppOptions = {}): Express {
+    const { host = '127.0.0.1', allowedHosts } = options;
+
+    const app = express();
+    app.use(express.json());
+
+    // If allowedHosts is explicitly provided, use that for validation
+    if (allowedHosts) {
+        app.use(hostHeaderValidation(allowedHosts));
+    } else {
+        // Apply DNS rebinding protection automatically for localhost hosts
+        const localhostHosts = ['127.0.0.1', 'localhost', '::1'];
+        if (localhostHosts.includes(host)) {
+            app.use(localhostHostValidation());
+        } else if (host === '0.0.0.0' || host === '::') {
+            // Warn when binding to all interfaces without DNS rebinding protection
+            // eslint-disable-next-line no-console
+            console.warn(
+                `Warning: Server is binding to ${host} without DNS rebinding protection. ` +
+                    'Consider using the allowedHosts option to restrict allowed hosts, ' +
+                    'or use authentication to protect your server.'
+            );
+        }
+    }
+
+    return app;
+}

--- a/src/server/index.test.ts
+++ b/src/server/index.test.ts
@@ -3,7 +3,7 @@ import supertest from 'supertest';
 import { Client } from '../client/index.js';
 import { InMemoryTransport } from '../inMemory.js';
 import type { Transport } from '../shared/transport.js';
-import { createMcpExpressApp } from './index.js';
+import { createMcpExpressApp } from './express.js';
 import {
     CreateMessageRequestSchema,
     CreateMessageResultSchema,

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,6 +1,4 @@
-import express, { Express } from 'express';
 import { mergeCapabilities, Protocol, type NotificationOptions, type ProtocolOptions, type RequestOptions } from '../shared/protocol.js';
-import { hostHeaderValidation, localhostHostValidation } from './middleware/hostHeaderValidation.js';
 import {
     type ClientCapabilities,
     type CreateMessageRequest,
@@ -668,76 +666,4 @@ export class Server<
     async sendPromptListChanged() {
         return this.notification({ method: 'notifications/prompts/list_changed' });
     }
-}
-
-/**
- * Options for creating an MCP Express application.
- */
-export interface CreateMcpExpressAppOptions {
-    /**
-     * The hostname to bind to. Defaults to '127.0.0.1'.
-     * When set to '127.0.0.1', 'localhost', or '::1', DNS rebinding protection is automatically enabled.
-     */
-    host?: string;
-
-    /**
-     * List of allowed hostnames for DNS rebinding protection.
-     * If provided, host header validation will be applied using this list.
-     * For IPv6, provide addresses with brackets (e.g., '[::1]').
-     *
-     * This is useful when binding to '0.0.0.0' or '::' but still wanting
-     * to restrict which hostnames are allowed.
-     */
-    allowedHosts?: string[];
-}
-
-/**
- * Creates an Express application pre-configured for MCP servers.
- *
- * When the host is '127.0.0.1', 'localhost', or '::1' (the default is '127.0.0.1'),
- * DNS rebinding protection middleware is automatically applied to protect against
- * DNS rebinding attacks on localhost servers.
- *
- * @param options - Configuration options
- * @returns A configured Express application
- *
- * @example
- * ```typescript
- * // Basic usage - defaults to 127.0.0.1 with DNS rebinding protection
- * const app = createMcpExpressApp();
- *
- * // Custom host - DNS rebinding protection only applied for localhost hosts
- * const app = createMcpExpressApp({ host: '0.0.0.0' }); // No automatic DNS rebinding protection
- * const app = createMcpExpressApp({ host: 'localhost' }); // DNS rebinding protection enabled
- *
- * // Custom allowed hosts for non-localhost binding
- * const app = createMcpExpressApp({ host: '0.0.0.0', allowedHosts: ['myapp.local', 'localhost'] });
- * ```
- */
-export function createMcpExpressApp(options: CreateMcpExpressAppOptions = {}): Express {
-    const { host = '127.0.0.1', allowedHosts } = options;
-
-    const app = express();
-    app.use(express.json());
-
-    // If allowedHosts is explicitly provided, use that for validation
-    if (allowedHosts) {
-        app.use(hostHeaderValidation(allowedHosts));
-    } else {
-        // Apply DNS rebinding protection automatically for localhost hosts
-        const localhostHosts = ['127.0.0.1', 'localhost', '::1'];
-        if (localhostHosts.includes(host)) {
-            app.use(localhostHostValidation());
-        } else if (host === '0.0.0.0' || host === '::') {
-            // Warn when binding to all interfaces without DNS rebinding protection
-            // eslint-disable-next-line no-console
-            console.warn(
-                `Warning: Server is binding to ${host} without DNS rebinding protection. ` +
-                    'Consider using the allowedHosts option to restrict allowed hosts, ' +
-                    'or use authentication to protect your server.'
-            );
-        }
-    }
-
-    return app;
 }

--- a/src/server/sse.ts
+++ b/src/server/sse.ts
@@ -17,7 +17,7 @@ export interface SSEServerTransportOptions {
      * List of allowed host header values for DNS rebinding protection.
      * If not specified, host validation is disabled.
      * @deprecated Use the `hostHeaderValidation` middleware from `@modelcontextprotocol/sdk/server/middleware/hostHeaderValidation.js` instead,
-     * or use `createMcpExpressApp` from `@modelcontextprotocol/sdk/server/index.js` which includes localhost protection by default.
+     * or use `createMcpExpressApp` from `@modelcontextprotocol/sdk/server/express.js` which includes localhost protection by default.
      */
     allowedHosts?: string[];
 
@@ -25,7 +25,7 @@ export interface SSEServerTransportOptions {
      * List of allowed origin header values for DNS rebinding protection.
      * If not specified, origin validation is disabled.
      * @deprecated Use the `hostHeaderValidation` middleware from `@modelcontextprotocol/sdk/server/middleware/hostHeaderValidation.js` instead,
-     * or use `createMcpExpressApp` from `@modelcontextprotocol/sdk/server/index.js` which includes localhost protection by default.
+     * or use `createMcpExpressApp` from `@modelcontextprotocol/sdk/server/express.js` which includes localhost protection by default.
      */
     allowedOrigins?: string[];
 
@@ -33,7 +33,7 @@ export interface SSEServerTransportOptions {
      * Enable DNS rebinding protection (requires allowedHosts and/or allowedOrigins to be configured).
      * Default is false for backwards compatibility.
      * @deprecated Use the `hostHeaderValidation` middleware from `@modelcontextprotocol/sdk/server/middleware/hostHeaderValidation.js` instead,
-     * or use `createMcpExpressApp` from `@modelcontextprotocol/sdk/server/index.js` which includes localhost protection by default.
+     * or use `createMcpExpressApp` from `@modelcontextprotocol/sdk/server/express.js` which includes localhost protection by default.
      */
     enableDnsRebindingProtection?: boolean;
 }

--- a/src/server/streamableHttp.ts
+++ b/src/server/streamableHttp.ts
@@ -105,7 +105,7 @@ export interface StreamableHTTPServerTransportOptions {
      * List of allowed host header values for DNS rebinding protection.
      * If not specified, host validation is disabled.
      * @deprecated Use the `hostHeaderValidation` middleware from `@modelcontextprotocol/sdk/server/middleware/hostHeaderValidation.js` instead,
-     * or use `createMcpExpressApp` from `@modelcontextprotocol/sdk/server/index.js` which includes localhost protection by default.
+     * or use `createMcpExpressApp` from `@modelcontextprotocol/sdk/server/express.js` which includes localhost protection by default.
      */
     allowedHosts?: string[];
 
@@ -113,7 +113,7 @@ export interface StreamableHTTPServerTransportOptions {
      * List of allowed origin header values for DNS rebinding protection.
      * If not specified, origin validation is disabled.
      * @deprecated Use the `hostHeaderValidation` middleware from `@modelcontextprotocol/sdk/server/middleware/hostHeaderValidation.js` instead,
-     * or use `createMcpExpressApp` from `@modelcontextprotocol/sdk/server/index.js` which includes localhost protection by default.
+     * or use `createMcpExpressApp` from `@modelcontextprotocol/sdk/server/express.js` which includes localhost protection by default.
      */
     allowedOrigins?: string[];
 
@@ -121,7 +121,7 @@ export interface StreamableHTTPServerTransportOptions {
      * Enable DNS rebinding protection (requires allowedHosts and/or allowedOrigins to be configured).
      * Default is false for backwards compatibility.
      * @deprecated Use the `hostHeaderValidation` middleware from `@modelcontextprotocol/sdk/server/middleware/hostHeaderValidation.js` instead,
-     * or use `createMcpExpressApp` from `@modelcontextprotocol/sdk/server/index.js` which includes localhost protection by default.
+     * or use `createMcpExpressApp` from `@modelcontextprotocol/sdk/server/express.js` which includes localhost protection by default.
      */
     enableDnsRebindingProtection?: boolean;
 


### PR DESCRIPTION
refactor: make Server class framework-agnostic by moving express to separate module

- Move createMcpExpressApp and CreateMcpExpressAppOptions to src/server/express.ts
- Remove express import from src/server/index.ts to make Server class usable in browser environments
- Update all imports to use server/express.js instead of server/index.js for createMcpExpressApp
- Update documentation and comments to reference the new import path

This allows Server class to be used without forcing express dependency, making it framework-agnostic and browser-compatible.

## Summary

This PR refactors the `Server` class to be framework-agnostic by moving Express-related functionality to a separate module. The `createMcpExpressApp` function and `CreateMcpExpressAppOptions` interface have been moved from `src/server/index.ts` to `src/server/express.ts`, and the `express` import has been removed from the main server module.

## Motivation and Context

The `Server` class was previously importing `express` at the top level of `src/server/index.ts`, which created an unnecessary coupling to the Express framework. This prevented the `Server` class from being used in browser environments, as bundlers would attempt to resolve the Node.js-only `express` dependency.

**Problem:**
- `Server` class cannot be used in browser environments due to `express` dependency
- Unnecessary framework coupling limits usage with other frameworks (Fastify, Koa, Cloudflare Workers, etc.)
- All code importing `Server` was forced to include `express` even if not needed

**Solution:**
- Move Express-related functionality to `src/server/express.ts`
- Remove `express` import from `src/server/index.ts`
- Update all imports to use `server/express.js` for `createMcpExpressApp`
- This makes `Server` class framework-agnostic and browser-compatible

## How Has This Been Tested?

- ✅ Updated all example files to import `createMcpExpressApp` from the new location
- ✅ Updated test files to use the new import path
- ✅ Verified that `Server` class no longer imports `express` directly
- ✅ Updated documentation and comments to reference the new import path
- ✅ Type checking passes (no TypeScript errors)
- ✅ All linting checks pass

**Files updated:**
- 11 example files in `src/examples/server/`
- 1 test file (`src/server/index.test.ts`)
- 2 transport files (`src/server/sse.ts`, `src/server/streamableHttp.ts`)
- Documentation (`docs/server.md`)

## Breaking Changes

**Yes, this is a breaking change for users importing `createMcpExpressApp`.**

Users who were importing `createMcpExpressApp` from `@modelcontextprotocol/sdk/server` or `@modelcontextprotocol/sdk/server/index.js` need to update their imports to:
cript
// Before
import { createMcpExpressApp } from '@modelcontextprotocol/sdk/server';
// or
import { createMcpExpressApp } from '@modelcontextprotocol/sdk/server/index.js';

// After
import { createMcpExpressApp } from '@modelcontextprotocol/sdk/server/express.js';**Migration guide:**
- All examples and tests have been updated to demonstrate the new import path
- The `Server` class itself remains unchanged and can still be imported from `@modelcontextprotocol/sdk/server`
- Only Express-related functionality (`createMcpExpressApp`, `CreateMcpExpressAppOptions`) has moved

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

**Design decisions:**
1. **Separate module approach**: Instead of using conditional imports or making `express` optional, we chose to completely separate Express functionality into its own module. This provides the cleanest separation of concerns and makes it explicit when Express is being used.

2. **No re-exports**: We intentionally did not re-export `createMcpExpressApp` from `index.ts` to avoid any possibility of the `express` dependency being pulled in when importing `Server`. Users must explicitly import from `server/express.js` if they need Express functionality.

3. **Backward compatibility**: While this is a breaking change, the migration is straightforward - users just need to update their import path. The functionality itself remains identical.

**Benefits:**
- ✅ `Server` class can now be used in browser environments
- ✅ No forced `express` dependency when using `Server` class
- ✅ Framework-agnostic design allows use with any HTTP framework
- ✅ Clear separation between core server functionality and Express-specific utilities

**Related issue:** This addresses the concern raised in the GitHub issue about making `Server` class framework-agnostic.