### PR TITLE
fix: call onerror for silently swallowed transport errors

### DIFF
--- a/.changeset/fix-transport-onerror-swallowed.md
+++ b/.changeset/fix-transport-onerror-swallowed.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/server': patch
+---
+
+Call `onerror` callback for transport errors that were previously silently swallowed. Nested try/catch blocks in `handlePostRequest` for JSON parsing and JSON-RPC validation now invoke `onerror` before returning error responses. The `writeSSEEvent` method also reports errors via `onerror` instead of silently returning `false`.

--- a/packages/server/src/server/streamableHttp.ts
+++ b/packages/server/src/server/streamableHttp.ts
@@ -569,7 +569,8 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
             eventData += `data: ${JSON.stringify(message)}\n\n`;
             controller.enqueue(encoder.encode(eventData));
             return true;
-        } catch {
+        } catch (error) {
+            this.onerror?.(error as Error);
             return false;
         }
     }
@@ -627,7 +628,8 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
             if (options?.parsedBody === undefined) {
                 try {
                     rawMessage = await req.json();
-                } catch {
+                } catch (error) {
+                    this.onerror?.(error as Error);
                     return this.createJsonErrorResponse(400, -32_700, 'Parse error: Invalid JSON');
                 }
             } else {
@@ -641,7 +643,8 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
                 messages = Array.isArray(rawMessage)
                     ? rawMessage.map(msg => JSONRPCMessageSchema.parse(msg))
                     : [JSONRPCMessageSchema.parse(rawMessage)];
-            } catch {
+            } catch (error) {
+                this.onerror?.(error as Error);
                 return this.createJsonErrorResponse(400, -32_700, 'Parse error: Invalid JSON-RPC message');
             }
 


### PR DESCRIPTION
## Summary

- Nested try/catch blocks in `WebStandardStreamableHTTPServerTransport.handlePostRequest` were returning error responses without invoking the `onerror` callback, making transport errors invisible to consumers
- JSON parsing errors (`req.json()` failures) now call `onerror` before returning the error response
- JSON-RPC message validation errors (Zod schema parse failures) now call `onerror`
- `writeSSEEvent` failures now call `onerror` instead of silently returning `false`

Closes #1395

## Test plan

- [x] `pnpm typecheck:all` passes
- [x] `pnpm --filter @modelcontextprotocol/server test` — all 37 tests pass
- [ ] Verify `onerror` fires for invalid JSON request body
- [ ] Verify `onerror` fires for malformed JSON-RPC messages
- [ ] Verify `onerror` fires when SSE stream write fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)