### PR TITLE
feat(server): add host process watchdog to StdioServerTransport

### DIFF
--- a/.changeset/stdio-host-watchdog.md
+++ b/.changeset/stdio-host-watchdog.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/server': minor
+---
+
+Add host process watchdog to StdioServerTransport. When `clientProcessId` is provided, the transport periodically checks if the host process is alive and self-terminates if it is gone, preventing orphaned server processes.


### PR DESCRIPTION
## Summary

- Adds `clientProcessId` option to `StdioServerTransport` that enables a watchdog timer
- Watchdog periodically checks if the host process is alive using signal 0 (`process.kill(pid, 0)`)
- Self-terminates the transport when the host is gone, preventing orphaned server processes
- Configurable check interval via `watchdogIntervalMs` (default: 3s)
- New `StdioServerTransportOptions` interface with backwards-compatible constructor overloads
- Timer uses `unref()` so it doesn't prevent clean process exit

Follows the same pattern used in [vscode-languageserver-node](https://github.com/microsoft/vscode-languageserver-node/blob/main/server/src/node/main.ts#L51) as suggested in the issue.

Closes #208

## Test plan

- [x] `should close transport when host process is gone` — watchdog detects dead PID and closes
- [x] `should not close when host process is alive` — no false positives with own PID
- [x] `should stop watchdog on close` — cleanup on transport close
- [x] `should accept options object constructor` — new constructor form works
- [x] All 7 stdio tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)