### PR TITLE
fix: add missing size field to ResourceSchema

### DIFF
--- a/.changeset/add-resource-size-field.md
+++ b/.changeset/add-resource-size-field.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/core': patch
+---
+
+Add missing `size` field to `ResourceSchema` to match the MCP specification

--- a/packages/core/src/types/schemas.ts
+++ b/packages/core/src/types/schemas.ts
@@ -833,6 +833,13 @@ export const ResourceSchema = z.object({
     mimeType: z.optional(z.string()),
 
     /**
+     * The size of the raw resource content, in bytes (i.e., before base64 encoding or any tokenization), if known.
+     *
+     * This can be used by Hosts to display file sizes and estimate context window usage.
+     */
+    size: z.optional(z.number()),
+
+    /**
      * Optional annotations for the client.
      */
     annotations: AnnotationsSchema.optional(),


### PR DESCRIPTION
## Summary
- Adds the optional `size` number field to `ResourceSchema` in the Zod schema definition, matching the MCP specification (added in spec revision 2025-06-18)
- The `spec.types.ts` (auto-generated from spec) already includes `size?: number` on the `Resource` interface, but the hand-maintained Zod schema was missing it
- Downstream schemas (`ResourceLinkSchema`, `ListResourcesResultSchema`) inherit the field automatically

Fixes #1573

## Test plan
- [x] `pnpm typecheck:all` passes
- [x] `pnpm --filter @modelcontextprotocol/core test` — all 440 tests pass
- [x] Verified `ResourceSchema.shape.size` exists after the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)