### PR TITLE
fix: prevent ReDoS vulnerability in UriTemplate regex patterns

### DIFF
--- a/.changeset/busy-weeks-hang.md
+++ b/.changeset/busy-weeks-hang.md
@@ -1,0 +1,6 @@
+---
+'@modelcontextprotocol/core': patch
+'@modelcontextprotocol/server': patch
+---
+
+Fix ReDoS vulnerability in UriTemplate regex patterns (CVE-2026-0621)

--- a/packages/core/src/shared/uriTemplate.ts
+++ b/packages/core/src/shared/uriTemplate.ts
@@ -225,7 +225,7 @@ export class UriTemplate {
 
         switch (part.operator) {
             case '':
-                pattern = part.exploded ? '([^/]+(?:,[^/]+)*)' : '([^/,]+)';
+                pattern = part.exploded ? '([^/,]+(?:,[^/,]+)*)' : '([^/,]+)';
                 break;
             case '+':
             case '#':
@@ -235,7 +235,7 @@ export class UriTemplate {
                 pattern = '\\.([^/,]+)';
                 break;
             case '/':
-                pattern = '/' + (part.exploded ? '([^/]+(?:,[^/]+)*)' : '([^/,]+)');
+                pattern = '/' + (part.exploded ? '([^/,]+(?:,[^/,]+)*)' : '([^/,]+)');
                 break;
             default:
                 pattern = '([^/]+)';

--- a/packages/core/test/shared/uriTemplate.test.ts
+++ b/packages/core/test/shared/uriTemplate.test.ts
@@ -284,5 +284,32 @@ describe('UriTemplate', () => {
             vars[longName] = 'value';
             expect(() => template.expand(vars)).not.toThrow();
         });
+
+        it('should not be vulnerable to ReDoS with exploded path patterns', () => {
+            // Test for ReDoS vulnerability (CVE-2026-0621)
+            // See: https://github.com/modelcontextprotocol/typescript-sdk/issues/965
+            const template = new UriTemplate('{/id*}');
+            const maliciousPayload = '/' + ','.repeat(50);
+
+            const startTime = Date.now();
+            template.match(maliciousPayload);
+            const elapsed = Date.now() - startTime;
+
+            // Should complete in under 100ms, not hang for seconds
+            expect(elapsed).toBeLessThan(100);
+        });
+
+        it('should not be vulnerable to ReDoS with exploded simple patterns', () => {
+            // Test for ReDoS vulnerability with simple exploded operator
+            const template = new UriTemplate('{id*}');
+            const maliciousPayload = ','.repeat(50);
+
+            const startTime = Date.now();
+            template.match(maliciousPayload);
+            const elapsed = Date.now() - startTime;
+
+            // Should complete in under 100ms, not hang for seconds
+            expect(elapsed).toBeLessThan(100);
+        });
     });
 });


### PR DESCRIPTION
## Summary

This PR fixes the ReDoS (Regular Expression Denial of Service) vulnerability in the `UriTemplate` class (CVE-2026-0621).

## Problem

The regex patterns for exploded array templates (`{/id*}` and `{id*}`) used `([^/]+(?:,[^/]+)*)` which causes catastrophic backtracking when processing malicious URIs containing many commas.

## Solution

Replace the vulnerable pattern with `([^/,]+(?:,[^/,]+)*)` - explicitly excluding commas from the first character class prevents nested quantifier backtracking.

## Changes

- `packages/core/src/shared/uriTemplate.ts`: Fix regex patterns on lines 228 and 238
- `packages/core/test/shared/uriTemplate.test.ts`: Add regression tests for ReDoS

## Testing

All existing tests pass, plus 2 new tests verify the fix prevents ReDoS:
- `should not be vulnerable to ReDoS with exploded path patterns`
- `should not be vulnerable to ReDoS with exploded simple patterns`

Fixes #965