### PR TITLE
server: add maxBodyBytes guard for streamable HTTP

### DIFF
--- a/.changeset/streamable-http-body-size-limit.md
+++ b/.changeset/streamable-http-body-size-limit.md
@@ -1,0 +1,6 @@
+---
+'@modelcontextprotocol/server': patch
+---
+
+Add a default `maxBodyBytes` limit for `WebStandardStreamableHTTPServerTransport` to prevent unbounded JSON request body buffering (413 on oversized payloads).
+


### PR DESCRIPTION
`WebStandardStreamableHTTPServerTransport` currently parses POST bodies via `await req.json()`, which buffers the full request body in memory.

This PR adds a `maxBodyBytes` option (default: `1_000_000`) and enforces it when parsing JSON bodies. Oversized payloads return **413**.

- Adds `maxBodyBytes` to `WebStandardStreamableHTTPServerTransportOptions` (negative disables)
- Enforces the limit via streaming read + byte count (fast `Content-Length` reject when present)
- Returns `413` with JSON error response (`-32_000`, "Payload too large")
- Adds a focused test

Note: if callers pass `parsedBody` to `handleRequest`, they must enforce limits in their framework/body parser.
