### PR TITLE
fix(client): skip output schema validation on error results

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -757,7 +757,7 @@ export class Client<
             }
 
             // Only validate structured content if present (not when there's an error)
-            if (result.structuredContent) {
+            if (result.structuredContent && !result.isError) {
                 try {
                     // Validate the structured content against the schema
                     const validationResult = validator(result.structuredContent);

--- a/src/experimental/tasks/client.ts
+++ b/src/experimental/tasks/client.ts
@@ -122,7 +122,7 @@ export class ExperimentalClientTasks<
                 }
 
                 // Only validate structured content if present (not when there's an error)
-                if (result.structuredContent) {
+                if (result.structuredContent && !result.isError) {
                     try {
                         // Validate the structured content against the schema
                         const validationResult = validator(result.structuredContent);


### PR DESCRIPTION
## Motivation and Context

The MCP Inspector client failed tool calls that returned `isError: true` alongside `structuredContent`, because the SDK still validated the output schema even on error results.

## How Has This Been Tested?

new tests and manual

## Breaking Changes

None.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context

Verified with MCP inspector against IntelliJ

Found the port of IntelliJ with MCP server enabled (Note: HTTP Streamable isn't default yet, so this is SSE)
```bash
$ grep -i mcp $HOME/Library/Application\ Support/JetBrains/*/options/mcpServer.xml
/Users/codefromthecrypt/Library/Application Support/JetBrains/IntelliJIdea2025.3/options/mcpServer.xml:  <component name="McpServerSettings">
/Users/codefromthecrypt/Library/Application Support/JetBrains/IntelliJIdea2025.3/options/mcpServer.xml:    <option name="enableMcpServer" value="true" />
/Users/codefromthecrypt/Library/Application Support/JetBrains/IntelliJIdea2025.3/options/mcpServer.xml:    <option name="mcpServerPort" value="64344" />
```

### MCP inspector against IntelliJ before this fix

Tried the CLI 
```bash
$ npx @modelcontextprotocol/inspector \
    http://127.0.0.1:64344/sse \
    --cli \
    --method tools/call \
    --tool-name get_repositories
Failed to call tool get_repositories: MCP error -32602: Structured content does not match the tool's output schema: data must have required property 'roots'

Failed with exit code: 1
```

Tried the UI
```bash
$ MCP_SERVER_URL=http://127.0.0.1:64344/sse npm start
Starting MCP inspector...
⚙️ Proxy server listening on localhost:6277
🔑 Session token: c4aa2d10d863a6672d4bc85eae9f5f372041ac8b1d268e016af9c16a04391933
   Use this token to authenticate requests or set DANGEROUSLY_OMIT_AUTH=true to disable auth

🚀 MCP Inspector is up and running at:
   http://localhost:6274/?MCP_PROXY_AUTH_TOKEN=c4aa2d10d863a6672d4bc85eae9f5f372041ac8b1d268e016af9c16a04391933

🌐 Opening browser...
``` 

<img width="1707" height="821" alt="Screenshot 2026-02-02 at 4 32 46 PM" src="https://github.com/user-attachments/assets/5562dc09-2ec0-4610-9a26-6f939890e439" />

### MCP inspector against IntelliJ after this fix

Installation

Patching all inspector package.json like so:
```diff
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.25.2",
+    "@modelcontextprotocol/sdk": "file:../../typescript-sdk",
```

Applied like this:
```bash
npm run clean
npm run build
```

Tried the CLI and it works as you can see the user error missing the projectPath, which is friendly due to showing valid choices:
```bash
$ node ~/oss/inspector/cli/build/cli.js \
    http://127.0.0.1:64344/sse \
    --cli \
    --method tools/call \
    --tool-name get_repositories
{
  "content": [
    {
      "type": "text",
      "text": "No exact project is specified while multiple projects are opened.\n You may specify the project path via `projectPath` parameter when calling a tool. \n If you're aware of the current working directory you may pass it as `projectPath`. \n In the case when it's unobvious which project to use you have to ASK the USER about a project providing him a numbered list of the projects.\n Currently open projects: {\"projects\":[{\"path\":\"/Users/codefromthecrypt/oss/intellij-community/plugins/mcp-server\"},{\"path\":\"/Users/codefromthecrypt/oss/koog\"}]}"
    }
  ],
  "structuredContent": {
    "projects": [
      {
        "path": "/Users/codefromthecrypt/oss/intellij-community/plugins/mcp-server"
      },
      {
        "path": "/Users/codefromthecrypt/oss/koog"
      }
    ]
  },
  "isError": true
}
```

Tried the UI and it shows valid error choices (relies on an inspector bug to fully correct the UI)

<img width="1703" height="777" alt="Screenshot 2026-02-02 at 5 00 18 PM" src="https://github.com/user-attachments/assets/12b5de13-4eee-4c47-875a-c8d52b19f1aa" />


```bash
$ MCP_SERVER_URL=http://127.0.0.1:64344/sse npm start

> @modelcontextprotocol/inspector@0.19.0 start
> node client/bin/start.js

Starting MCP inspector...
⚙️ Proxy server listening on localhost:6277
🔑 Session token: f06b424e9e240977d39e44a7444a25099d90b1fd7f432b9428ab86df58e03087
   Use this token to authenticate requests or set DANGEROUSLY_OMIT_AUTH=true to disable auth

🚀 MCP Inspector is up and running at:
   http://localhost:6274/?MCP_PROXY_AUTH_TOKEN=f06b424e9e240977d39e44a7444a25099d90b1fd7f432b9428ab86df58e03087

🌐 Opening browser...
``` 

### MCP inspector follow-up

Inspector has a bug here which will be fixed once this PR is merged and released as a part of https://github.com/modelcontextprotocol/inspector/pull/1045

<img width="1727" height="685" alt="errors" src="https://github.com/user-attachments/assets/00fc6ae4-743a-4df6-b356-3c09f686666b" />

```diff
--- a/client/src/components/ToolResults.tsx
+++ b/client/src/components/ToolResults.tsx
@@ -115,7 +115,7 @@ const ToolResults = ({
           error:
             "Tool has an output schema but did not return structured content",
         };
-      } else if (structuredResult.structuredContent) {
+      } else if (structuredResult.structuredContent && !isError) {
         validationResult = validateToolOutput(
           selectedTool.name,
           structuredResult.structuredContent,
```