### PR TITLE
fix(server): prioritize zod issues and format them

### DIFF
--- a/.changeset/fix-zod-error-message-priority.md
+++ b/.changeset/fix-zod-error-message-priority.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/sdk': patch
+---
+
+Prioritize `error.issues[].message` over `error.message` in `getParseErrorMessage` so custom Zod error messages surface correctly. In Zod v4, `error.message` is a JSON blob of all issues, not a readable string.

--- a/src/server/zod-compat.ts
+++ b/src/server/zod-compat.ts
@@ -214,7 +214,7 @@ export function getParseErrorMessage(error: unknown): string {
         if ('issues' in error && Array.isArray(error.issues) && error.issues.length > 0) {
             return error.issues
                 .map((i: { message: string; path?: (string | number)[] }) => {
-                    if (!i.path) {
+                    if (!i.path?.length) {
                         return i.message;
                     }
                     return `${i.message} at ${getDotPath(i.path)}`;


### PR DESCRIPTION
By default, when a parse fails, the output message now prioritizes zod issues by formatting each issue as a line with its message and associated path. This is in line with zod's [prettify](https://github.com/colinhacks/zod/blob/3cd45ebcbcf06a3f16e702a010074dfceca3ea50/packages/zod/src/v4/core/errors.ts#L435) and the current approach on [main branch](https://github.com/modelcontextprotocol/typescript-sdk/blob/65bbceab773277f056a9d3e385e7e7d8cef54f9b/packages/server/src/server/mcp.ts#L246)

## Motivation and Context
Currently, when a parse against an input or output schema fails, the default value error.message that is used is unclear and bloated. In addition, with zod4, we cannot assume that error.message will have all the zod issues aggregated properly under it. Reference this for more details:
https://github.com/issues/created?issue=modelcontextprotocol%7Ctypescript-sdk%7C1415

## How Has This Been Tested?
I built the package and tested it in my mcp-based project by sending tool call requests that will fail, the output is a set of lines each representing a zod-issue, with custom messages appearing clearly. For example:
```
Invalid input: expected string, received undefined at path personalData.dateOfBirth
Invalid country of birth at path personalData.countryOfBirth  <--- custom error
Unrecognized key: "termAndConditions" at object root
```

## Breaking Changes
There should not be any breaking changes. If some mcp-client implementations are making assumptions about error output for InvalidParams 32602 errors and running special logic based on that, they may run into issues. But I would not think that its the case since the error output format was previously also prone to vary. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed