### PR TITLE
fix(server): auto-unwrap z.object() schemas in server.tool()

### DIFF
--- a/.changeset/fix-zod-object-schema-unwrap.md
+++ b/.changeset/fix-zod-object-schema-unwrap.md
@@ -1,17 +1,12 @@
 ---
-"@modelcontextprotocol/sdk": patch
+'@modelcontextprotocol/sdk': patch
 ---
 
 fix(server): auto-unwrap z.object() schemas passed to server.tool()
 
-When `z.object({...})` was passed as the `inputSchema` argument to `server.tool()`,
-the SDK would silently interpret it as `ToolAnnotations` instead of an input schema,
-resulting in the tool being registered with empty parameters. Arguments passed to the
-tool would be stripped without any error.
+When `z.object({...})` was passed as the `inputSchema` argument to `server.tool()`, the SDK would silently interpret it as `ToolAnnotations` instead of an input schema, resulting in the tool being registered with empty parameters. Arguments passed to the tool would be stripped
+without any error.
 
-Added `extractZodObjectShape()` that detects ZodObject schemas (both Zod v3 and v4)
-and extracts their raw shape for proper registration. Tools using the idiomatic
-`z.object({ name: z.string() })` form now work identically to the raw shape form
-`{ name: z.string() }`.
+Added `extractZodObjectShape()` that detects ZodObject schemas (both Zod v3 and v4) and extracts their raw shape for proper registration. Tools using the idiomatic `z.object({ name: z.string() })` form now work identically to the raw shape form `{ name: z.string() }`.
 
 Fixes #1291


### PR DESCRIPTION
## Problem

When `z.object({...})` is passed as `inputSchema` to `server.tool()`, the SDK silently interprets it as `ToolAnnotations` instead of an input schema. The tool registers with empty parameters and arguments are stripped without any error.

This is because `isZodRawShapeCompat()` correctly identifies ZodObject instances as **not** raw shapes (they have internal `_def`/`_zod` properties, not field schemas as values). But the fallback branch at line 1026 unconditionally treats any remaining object as `ToolAnnotations`.

## Root Cause

```typescript
if (isZodRawShapeCompat(firstArg)) {
    inputSchema = rest.shift();       // z.object({...}) fails this check
} else if (typeof firstArg === 'object') {
    annotations = rest.shift();       // ← z.object({...}) silently lands here
}
```

## Fix

Added `extractZodObjectShape()` that detects ZodObject schemas (both Zod v3 and v4) by checking for a `.shape` property whose values are Zod type instances. When detected, the raw shape is extracted and used as `inputSchema`.

Both forms now work identically:
```typescript
// Raw shape (always worked)
server.tool('test', { message: z.string() }, handler);

// ZodObject (now also works)
server.tool('test', z.object({ message: z.string() }), handler);
```

## Tests

- Added test for `z.object()` auto-unwrap with schema verification and argument passing
- Added test for `z.object()` combined with annotations
- All 1551 tests pass (2 consecutive clean runs)

Fixes #1291