### PR TITLE
fix(auth): change default client_secret expiry from 30 days to no expiration

### DIFF
--- a/test/server/auth/handlers/register.test.ts
+++ b/test/server/auth/handlers/register.test.ts
@@ -190,7 +190,7 @@ describe('Client Registration Handler', () => {
         });
 
         it('sets no expiry when clientSecretExpirySeconds=0', async () => {
-            // Create handler with no expiry
+            // Create handler with explicit 0 (no expiry per RFC 7591)
             const customApp = express();
             const options: ClientRegistrationHandlerOptions = {
                 clientsStore: mockClientStoreWithRegistration,
@@ -207,6 +207,27 @@ describe('Client Registration Handler', () => {
 
             expect(response.status).toBe(201);
             expect(response.body.client_secret_expires_at).toBe(0);
+        });
+
+        it('omits client_secret_expires_at when clientSecretExpirySeconds is undefined (default)', async () => {
+            // Create handler with default undefined (no expiry, omit from response)
+            const customApp = express();
+            const options: ClientRegistrationHandlerOptions = {
+                clientsStore: mockClientStoreWithRegistration
+                // clientSecretExpirySeconds not set - defaults to undefined
+            };
+
+            customApp.use('/register', clientRegistrationHandler(options));
+
+            const response = await supertest(customApp)
+                .post('/register')
+                .send({
+                    redirect_uris: ['https://example.com/callback']
+                });
+
+            expect(response.status).toBe(201);
+            expect(response.body.client_secret).toBeDefined();
+            expect(response.body.client_secret_expires_at).toBeUndefined();
         });
 
         it('sets no client_id when clientIdGeneration=false', async () => {


### PR DESCRIPTION
The 30-day default for `clientSecretExpirySeconds` caused production issues where MCP clients fail with "Client secret has expired" after 30 days.

## Motivation and Context

MCP servers using the SDK's default settings issue client secrets that expire in 30 days. Some MCP clients (e.g., ChatGPT certified connectors) don't automatically re-register when secrets expire, causing users to see cryptic "invalid_client: Client secret has expired" errors.

This change aligns TypeScript SDK with Python SDK behavior, which defaults to `None` (no expiration). Per RFC 7591, `client_secret_expires_at` is optional - servers that want expiring secrets can still explicitly set `clientSecretExpirySeconds`.

## How Has This Been Tested?

- All existing tests pass
- Added new test case for default undefined behavior
- Verified in production environment (Fireflies.ai MCP server) where this issue was discovered

## Breaking Changes

None. This is a relaxation of default behavior:
- Existing code explicitly setting `clientSecretExpirySeconds` works unchanged
- New default (no expiry) is more permissive than old default (30 days)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

Behavior after this change:

| `clientSecretExpirySeconds` | `client_secret_expires_at` |
|----------------------------|---------------------------|
| `undefined` (new default)  | omitted (no expiry)       |
| `0`                        | `0` (no expiry per RFC 7591) |
| `> 0`                      | `now + seconds`           |

Related: Python SDK already defaults to `None` in `src/mcp/server/auth/settings.py`