### PR TITLE
feat: Context API - simplified types (alternative to #1241)

### DIFF
--- a/.changeset/hot-trees-sing.md
+++ b/.changeset/hot-trees-sing.md
@@ -1,0 +1,12 @@
+---
+'@modelcontextprotocol/express': patch
+'@modelcontextprotocol/hono': patch
+'@modelcontextprotocol/node': patch
+'@modelcontextprotocol/eslint-config': patch
+'@modelcontextprotocol/test-integration': patch
+'@modelcontextprotocol/client': patch
+'@modelcontextprotocol/server': patch
+'@modelcontextprotocol/core': patch
+---
+
+add context API to tool, prompt, resource callbacks, linting

--- a/docs/migration-SKILL.md
+++ b/docs/migration-SKILL.md
@@ -20,13 +20,13 @@ Remove the old package and install only what you need:
 npm uninstall @modelcontextprotocol/sdk
 ```
 
-| You need | Install |
-|----------|---------|
-| Client only | `npm install @modelcontextprotocol/client` |
-| Server only | `npm install @modelcontextprotocol/server` |
-| Server + Node.js HTTP | `npm install @modelcontextprotocol/server @modelcontextprotocol/node` |
-| Server + Express | `npm install @modelcontextprotocol/server @modelcontextprotocol/express` |
-| Server + Hono | `npm install @modelcontextprotocol/server @modelcontextprotocol/hono` |
+| You need              | Install                                                                  |
+| --------------------- | ------------------------------------------------------------------------ |
+| Client only           | `npm install @modelcontextprotocol/client`                               |
+| Server only           | `npm install @modelcontextprotocol/server`                               |
+| Server + Node.js HTTP | `npm install @modelcontextprotocol/server @modelcontextprotocol/node`    |
+| Server + Express      | `npm install @modelcontextprotocol/server @modelcontextprotocol/express` |
+| Server + Hono         | `npm install @modelcontextprotocol/server @modelcontextprotocol/hono`    |
 
 `@modelcontextprotocol/core` is installed automatically as a dependency.
 
@@ -36,65 +36,67 @@ Replace all `@modelcontextprotocol/sdk/...` imports using this table.
 
 ### Client imports
 
-| v1 import path | v2 package |
-|----------------|------------|
-| `@modelcontextprotocol/sdk/client/index.js` | `@modelcontextprotocol/client` |
-| `@modelcontextprotocol/sdk/client/auth.js` | `@modelcontextprotocol/client` |
+| v1 import path                                       | v2 package                     |
+| ---------------------------------------------------- | ------------------------------ |
+| `@modelcontextprotocol/sdk/client/index.js`          | `@modelcontextprotocol/client` |
+| `@modelcontextprotocol/sdk/client/auth.js`           | `@modelcontextprotocol/client` |
 | `@modelcontextprotocol/sdk/client/streamableHttp.js` | `@modelcontextprotocol/client` |
-| `@modelcontextprotocol/sdk/client/sse.js` | `@modelcontextprotocol/client` |
-| `@modelcontextprotocol/sdk/client/stdio.js` | `@modelcontextprotocol/client` |
-| `@modelcontextprotocol/sdk/client/websocket.js` | `@modelcontextprotocol/client` |
+| `@modelcontextprotocol/sdk/client/sse.js`            | `@modelcontextprotocol/client` |
+| `@modelcontextprotocol/sdk/client/stdio.js`          | `@modelcontextprotocol/client` |
+| `@modelcontextprotocol/sdk/client/websocket.js`      | `@modelcontextprotocol/client` |
 
 ### Server imports
 
-| v1 import path | v2 package |
-|----------------|------------|
-| `@modelcontextprotocol/sdk/server/mcp.js` | `@modelcontextprotocol/server` |
-| `@modelcontextprotocol/sdk/server/index.js` | `@modelcontextprotocol/server` |
-| `@modelcontextprotocol/sdk/server/stdio.js` | `@modelcontextprotocol/server` |
+| v1 import path                                       | v2 package                                                                          |
+| ---------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| `@modelcontextprotocol/sdk/server/mcp.js`            | `@modelcontextprotocol/server`                                                      |
+| `@modelcontextprotocol/sdk/server/index.js`          | `@modelcontextprotocol/server`                                                      |
+| `@modelcontextprotocol/sdk/server/stdio.js`          | `@modelcontextprotocol/server`                                                      |
 | `@modelcontextprotocol/sdk/server/streamableHttp.js` | `@modelcontextprotocol/node` (class renamed to `NodeStreamableHTTPServerTransport`) |
-| `@modelcontextprotocol/sdk/server/sse.js` | REMOVED (migrate to Streamable HTTP) |
-| `@modelcontextprotocol/sdk/server/auth/*` | REMOVED (use external auth library) |
-| `@modelcontextprotocol/sdk/server/middleware.js` | `@modelcontextprotocol/express` (signature changed, see section 8) |
+| `@modelcontextprotocol/sdk/server/sse.js`            | REMOVED (migrate to Streamable HTTP)                                                |
+| `@modelcontextprotocol/sdk/server/auth/*`            | REMOVED (use external auth library)                                                 |
+| `@modelcontextprotocol/sdk/server/middleware.js`     | `@modelcontextprotocol/express` (signature changed, see section 8)                  |
 
 ### Types / shared imports
 
-| v1 import path | v2 package |
-|----------------|------------|
-| `@modelcontextprotocol/sdk/types.js` | `@modelcontextprotocol/core` |
-| `@modelcontextprotocol/sdk/shared/protocol.js` | `@modelcontextprotocol/core` |
-| `@modelcontextprotocol/sdk/shared/transport.js` | `@modelcontextprotocol/core` |
-| `@modelcontextprotocol/sdk/shared/stdio.js` | `@modelcontextprotocol/core` |
+| v1 import path                                    | v2 package                   |
+| ------------------------------------------------- | ---------------------------- |
+| `@modelcontextprotocol/sdk/types.js`              | `@modelcontextprotocol/core` |
+| `@modelcontextprotocol/sdk/shared/protocol.js`    | `@modelcontextprotocol/core` |
+| `@modelcontextprotocol/sdk/shared/transport.js`   | `@modelcontextprotocol/core` |
+| `@modelcontextprotocol/sdk/shared/stdio.js`       | `@modelcontextprotocol/core` |
 | `@modelcontextprotocol/sdk/shared/uriTemplate.js` | `@modelcontextprotocol/core` |
-| `@modelcontextprotocol/sdk/shared/auth.js` | `@modelcontextprotocol/core` |
+| `@modelcontextprotocol/sdk/shared/auth.js`        | `@modelcontextprotocol/core` |
 
 Notes:
+
 - `@modelcontextprotocol/client` and `@modelcontextprotocol/server` both re-export everything from `@modelcontextprotocol/core`, so you can import types from whichever package you already depend on.
 - When multiple v1 imports map to the same v2 package, consolidate them into a single import statement.
 - If code imports from `sdk/client/...`, install `@modelcontextprotocol/client`. If from `sdk/server/...`, install `@modelcontextprotocol/server`. If from `sdk/types.js` or `sdk/shared/...` only, install `@modelcontextprotocol/core`.
 
 ## 4. Renamed Symbols
 
-| v1 symbol | v2 symbol | v2 package |
-|-----------|-----------|------------|
+| v1 symbol                       | v2 symbol                           | v2 package                   |
+| ------------------------------- | ----------------------------------- | ---------------------------- |
 | `StreamableHTTPServerTransport` | `NodeStreamableHTTPServerTransport` | `@modelcontextprotocol/node` |
 
 ## 5. Removed / Renamed Type Aliases and Symbols
 
-| v1 (removed) | v2 (replacement) |
-|--------------|------------------|
-| `JSONRPCError` | `JSONRPCErrorResponse` |
-| `JSONRPCErrorSchema` | `JSONRPCErrorResponseSchema` |
-| `isJSONRPCError` | `isJSONRPCErrorResponse` |
-| `isJSONRPCResponse` | `isJSONRPCResultResponse` |
-| `ResourceReference` | `ResourceTemplateReference` |
-| `ResourceReferenceSchema` | `ResourceTemplateReferenceSchema` |
-| `IsomorphicHeaders` | REMOVED (use Web Standard `Headers`) |
+| v1 (removed)                             | v2 (replacement)                                 |
+| ---------------------------------------- | ------------------------------------------------ |
+| `JSONRPCError`                           | `JSONRPCErrorResponse`                           |
+| `JSONRPCErrorSchema`                     | `JSONRPCErrorResponseSchema`                     |
+| `isJSONRPCError`                         | `isJSONRPCErrorResponse`                         |
+| `isJSONRPCResponse`                      | `isJSONRPCResultResponse`                        |
+| `ResourceReference`                      | `ResourceTemplateReference`                      |
+| `ResourceReferenceSchema`                | `ResourceTemplateReferenceSchema`                |
+| `IsomorphicHeaders`                      | REMOVED (use Web Standard `Headers`)             |
 | `AuthInfo` (from `server/auth/types.js`) | `AuthInfo` (now in `@modelcontextprotocol/core`) |
 
 All other symbols from `@modelcontextprotocol/sdk/types.js` retain their original names (e.g., `CallToolResultSchema`, `ListToolsResultSchema`, etc.).
 
-**Unchanged APIs** (only import paths changed): `Client` constructor and methods, `McpServer` constructor, `server.connect()`, `server.close()`, all client transports (`StreamableHTTPClientTransport`, `SSEClientTransport`, `StdioClientTransport`), `StdioServerTransport`, all Zod schemas, all callback return types.
+**Unchanged APIs** (only import paths changed): `Client` constructor and methods, `McpServer` constructor, `server.connect()`, `server.close()`, all client transports (`StreamableHTTPClientTransport`, `SSEClientTransport`, `StdioClientTransport`), `StdioServerTransport`, all Zod
+schemas, all callback return types.
 
 ## 6. McpServer API Changes
 
@@ -105,21 +107,25 @@ The variadic `.tool()`, `.prompt()`, `.resource()` methods are removed. Use the 
 ```typescript
 // v1: server.tool(name, schema, callback)
 server.tool('greet', { name: z.string() }, async ({ name }) => {
-  return { content: [{ type: 'text', text: `Hello, ${name}!` }] };
+    return { content: [{ type: 'text', text: `Hello, ${name}!` }] };
 });
 
 // v1: server.tool(name, description, schema, callback)
 server.tool('greet', 'Greet a user', { name: z.string() }, async ({ name }) => {
-  return { content: [{ type: 'text', text: `Hello, ${name}!` }] };
+    return { content: [{ type: 'text', text: `Hello, ${name}!` }] };
 });
 
 // v2: server.registerTool(name, config, callback)
-server.registerTool('greet', {
-  description: 'Greet a user',
-  inputSchema: { name: z.string() },
-}, async ({ name }) => {
-  return { content: [{ type: 'text', text: `Hello, ${name}!` }] };
-});
+server.registerTool(
+    'greet',
+    {
+        description: 'Greet a user',
+        inputSchema: { name: z.string() }
+    },
+    async ({ name }) => {
+        return { content: [{ type: 'text', text: `Hello, ${name}!` }] };
+    }
+);
 ```
 
 Config object fields: `title?`, `description?`, `inputSchema?`, `outputSchema?`, `annotations?`, `_meta?`
@@ -129,15 +135,19 @@ Config object fields: `title?`, `description?`, `inputSchema?`, `outputSchema?`,
 ```typescript
 // v1: server.prompt(name, schema, callback)
 server.prompt('summarize', { text: z.string() }, async ({ text }) => {
-  return { messages: [{ role: 'user', content: { type: 'text', text } }] };
+    return { messages: [{ role: 'user', content: { type: 'text', text } }] };
 });
 
 // v2: server.registerPrompt(name, config, callback)
-server.registerPrompt('summarize', {
-  argsSchema: { text: z.string() },
-}, async ({ text }) => {
-  return { messages: [{ role: 'user', content: { type: 'text', text } }] };
-});
+server.registerPrompt(
+    'summarize',
+    {
+        argsSchema: { text: z.string() }
+    },
+    async ({ text }) => {
+        return { messages: [{ role: 'user', content: { type: 'text', text } }] };
+    }
+);
 ```
 
 Config object fields: `title?`, `description?`, `argsSchema?`
@@ -146,13 +156,13 @@ Config object fields: `title?`, `description?`, `argsSchema?`
 
 ```typescript
 // v1: server.resource(name, uri, callback)
-server.resource('config', 'config://app', async (uri) => {
-  return { contents: [{ uri: uri.href, text: '{}' }] };
+server.resource('config', 'config://app', async uri => {
+    return { contents: [{ uri: uri.href, text: '{}' }] };
 });
 
 // v2: server.registerResource(name, uri, metadata, callback)
-server.registerResource('config', 'config://app', {}, async (uri) => {
-  return { contents: [{ uri: uri.href, text: '{}' }] };
+server.registerResource('config', 'config://app', {}, async uri => {
+    return { contents: [{ uri: uri.href, text: '{}' }] };
 });
 ```
 
@@ -180,7 +190,8 @@ extra.requestInfo?.headers.get('mcp-session-id')
 
 ### Server-side auth
 
-All server OAuth exports removed: `mcpAuthRouter`, `OAuthServerProvider`, `OAuthTokenVerifier`, `requireBearerAuth`, `authenticateClient`, `ProxyOAuthServerProvider`, `allowedMethods`, and associated types. Use an external auth library (e.g., `better-auth`). See `examples/server/src/` for demos.
+All server OAuth exports removed: `mcpAuthRouter`, `OAuthServerProvider`, `OAuthTokenVerifier`, `requireBearerAuth`, `authenticateClient`, `ProxyOAuthServerProvider`, `allowedMethods`, and associated types. Use an external auth library (e.g., `better-auth`). See
+`examples/server/src/` for demos.
 
 ### Host header validation (Express)
 
@@ -214,32 +225,113 @@ server.setNotificationHandler('notifications/message', (notification) => { ... }
 
 Schema to method string mapping:
 
-| v1 Schema | v2 Method String |
-|-----------|-----------------|
-| `InitializeRequestSchema` | `'initialize'` |
-| `CallToolRequestSchema` | `'tools/call'` |
-| `ListToolsRequestSchema` | `'tools/list'` |
-| `ListPromptsRequestSchema` | `'prompts/list'` |
-| `GetPromptRequestSchema` | `'prompts/get'` |
-| `ListResourcesRequestSchema` | `'resources/list'` |
-| `ReadResourceRequestSchema` | `'resources/read'` |
-| `CreateMessageRequestSchema` | `'sampling/createMessage'` |
-| `ElicitRequestSchema` | `'elicitation/create'` |
-| `SetLevelRequestSchema` | `'logging/setLevel'` |
-| `PingRequestSchema` | `'ping'` |
-| `LoggingMessageNotificationSchema` | `'notifications/message'` |
-| `ToolListChangedNotificationSchema` | `'notifications/tools/list_changed'` |
+| v1 Schema                               | v2 Method String                         |
+| --------------------------------------- | ---------------------------------------- |
+| `InitializeRequestSchema`               | `'initialize'`                           |
+| `CallToolRequestSchema`                 | `'tools/call'`                           |
+| `ListToolsRequestSchema`                | `'tools/list'`                           |
+| `ListPromptsRequestSchema`              | `'prompts/list'`                         |
+| `GetPromptRequestSchema`                | `'prompts/get'`                          |
+| `ListResourcesRequestSchema`            | `'resources/list'`                       |
+| `ReadResourceRequestSchema`             | `'resources/read'`                       |
+| `CreateMessageRequestSchema`            | `'sampling/createMessage'`               |
+| `ElicitRequestSchema`                   | `'elicitation/create'`                   |
+| `SetLevelRequestSchema`                 | `'logging/setLevel'`                     |
+| `PingRequestSchema`                     | `'ping'`                                 |
+| `LoggingMessageNotificationSchema`      | `'notifications/message'`                |
+| `ToolListChangedNotificationSchema`     | `'notifications/tools/list_changed'`     |
 | `ResourceListChangedNotificationSchema` | `'notifications/resources/list_changed'` |
-| `PromptListChangedNotificationSchema` | `'notifications/prompts/list_changed'` |
-| `ProgressNotificationSchema` | `'notifications/progress'` |
-| `CancelledNotificationSchema` | `'notifications/cancelled'` |
-| `InitializedNotificationSchema` | `'notifications/initialized'` |
+| `PromptListChangedNotificationSchema`   | `'notifications/prompts/list_changed'`   |
+| `ProgressNotificationSchema`            | `'notifications/progress'`               |
+| `CancelledNotificationSchema`           | `'notifications/cancelled'`              |
+| `InitializedNotificationSchema`         | `'notifications/initialized'`            |
 
 Request/notification params remain fully typed. Remove unused schema imports after migration.
 
 ## 10. Client Behavioral Changes
 
 `Client.listPrompts()`, `listResources()`, `listResourceTemplates()`, `listTools()` now return empty results when the server lacks the corresponding capability (instead of sending the request). Set `enforceStrictCapabilities: true` in `ClientOptions` to throw an error instead.
+
+## 10. Context API (replaces `RequestHandlerExtra`)
+
+Tool, prompt, and resource callbacks now receive a structured context object (`ctx`) instead of the flat `extra` parameter.
+
+### Property Mapping
+
+| v1 (`extra.`)                        | v2 (`ctx.`)                        |
+| ------------------------------------ | ---------------------------------- |
+| `extra.requestId`                    | `ctx.mcpReq.id`                    |
+| `extra.sessionId`                    | `ctx.sessionId`                    |
+| `extra._meta`                        | `ctx.mcpReq._meta`                 |
+| `extra.signal`                       | `ctx.mcpReq.signal`                |
+| `extra.authInfo`                     | `ctx.http?.authInfo`               |
+| `extra.requestInfo?.headers`         | `ctx.http?.req.headers`            |
+| `extra.sendNotification(n)`          | `ctx.notification.send(n)`         |
+| `extra.sendRequest(r, s, o)`         | `ctx.mcpReq.send(r, s, o)`         |
+| `extra.taskId`                       | `ctx.task?.id`                     |
+| `extra.taskStore`                    | `ctx.task?.store`                  |
+| `extra.taskRequestedTtl`             | `ctx.task?.requestedTtl`           |
+| `extra.closeSSEStream?.()`           | `ctx.http?.closeSSE?.()`           |
+| `extra.closeStandaloneSSEStream?.()` | `ctx.http?.closeStandaloneSSE?.()` |
+
+### Server-specific context methods
+
+| Method                                      | Description                        |
+| ------------------------------------------- | ---------------------------------- |
+| `ctx.notification.log(params)`              | Send logging message               |
+| `ctx.notification.debug(msg, data?)`        | Send debug log                     |
+| `ctx.notification.info(msg, data?)`         | Send info log                      |
+| `ctx.notification.warning(msg, data?)`      | Send warning log                   |
+| `ctx.notification.error(msg, data?)`        | Send error log                     |
+| `ctx.mcpReq.elicitInput(params, opts?)`     | Request user input via elicitation |
+| `ctx.mcpReq.requestSampling(params, opts?)` | Request LLM sampling from client   |
+| `ctx.http?.req`                             | Raw fetch `Request` object         |
+
+### Context structure overview
+
+```typescript
+// Common structure (client and server)
+ctx.sessionId                // top-level
+ctx.mcpReq.id                // request ID
+ctx.mcpReq.method            // request method
+ctx.mcpReq._meta             // request metadata
+ctx.mcpReq.signal            // abort signal
+ctx.mcpReq.send(req, schema) // send related request
+ctx.http?.authInfo           // auth info (HTTP transports)
+ctx.task?.id                 // task ID (if task-augmented)
+ctx.task?.store              // task store
+ctx.task?.requestedTtl       // task TTL
+ctx.notification.send(n)     // send notification
+
+// Server additions
+ctx.http?.req                // raw fetch Request object
+ctx.http?.closeSSE?.()       // close SSE stream
+ctx.http?.closeStandaloneSSE?.() // close standalone SSE
+ctx.notification.log(params) // logging
+ctx.notification.debug/info/warning/error(msg, data?)
+ctx.mcpReq.elicitInput(params, opts?)
+ctx.mcpReq.requestSampling(params, opts?)
+```
+
+### Example migration
+
+```typescript
+// v1
+server.registerTool('my-tool', { inputSchema: { q: z.string() } }, async ({ q }, extra) => {
+    if (extra.signal.aborted) throw new Error('Cancelled');
+    await extra.sendNotification({ method: 'n', params: {} });
+    if (extra.taskStore) await extra.taskStore.updateTaskStatus(extra.taskId!, 'running');
+    return { content: [{ type: 'text', text: 'Done' }] };
+});
+
+// v2
+server.registerTool('my-tool', { inputSchema: { q: z.string() } }, async ({ q }, ctx) => {
+    if (ctx.mcpReq.signal.aborted) throw new Error('Cancelled');
+    await ctx.notification.send({ method: 'n', params: {} });
+    if (ctx.task) await ctx.task.store.updateTaskStatus(ctx.task.id, 'running');
+    return { content: [{ type: 'text', text: 'Done' }] };
+});
+```
 
 ## 11. Migration Steps (apply in this order)
 
@@ -252,4 +344,5 @@ Request/notification params remain fully typed. Remove unused schema imports aft
 7. If using server SSE transport, migrate to Streamable HTTP
 8. If using server auth from the SDK, migrate to an external auth library
 9. If relying on `listTools()`/`listPrompts()`/etc. throwing on missing capabilities, set `enforceStrictCapabilities: true`
-10. Verify: build with `tsc` / run tests
+10. Update tool/prompt/resource callbacks: rename `extra` parameter to `ctx` and update property access per section 10
+11. Verify: build with `tsc` / run tests

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -4,7 +4,8 @@ This guide covers the breaking changes introduced in v2 of the MCP TypeScript SD
 
 ## Overview
 
-Version 2 of the MCP TypeScript SDK introduces several breaking changes to improve modularity, reduce dependency bloat, and provide a cleaner API surface. The biggest change is the split from a single `@modelcontextprotocol/sdk` package into separate `@modelcontextprotocol/core`, `@modelcontextprotocol/client`, and `@modelcontextprotocol/server` packages.
+Version 2 of the MCP TypeScript SDK introduces several breaking changes to improve modularity, reduce dependency bloat, and provide a cleaner API surface. The biggest change is the split from a single `@modelcontextprotocol/sdk` package into separate `@modelcontextprotocol/core`,
+`@modelcontextprotocol/client`, and `@modelcontextprotocol/server` packages.
 
 ## Breaking Changes
 
@@ -12,11 +13,11 @@ Version 2 of the MCP TypeScript SDK introduces several breaking changes to impro
 
 The single `@modelcontextprotocol/sdk` package has been split into three packages:
 
-| v1 | v2 |
-|----|-----|
+| v1                          | v2                                                         |
+| --------------------------- | ---------------------------------------------------------- |
 | `@modelcontextprotocol/sdk` | `@modelcontextprotocol/core` (types, protocol, transports) |
-| | `@modelcontextprotocol/client` (client implementation) |
-| | `@modelcontextprotocol/server` (server implementation) |
+|                             | `@modelcontextprotocol/client` (client implementation)     |
+|                             | `@modelcontextprotocol/server` (server implementation)     |
 
 Remove the old package and install only the packages you need:
 
@@ -64,6 +65,7 @@ Note: `@modelcontextprotocol/client` and `@modelcontextprotocol/server` both re-
 v2 requires **Node.js 20+** and ships **ESM only** (no more CommonJS builds).
 
 If your project uses CommonJS (`require()`), you will need to either:
+
 - Migrate to ESM (`import`/`export`)
 - Use dynamic `import()` to load the SDK
 
@@ -71,11 +73,11 @@ If your project uses CommonJS (`require()`), you will need to either:
 
 The server package no longer depends on Express or Hono. HTTP framework integrations are now separate middleware packages:
 
-| v1 | v2 |
-|----|-----|
+| v1                                     | v2                                          |
+| -------------------------------------- | ------------------------------------------- |
 | Built into `@modelcontextprotocol/sdk` | `@modelcontextprotocol/node` (Node.js HTTP) |
-| | `@modelcontextprotocol/express` (Express) |
-| | `@modelcontextprotocol/hono` (Hono) |
+|                                        | `@modelcontextprotocol/express` (Express)   |
+|                                        | `@modelcontextprotocol/hono` (Hono)         |
 
 Install the middleware package for your framework:
 
@@ -128,12 +130,12 @@ This affects both transport constructors and request handler code that reads hea
 ```typescript
 // Transport headers
 const transport = new StreamableHTTPClientTransport(url, {
-  requestInit: {
-    headers: {
-      'Authorization': 'Bearer token',
-      'X-Custom': 'value',
-    },
-  },
+    requestInit: {
+        headers: {
+            Authorization: 'Bearer token',
+            'X-Custom': 'value'
+        }
+    }
 });
 
 // Reading headers in a request handler
@@ -145,12 +147,12 @@ const sessionId = extra.requestInfo?.headers['mcp-session-id'];
 ```typescript
 // Transport headers
 const transport = new StreamableHTTPClientTransport(url, {
-  requestInit: {
-    headers: new Headers({
-      'Authorization': 'Bearer token',
-      'X-Custom': 'value',
-    }),
-  },
+    requestInit: {
+        headers: new Headers({
+            Authorization: 'Bearer token',
+            'X-Custom': 'value'
+        })
+    }
 });
 
 // Reading headers in a request handler
@@ -170,22 +172,22 @@ const server = new McpServer({ name: 'demo', version: '1.0.0' });
 
 // Tool with schema
 server.tool('greet', { name: z.string() }, async ({ name }) => {
-  return { content: [{ type: 'text', text: `Hello, ${name}!` }] };
+    return { content: [{ type: 'text', text: `Hello, ${name}!` }] };
 });
 
 // Tool with description
 server.tool('greet', 'Greet a user', { name: z.string() }, async ({ name }) => {
-  return { content: [{ type: 'text', text: `Hello, ${name}!` }] };
+    return { content: [{ type: 'text', text: `Hello, ${name}!` }] };
 });
 
 // Prompt
 server.prompt('summarize', { text: z.string() }, async ({ text }) => {
-  return { messages: [{ role: 'user', content: { type: 'text', text: `Summarize: ${text}` } }] };
+    return { messages: [{ role: 'user', content: { type: 'text', text: `Summarize: ${text}` } }] };
 });
 
 // Resource
-server.resource('config', 'config://app', async (uri) => {
-  return { contents: [{ uri: uri.href, text: '{}' }] };
+server.resource('config', 'config://app', async uri => {
+    return { contents: [{ uri: uri.href, text: '{}' }] };
 });
 ```
 
@@ -198,28 +200,29 @@ const server = new McpServer({ name: 'demo', version: '1.0.0' });
 
 // Tool with schema
 server.registerTool('greet', { inputSchema: { name: z.string() } }, async ({ name }) => {
-  return { content: [{ type: 'text', text: `Hello, ${name}!` }] };
+    return { content: [{ type: 'text', text: `Hello, ${name}!` }] };
 });
 
 // Tool with description
 server.registerTool('greet', { description: 'Greet a user', inputSchema: { name: z.string() } }, async ({ name }) => {
-  return { content: [{ type: 'text', text: `Hello, ${name}!` }] };
+    return { content: [{ type: 'text', text: `Hello, ${name}!` }] };
 });
 
 // Prompt
 server.registerPrompt('summarize', { argsSchema: { text: z.string() } }, async ({ text }) => {
-  return { messages: [{ role: 'user', content: { type: 'text', text: `Summarize: ${text}` } }] };
+    return { messages: [{ role: 'user', content: { type: 'text', text: `Summarize: ${text}` } }] };
 });
 
 // Resource
-server.registerResource('config', 'config://app', {}, async (uri) => {
-  return { contents: [{ uri: uri.href, text: '{}' }] };
+server.registerResource('config', 'config://app', {}, async uri => {
+    return { contents: [{ uri: uri.href, text: '{}' }] };
 });
 ```
 
 ### Host header validation moved
 
-Express-specific middleware (`hostHeaderValidation()`, `localhostHostValidation()`) moved from the server package to `@modelcontextprotocol/express`. The server package now exports framework-agnostic functions instead: `validateHostHeader()`, `localhostAllowedHostnames()`, `hostHeaderValidationResponse()`.
+Express-specific middleware (`hostHeaderValidation()`, `localhostHostValidation()`) moved from the server package to `@modelcontextprotocol/express`. The server package now exports framework-agnostic functions instead: `validateHostHeader()`, `localhostAllowedHostnames()`,
+`hostHeaderValidationResponse()`.
 
 **Before (v1):**
 
@@ -297,6 +300,103 @@ Common method string replacements:
 | `ResourceListChangedNotificationSchema` | `'notifications/resources/list_changed'` |
 | `PromptListChangedNotificationSchema` | `'notifications/prompts/list_changed'` |
 
+### Context API replaces `RequestHandlerExtra`
+
+The `extra` parameter in tool, prompt, and resource callbacks has been replaced with a structured context object (`ctx`). The old flat `RequestHandlerExtra` type is replaced by `ServerContext` (for server callbacks) and `ClientContext` (for client callbacks).
+
+**Before (v1):**
+
+```typescript
+server.registerTool('my-tool', { inputSchema: { query: z.string() } }, async ({ query }, extra) => {
+  // Flat properties
+  console.log(extra.requestId);
+  console.log(extra.sessionId);
+  console.log(extra.authInfo?.token);
+
+  // Check cancellation
+  if (extra.signal.aborted) throw new Error('Cancelled');
+
+  // Send notification
+  await extra.sendNotification({ method: 'notifications/progress', params: { progress: 50 } });
+
+  // Task access
+  if (extra.taskStore) {
+    await extra.taskStore.updateTaskStatus(extra.taskId!, 'running');
+  }
+
+  // SSE stream control
+  extra.closeSSEStream?.();
+
+  return { content: [{ type: 'text', text: 'Done' }] };
+});
+```
+
+**After (v2):**
+
+```typescript
+server.registerTool('my-tool', { inputSchema: { query: z.string() } }, async ({ query }, ctx) => {
+  // Grouped into nested objects
+  console.log(ctx.mcpReq.id);          // was extra.requestId
+  console.log(ctx.sessionId);           // still at top level
+  console.log(ctx.http?.authInfo?.token); // was extra.authInfo
+
+  // Check cancellation (signal moved to mcpReq)
+  if (ctx.mcpReq.signal.aborted) throw new Error('Cancelled');
+
+  // Send notification (via notification.send)
+  await ctx.notification.send({ method: 'notifications/progress', params: { progress: 50 } });
+
+  // Task access (grouped in task object)
+  if (ctx.task) {
+    await ctx.task.store.updateTaskStatus(ctx.task.id, 'running');
+  }
+
+  // SSE stream control (moved to http)
+  ctx.http?.closeSSE?.();
+
+  // Server-specific: logging methods on notification
+  await ctx.notification.info('Processing query');
+  await ctx.notification.debug('Debug details', { query });
+
+  // Server-specific: elicitation and sampling on mcpReq
+  const userInput = await ctx.mcpReq.elicitInput({ message: 'Confirm?', mode: 'form', form: {} });
+  const message = await ctx.mcpReq.requestSampling({ messages: [...], maxTokens: 100 });
+
+  return { content: [{ type: 'text', text: 'Done' }] };
+});
+```
+
+#### Property mapping
+
+| v1 (`extra.`)                        | v2 (`ctx.`)                        |
+| ------------------------------------ | ---------------------------------- |
+| `extra.requestId`                    | `ctx.mcpReq.id`                    |
+| `extra.sessionId`                    | `ctx.sessionId`                    |
+| `extra._meta`                        | `ctx.mcpReq._meta`                 |
+| `extra.signal`                       | `ctx.mcpReq.signal`                |
+| `extra.authInfo`                     | `ctx.http?.authInfo`               |
+| `extra.requestInfo?.headers`         | `ctx.http?.req.headers`            |
+| `extra.sendNotification(n)`          | `ctx.notification.send(n)`         |
+| `extra.sendRequest(r, s, o)`         | `ctx.mcpReq.send(r, s, o)`         |
+| `extra.taskId`                       | `ctx.task?.id`                     |
+| `extra.taskStore`                    | `ctx.task?.store`                  |
+| `extra.taskRequestedTtl`             | `ctx.task?.requestedTtl`           |
+| `extra.closeSSEStream?.()`           | `ctx.http?.closeSSE?.()`           |
+| `extra.closeStandaloneSSEStream?.()` | `ctx.http?.closeStandaloneSSE?.()` |
+
+#### Server-specific additions on context
+
+| Method                                      | Description                                            |
+| ------------------------------------------- | ------------------------------------------------------ |
+| `ctx.notification.log(params)`              | Send logging message                                   |
+| `ctx.notification.debug(msg, data?)`        | Send debug log                                         |
+| `ctx.notification.info(msg, data?)`         | Send info log                                          |
+| `ctx.notification.warning(msg, data?)`      | Send warning log                                       |
+| `ctx.notification.error(msg, data?)`        | Send error log                                         |
+| `ctx.mcpReq.elicitInput(params, opts?)`     | Request user input via elicitation                     |
+| `ctx.mcpReq.requestSampling(params, opts?)` | Request LLM sampling from client                       |
+| `ctx.http?.req`                             | Raw fetch `Request` object (access URL, headers, etc.) |
+
 ### Client list methods return empty results for missing capabilities
 
 `Client.listPrompts()`, `listResources()`, `listResourceTemplates()`, and `listTools()` now return empty results when the server didn't advertise the corresponding capability, instead of sending the request. This respects the MCP spec's capability negotiation.
@@ -307,21 +407,21 @@ To restore v1 behavior (throw an error when capabilities are missing), set `enfo
 const client = new Client({ name: 'my-client', version: '1.0.0' }, {
   enforceStrictCapabilities: true,
 });
-```
+````
 
 ### Removed type aliases and deprecated exports
 
 The following deprecated type aliases have been removed from `@modelcontextprotocol/core`:
 
-| Removed | Replacement |
-|---------|-------------|
-| `JSONRPCError` | `JSONRPCErrorResponse` |
-| `JSONRPCErrorSchema` | `JSONRPCErrorResponseSchema` |
-| `isJSONRPCError` | `isJSONRPCErrorResponse` |
-| `isJSONRPCResponse` | `isJSONRPCResultResponse` |
-| `ResourceReferenceSchema` | `ResourceTemplateReferenceSchema` |
-| `ResourceReference` | `ResourceTemplateReference` |
-| `IsomorphicHeaders` | Use Web Standard `Headers` |
+| Removed                                  | Replacement                                      |
+| ---------------------------------------- | ------------------------------------------------ |
+| `JSONRPCError`                           | `JSONRPCErrorResponse`                           |
+| `JSONRPCErrorSchema`                     | `JSONRPCErrorResponseSchema`                     |
+| `isJSONRPCError`                         | `isJSONRPCErrorResponse`                         |
+| `isJSONRPCResponse`                      | `isJSONRPCResultResponse`                        |
+| `ResourceReferenceSchema`                | `ResourceTemplateReferenceSchema`                |
+| `ResourceReference`                      | `ResourceTemplateReference`                      |
+| `IsomorphicHeaders`                      | Use Web Standard `Headers`                       |
 | `AuthInfo` (from `server/auth/types.js`) | `AuthInfo` (now in `@modelcontextprotocol/core`) |
 
 All other types and schemas exported from `@modelcontextprotocol/sdk/types.js` retain their original names in `@modelcontextprotocol/core`.
@@ -352,7 +452,8 @@ The following APIs are unchanged between v1 and v2 (only the import paths change
 
 ## Using an LLM to migrate your code
 
-An LLM-optimized version of this guide is available at [`docs/migration-SKILL.md`](migration-SKILL.md). It contains dense mapping tables designed for tools like Claude Code to mechanically apply all the changes described above. You can paste it into your LLM context or load it as a skill.
+An LLM-optimized version of this guide is available at [`docs/migration-SKILL.md`](migration-SKILL.md). It contains dense mapping tables designed for tools like Claude Code to mechanically apply all the changes described above. You can paste it into your LLM context or load it as
+a skill.
 
 ## Need Help?
 

--- a/examples/client/src/simpleStreamableHttp.ts
+++ b/examples/client/src/simpleStreamableHttp.ts
@@ -268,10 +268,12 @@ async function connect(url?: string): Promise<void> {
         };
 
         // Set up elicitation request handler with proper validation
-        client.setRequestHandler('elicitation/create', async request => {
+        client.setRequestHandler('elicitation/create', async (request, ctx) => {
             if (request.params.mode !== 'form') {
                 throw new McpError(ErrorCode.InvalidParams, `Unsupported elicitation mode: ${request.params.mode}`);
             }
+
+            console.log(`${ctx.mcpReq.method} elicitation request received`);
             console.log('\n🔔 Elicitation (form) Request Received:');
             console.log(`Message: ${request.params.message}`);
             console.log(`Related Task: ${request.params._meta?.[RELATED_TASK_META_KEY]?.taskId}`);

--- a/examples/server/src/elicitationUrlExample.ts
+++ b/examples/server/src/elicitationUrlExample.ts
@@ -46,12 +46,12 @@ const getServer = () => {
                 cartId: z.string().describe('The ID of the cart to confirm')
             }
         },
-        async ({ cartId }, extra): Promise<CallToolResult> => {
+        async ({ cartId }, ctx): Promise<CallToolResult> => {
             /*
         In a real world scenario, there would be some logic here to check if the user has the provided cartId.
         For the purposes of this example, we'll throw an error (-> elicits the client to open a URL to confirm payment)
         */
-            const sessionId = extra.sessionId;
+            const sessionId = ctx.sessionId;
             if (!sessionId) {
                 throw new Error('Expected a Session ID');
             }
@@ -79,15 +79,15 @@ const getServer = () => {
                 param1: z.string().describe('First parameter')
             }
         },
