### PR TITLE
[v2] fix: Update UriTemplate implementation to handle optional/omitted, out-of-order, and encoded query parameters

### DIFF
--- a/packages/core/test/shared/uriTemplate.test.ts
+++ b/packages/core/test/shared/uriTemplate.test.ts
@@ -191,10 +191,59 @@ describe('UriTemplate', () => {
             expect(template.variableNames).toEqual(['q', 'page']);
         });
 
+        it('should handle partial query parameter matches correctly', () => {
+            const template = new UriTemplate('/search{?q,page}');
+            const match = template.match('/search?q=test');
+            expect(match).toEqual({ q: 'test', page: '' });
+            expect(template.variableNames).toEqual(['q', 'page']);
+        });
+
+        it('should match multiple query parameters if provided in a different order', () => {
+            const template = new UriTemplate('/search{?q,page}');
+            const match = template.match('/search?page=1&q=test');
+            expect(match).toEqual({ q: 'test', page: '1' });
+            expect(template.variableNames).toEqual(['q', 'page']);
+        });
+
+        it('should still match if additional query parameters are provided', () => {
+            const template = new UriTemplate('/search{?q,page}');
+            const match = template.match('/search?q=test&page=1&sort=desc');
+            expect(match).toEqual({ q: 'test', page: '1' });
+            expect(template.variableNames).toEqual(['q', 'page']);
+        });
+
+        it('should match omitted query parameters', () => {
+            const template = new UriTemplate('/search{?q,page}');
+            const match = template.match('/search');
+            expect(match).toEqual({ q: '', page: '' });
+            expect(template.variableNames).toEqual(['q', 'page']);
+        });
+
+        it('should match nested path segments with query parameters', () => {
+            const template = new UriTemplate('/api/{version}/{resource}{?apiKey,q,p,sort}');
+            const match = template.match('/api/v1/users?apiKey=testkey&q=user');
+            expect(match).toEqual({
+                version: 'v1',
+                resource: 'users',
+                apiKey: 'testkey',
+                q: 'user',
+                p: '',
+                sort: ''
+            });
+            expect(template.variableNames).toEqual(['version', 'resource', 'apiKey', 'q', 'p', 'sort']);
+        });
+
         it('should handle partial matches correctly', () => {
             const template = new UriTemplate('/users/{id}');
             expect(template.match('/users/123/extra')).toBeNull();
             expect(template.match('/users')).toBeNull();
+        });
+
+        it('should handle encoded query parameters', () => {
+            const template = new UriTemplate('/search{?q}');
+            const match = template.match('/search?q=hello%20world');
+            expect(match).toEqual({ q: 'hello world' });
+            expect(template.variableNames).toEqual(['q']);
         });
     });
 


### PR DESCRIPTION
This PR addresses several limitations of the current `UriTemplate#match` implementation:

- template matching fails when optional query parameters are not provided
- template matching fails when query parameters are provided out of order from the sequence specified in the template
- template matching does not decode uri-encoded query parameters

Omitted query parameters are parsed as an empty string per guidance of [RFC 6570 Section 2.3](https://www.rfc-editor.org/rfc/rfc6570.html#section-2.3).

## Motivation and Context
Fixes https://github.com/modelcontextprotocol/typescript-sdk/issues/1079
Fixes https://github.com/modelcontextprotocol/typescript-sdk/issues/149

## How Has This Been Tested?
New test additions cover all of the cases mentioned in https://github.com/modelcontextprotocol/typescript-sdk/issues/1079 and https://github.com/modelcontextprotocol/typescript-sdk/issues/149 as well as a few additional potential edge cases I could come up with.

## Breaking Changes
n/a

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
