### PR TITLE
fix(core): allow additional JSON Schema properties in elicitInput requestedSchema

### DIFF
--- a/.changeset/zod-json-schema-compat.md
+++ b/.changeset/zod-json-schema-compat.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/core': patch
+---
+
+Allow additional JSON Schema properties in elicitInput's requestedSchema type by adding .catchall(z.unknown()), matching the pattern used by inputSchema. This fixes type incompatibility when using Zod v4's .toJSONSchema() output which includes extra properties like $schema and additionalProperties.

--- a/packages/core/src/types/schemas.ts
+++ b/packages/core/src/types/schemas.ts
@@ -1855,11 +1855,13 @@ export const ElicitRequestFormParamsSchema = TaskAugmentedRequestParamsSchema.ex
      * A restricted subset of JSON Schema.
      * Only top-level properties are allowed, without nesting.
      */
-    requestedSchema: z.object({
-        type: z.literal('object'),
-        properties: z.record(z.string(), PrimitiveSchemaDefinitionSchema),
-        required: z.array(z.string()).optional()
-    })
+    requestedSchema: z
+        .object({
+            type: z.literal('object'),
+            properties: z.record(z.string(), PrimitiveSchemaDefinitionSchema),
+            required: z.array(z.string()).optional()
+        })
+        .catchall(z.unknown())
 });
 
 /**


### PR DESCRIPTION
## Summary

- Adds `.catchall(z.unknown())` to the `requestedSchema` object type in `ElicitRequestFormParamsSchema`, matching the existing pattern used by `inputSchema` and `outputSchema` for tool definitions
- This allows Zod v4's `.toJSONSchema()` output (which includes extra properties like `$schema` and `additionalProperties`) to be passed directly to `elicitInput()` without type errors

## Problem

When using Zod v4's `.toJSONSchema()` to generate a schema for `elicitInput`, the resulting object includes standard JSON Schema properties like `$schema` and `additionalProperties` that are not present in the `requestedSchema` TypeScript type. This works at runtime but fails type-checking, forcing users to use type casts.

```typescript
// This fails type-checking today:
const result = await server.elicitInput({
  mode: 'form',
  message: 'Enter info',
  requestedSchema: z.object({ name: z.string() }).toJSONSchema()
  //                ^^^^^^^^ Type error: $schema, additionalProperties not assignable
});
```

## Fix

The fix follows the same pattern already established in this codebase for `inputSchema` and `outputSchema` (lines 1391-1409 of `types.ts`), which use `.catchall(z.unknown())` to accept additional JSON Schema properties beyond the required `type`, `properties`, and `required` fields.

The spec type in `spec.types.ts` already includes `$schema?: string` in its `requestedSchema` definition (line 2155), confirming that additional properties are expected.

Fixes #1362

## Test plan

- [ ] Existing elicitation tests continue to pass (no behavioral change -- `.catchall(z.unknown())` only widens the accepted type)
- [ ] Spec type compatibility test (`spec.types.test.ts`) continues to pass (`.catchall(z.unknown())` adds an index signature which is structurally compatible)
- [ ] Verify that `z.object({ name: z.string() }).toJSONSchema()` is now accepted by `elicitInput` without type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)