-        async (_, extra): Promise<CallToolResult> => {
+        async (_, ctx): Promise<CallToolResult> => {
             /*
         In a real world scenario, there would be some logic here to check if we already have a valid access token for the user.
-        Auth info (with a subject or `sub` claim) can be typically be found in `extra.authInfo`.
+        Auth info (with a subject or `sub` claim) can be typically be found in `ctx.requestCtx.authInfo`.
         If we do, we can just return the result of the tool call.
         If we don't, we can throw an ElicitationRequiredError to request the user to authenticate.
         For the purposes of this example, we'll throw an error (-> elicits the client to open a URL to authenticate).
       */
-            const sessionId = extra.sessionId;
+            const sessionId = ctx.sessionId;
             if (!sessionId) {
                 throw new Error('Expected a Session ID');
             }

--- a/examples/server/src/jsonResponseStreamableHttp.ts
+++ b/examples/server/src/jsonResponseStreamableHttp.ts
@@ -51,7 +51,7 @@ const getServer = () => {
                 name: z.string().describe('Name to greet')
             }
         },
-        async ({ name }, extra): Promise<CallToolResult> => {
+        async ({ name }, ctx): Promise<CallToolResult> => {
             const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
             await server.sendLoggingMessage(
@@ -59,7 +59,7 @@ const getServer = () => {
                     level: 'debug',
                     data: `Starting multi-greet for ${name}`
                 },
-                extra.sessionId
+                ctx.sessionId
             );
 
             await sleep(1000); // Wait 1 second before first greeting
@@ -69,7 +69,7 @@ const getServer = () => {
                     level: 'info',
                     data: `Sending first greeting to ${name}`
                 },
-                extra.sessionId
+                ctx.sessionId
             );
 
             await sleep(1000); // Wait another second before second greeting
@@ -79,7 +79,7 @@ const getServer = () => {
                     level: 'info',
                     data: `Sending second greeting to ${name}`
                 },
-                extra.sessionId
+                ctx.sessionId
             );
 
             return {

--- a/examples/server/src/simpleStatelessStreamableHttp.ts
+++ b/examples/server/src/simpleStatelessStreamableHttp.ts
@@ -49,7 +49,7 @@ const getServer = () => {
                 count: z.number().describe('Number of notifications to send (0 for 100)').default(10)
             }
         },
-        async ({ interval, count }, extra): Promise<CallToolResult> => {
+        async ({ interval, count }, ctx): Promise<CallToolResult> => {
             const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
             let counter = 0;
 
@@ -61,7 +61,7 @@ const getServer = () => {
                             level: 'info',
                             data: `Periodic notification #${counter} at ${new Date().toISOString()}`
                         },
-                        extra.sessionId
+                        ctx.sessionId
                     );
                 } catch (error) {
                     console.error('Error sending notification:', error);

--- a/examples/server/src/simpleTaskInteractive.ts
+++ b/examples/server/src/simpleTaskInteractive.ts
@@ -507,7 +507,7 @@ const createServer = (): Server => {
     });
 
     // Handle tool calls
-    server.setRequestHandler('tools/call', async (request, extra): Promise<CallToolResult | CreateTaskResult> => {
+    server.setRequestHandler('tools/call', async (request, ctx): Promise<CallToolResult | CreateTaskResult> => {
         const { name, arguments: args } = request.params;
         const taskParams = (request.params._meta?.task || request.params.task) as { ttl?: number; pollInterval?: number } | undefined;
 
@@ -522,7 +522,7 @@ const createServer = (): Server => {
             pollInterval: taskParams.pollInterval ?? 1000
         };
 
-        const task = await taskStore.createTask(taskOptions, extra.requestId, request, extra.sessionId);
+        const task = await taskStore.createTask(taskOptions, ctx.mcpReq.id, request, ctx.sessionId);
 
         console.log(`\n[Server] ${name} called, task created: ${task.taskId}`);
 
@@ -600,7 +600,7 @@ const createServer = (): Server => {
         activeTaskExecutions.set(task.taskId, {
             promise: taskExecution,
             server,
-            sessionId: extra.sessionId ?? ''
+            sessionId: ctx.sessionId ?? ''
         });
 
         return { task };
@@ -617,10 +617,10 @@ const createServer = (): Server => {
     });
 
     // Handle tasks/result
-    server.setRequestHandler('tasks/result', async (request, extra): Promise<GetTaskPayloadResult> => {
+    server.setRequestHandler('tasks/result', async (request, ctx): Promise<GetTaskPayloadResult> => {
         const { taskId } = request.params;
         console.log(`[Server] tasks/result called for task ${taskId}`);
-        return taskResultHandler.handle(taskId, server, extra.sessionId ?? '');
+        return taskResultHandler.handle(taskId, server, ctx.sessionId ?? '');
     });
 
     return server;

--- a/packages/client/src/client/context.ts
+++ b/packages/client/src/client/context.ts
@@ -1,0 +1,13 @@
+import type { BaseContext, ClientNotification, ClientRequest, Notification, Request } from '@modelcontextprotocol/core';
+
+/**
+ * Client-specific context type for request handlers.
+ * Used when the client handles requests from the server (e.g., sampling, elicitation).
+ *
+ * @typeParam RequestT - Additional request types beyond ClientRequest
+ * @typeParam NotificationT - Additional notification types beyond ClientNotification
+ */
+export type ClientContext<RequestT extends Request = Request, NotificationT extends Notification = Notification> = BaseContext<
+    ClientRequest | RequestT,
+    ClientNotification | NotificationT
+>;

--- a/packages/core/src/experimental/tasks/interfaces.ts
+++ b/packages/core/src/experimental/tasks/interfaces.ts
@@ -3,7 +3,6 @@
  * WARNING: These APIs are experimental and may change without notice.
  */
 
-import type { RequestHandlerExtra, RequestTaskStore } from '../../shared/protocol.js';
 import type {
     JSONRPCErrorResponse,
     JSONRPCNotification,
@@ -12,8 +11,6 @@ import type {
     Request,
     RequestId,
     Result,
-    ServerNotification,
-    ServerRequest,
     Task,
     ToolExecution
 } from '../../types/types.js';
@@ -21,23 +18,6 @@ import type {
 // ============================================================================
 // Task Handler Types (for registerToolTask)
 // ============================================================================
-
-/**
- * Extended handler extra with task store for task creation.
- * @experimental
- */
-export interface CreateTaskRequestHandlerExtra extends RequestHandlerExtra<ServerRequest, ServerNotification> {
-    taskStore: RequestTaskStore;
-}
-
-/**
- * Extended handler extra with task ID and store for task operations.
- * @experimental
- */
-export interface TaskRequestHandlerExtra extends RequestHandlerExtra<ServerRequest, ServerNotification> {
-    taskId: string;
-    taskStore: RequestTaskStore;
-}
 
 /**
  * Task-specific execution configuration.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,7 @@
 export * from './auth/errors.js';
 export * from './shared/auth.js';
 export * from './shared/authUtils.js';
+export * from './shared/context.js';
 export * from './shared/metadataUtils.js';
 export * from './shared/protocol.js';
 export * from './shared/responseMessage.js';
@@ -9,6 +10,7 @@ export * from './shared/toolNameValidation.js';
 export * from './shared/transport.js';
 export * from './shared/uriTemplate.js';
 export * from './types/types.js';
+export * from './types/utility.js';
 export * from './util/inMemory.js';
 export * from './util/zodCompat.js';
 export * from './util/zodJsonSchemaCompat.js';

--- a/packages/core/src/shared/context.ts
+++ b/packages/core/src/shared/context.ts
@@ -1,0 +1,125 @@
+import type { CreateTaskOptions } from '../experimental/tasks/interfaces.js';
+import type { AuthInfo, Notification, Request, RequestId, RequestMeta, Result, Task } from '../types/types.js';
+import type { AnySchema, SchemaOutput } from '../util/zodCompat.js';
+import type { RequestOptions } from './protocol.js';
+
+/**
+ * Request-scoped task store for managing task state within a handler.
+ */
+export interface RequestTaskStore {
+    /**
+     * Creates a new task with the given creation parameters.
+     */
+    createTask(taskParams: CreateTaskOptions): Promise<Task>;
+
+    /**
+     * Gets the current status of a task.
+     */
+    getTask(taskId: string): Promise<Task>;
+
+    /**
+     * Stores the result of a task and sets its final status.
+     */
+    storeTaskResult(taskId: string, status: 'completed' | 'failed', result: Result): Promise<void>;
+
+    /**
+     * Retrieves the stored result of a task.
+     */
+    getTaskResult(taskId: string): Promise<Result>;
+
+    /**
+     * Updates a task's status (e.g., to 'cancelled', 'failed', 'completed').
+     */
+    updateTaskStatus(taskId: string, status: Task['status'], statusMessage?: string): Promise<void>;
+
+    /**
+     * Lists tasks, optionally starting from a pagination cursor.
+     */
+    listTasks(cursor?: string): Promise<{ tasks: Task[]; nextCursor?: string }>;
+}
+
+/**
+ * Task-related context for task-augmented requests.
+ */
+export type TaskContext = {
+    /**
+     * The ID of the task.
+     */
+    id: string;
+    /**
+     * The task store for managing task state.
+     */
+    store: RequestTaskStore;
+    /**
+     * The requested TTL for the task, or null if not specified.
+     */
+    requestedTtl: number | null;
+};
+
+/**
+ * Base context interface for request handlers.
+ * Defines the common structure shared by both client and server contexts.
+ *
+ * @typeParam RequestT - The type of requests that can be sent from this context
+ * @typeParam NotificationT - The type of notifications that can be sent from this context
+ */
+export type BaseContext<RequestT extends Request = Request, NotificationT extends Notification = Notification> = {
+    /**
+     * The session ID of the request.
+     */
+    sessionId?: string;
+
+    /**
+     * MCP request context containing protocol-level information.
+     */
+    mcpReq: {
+        /**
+         * The JSON-RPC ID of the request being handled.
+         * This can be useful for tracking or logging purposes.
+         */
+        id: RequestId;
+        /**
+         * The method of the request.
+         */
+        method: string;
+        /**
+         * The metadata of the request.
+         */
+        _meta?: RequestMeta;
+        /**
+         * An abort signal used to communicate if the request was cancelled.
+         */
+        signal: AbortSignal;
+        /**
+         * Sends a request that relates to the current request being handled.
+         * This is used by certain transports to correctly associate related messages.
+         */
+        send: <U extends AnySchema>(request: RequestT, resultSchema: U, options?: RequestOptions) => Promise<SchemaOutput<U>>;
+    };
+
+    /**
+     * HTTP request context with authentication information.
+     */
+    http?: {
+        /**
+         * The authentication information, if available.
+         */
+        authInfo?: AuthInfo;
+    };
+
+    /**
+     * Task context if this is a task-augmented request, undefined otherwise.
+     */
+    task: TaskContext | undefined;
+
+    /**
+     * Notification context with send method.
+     */
+    notification: {
+        /**
+         * Sends a notification that relates to the current request being handled.
+         * This is used by certain transports to correctly associate related messages.
+         */
+        send: (notification: NotificationT) => Promise<void>;
+    };
+};

--- a/packages/core/src/shared/protocol.ts
+++ b/packages/core/src/shared/protocol.ts
@@ -1,7 +1,6 @@
-import type { CreateTaskOptions, QueuedMessage, TaskMessageQueue, TaskStore } from '../experimental/tasks/interfaces.js';
+import type { QueuedMessage, TaskMessageQueue, TaskStore } from '../experimental/tasks/interfaces.js';
 import { isTerminal } from '../experimental/tasks/interfaces.js';
 import type {
-    AuthInfo,
     CancelledNotification,
     ClientCapabilities,
     GetTaskPayloadRequest,
@@ -12,7 +11,6 @@ import type {
     JSONRPCRequest,
     JSONRPCResponse,
     JSONRPCResultResponse,
-    MessageExtraInfo,
     Notification,
     NotificationMethod,
     NotificationTypeMap,
@@ -21,15 +19,11 @@ import type {
     RelatedTaskMetadata,
     Request,
     RequestId,
-    RequestInfo,
-    RequestMeta,
     RequestMethod,
     RequestTypeMap,
     Result,
     ServerCapabilities,
-    Task,
-    TaskCreationParams,
-    TaskStatusNotification
+    TaskCreationParams
 } from '../types/types.js';
 import {
     CancelTaskResultSchema,
@@ -45,12 +39,13 @@ import {
     isTaskAugmentedRequestParams,
     ListTasksResultSchema,
     McpError,
-    RELATED_TASK_META_KEY,
-    TaskStatusNotificationSchema
+    RELATED_TASK_META_KEY
 } from '../types/types.js';
+import type { MessageExtraInfo } from '../types/utility.js';
 import type { AnySchema, SchemaOutput } from '../util/zodCompat.js';
 import { safeParse } from '../util/zodCompat.js';
 import { parseWithCompat } from '../util/zodJsonSchemaCompat.js';
+import type { BaseContext, RequestTaskStore, TaskContext } from './context.js';
 import type { ResponseMessage } from './responseMessage.js';
 import type { Transport, TransportSendOptions } from './transport.js';
 
@@ -176,134 +171,6 @@ export type NotificationOptions = {
  */
 // relatedTask is excluded as the SDK controls if this is sent according to if the source is a task.
 export type TaskRequestOptions = Omit<RequestOptions, 'relatedTask'>;
-
-/**
- * Request-scoped TaskStore interface.
- */
-export interface RequestTaskStore {
-    /**
-     * Creates a new task with the given creation parameters.
-     * The implementation generates a unique taskId and createdAt timestamp.
-     *
-     * @param taskParams - The task creation parameters from the request
-     * @returns The created task object
-     */
-    createTask(taskParams: CreateTaskOptions): Promise<Task>;
-
-    /**
-     * Gets the current status of a task.
-     *
-     * @param taskId - The task identifier
-     * @returns The task object
-     * @throws If the task does not exist
-     */
-    getTask(taskId: string): Promise<Task>;
-
-    /**
-     * Stores the result of a task and sets its final status.
-     *
-     * @param taskId - The task identifier
-     * @param status - The final status: 'completed' for success, 'failed' for errors
-     * @param result - The result to store
-     */
-    storeTaskResult(taskId: string, status: 'completed' | 'failed', result: Result): Promise<void>;
-
-    /**
-     * Retrieves the stored result of a task.
-     *
-     * @param taskId - The task identifier
-     * @returns The stored result
-     */
-    getTaskResult(taskId: string): Promise<Result>;
-
-    /**
-     * Updates a task's status (e.g., to 'cancelled', 'failed', 'completed').
-     *
-     * @param taskId - The task identifier
-     * @param status - The new status
-     * @param statusMessage - Optional diagnostic message for failed tasks or other status information
-     */
-    updateTaskStatus(taskId: string, status: Task['status'], statusMessage?: string): Promise<void>;
-
-    /**
-     * Lists tasks, optionally starting from a pagination cursor.
-     *
-     * @param cursor - Optional cursor for pagination
-     * @returns An object containing the tasks array and an optional nextCursor
-     */
-    listTasks(cursor?: string): Promise<{ tasks: Task[]; nextCursor?: string }>;
-}
-
-/**
- * Extra data given to request handlers.
- */
-export type RequestHandlerExtra<SendRequestT extends Request, SendNotificationT extends Notification> = {
-    /**
-     * An abort signal used to communicate if the request was cancelled from the sender's side.
-     */
-    signal: AbortSignal;
-
-    /**
-     * Information about a validated access token, provided to request handlers.
-     */
-    authInfo?: AuthInfo;
-
-    /**
-     * The session ID from the transport, if available.
-     */
-    sessionId?: string;
-
-    /**
-     * Metadata from the original request.
-     */
-    _meta?: RequestMeta;
-
-    /**
-     * The JSON-RPC ID of the request being handled.
-     * This can be useful for tracking or logging purposes.
-     */
-    requestId: RequestId;
-
-    taskId?: string;
-
-    taskStore?: RequestTaskStore;
-
-    taskRequestedTtl?: number | null;
-
-    /**
-     * The original HTTP request.
-     */
-    requestInfo?: RequestInfo;
-
-    /**
-     * Sends a notification that relates to the current request being handled.
-     *
-     * This is used by certain transports to correctly associate related messages.
-     */
-    sendNotification: (notification: SendNotificationT) => Promise<void>;
-
-    /**
-     * Sends a request that relates to the current request being handled.
-     *
-     * This is used by certain transports to correctly associate related messages.
-     */
-    sendRequest: <U extends AnySchema>(request: SendRequestT, resultSchema: U, options?: TaskRequestOptions) => Promise<SchemaOutput<U>>;
-
-    /**
-     * Closes the SSE stream for this request, triggering client reconnection.
-     * Only available when using a StreamableHTTPServerTransport with eventStore configured.
-     * Use this to implement polling behavior during long-running operations.
-     */
-    closeSSEStream?: () => void;
-
-    /**
-     * Closes the standalone GET SSE stream, triggering client reconnection.
-     * Only available when using a StreamableHTTPServerTransport with eventStore configured.
-     * Use this to implement polling behavior for server-initiated notifications.
-     */
-    closeStandaloneSSEStream?: () => void;
-};
-
 /**
  * Information about a request's timeout state
  */
@@ -325,7 +192,7 @@ export abstract class Protocol<SendRequestT extends Request, SendNotificationT e
     private _requestMessageId = 0;
     private _requestHandlers: Map<
         string,
-        (request: JSONRPCRequest, extra: RequestHandlerExtra<SendRequestT, SendNotificationT>) => Promise<SendResultT>
+        (request: JSONRPCRequest, extra: BaseContext<SendRequestT, SendNotificationT>) => Promise<SendResultT>
     > = new Map();
     private _requestHandlerAbortControllers: Map<RequestId, AbortController> = new Map();
     private _notificationHandlers: Map<string, (notification: JSONRPCNotification) => Promise<void>> = new Map();
@@ -359,7 +226,7 @@ export abstract class Protocol<SendRequestT extends Request, SendNotificationT e
     /**
      * A handler to invoke for any request types that do not have their own handler installed.
      */
-    fallbackRequestHandler?: (request: JSONRPCRequest, extra: RequestHandlerExtra<SendRequestT, SendNotificationT>) => Promise<SendResultT>;
+    fallbackRequestHandler?: (request: JSONRPCRequest, extra: BaseContext<SendRequestT, SendNotificationT>) => Promise<SendResultT>;
 
     /**
      * A handler to invoke for any notification types that do not have their own handler installed.
@@ -385,8 +252,8 @@ export abstract class Protocol<SendRequestT extends Request, SendNotificationT e
         this._taskStore = _options?.taskStore;
         this._taskMessageQueue = _options?.taskMessageQueue;
         if (this._taskStore) {
-            this.setRequestHandler('tasks/get', async (request, extra) => {
-                const task = await this._taskStore!.getTask(request.params.taskId, extra.sessionId);
+            this.setRequestHandler('tasks/get', async (request, ctx) => {
+                const task = await this._taskStore!.getTask(request.params.taskId, ctx.sessionId);
                 if (!task) {
                     throw new McpError(ErrorCode.InvalidParams, 'Failed to retrieve task: Task not found');
                 }
@@ -398,14 +265,14 @@ export abstract class Protocol<SendRequestT extends Request, SendNotificationT e
                 } as unknown as SendResultT;
             });
 
-            this.setRequestHandler('tasks/result', async (request, extra) => {
+            this.setRequestHandler('tasks/result', async (request, ctx) => {
                 const handleTaskResult = async (): Promise<SendResultT> => {
                     const taskId = request.params.taskId;
 
                     // Deliver queued messages
                     if (this._taskMessageQueue) {
                         let queuedMessage: QueuedMessage | undefined;
-                        while ((queuedMessage = await this._taskMessageQueue.dequeue(taskId, extra.sessionId))) {
+                        while ((queuedMessage = await this._taskMessageQueue.dequeue(taskId, ctx.sessionId))) {
                             // Handle response and error messages by routing them to the appropriate resolver
                             if (queuedMessage.type === 'response' || queuedMessage.type === 'error') {
                                 const message = queuedMessage.message;
@@ -443,12 +310,12 @@ export abstract class Protocol<SendRequestT extends Request, SendNotificationT e
 
                             // Send the message on the response stream by passing the relatedRequestId
                             // This tells the transport to write the message to the tasks/result response stream
-                            await this._transport?.send(queuedMessage.message, { relatedRequestId: extra.requestId });
+                            await this._transport?.send(queuedMessage.message, { relatedRequestId: ctx.mcpReq.id });
                         }
                     }
 
                     // Now check task status
-                    const task = await this._taskStore!.getTask(taskId, extra.sessionId);
+                    const task = await this._taskStore!.getTask(taskId, ctx.sessionId);
                     if (!task) {
                         throw new McpError(ErrorCode.InvalidParams, `Task not found: ${taskId}`);
                     }
@@ -456,7 +323,7 @@ export abstract class Protocol<SendRequestT extends Request, SendNotificationT e
                     // Block if task is not terminal (we've already delivered all queued messages above)
                     if (!isTerminal(task.status)) {
                         // Wait for status change or new messages
-                        await this._waitForTaskUpdate(taskId, extra.signal);
+                        await this._waitForTaskUpdate(taskId, ctx.mcpReq.signal);
 
                         // After waking up, recursively call to deliver any new messages or result
                         return await handleTaskResult();
@@ -464,7 +331,7 @@ export abstract class Protocol<SendRequestT extends Request, SendNotificationT e
 
                     // If task is terminal, return the result
                     if (isTerminal(task.status)) {
-                        const result = await this._taskStore!.getTaskResult(taskId, extra.sessionId);
+                        const result = await this._taskStore!.getTaskResult(taskId, ctx.sessionId);
 
                         this._clearTaskQueue(taskId);
 
@@ -485,9 +352,9 @@ export abstract class Protocol<SendRequestT extends Request, SendNotificationT e
                 return await handleTaskResult();
             });
 
-            this.setRequestHandler('tasks/list', async (request, extra) => {
+            this.setRequestHandler('tasks/list', async (request, ctx) => {
                 try {
-                    const { tasks, nextCursor } = await this._taskStore!.listTasks(request.params?.cursor, extra.sessionId);
+                    const { tasks, nextCursor } = await this._taskStore!.listTasks(request.params?.cursor, ctx.sessionId);
                     return {
                         tasks,
                         nextCursor,
@@ -501,10 +368,10 @@ export abstract class Protocol<SendRequestT extends Request, SendNotificationT e
                 }
             });
 
-            this.setRequestHandler('tasks/cancel', async (request, extra) => {
+            this.setRequestHandler('tasks/cancel', async (request, ctx) => {
                 try {
                     // Get the current task to check if it's in a terminal state, in case the implementation is not atomic
-                    const task = await this._taskStore!.getTask(request.params.taskId, extra.sessionId);
+                    const task = await this._taskStore!.getTask(request.params.taskId, ctx.sessionId);
 
                     if (!task) {
                         throw new McpError(ErrorCode.InvalidParams, `Task not found: ${request.params.taskId}`);
@@ -519,12 +386,12 @@ export abstract class Protocol<SendRequestT extends Request, SendNotificationT e
                         request.params.taskId,
                         'cancelled',
                         'Client cancelled task execution.',
-                        extra.sessionId
+                        ctx.sessionId
                     );
 
                     this._clearTaskQueue(request.params.taskId);
 
-                    const cancelledTask = await this._taskStore!.getTask(request.params.taskId, extra.sessionId);
+                    const cancelledTask = await this._taskStore!.getTask(request.params.taskId, ctx.sessionId);
                     if (!cancelledTask) {
                         // Task was deleted during cancellation (e.g., cleanup happened)
                         throw new McpError(ErrorCode.InvalidParams, `Task not found after cancellation: ${request.params.taskId}`);
@@ -713,45 +580,16 @@ export abstract class Protocol<SendRequestT extends Request, SendNotificationT e
         this._requestHandlerAbortControllers.set(request.id, abortController);
 
         const taskCreationParams = isTaskAugmentedRequestParams(request.params) ? request.params.task : undefined;
-        const taskStore = this._taskStore ? this.requestTaskStore(request, capturedTransport?.sessionId) : undefined;
 
-        const fullExtra: RequestHandlerExtra<SendRequestT, SendNotificationT> = {
-            signal: abortController.signal,
-            sessionId: capturedTransport?.sessionId,
-            _meta: request.params?._meta,
-            sendNotification: async notification => {
-                // Include related-task metadata if this request is part of a task
-                const notificationOptions: NotificationOptions = { relatedRequestId: request.id };
-                if (relatedTaskId) {
-                    notificationOptions.relatedTask = { taskId: relatedTaskId };
-                }
-                await this.notification(notification, notificationOptions);
-            },
-            sendRequest: async (r, resultSchema, options?) => {
-                // Include related-task metadata if this request is part of a task
-                const requestOptions: RequestOptions = { ...options, relatedRequestId: request.id };
-                if (relatedTaskId && !requestOptions.relatedTask) {
-                    requestOptions.relatedTask = { taskId: relatedTaskId };
-                }
-
-                // Set task status to input_required when sending a request within a task context
-                // Use the taskId from options (explicit) or fall back to relatedTaskId (inherited)
-                const effectiveTaskId = requestOptions.relatedTask?.taskId ?? relatedTaskId;
-                if (effectiveTaskId && taskStore) {
-                    await taskStore.updateTaskStatus(effectiveTaskId, 'input_required');
-                }
-
-                return await this.request(r, resultSchema, requestOptions);
-            },
-            authInfo: extra?.authInfo,
-            requestId: request.id,
-            requestInfo: extra?.requestInfo,
-            taskId: relatedTaskId,
-            taskStore: taskStore,
-            taskRequestedTtl: taskCreationParams?.ttl,
-            closeSSEStream: extra?.closeSSEStream,
-            closeStandaloneSSEStream: extra?.closeStandaloneSSEStream
-        };
+        const ctx: BaseContext<SendRequestT, SendNotificationT> = this.createRequestContext({
+            request,
+            taskStore: this._taskStore,
+            relatedTaskId,
+            taskCreationParams,
+            abortController,
+            capturedTransport,
+            extra
+        });
 
         // Starting with Promise.resolve() puts any synchronous errors into the monad as well.
         Promise.resolve()
@@ -762,7 +600,7 @@ export abstract class Protocol<SendRequestT extends Request, SendNotificationT e
                     this.assertTaskHandlerCapability(request.method);
                 }
             })
-            .then(() => handler(request, fullExtra))
+            .then(() => handler(request, ctx))
             .then(
                 async result => {
                     if (abortController.signal.aborted) {
@@ -824,6 +662,77 @@ export abstract class Protocol<SendRequestT extends Request, SendNotificationT e
                 this._requestHandlerAbortControllers.delete(request.id);
             });
     }
+
+    /**
+     * Builds the task context from a task store, if applicable.
+     * Returns undefined if no taskStore is provided.
+     * This is used by subclass implementations of createRequestContext.
+     */
+    protected buildTaskContext(args: {
+        taskStore: TaskStore | undefined;
+        request: JSONRPCRequest;
+        sessionId: string | undefined;
+        relatedTaskId: string | undefined;
+        taskCreationParams: TaskCreationParams | undefined;
+    }): TaskContext | undefined {
+        const { taskStore, request, sessionId, relatedTaskId, taskCreationParams } = args;
+
+        if (!taskStore) {
+            return undefined;
+        }
+
+        // Mutable task ID that updates after createTask is called
+        let currentTaskId = relatedTaskId ?? '';
+
+        // Build a request-scoped task store POJO that binds sessionId and requestId
+        const store: RequestTaskStore = {
+            createTask: async taskParams => {
+                const task = await taskStore.createTask(taskParams, request.id, request, sessionId);
+                currentTaskId = task.taskId;
+                return task;
+            },
+            getTask: async taskId => {
+                const task = await taskStore.getTask(taskId, sessionId);
+                if (!task) throw new McpError(ErrorCode.InvalidParams, `Task not found: ${taskId}`);
+                return task;
+            },
+            storeTaskResult: (taskId, status, result) => {
+                return taskStore.storeTaskResult(taskId, status, result, sessionId);
+            },
+            getTaskResult: taskId => {
+                return taskStore.getTaskResult(taskId, sessionId);
+            },
+            updateTaskStatus: (taskId, status, statusMessage) => {
+                return taskStore.updateTaskStatus(taskId, status, statusMessage, sessionId);
+            },
+            listTasks: cursor => {
+                return taskStore.listTasks(sessionId, cursor);
+            }
+        };
+
+        return {
+            get id() {
+                return currentTaskId;
+            },
+            store,
+            requestedTtl: taskCreationParams?.ttl ?? null
+        };
+    }
+
+    /**
+     * Creates the context object passed to request handlers.
+     * Subclasses must implement this to provide the appropriate context type
+     * (ClientContext for Client, ServerContext for Server).
+     */
+    protected abstract createRequestContext(args: {
+        request: JSONRPCRequest;
+        taskStore: TaskStore | undefined;
+        relatedTaskId: string | undefined;
+        taskCreationParams: TaskCreationParams | undefined;
+        abortController: AbortController;
+        capturedTransport: Transport | undefined;
+        extra?: MessageExtraInfo;
+    }): BaseContext<SendRequestT, SendNotificationT>;
 
     private _onprogress(notification: ProgressNotification): void {
         const { progressToken, ...params } = notification.params;
@@ -1200,9 +1109,9 @@ export abstract class Protocol<SendRequestT extends Request, SendNotificationT e
 
             this._setupTimeout(messageId, timeout, options?.maxTotalTimeout, timeoutHandler, options?.resetTimeoutOnProgress ?? false);
 
-            // Queue request if related to a task
+            // Queue request if related to a task AND task message queue is configured
             const relatedTaskId = relatedTask?.taskId;
-            if (relatedTaskId) {
+            if (relatedTaskId && this._taskStore && this._taskMessageQueue) {
                 // Store the response resolver for this request so responses can be routed back
                 const responseResolver = (response: JSONRPCResultResponse | Error) => {
                     const handler = this._responseHandlers.get(messageId);
@@ -1227,7 +1136,8 @@ export abstract class Protocol<SendRequestT extends Request, SendNotificationT e
                 // Don't send through transport - queued messages are delivered via tasks/result only
                 // This prevents duplicate delivery for bidirectional transports
             } else {
-                // No related task - send through transport normally
+                // No related task OR no task message queue configured - send through transport normally
+                // Note: relatedTask metadata is still included in jsonrpcRequest.params._meta for receivers to see
                 this._transport.send(jsonrpcRequest, { relatedRequestId, resumptionToken, onresumptiontoken }).catch(error => {
                     this._cleanupTimeout(messageId);
                     reject(error);
@@ -1290,9 +1200,9 @@ export abstract class Protocol<SendRequestT extends Request, SendNotificationT e
 
         this.assertNotificationCapability(notification.method);
 
-        // Queue notification if related to a task
+        // Queue notification if related to a task AND task message queue is configured
         const relatedTaskId = options?.relatedTask?.taskId;
-        if (relatedTaskId) {
+        if (relatedTaskId && this._taskStore && this._taskMessageQueue) {
             // Build the JSONRPC notification with metadata
             const jsonrpcNotification: JSONRPCNotification = {
                 ...notification,
@@ -1400,17 +1310,14 @@ export abstract class Protocol<SendRequestT extends Request, SendNotificationT e
      */
     setRequestHandler<M extends RequestMethod>(
         method: M,
-        handler: (
-            request: RequestTypeMap[M],
-            extra: RequestHandlerExtra<SendRequestT, SendNotificationT>
-        ) => SendResultT | Promise<SendResultT>
+        handler: (request: RequestTypeMap[M], ctx: BaseContext<SendRequestT, SendNotificationT>) => SendResultT | Promise<SendResultT>
     ): void {
         this.assertRequestHandlerCapability(method);
         const schema = getRequestSchema(method);
 
-        this._requestHandlers.set(method, (request, extra) => {
+        this._requestHandlers.set(method, (request, ctx) => {
             const parsed = parseWithCompat(schema, request) as RequestTypeMap[M];
-            return Promise.resolve(handler(parsed, extra));
+            return Promise.resolve(handler(parsed, ctx));
         });
     }
 
@@ -1551,95 +1458,6 @@ export abstract class Protocol<SendRequestT extends Request, SendNotificationT e
                 { once: true }
             );
         });
-    }
-
-    private requestTaskStore(request?: JSONRPCRequest, sessionId?: string): RequestTaskStore {
-        const taskStore = this._taskStore;
-        if (!taskStore) {
-            throw new Error('No task store configured');
-        }
-
-        return {
-            createTask: async taskParams => {
-                if (!request) {
-                    throw new Error('No request provided');
-                }
-
-                return await taskStore.createTask(
-                    taskParams,
-                    request.id,
-                    {
-                        method: request.method,
-                        params: request.params
-                    },
-                    sessionId
-                );
-            },
-            getTask: async taskId => {
-                const task = await taskStore.getTask(taskId, sessionId);
-                if (!task) {
-                    throw new McpError(ErrorCode.InvalidParams, 'Failed to retrieve task: Task not found');
-                }
-
-                return task;
-            },
-            storeTaskResult: async (taskId, status, result) => {
-                await taskStore.storeTaskResult(taskId, status, result, sessionId);
-
-                // Get updated task state and send notification
-                const task = await taskStore.getTask(taskId, sessionId);
-                if (task) {
-                    const notification: TaskStatusNotification = TaskStatusNotificationSchema.parse({
-                        method: 'notifications/tasks/status',
-                        params: task
-                    });
-                    await this.notification(notification as SendNotificationT);
-
-                    if (isTerminal(task.status)) {
-                        this._cleanupTaskProgressHandler(taskId);
-                        // Don't clear queue here - it will be cleared after delivery via tasks/result
-                    }
-                }
-            },
-            getTaskResult: taskId => {
-                return taskStore.getTaskResult(taskId, sessionId);
-            },
-            updateTaskStatus: async (taskId, status, statusMessage) => {
-                // Check if task exists
-                const task = await taskStore.getTask(taskId, sessionId);
-                if (!task) {
-                    throw new McpError(ErrorCode.InvalidParams, `Task "${taskId}" not found - it may have been cleaned up`);
-                }
-
-                // Don't allow transitions from terminal states
-                if (isTerminal(task.status)) {
-                    throw new McpError(
-                        ErrorCode.InvalidParams,
-                        `Cannot update task "${taskId}" from terminal status "${task.status}" to "${status}". Terminal states (completed, failed, cancelled) cannot transition to other states.`
-                    );
-                }
-
-                await taskStore.updateTaskStatus(taskId, status, statusMessage, sessionId);
-
-                // Get updated task state and send notification
-                const updatedTask = await taskStore.getTask(taskId, sessionId);
-                if (updatedTask) {
-                    const notification: TaskStatusNotification = TaskStatusNotificationSchema.parse({
-                        method: 'notifications/tasks/status',
-                        params: updatedTask
-                    });
-                    await this.notification(notification as SendNotificationT);
-
-                    if (isTerminal(updatedTask.status)) {
-                        this._cleanupTaskProgressHandler(taskId);
-                        // Don't clear queue here - it will be cleared after delivery via tasks/result
-                    }
-                }
-            },
-            listTasks: cursor => {
-                return taskStore.listTasks(cursor, sessionId);
-            }
-        };
     }
 }
 

--- a/packages/core/src/shared/transport.ts
+++ b/packages/core/src/shared/transport.ts
@@ -1,4 +1,5 @@
-import type { JSONRPCMessage, MessageExtraInfo, RequestId } from '../types/types.js';
+import type { JSONRPCMessage, RequestId } from '../types/types.js';
+import type { MessageExtraInfo } from '../types/utility.js';
 
 export type FetchLike = (url: string | URL, init?: RequestInit) => Promise<Response>;
 

--- a/packages/core/src/types/types.ts
+++ b/packages/core/src/types/types.ts
@@ -2360,43 +2360,6 @@ type Flatten<T> = T extends Primitive
 
 type Infer<Schema extends z.ZodTypeAny> = Flatten<z.infer<Schema>>;
 
-/**
- * Information about the incoming request.
- */
-export interface RequestInfo {
-    /**
-     * The headers of the request.
-     */
-    headers: Headers;
-}
-
-/**
- * Extra information about a message.
- */
-export interface MessageExtraInfo {
-    /**
-     * The request information.
-     */
-    requestInfo?: RequestInfo;
-
-    /**
-     * The authentication information.
-     */
-    authInfo?: AuthInfo;
-
-    /**
-     * Callback to close the SSE stream for this request, triggering client reconnection.
-     * Only available when using NodeStreamableHTTPServerTransport with eventStore configured.
-     */
-    closeSSEStream?: () => void;
-
-    /**
-     * Callback to close the standalone GET SSE stream, triggering client reconnection.
-     * Only available when using NodeStreamableHTTPServerTransport with eventStore configured.
-     */
-    closeStandaloneSSEStream?: () => void;
-}
-
 /* JSON-RPC types */
 export type ProgressToken = Infer<typeof ProgressTokenSchema>;
 export type Cursor = Infer<typeof CursorSchema>;

--- a/packages/core/src/types/utility.ts
+++ b/packages/core/src/types/utility.ts
@@ -1,0 +1,29 @@
+import type { AuthInfo } from './types.js';
+
+/**
+ * Extra information about a message.
+ */
+export interface MessageExtraInfo {
+    /**
+     * The raw Request object (fetch API Request).
+     * Provides access to url, headers, and other request properties.
+     */
+    request?: Request;
+
+    /**
+     * The authentication information.
+     */
+    authInfo?: AuthInfo;
+
+    /**
+     * Callback to close the SSE stream for this request, triggering client reconnection.
+     * Only available when using NodeStreamableHTTPServerTransport with eventStore configured.
+     */
+    closeSSEStream?: () => void;
+
+    /**
+     * Callback to close the standalone GET SSE stream, triggering client reconnection.
+     * Only available when using NodeStreamableHTTPServerTransport with eventStore configured.
+     */
+    closeStandaloneSSEStream?: () => void;
+}

--- a/packages/server/src/experimental/tasks/interfaces.ts
+++ b/packages/server/src/experimental/tasks/interfaces.ts
@@ -6,14 +6,15 @@
 import type {
     AnySchema,
     CallToolResult,
-    CreateTaskRequestHandlerExtra,
     CreateTaskResult,
     GetTaskResult,
     Result,
-    TaskRequestHandlerExtra,
+    ServerNotification,
+    ServerRequest,
     ZodRawShapeCompat
 } from '@modelcontextprotocol/core';
 
+import type { ServerContext } from '../../server/context.js';
 import type { BaseToolCallback } from '../../server/mcp.js';
 
 // ============================================================================
@@ -27,7 +28,7 @@ import type { BaseToolCallback } from '../../server/mcp.js';
 export type CreateTaskRequestHandler<
     SendResultT extends Result,
     Args extends undefined | ZodRawShapeCompat | AnySchema = undefined
-> = BaseToolCallback<SendResultT, CreateTaskRequestHandlerExtra, Args>;
+> = BaseToolCallback<SendResultT, ServerContext<ServerRequest, ServerNotification>, Args>;
 
 /**
  * Handler for task operations (get, getResult).
@@ -36,7 +37,7 @@ export type CreateTaskRequestHandler<
 export type TaskRequestHandler<
     SendResultT extends Result,
     Args extends undefined | ZodRawShapeCompat | AnySchema = undefined
-> = BaseToolCallback<SendResultT, TaskRequestHandlerExtra, Args>;
+> = BaseToolCallback<SendResultT, ServerContext<ServerRequest, ServerNotification>, Args>;
 
 /**
  * Interface for task-based tool handlers.

--- a/packages/server/src/experimental/tasks/mcpServer.ts
+++ b/packages/server/src/experimental/tasks/mcpServer.ts
@@ -55,16 +55,16 @@ export class ExperimentalMcpServerTasks {
      *   inputSchema: { input: z.string() },
      *   execution: { taskSupport: 'required' }
      * }, {
-     *   createTask: async (args, extra) => {
-     *     const task = await extra.taskStore.createTask({ ttl: 300000 });
+     *   createTask: async (args, ctx) => {
+     *     const task = await ctx.task!.store.createTask({ ttl: 300000 });
      *     startBackgroundWork(task.taskId, args);
      *     return { task };
      *   },
-     *   getTask: async (args, extra) => {
-     *     return extra.taskStore.getTask(extra.taskId);
+     *   getTask: async (args, ctx) => {
+     *     return ctx.task!.store.getTask(ctx.task!.id);
      *   },
-     *   getTaskResult: async (args, extra) => {
-     *     return extra.taskStore.getTaskResult(extra.taskId);
+     *   getTaskResult: async (args, ctx) => {
+     *     return ctx.task!.store.getTaskResult(ctx.task!.id);
      *   }
      * });
      * ```

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,4 +1,5 @@
 export * from './server/completable.js';
+export * from './server/context.js';
 export * from './server/mcp.js';
 export * from './server/middleware/hostHeaderValidation.js';
 export * from './server/server.js';

--- a/packages/server/src/server/context.ts
+++ b/packages/server/src/server/context.ts
@@ -1,0 +1,86 @@
+import type {
+    BaseContext,
+    CreateMessageRequest,
+    CreateMessageResult,
+    ElicitRequest,
+    ElicitResult,
+    LoggingMessageNotification,
+    Notification,
+    Request,
+    RequestOptions,
+    ServerNotification,
+    ServerRequest
+} from '@modelcontextprotocol/core';
+
+/**
+ * Server-specific context type for request handlers.
+ * Extends BaseContext with server-specific methods for logging, elicitation, and sampling.
+ *
+ * @typeParam RequestT - Additional request types beyond ServerRequest
+ * @typeParam NotificationT - Additional notification types beyond ServerNotification
+ */
+export type ServerContext<RequestT extends Request = Request, NotificationT extends Notification = Notification> = Omit<
+    BaseContext<ServerRequest | RequestT, ServerNotification | NotificationT>,
+    'mcpReq' | 'http' | 'notification'
+> & {
+    /**
+     * MCP request context containing protocol-level information and server-specific methods.
+     */
+    mcpReq: BaseContext<ServerRequest | RequestT, ServerNotification | NotificationT>['mcpReq'] & {
+        /**
+         * Sends an elicitation request to the client.
+         */
+        elicitInput: (params: ElicitRequest['params'], options?: RequestOptions) => Promise<ElicitResult>;
+        /**
+         * Sends a sampling request to the client.
+         */
+        requestSampling: (params: CreateMessageRequest['params'], options?: RequestOptions) => Promise<CreateMessageResult>;
+    };
+
+    /**
+     * HTTP request context with authentication, raw Request object, and SSE controls.
+     */
+    http?: BaseContext['http'] & {
+        /**
+         * The raw Request object (fetch API Request).
+         * Provides access to url, headers, and other request properties.
+         */
+        req: globalThis.Request;
+        /**
+         * Closes the SSE stream for this request, triggering client reconnection.
+         * Only available when using StreamableHTTPServerTransport with eventStore configured.
+         */
+        closeSSE?: () => void;
+        /**
+         * Closes the standalone GET SSE stream, triggering client reconnection.
+         * Only available when using StreamableHTTPServerTransport with eventStore configured.
+         */
+        closeStandaloneSSE?: () => void;
+    };
+
+    /**
+     * Notification context with send method and logging helpers.
+     */
+    notification: BaseContext<ServerRequest | RequestT, ServerNotification | NotificationT>['notification'] & {
+        /**
+         * Sends a logging message to the client.
+         */
+        log: (params: LoggingMessageNotification['params']) => Promise<void>;
+        /**
+         * Sends a debug log message to the client.
+         */
+        debug: (message: string, extraLogData?: Record<string, unknown>) => Promise<void>;
+        /**
+         * Sends an info log message to the client.
+         */
+        info: (message: string, extraLogData?: Record<string, unknown>) => Promise<void>;
+        /**
+         * Sends a warning log message to the client.
+         */
+        warning: (message: string, extraLogData?: Record<string, unknown>) => Promise<void>;
+        /**
+         * Sends an error log message to the client.
+         */
+        error: (message: string, extraLogData?: Record<string, unknown>) => Promise<void>;
+    };
+};

--- a/packages/server/src/server/streamableHttp.ts
+++ b/packages/server/src/server/streamableHttp.ts
@@ -9,7 +9,7 @@
 
 import { TextEncoder } from 'node:util';
 
-import type { AuthInfo, JSONRPCMessage, MessageExtraInfo, RequestId, RequestInfo, Transport } from '@modelcontextprotocol/core';
+import type { AuthInfo, JSONRPCMessage, MessageExtraInfo, RequestId, Transport } from '@modelcontextprotocol/core';
 import {
     DEFAULT_NEGOTIATED_PROTOCOL_VERSION,
     isInitializeRequest,
@@ -598,11 +598,6 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
                 return this.createJsonErrorResponse(415, -32_000, 'Unsupported Media Type: Content-Type must be application/json');
             }
 
-            // Build request info from headers
-            const requestInfo: RequestInfo = {
-                headers: req.headers
-            };
-
             let rawMessage;
             if (options?.parsedBody === undefined) {
                 try {
@@ -667,7 +662,7 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
             if (!hasRequests) {
                 // if it only contains notifications or responses, return 202
                 for (const message of messages) {
-                    this.onmessage?.(message, { authInfo: options?.authInfo, requestInfo });
+                    this.onmessage?.(message, { authInfo: options?.authInfo, request: req });
                 }
                 return new Response(null, { status: 202 });
             }
@@ -701,7 +696,7 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
                     }
 
                     for (const message of messages) {
-                        this.onmessage?.(message, { authInfo: options?.authInfo, requestInfo });
+                        this.onmessage?.(message, { authInfo: options?.authInfo, request: req });
                     }
                 });
             }
@@ -771,7 +766,7 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
                     };
                 }
 
-                this.onmessage?.(message, { authInfo: options?.authInfo, requestInfo, closeSSEStream, closeStandaloneSSEStream });
+                this.onmessage?.(message, { authInfo: options?.authInfo, request: req, closeSSEStream, closeStandaloneSSEStream });
             }
             // The server SHOULD NOT close the SSE stream before sending all JSON-RPC responses
             // This will be handled by the send() method when responses are ready

--- a/src/conformance/everything-client.ts
+++ b/src/conformance/everything-client.ts
@@ -12,12 +12,7 @@
  * consolidating all the individual test clients into one.
  */
 
-import {
-    Client,
-    StreamableHTTPClientTransport,
-    ClientCredentialsProvider,
-    PrivateKeyJwtProvider
-} from '@modelcontextprotocol/client';
+import { Client, StreamableHTTPClientTransport, ClientCredentialsProvider, PrivateKeyJwtProvider } from '@modelcontextprotocol/client';
 import { z } from 'zod';
 import { withOAuthRetry, handle401 } from './helpers/withOAuthRetry.js';
 import { logger } from './helpers/logger.js';

--- a/test/integration/test/client/client.test.ts
+++ b/test/integration/test/client/client.test.ts
@@ -1095,10 +1095,10 @@ test('should handle request timeout', async () => {
     );
 
     // Set up server with a delayed response
-    server.setRequestHandler('resources/list', async (_request, extra) => {
+    server.setRequestHandler('resources/list', async (_request, ctx) => {
         const timer = new Promise(resolve => {
             const timeout = setTimeout(resolve, 100);
-            extra.signal.addEventListener('abort', () => clearTimeout(timeout));
+            ctx.mcpReq.signal.addEventListener('abort', () => clearTimeout(timeout));
         });
 
         await timer;
@@ -2268,27 +2268,27 @@ describe('Task-based execution', () => {
                     inputSchema: {}
                 },
                 {
-                    async createTask(_args, extra) {
-                        const task = await extra.taskStore.createTask({
-                            ttl: extra.taskRequestedTtl
+                    async createTask(_args, ctx) {
+                        const task = await ctx.task!.store.createTask({
+                            ttl: ctx.task!.requestedTtl
                         });
 
                         const result = {
                             content: [{ type: 'text', text: 'Tool executed successfully!' }]
                         };
-                        await extra.taskStore.storeTaskResult(task.taskId, 'completed', result);
+                        await ctx.task!.store.storeTaskResult(task.taskId, 'completed', result);
 
                         return { task };
                     },
-                    async getTask(_args, extra) {
-                        const task = await extra.taskStore.getTask(extra.taskId);
+                    async getTask(_args, ctx) {
+                        const task = await ctx.task!.store.getTask(ctx.task!.id);
                         if (!task) {
-                            throw new Error(`Task ${extra.taskId} not found`);
+                            throw new Error(`Task ${ctx.task!.id} not found`);
                         }
                         return task;
                     },
-                    async getTaskResult(_args, extra) {
-                        const result = await extra.taskStore.getTaskResult(extra.taskId);
+                    async getTaskResult(_args, ctx) {
+                        const result = await ctx.task!.store.getTaskResult(ctx.task!.id);
                         return result as { content: Array<{ type: 'text'; text: string }> };
                     }
                 }
@@ -2344,27 +2344,27 @@ describe('Task-based execution', () => {
                     inputSchema: {}
                 },
                 {
-                    async createTask(_args, extra) {
-                        const task = await extra.taskStore.createTask({
-                            ttl: extra.taskRequestedTtl
+                    async createTask(_args, ctx) {
+                        const task = await ctx.task!.store.createTask({
+                            ttl: ctx.task!.requestedTtl
                         });
 
                         const result = {
                             content: [{ type: 'text', text: 'Success!' }]
                         };
-                        await extra.taskStore.storeTaskResult(task.taskId, 'completed', result);
+                        await ctx.task!.store.storeTaskResult(task.taskId, 'completed', result);
 
                         return { task };
                     },
-                    async getTask(_args, extra) {
-                        const task = await extra.taskStore.getTask(extra.taskId);
+                    async getTask(_args, ctx) {
+                        const task = await ctx.task!.store.getTask(ctx.task!.id);
                         if (!task) {
-                            throw new Error(`Task ${extra.taskId} not found`);
+                            throw new Error(`Task ${ctx.task!.id} not found`);
                         }
                         return task;
                     },
-                    async getTaskResult(_args, extra) {
-                        const result = await extra.taskStore.getTaskResult(extra.taskId);
+                    async getTaskResult(_args, ctx) {
+                        const result = await ctx.task!.store.getTaskResult(ctx.task!.id);
                         return result as { content: Array<{ type: 'text'; text: string }> };
                     }
                 }
@@ -2421,27 +2421,27 @@ describe('Task-based execution', () => {
                     inputSchema: {}
                 },
                 {
-                    async createTask(_args, extra) {
-                        const task = await extra.taskStore.createTask({
-                            ttl: extra.taskRequestedTtl
+                    async createTask(_args, ctx) {
+                        const task = await ctx.task!.store.createTask({
+                            ttl: ctx.task!.requestedTtl
                         });
 
                         const result = {
                             content: [{ type: 'text', text: 'Result data!' }]
                         };
-                        await extra.taskStore.storeTaskResult(task.taskId, 'completed', result);
+                        await ctx.task!.store.storeTaskResult(task.taskId, 'completed', result);
 
                         return { task };
                     },
-                    async getTask(_args, extra) {
-                        const task = await extra.taskStore.getTask(extra.taskId);
+                    async getTask(_args, ctx) {
+                        const task = await ctx.task!.store.getTask(ctx.task!.id);
                         if (!task) {
-                            throw new Error(`Task ${extra.taskId} not found`);
+                            throw new Error(`Task ${ctx.task!.id} not found`);
                         }
                         return task;
                     },
-                    async getTaskResult(_args, extra) {
-                        const result = await extra.taskStore.getTaskResult(extra.taskId);
+                    async getTaskResult(_args, ctx) {
+                        const result = await ctx.task!.store.getTaskResult(ctx.task!.id);
                         return result as { content: Array<{ type: 'text'; text: string }> };
                     }
                 }
@@ -2502,27 +2502,27 @@ describe('Task-based execution', () => {
                     inputSchema: {}
                 },
                 {
-                    async createTask(_args, extra) {
-                        const task = await extra.taskStore.createTask({
-                            ttl: extra.taskRequestedTtl
+                    async createTask(_args, ctx) {
+                        const task = await ctx.task!.store.createTask({
+                            ttl: ctx.task!.requestedTtl
                         });
 
                         const result = {
                             content: [{ type: 'text', text: 'Success!' }]
                         };
-                        await extra.taskStore.storeTaskResult(task.taskId, 'completed', result);
+                        await ctx.task!.store.storeTaskResult(task.taskId, 'completed', result);
 
                         return { task };
                     },
-                    async getTask(_args, extra) {
-                        const task = await extra.taskStore.getTask(extra.taskId);
+                    async getTask(_args, ctx) {
+                        const task = await ctx.task!.store.getTask(ctx.task!.id);
                         if (!task) {
-                            throw new Error(`Task ${extra.taskId} not found`);
+                            throw new Error(`Task ${ctx.task!.id} not found`);
                         }
                         return task;
                     },
-                    async getTaskResult(_args, extra) {
-                        const result = await extra.taskStore.getTaskResult(extra.taskId);
+                    async getTaskResult(_args, ctx) {
+                        const result = await ctx.task!.store.getTaskResult(ctx.task!.id);
                         return result as { content: Array<{ type: 'text'; text: string }> };
                     }
                 }
@@ -2599,18 +2599,18 @@ describe('Task-based execution', () => {
                 }
             );
 
-            client.setRequestHandler('elicitation/create', async (request, extra) => {
+            client.setRequestHandler('elicitation/create', async (request, ctx) => {
                 const result = {
                     action: 'accept',
                     content: { username: 'list-user' }
                 };
 
                 // Check if task creation is requested
-                if (request.params.task && extra.taskStore) {
-                    const task = await extra.taskStore.createTask({
-                        ttl: extra.taskRequestedTtl
+                if (request.params.task && ctx.task!.store) {
+                    const task = await ctx.task!.store.createTask({
+                        ttl: ctx.task!.requestedTtl
                     });
-                    await extra.taskStore.storeTaskResult(task.taskId, 'completed', result);
+                    await ctx.task!.store.storeTaskResult(task.taskId, 'completed', result);
                     // Return CreateTaskResult when task creation is requested
                     return { task };
                 }
@@ -2692,18 +2692,18 @@ describe('Task-based execution', () => {
                 }
             );
 
-            client.setRequestHandler('elicitation/create', async (request, extra) => {
+            client.setRequestHandler('elicitation/create', async (request, ctx) => {
                 const result = {
                     action: 'accept',
                     content: { username: 'list-user' }
                 };
 
                 // Check if task creation is requested
-                if (request.params.task && extra.taskStore) {
-                    const task = await extra.taskStore.createTask({
-                        ttl: extra.taskRequestedTtl
+                if (request.params.task && ctx.task!.store) {
+                    const task = await ctx.task!.store.createTask({
+                        ttl: ctx.task!.requestedTtl
                     });
-                    await extra.taskStore.storeTaskResult(task.taskId, 'completed', result);
+                    await ctx.task!.store.storeTaskResult(task.taskId, 'completed', result);
                     // Return CreateTaskResult when task creation is requested
                     return { task };
                 }
@@ -2784,18 +2784,18 @@ describe('Task-based execution', () => {
                 }
             );
 
-            client.setRequestHandler('elicitation/create', async (request, extra) => {
+            client.setRequestHandler('elicitation/create', async (request, ctx) => {
                 const result = {
                     action: 'accept',
                     content: { username: 'result-user' }
                 };
 
                 // Check if task creation is requested
-                if (request.params.task && extra.taskStore) {
-                    const task = await extra.taskStore.createTask({
-                        ttl: extra.taskRequestedTtl
+                if (request.params.task && ctx.task!.store) {
+                    const task = await ctx.task!.store.createTask({
+                        ttl: ctx.task!.requestedTtl
                     });
-                    await extra.taskStore.storeTaskResult(task.taskId, 'completed', result);
+                    await ctx.task!.store.storeTaskResult(task.taskId, 'completed', result);
                     // Return CreateTaskResult when task creation is requested
                     return { task };
                 }
@@ -2875,18 +2875,18 @@ describe('Task-based execution', () => {
                 }
             );
 
-            client.setRequestHandler('elicitation/create', async (request, extra) => {
+            client.setRequestHandler('elicitation/create', async (request, ctx) => {
                 const result = {
                     action: 'accept',
                     content: { username: 'list-user' }
                 };
 
                 // Check if task creation is requested
-                if (request.params.task && extra.taskStore) {
-                    const task = await extra.taskStore.createTask({
-                        ttl: extra.taskRequestedTtl
+                if (request.params.task && ctx.task!.store) {
+                    const task = await ctx.task!.store.createTask({
+                        ttl: ctx.task!.requestedTtl
                     });
-                    await extra.taskStore.storeTaskResult(task.taskId, 'completed', result);
+                    await ctx.task!.store.storeTaskResult(task.taskId, 'completed', result);
                     // Return CreateTaskResult when task creation is requested
                     return { task };
                 }
@@ -2987,27 +2987,27 @@ describe('Task-based execution', () => {
                 }
             },
             {
-                async createTask({ id }, extra) {
-                    const task = await extra.taskStore.createTask({
-                        ttl: extra.taskRequestedTtl
+                async createTask({ id }, ctx) {
+                    const task = await ctx.task!.store.createTask({
+                        ttl: ctx.task!.requestedTtl
                     });
 
                     const result = {
                         content: [{ type: 'text', text: `Result for ${id || 'unknown'}` }]
                     };
-                    await extra.taskStore.storeTaskResult(task.taskId, 'completed', result);
+                    await ctx.task!.store.storeTaskResult(task.taskId, 'completed', result);
 
                     return { task };
                 },
-                async getTask(_args, extra) {
-                    const task = await extra.taskStore.getTask(extra.taskId);
+                async getTask(_args, ctx) {
+                    const task = await ctx.task!.store.getTask(ctx.task!.id);
                     if (!task) {
-                        throw new Error(`Task ${extra.taskId} not found`);
+                        throw new Error(`Task ${ctx.task!.id} not found`);
                     }
                     return task;
                 },
-                async getTaskResult(_args, extra) {
-                    const result = await extra.taskStore.getTaskResult(extra.taskId);
+                async getTaskResult(_args, ctx) {
+                    const result = await ctx.task!.store.getTaskResult(ctx.task!.id);
                     return result as { content: Array<{ type: 'text'; text: string }> };
                 }
             }
@@ -3255,27 +3255,27 @@ test('should respect server task capabilities', async () => {
             inputSchema: {}
         },
         {
-            async createTask(_args, extra) {
-                const task = await extra.taskStore.createTask({
-                    ttl: extra.taskRequestedTtl
+            async createTask(_args, ctx) {
+                const task = await ctx.task!.store.createTask({
+                    ttl: ctx.task!.requestedTtl
                 });
 
                 const result = {
                     content: [{ type: 'text', text: 'Success!' }]
                 };
-                await extra.taskStore.storeTaskResult(task.taskId, 'completed', result);
+                await ctx.task!.store.storeTaskResult(task.taskId, 'completed', result);
 
                 return { task };
             },
-            async getTask(_args, extra) {
-                const task = await extra.taskStore.getTask(extra.taskId);
+            async getTask(_args, ctx) {
+                const task = await ctx.task!.store.getTask(ctx.task!.id);
                 if (!task) {
-                    throw new Error(`Task ${extra.taskId} not found`);
+                    throw new Error(`Task ${ctx.task!.id} not found`);
                 }
                 return task;
             },
-            async getTaskResult(_args, extra) {
-                const result = await extra.taskStore.getTaskResult(extra.taskId);
+            async getTaskResult(_args, ctx) {
+                const result = await ctx.task!.store.getTaskResult(ctx.task!.id);
                 return result as { content: Array<{ type: 'text'; text: string }> };
             }
         }

--- a/test/integration/test/server.test.ts
+++ b/test/integration/test/server.test.ts
@@ -1384,12 +1384,12 @@ test('should handle request timeout', async () => {
         }
     );
 
-    client.setRequestHandler('sampling/createMessage', async (_request, extra) => {
+    client.setRequestHandler('sampling/createMessage', async (_request, ctx) => {
         await new Promise((resolve, reject) => {
             const timeout = setTimeout(resolve, 100);
-            extra.signal.addEventListener('abort', () => {
+            ctx.mcpReq.signal.addEventListener('abort', () => {
                 clearTimeout(timeout);
-                reject(extra.signal.reason);
+                reject(ctx.mcpReq.signal.reason);
             });
         });
 
@@ -2144,9 +2144,9 @@ describe('Task-based execution', () => {
                 inputSchema: {}
             },
             {
-                async createTask(_args, extra) {
-                    const task = await extra.taskStore.createTask({
-                        ttl: extra.taskRequestedTtl
+                async createTask(_args, ctx) {
+                    const task = await ctx.task!.store.createTask({
+                        ttl: ctx.task!.requestedTtl
                     });
 
                     // Simulate some async work
@@ -2155,20 +2155,20 @@ describe('Task-based execution', () => {
                         const result = {
                             content: [{ type: 'text', text: 'Tool executed successfully!' }]
                         };
-                        await extra.taskStore.storeTaskResult(task.taskId, 'completed', result);
+                        await ctx.task!.store.storeTaskResult(task.taskId, 'completed', result);
                     })();
 
                     return { task };
                 },
-                async getTask(_args, extra) {
-                    const task = await extra.taskStore.getTask(extra.taskId);
+                async getTask(_args, ctx) {
+                    const task = await ctx.task!.store.getTask(ctx.task!.id);
                     if (!task) {
-                        throw new Error(`Task ${extra.taskId} not found`);
+                        throw new Error(`Task ${ctx.task!.id} not found`);
                     }
                     return task;
                 },
-                async getTaskResult(_args, extra) {
-                    const result = await extra.taskStore.getTaskResult(extra.taskId);
+                async getTaskResult(_args, ctx) {
+                    const result = await ctx.task!.store.getTaskResult(ctx.task!.id);
                     return result as { content: Array<{ type: 'text'; text: string }> };
                 }
             }
@@ -2336,13 +2336,13 @@ describe('Task-based execution', () => {
         let capturedElicitRequest: z4.infer<typeof ElicitRequestSchema> | null = null;
 
         // Set up client elicitation handler
-        client.setRequestHandler('elicitation/create', async (request, extra) => {
+        client.setRequestHandler('elicitation/create', async (request, ctx) => {
             let taskId: string | undefined;
 
             // Check if task creation is requested
-            if (request.params.task && extra.taskStore) {
-                const createdTask = await extra.taskStore.createTask({
-                    ttl: extra.taskRequestedTtl
+            if (request.params.task && ctx.task!.store) {
+                const createdTask = await ctx.task!.store.createTask({
+                    ttl: ctx.task!.requestedTtl
                 });
                 taskId = createdTask.taskId;
             }
@@ -2366,15 +2366,15 @@ describe('Task-based execution', () => {
                 inputSchema: {}
             },
             {
-                async createTask(_args, extra) {
-                    const task = await extra.taskStore.createTask({
-                        ttl: extra.taskRequestedTtl
+                async createTask(_args, ctx) {
+                    const task = await ctx.task!.store.createTask({
+                        ttl: ctx.task!.requestedTtl
                     });
 
                     // Perform async work that makes a nested request
                     (async () => {
-                        // During tool execution, make a nested request to the client using extra.sendRequest
-                        const elicitResult = await extra.sendRequest(
+                        // During tool execution, make a nested request to the client using ctx.sendRequest
+                        const elicitResult = await ctx.mcpReq.send(
                             {
                                 method: 'elicitation/create',
                                 params: {
@@ -2400,20 +2400,20 @@ describe('Task-based execution', () => {
                                 }
                             ]
                         };
-                        await extra.taskStore.storeTaskResult(task.taskId, 'completed', result);
+                        await ctx.task!.store.storeTaskResult(task.taskId, 'completed', result);
                     })();
 
                     return { task };
                 },
-                async getTask(_args, extra) {
-                    const task = await extra.taskStore.getTask(extra.taskId);
+                async getTask(_args, ctx) {
+                    const task = await ctx.task!.store.getTask(ctx.task!.id);
                     if (!task) {
-                        throw new Error(`Task ${extra.taskId} not found`);
+                        throw new Error(`Task ${ctx.task!.id} not found`);
                     }
                     return task;
                 },
-                async getTaskResult(_args, extra) {
-                    const result = await extra.taskStore.getTaskResult(extra.taskId);
+                async getTaskResult(_args, ctx) {
+                    const result = await ctx.task!.store.getTaskResult(ctx.task!.id);
                     return result as { content: Array<{ type: 'text'; text: string }> };
                 }
             }
@@ -2490,18 +2490,18 @@ describe('Task-based execution', () => {
                 }
             );
 
-            client.setRequestHandler('elicitation/create', async (request, extra) => {
+            client.setRequestHandler('elicitation/create', async (request, ctx) => {
                 const result = {
                     action: 'accept',
                     content: { username: 'server-test-user', confirmed: true }
                 };
 
                 // Check if task creation is requested
-                if (request.params.task && extra.taskStore) {
-                    const task = await extra.taskStore.createTask({
-                        ttl: extra.taskRequestedTtl
+                if (request.params.task && ctx.task!.store) {
+                    const task = await ctx.task!.store.createTask({
+                        ttl: ctx.task!.requestedTtl
                     });
-                    await extra.taskStore.storeTaskResult(task.taskId, 'completed', result);
+                    await ctx.task!.store.storeTaskResult(task.taskId, 'completed', result);
                     // Return CreateTaskResult when task creation is requested
                     return { task };
                 }
@@ -2571,18 +2571,18 @@ describe('Task-based execution', () => {
                 }
             );
 
-            client.setRequestHandler('elicitation/create', async (request, extra) => {
+            client.setRequestHandler('elicitation/create', async (request, ctx) => {
                 const result = {
                     action: 'accept',
                     content: { username: 'list-user' }
                 };
 
                 // Check if task creation is requested
-                if (request.params.task && extra.taskStore) {
-                    const task = await extra.taskStore.createTask({
-                        ttl: extra.taskRequestedTtl
+                if (request.params.task && ctx.task!.store) {
+                    const task = await ctx.task!.store.createTask({
+                        ttl: ctx.task!.requestedTtl
                     });
-                    await extra.taskStore.storeTaskResult(task.taskId, 'completed', result);
+                    await ctx.task!.store.storeTaskResult(task.taskId, 'completed', result);
                     // Return CreateTaskResult when task creation is requested
                     return { task };
                 }
@@ -2650,18 +2650,18 @@ describe('Task-based execution', () => {
                 }
             );
 
-            client.setRequestHandler('elicitation/create', async (request, extra) => {
+            client.setRequestHandler('elicitation/create', async (request, ctx) => {
                 const result = {
                     action: 'accept',
                     content: { username: 'result-user', confirmed: true }
                 };
 
                 // Check if task creation is requested
-                if (request.params.task && extra.taskStore) {
-                    const task = await extra.taskStore.createTask({
-                        ttl: extra.taskRequestedTtl
+                if (request.params.task && ctx.task!.store) {
+                    const task = await ctx.task!.store.createTask({
+                        ttl: ctx.task!.requestedTtl
                     });
-                    await extra.taskStore.storeTaskResult(task.taskId, 'completed', result);
+                    await ctx.task!.store.storeTaskResult(task.taskId, 'completed', result);
                     // Return CreateTaskResult when task creation is requested
                     return { task };
                 }
@@ -2731,18 +2731,18 @@ describe('Task-based execution', () => {
                 }
             );
 
-            client.setRequestHandler('elicitation/create', async (request, extra) => {
+            client.setRequestHandler('elicitation/create', async (request, ctx) => {
                 const result = {
                     action: 'accept',
                     content: { username: 'list-user' }
                 };
 
                 // Check if task creation is requested
-                if (request.params.task && extra.taskStore) {
-                    const task = await extra.taskStore.createTask({
-                        ttl: extra.taskRequestedTtl
+                if (request.params.task && ctx.task!.store) {
+                    const task = await ctx.task!.store.createTask({
+                        ttl: ctx.task!.requestedTtl
                     });
-                    await extra.taskStore.storeTaskResult(task.taskId, 'completed', result);
+                    await ctx.task!.store.storeTaskResult(task.taskId, 'completed', result);
                     // Return CreateTaskResult when task creation is requested
                     return { task };
                 }
@@ -2845,9 +2845,9 @@ describe('Task-based execution', () => {
                 }
             },
             {
-                async createTask({ delay, taskNum }, extra) {
-                    const task = await extra.taskStore.createTask({
-                        ttl: extra.taskRequestedTtl
+                async createTask({ delay, taskNum }, ctx) {
+                    const task = await ctx.task!.store.createTask({
+                        ttl: ctx.task!.requestedTtl
                     });
 
                     // Simulate async work
@@ -2856,20 +2856,20 @@ describe('Task-based execution', () => {
                         const result = {
                             content: [{ type: 'text', text: `Completed task ${taskNum || 'unknown'}` }]
                         };
-                        await extra.taskStore.storeTaskResult(task.taskId, 'completed', result);
+                        await ctx.task!.store.storeTaskResult(task.taskId, 'completed', result);
                     })();
 
                     return { task };
                 },
-                async getTask(_args, extra) {
-                    const task = await extra.taskStore.getTask(extra.taskId);
+                async getTask(_args, ctx) {
+                    const task = await ctx.task!.store.getTask(ctx.task!.id);
                     if (!task) {
-                        throw new Error(`Task ${extra.taskId} not found`);
+                        throw new Error(`Task ${ctx.task!.id} not found`);
                     }
                     return task;
                 },
-                async getTaskResult(_args, extra) {
-                    const result = await extra.taskStore.getTaskResult(extra.taskId);
+                async getTaskResult(_args, ctx) {
+                    const result = await ctx.task!.store.getTaskResult(ctx.task!.id);
                     return result as { content: Array<{ type: 'text'; text: string }> };
                 }
             }
@@ -3074,18 +3074,18 @@ test('should respect client task capabilities', async () => {
         }
     );
 
-    client.setRequestHandler('elicitation/create', async (request, extra) => {
+    client.setRequestHandler('elicitation/create', async (request, ctx) => {
         const result = {
             action: 'accept',
             content: { username: 'test-user' }
         };
 
         // Check if task creation is requested
-        if (request.params.task && extra.taskStore) {
-            const task = await extra.taskStore.createTask({
-                ttl: extra.taskRequestedTtl
+        if (request.params.task && ctx.task!.store) {
+            const task = await ctx.task!.store.createTask({
+                ttl: ctx.task!.requestedTtl
             });
-            await extra.taskStore.storeTaskResult(task.taskId, 'completed', result);
+            await ctx.task!.store.storeTaskResult(task.taskId, 'completed', result);
             // Return CreateTaskResult when task creation is requested
             return { task };
         }

--- a/test/integration/test/server/context.test.ts
+++ b/test/integration/test/server/context.test.ts
@@ -1,0 +1,265 @@
+import { Client } from '@modelcontextprotocol/client';
+import type { BaseContext, ServerNotification, ServerRequest } from '@modelcontextprotocol/core';
+import {
+    CallToolResultSchema,
+    GetPromptResultSchema,
+    InMemoryTransport,
+    ListResourcesResultSchema,
+    ReadResourceResultSchema
+} from '@modelcontextprotocol/core';
+import type { ServerContext } from '@modelcontextprotocol/server';
+import { McpServer, ResourceTemplate } from '@modelcontextprotocol/server';
+import { z } from 'zod/v4';
+
+describe('ServerContext', () => {
+    /***
+     * Test: `ctx` provided to callbacks is ServerContext (parameterized)
+     */
+    type Seen = { isContext: boolean; hasRequestId: boolean };
+    const contextCases: Array<[string, (mcpServer: McpServer, seen: Seen) => void | Promise<void>, (client: Client) => Promise<unknown>]> =
+        [
+            [
+                'tool',
+                (mcpServer, seen) => {
+                    mcpServer.registerTool(
+                        'ctx-tool',
+                        {
+                            inputSchema: z.object({ name: z.string() })
+                        },
+                        (_args: { name: string }, ctx) => {
+                            seen.isContext = 'elicitInput' in ctx.mcpReq;
+                            seen.hasRequestId = !!ctx.mcpReq.id;
+                            return { content: [{ type: 'text', text: 'ok' }] };
+                        }
+                    );
+                },
+                client =>
+                    client.request(
+                        {
+                            method: 'tools/call',
+                            params: {
+                                name: 'ctx-tool',
+                                arguments: {
+                                    name: 'ctx-tool-name'
+                                }
+                            }
+                        },
+                        CallToolResultSchema
+                    )
+            ],
+            [
+                'resource',
+                (mcpServer, seen) => {
+                    mcpServer.registerResource('ctx-resource', 'test://res/1', { title: 'ctx-resource' }, async (_uri, ctx) => {
+                        seen.isContext = 'elicitInput' in ctx.mcpReq;
+                        seen.hasRequestId = !!ctx.mcpReq.id;
+                        return { contents: [{ uri: 'test://res/1', mimeType: 'text/plain', text: 'hello' }] };
+                    });
+                },
+                client => client.request({ method: 'resources/read', params: { uri: 'test://res/1' } }, ReadResourceResultSchema)
+            ],
+            [
+                'resource template list',
+                (mcpServer, seen) => {
+                    const template = new ResourceTemplate('test://items/{id}', {
+                        list: async ctx => {
+                            seen.isContext = 'elicitInput' in ctx.mcpReq;
+                            seen.hasRequestId = !!ctx.mcpReq.id;
+                            return { resources: [] };
+                        }
+                    });
+                    mcpServer.registerResource('ctx-template', template, { title: 'ctx-template' }, async (_uri, _vars, _ctx) => ({
+                        contents: []
+                    }));
+                },
+                client => client.request({ method: 'resources/list', params: {} }, ListResourcesResultSchema)
+            ],
+            [
+                'prompt',
+                (mcpServer, seen) => {
+                    mcpServer.registerPrompt('ctx-prompt', {}, async ctx => {
+                        seen.isContext = 'elicitInput' in ctx.mcpReq;
+                        seen.hasRequestId = !!ctx.mcpReq.id;
+                        return { messages: [] };
+                    });
+                },
+                client => client.request({ method: 'prompts/get', params: { name: 'ctx-prompt', arguments: {} } }, GetPromptResultSchema)
+            ]
+        ];
+
+    test.each(contextCases)('should pass ServerContext as ctx to %s callbacks', async (_kind, register, trigger) => {
+        const mcpServer = new McpServer({ name: 'ctx-test', version: '1.0' });
+        const client = new Client({ name: 'ctx-client', version: '1.0' });
+
+        const seen: Seen = { isContext: false, hasRequestId: false };
+
+        await register(mcpServer, seen);
+
+        const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+        await Promise.all([client.connect(clientTransport), mcpServer.server.connect(serverTransport)]);
+
+        await trigger(client);
+
+        expect(seen.isContext).toBe(true);
+        expect(seen.hasRequestId).toBe(true);
+    });
+
+    const logLevelsThroughContext = ['debug', 'info', 'warning', 'error'] as const;
+
+    //it.each for each log level, test that logging message is sent to client
+    it.each(logLevelsThroughContext)('should send logging message to client for %s level from ServerContext', async level => {
+        const mcpServer = new McpServer(
+            { name: 'ctx-test', version: '1.0' },
+            {
+                capabilities: {
+                    logging: {}
+                }
+            }
+        );
+        const client = new Client(
+            { name: 'ctx-client', version: '1.0' },
+            {
+                capabilities: {}
+            }
+        );
+
+        let seen = 0;
+
+        client.setNotificationHandler('notifications/message', notification => {
+            seen++;
+            expect(notification.params.level).toBe(level);
+            return;
+        });
+
+        mcpServer.registerTool('ctx-log-test', { inputSchema: z.object({ name: z.string() }) }, async (_args: { name: string }, ctx) => {
+            const serverCtx = ctx as ServerContext;
+            // Use the new notification API (no sessionId parameter)
+            await serverCtx.notification[level]('Test message', { test: 'test' });
+            await serverCtx.notification.log({
+                level,
+                data: 'Test message',
+                logger: 'test-logger-namespace'
+            });
+            return { content: [{ type: 'text', text: 'ok' }] };
+        });
+
+        const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+        await Promise.all([client.connect(clientTransport), mcpServer.server.connect(serverTransport)]);
+
+        const result = await client.request(
+            {
+                method: 'tools/call',
+                params: { name: 'ctx-log-test', arguments: { name: 'ctx-log-test-name' } }
+            },
+            CallToolResultSchema
+        );
+
+        // two messages should have been sent - one from the .log method and one from the .debug/info/warning/error method
+        expect(seen).toBe(2);
+
+        expect(result.content).toHaveLength(1);
+        expect(result.content[0]).toMatchObject({
+            type: 'text',
+            text: 'ok'
+        });
+    });
+    describe('BaseContext compatibility', () => {
+        const contextCases: Array<
+            [string, (mcpServer: McpServer, seen: Seen) => void | Promise<void>, (client: Client) => Promise<unknown>]
+        > = [
+            [
+                'tool',
+                (mcpServer, seen) => {
+                    mcpServer.registerTool(
+                        'ctx-tool',
+                        {
+                            inputSchema: z.object({ name: z.string() })
+                        },
+                        // The test is to ensure that the ctx is compatible with the BaseContext type
+                        (_args: { name: string }, ctx: BaseContext<ServerRequest, ServerNotification>) => {
+                            seen.isContext = 'elicitInput' in ctx.mcpReq;
+                            seen.hasRequestId = !!ctx.mcpReq.id;
+                            return { content: [{ type: 'text', text: 'ok' }] };
+                        }
+                    );
+                },
+                client =>
+                    client.request(
+                        {
+                            method: 'tools/call',
+                            params: {
+                                name: 'ctx-tool',
+                                arguments: {
+                                    name: 'ctx-tool-name'
+                                }
+                            }
+                        },
+                        CallToolResultSchema
+                    )
+            ],
+            [
+                'resource',
+                (mcpServer, seen) => {
+                    // The test is to ensure that the ctx is compatible with the BaseContext type
+                    mcpServer.registerResource(
+                        'ctx-resource',
+                        'test://res/1',
+                        { title: 'ctx-resource' },
+                        async (_uri, ctx: BaseContext<ServerRequest, ServerNotification>) => {
+                            seen.isContext = 'elicitInput' in ctx.mcpReq;
+                            seen.hasRequestId = !!ctx.mcpReq.id;
+                            return { contents: [{ uri: 'test://res/1', mimeType: 'text/plain', text: 'hello' }] };
+                        }
+                    );
+                },
+                client => client.request({ method: 'resources/read', params: { uri: 'test://res/1' } }, ReadResourceResultSchema)
+            ],
+            [
+                'resource template list',
+                (mcpServer, seen) => {
+                    // The test is to ensure that the ctx is compatible with the BaseContext type
+                    const template = new ResourceTemplate('test://items/{id}', {
+                        list: async (ctx: BaseContext<ServerRequest, ServerNotification>) => {
+                            seen.isContext = 'elicitInput' in ctx.mcpReq;
+                            seen.hasRequestId = !!ctx.mcpReq.id;
+                            return { resources: [] };
+                        }
+                    });
+                    mcpServer.registerResource('ctx-template', template, { title: 'ctx-template' }, async (_uri, _vars, _ctx) => ({
+                        contents: []
+                    }));
+                },
+                client => client.request({ method: 'resources/list', params: {} }, ListResourcesResultSchema)
+            ],
+            [
+                'prompt',
+                (mcpServer, seen) => {
+                    // The test is to ensure that the ctx is compatible with the BaseContext type
+                    mcpServer.registerPrompt('ctx-prompt', {}, async (ctx: BaseContext<ServerRequest, ServerNotification>) => {
+                        seen.isContext = 'elicitInput' in ctx.mcpReq;
+                        seen.hasRequestId = !!ctx.mcpReq.id;
+                        return { messages: [] };
+                    });
+                },
+                client => client.request({ method: 'prompts/get', params: { name: 'ctx-prompt', arguments: {} } }, GetPromptResultSchema)
+            ]
+        ];
+
+        test.each(contextCases)('should pass ServerContext as ctx to %s callbacks', async (_kind, register, trigger) => {
+            const mcpServer = new McpServer({ name: 'ctx-test', version: '1.0' });
+            const client = new Client({ name: 'ctx-client', version: '1.0' });
+
+            const seen: Seen = { isContext: false, hasRequestId: false };
+
+            await register(mcpServer, seen);
+
+            const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+            await Promise.all([client.connect(clientTransport), mcpServer.server.connect(serverTransport)]);
+
+            await trigger(client);
+
+            expect(seen.isContext).toBe(true);
+            expect(seen.hasRequestId).toBe(true);
+        });
+    });
+});

--- a/test/integration/test/taskLifecycle.test.ts
+++ b/test/integration/test/taskLifecycle.test.ts
@@ -63,8 +63,8 @@ describe('Task Lifecycle Integration Tests', () => {
                 }
             },
             {
-                async createTask({ duration, shouldFail }, extra) {
-                    const task = await extra.taskStore.createTask({
+                async createTask({ duration, shouldFail }, ctx) {
+                    const task = await ctx.task!.store.createTask({
                         ttl: 60_000,
                         pollInterval: 100
                     });
@@ -75,11 +75,11 @@ describe('Task Lifecycle Integration Tests', () => {
 
                         try {
                             await (shouldFail
-                                ? extra.taskStore.storeTaskResult(task.taskId, 'failed', {
+                                ? ctx.task!.store.storeTaskResult(task.taskId, 'failed', {
                                       content: [{ type: 'text', text: 'Task failed as requested' }],
                                       isError: true
                                   })
-                                : extra.taskStore.storeTaskResult(task.taskId, 'completed', {
+                                : ctx.task!.store.storeTaskResult(task.taskId, 'completed', {
                                       content: [{ type: 'text', text: `Completed after ${duration}ms` }]
                                   }));
                         } catch {
@@ -89,15 +89,15 @@ describe('Task Lifecycle Integration Tests', () => {
 
                     return { task };
                 },
-                async getTask(_args, extra) {
-                    const task = await extra.taskStore.getTask(extra.taskId);
+                async getTask(_args, ctx) {
+                    const task = await ctx.task!.store.getTask(ctx.task!.id);
                     if (!task) {
-                        throw new Error(`Task ${extra.taskId} not found`);
+                        throw new Error(`Task ${ctx.task!.id} not found`);
                     }
                     return task;
                 },
-                async getTaskResult(_args, extra) {
-                    const result = await extra.taskStore.getTaskResult(extra.taskId);
+                async getTaskResult(_args, ctx) {
+                    const result = await ctx.task!.store.getTaskResult(ctx.task!.id);
                     return result as { content: Array<{ type: 'text'; text: string }> };
                 }
             }
@@ -114,8 +114,8 @@ describe('Task Lifecycle Integration Tests', () => {
                 }
             },
             {
-                async createTask({ userName }, extra) {
-                    const task = await extra.taskStore.createTask({
+                async createTask({ userName }, ctx) {
+                    const task = await ctx.task!.store.createTask({
                         ttl: 60_000,
                         pollInterval: 100
                     });
@@ -128,14 +128,14 @@ describe('Task Lifecycle Integration Tests', () => {
                         if (userName) {
                             // Complete immediately if userName was provided
                             try {
-                                await extra.taskStore.storeTaskResult(task.taskId, 'completed', {
+                                await ctx.task!.store.storeTaskResult(task.taskId, 'completed', {
                                     content: [{ type: 'text', text: `Hello, ${userName}!` }]
                                 });
                             } catch {
                                 // Task may have been cleaned up if test ended
                             }
                         } else {
-                            const elicitationResult = await extra.sendRequest(
+                            const elicitationResult = await ctx.mcpReq.send(
                                 {
                                     method: 'elicitation/create',
                                     params: {
@@ -160,7 +160,7 @@ describe('Task Lifecycle Integration Tests', () => {
                                     ? elicitationResult.content.userName
                                     : 'Unknown';
                             try {
-                                await extra.taskStore.storeTaskResult(task.taskId, 'completed', {
+                                await ctx.task!.store.storeTaskResult(task.taskId, 'completed', {
                                     content: [{ type: 'text', text: `Hello, ${name}!` }]
                                 });
                             } catch {
@@ -171,15 +171,15 @@ describe('Task Lifecycle Integration Tests', () => {
 
                     return { task };
                 },
-                async getTask(_args, extra) {
-                    const task = await extra.taskStore.getTask(extra.taskId);
+                async getTask(_args, ctx) {
+                    const task = await ctx.task!.store.getTask(ctx.task!.id);
                     if (!task) {
-                        throw new Error(`Task ${extra.taskId} not found`);
+                        throw new Error(`Task ${ctx.task!.id} not found`);
                     }
                     return task;
                 },
-                async getTaskResult(_args, extra) {
-                    const result = await extra.taskStore.getTaskResult(extra.taskId);
+                async getTaskResult(_args, ctx) {
+                    const result = await ctx.task!.store.getTaskResult(ctx.task!.id);
                     return result as { content: Array<{ type: 'text'; text: string }> };
                 }
             }
@@ -418,8 +418,8 @@ describe('Task Lifecycle Integration Tests', () => {
                     }
                 },
                 {
-                    async createTask({ requestCount }, extra) {
-                        const task = await extra.taskStore.createTask({
+                    async createTask({ requestCount }, ctx) {
+                        const task = await ctx.task!.store.createTask({
                             ttl: 60_000,
                             pollInterval: 100
                         });
@@ -432,7 +432,7 @@ describe('Task Lifecycle Integration Tests', () => {
 
                             // Send multiple elicitation requests
                             for (let i = 0; i < requestCount; i++) {
-                                const elicitationResult = await extra.sendRequest(
+                                const elicitationResult = await ctx.mcpReq.send(
                                     {
                                         method: 'elicitation/create',
                                         params: {
@@ -458,7 +458,7 @@ describe('Task Lifecycle Integration Tests', () => {
 
                             // Complete with all responses
                             try {
-                                await extra.taskStore.storeTaskResult(task.taskId, 'completed', {
+                                await ctx.task!.store.storeTaskResult(task.taskId, 'completed', {
                                     content: [{ type: 'text', text: `Received responses: ${responses.join(', ')}` }]
                                 });
                             } catch {
@@ -468,15 +468,15 @@ describe('Task Lifecycle Integration Tests', () => {
 
                         return { task };
                     },
-                    async getTask(_args, extra) {
-                        const task = await extra.taskStore.getTask(extra.taskId);
+                    async getTask(_args, ctx) {
+                        const task = await ctx.task!.store.getTask(ctx.task!.id);
                         if (!task) {
-                            throw new Error(`Task ${extra.taskId} not found`);
+                            throw new Error(`Task ${ctx.task!.id} not found`);
                         }
                         return task;
                     },
-                    async getTaskResult(_args, extra) {
-                        const result = await extra.taskStore.getTaskResult(extra.taskId);
+                    async getTaskResult(_args, ctx) {
+                        const result = await ctx.task!.store.getTaskResult(ctx.task!.id);
                         return result as { content: Array<{ type: 'text'; text: string }> };
                     }
                 }
@@ -907,8 +907,8 @@ describe('Task Lifecycle Integration Tests', () => {
                     }
                 },
                 {
-                    async createTask({ messageCount }, extra) {
-                        const task = await extra.taskStore.createTask({
+                    async createTask({ messageCount }, ctx) {
+                        const task = await ctx.task!.store.createTask({
                             ttl: 60_000,
                             pollInterval: 100
                         });
@@ -921,8 +921,8 @@ describe('Task Lifecycle Integration Tests', () => {
                                 // Queue multiple elicitation requests
                                 for (let i = 0; i < messageCount; i++) {
                                     // Send request but don't await - let it queue
-                                    extra
-                                        .sendRequest(
+                                    ctx.mcpReq
+                                        .send(
                                             {
                                                 method: 'elicitation/create',
                                                 params: {
@@ -957,15 +957,15 @@ describe('Task Lifecycle Integration Tests', () => {
 
                         return { task };
                     },
-                    async getTask(_args, extra) {
-                        const task = await extra.taskStore.getTask(extra.taskId);
+                    async getTask(_args, ctx) {
+                        const task = await ctx.task!.store.getTask(ctx.task!.id);
                         if (!task) {
-                            throw new Error(`Task ${extra.taskId} not found`);
+                            throw new Error(`Task ${ctx.task!.id} not found`);
                         }
                         return task;
                     },
-                    async getTaskResult(_args, extra) {
-                        const result = await extra.taskStore.getTaskResult(extra.taskId);
+                    async getTaskResult(_args, ctx) {
+                        const result = await ctx.task!.store.getTaskResult(ctx.task!.id);
                         return result as { content: Array<{ type: 'text'; text: string }> };
                     }
                 }
@@ -1105,8 +1105,8 @@ describe('Task Lifecycle Integration Tests', () => {
                     }
                 },
                 {
-                    async createTask({ messageCount, delayBetweenMessages }, extra) {
-                        const task = await extra.taskStore.createTask({
+                    async createTask({ messageCount, delayBetweenMessages }, ctx) {
+                        const task = await ctx.task!.store.createTask({
                             ttl: 60_000,
                             pollInterval: 100
                         });
@@ -1121,7 +1121,7 @@ describe('Task Lifecycle Integration Tests', () => {
 
                                 // Send messages with delays between them
                                 for (let i = 0; i < messageCount; i++) {
-                                    const elicitationResult = await extra.sendRequest(
+                                    const elicitationResult = await ctx.mcpReq.send(
                                         {
                                             method: 'elicitation/create',
                                             params: {
@@ -1152,7 +1152,7 @@ describe('Task Lifecycle Integration Tests', () => {
 
                                 // Complete with all responses
                                 try {
-                                    await extra.taskStore.storeTaskResult(task.taskId, 'completed', {
+                                    await ctx.task!.store.storeTaskResult(task.taskId, 'completed', {
                                         content: [{ type: 'text', text: `Received all responses: ${responses.join(', ')}` }]
                                     });
                                 } catch {
@@ -1161,7 +1161,7 @@ describe('Task Lifecycle Integration Tests', () => {
                             } catch (error) {
                                 // Handle errors
                                 try {
-                                    await extra.taskStore.storeTaskResult(task.taskId, 'failed', {
+                                    await ctx.task!.store.storeTaskResult(task.taskId, 'failed', {
                                         content: [{ type: 'text', text: `Error: ${error}` }],
                                         isError: true
                                     });
@@ -1173,15 +1173,15 @@ describe('Task Lifecycle Integration Tests', () => {
 
                         return { task };
                     },
-                    async getTask(_args, extra) {
-                        const task = await extra.taskStore.getTask(extra.taskId);
+                    async getTask(_args, ctx) {
+                        const task = await ctx.task!.store.getTask(ctx.task!.id);
                         if (!task) {
-                            throw new Error(`Task ${extra.taskId} not found`);
+                            throw new Error(`Task ${ctx.task!.id} not found`);
                         }
                         return task;
                     },
-                    async getTaskResult(_args, extra) {
-                        const result = await extra.taskStore.getTaskResult(extra.taskId);
+                    async getTaskResult(_args, ctx) {
+                        const result = await ctx.task!.store.getTaskResult(ctx.task!.id);
                         return result as { content: Array<{ type: 'text'; text: string }> };
                     }
                 }
@@ -1321,8 +1321,8 @@ describe('Task Lifecycle Integration Tests', () => {
                     }
                 },
                 {
-                    async createTask({ messageCount }, extra) {
-                        const task = await extra.taskStore.createTask({
+                    async createTask({ messageCount }, ctx) {
+                        const task = await ctx.task!.store.createTask({
                             ttl: 60_000,
                             pollInterval: 100
                         });
@@ -1335,8 +1335,8 @@ describe('Task Lifecycle Integration Tests', () => {
                                 for (let i = 0; i < messageCount; i++) {
                                     // Start the request but don't wait for response
                                     // The request gets queued when sendRequest is called
-                                    extra
-                                        .sendRequest(
+                                    ctx.mcpReq
+                                        .send(
                                             {
                                                 method: 'elicitation/create',
                                                 params: {
@@ -1361,7 +1361,7 @@ describe('Task Lifecycle Integration Tests', () => {
 
                                 // Complete the task after all messages are queued
                                 try {
-                                    await extra.taskStore.storeTaskResult(task.taskId, 'completed', {
+                                    await ctx.task!.store.storeTaskResult(task.taskId, 'completed', {
                                         content: [{ type: 'text', text: 'Task completed quickly' }]
                                     });
                                 } catch {
@@ -1370,7 +1370,7 @@ describe('Task Lifecycle Integration Tests', () => {
                             } catch (error) {
                                 // Handle errors
                                 try {
-                                    await extra.taskStore.storeTaskResult(task.taskId, 'failed', {
+                                    await ctx.task!.store.storeTaskResult(task.taskId, 'failed', {
                                         content: [{ type: 'text', text: `Error: ${error}` }],
                                         isError: true
                                     });
@@ -1382,15 +1382,15 @@ describe('Task Lifecycle Integration Tests', () => {
 
                         return { task };
                     },
-                    async getTask(_args, extra) {
-                        const task = await extra.taskStore.getTask(extra.taskId);
+                    async getTask(_args, ctx) {
+                        const task = await ctx.task!.store.getTask(ctx.task!.id);
                         if (!task) {
-                            throw new Error(`Task ${extra.taskId} not found`);
+                            throw new Error(`Task ${ctx.task!.id} not found`);
                         }
                         return task;
                     },
-                    async getTaskResult(_args, extra) {
-                        const result = await extra.taskStore.getTaskResult(extra.taskId);
+                    async getTaskResult(_args, ctx) {
+                        const result = await ctx.task!.store.getTaskResult(ctx.task!.id);
                         return result as { content: Array<{ type: 'text'; text: string }> };
                     }
                 }

--- a/test/integration/test/taskResumability.test.ts
+++ b/test/integration/test/taskResumability.test.ts
@@ -68,9 +68,9 @@ describe.each(zodTestMatrix)('$zodVersionLabel', (entry: ZodMatrixEntry) => {
                         message: z.string().describe('Message to send').default('Test notification')
                     }
                 },
-                async ({ message }, { sendNotification }) => {
+                async ({ message }, ctx) => {
                     // Send notification immediately
-                    await sendNotification({
+                    await ctx.notification.send({
                         method: 'notifications/message',
                         params: {
                             level: 'info',
@@ -94,10 +94,10 @@ describe.each(zodTestMatrix)('$zodVersionLabel', (entry: ZodMatrixEntry) => {
                         interval: z.number().describe('Interval between notifications in ms').default(50)
                     }
                 },
-                async ({ count, interval }, { sendNotification }) => {
+                async ({ count, interval }, ctx) => {
                     // Send notifications at specified intervals
                     for (let i = 0; i < count; i++) {
-                        await sendNotification({
+                        await ctx.notification.send({
                             method: 'notifications/message',
                             params: {
                                 level: 'info',


### PR DESCRIPTION
## Summary

Alternative implementation of the Context API from PR #1241, using **plain types and POJOs** instead of a class hierarchy.

This PR replaces the flat `RequestHandlerExtra` type with a structured context system using 4 types:

| Type | Description |
|------|-------------|
| `BaseContext` | Common context for all handlers (session, mcpReq, http, task, notification) |
| `ServerContext` | Extends BaseContext with server-specific methods (logging, elicitation, sampling, SSE controls) |
| `ClientContext` | Type alias for BaseContext with client-specific generics |
| `TaskContext` | Task-related fields (id, store, requestedTtl) |

## Key differences from #1241

| Aspect | PR #1241 | This PR |
|--------|----------|---------|
| Implementation | Abstract class hierarchy (`BaseContext` class → `ServerContext`/`ClientContext` subclasses) | Plain types with POJO construction |
| Type count | ~13 types/interfaces/classes | 4 types |
| Construction | `new ServerContext(...)` / `new ClientContext(...)` | Plain object literals with closures |
| Type checking | `ctx instanceof ServerContext` | Duck-type checks (`"elicitInput" in ctx.mcpReq`) |
| Method sharing | Prototype-based (shared across instances) | Closures per request (same as current `RequestHandlerExtra`) |

## Context structure (same nested grouping as #1241)

```typescript
ctx.sessionId
ctx.mcpReq.id / .method / ._meta / .signal / .send()
ctx.http?.authInfo / .req / .closeSSE / .closeStandaloneSSE  // server only
ctx.task?.id / .store / .requestedTtl
ctx.notification.send() / .log() / .debug() / .info() / ...  // logging on server only
ctx.mcpReq.elicitInput() / .requestSampling()                // server only
```

## Motivation

- **Simpler**: 4 types vs ~13 — easier to understand and maintain
- **Consistent**: Keeps the POJO+closure pattern from the existing `RequestHandlerExtra`
- **Same API surface**: Users get the same nested structure and convenience methods
- **No runtime overhead**: No class instantiation, prototype chains, or `instanceof` checks

## Breaking Changes

Same breaking changes as #1241 — `RequestHandlerExtra` properties move to the nested context structure.

## How Has This Been Tested

- All existing tests updated and passing (497 tests)
- `pnpm check:all` (typecheck + lint) passes
- `pnpm test:all` passes

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed