### PR TITLE
fix(core): support Zod toJSONSchema output in elicitInput requestedSchema

### DIFF
--- a/.changeset/fix-zod-tojsonschema-type.md
+++ b/.changeset/fix-zod-tojsonschema-type.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/core': patch
+---
+
+Add support for `$schema` and `additionalProperties` fields in `requestedSchema` for elicitation forms. This allows using Zod's `.toJSONSchema()` output directly with `elicitInput()` without TypeScript errors.

--- a/packages/core/src/types/spec.types.ts
+++ b/packages/core/src/types/spec.types.ts
@@ -2158,6 +2158,7 @@ export interface ElicitRequestFormParams extends TaskAugmentedRequestParams {
             [key: string]: PrimitiveSchemaDefinition;
         };
         required?: string[];
+        additionalProperties?: boolean;
     };
 }
 

--- a/packages/core/src/types/types.ts
+++ b/packages/core/src/types/types.ts
@@ -1997,9 +1997,11 @@ export const ElicitRequestFormParamsSchema = TaskAugmentedRequestParamsSchema.ex
      * Only top-level properties are allowed, without nesting.
      */
     requestedSchema: z.object({
+        $schema: z.string().optional(),
         type: z.literal('object'),
         properties: z.record(z.string(), PrimitiveSchemaDefinitionSchema),
-        required: z.array(z.string()).optional()
+        required: z.array(z.string()).optional(),
+        additionalProperties: z.boolean().optional()
     })
 });
 

--- a/packages/core/test/types.test.ts
+++ b/packages/core/test/types.test.ts
@@ -6,6 +6,7 @@ import {
     CreateMessageRequestSchema,
     CreateMessageResultSchema,
     CreateMessageResultWithToolsSchema,
+    ElicitRequestFormParamsSchema,
     LATEST_PROTOCOL_VERSION,
     PromptMessageSchema,
     ResourceLinkSchema,
@@ -981,6 +982,53 @@ describe('Types', () => {
                 expect(result.data.sampling?.context).toBeDefined();
                 expect(result.data.sampling?.tools).toBeDefined();
             }
+        });
+    });
+
+    describe('ElicitRequestFormParams', () => {
+        test('should accept requestedSchema with $schema and additionalProperties from Zod toJSONSchema output', () => {
+            const formParams = {
+                mode: 'form',
+                message: 'Please provide information',
+                requestedSchema: {
+                    $schema: 'https://json-schema.org/draft/2020-12/schema',
+                    type: 'object',
+                    properties: {
+                        name: {
+                            type: 'string',
+                            description: 'Your name'
+                        },
+                        age: {
+                            type: 'number',
+                            description: 'Your age'
+                        }
+                    },
+                    required: ['name'],
+                    additionalProperties: false
+                }
+            };
+
+            const result = ElicitRequestFormParamsSchema.safeParse(formParams);
+            expect(result.success).toBe(true);
+        });
+
+        test('should accept requestedSchema without optional $schema and additionalProperties', () => {
+            const formParams = {
+                mode: 'form',
+                message: 'Please provide information',
+                requestedSchema: {
+                    type: 'object',
+                    properties: {
+                        name: {
+                            type: 'string',
+                            description: 'Your name'
+                        }
+                    }
+                }
+            };
+
+            const result = ElicitRequestFormParamsSchema.safeParse(formParams);
+            expect(result.success).toBe(true);
         });
     });
 });


### PR DESCRIPTION
## Summary

Fixes #1362 - Zod's `.toJSONSchema()` output type is now compatible with `elicitInput()`'s `requestedSchema` parameter.

## Problem

When using Zod v4's `.toJSONSchema()` method to generate schema for `elicitInput()`, TypeScript threw errors because the output includes extra fields (`$schema`, `additionalProperties`) not in the type definition:

```typescript
// ❌ Before: TypeScript error
const result = await server.elicitInput({
  mode: 'form',
  message: 'Enter details',
  requestedSchema: z.object({
    name: z.string()
  }).toJSONSchema()  // Error: excess properties
});
```

## Solution

Added optional fields to `requestedSchema` type in both:
- `ElicitRequestFormParamsSchema` (Zod schema in `types.ts`)
- `ElicitRequestFormParams` (TypeScript interface in `spec.types.ts`)

### Fields Added

| Field | Type | Purpose |
|-------|------|---------|
| `$schema` | `string?` | JSON Schema version URI (draft-2020-12) |
| `additionalProperties` | `boolean?` | Zod sets this to `false` by default |

## Changes

### `packages/core/src/types/types.ts`
```diff
requestedSchema: z.object({
+   $schema: z.string().optional(),
    type: z.literal('object'),
    properties: z.record(z.string(), PrimitiveSchemaDefinitionSchema),
-   required: z.array(z.string()).optional()
+   required: z.array(z.string()).optional(),
+   additionalProperties: z.boolean().optional()
})
```

### `packages/core/src/types/spec.types.ts`
```diff
requestedSchema: {
    $schema?: string;
    type: 'object';
    properties: { ... };
    required?: string[];
+   additionalProperties?: boolean;
};
```

### `packages/core/test/types.test.ts`
- Added 2 test cases validating Zod-style schemas with and without optional fields

## Testing

```bash
pnpm --filter @modelcontextprotocol/core test  # 432 tests pass
pnpm --filter @modelcontextprotocol/core lint  # passes
```

## Backwards Compatibility

✅ All new fields are optional - existing code continues to work unchanged.