### PR TITLE
fix: prevent command injection in example URL opening (v1.x backport)

### DIFF
--- a/src/examples/client/elicitationUrlExample.ts
+++ b/src/examples/client/elicitationUrlExample.ts
@@ -25,7 +25,6 @@ import {
 } from '../../types.js';
 import { getDisplayName } from '../../shared/metadataUtils.js';
 import { OAuthClientMetadata } from '../../shared/auth.js';
-import { exec } from 'node:child_process';
 import { InMemoryOAuthClientProvider } from './simpleOAuthClientProvider.js';
 import { UnauthorizedError } from '../../client/auth.js';
 import { createServer } from 'node:http';
@@ -45,8 +44,7 @@ const clientMetadata: OAuthClientMetadata = {
     scope: 'mcp:tools'
 };
 oauthProvider = new InMemoryOAuthClientProvider(OAUTH_CALLBACK_URL, clientMetadata, (redirectUrl: URL) => {
-    console.log(`🌐 Opening browser for OAuth redirect: ${redirectUrl.toString()}`);
-    openBrowser(redirectUrl.toString());
+    console.log(`\n🔗 Please open this URL in your browser to authorize:\n  ${redirectUrl.toString()}`);
 });
 
 // Create readline interface for user input
@@ -259,17 +257,6 @@ async function elicitationLoop(): Promise<void> {
     }
 }
 
-async function openBrowser(url: string): Promise<void> {
-    const command = `open "${url}"`;
-
-    exec(command, error => {
-        if (error) {
-            console.error(`Failed to open browser: ${error.message}`);
-            console.log(`Please manually open: ${url}`);
-        }
-    });
-}
-
 /**
  * Enqueues an elicitation request and returns the result.
  *
@@ -402,9 +389,8 @@ async function handleURLElicitation(params: ElicitRequestURLParams): Promise<Eli
         console.error('Background completion wait failed:', error);
     });
 
-    // 4. Open the URL in the browser
-    console.log(`\n🚀 Opening browser to: ${url}`);
-    await openBrowser(url);
+    // 4. Direct user to open the URL in their browser
+    console.log(`\n🔗 Please open this URL in your browser:\n  ${url}`);
 
     console.log('\n⏳ Waiting for you to complete the interaction in your browser...');
     console.log('   The server will send a notification once you complete the action.');

--- a/src/examples/client/simpleOAuthClient.ts
+++ b/src/examples/client/simpleOAuthClient.ts
@@ -3,7 +3,6 @@
 import { createServer } from 'node:http';
 import { createInterface } from 'node:readline';
 import { URL } from 'node:url';
-import { exec } from 'node:child_process';
 import { Client } from '../../client/index.js';
 import { StreamableHTTPClientTransport } from '../../client/streamableHttp.js';
 import { OAuthClientMetadata } from '../../shared/auth.js';
@@ -41,21 +40,6 @@ class InteractiveOAuthClient {
         });
     }
 
-    /**
-     * Opens the authorization URL in the user's default browser
-     */
-    private async openBrowser(url: string): Promise<void> {
-        console.log(`🌐 Opening browser for authorization: ${url}`);
-
-        const command = `open "${url}"`;
-
-        exec(command, error => {
-            if (error) {
-                console.error(`Failed to open browser: ${error.message}`);
-                console.log(`Please manually open: ${url}`);
-            }
-        });
-    }
     /**
      * Example OAuth callback handler - in production, use a more robust approach
      * for handling callbacks and storing tokens
@@ -166,9 +150,7 @@ class InteractiveOAuthClient {
             CALLBACK_URL,
             clientMetadata,
             (redirectUrl: URL) => {
-                console.log(`📌 OAuth redirect handler called - opening browser`);
-                console.log(`Opening browser to: ${redirectUrl.toString()}`);
-                this.openBrowser(redirectUrl.toString());
+                console.log(`\n🔗 Please open this URL in your browser to authorize:\n  ${redirectUrl.toString()}`);
             },
             this.clientMetadataUrl
         );


### PR DESCRIPTION
Backport of #1553 to v1.x.

Removes the use of `exec()` with string interpolation to open URLs in `elicitationUrlExample.ts` and `simpleOAuthClient.ts`, which allowed command injection via crafted URLs.

Rather than adding the `open` npm package (as #1553 does on `main`), this takes a simpler approach: remove the auto-open behavior entirely and print the URL for the user to open manually. On v1.x there is no separate examples package, so adding `open` would introduce a new runtime dependency on the published SDK. Since the examples already handle waiting via HTTP callbacks and MCP notifications (not the browser process), this change has no effect on functionality.

<sub>[AI Disclaimer](https://gist.github.com/maxisbey/6123d132484e4c533eab519a2800693d)</sub>