### PR TITLE
feat: change resetTimeoutOnProgress default to true

### DIFF
--- a/packages/core/src/shared/protocol.ts
+++ b/packages/core/src/shared/protocol.ts
@@ -135,7 +135,7 @@ export type RequestOptions = {
     /**
      * If true, receiving a progress notification will reset the request timeout.
      * This is useful for long-running operations that send periodic progress updates.
-     * Default: false
+     * Default: true
      */
     resetTimeoutOnProgress?: boolean;
 
@@ -1194,7 +1194,7 @@ export abstract class Protocol<SendRequestT extends Request, SendNotificationT e
             const timeout = options?.timeout ?? DEFAULT_REQUEST_TIMEOUT_MSEC;
             const timeoutHandler = () => cancel(McpError.fromError(ErrorCode.RequestTimeout, 'Request timed out', { timeout }));
 
-            this._setupTimeout(messageId, timeout, options?.maxTotalTimeout, timeoutHandler, options?.resetTimeoutOnProgress ?? false);
+            this._setupTimeout(messageId, timeout, options?.maxTotalTimeout, timeoutHandler, options?.resetTimeoutOnProgress ?? true);
 
             // Queue request if related to a task
             const relatedTaskId = relatedTask?.taskId;


### PR DESCRIPTION
## Summary
Changes the default value of `resetTimeoutOnProgress` from `false` to `true`.

## Motivation
Long-running MCP tools (like AI research tools) can take 60+ seconds to complete. Servers can send progress notifications to indicate they're still working, but clients currently ignore these by default and timeout after 60 seconds.

This change makes progress notifications actually useful by default - if a server sends progress updates, the client will reset its timeout automatically.

## Changes
- `packages/core/src/shared/protocol.ts`: Changed default from `false` to `true`
- Updated JSDoc to reflect new default

## Backward Compatibility
Clients that explicitly set `resetTimeoutOnProgress: false` will continue to work as before. This only affects clients that don't specify the option.

## Cross-SDK Consistency
I understand MCP has SDKs in multiple languages. If this change is accepted, should similar changes be made to other SDKs (Python, Java, etc.) for consistency? Happy to submit PRs to other SDKs if the team agrees this should be the default behavior across all implementations.