### PR TITLE
fix(client): accumulate scopes across 401/403 auth challenges

### DIFF
--- a/packages/client/src/client/streamableHttp.ts
+++ b/packages/client/src/client/streamableHttp.ts
@@ -16,6 +16,18 @@ import { EventSourceParserStream } from 'eventsource-parser/stream';
 import type { AuthResult, OAuthClientProvider } from './auth.js';
 import { auth, extractWWWAuthenticateParams, UnauthorizedError } from './auth.js';
 
+function mergeScopes(existing?: string, incoming?: string): string | undefined {
+    if (!existing) {
+        return incoming;
+    }
+
+    if (!incoming) {
+        return existing;
+    }
+
+    return Array.from(new Set(`${existing} ${incoming}`.split(/\s+/).filter(Boolean))).join(' ');
+}
+
 // Default reconnection options for StreamableHTTP connections
 const DEFAULT_STREAMABLE_HTTP_RECONNECTION_OPTIONS: StreamableHTTPReconnectionOptions = {
     initialReconnectionDelay: 1000,
@@ -504,7 +516,7 @@ export class StreamableHTTPClientTransport implements Transport {
 
                     const { resourceMetadataUrl, scope } = extractWWWAuthenticateParams(response);
                     this._resourceMetadataUrl = resourceMetadataUrl;
-                    this._scope = scope;
+                    this._scope = mergeScopes(this._scope, scope);
 
                     const result = await auth(this._authProvider, {
                         serverUrl: this._url,
@@ -537,7 +549,7 @@ export class StreamableHTTPClientTransport implements Transport {
                         }
 
                         if (scope) {
-                            this._scope = scope;
+                            this._scope = mergeScopes(this._scope, scope);
                         }
 
                         if (resourceMetadataUrl) {

--- a/packages/client/test/client/streamableHttp.test.ts
+++ b/packages/client/test/client/streamableHttp.test.ts
@@ -635,6 +635,50 @@ describe('StreamableHTTPClientTransport', () => {
         expect(mockAuthProvider.redirectToAuthorization.mock.calls).toHaveLength(1);
     });
 
+    it('accumulates scopes on 401 auth challenge', async () => {
+        const message: JSONRPCMessage = {
+            jsonrpc: '2.0',
+            method: 'test',
+            params: {},
+            id: 'test-id'
+        };
+
+        const fetchMock = globalThis.fetch as Mock;
+        (transport as unknown as { _scope?: string })._scope = 'existing_scope';
+
+        fetchMock
+            .mockResolvedValueOnce({
+                ok: false,
+                status: 401,
+                statusText: 'Unauthorized',
+                headers: new Headers({
+                    'WWW-Authenticate': 'Bearer scope="new_scope", resource_metadata="http://example.com/resource"'
+                }),
+                text: () => Promise.resolve('Unauthorized')
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                status: 202,
+                headers: new Headers()
+            });
+
+        const authModule = await import('../../src/client/auth.js');
+        const authSpy = vi.spyOn(authModule, 'auth');
+        authSpy.mockResolvedValue('AUTHORIZED');
+
+        await transport.send(message);
+
+        expect(authSpy).toHaveBeenCalledWith(
+            mockAuthProvider,
+            expect.objectContaining({
+                scope: 'existing_scope new_scope',
+                resourceMetadataUrl: new URL('http://example.com/resource')
+            })
+        );
+
+        authSpy.mockRestore();
+    });
+
     it('attempts upscoping on 403 with WWW-Authenticate header', async () => {
         const message: JSONRPCMessage = {
             jsonrpc: '2.0',
@@ -644,6 +688,7 @@ describe('StreamableHTTPClientTransport', () => {
         };
 
         const fetchMock = globalThis.fetch as Mock;
+        (transport as unknown as { _scope?: string })._scope = 'existing_scope';
         fetchMock
             // First call: returns 403 with insufficient_scope
             .mockResolvedValueOnce({
@@ -673,11 +718,11 @@ describe('StreamableHTTPClientTransport', () => {
         // Verify fetch was called twice
         expect(fetchMock).toHaveBeenCalledTimes(2);
 
-        // Verify auth was called with the new scope
+        // Verify auth was called with accumulated scope
         expect(authSpy).toHaveBeenCalledWith(
             mockAuthProvider,
             expect.objectContaining({
-                scope: 'new_scope',
+                scope: 'existing_scope new_scope',
                 resourceMetadataUrl: new URL('http://example.com/resource')
             })
         );


### PR DESCRIPTION
## Summary
- fix StreamableHTTPClientTransport scope handling to merge (`union`) scopes from new `WWW-Authenticate` challenges instead of overwriting existing scope
- apply this for both 401 auth challenges and 403 `insufficient_scope` upscoping
- add/adjust tests to verify progressive scope accumulation behavior

## Why
Servers with per-operation scopes may return only the scope needed for the current resource (RFC 6750). Overwriting client scope causes previously granted scopes to be dropped and can lead to re-authorization loops.

Fixes #1582.
