### PR TITLE
fix: nullable json-rpc id instead of optional

### DIFF
--- a/src/server/streamableHttp.ts
+++ b/src/server/streamableHttp.ts
@@ -873,7 +873,7 @@ export class StreamableHTTPServerTransport implements Transport {
         let requestId = options?.relatedRequestId;
         if (isJSONRPCResultResponse(message) || isJSONRPCErrorResponse(message)) {
             // If the message is a response, use the request ID from the message
-            requestId = message.id;
+            requestId = message.id ?? undefined;
         }
 
         // Check if this message should be sent on the standalone SSE stream (no request ID)

--- a/src/spec.types.ts
+++ b/src/spec.types.ts
@@ -169,7 +169,7 @@ export interface JSONRPCResultResponse {
  */
 export interface JSONRPCErrorResponse {
   jsonrpc: typeof JSONRPC_VERSION;
-  id?: RequestId;
+  id: RequestId | null;
   error: Error;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -198,7 +198,7 @@ export enum ErrorCode {
 export const JSONRPCErrorResponseSchema = z
     .object({
         jsonrpc: z.literal(JSONRPC_VERSION),
-        id: RequestIdSchema.optional(),
+        id: RequestIdSchema.nullable(),
         error: z.object({
             /**
              * The error type that occurred.


### PR DESCRIPTION
Deny undefined for json-rpc error response id, make it spec compliant.

https://www.jsonrpc.org/specification#response_object
> **id**
> This member is REQUIRED.
> It MUST be the same as the value of the id member in the Request Object.
> If there was an error in detecting the id in the Request object (e.g. Parse error/Invalid Request), it MUST be Null.

Fix for the change in: https://github.com/modelcontextprotocol/typescript-sdk/pull/1242.
Related: https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1939

## How Has This Been Tested?

unit tests, type checking 

## Breaking Changes

undefined won't be allowed as id

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

