### PR TITLE
fix: prevent task-augmented tool errors from being masked

### DIFF
--- a/.changeset/task-error-masking.md
+++ b/.changeset/task-error-masking.md
@@ -1,0 +1,11 @@
+---
+"@modelcontextprotocol/server": patch
+---
+
+fix: prevent task-augmented tool errors from being masked
+
+Re-throw McpErrors for task-augmented requests instead of wrapping them
+in createToolError(). This prevents protocol errors from being masked
+by "Invalid task creation result" errors during CreateTaskResultSchema validation.
+
+Fixes #1385

--- a/packages/server/src/server/mcp.ts
+++ b/packages/server/src/server/mcp.ts
@@ -224,8 +224,13 @@ export class McpServer {
                 await this.validateToolOutput(tool, result, request.params.name);
                 return result;
             } catch (error) {
+                // For task-augmented requests, re-throw McpErrors to avoid masking
+                // them with "Invalid task creation result" errors in server.ts
+                if (request.params.task && error instanceof McpError) {
+                    throw error;
+                }
                 if (error instanceof McpError && error.code === ErrorCode.UrlElicitationRequired) {
-                    throw error; // Return the error to the caller without wrapping in CallToolResult
+                    throw error;
                 }
                 return this.createToolError(error instanceof Error ? error.message : String(error));
             }


### PR DESCRIPTION
## Summary

Fixes #1385

When a task-augmented `tools/call` request fails validation, the error was being masked by "Invalid task creation result" instead of showing the actual error message.

### The Problem

1. Task-augmented request fails (e.g., `InvalidParams`)
2. Error is caught in `mcp.ts` and wrapped via `createToolError()` → returns `{ isError: true }`
3. In `server.ts`, result is validated against `CreateTaskResultSchema`
4. Validation fails because `{ isError: true }` doesn't have a `task` property
5. User sees: "Invalid task creation result: ..." instead of the actual validation error

### The Fix

Re-throw **all** `McpError` types for task-augmented requests instead of wrapping them in `createToolError()`. This allows protocol-level errors to propagate correctly rather than being masked by task result validation.

```typescript
} catch (error) {
    // For task-augmented requests, re-throw McpErrors to avoid masking
    // them with "Invalid task creation result" errors in server.ts
    if (request.params.task && error instanceof McpError) {
        throw error;
    }
    if (error instanceof McpError && error.code === ErrorCode.UrlElicitationRequired) {
        throw error;
    }
    return this.createToolError(error instanceof Error ? error.message : String(error));
}
```

### Rationale

This follows established RPC patterns (JSON-RPC, gRPC, tRPC) where validation errors are protocol-level errors, not application results. The MCP spec also distinguishes between:
- **Tool execution errors** → `isError: true` (so LLM can see and self-correct)
- **Protocol/exceptional errors** → Protocol-level error response

Task result validation failures fall into the "exceptional conditions" category and should propagate as protocol errors.

### Testing

- Typecheck passes
- Existing task lifecycle integration tests pass
- Pre-existing test failure in `authExtensions.test.ts` is unrelated (exists on `main`)