### PR TITLE
Protocol date validation

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -442,12 +442,6 @@ export class Server<
 
         const protocolVersion = SUPPORTED_PROTOCOL_VERSIONS.includes(requestedVersion) ? requestedVersion : LATEST_PROTOCOL_VERSION;
 
-        // Inform the transport of the negotiated protocol version.
-        // This allows the transport to validate subsequent request headers.
-        if (this.transport?.setProtocolVersion) {
-            this.transport.setProtocolVersion(protocolVersion);
-        }
-
         return {
             protocolVersion,
             capabilities: this.getCapabilities(),

--- a/src/server/streamableHttp.ts
+++ b/src/server/streamableHttp.ts
@@ -184,7 +184,6 @@ export class StreamableHTTPServerTransport implements Transport {
     private _allowedOrigins?: string[];
     private _enableDnsRebindingProtection: boolean;
     private _retryInterval?: number;
-    private _protocolVersion?: string;
 
     sessionId?: string;
     onclose?: () => void;
@@ -212,21 +211,6 @@ export class StreamableHTTPServerTransport implements Transport {
             throw new Error('Transport already started');
         }
         this._started = true;
-    }
-
-    /**
-     * Sets the protocol version after negotiation during initialization.
-     * This is called by the Server class after the initialize handshake completes.
-     */
-    setProtocolVersion(version: string): void {
-        this._protocolVersion = version;
-    }
-
-    /**
-     * Gets the negotiated protocol version, if set.
-     */
-    get protocolVersion(): string | undefined {
-        return this._protocolVersion;
     }
 
     /**

--- a/src/shared/transport.ts
+++ b/src/shared/transport.ts
@@ -122,14 +122,7 @@ export interface Transport {
     sessionId?: string;
 
     /**
-     * Sets the protocol version after negotiation during initialization.
-     * This is called by the Server/Client class after the initialize handshake completes.
+     * Sets the protocol version used for the connection (called when the initialize response is received).
      */
     setProtocolVersion?: (version: string) => void;
-
-    /**
-     * Gets the negotiated protocol version, if set.
-     * Available after initialization completes.
-     */
-    protocolVersion?: string;
 }


### PR DESCRIPTION
Cleanup the fallback strategy for protocol validation in the streamable http transport. Alot of people building MCP Servers end up validating this based on a static list in their transport which is not ideal and leads to these errors: https://github.com/modelcontextprotocol/inspector/issues/959.


## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->


## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
Bug fix in agents sdk - https://github.com/cloudflare/agents/pull/720
