### PR TITLE
feat: implement auth/pre-registration conformance scenario

### DIFF
--- a/test/conformance/src/everythingClient.ts
+++ b/test/conformance/src/everythingClient.ts
@@ -247,24 +247,17 @@ async function runPreRegistrationClient(serverUrl: string): Promise<void> {
 
     // Create a provider pre-populated with registered credentials,
     // so the SDK skips dynamic client registration.
-    const provider = new ConformanceOAuthProvider(
-        'http://localhost:3000/callback',
-        {
-            client_name: 'conformance-pre-registration',
-            redirect_uris: ['http://localhost:3000/callback']
-        }
-    );
+    const provider = new ConformanceOAuthProvider('http://localhost:3000/callback', {
+        client_name: 'conformance-pre-registration',
+        redirect_uris: ['http://localhost:3000/callback']
+    });
     provider.saveClientInformation({
         client_id: ctx.client_id,
         client_secret: ctx.client_secret,
         redirect_uris: ['http://localhost:3000/callback']
     });
 
-    const oauthFetch = withOAuthRetry(
-        'conformance-pre-registration',
-        new URL(serverUrl),
-        handle401
-    )(fetch);
+    const oauthFetch = withOAuthRetry('conformance-pre-registration', new URL(serverUrl), handle401)(fetch);
 
     // Replace the provider in the middleware — we need to use our pre-populated one.
     // withOAuthRetry creates its own provider, so instead we use the provider directly.


### PR DESCRIPTION
<!-- Add conformance client test for auth/pre-registration scenario -->

## Motivation and Context
The conformance suite includes an `auth/pre-registration` scenario that tests OAuth flows where the client is pre-registered with the authorization server (no dynamic client registration). The SDK supports this but had no conformance client test.

## How Has This Been Tested?
Tested against the conformance server — passes all 15 checks for the `auth/pre-registration` scenario.

## Breaking Changes
None.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
Part 3 of 3 in a stack (depends on #1543).

Adds `test/conformance/src/everythingClient.ts` scenario that exercises the pre-registration OAuth flow with a pre-configured client ID and secret.