### PR TITLE
feat(express): add jsonLimit option to createMcpExpressApp

### DIFF
--- a/.changeset/feat-express-json-limit.md
+++ b/.changeset/feat-express-json-limit.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/express': patch
+---
+
+Add `jsonLimit` option to `createMcpExpressApp()` to allow overriding the default JSON body parser limit of 100kb. Accepts a string (e.g., '5mb') or number (bytes).

--- a/packages/middleware/express/src/express.ts
+++ b/packages/middleware/express/src/express.ts
@@ -22,6 +22,13 @@ export interface CreateMcpExpressAppOptions {
      * to restrict which hostnames are allowed.
      */
     allowedHosts?: string[];
+
+    /**
+     * Maximum request body size for the JSON body parser.
+     * Accepts a number (bytes) or a string with units (e.g., '1mb', '100kb').
+     * Defaults to Express's default of '100kb'.
+     */
+    jsonLimit?: string | number;
 }
 
 /**
@@ -48,10 +55,10 @@ export interface CreateMcpExpressAppOptions {
  * ```
  */
 export function createMcpExpressApp(options: CreateMcpExpressAppOptions = {}): Express {
-    const { host = '127.0.0.1', allowedHosts } = options;
+    const { host = '127.0.0.1', allowedHosts, jsonLimit } = options;
 
     const app = express();
-    app.use(express.json());
+    app.use(express.json(jsonLimit === undefined ? {} : { limit: jsonLimit }));
 
     // If allowedHosts is explicitly provided, use that for validation
     if (allowedHosts) {

--- a/packages/middleware/express/test/express.test.ts
+++ b/packages/middleware/express/test/express.test.ts
@@ -178,5 +178,15 @@ describe('@modelcontextprotocol/express', () => {
 
             warn.mockRestore();
         });
+
+        test('should accept jsonLimit option', () => {
+            const app = createMcpExpressApp({ jsonLimit: '5mb' });
+            expect(app).toBeDefined();
+        });
+
+        test('should accept numeric jsonLimit option', () => {
+            const app = createMcpExpressApp({ jsonLimit: 1024 * 1024 });
+            expect(app).toBeDefined();
+        });
     });
 });


### PR DESCRIPTION
## Summary

Fixes #1354 - Adds `jsonLimit` option to `createMcpExpressApp()` to override the default JSON body parser limit.

## Changes

### `packages/middleware/express/src/express.ts`
- Added `jsonLimit` option to `CreateMcpExpressAppOptions` interface
- Pass limit to `express.json()` middleware when provided

### `packages/middleware/express/test/express.test.ts`
- Added 2 test cases for string and numeric limit values

## Usage

```typescript
// String format
const app = createMcpExpressApp({ jsonLimit: '5mb' });

// Numeric format (bytes)
const app = createMcpExpressApp({ jsonLimit: 1024 * 1024 }); // 1MB
```

## Testing

```bash
pnpm --filter @modelcontextprotocol/express test  # 17 tests pass
pnpm --filter @modelcontextprotocol/express lint  # passes
```

Based on the patch provided in the issue.