### PR TITLE
ci: trigger workflow on v1.x branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,7 @@
 on:
     push:
         branches:
-            - main
+            - v1.x
     pull_request:
     workflow_dispatch:
     release:


### PR DESCRIPTION
Update CI workflow to trigger on pushes to `v1.x` instead of `main`.

## Motivation and Context

After the v2 monorepo merge to `main`, the `v1.x` branch needs its own CI triggers. Currently, the workflow only triggers on pushes to `main`, which means CI doesn't run when pushing to `v1.x`.

## Changes

- Changed push trigger from `main` to `v1.x` in `.github/workflows/main.yml`

## Types of changes

- [x] Bug fix (CI wasn't triggering for v1.x pushes)

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines