### PR TITLE
Support ZodObject schemas in tool method

### DIFF
--- a/packages/server/src/server/mcp.ts
+++ b/packages/server/src/server/mcp.ts
@@ -951,6 +951,13 @@ export class McpServer {
     ): RegisteredTool;
 
     /**
+     * Registers a tool with a ZodObject schema (e.g., z.object({ ... })).
+     * The schema's shape will be extracted and used for validation.
+     * @deprecated Use `registerTool` instead.
+     */
+    tool<Schema extends AnyObjectSchema>(name: string, paramsSchema: Schema, cb: ToolCallback<Schema>): RegisteredTool;
+
+    /**
      * Registers a tool `name` (with a description) taking either parameter schema or annotations.
      * This unified overload handles both `tool(name, description, paramsSchema, cb)` and
      * `tool(name, description, annotations, cb)` cases.
@@ -967,6 +974,13 @@ export class McpServer {
     ): RegisteredTool;
 
     /**
+     * Registers a tool with a description and ZodObject schema (e.g., z.object({ ... })).
+     * The schema's shape will be extracted and used for validation.
+     * @deprecated Use `registerTool` instead.
+     */
+    tool<Schema extends AnyObjectSchema>(name: string, description: string, paramsSchema: Schema, cb: ToolCallback<Schema>): RegisteredTool;
+
+    /**
      * Registers a tool with both parameter schema and annotations.
      * @deprecated Use `registerTool` instead.
      */
@@ -975,6 +989,18 @@ export class McpServer {
         paramsSchema: Args,
         annotations: ToolAnnotations,
         cb: ToolCallback<Args>
+    ): RegisteredTool;
+
+    /**
+     * Registers a tool with a ZodObject schema and annotations.
+     * The schema's shape will be extracted and used for validation.
+     * @deprecated Use `registerTool` instead.
+     */
+    tool<Schema extends AnyObjectSchema>(
+        name: string,
+        paramsSchema: Schema,
+        annotations: ToolAnnotations,
+        cb: ToolCallback<Schema>
     ): RegisteredTool;
 
     /**
@@ -987,6 +1013,19 @@ export class McpServer {
         paramsSchema: Args,
         annotations: ToolAnnotations,
         cb: ToolCallback<Args>
+    ): RegisteredTool;
+
+    /**
+     * Registers a tool with description, ZodObject schema, and annotations.
+     * The schema's shape will be extracted and used for validation.
+     * @deprecated Use `registerTool` instead.
+     */
+    tool<Schema extends AnyObjectSchema>(
+        name: string,
+        description: string,
+        paramsSchema: Schema,
+        annotations: ToolAnnotations,
+        cb: ToolCallback<Schema>
     ): RegisteredTool;
 
     /**
@@ -1025,8 +1064,31 @@ export class McpServer {
                     // Or: tool(name, description, paramsSchema, annotations, cb)
                     annotations = rest.shift() as ToolAnnotations;
                 }
+            } else if (typeof firstArg === 'object' && firstArg !== null && isZodSchemaInstance(firstArg)) {
+                // It's a Zod schema instance (like z.object()), extract its shape if it's an object schema
+                const shape = getObjectShape(firstArg as AnyObjectSchema);
+                if (shape) {
+                    // We found an object schema, use its shape
+                    inputSchema = shape;
+                    rest.shift();
+
+                    // Check if the next arg is potentially annotations
+                    if (
+                        rest.length > 1 &&
+                        typeof rest[0] === 'object' &&
+                        rest[0] !== null &&
+                        !isZodRawShapeCompat(rest[0]) &&
+                        !isZodSchemaInstance(rest[0])
+                    ) {
+                        annotations = rest.shift() as ToolAnnotations;
+                    }
+                } else {
+                    // It's a schema but not an object schema, treat as annotations
+                    // (This maintains backward compatibility for edge cases)
+                    annotations = rest.shift() as ToolAnnotations;
+                }
             } else if (typeof firstArg === 'object' && firstArg !== null) {
-                // Not a ZodRawShapeCompat, so must be annotations in this position
+                // Not a ZodRawShapeCompat or Zod schema, so must be annotations in this position
                 // Case: tool(name, annotations, cb)
                 // Or: tool(name, description, annotations, cb)
                 annotations = rest.shift() as ToolAnnotations;


### PR DESCRIPTION
Fixes #1291

## Motivation and Context

When using the `tool()` method with a ZodObject schema like `z.object({ message: z.string() })`, the SDK was silently treating the schema as annotations instead of a parameter schema.

## How Has This Been Tested?

Added some tests to verify that the `tool()` method handles ZodObject schemas as expected.

## Breaking Changes

No breaking changes. This is a backward-compatible bug fix.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
