### PR TITLE
fix(stdio): close server transport on stdin EOF

### DIFF
--- a/.changeset/stdio-server-stdin-eof.md
+++ b/.changeset/stdio-server-stdin-eof.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/server': patch
+---
+
+Close StdioServerTransport when stdin reaches EOF. The MCP spec requires the client to close stdin as the first step of stdio shutdown, but the server transport never listened for the `end` event, leaving it in a zombie state until SIGTERM escalation. Also adds an idempotency guard to `close()` to prevent double `onclose` invocation.

--- a/packages/server/src/server/stdio.ts
+++ b/packages/server/src/server/stdio.ts
@@ -19,6 +19,7 @@ import { process } from '@modelcontextprotocol/server/_shims';
 export class StdioServerTransport implements Transport {
     private _readBuffer: ReadBuffer = new ReadBuffer();
     private _started = false;
+    private _closed = false;
 
     constructor(
         private _stdin: Readable = process.stdin,
@@ -37,6 +38,9 @@ export class StdioServerTransport implements Transport {
     _onerror = (error: Error) => {
         this.onerror?.(error);
     };
+    _onclose = () => {
+        this.close();
+    };
 
     /**
      * Starts listening for messages on `stdin`.
@@ -51,6 +55,7 @@ export class StdioServerTransport implements Transport {
         this._started = true;
         this._stdin.on('data', this._ondata);
         this._stdin.on('error', this._onerror);
+        this._stdin.on('end', this._onclose);
     }
 
     private processReadBuffer() {
@@ -69,9 +74,15 @@ export class StdioServerTransport implements Transport {
     }
 
     async close(): Promise<void> {
+        if (this._closed) {
+            return;
+        }
+        this._closed = true;
+
         // Remove our event listeners first
         this._stdin.off('data', this._ondata);
         this._stdin.off('error', this._onerror);
+        this._stdin.off('end', this._onclose);
 
         // Check if we were the only data listener
         const remainingDataListeners = this._stdin.listenerCount('data');

--- a/packages/server/test/server/stdio.test.ts
+++ b/packages/server/test/server/stdio.test.ts
@@ -67,6 +67,74 @@ test('should not read until started', async () => {
     expect(await readMessage).toEqual(message);
 });
 
+test('should close transport when stdin ends', async () => {
+    const server = new StdioServerTransport(input, output);
+    server.onerror = error => {
+        throw error;
+    };
+
+    let didClose = false;
+    server.onclose = () => {
+        didClose = true;
+    };
+
+    await server.start();
+    expect(didClose).toBeFalsy();
+
+    // Simulate the client closing stdin (EOF)
+    input.push(null);
+
+    // Allow the event to propagate
+    await new Promise(resolve => setTimeout(resolve, 50));
+    expect(didClose).toBeTruthy();
+});
+
+test('should invoke onclose only once when close() is called then stdin ends', async () => {
+    const server = new StdioServerTransport(input, output);
+    server.onerror = error => {
+        throw error;
+    };
+
+    let closeCount = 0;
+    server.onclose = () => {
+        closeCount++;
+    };
+
+    await server.start();
+
+    // Explicit close, then stdin EOF arrives
+    await server.close();
+    input.push(null);
+
+    await new Promise(resolve => setTimeout(resolve, 50));
+    expect(closeCount).toBe(1);
+});
+
+test('should close cleanly on EOF after a partial message', async () => {
+    const server = new StdioServerTransport(input, output);
+
+    const errors: Error[] = [];
+    server.onerror = error => {
+        errors.push(error);
+    };
+
+    let didClose = false;
+    server.onclose = () => {
+        didClose = true;
+    };
+
+    await server.start();
+
+    // Push an incomplete JSON-RPC message (no trailing newline)
+    input.push(Buffer.from('{"jsonrpc":"2.0"'));
+    // Then EOF
+    input.push(null);
+
+    await new Promise(resolve => setTimeout(resolve, 50));
+    expect(didClose).toBeTruthy();
+    expect(errors).toHaveLength(0);
+});
+
 test('should read multiple messages', async () => {
     const server = new StdioServerTransport(input, output);
     server.onerror = error => {


### PR DESCRIPTION
## Summary

`StdioServerTransport` never listened for the `end` event on stdin. When a client initiates shutdown by closing stdin (step 1 of the [MCP spec's stdio shutdown sequence](https://modelcontextprotocol.io/specification/2025-03-26/basic/lifecycle#stdio)), the server transport didn't detect it. The connection hung in a zombie state until the client escalated to SIGTERM (2 seconds later per `StdioClientTransport.close()`).

This adds an `end` listener in `start()` that calls `close()` on EOF, and an idempotency guard (`_closed` flag) to prevent double `onclose` invocation when explicit `close()` and stdin EOF race.

Related: #579