### PR TITLE
fix: throw error when connecting to already-connected Protocol

### DIFF
--- a/.changeset/connect-already-connected.md
+++ b/.changeset/connect-already-connected.md
@@ -1,0 +1,11 @@
+---
+"@modelcontextprotocol/core": patch
+---
+
+fix: throw error when connecting to already-connected Protocol
+
+Protocol.connect() now throws a descriptive error if called when already
+connected to a transport. This prevents silent overwrites that break
+concurrent HTTP sessions.
+
+Fixes #1405

--- a/packages/core/src/shared/protocol.ts
+++ b/packages/core/src/shared/protocol.ts
@@ -609,6 +609,14 @@ export abstract class Protocol<SendRequestT extends Request, SendNotificationT e
      * The Protocol object assumes ownership of the Transport, replacing any callbacks that have already been set, and expects that it is the only user of the Transport instance going forward.
      */
     async connect(transport: Transport): Promise<void> {
+        if (this._transport) {
+            throw new Error(
+                'Protocol is already connected to a transport. ' +
+                    'Call close() before connecting to a new transport, ' +
+                    'or create a new Protocol instance for concurrent connections.'
+            );
+        }
+
         this._transport = transport;
         const _onclose = this.transport?.onclose;
         this._transport.onclose = () => {


### PR DESCRIPTION
## Summary

Fixes #1405

`Protocol.connect()` now throws a descriptive error if called when already connected to a transport. This prevents silent overwrites that break concurrent HTTP sessions.

## Problem

When calling `connect()` twice on the same Protocol instance, the second call would silently overwrite `_transport`, causing existing sessions to receive `AbortError` as responses get routed to the wrong transport.

## Solution

Add a guard at the start of `connect()` that throws an informative error if `_transport` is already set. The error message suggests both options:
1. Call `close()` before reconnecting
2. Create a new Protocol instance for concurrent connections

This follows the "fail fast" principle used by similar libraries (gRPC, Socket.io, tRPC).

## Changes

- `packages/core/src/shared/protocol.ts`: Add connected check with descriptive error
- `packages/core/test/shared/protocolTransportHandling.test.ts`: Update tests

## Testing

- Added test: throws error on double connect
- Added test: reconnection works after close()
- Updated existing tests: use separate Protocol instances (the correct pattern)