### PR TITLE
feat(express): add jsonOptions to createMcpExpressApp()

### DIFF
--- a/.changeset/express-json-options.md
+++ b/.changeset/express-json-options.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/express': patch
+---
+
+Add `jsonOptions` option to `createMcpExpressApp()` to allow configuring `express.json()` body parser options (e.g. request body size limit).

--- a/packages/middleware/express/src/express.examples.ts
+++ b/packages/middleware/express/src/express.examples.ts
@@ -39,3 +39,13 @@ function createMcpExpressApp_allowedHosts() {
     //#endregion createMcpExpressApp_allowedHosts
     return app;
 }
+
+/**
+ * Example: Custom JSON body parser options.
+ */
+function createMcpExpressApp_jsonOptions() {
+    //#region createMcpExpressApp_jsonOptions
+    const app = createMcpExpressApp({ jsonOptions: { limit: '5mb' } });
+    //#endregion createMcpExpressApp_jsonOptions
+    return app;
+}

--- a/packages/middleware/express/src/express.ts
+++ b/packages/middleware/express/src/express.ts
@@ -22,6 +22,13 @@ export interface CreateMcpExpressAppOptions {
      * to restrict which hostnames are allowed.
      */
     allowedHosts?: string[];
+
+    /**
+     * Options passed directly to `express.json()` body parser.
+     * Use this to configure the request body size limit, e.g. `{ limit: '5mb' }`.
+     * @see https://expressjs.com/en/api.html#express.json
+     */
+    jsonOptions?: Parameters<typeof express.json>[0];
 }
 
 /**
@@ -49,12 +56,17 @@ export interface CreateMcpExpressAppOptions {
  * ```ts source="./express.examples.ts#createMcpExpressApp_allowedHosts"
  * const app = createMcpExpressApp({ host: '0.0.0.0', allowedHosts: ['myapp.local', 'localhost'] });
  * ```
+ *
+ * @example Custom JSON body parser options
+ * ```ts source="./express.examples.ts#createMcpExpressApp_jsonOptions"
+ * const app = createMcpExpressApp({ jsonOptions: { limit: '5mb' } });
+ * ```
  */
 export function createMcpExpressApp(options: CreateMcpExpressAppOptions = {}): Express {
-    const { host = '127.0.0.1', allowedHosts } = options;
+    const { host = '127.0.0.1', allowedHosts, jsonOptions } = options;
 
     const app = express();
-    app.use(express.json());
+    app.use(express.json(jsonOptions));
 
     // If allowedHosts is explicitly provided, use that for validation
     if (allowedHosts) {

--- a/packages/middleware/express/test/express.test.ts
+++ b/packages/middleware/express/test/express.test.ts
@@ -167,6 +167,18 @@ describe('@modelcontextprotocol/express', () => {
             warn.mockRestore();
         });
 
+        test('should pass jsonOptions to express.json()', () => {
+            const app = createMcpExpressApp({ jsonOptions: { limit: '5mb' } });
+            expect(app).toBeDefined();
+            expect(typeof app.use).toBe('function');
+        });
+
+        test('should use default json options when jsonOptions not provided', () => {
+            const app = createMcpExpressApp();
+            expect(app).toBeDefined();
+            expect(typeof app.use).toBe('function');
+        });
+
         test('should not apply host validation for non-localhost hosts without allowedHosts', () => {
             const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
 


### PR DESCRIPTION
## Motivation and Context

`createMcpExpressApp()` calls `express.json()` with no options, inheriting Express's default 100KB body limit. MCP payloads can exceed this, causing `413 Payload Too Large` failures. Rather than exposing a single `limit` option, this adds a full `jsonOptions` pass-through so users can configure any `express.json()` setting.

Closes #1354

## How Has This Been Tested?

- 2 new unit tests added (`should pass jsonOptions to express.json()`, `should use default json options when jsonOptions not provided`)
- All 17 express package tests pass (`pnpm --filter @modelcontextprotocol/express test`)
- Full typecheck passes (`pnpm typecheck:all`)
- Full lint passes (`pnpm lint:all`)
- Snippet sync verified (`pnpm sync:snippets`)
- Full build passes (`pnpm build:all`)

## Breaking Changes

None. `jsonOptions` is optional — when omitted, `express.json()` uses its defaults.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed