### PR TITLE
fix: support exactOptionalPropertyTypes in Transport interface

### DIFF
--- a/.changeset/fix-exact-optional-types.md
+++ b/.changeset/fix-exact-optional-types.md
@@ -1,0 +1,6 @@
+---
+'@modelcontextprotocol/core': patch
+'@modelcontextprotocol/server': patch
+---
+
+Add explicit `| undefined` to optional properties in Transport interface and related option types to support TypeScript's `exactOptionalPropertyTypes` compiler option

--- a/packages/core/src/shared/transport.ts
+++ b/packages/core/src/shared/transport.ts
@@ -66,7 +66,7 @@ export type TransportSendOptions = {
      *
      * This allows clients to persist the latest token for potential reconnection.
      */
-    onresumptiontoken?: (token: string) => void;
+    onresumptiontoken?: ((token: string) => void) | undefined;
 };
 /**
  * Describes the minimal contract for an MCP transport that a client or server can communicate over.
@@ -98,14 +98,14 @@ export interface Transport {
      *
      * This should be invoked when close() is called as well.
      */
-    onclose?: () => void;
+    onclose?: (() => void) | undefined;
 
     /**
      * Callback for when an error occurs.
      *
      * Note that errors are not necessarily fatal; they are used for reporting any kind of exceptional condition out of band.
      */
-    onerror?: (error: Error) => void;
+    onerror?: ((error: Error) => void) | undefined;
 
     /**
      * Callback for when a message (request or response) is received over the connection.
@@ -114,21 +114,21 @@ export interface Transport {
      *
      * The requestInfo can be used to get the original request information (headers, etc.)
      */
-    onmessage?: <T extends JSONRPCMessage>(message: T, extra?: MessageExtraInfo) => void;
+    onmessage?: (<T extends JSONRPCMessage>(message: T, extra?: MessageExtraInfo) => void) | undefined;
 
     /**
      * The session ID generated for this connection.
      */
-    sessionId?: string;
+    sessionId?: string | undefined;
 
     /**
      * Sets the protocol version used for the connection (called when the initialize response is received).
      */
-    setProtocolVersion?: (version: string) => void;
+    setProtocolVersion?: ((version: string) => void) | undefined;
 
     /**
      * Sets the supported protocol versions for header validation (called during connect).
      * This allows the server to pass its supported versions to the transport.
      */
-    setSupportedProtocolVersions?: (versions: string[]) => void;
+    setSupportedProtocolVersions?: ((versions: string[]) => void) | undefined;
 }

--- a/packages/server/src/server/streamableHttp.ts
+++ b/packages/server/src/server/streamableHttp.ts
@@ -77,7 +77,7 @@ export interface WebStandardStreamableHTTPServerTransportOptions {
      *
      * If not provided, session management is disabled (stateless mode).
      */
-    sessionIdGenerator?: () => string;
+    sessionIdGenerator?: (() => string) | undefined;
 
     /**
      * A callback for session initialization events
@@ -86,7 +86,7 @@ export interface WebStandardStreamableHTTPServerTransportOptions {
      * and need to keep track of them.
      * @param sessionId The generated session ID
      */
-    onsessioninitialized?: (sessionId: string) => void | Promise<void>;
+    onsessioninitialized?: ((sessionId: string) => void | Promise<void>) | undefined;
 
     /**
      * A callback for session close events
@@ -98,7 +98,7 @@ export interface WebStandardStreamableHTTPServerTransportOptions {
      * session open/running.
      * @param sessionId The session ID that was closed
      */
-    onsessionclosed?: (sessionId: string) => void | Promise<void>;
+    onsessionclosed?: ((sessionId: string) => void | Promise<void>) | undefined;
 
     /**
      * If true, the server will return JSON responses instead of starting an SSE stream.


### PR DESCRIPTION
## Summary

- Add explicit `| undefined` to all optional properties in the `Transport` interface, `TransportSendOptions` type, and `WebStandardStreamableHTTPServerTransportOptions` interface
- This ensures compatibility with TypeScript's `exactOptionalPropertyTypes` compiler option, which otherwise causes `TS2420: Class incorrectly implements interface` errors when implementing `Transport`

## Details

When `exactOptionalPropertyTypes: true` is enabled in `tsconfig.json`, TypeScript distinguishes between "property may be missing" (`prop?: T`) and "property may be undefined" (`prop?: T | undefined`). Without the `| undefined` union, classes that declare optional properties (e.g., `onclose?: () => void`) cannot be assigned `undefined` at runtime, triggering type errors.

**Affected types:**
- `Transport.onclose`, `Transport.onerror`, `Transport.onmessage`, `Transport.sessionId`, `Transport.setProtocolVersion`, `Transport.setSupportedProtocolVersions`
- `TransportSendOptions.onresumptiontoken`
- `WebStandardStreamableHTTPServerTransportOptions.sessionIdGenerator`, `.onsessioninitialized`, `.onsessionclosed`

Fixes #1314

## Test plan

- [x] `tsc --noEmit` passes for all packages (core, server, client, middleware/node, middleware/express, middleware/hono)
- [x] No functional changes -- only type-level additions of `| undefined` to optional property types
- [x] Existing tests remain unaffected (this is a purely additive type change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)