### PR TITLE
docs: clarify that JSON response mode doesn't deliver notifications

### DIFF
--- a/src/examples/server/jsonResponseStreamableHttp.ts
+++ b/src/examples/server/jsonResponseStreamableHttp.ts
@@ -1,3 +1,11 @@
+/**
+ * Example: Streamable HTTP server with JSON response mode
+ *
+ * This example demonstrates `enableJsonResponse: true`, which returns JSON responses
+ * instead of SSE streams. This is useful for simple request/response scenarios but
+ * has an important limitation: notifications (logging, progress, etc.) are NOT delivered
+ * to the client. Compare with simpleStreamableHttp.ts which uses SSE and delivers notifications.
+ */
 import { Request, Response } from 'express';
 import { randomUUID } from 'node:crypto';
 import { McpServer } from '../../server/mcp.js';
@@ -41,7 +49,9 @@ const getServer = () => {
         }
     );
 
-    // Register a tool that sends multiple greetings with notifications
+    // Register a tool that sends notifications during execution.
+    // NOTE: These notifications will NOT be delivered to the client in JSON response mode.
+    // This tool is included to demonstrate the difference vs SSE mode (see simpleStreamableHttp.ts).
     server.registerTool(
         'multi-greet',
         {


### PR DESCRIPTION
Clarifies that `enableJsonResponse` mode does not deliver notifications to the client.

## Motivation and Context
Issue #866 reported confusion about notifications being silently dropped in JSON response mode. The example includes a `multi-greet` tool that sends notifications, but without explanation that these won't be delivered.

This was actually intentional (see PR #299: "Returning JSON is more limited in functionality as we are losing streaming tool notification/logging etc."), but the example didn't make this clear.

## How Has This Been Tested?
Documentation-only change.

## Breaking Changes
None.

## Types of changes
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
Fixes #866