### PR TITLE
fix(examples): use 404 status for invalid session IDs

### DIFF
--- a/examples/server/src/elicitationFormExample.ts
+++ b/examples/server/src/elicitationFormExample.ts
@@ -361,11 +361,11 @@ async function main() {
                 return;
             } else {
                 // Invalid request - no session ID or not initialization request
-                res.status(400).json({
+                res.status(404).json({
                     jsonrpc: '2.0',
                     error: {
                         code: -32_000,
-                        message: 'Bad Request: No valid session ID provided'
+                        message: 'Not Found: No valid session ID provided'
                     },
                     id: null
                 });
@@ -395,7 +395,7 @@ async function main() {
     const mcpGetHandler = async (req: Request, res: Response) => {
         const sessionId = req.headers['mcp-session-id'] as string | undefined;
         if (!sessionId || !transports[sessionId]) {
-            res.status(400).send('Invalid or missing session ID');
+            res.status(404).send('Invalid or missing session ID');
             return;
         }
 
@@ -410,7 +410,7 @@ async function main() {
     const mcpDeleteHandler = async (req: Request, res: Response) => {
         const sessionId = req.headers['mcp-session-id'] as string | undefined;
         if (!sessionId || !transports[sessionId]) {
-            res.status(400).send('Invalid or missing session ID');
+            res.status(404).send('Invalid or missing session ID');
             return;
         }
 

--- a/examples/server/src/elicitationUrlExample.ts
+++ b/examples/server/src/elicitationUrlExample.ts
@@ -608,11 +608,11 @@ const mcpPostHandler = async (req: Request, res: Response) => {
             return; // Already handled
         } else {
             // Invalid request - no session ID or not initialization request
-            res.status(400).json({
+            res.status(404).json({
                 jsonrpc: '2.0',
                 error: {
                     code: -32_000,
-                    message: 'Bad Request: No valid session ID provided'
+                    message: 'Not Found: No valid session ID provided'
                 },
                 id: null
             });
@@ -644,7 +644,7 @@ app.post('/mcp', authMiddleware, mcpPostHandler);
 const mcpGetHandler = async (req: Request, res: Response) => {
     const sessionId = req.headers['mcp-session-id'] as string | undefined;
     if (!sessionId || !transports[sessionId]) {
-        res.status(400).send('Invalid or missing session ID');
+        res.status(404).send('Invalid or missing session ID');
         return;
     }
 
@@ -683,7 +683,7 @@ app.get('/mcp', authMiddleware, mcpGetHandler);
 const mcpDeleteHandler = async (req: Request, res: Response) => {
     const sessionId = req.headers['mcp-session-id'] as string | undefined;
     if (!sessionId || !transports[sessionId]) {
-        res.status(400).send('Invalid or missing session ID');
+        res.status(404).send('Invalid or missing session ID');
         return;
     }
 

--- a/examples/server/src/jsonResponseStreamableHttp.ts
+++ b/examples/server/src/jsonResponseStreamableHttp.ts
@@ -112,11 +112,11 @@ app.post('/mcp', async (req: Request, res: Response) => {
             return; // Already handled
         } else {
             // Invalid request - no session ID or not initialization request
-            res.status(400).json({
+            res.status(404).json({
                 jsonrpc: '2.0',
                 error: {
                     code: -32_000,
-                    message: 'Bad Request: No valid session ID provided'
+                    message: 'Not Found: No valid session ID provided'
                 },
                 id: null
             });

--- a/examples/server/src/simpleStreamableHttp.ts
+++ b/examples/server/src/simpleStreamableHttp.ts
@@ -586,11 +586,11 @@ const mcpPostHandler = async (req: Request, res: Response) => {
             return; // Already handled
         } else {
             // Invalid request - no session ID or not initialization request
-            res.status(400).json({
+            res.status(404).json({
                 jsonrpc: '2.0',
                 error: {
                     code: -32_000,
-                    message: 'Bad Request: No valid session ID provided'
+                    message: 'Not Found: No valid session ID provided'
                 },
                 id: null
             });
@@ -626,7 +626,7 @@ if (useOAuth && authMiddleware) {
 const mcpGetHandler = async (req: Request, res: Response) => {
     const sessionId = req.headers['mcp-session-id'] as string | undefined;
     if (!sessionId || !transports[sessionId]) {
-        res.status(400).send('Invalid or missing session ID');
+        res.status(404).send('Invalid or missing session ID');
         return;
     }
 
@@ -657,7 +657,7 @@ if (useOAuth && authMiddleware) {
 const mcpDeleteHandler = async (req: Request, res: Response) => {
     const sessionId = req.headers['mcp-session-id'] as string | undefined;
     if (!sessionId || !transports[sessionId]) {
-        res.status(400).send('Invalid or missing session ID');
+        res.status(404).send('Invalid or missing session ID');
         return;
     }
 

--- a/examples/server/src/simpleTaskInteractive.ts
+++ b/examples/server/src/simpleTaskInteractive.ts
@@ -671,9 +671,9 @@ app.post('/mcp', async (req: Request, res: Response) => {
             await transport.handleRequest(req, res, req.body);
             return;
         } else {
-            res.status(400).json({
+            res.status(404).json({
                 jsonrpc: '2.0',
-                error: { code: -32_000, message: 'Bad Request: No valid session ID' },
+                error: { code: -32_000, message: 'Not Found: No valid session ID' },
                 id: null
             });
             return;
@@ -696,7 +696,7 @@ app.post('/mcp', async (req: Request, res: Response) => {
 app.get('/mcp', async (req: Request, res: Response) => {
     const sessionId = req.headers['mcp-session-id'] as string | undefined;
     if (!sessionId || !transports[sessionId]) {
-        res.status(400).send('Invalid or missing session ID');
+        res.status(404).send('Invalid or missing session ID');
         return;
     }
 
@@ -708,7 +708,7 @@ app.get('/mcp', async (req: Request, res: Response) => {
 app.delete('/mcp', async (req: Request, res: Response) => {
     const sessionId = req.headers['mcp-session-id'] as string | undefined;
     if (!sessionId || !transports[sessionId]) {
-        res.status(400).send('Invalid or missing session ID');
+        res.status(404).send('Invalid or missing session ID');
         return;
     }
 

--- a/examples/server/src/standaloneSseWithGetStreamableHttp.ts
+++ b/examples/server/src/standaloneSseWithGetStreamableHttp.ts
@@ -68,11 +68,11 @@ app.post('/mcp', async (req: Request, res: Response) => {
             return; // Already handled
         } else {
             // Invalid request - no session ID or not initialization request
-            res.status(400).json({
+            res.status(404).json({
                 jsonrpc: '2.0',
                 error: {
                     code: -32_000,
-                    message: 'Bad Request: No valid session ID provided'
+                    message: 'Not Found: No valid session ID provided'
                 },
                 id: null
             });
@@ -100,7 +100,7 @@ app.post('/mcp', async (req: Request, res: Response) => {
 app.get('/mcp', async (req: Request, res: Response) => {
     const sessionId = req.headers['mcp-session-id'] as string | undefined;
     if (!sessionId || !transports[sessionId]) {
-        res.status(400).send('Invalid or missing session ID');
+        res.status(404).send('Invalid or missing session ID');
         return;
     }
 


### PR DESCRIPTION
## Summary
- Changes HTTP status code from `400` to `404` for invalid/missing session ID responses across all streamable HTTP examples
- Per the MCP spec: "When a client receives HTTP 404 in response to a request containing an Mcp-Session-Id, it MUST start a new session"
- Updated error messages from "Bad Request" to "Not Found" for consistency

## Files changed
- `jsonResponseStreamableHttp.ts` — POST handler
- `simpleStreamableHttp.ts` — POST, GET, DELETE handlers
- `standaloneSseWithGetStreamableHttp.ts` — POST, GET handlers
- `simpleTaskInteractive.ts` — POST, GET, DELETE handlers
- `elicitationFormExample.ts` — POST, GET, DELETE handlers
- `elicitationUrlExample.ts` — POST, GET, DELETE handlers

Closes #389

## Test plan
- [x] Verify all session-related 400 responses changed to 404
- [x] Non-session 400 responses (e.g., missing parameters) left unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)