### PR TITLE
Modify registerPrompt to accept undefined Args type

### DIFF
--- a/.changeset/moody-humans-grow.md
+++ b/.changeset/moody-humans-grow.md
@@ -1,0 +1,5 @@
+---
+"@modelcontextprotocol/server": patch
+---
+
+Fix `registerPrompt` generic to allow the no-args callback overload. The `Args` type parameter now defaults to `undefined`, matching `registerTool`.

--- a/packages/server/src/server/mcp.ts
+++ b/packages/server/src/server/mcp.ts
@@ -1239,7 +1239,7 @@ export type RegisteredPrompt = {
     enabled: boolean;
     enable(): void;
     disable(): void;
-    update<Args extends StandardSchemaWithJSON>(updates: {
+    update<Args extends StandardSchemaWithJSON | undefined = undefined>(updates: {
         name?: string | null;
         title?: string;
         description?: string;

--- a/packages/server/src/server/mcp.ts
+++ b/packages/server/src/server/mcp.ts
@@ -915,7 +915,7 @@ export class McpServer {
      * );
      * ```
      */
-    registerPrompt<Args extends StandardSchemaWithJSON>(
+    registerPrompt<Args extends StandardSchemaWithJSON | undefined = undefined>(
         name: string,
         config: {
             title?: string;

--- a/packages/server/test/server/mcp.types.test.ts
+++ b/packages/server/test/server/mcp.types.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Compile-time type checks for McpServer registration methods.
+ *
+ * These verify that generic type parameters resolve correctly for the
+ * no-argsSchema and with-argsSchema overloads of registerPrompt.
+ */
+import type { GetPromptResult, ServerContext } from '@modelcontextprotocol/core';
+import * as z from 'zod/v4';
+
+import { McpServer } from '../../src/server/mcp.js';
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+declare const server: McpServer;
+declare const result: GetPromptResult;
+
+// Without argsSchema, the callback must accept (ctx) only.
+// Before the fix, Args had no default and could not be undefined, so the
+// PromptCallback conditional never resolved to the no-args branch.
+function registerPrompt_noArgs() {
+    server.registerPrompt('no-args', {}, (ctx: ServerContext) => result);
+
+    // @ts-expect-error -- callback cannot take an args parameter when argsSchema is omitted
+    server.registerPrompt('no-args', {}, (args: { code: string }, ctx: ServerContext) => result);
+}
+
+// With argsSchema, the callback must accept (args, ctx).
+function registerPrompt_withArgs() {
+    server.registerPrompt(
+        'with-args',
+        { argsSchema: z.object({ code: z.string() }) },
+        (args: { code: string }, ctx: ServerContext) => result
+    );
+}

--- a/packages/server/test/server/mcp.types.test.ts
+++ b/packages/server/test/server/mcp.types.test.ts
@@ -5,6 +5,7 @@
  * no-argsSchema and with-argsSchema overloads of registerPrompt.
  */
 import type { GetPromptResult, ServerContext } from '@modelcontextprotocol/core';
+import { describe, it } from 'vitest';
 import * as z from 'zod/v4';
 
 import { McpServer } from '../../src/server/mcp.js';
@@ -32,3 +33,10 @@ function registerPrompt_withArgs() {
         (args: { code: string }, ctx: ServerContext) => result
     );
 }
+
+describe('registerPrompt types', () => {
+    it('compiles', () => {
+        // The functions above are compile-time type assertions; this suite
+        // exists so vitest detects the file as containing tests.
+    });
+});


### PR DESCRIPTION
## Motivation and Context

When using `registerPrompt` without any `argsSchema` the callback will still be typed as the first argument is the input of the argsSchema, which is not the case.

This PR corrects that.

Code:
```typescript
server.registerPrompt(
  'my_prompt',
  { title: 'My Prompt' },
  ({ authInfo }) => {
```

Current type:
```typescript
McpServer.registerPrompt<ZodRawShapeCompat>(name: string, config: {
  ...
}, cb: (args: ShapeOutput<ZodRawShapeCompat>, extra: RequestHandlerExtra<ServerRequest, ServerNotification>) => ...
```

Correct type:
```typescript
McpServer.registerPrompt<undefined>(name: string, config: {
 ...
}, cb: (extra: RequestHandlerExtra<ServerRequest, ServerNotification>) => ...
```

## How Has This Been Tested?

Tested in a project using `mcp-handler`

## Breaking Changes

Maybe someone has used the types incorrectly. Unsure if this counts as breaking, as it's a bugfix.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed