### PR TITLE
feat(client): add configurable periodic ping for connection health

### DIFF
--- a/.changeset/periodic-ping.md
+++ b/.changeset/periodic-ping.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/client': minor
+---
+
+Add configurable periodic ping to Client for connection health monitoring, as recommended by the MCP specification.


### PR DESCRIPTION
## Summary

- Adds opt-in periodic ping configuration to `ClientOptions` (`ping.enabled`, `ping.intervalMs`)
- Client sends `ping` requests at the configured interval after connecting
- Pings are automatically stopped on `close()`
- Defaults: disabled, 60s interval when enabled

Implements the MCP specification recommendation that implementations SHOULD periodically issue pings to detect connection health, with configurable frequency.

Closes #1000

## Test plan

- [x] `should send periodic pings when enabled` — verifies pings are sent at configured interval
- [x] `should not send pings when disabled (default)` — verifies no pings sent by default
- [x] `should stop pings on close` — verifies pings stop after `client.close()`
- [x] All 70 client tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)