### PR TITLE
fix: improve Zod v4 optional schema detection

### DIFF
--- a/src/server/zod-compat.ts
+++ b/src/server/zod-compat.ts
@@ -32,6 +32,7 @@ export interface ZodV4Internal {
     _zod?: {
         def?: {
             type?: string;
+            typeName?: string;
             value?: unknown;
             values?: unknown[];
             shape?: Record<string, AnySchema> | (() => Record<string, AnySchema>);
@@ -236,15 +237,16 @@ export function getSchemaDescription(schema: AnySchema): string | undefined {
  * Works with both Zod v3 and v4.
  */
 export function isSchemaOptional(schema: AnySchema): boolean {
-    if (isZ4Schema(schema)) {
-        const v4Schema = schema as unknown as ZodV4Internal;
-        return v4Schema._zod?.def?.type === 'optional';
-    }
-    const v3Schema = schema as unknown as ZodV3Internal;
-    // v3 has isOptional() method
+    // Check for isOptional method first (works for both v3 and v4 usually)
     if (typeof (schema as { isOptional?: () => boolean }).isOptional === 'function') {
         return (schema as { isOptional: () => boolean }).isOptional();
     }
+
+    if (isZ4Schema(schema)) {
+        const v4Schema = schema as unknown as ZodV4Internal;
+        return v4Schema._zod?.def?.type === 'optional' || v4Schema._zod?.def?.typeName === 'ZodOptional';
+    }
+    const v3Schema = schema as unknown as ZodV3Internal;
     return v3Schema._def?.typeName === 'ZodOptional';
 }
 


### PR DESCRIPTION
## Motivation and Context
This PR fixes a compatibility issue with Zod v4 where optional schemas were incorrectly identified as required.
Specifically, [isSchemaOptional](cci:1://file:///Users/seokyoung-won/Desktop/typescript-sdk/src/server/zod-compat.ts:234:0-250:1) in [zod-compat.ts](cci:7://file:///Users/seokyoung-won/Desktop/typescript-sdk/src/server/zod-compat.ts:0:0-0:0) was failing to detect optional fields because it relied on internal properties that differ in Zod v4, causing optional tool arguments to be marked as `required` in the generated JSON Schema.

## How Has This Been Tested?
I verified the fix by running the existing test suite (`npm test`), specifically the `should support optional prompt arguments` test case in [src/server/mcp.test.ts](cci:7://file:///Users/seokyoung-won/Desktop/typescript-sdk/src/server/mcp.test.ts:0:0-0:0), which now passes correctly.
I also manually verified that [isSchemaOptional](cci:1://file:///Users/seokyoung-won/Desktop/typescript-sdk/src/server/zod-compat.ts:234:0-250:1) correctly returns `true` for `z.string().optional()` using Zod v4.

## Breaking Changes
None. This is a bug fix that improves compatibility.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed