### PR TITLE
fix(server): handle undefined arguments for tools with all optional params

### DIFF
--- a/test/integration/test/issues/test400.optional-tool-params.test.ts
+++ b/test/integration/test/issues/test400.optional-tool-params.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Regression test for https://github.com/modelcontextprotocol/typescript-sdk/issues/400
+ *
+ * When a tool has all optional parameters, some LLM models call the tool without
+ * providing an `arguments` field. This test verifies that undefined arguments are
+ * handled correctly by defaulting to an empty object.
+ */
+
+import { Client } from '@modelcontextprotocol/client';
+import { CallToolResultSchema, InMemoryTransport } from '@modelcontextprotocol/core';
+import { McpServer } from '@modelcontextprotocol/server';
+import type { ZodMatrixEntry } from '@modelcontextprotocol/test-helpers';
+import { zodTestMatrix } from '@modelcontextprotocol/test-helpers';
+
+describe.each(zodTestMatrix)('Issue #400: $zodVersionLabel', (entry: ZodMatrixEntry) => {
+    const { z } = entry;
+
+    test('should accept undefined arguments when all tool params are optional', async () => {
+        const mcpServer = new McpServer({
+            name: 'test server',
+            version: '1.0'
+        });
+        const client = new Client({
+            name: 'test client',
+            version: '1.0'
+        });
+
+        mcpServer.registerTool(
+            'optional-params-tool',
+            {
+                inputSchema: {
+                    limit: z.number().optional(),
+                    offset: z.number().optional()
+                }
+            },
+            async ({ limit, offset }) => ({
+                content: [
+                    {
+                        type: 'text',
+                        text: `limit: ${limit ?? 'default'}, offset: ${offset ?? 'default'}`
+                    }
+                ]
+            })
+        );
+
+        const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+        await Promise.all([client.connect(clientTransport), mcpServer.server.connect(serverTransport)]);
+
+        // Call tool without arguments (arguments is undefined)
+        const result = await client.request(
+            {
+                method: 'tools/call',
+                params: {
+                    name: 'optional-params-tool'
+                    // arguments is intentionally omitted (undefined)
+                }
+            },
+            CallToolResultSchema
+        );
+
+        expect(result.isError).toBeUndefined();
+        expect(result.content).toEqual([
+            {
+                type: 'text',
+                text: 'limit: default, offset: default'
+            }
+        ]);
+    });
+});

--- a/test/integration/test/server/mcp.test.ts
+++ b/test/integration/test/server/mcp.test.ts
@@ -982,63 +982,6 @@ describe.each(zodTestMatrix)('$zodVersionLabel', (entry: ZodMatrixEntry) => {
         });
 
         /***
-         * Test: Tool with all optional parameters called without arguments (Issue #400)
-         * @see https://github.com/modelcontextprotocol/typescript-sdk/issues/400
-         */
-        test('should accept undefined arguments when all tool params are optional', async () => {
-            const mcpServer = new McpServer({
-                name: 'test server',
-                version: '1.0'
-            });
-            const client = new Client({
-                name: 'test client',
-                version: '1.0'
-            });
-
-            mcpServer.registerTool(
-                'optional-params-tool',
-                {
-                    inputSchema: {
-                        limit: z.number().optional(),
-                        offset: z.number().optional()
-                    }
-                },
-                async ({ limit, offset }) => ({
-                    content: [
-                        {
-                            type: 'text',
-                            text: `limit: ${limit ?? 'default'}, offset: ${offset ?? 'default'}`
-                        }
-                    ]
-                })
-            );
-
-            const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
-
-            await Promise.all([client.connect(clientTransport), mcpServer.server.connect(serverTransport)]);
-
-            // Call tool without arguments (arguments is undefined)
-            const result = await client.request(
-                {
-                    method: 'tools/call',
-                    params: {
-                        name: 'optional-params-tool'
-                        // arguments is intentionally omitted (undefined)
-                    }
-                },
-                CallToolResultSchema
-            );
-
-            expect(result.isError).toBeUndefined();
-            expect(result.content).toEqual([
-                {
-                    type: 'text',
-                    text: 'limit: default, offset: default'
-                }
-            ]);
-        });
-
-        /***
          * Test: Preventing Duplicate Tool Registration
          */
         test('should prevent duplicate tool registration', () => {


### PR DESCRIPTION


Fixes #400                                                                                      
                                                                                                  
  ## Motivation and Context                                                                       
                                                                                                  
  When a tool has all optional parameters, some LLM models call the tool without providing an     
  `arguments` field. This causes Zod validation to fail with:                                     
                                                                                                  
  MCP error -32602: Invalid arguments for tool [name]: Invalid input: expected object, received   
  undefined                                                                                       
                                                                                                  
  Even though the schema allows all fields to be optional, Zod's `z.object()` expects the input   
  itself to be an object, not `undefined` or `null`.                                              
                                                                                                  
  ## How Has This Been Tested?                                                                    
                                                                                                  
  - Added unit test: `should accept undefined arguments when all tool params are optional`        
  - Verified Zod behavior with direct testing:                                                    
    - `undefined` → fails with "expected object, received undefined"                              
    - `null` → fails with "expected object, received null"                                        
    - `{}` → passes validation                                                                    
  - All existing tests pass (1,392 tests)                                                         
                                                                                                  
  ## Breaking Changes                                                                             
                                                                                                  
  None. This is a backward-compatible fix that only affects edge cases where `arguments` is       
  omitted.                                                                                        
                                                                                                  
  ## Types of changes                                                                             
                                                                                                  
  - [x] Bug fix (non-breaking change which fixes an issue)                                        
  - [ ] New feature (non-breaking change which adds functionality)                                
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)        
  - [ ] Documentation update                                                                      
                                                                                                  
  ## Checklist                                                                                    
                                                                                                  
  - [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)                      
  - [x] My code follows the repository's style guidelines                                         
  - [x] New and existing tests pass locally                                                       
  - [x] I have added appropriate error handling                                                   
  - [ ] I have added or updated documentation as needed                                           
                                                                                                  
  ## Additional context                                                                           
                                                                                                  
  The fix is a single line change in `packages/server/src/server/mcp.ts`:                         
                                                                                                  
  ```typescript                                                                                   
  // Before                                                                                       
  const parseResult = await safeParseAsync(schemaToParse, args);                                  
                                                                                                  
  // After                                                                                        
  const parseResult = await safeParseAsync(schemaToParse, args ?? {});                            
                                                                                                  
  Using ?? handles both undefined and null cases.                                                 
  ```       