### PR TITLE
[1.x] fix(client): retry SSE stream after receiving session ID

### DIFF
--- a/src/client/streamableHttp.ts
+++ b/src/client/streamableHttp.ts
@@ -137,6 +137,7 @@ export class StreamableHTTPClientTransport implements Transport {
     private _lastUpscopingHeader?: string; // Track last upscoping header to prevent infinite upscoping.
     private _serverRetryMs?: number; // Server-provided retry delay from SSE retry field
     private _reconnectionTimeout?: ReturnType<typeof setTimeout>;
+    private _sseStreamOpened = false; // Track if SSE stream was successfully opened
 
     onclose?: () => void;
     onerror?: (error: Error) => void;
@@ -240,6 +241,7 @@ export class StreamableHTTPClientTransport implements Transport {
                 throw new StreamableHTTPError(response.status, `Failed to open SSE stream: ${response.statusText}`);
             }
 
+            this._sseStreamOpened = true;
             this._handleSseStream(response.body, options, true);
         } catch (error) {
             this.onerror?.(error as Error);
@@ -479,8 +481,17 @@ export class StreamableHTTPClientTransport implements Transport {
 
             // Handle session ID received during initialization
             const sessionId = response.headers.get('mcp-session-id');
+            const hadSessionId = this._sessionId !== undefined;
             if (sessionId) {
                 this._sessionId = sessionId;
+            }
+
+            // If we just received a session ID for the first time and SSE stream is not open,
+            // try to open it now. This handles the case where the initial SSE connection
+            // during start() was rejected because the server wasn't initialized yet.
+            // See: https://github.com/modelcontextprotocol/typescript-sdk/issues/1167
+            if (sessionId && !hadSessionId && !this._sseStreamOpened) {
+                this._startOrAuthSse({ resumptionToken: undefined }).catch(err => this.onerror?.(err));
             }
 
             if (!response.ok) {

--- a/src/client/streamableHttp.ts
+++ b/src/client/streamableHttp.ts
@@ -137,6 +137,7 @@ export class StreamableHTTPClientTransport implements Transport {
     private _lastUpscopingHeader?: string; // Track last upscoping header to prevent infinite upscoping.
     private _serverRetryMs?: number; // Server-provided retry delay from SSE retry field
     private _reconnectionTimeout?: ReturnType<typeof setTimeout>;
+    private _sseStreamOpened = false; // Track if SSE stream was successfully opened
 
     onclose?: () => void;
     onerror?: (error: Error) => void;
@@ -240,6 +241,7 @@ export class StreamableHTTPClientTransport implements Transport {
                 throw new StreamableHTTPError(response.status, `Failed to open SSE stream: ${response.statusText}`);
             }
 
+            this._sseStreamOpened = true;
             this._handleSseStream(response.body, options, true);
         } catch (error) {
             this.onerror?.(error as Error);
@@ -479,8 +481,17 @@ export class StreamableHTTPClientTransport implements Transport {
 
             // Handle session ID received during initialization
             const sessionId = response.headers.get('mcp-session-id');
+            const hadSessionId = this._sessionId !== undefined;
             if (sessionId) {
                 this._sessionId = sessionId;
+            }
+
+            // If we just received a session ID for the first time and SSE stream is not open,
+            // try to open it now. This handles the case where the initial SSE connection
+            // during start() was rejected because the server wasn't initialized yet.
+            // See: https://github.com/modelcontextprotocol/typescript-sdk/issues/1167
+            if (sessionId && !hadSessionId && !this._sseStreamOpened) {
+                this._startOrAuthSse({ resumptionToken: undefined }).catch(err => this.onerror?.(err));
             }
 
             if (!response.ok) {
@@ -561,12 +572,8 @@ export class StreamableHTTPClientTransport implements Transport {
                 // if the accepted notification is initialized, we start the SSE stream
                 // if it's supported by the server
                 if (isInitializedNotification(message)) {
-                    // Await the SSE stream opening so that connect() does not resolve
-                    // until the GET listener is established.  This prevents a race where
-                    // the server sends a request (e.g. roots/list) before the stream is ready.
-                    // Errors are swallowed here because _startOrAuthSse already reports
-                    // them via onerror, and the SSE stream is optional (server may 405).
-                    await this._startOrAuthSse({ resumptionToken: undefined }).catch(() => {});
+                    // Start without a lastEventId since this is a fresh connection
+                    this._startOrAuthSse({ resumptionToken: undefined }).catch(err => this.onerror?.(err));
                 }
                 return;
             }

--- a/src/client/streamableHttp.ts
+++ b/src/client/streamableHttp.ts
@@ -137,7 +137,6 @@ export class StreamableHTTPClientTransport implements Transport {
     private _lastUpscopingHeader?: string; // Track last upscoping header to prevent infinite upscoping.
     private _serverRetryMs?: number; // Server-provided retry delay from SSE retry field
     private _reconnectionTimeout?: ReturnType<typeof setTimeout>;
-    private _sseStreamOpened = false; // Track if SSE stream was successfully opened
 
     onclose?: () => void;
     onerror?: (error: Error) => void;
@@ -241,7 +240,6 @@ export class StreamableHTTPClientTransport implements Transport {
                 throw new StreamableHTTPError(response.status, `Failed to open SSE stream: ${response.statusText}`);
             }
 
-            this._sseStreamOpened = true;
             this._handleSseStream(response.body, options, true);
         } catch (error) {
             this.onerror?.(error as Error);
@@ -481,17 +479,8 @@ export class StreamableHTTPClientTransport implements Transport {
 
             // Handle session ID received during initialization
             const sessionId = response.headers.get('mcp-session-id');
-            const hadSessionId = this._sessionId !== undefined;
             if (sessionId) {
                 this._sessionId = sessionId;
-            }
-
-            // If we just received a session ID for the first time and SSE stream is not open,
-            // try to open it now. This handles the case where the initial SSE connection
-            // during start() was rejected because the server wasn't initialized yet.
-            // See: https://github.com/modelcontextprotocol/typescript-sdk/issues/1167
-            if (sessionId && !hadSessionId && !this._sseStreamOpened) {
-                this._startOrAuthSse({ resumptionToken: undefined }).catch(err => this.onerror?.(err));
             }
 
             if (!response.ok) {
@@ -572,8 +561,12 @@ export class StreamableHTTPClientTransport implements Transport {
                 // if the accepted notification is initialized, we start the SSE stream
                 // if it's supported by the server
                 if (isInitializedNotification(message)) {
-                    // Start without a lastEventId since this is a fresh connection
-                    this._startOrAuthSse({ resumptionToken: undefined }).catch(err => this.onerror?.(err));
+                    // Await the SSE stream opening so that connect() does not resolve
+                    // until the GET listener is established.  This prevents a race where
+                    // the server sends a request (e.g. roots/list) before the stream is ready.
+                    // Errors are swallowed here because _startOrAuthSse already reports
+                    // them via onerror, and the SSE stream is optional (server may 405).
+                    await this._startOrAuthSse({ resumptionToken: undefined }).catch(() => {});
                 }
                 return;
             }

--- a/test/client/streamableHttp.test.ts
+++ b/test/client/streamableHttp.test.ts
@@ -101,7 +101,18 @@ describe('StreamableHTTPClientTransport', () => {
             headers: new Headers({ 'content-type': 'text/event-stream', 'mcp-session-id': 'test-session-id' })
         });
 
+        // Mock the SSE stream GET request that happens after receiving session ID
+        (global.fetch as Mock).mockResolvedValueOnce({
+            ok: false,
+            status: 405,
+            headers: new Headers(),
+            body: { cancel: vi.fn() }
+        });
+
         await transport.send(message);
+
+        // Allow the async SSE connection attempt to complete
+        await new Promise(resolve => setTimeout(resolve, 10));
 
         // Send a second message that should include the session ID
         (global.fetch as Mock).mockResolvedValueOnce({
@@ -137,7 +148,19 @@ describe('StreamableHTTPClientTransport', () => {
             headers: new Headers({ 'content-type': 'text/event-stream', 'mcp-session-id': 'test-session-id' })
         });
 
+        // Mock the SSE stream GET request that happens after receiving session ID
+        (global.fetch as Mock).mockResolvedValueOnce({
+            ok: false,
+            status: 405,
+            headers: new Headers(),
+            body: { cancel: vi.fn() }
+        });
+
         await transport.send(message);
+
+        // Allow the async SSE connection attempt to complete
+        await new Promise(resolve => setTimeout(resolve, 10));
+
         expect(transport.sessionId).toBe('test-session-id');
 
         // Now terminate the session
@@ -177,7 +200,18 @@ describe('StreamableHTTPClientTransport', () => {
             headers: new Headers({ 'content-type': 'text/event-stream', 'mcp-session-id': 'test-session-id' })
         });
 
+        // Mock the SSE stream GET request that happens after receiving session ID
+        (global.fetch as Mock).mockResolvedValueOnce({
+            ok: false,
+            status: 405,
+            headers: new Headers(),
+            body: { cancel: vi.fn() }
+        });
+
         await transport.send(message);
+
+        // Allow the async SSE connection attempt to complete
+        await new Promise(resolve => setTimeout(resolve, 10));
 
         // Now terminate the session, but server responds with 405
         (global.fetch as Mock).mockResolvedValueOnce({

--- a/test/client/streamableHttp.test.ts
+++ b/test/client/streamableHttp.test.ts
@@ -101,7 +101,18 @@ describe('StreamableHTTPClientTransport', () => {
             headers: new Headers({ 'content-type': 'text/event-stream', 'mcp-session-id': 'test-session-id' })
         });
 
+        // Mock the SSE stream GET request that happens after receiving session ID
+        (global.fetch as Mock).mockResolvedValueOnce({
+            ok: false,
+            status: 405,
+            headers: new Headers(),
+            body: { cancel: vi.fn() }
+        });
+
         await transport.send(message);
+
+        // Allow the async SSE connection attempt to complete
+        await new Promise(resolve => setTimeout(resolve, 10));
 
         // Send a second message that should include the session ID
         (global.fetch as Mock).mockResolvedValueOnce({
@@ -137,7 +148,18 @@ describe('StreamableHTTPClientTransport', () => {
             headers: new Headers({ 'content-type': 'text/event-stream', 'mcp-session-id': 'test-session-id' })
         });
 
+        // Mock the SSE stream GET request that happens after receiving session ID
+        (global.fetch as Mock).mockResolvedValueOnce({
+            ok: false,
+            status: 405,
+            headers: new Headers(),
+            body: { cancel: vi.fn() }
+        });
+
         await transport.send(message);
+
+        // Allow the async SSE connection attempt to complete
+        await new Promise(resolve => setTimeout(resolve, 10));
 
         expect(transport.sessionId).toBe('test-session-id');
 
@@ -178,7 +200,18 @@ describe('StreamableHTTPClientTransport', () => {
             headers: new Headers({ 'content-type': 'text/event-stream', 'mcp-session-id': 'test-session-id' })
         });
 
+        // Mock the SSE stream GET request that happens after receiving session ID
+        (global.fetch as Mock).mockResolvedValueOnce({
+            ok: false,
+            status: 405,
+            headers: new Headers(),
+            body: { cancel: vi.fn() }
+        });
+
         await transport.send(message);
+
+        // Allow the async SSE connection attempt to complete
+        await new Promise(resolve => setTimeout(resolve, 10));
 
         // Now terminate the session, but server responds with 405
         (global.fetch as Mock).mockResolvedValueOnce({

--- a/test/client/streamableHttp.test.ts
+++ b/test/client/streamableHttp.test.ts
@@ -101,18 +101,7 @@ describe('StreamableHTTPClientTransport', () => {
             headers: new Headers({ 'content-type': 'text/event-stream', 'mcp-session-id': 'test-session-id' })
         });
 
-        // Mock the SSE stream GET request that happens after receiving session ID
-        (global.fetch as Mock).mockResolvedValueOnce({
-            ok: false,
-            status: 405,
-            headers: new Headers(),
-            body: { cancel: vi.fn() }
-        });
-
         await transport.send(message);
-
-        // Allow the async SSE connection attempt to complete
-        await new Promise(resolve => setTimeout(resolve, 10));
 
         // Send a second message that should include the session ID
         (global.fetch as Mock).mockResolvedValueOnce({
@@ -148,18 +137,7 @@ describe('StreamableHTTPClientTransport', () => {
             headers: new Headers({ 'content-type': 'text/event-stream', 'mcp-session-id': 'test-session-id' })
         });
 
-        // Mock the SSE stream GET request that happens after receiving session ID
-        (global.fetch as Mock).mockResolvedValueOnce({
-            ok: false,
-            status: 405,
-            headers: new Headers(),
-            body: { cancel: vi.fn() }
-        });
-
         await transport.send(message);
-
-        // Allow the async SSE connection attempt to complete
-        await new Promise(resolve => setTimeout(resolve, 10));
 
         expect(transport.sessionId).toBe('test-session-id');
 
@@ -200,18 +178,7 @@ describe('StreamableHTTPClientTransport', () => {
             headers: new Headers({ 'content-type': 'text/event-stream', 'mcp-session-id': 'test-session-id' })
         });
 
-        // Mock the SSE stream GET request that happens after receiving session ID
-        (global.fetch as Mock).mockResolvedValueOnce({
-            ok: false,
-            status: 405,
-            headers: new Headers(),
-            body: { cancel: vi.fn() }
-        });
-
         await transport.send(message);
-
-        // Allow the async SSE connection attempt to complete
-        await new Promise(resolve => setTimeout(resolve, 10));
 
         // Now terminate the session, but server responds with 405
         (global.fetch as Mock).mockResolvedValueOnce({

--- a/test/server/index.test.ts
+++ b/test/server/index.test.ts
@@ -13,12 +13,14 @@ import {
     LATEST_PROTOCOL_VERSION,
     ListPromptsRequestSchema,
     ListResourcesRequestSchema,
+    ListRootsRequestSchema,
     ListToolsRequestSchema,
     type LoggingMessageNotification,
     McpError,
     NotificationSchema,
     RequestSchema,
     ResultSchema,
+    RootsListChangedNotificationSchema,
     SetLevelRequestSchema,
     SUPPORTED_PROTOCOL_VERSIONS,
     CreateTaskResultSchema
@@ -3276,4 +3278,329 @@ test('should respect client task capabilities', async () => {
     ).rejects.toThrow('Client does not support task creation for sampling/createMessage');
 
     clientTaskStore.cleanup();
+});
+
+describe('roots/list', () => {
+    test('should successfully list roots when client supports roots capability', async () => {
+        const server = new Server(
+            {
+                name: 'test server',
+                version: '1.0'
+            },
+            {
+                capabilities: {
+                    prompts: {},
+                    resources: {},
+                    tools: {},
+                    logging: {}
+                },
+                enforceStrictCapabilities: true
+            }
+        );
+
+        const client = new Client(
+            {
+                name: 'test client',
+                version: '1.0'
+            },
+            {
+                capabilities: {
+                    roots: {}
+                }
+            }
+        );
+
+        // Register handler for roots/list
+        client.setRequestHandler(ListRootsRequestSchema, async () => {
+            return {
+                roots: [
+                    {
+                        uri: 'file:///home/user/project',
+                        name: 'My Project'
+                    }
+                ]
+            };
+        });
+
+        const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+        await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
+
+        const result = await server.listRoots();
+
+        expect(result.roots).toHaveLength(1);
+        expect(result.roots[0]).toEqual({
+            uri: 'file:///home/user/project',
+            name: 'My Project'
+        });
+    });
+
+    test('should handle empty roots list', async () => {
+        const server = new Server(
+            {
+                name: 'test server',
+                version: '1.0'
+            },
+            {
+                capabilities: {
+                    prompts: {},
+                    resources: {},
+                    tools: {},
+                    logging: {}
+                },
+                enforceStrictCapabilities: true
+            }
+        );
+
+        const client = new Client(
+            {
+                name: 'test client',
+                version: '1.0'
+            },
+            {
+                capabilities: {
+                    roots: {}
+                }
+            }
+        );
+
+        // Return empty roots list
+        client.setRequestHandler(ListRootsRequestSchema, async () => {
+            return {
+                roots: []
+            };
+        });
+
+        const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+        await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
+
+        const result = await server.listRoots();
+
+        expect(result.roots).toHaveLength(0);
+        expect(result.roots).toEqual([]);
+    });
+
+    test('should handle multiple roots', async () => {
+        const server = new Server(
+            {
+                name: 'test server',
+                version: '1.0'
+            },
+            {
+                capabilities: {
+                    prompts: {},
+                    resources: {},
+                    tools: {},
+                    logging: {}
+                },
+                enforceStrictCapabilities: true
+            }
+        );
+
+        const client = new Client(
+            {
+                name: 'test client',
+                version: '1.0'
+            },
+            {
+                capabilities: {
+                    roots: {}
+                }
+            }
+        );
+
+        const expectedRoots = [
+            { uri: 'file:///home/user/project1', name: 'Project 1' },
+            { uri: 'file:///home/user/project2', name: 'Project 2' },
+            { uri: 'file:///var/data/shared' }
+        ];
+
+        client.setRequestHandler(ListRootsRequestSchema, async () => {
+            return { roots: expectedRoots };
+        });
+
+        const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+        await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
+
+        const result = await server.listRoots();
+
+        expect(result.roots).toHaveLength(3);
+        expect(result.roots).toEqual(expectedRoots);
+    });
+
+    test('should handle roots with optional name and _meta fields', async () => {
+        const server = new Server(
+            {
+                name: 'test server',
+                version: '1.0'
+            },
+            {
+                capabilities: {
+                    prompts: {},
+                    resources: {},
+                    tools: {},
+                    logging: {}
+                },
+                enforceStrictCapabilities: true
+            }
+        );
+
+        const client = new Client(
+            {
+                name: 'test client',
+                version: '1.0'
+            },
+            {
+                capabilities: {
+                    roots: {}
+                }
+            }
+        );
+
+        const expectedRoots = [
+            // Root with all optional fields
+            {
+                uri: 'file:///home/user/project',
+                name: 'Full Project',
+                _meta: {
+                    type: 'workspace',
+                    priority: 1
+                }
+            },
+            // Root with only uri (minimal)
+            {
+                uri: 'file:///tmp/scratch'
+            },
+            // Root with name but no _meta
+            {
+                uri: 'file:///var/logs',
+                name: 'Log Directory'
+            }
+        ];
+
+        client.setRequestHandler(ListRootsRequestSchema, async () => {
+            return { roots: expectedRoots };
+        });
+
+        const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+        await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
+
+        const result = await server.listRoots();
+
+        expect(result.roots).toHaveLength(3);
+        expect(result.roots[0]).toEqual({
+            uri: 'file:///home/user/project',
+            name: 'Full Project',
+            _meta: {
+                type: 'workspace',
+                priority: 1
+            }
+        });
+        expect(result.roots[1]).toEqual({
+            uri: 'file:///tmp/scratch'
+        });
+        expect(result.roots[2]).toEqual({
+            uri: 'file:///var/logs',
+            name: 'Log Directory'
+        });
+    });
+
+    test('should send roots list changed notification', async () => {
+        const server = new Server(
+            {
+                name: 'test server',
+                version: '1.0'
+            },
+            {
+                capabilities: {
+                    prompts: {},
+                    resources: {},
+                    tools: {},
+                    logging: {}
+                },
+                enforceStrictCapabilities: true
+            }
+        );
+
+        const client = new Client(
+            {
+                name: 'test client',
+                version: '1.0'
+            },
+            {
+                capabilities: {
+                    roots: {
+                        listChanged: true
+                    }
+                }
+            }
+        );
+
+        // Track if notification was received
+        let notificationReceived = false;
+
+        server.setNotificationHandler(RootsListChangedNotificationSchema, async () => {
+            notificationReceived = true;
+        });
+
+        client.setRequestHandler(ListRootsRequestSchema, async () => {
+            return { roots: [] };
+        });
+
+        const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+        await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
+
+        // Send the notification
+        await client.sendRootsListChanged();
+
+        // Give a moment for the notification to be processed
+        await new Promise(resolve => setTimeout(resolve, 10));
+
+        expect(notificationReceived).toBe(true);
+    });
+
+    test('should pass context to roots/list handler', async () => {
+        const server = new Server(
+            {
+                name: 'test server',
+                version: '1.0'
+            },
+            {
+                capabilities: {
+                    prompts: {},
+                    resources: {},
+                    tools: {},
+                    logging: {}
+                },
+                enforceStrictCapabilities: true
+            }
+        );
+
+        const client = new Client(
+            {
+                name: 'test client',
+                version: '1.0'
+            },
+            {
+                capabilities: {
+                    roots: {}
+                }
+            }
+        );
+
+        let capturedExtra: unknown = null;
+
+        client.setRequestHandler(ListRootsRequestSchema, async (_request, extra) => {
+            capturedExtra = extra;
+            return { roots: [] };
+        });
+
+        const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+        await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
+
+        await server.listRoots();
+
+        expect(capturedExtra).not.toBeNull();
+        expect(capturedExtra).toHaveProperty('sessionId');
+        expect(capturedExtra).toHaveProperty('signal');
+    });
 });


### PR DESCRIPTION
Fixes server-initiated requests (roots/list, sampling, elicitation) hanging over sHTTP when not issued as part of a client-to-server request. The client now retries opening the GET SSE stream after receiving a session ID during initialization.

## Motivation and Context
Without this fix, sending requests to the client (particularly roots/elicitation requests) hangs on the server unless that is bounded by some other request, like a tool call. Naturally, this doesn't guarantee compatibility with any other SDK, but at least ensures that using the client and server from this SDK together works as intended.

## How Has This Been Tested?
Updated unit/integration tests.

## Breaking Changes
None.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
Should fix #1167
v2: https://github.com/modelcontextprotocol/typescript-sdk/pull/1521