### PR TITLE
fix: Update package exports to use src directory for ESM and CommonJS…

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,46 +20,46 @@
     ],
     "exports": {
         ".": {
-            "import": "./dist/esm/index.js",
-            "require": "./dist/cjs/index.js"
+            "import": "./dist/esm/src/index.js",
+            "require": "./dist/cjs/src/index.js"
         },
         "./client": {
-            "import": "./dist/esm/client/index.js",
-            "require": "./dist/cjs/client/index.js"
+            "import": "./dist/esm/src/client/index.js",
+            "require": "./dist/cjs/src/client/index.js"
         },
         "./server": {
-            "import": "./dist/esm/server/index.js",
-            "require": "./dist/cjs/server/index.js"
+            "import": "./dist/esm/src/server/index.js",
+            "require": "./dist/cjs/src/server/index.js"
         },
         "./validation": {
-            "import": "./dist/esm/validation/index.js",
-            "require": "./dist/cjs/validation/index.js"
+            "import": "./dist/esm/src/validation/index.js",
+            "require": "./dist/cjs/src/validation/index.js"
         },
         "./validation/ajv": {
-            "import": "./dist/esm/validation/ajv-provider.js",
-            "require": "./dist/cjs/validation/ajv-provider.js"
+            "import": "./dist/esm/src/validation/ajv-provider.js",
+            "require": "./dist/cjs/src/validation/ajv-provider.js"
         },
         "./validation/cfworker": {
-            "import": "./dist/esm/validation/cfworker-provider.js",
-            "require": "./dist/cjs/validation/cfworker-provider.js"
+            "import": "./dist/esm/src/validation/cfworker-provider.js",
+            "require": "./dist/cjs/src/validation/cfworker-provider.js"
         },
         "./experimental": {
-            "import": "./dist/esm/experimental/index.js",
-            "require": "./dist/cjs/experimental/index.js"
+            "import": "./dist/esm/src/experimental/index.js",
+            "require": "./dist/cjs/src/experimental/index.js"
         },
         "./experimental/tasks": {
-            "import": "./dist/esm/experimental/tasks/index.js",
-            "require": "./dist/cjs/experimental/tasks/index.js"
+            "import": "./dist/esm/src/experimental/tasks/index.js",
+            "require": "./dist/cjs/src/experimental/tasks/index.js"
         },
         "./*": {
-            "import": "./dist/esm/*",
-            "require": "./dist/cjs/*"
+            "import": "./dist/esm/src/*",
+            "require": "./dist/cjs/src/*"
         }
     },
     "typesVersions": {
         "*": {
             "*": [
-                "./dist/esm/*"
+                "./dist/esm/src/*"
             ]
         }
     },


### PR DESCRIPTION
… modules after tests migration

<!-- Provide a brief summary of your changes -->
This PR updates the exports fields in the root package.json to match the new build output structure after the tests migration (#1220).

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Since the build artifacts are now generated under `dist/{cjs,esm}/src` instead of directly under `dist/{cjs,esm}`, the exports paths must be adjusted accordingly. Without this change, all public consumer import paths resolve incorrectly.
## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
