### PR TITLE
feat(express): add jsonBodyLimit option to createMcpExpressApp

### DIFF
--- a/packages/middleware/express/src/express.ts
+++ b/packages/middleware/express/src/express.ts
@@ -58,7 +58,7 @@ export function createMcpExpressApp(options: CreateMcpExpressAppOptions = {}): E
     const { host = '127.0.0.1', allowedHosts, jsonBodyLimit } = options;
 
     const app = express();
-    app.use(express.json(jsonBodyLimit !== undefined ? { limit: jsonBodyLimit } : {}));
+    app.use(express.json(jsonBodyLimit === undefined ? {} : { limit: jsonBodyLimit }));
 
     // If allowedHosts is explicitly provided, use that for validation
     if (allowedHosts) {


### PR DESCRIPTION
## Summary
- Adds a `jsonBodyLimit` option to `CreateMcpExpressAppOptions` to allow configuring the maximum request body size for the JSON body parser
- Accepts a number (bytes) or a string (e.g., `'1mb'`, `'500kb'`)
- Defaults to Express's built-in default of `100kb` if not specified

## Motivation
When MCP payloads exceed Express's default 100kb limit, the body parser rejects the request. This change allows users to configure the limit without needing to patch the package.

Closes #1354

## Test plan
- [x] Verify default behavior unchanged (no `jsonBodyLimit` = Express default 100kb)
- [x] Verify custom limit works (e.g., `jsonBodyLimit: '1mb'`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)