### PR TITLE
No automatic completion support unless needed - Revisited yet again

### DIFF
--- a/src/server/mcp.test.ts
+++ b/src/server/mcp.test.ts
@@ -2670,6 +2670,41 @@ describe.each(zodTestMatrix)('$zodVersionLabel', (entry: ZodMatrixEntry) => {
         });
 
         /***
+         * Test: Registering a resource template without a complete callback should not update server capabilities to advertise support for completion
+         */
+        test('should not advertise support for completion when a resource template without a complete callback is defined', async () => {
+            const mcpServer = new McpServer({
+                name: 'test server',
+                version: '1.0'
+            });
+            const client = new Client({
+                name: 'test client',
+                version: '1.0'
+            });
+
+            mcpServer.resource(
+                'test',
+                new ResourceTemplate('test://resource/{category}', {
+                    list: undefined
+                }),
+                async () => ({
+                    contents: [
+                        {
+                            uri: 'test://resource/test',
+                            text: 'Test content'
+                        }
+                    ]
+                })
+            );
+
+            const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+            await Promise.all([client.connect(clientTransport), mcpServer.server.connect(serverTransport)]);
+
+            expect(client.getServerCapabilities()).not.toHaveProperty('completions');
+        });
+
+        /***
          * Test: Registering a resource template with a complete callback should update server capabilities to advertise support for completion
          */
         test('should advertise support for completion when a resource template with a complete callback is defined', async () => {
@@ -3546,6 +3581,46 @@ describe.each(zodTestMatrix)('$zodVersionLabel', (entry: ZodMatrixEntry) => {
                     GetPromptResultSchema
                 )
             ).rejects.toThrow(/Prompt nonexistent-prompt not found/);
+        });
+
+        /***
+         * Test: Registering a prompt without a completable argument should not update server capabilities to advertise support for completion
+         */
+        test('should not advertise support for completion when a prompt without a completable argument is defined', async () => {
+            const mcpServer = new McpServer({
+                name: 'test server',
+                version: '1.0'
+            });
+            const client = new Client({
+                name: 'test client',
+                version: '1.0'
+            });
+
+            mcpServer.prompt(
+                'test-prompt',
+                {
+                    name: z.string()
+                },
+                async ({ name }) => ({
+                    messages: [
+                        {
+                            role: 'assistant',
+                            content: {
+                                type: 'text',
+                                text: `Hello ${name}`
+                            }
+                        }
+                    ]
+                })
+            );
+
+            const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+            await Promise.all([client.connect(clientTransport), mcpServer.server.connect(serverTransport)]);
+
+            const capabilities = client.getServerCapabilities() || {};
+            const keys = Object.keys(capabilities);
+            expect(keys).not.toContain('completions');
         });
 
         /***


### PR DESCRIPTION
## Description
* In mcp.test.ts
  - Added tests
    - "should not advertise support for completion when a resource template without a complete callback is defined"
    - "should not advertise support for completion when a prompt without a completable argument is defined"
* In mcp.ts
  - in `setResourceRequestHandlers` method
    - remove unconditional call to `setCompletionRequestHandler` - supporting resources does not automatically mean that resource template completion is supported
  - in `setPromptRequestHandlers` method
    - remove unconditional call to `setCompletionRequestHandler` - supporting prompts does not automatically mean that prompt argument completion is supported
  - in `_createRegisteredResourceTemplate` method
    - check if the resource template being registered has a complete callback,
    - if so, call `setCompletionRequestHandler`
  - in _`createRegisteredPrompt` method
    - check if any argument of the prompt has a `Completable` schema
    - if so, call `setCompletionRequestHandler`

## Motivation and Context
@evalstate discovered that when registering a prompt or resource template, it was automatically setting a completion request handler and advertising the `completions` capability. However in order to support completions, at least one argument of a prompt must have a `Completable` schema or one argument of a resource template must have a `completeCallback`.

In his case, he was **not** supporting `completions` on his prompts and resources, and was concerned that clients would send unnecessary completion requests because of this automatic advertisement of completions. 

This PR checks each registered prompt and resource template, and only does automatic advertisement and listening for completion requests if completable argument is found.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
* Existing tests that auto advertisement is triggered by prompts and resource templates with completable arguments still pass: 
    - "should advertise support for completion when a resource template with a complete callback is defined"
    - "should advertise support for completion when a prompt with a completable argument is defined"
* New tests that auto advertisement is not triggered by prompts and resource templates with no completable arguments also pass:
    - "should not advertise support for completion when a resource template without a complete callback is defined"
    - "should not advertise support for completion when a prompt without a completable argument is defined"

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
Nope. Existing behavior for auto-advertisement of completions will still allow completable arguments to be completed. If no completable prompt or resource template arguments exist, then the previous behavior of allowing completion requests was a bug and will now be defeated.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
Redo of https://github.com/modelcontextprotocol/typescript-sdk/pull/1024 which was a redo of https://github.com/modelcontextprotocol/typescript-sdk/pull/974. Both languished so long that when I tried to resolve conflicts, the files had changed too much to do it with confidence. So, _once again_ I have made the changes against what's currently on `main`.