### PR TITLE
fix: #780 onerror and other listener not remove after client close

### DIFF
--- a/.changeset/stdio-cleanup-listeners-on-close.md
+++ b/.changeset/stdio-cleanup-listeners-on-close.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/client': patch
+---
+
+Detach stdio transport stdout/stdin listeners on `close()`. Previously, if the child process wrote to stdout during shutdown (after `close()` was called), the still-attached data listener would attempt to parse it as JSON-RPC and emit a spurious parse error via `onerror`. Fixes #780.

--- a/packages/client/src/client/stdio.ts
+++ b/packages/client/src/client/stdio.ts
@@ -97,6 +97,7 @@ export class StdioClientTransport implements Transport {
     private _stderrStream: PassThrough | null = null;
     private _onServerDataHandler?: (chunk: Buffer) => void;
     private _onServerErrorHandler?: (error: Error) => void;
+    private _onProcessErrorHandler?: (error: Error) => void;
 
     onclose?: () => void;
     onerror?: (error: Error) => void;
@@ -144,10 +145,11 @@ export class StdioClientTransport implements Transport {
             this._process.stdout?.on('error', this._onServerErrorHandler);
             this._process.stdin?.on('error', this._onServerErrorHandler);
 
-            this._process.on('error', error => {
+            this._onProcessErrorHandler = error => {
                 reject(error);
                 this.onerror?.(error);
-            });
+            };
+            this._process.on('error', this._onProcessErrorHandler);
             this._process.once('spawn', () => resolve());
             this._process.once('close', _code => {
                 if (this._process) {
@@ -209,6 +211,9 @@ export class StdioClientTransport implements Transport {
         if (this._onServerErrorHandler) {
             process.stdout?.off('error', this._onServerErrorHandler);
             process.stdin?.off('error', this._onServerErrorHandler);
+        }
+        if (this._onProcessErrorHandler) {
+            process.off('error', this._onProcessErrorHandler);
         }
     }
 

--- a/packages/client/test/client/crossSpawn.test.ts
+++ b/packages/client/test/client/crossSpawn.test.ts
@@ -3,6 +3,7 @@ import type { ChildProcess } from 'node:child_process';
 import type { JSONRPCMessage } from '@modelcontextprotocol/core';
 import spawn from 'cross-spawn';
 import type { Mock, MockedFunction } from 'vitest';
+import { vi } from 'vitest';
 
 import { getDefaultEnvironment, StdioClientTransport } from '../../src/client/stdio.js';
 
@@ -16,8 +17,9 @@ describe('StdioClientTransport using cross-spawn', () => {
         mockSpawn.mockImplementation(() => {
             const mockProcess: {
                 on: Mock;
-                stdin?: { on: Mock; write: Mock };
-                stdout?: { on: Mock };
+                once: Mock;
+                stdin?: { on: Mock; write: Mock; off: Mock };
+                stdout?: { on: Mock; off: Mock };
                 stderr?: null;
             } = {
                 on: vi.fn((event: string, callback: () => void) => {
@@ -26,12 +28,20 @@ describe('StdioClientTransport using cross-spawn', () => {
                     }
                     return mockProcess;
                 }),
+                once: vi.fn((event: string, callback: () => void) => {
+                    if (event === 'spawn') {
+                        callback();
+                    }
+                    return mockProcess;
+                }),
                 stdin: {
                     on: vi.fn(),
-                    write: vi.fn().mockReturnValue(true)
+                    write: vi.fn().mockReturnValue(true),
+                    off: vi.fn()
                 },
                 stdout: {
-                    on: vi.fn()
+                    on: vi.fn(),
+                    off: vi.fn()
                 },
                 stderr: null
             };
@@ -109,13 +119,16 @@ describe('StdioClientTransport using cross-spawn', () => {
         // get the mock process object
         const mockProcess: {
             on: Mock;
+            once: Mock;
             stdin: {
                 on: Mock;
                 write: Mock;
                 once: Mock;
+                off: Mock;
             };
             stdout: {
                 on: Mock;
+                off: Mock;
             };
             stderr: null;
         } = {
@@ -125,13 +138,21 @@ describe('StdioClientTransport using cross-spawn', () => {
                 }
                 return mockProcess;
             }),
+            once: vi.fn((event: string, callback: () => void) => {
+                if (event === 'spawn') {
+                    callback();
+                }
+                return mockProcess;
+            }),
             stdin: {
                 on: vi.fn(),
                 write: vi.fn().mockReturnValue(true),
-                once: vi.fn()
+                once: vi.fn(),
+                off: vi.fn()
             },
             stdout: {
-                on: vi.fn()
+                on: vi.fn(),
+                off: vi.fn()
             },
             stderr: null
         };

--- a/packages/client/test/client/crossSpawn.test.ts
+++ b/packages/client/test/client/crossSpawn.test.ts
@@ -1,4 +1,5 @@
 import type { ChildProcess } from 'node:child_process';
+import { EventEmitter } from 'node:events';
 
 import type { JSONRPCMessage } from '@modelcontextprotocol/core';
 import spawn from 'cross-spawn';
@@ -172,6 +173,42 @@ describe('StdioClientTransport using cross-spawn', () => {
 
         // verify message is sent correctly
         expect(mockProcess.stdin.write).toHaveBeenCalled();
+    });
+
+    // Regression test for #780: listeners must be detached from the child's
+    // stdio streams on close(), not left attached to a process we no longer track.
+    test('should detach stdout/stdin listeners on close', async () => {
+        const stdout = new EventEmitter();
+        const stdin = Object.assign(new EventEmitter(), {
+            write: vi.fn().mockReturnValue(true),
+            end: vi.fn()
+        });
+        const proc = Object.assign(new EventEmitter(), {
+            stdin,
+            stdout,
+            stderr: null,
+            exitCode: null as number | null,
+            kill: vi.fn()
+        });
+        mockSpawn.mockReturnValue(proc as unknown as ChildProcess);
+
+        const transport = new StdioClientTransport({ command: 'test-command' });
+        const started = transport.start();
+        proc.emit('spawn');
+        await started;
+
+        expect(stdout.listenerCount('data')).toBe(1);
+        expect(stdout.listenerCount('error')).toBe(1);
+        expect(stdin.listenerCount('error')).toBe(1);
+
+        const closed = transport.close();
+        proc.exitCode = 0;
+        proc.emit('close');
+        await closed;
+
+        expect(stdout.listenerCount('data')).toBe(0);
+        expect(stdout.listenerCount('error')).toBe(0);
+        expect(stdin.listenerCount('error')).toBe(0);
     });
 
     describe('windowsHide', () => {

--- a/packages/client/test/client/crossSpawn.test.ts
+++ b/packages/client/test/client/crossSpawn.test.ts
@@ -200,6 +200,7 @@ describe('StdioClientTransport using cross-spawn', () => {
         expect(stdout.listenerCount('data')).toBe(1);
         expect(stdout.listenerCount('error')).toBe(1);
         expect(stdin.listenerCount('error')).toBe(1);
+        expect(proc.listenerCount('error')).toBe(1);
 
         const closed = transport.close();
         proc.exitCode = 0;
@@ -209,6 +210,7 @@ describe('StdioClientTransport using cross-spawn', () => {
         expect(stdout.listenerCount('data')).toBe(0);
         expect(stdout.listenerCount('error')).toBe(0);
         expect(stdin.listenerCount('error')).toBe(0);
+        expect(proc.listenerCount('error')).toBe(0);
     });
 
     describe('windowsHide', () => {


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
Added logic to clean up residual listeners after calling transport.close().

This is my third attempt to submit a PR to the repository. I hope anybody can pay some attention to review it, I'd be truly grateful. and also point out any mistakes if there are any.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
see https://github.com/modelcontextprotocol/typescript-sdk/issues/780

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
After making this modification, residual listeners will not be triggered after closing the transport, and only "close" will be printed in the console.

and past all test suits

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No breaking changes

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
