### PR TITLE
fix: tighten request/notification handler types for Client and Server

### DIFF
--- a/packages/core/src/types/types.ts
+++ b/packages/core/src/types/types.ts
@@ -2610,10 +2610,24 @@ export type ServerResult = Infer<typeof ServerResultSchema>;
 type MethodToTypeMap<U> = {
     [T in U as T extends { method: infer M extends string } ? M : never]: T;
 };
+
+// Combined types (for Protocol base class)
 export type RequestMethod = ClientRequest['method'] | ServerRequest['method'];
 export type NotificationMethod = ClientNotification['method'] | ServerNotification['method'];
 export type RequestTypeMap = MethodToTypeMap<ClientRequest | ServerRequest>;
 export type NotificationTypeMap = MethodToTypeMap<ClientNotification | ServerNotification>;
+
+// Separate types for Client (receives ServerRequest/ServerNotification)
+export type ClientReceivableRequestMethod = ServerRequest['method'];
+export type ClientReceivableNotificationMethod = ServerNotification['method'];
+export type ClientReceivableRequestTypeMap = MethodToTypeMap<ServerRequest>;
+export type ClientReceivableNotificationTypeMap = MethodToTypeMap<ServerNotification>;
+
+// Separate types for Server (receives ClientRequest/ClientNotification)
+export type ServerReceivableRequestMethod = ClientRequest['method'];
+export type ServerReceivableNotificationMethod = ClientNotification['method'];
+export type ServerReceivableRequestTypeMap = MethodToTypeMap<ClientRequest>;
+export type ServerReceivableNotificationTypeMap = MethodToTypeMap<ClientNotification>;
 
 /* Runtime schema lookup */
 type RequestSchemaType = (typeof ClientRequestSchema.options)[number] | (typeof ServerRequestSchema.options)[number];

--- a/packages/server/src/server/server.ts
+++ b/packages/server/src/server/server.ts
@@ -21,13 +21,15 @@ import type {
     ProtocolOptions,
     Request,
     RequestHandlerExtra,
-    RequestMethod,
     RequestOptions,
-    RequestTypeMap,
     ResourceUpdatedNotification,
     Result,
     ServerCapabilities,
     ServerNotification,
+    ServerReceivableNotificationMethod,
+    ServerReceivableNotificationTypeMap,
+    ServerReceivableRequestMethod,
+    ServerReceivableRequestTypeMap,
     ServerRequest,
     ServerResult,
     ToolResultContent,
@@ -130,7 +132,15 @@ export class Server<
     RequestT extends Request = Request,
     NotificationT extends Notification = Notification,
     ResultT extends Result = Result
-> extends Protocol<ServerRequest | RequestT, ServerNotification | NotificationT, ServerResult | ResultT> {
+> extends Protocol<
+    ServerRequest | RequestT,
+    ServerNotification | NotificationT,
+    ServerResult | ResultT,
+    ServerReceivableRequestMethod,
+    ServerReceivableNotificationMethod,
+    ServerReceivableRequestTypeMap,
+    ServerReceivableNotificationTypeMap
+> {
     private _clientCapabilities?: ClientCapabilities;
     private _clientVersion?: Implementation;
     private _capabilities: ServerCapabilities;
@@ -213,18 +223,19 @@ export class Server<
     }
 
     /**
-     * Override request handler registration to enforce server-side validation for tools/call.
+     * Registers a handler for requests that the server receives from clients.
+     * Only accepts client-to-server request methods (tools/call, prompts/get, resources/read, etc.).
      */
-    public override setRequestHandler<M extends RequestMethod>(
+    public override setRequestHandler<M extends ServerReceivableRequestMethod>(
         method: M,
         handler: (
-            request: RequestTypeMap[M],
+            request: ServerReceivableRequestTypeMap[M],
             extra: RequestHandlerExtra<ServerRequest | RequestT, ServerNotification | NotificationT>
         ) => ServerResult | ResultT | Promise<ServerResult | ResultT>
     ): void {
         if (method === 'tools/call') {
             const wrappedHandler = async (
-                request: RequestTypeMap[M],
+                request: ServerReceivableRequestTypeMap[M],
                 extra: RequestHandlerExtra<ServerRequest | RequestT, ServerNotification | NotificationT>
             ): Promise<ServerResult | ResultT> => {
                 const validatedRequest = safeParse(CallToolRequestSchema, request);


### PR DESCRIPTION
## Summary
- Tighten `setRequestHandler` and `setNotificationHandler` types so Client and Server only accept methods they can actually receive
- Client can only register handlers for server-to-client methods (like `sampling/createMessage`, `elicitation/create`)
- Server can only register handlers for client-to-server methods (like `tools/call`, `prompts/get`)

## Motivation
Previously, both Client and Server accepted any `RequestMethod`, which meant you could accidentally register a handler for the wrong method type. For example, you could call `client.setRequestHandler('tools/call', ...)` even though `tools/call` is a request that goes FROM client TO server (not something the client receives).

This change provides:
- Compile-time prevention of registering handlers for wrong method types
- Better IDE autocompletion showing only valid methods
- Alignment with the Python SDK's approach

## Changes

**types.ts:**
- Add `ClientReceivableRequestMethod`, `ClientReceivableNotificationMethod` (methods the client RECEIVES)
- Add `ServerReceivableRequestMethod`, `ServerReceivableNotificationMethod` (methods the server RECEIVES)
- Add corresponding type maps for looking up request/notification types by method

**protocol.ts:**
- Add generic type parameters for receivable request/notification types
- Add internal `_setRequestHandlerInternal` and `_setNotificationHandlerInternal` methods for Protocol's built-in handlers (ping, cancelled, progress, tasks/*)
- Public `setRequestHandler`/`setNotificationHandler` now use the receivable type parameters

**client.ts:**
- Pass `ClientReceivable*` type parameters when extending Protocol
- `setRequestHandler` now only accepts server-to-client methods

**server.ts:**
- Pass `ServerReceivable*` type parameters when extending Protocol
- `setRequestHandler` now only accepts client-to-server methods

## Test plan
- [x] All 485 tests pass
- [x] Typecheck passes

🤖 Generated with [Claude Code](https://claude.ai/code)