### PR TITLE
fix: pass empty args to registerToolTask handler when no inputSchema

### DIFF
--- a/.changeset/fix-register-tool-task-args.md
+++ b/.changeset/fix-register-tool-task-args.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/server': patch
+---
+
+Fix `registerToolTask` to pass empty args object to `createTask` handler when no `inputSchema` is provided, allowing two-argument `(args, ctx)` handler signatures to work correctly.

--- a/packages/server/src/server/mcp.ts
+++ b/packages/server/src/server/mcp.ts
@@ -1042,10 +1042,10 @@ function createToolExecutor(inputSchema: AnySchema | undefined, handler: AnyTool
                 throw new Error('No task store provided.');
             }
             const taskCtx: CreateTaskServerContext = { ...ctx, task: { store: ctx.task.store, requestedTtl: ctx.task?.requestedTtl } };
-            if (inputSchema) {
-                return taskHandler.createTask(args, taskCtx);
+            if (inputSchema || taskHandler.createTask.length > 1) {
+                return taskHandler.createTask(inputSchema ? args : {}, taskCtx);
             }
-            // When no inputSchema, call with just ctx (the handler expects (ctx) signature)
+            // When no inputSchema and handler expects single arg, call with just ctx
             return (taskHandler.createTask as (ctx: CreateTaskServerContext) => CreateTaskResult | Promise<CreateTaskResult>)(taskCtx);
         };
     }


### PR DESCRIPTION
## Summary

- Fixes `registerToolTask` to correctly pass `({}, ctx)` to `createTask` handlers that use a two-argument `(args, ctx)` signature when no `inputSchema` is provided
- Uses `Function.length` to detect handler arity: single-arg `(ctx)` handlers continue working as before, while two-arg `(args, ctx)` handlers receive an empty object as the first argument
- No change to regular tool callbacks (only affects task handlers)

Closes #1471

## Test plan

- [x] All 37 server unit tests pass
- [x] All 364 integration tests pass (including existing `registerToolTask` tests with both single-arg and two-arg patterns)
- [x] Build passes (`pnpm build:all`)
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)