### PR TITLE
fix: add Transfer-Encoding header to SSE responses for HTTP/2 compati…

### DIFF
--- a/packages/server/src/server/streamableHttp.ts
+++ b/packages/server/src/server/streamableHttp.ts
@@ -450,7 +450,11 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
         const headers: Record<string, string> = {
             'Content-Type': 'text/event-stream',
             'Cache-Control': 'no-cache, no-transform',
-            Connection: 'keep-alive'
+            Connection: 'keep-alive',
+            // Ensures chunked transfer encoding for SSE streams. Some HTTP adapters
+            // (e.g., @hono/node-server) buffer small responses and add Content-Length,
+            // which causes HTTP/2 PROTOCOL_ERROR when the stream closes.
+            'Transfer-Encoding': 'chunked'
         };
 
         // After initialization, always include the session ID if we have one
@@ -503,7 +507,11 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
             const headers: Record<string, string> = {
                 'Content-Type': 'text/event-stream',
                 'Cache-Control': 'no-cache, no-transform',
-                Connection: 'keep-alive'
+                Connection: 'keep-alive',
+                // Prevents @hono/node-server from buffering small responses and adding
+                // Content-Length, which causes HTTP/2 PROTOCOL_ERROR on stream close.
+                // See: https://github.com/honojs/node-server/blob/main/src/listener.ts#L463-L491
+                'Transfer-Encoding': 'chunked'
             };
 
             if (this.sessionId !== undefined) {
@@ -751,7 +759,11 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
             const headers: Record<string, string> = {
                 'Content-Type': 'text/event-stream',
                 'Cache-Control': 'no-cache',
-                Connection: 'keep-alive'
+                Connection: 'keep-alive',
+                // Prevents @hono/node-server from buffering small responses and adding
+                // Content-Length, which causes HTTP/2 PROTOCOL_ERROR on stream close.
+                // See: https://github.com/honojs/node-server/blob/main/src/listener.ts#L463-L491
+                'Transfer-Encoding': 'chunked'
             };
 
             // After initialization, always include the session ID if we have one


### PR DESCRIPTION
…bility

<!-- Provide a brief summary of your changes -->
Adds `Transfer-Encoding: chunked` header to all SSE response headers in `WebStandardStreamableHTTPServerTransport` to prevent HTTP/2 protocol errors.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Some HTTP adapters (e.g., `@hono/node-server`) buffer small SSE responses and automatically add a `Content-Length` header. When the SSE stream closes, this causes an HTTP/2 `PROTOCOL_ERROR` because HTTP/2 doesn't allow `Content-Length` with streaming responses.

Adding `Transfer-Encoding: chunked` prevents this buffering behavior and ensures SSE streams work correctly over HTTP/2.

Fixes #1619 <!-- Replace with your issue number -->

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
- Ran all existing streamableHttp tests across packages:
  - `@modelcontextprotocol/server`: 28 tests passed
  - `@modelcontextprotocol/client`: 38 tests passed
  - `@modelcontextprotocol/node`: 73 tests passed

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
None. This is an additive change to response headers.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
Affected locations in `packages/server/src/server/streamableHttp.ts`:
- `handleGetRequest` method (~line 450)
- `replayEvents` method (~line 507)
- `handlePostRequest` method (~line 757)

Reference: https://github.com/honojs/node-server/blob/main/src/listener.ts#L463-L491


