### PR TITLE
feat(server): add request-time OAuth scope challenges

### DIFF
--- a/.changeset/scope-challenge-server.md
+++ b/.changeset/scope-challenge-server.md
@@ -1,0 +1,19 @@
+---
+'@modelcontextprotocol/server': minor
+'@modelcontextprotocol/node': minor
+---
+
+Add server-side OAuth scope challenge support (step-up auth) per MCP spec §10.1.
+
+Servers can now declare required OAuth scopes per tool and the Streamable HTTP transport
+automatically returns HTTP 403 with `WWW-Authenticate` headers when a client's token
+lacks sufficient scopes, triggering the client's existing re-authorization flow.
+
+New APIs:
+- `ToolScopeConfig` type for declaring `required` and `accepted` scopes per tool
+- `ScopeChallengeConfig` transport option with `resourceMetadataUrl`
+- `McpServer.registerTool()` accepts a `scopes` option (`string[]` or `ToolScopeConfig`)
+- `McpServer.setToolScopes()` for decoupled/centralized scope declaration
+- `McpServer.getToolScopes()` to query resolved scope config
+- `setScopeResolver()` on both `WebStandardStreamableHTTPServerTransport` and `NodeStreamableHTTPServerTransport`
+- Auto-wiring of scope resolver in `McpServer.connect()`

--- a/.changeset/scope-challenge-server.md
+++ b/.changeset/scope-challenge-server.md
@@ -3,15 +3,22 @@
 '@modelcontextprotocol/node': minor
 ---
 
-Add server-side OAuth scope challenge support (step-up auth) per MCP spec §10.1.
+Add server-side OAuth scope challenge support (step-up auth) per MCP spec §10.1
+and [SEP-2350](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2350).
 
 Servers can now declare required OAuth scopes per tool and the Streamable HTTP transport
 automatically returns HTTP 403 with `WWW-Authenticate` headers when a client's token
 lacks sufficient scopes, triggering the client's existing re-authorization flow.
 
+Per RFC 6750 §3.1 / SEP-2350, the `WWW-Authenticate` `scope` parameter advertises
+only the scopes required for the current operation — clients are expected to
+accumulate scopes across step-up challenges (see #1657). An opt-in
+`scopeChallenge.includeGrantedScopes: true` restores the additive union behavior
+for servers that need to defend against non-accumulating clients.
+
 New APIs:
-- `ToolScopeConfig` type for declaring `required` and `accepted` scopes per tool
-- `ScopeChallengeConfig` transport option with `resourceMetadataUrl`
+- `ToolScopeConfig` type for declaring `required` (AND) and `accepted` (OR / hierarchy) scopes per tool
+- `ScopeChallengeConfig` transport option with `resourceMetadataUrl` and optional `includeGrantedScopes`
 - `McpServer.registerTool()` accepts a `scopes` option (`string[]` or `ToolScopeConfig`)
 - `McpServer.setToolScopes()` for decoupled/centralized scope declaration
 - `McpServer.getToolScopes()` to query resolved scope config

--- a/.changeset/scope-challenge-server.md
+++ b/.changeset/scope-challenge-server.md
@@ -3,10 +3,11 @@
 '@modelcontextprotocol/node': minor
 ---
 
-Add request-time OAuth scope challenges for tools. A tool's `scopeChallenge`
-callback receives the parsed request and verified authentication info, then
-either continues or returns the exact scope set for an `insufficient_scope`
-response. `requireScopes` provides a small helper for static all-of checks.
+Add request-time OAuth scope challenges for tools, resources, resource templates,
+and prompts. Each primitive's `scopeChallenge` callback receives the parsed
+request and verified authentication info, then either continues or returns the
+exact scope set for an `insufficient_scope` response. `requireScopes` provides a
+small helper for static all-of checks.
 
 `createMcpHandler` and Streamable HTTP transports return HTTP 403 with an
-`insufficient_scope` challenge before tool execution or SSE setup.
+`insufficient_scope` challenge before handler execution or SSE setup.

--- a/.changeset/scope-challenge-server.md
+++ b/.changeset/scope-challenge-server.md
@@ -18,5 +18,5 @@ bearer-auth 401/403 answers, and its `resource_metadata` parameter is derived
 from the verified `AuthInfo`: `requireBearerAuth` / `verifyBearerToken` now
 stamp their configured `resourceMetadataUrl` onto the `AuthInfo` they return
 (new optional `AuthInfo.resourceMetadataUrl` field), with a fallback to the
-well-known location for the token's RFC 8707 `resource` identifier; the
+well-known location for an HTTP(S) RFC 8707 `resource` identifier; the
 parameter is omitted when neither is available.

--- a/.changeset/scope-challenge-server.md
+++ b/.changeset/scope-challenge-server.md
@@ -1,0 +1,12 @@
+---
+'@modelcontextprotocol/server': minor
+'@modelcontextprotocol/node': minor
+---
+
+Add request-time OAuth scope challenges for tools. A tool's `scopeChallenge`
+callback receives the parsed request and verified authentication info, then
+either continues or returns the exact scope set for an `insufficient_scope`
+response. `requireScopes` provides a small helper for static all-of checks.
+
+`createMcpHandler` and Streamable HTTP transports return HTTP 403 with an
+`insufficient_scope` challenge before tool execution or SSE setup.

--- a/.changeset/scope-challenge-server.md
+++ b/.changeset/scope-challenge-server.md
@@ -10,4 +10,13 @@ exact scope set for an `insufficient_scope` response. `requireScopes` provides a
 small helper for static all-of checks.
 
 `createMcpHandler` and Streamable HTTP transports return HTTP 403 with an
-`insufficient_scope` challenge before handler execution or SSE setup.
+`insufficient_scope` challenge before handler execution or SSE setup. The
+preflight is active whenever a registered primitive carries a `scopeChallenge`
+callback — there is no handler- or transport-level configuration. The
+challenge's `WWW-Authenticate` header is built by the same formatter as the
+bearer-auth 401/403 answers, and its `resource_metadata` parameter is derived
+from the verified `AuthInfo`: `requireBearerAuth` / `verifyBearerToken` now
+stamp their configured `resourceMetadataUrl` onto the `AuthInfo` they return
+(new optional `AuthInfo.resourceMetadataUrl` field), with a fallback to the
+well-known location for the token's RFC 8707 `resource` identifier; the
+parameter is omitted when neither is available.

--- a/docs/behavior-surface-pins.md
+++ b/docs/behavior-surface-pins.md
@@ -30,6 +30,7 @@ CI pass — that reopens the silent-drift hole the pin exists to close.
 | Published package set, export maps, dual ESM/CJS topology   | `packages/core-internal/test/packageTopologyPins.test.ts`      |
 | stdio environment-inheritance safelist                      | `packages/client/test/client/stdioEnvPins.test.ts`             |
 | 2025-11-25 wire method-registry membership, schema identity | `packages/core-internal/test/types/registryPins.test.ts`       |
+| OAuth scope challenge timing and serialization              | `packages/server/test/server/scopeChallenge.test.ts`           |
 
 ## Writing a new pin
 

--- a/docs/proposals/scope-challenge-server-sdk.md
+++ b/docs/proposals/scope-challenge-server-sdk.md
@@ -1,0 +1,447 @@
+# Server SDK Support for Scope Challenges (Step-Up Auth)
+
+**Author:** Sam Morrow  
+**Date:** 2026-03-04  
+**Status:** Spike Proposal — for discussion with SDK devs and Tool Scopes Working Group  
+**Relates to:** [TS SDK #1151](https://github.com/modelcontextprotocol/typescript-sdk/issues/1151), [TS SDK #1294](https://github.com/modelcontextprotocol/typescript-sdk/issues/1294), [MCP Spec §10.1 Scope Challenge Handling](https://modelcontextprotocol.io/specification/draft/basic/authorization#scope-challenge-handling)
+
+---
+
+## 1. Problem Statement
+
+Server SDK authors have **no ergonomic way to trigger OAuth scope challenges** during tool execution. The MCP spec ([SEP-835](https://modelcontextprotocol.io/specification/draft/basic/authorization#scope-challenge-handling)) fully defines how servers should return HTTP 403 with `WWW-Authenticate` headers when a client's token lacks required scopes, and how clients should perform step-up authorization. But today:
+
+- **Client-side handling is implemented** — the TypeScript SDK already handles 403 `insufficient_scope` responses, extracts scopes from `WWW-Authenticate`, performs re-authorization, and retries the request (with infinite-loop prevention).
+- **Server-side SDK support is missing** — there is no way to declare required scopes per tool, no way for tool handlers to trigger scope challenges, and no mechanism to convert a tool handler error into an HTTP 403 response.
+- **github/github-mcp-server works around this** by implementing scope challenges entirely in custom HTTP middleware and a bespoke inventory/scopes system *outside* any SDK, parsing raw JSON-RPC to extract tool names and match them against a scope map.
+
+## 2. Current State of the Art
+
+### 2.1 What the Spec Says (§10.1)
+
+When a client makes a request with an access token with insufficient scope:
+- Server responds with **HTTP 403 Forbidden**
+- `WWW-Authenticate: Bearer error="insufficient_scope", scope="required_scope1 required_scope2", resource_metadata="https://.../.well-known/oauth-protected-resource"`
+- Client parses the challenge, re-authorizes with the new scope set, and retries
+
+### 2.2 Client-Side (TypeScript SDK) — ✅ Already Implemented
+
+`packages/client/src/client/streamableHttp.ts` (lines 525-572):
+```typescript
+if (response.status === 403 && this._authProvider) {
+    const { resourceMetadataUrl, scope, error } = extractWWWAuthenticateParams(response);
+    if (error === 'insufficient_scope') {
+        // Prevent infinite loops
+        if (this._lastUpscopingHeader === wwwAuthHeader) {
+            throw new SdkError(SdkErrorCode.ClientHttpForbidden,
+              'Server returned 403 after trying upscoping', ...);
+        }
+        this._scope = scope;
+        this._resourceMetadataUrl = resourceMetadataUrl;
+        this._lastUpscopingHeader = wwwAuthHeader;
+        const result = await auth(this._authProvider,
+          { serverUrl, resourceMetadataUrl, scope, ... });
+        if (result !== 'AUTHORIZED') throw new UnauthorizedError();
+        return this.send(message); // Retry
+    }
+}
+```
+
+Open issues: [#1582](https://github.com/modelcontextprotocol/typescript-sdk/issues/1582) (scope overwrite during progressive auth), [#1618](https://github.com/modelcontextprotocol/typescript-sdk/pull/1618) (fix: accumulate scopes across challenges).
+
+### 2.3 Server-Side (github/github-mcp-server) — Custom Workaround via HTTP Middleware
+
+The GitHub MCP Server implements scope challenges entirely in custom application-level HTTP middleware and a bespoke inventory/scopes package — none of this is part of the Go SDK (`github.com/modelcontextprotocol/go-sdk`). The Go SDK itself has no scope challenge support. File: `pkg/http/middleware/scope_challenge.go`:
+
+```go
+func WithScopeChallenge(oauthCfg *oauth.Config,
+    scopeFetcher scopes.FetcherInterface) func(http.Handler) http.Handler {
+    return func(next http.Handler) http.Handler {
+        fn := func(w http.ResponseWriter, r *http.Request) {
+            // 1. Parse JSON-RPC body to extract tool name
+            // 2. Look up tool's RequiredScopes/AcceptedScopes from global scope map
+            // 3. Fetch user's active scopes from GitHub API
+            // 4. If user lacks required scopes → return HTTP 403 + WWW-Authenticate
+            // 5. Otherwise → next.ServeHTTP(w, r)
+        }
+        return http.HandlerFunc(fn)
+    }
+}
+```
+
+Tools declare scopes at registration time via `RequiredScopes` / `AcceptedScopes` on the github-mcp-server's custom `ServerTool` struct (not part of the Go SDK):
+
+```go
+func NewTool[In, Out any](toolset ToolsetMetadata, tool mcp.Tool,
+    requiredScopes []scopes.Scope, handler ...) ServerTool {
+    st := inventory.NewServerToolWithContextHandler(tool, toolset, handler)
+    st.RequiredScopes = scopes.ToStringSlice(requiredScopes...)
+    st.AcceptedScopes = scopes.ExpandScopes(requiredScopes...)
+    return st
+}
+```
+
+Key design pattern: **scope checking happens at the HTTP layer, BEFORE the JSON-RPC/SSE stream begins**. This is critical because once an HTTP 200 response with an SSE stream is opened, the HTTP status code cannot be changed. Note: all of this machinery is custom to the github-mcp-server application — the Go SDK provides none of it.
+
+### 2.4 Related Spec Proposals
+
+| SEP | Title | Status | Relevance |
+|-----|-------|--------|-----------|
+| [SEP-1488](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1488) | `securitySchemes` in Tool Metadata | Draft | Per-tool `oauth2` scheme with scopes array |
+| [SEP-1489](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1489) | Tool Error Responses for Triggering OAuth Flows | Draft | `_meta.mcp/www_authenticate` in tool results — transport-agnostic alternative (rejected by consensus in favor of HTTP-bound approach) |
+| [SEP-1880](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1880) | Tool-level scope requirements (`authorization.scopes`) | Closed (not planned) | `Tool.authorization.scopes` advisory metadata |
+| [SEP-1881](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1881) | Scope-Filtered Tool Discovery | Draft | Filter `tools/list` by token scopes |
+
+## 3. The Architectural Constraint
+
+The fundamental constraint that shapes this entire design:
+
+> **HTTP status codes are committed BEFORE tool handlers execute.**
+
+In the Streamable HTTP transport, `handlePostRequest()` returns `new Response(readable, { status: 200, headers })` immediately, then fires `onmessage()` callbacks that route through the Protocol layer to tool handlers. By the time a tool handler runs, HTTP 200 is already sent. Any error from the handler becomes a JSON-RPC error response delivered as an SSE event — **not an HTTP 403**.
+
+This means **scope challenges must be evaluated before the SSE stream opens**, at the HTTP middleware/transport layer. This is exactly how github/github-mcp-server does it.
+
+## 4. Proposed Design
+
+### 4.1 Declare scopes at tool registration (co-located)
+
+Add optional scope metadata to `McpServer.registerTool()`:
+
+```typescript
+mcpServer.registerTool(
+  'get_private_repo',
+  {
+    description: 'Get private repository details',
+    inputSchema: { repo: z.string() },
+    scopes: ['repo:read'],  // Simple: just an array of required scopes
+  },
+  async ({ repo }, ctx) => { /* ... */ }
+);
+
+// Or with scope hierarchy support:
+mcpServer.registerTool(
+  'get_repo',
+  {
+    scopes: {
+      required: ['public_repo'],
+      accepted: ['public_repo', 'repo'], // 'repo' implies 'public_repo'
+    },
+  },
+  handler
+);
+```
+
+### 4.2 Declare scopes separately (decoupled)
+
+Scopes don't have to live with tool definitions. `setToolScopes()` lets implementers
+define scopes in one central place — from a config file, a mapping, or dynamically:
+
+```typescript
+// Define all scopes in one place
+const TOOL_SCOPES: Record<string, string[]> = {
+    'get_repo': ['repo:read'],
+    'create_issue': ['repo:write'],
+    'list_orgs': ['read:org'],
+};
+
+for (const [tool, scopes] of Object.entries(TOOL_SCOPES)) {
+    mcpServer.setToolScopes(tool, scopes);
+}
+```
+
+Scopes set via `setToolScopes()` take precedence over any `scopes` provided during
+tool registration. Both approaches can be mixed freely.
+
+### 4.3 Transport configuration
+
+Add a `scopeChallenge` option to `StreamableHTTPServerTransport`. Only one field
+is required — the `resourceMetadataUrl` for the `WWW-Authenticate` header:
+
+```typescript
+const transport = new WebStandardStreamableHTTPServerTransport({
+  sessionIdGenerator: () => randomUUID(),
+  scopeChallenge: {
+    resourceMetadataUrl:
+      'https://mcp.example.com/.well-known/oauth-protected-resource',
+  }
+});
+```
+
+The transport reads the token's active scopes from `AuthInfo.scopes`, which is
+populated by the implementer's own auth middleware. The SDK does not determine what
+scopes are active — that is entirely the implementer's responsibility, just as it is
+the implementer's choice what scopes to require per tool.
+
+### 4.4 Automatic wiring via `connect()`
+
+`McpServer.connect()` automatically wires the scope resolver to the transport:
+
+```typescript
+await mcpServer.connect(transport);
+// That's it — scope challenges are now active.
+```
+
+Under the hood, `connect()` detects if the transport supports `setScopeResolver()`
+and wires `McpServer.getToolScopes()` into it. No manual plumbing needed.
+
+When `scopeChallenge` is configured, the transport:
+1. Before opening the SSE stream, parses the JSON-RPC message to identify `tools/call` requests
+2. Looks up the tool's registered scopes via the auto-wired resolver
+3. Compares against the token's active scopes from `authInfo.scopes`
+4. If insufficient: returns HTTP 403 + `WWW-Authenticate` header **without opening the SSE stream**
+5. If sufficient: proceeds normally
+
+### 4.5 Transport-scoping: stdio and other transports ignore this entirely
+
+The `scopeChallenge` configuration is only available on `StreamableHTTPServerTransport`. The `StdioServerTransport` and any non-HTTP transports have no concept of HTTP status codes and no OAuth flow — scope challenges are meaningless there. This aligns with the MCP spec: "Implementations using an STDIO transport SHOULD NOT follow this specification."
+
+### 4.6 Error response format
+
+The 403 response body matches the protected resource metadata error format:
+
+```
+HTTP/1.1 403 Forbidden
+WWW-Authenticate: Bearer error="insufficient_scope",
+                         scope="repo:read user:profile",
+                         resource_metadata="https://mcp.example.com/...",
+                         error_description="Additional repository read permission required"
+Content-Type: application/json
+
+{
+  "jsonrpc": "2.0",
+  "error": {
+    "code": -32403,
+    "message": "Insufficient scope: required repo:read"
+  },
+  "id": 1
+}
+```
+
+This reuses the existing `createJsonErrorResponse` helper in the transport, which already handles headers and status codes.
+
+## 5. Worked Example: End-to-End Flow
+
+```
+┌─────────┐                        ┌─────────────────┐            ┌──────────┐
+│  Client  │                        │  MCP Server      │            │ Auth Srv │
+└────┬─────┘                        └────────┬─────────┘            └────┬─────┘
+     │                                       │                           │
+     │ POST /mcp  (tools/call: get_repo)     │                           │
+     │ Authorization: Bearer <token_v1>      │                           │
+     ├──────────────────────────────────────►│                           │
+     │                                       │                           │
+     │                     [Transport layer: │                           │
+     │                      parse JSON-RPC,  │                           │
+     │                      find tool scope  │                           │
+     │                      metadata,        │                           │
+     │                      check token      │                           │
+     │                      scopes vs        │                           │
+     │                      required scopes] │                           │
+     │                                       │                           │
+     │ 403 Forbidden                         │                           │
+     │ WWW-Authenticate: Bearer              │                           │
+     │   error="insufficient_scope"          │                           │
+     │   scope="repo:read"                   │                           │
+     │   resource_metadata="https://..."     │                           │
+     │◄──────────────────────────────────────┤                           │
+     │                                       │                           │
+     │ [Client SDK: extract scope,           │                           │
+     │  re-authorize with new scope]         │                           │
+     │                                       │                           │
+     │ Authorization request (scope=repo:read)                           │
+     ├──────────────────────────────────────────────────────────────────►│
+     │                                                                   │
+     │ Access token (scope=repo:read)                                    │
+     │◄──────────────────────────────────────────────────────────────────┤
+     │                                       │                           │
+     │ POST /mcp  (tools/call: get_repo)     │                           │
+     │ Authorization: Bearer <token_v2>      │                           │
+     ├──────────────────────────────────────►│                           │
+     │                                       │                           │
+     │                     [Scope check OK]  │                           │
+     │                                       │                           │
+     │ 200 OK (SSE stream)                   │                           │
+     │ data: {"result": {...}}               │                           │
+     │◄──────────────────────────────────────┤                           │
+```
+
+## 6. Mid-Tool-Call Scope Challenges: The Unsolved Problem
+
+This proposal **explicitly does not attempt** mid-tool-call scope challenges. Here's why, and what the future might look like.
+
+### 6.1 The Problem
+
+Some scope requirements are **dynamic** — they depend on runtime data. Example: calling `get_repo` for a public repo needs no extra scopes, but for a private repo needs `repo:read`. The server only discovers this after making an upstream API call, by which point the HTTP 200 SSE stream is already open.
+
+### 6.2 Why It's Hard
+
+Mid-handler scope challenges would require fundamentally changing how JSON-RPC over HTTP works:
+
+1. **HTTP status is already committed**: The 200+SSE model means we can't retroactively return 403
+2. **JSON-RPC has no concept of "retry with different auth"**: The protocol has no standardized error code for "re-authenticate and retry"
+3. **Multiplexed requests**: A single HTTP POST can contain multiple JSON-RPC requests — one needing a scope challenge doesn't mean all do
+
+### 6.3 Potential Future Approaches
+
+**Option A: Sentinel error in JSON-RPC result (`_meta` approach — SEP-1489)**
+
+```typescript
+// Server returns this as a tool result:
+{
+  "content": [{ "type": "text", "text": "Additional permissions required" }],
+  "isError": true,
+  "_meta": {
+    "mcp/www_authenticate": [
+      "Bearer error=\"insufficient_scope\", scope=\"repo:read\", ..."
+    ]
+  }
+}
+```
+
+Client detects `_meta.mcp/www_authenticate`, triggers OAuth flow, retries. This is **transport-agnostic** but was rejected by consensus in favor of the HTTP-bound approach. It also requires client SDK changes to recognize and act on this `_meta` field.
+
+**Option B: Sentinel error thrown by handler (`ScopeChallengeError`)**
+
+```typescript
+throw new ScopeChallengeError(['repo:read']);
+```
+
+The Protocol layer catches this, and... what? Within an SSE stream, it can only send a JSON-RPC error response. The client SDK would need to recognize this specific error shape and trigger re-auth. This is essentially Option A with extra SDK machinery to translate the thrown error into the right JSON-RPC shape.
+
+**Option C: Breaking change — defer HTTP response**
+
+The transport could buffer requests and not open the SSE stream until the tool handler completes (or explicitly signals success). This would allow the transport to still return 403 for scope challenges. However, this **fundamentally breaks streaming** — the entire point of SSE is to start sending data immediately. This is a major architectural change.
+
+**Option D: Protocol-level step-up negotiation**
+
+A new MCP method like `auth/stepUp` that the server sends as a request to the client (using the bidirectional protocol), carrying the scope challenge information. The client handles it, re-authorizes, and the server retries the upstream call. This is the cleanest approach but requires spec changes and is a significant addition to the protocol.
+
+### 6.4 Recommendation for Mid-Handler Challenges
+
+For now, servers with dynamic scope requirements should:
+1. Use the pre-execution static scope check where possible (covering the common case)
+2. For truly dynamic cases, return a tool error result with a descriptive message that explains what permissions are needed — the LLM/user can then retry after re-authorizing
+3. Future spec work (potentially via the working group) should evaluate Option D (protocol-level step-up) as the cleanest long-term solution
+
+## 7. Implementation (Shipped with This Proposal)
+
+This is not a sketch — working code is included in this PR. Here's what was added:
+
+### 7.1 `ToolScopeConfig` type (`packages/server/src/server/mcp.ts`)
+
+```typescript
+export interface ToolScopeConfig {
+  required: string[];
+  accepted?: string[]; // Defaults to required if not provided
+}
+```
+
+### 7.2 `ScopeChallengeConfig` type (`packages/server/src/server/streamableHttp.ts`)
+
+```typescript
+export interface ScopeChallengeConfig {
+  resourceMetadataUrl: string;
+  buildErrorDescription?: (toolName: string, requiredScopes: string[]) => string;
+}
+```
+
+No `getTokenScopes` callback — the transport reads `authInfo.scopes` directly.
+The implementer populates `authInfo` in their auth middleware; the SDK does not
+determine what scopes are active.
+
+### 7.3 Tool scope registration — two paths
+
+**Co-located** (via `registerTool` config):
+```typescript
+server.registerTool('get_repo', { scopes: ['repo:read'] }, handler);
+```
+
+**Decoupled** (via `setToolScopes`):
+```typescript
+server.setToolScopes('get_repo', ['repo:read']);
+```
+
+`setToolScopes` takes precedence when both are used. Both accept `string[]` (sugar)
+or `{ required, accepted }` (for scope hierarchy).
+
+### 7.4 Auto-wiring in `McpServer.connect()`
+
+```typescript
+async connect(transport: Transport): Promise<void> {
+    if ('setScopeResolver' in transport && typeof transport.setScopeResolver === 'function') {
+        transport.setScopeResolver((toolName: string) => this.getToolScopes(toolName));
+    }
+    return await this.server.connect(transport);
+}
+```
+
+### 7.5 Pre-execution check in transport
+
+The `_checkScopeChallenge()` method runs after message parsing but before the SSE
+stream opens. It only fires for `tools/call` requests where scope metadata exists.
+
+**Additive scoping:** The `scope` value in the `WWW-Authenticate` challenge header
+is always the **union** of the token's existing scopes plus the tool's `required`
+scopes. This ensures the client never loses scopes it already has when
+re-authorizing — a pattern established by github/github-mcp-server and consistent
+with how OAuth scope accumulation should work. For example, if a token has
+`['user:read', 'user:write']` and the tool requires `['repo:read']`, the challenge
+recommends `scope="user:read user:write repo:read"`.
+
+### 7.6 What this does NOT change
+
+- **No changes to the Protocol layer** — scope challenges are purely at the transport level
+- **No changes to JSON-RPC message handling** — errors stay as JSON-RPC errors
+- **No changes to stdio transport** — scope challenges are HTTP-only
+- **No changes to client SDK** — the existing 403 handling already works
+- **No changes to the MCP specification** — this implements existing spec behavior
+
+## 8. Comparison with github/github-mcp-server Approach
+
+| Aspect | github-mcp-server (custom, not Go SDK) | This Proposal (TS SDK) |
+|--------|----------------------|-------------------------------|
+| **Scope declaration** | `ServerTool.RequiredScopes` + `AcceptedScopes` set at tool creation via `NewTool()` | `scopes: { required, accepted }` in `McpServer.tool()` config |
+| **Scope checking** | HTTP middleware (`WithScopeChallenge`) parses JSON-RPC body to find tool name | Transport-level pre-execution hook, tool registry lookup |
+| **Scope hierarchy** | `ExpandScopes()` with explicit `ScopeHierarchy` map | Server author provides `accepted` explicitly (utilities can be offered separately) |
+| **Scope fetching** | `scopeFetcher.FetchTokenScopes()` — can call GitHub API | Reads `authInfo.scopes` directly — populated by the implementer's auth middleware |
+| **Where it runs** | Completely outside any SDK, in custom application middleware | Inside the SDK transport layer, configured via options |
+| **Dynamic challenges** | Not supported (only static pre-check) | Not supported (same constraint) |
+
+The key difference: this proposal brings scope challenge support **into the SDK** rather than requiring every server author to implement it in custom application middleware (as github-mcp-server had to). All MCP SDKs (Go, Python, etc.) could adopt a similar SDK-level approach.
+
+## 9. Open Questions for Working Group
+
+1. **Should `ToolScopeConfig` be part of the `Tool` schema?** SEP-1880 proposed `Tool.authorization.scopes` at the spec level. This was closed, but there's clear demand. Should the working group champion this?
+
+2. **Scope hierarchy utilities:** Should the SDK provide `expandScopes()` with a configurable hierarchy, or is this the server author's responsibility?
+
+3. **Scope-filtered discovery (SEP-1881):** If tools declare scopes, should `tools/list` automatically filter tools the client can't use? This is a related but separable concern.
+
+4. **Protocol-level step-up (Option D):** Is there appetite for a new MCP method like `auth/stepUp` that enables mid-handler scope challenges without breaking the HTTP model?
+
+5. **Multi-request batches:** When a single HTTP POST contains multiple JSON-RPC requests, and one needs a scope challenge, should the entire batch be rejected with 403, or should only the failing tool call get an error?
+
+6. **Accumulative scoping:** The current client overwrite behavior ([#1582](https://github.com/modelcontextprotocol/typescript-sdk/issues/1582)) means progressive authorization drops previous scopes. [PR #1618](https://github.com/modelcontextprotocol/typescript-sdk/pull/1618) proposes union-based accumulation. This proposal takes the position that **additive scoping is correct**: the server always includes the token's existing scopes in the challenge `scope` parameter, so the client re-authorizes with the full union. The spec should mandate this behavior — dropping scopes on step-up creates a broken loop where gaining one scope loses another.
+
+## 10. What's NOT in Scope (Pun Intended)
+
+- **Transport-agnostic scope challenges** (SEP-1489's `_meta` approach) — consensus rejected this
+- **Mid-handler scope challenges** — acknowledged as desirable but architecturally constrained; deferred to future work
+- **Changes to the MCP specification** — this implements existing spec behavior
+- **Token expiry signaling** ([#1294](https://github.com/modelcontextprotocol/typescript-sdk/issues/1294)) — related pattern (401 from tool handler) but separate concern
+
+## Appendix A: Reference Links
+
+- [MCP Spec — Scope Challenge Handling](https://modelcontextprotocol.io/specification/draft/basic/authorization#scope-challenge-handling)
+- [TS SDK Issue #1151 — Server SDK support for scope challenges](https://github.com/modelcontextprotocol/typescript-sdk/issues/1151)
+- [TS SDK Issue #1294 — Server SDK support for signaling token expiry](https://github.com/modelcontextprotocol/typescript-sdk/issues/1294)
+- [TS SDK Issue #1582 — Scope overwrite during progressive auth](https://github.com/modelcontextprotocol/typescript-sdk/issues/1582)
+- [TS SDK PR #1618 — Fix: accumulate scopes across challenges](https://github.com/modelcontextprotocol/typescript-sdk/pull/1618)
+- [github/github-mcp-server — scope_challenge.go](https://github.com/github/github-mcp-server/blob/main/pkg/http/middleware/scope_challenge.go)
+- [github/github-mcp-server — scopes package](https://github.com/github/github-mcp-server/tree/main/pkg/scopes)
+- [SEP-1488 — securitySchemes in Tool Metadata](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1488)
+- [SEP-1489 — Tool Error Responses for OAuth Flows](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1489)
+- [SEP-1880 — Tool-level scope requirements](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1880)
+- [SEP-1881 — Scope-Filtered Tool Discovery](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1881)
+- [Conformance test — scope step-up](https://github.com/modelcontextprotocol/conformance/blob/main/src/scenarios/client/auth/scope-handling.ts#L237)

--- a/docs/proposals/scope-challenge-server-sdk.md
+++ b/docs/proposals/scope-challenge-server-sdk.md
@@ -381,21 +381,40 @@ async connect(transport: Transport): Promise<void> {
 The `_checkScopeChallenge()` method runs after message parsing but before the SSE
 stream opens. It only fires for `tools/call` requests where scope metadata exists.
 
-**Additive scoping:** The `scope` value in the `WWW-Authenticate` challenge header
-is always the **union** of the token's existing scopes plus the tool's `required`
-scopes. This ensures the client never loses scopes it already has when
-re-authorizing — a pattern established by github/github-mcp-server and consistent
-with how OAuth scope accumulation should work. For example, if a token has
-`['user:read', 'user:write']` and the tool requires `['repo:read']`, the challenge
-recommends `scope="user:read user:write repo:read"`.
+**Per-operation scoping (default, post-SEP-2350):** The `scope` value in the
+`WWW-Authenticate` challenge header advertises only the scopes required for the
+current operation, per [RFC 6750 §3.1](https://datatracker.ietf.org/doc/html/rfc6750#section-3.1)
+and [SEP-2350](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2350).
+Clients are responsible for accumulating scopes across step-up challenges (see
+[TS SDK #1657](https://github.com/modelcontextprotocol/typescript-sdk/pull/1657)).
+
+**Opt-in additive scoping:** Servers that need to defend against older / non-accumulating
+clients can set `scopeChallenge.includeGrantedScopes: true`, which restores the
+union behavior (`activeScopes ∪ required`). This is the pattern previously used
+by `github/github-mcp-server`, kept available for compatibility but no longer
+the default.
+
+**Required vs accepted semantics:**
+- `required` uses **AND** — every entry must be present in the token (or `accepted`
+  must satisfy the OR escape hatch).
+- `accepted` (optional) uses **OR** — if any entry is present in the token, the
+  call proceeds. Use for scope hierarchies (e.g. `repo` subsumes `repo:read`).
+
+**Header quoting:** All `WWW-Authenticate` `quoted-string` auth-param values
+(`scope`, `resource_metadata`, `error_description`) are escaped per RFC 7235 so
+that developer-supplied descriptions or scopes containing `"` or `\` do not break
+the header.
 
 ### 7.6 What this does NOT change
 
 - **No changes to the Protocol layer** — scope challenges are purely at the transport level
 - **No changes to JSON-RPC message handling** — errors stay as JSON-RPC errors
 - **No changes to stdio transport** — scope challenges are HTTP-only
-- **No changes to client SDK** — the existing 403 handling already works
-- **No changes to the MCP specification** — this implements existing spec behavior
+- **No changes to client SDK** — the existing 403 handling already works (client-side accumulation lands separately in [#1657](https://github.com/modelcontextprotocol/typescript-sdk/pull/1657))
+- **No changes to the MCP specification** — this implements existing spec behavior (post-SEP-2350)
+- **Tools/call only** — scope challenges for `resources/read`, `prompts/get`, etc. are
+  follow-up work; the SEP language talks about generic "operations" but this
+  initial implementation covers tools only.
 
 ## 8. Comparison with github/github-mcp-server Approach
 
@@ -422,7 +441,21 @@ The key difference: this proposal brings scope challenge support **into the SDK*
 
 5. **Multi-request batches:** When a single HTTP POST contains multiple JSON-RPC requests, and one needs a scope challenge, should the entire batch be rejected with 403, or should only the failing tool call get an error?
 
-6. **Accumulative scoping:** The current client overwrite behavior ([#1582](https://github.com/modelcontextprotocol/typescript-sdk/issues/1582)) means progressive authorization drops previous scopes. [PR #1618](https://github.com/modelcontextprotocol/typescript-sdk/pull/1618) proposes union-based accumulation. This proposal takes the position that **additive scoping is correct**: the server always includes the token's existing scopes in the challenge `scope` parameter, so the client re-authorizes with the full union. The spec should mandate this behavior — dropping scopes on step-up creates a broken loop where gaining one scope loses another.
+6. **Accumulative scoping (resolved by SEP-2350):** The earlier draft of this
+   proposal took the position that the **server** should always include the token's
+   existing scopes in the challenge `scope` parameter (additive scoping). This
+   has since been resolved by [SEP-2350](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2350)
+   (merged), which aligns MCP with [RFC 6750 §3.1](https://datatracker.ietf.org/doc/html/rfc6750#section-3.1):
+   **servers emit per-operation scopes only; clients accumulate scopes across
+   step-up challenges.** Client-side accumulation in the TS SDK lands in
+   [#1657](https://github.com/modelcontextprotocol/typescript-sdk/pull/1657).
+   This implementation defaults to per-operation, with `includeGrantedScopes`
+   as an opt-in for servers that need to defend against non-accumulating clients.
+
+7. **Resources/prompts step-up:** The SEP talks about generic "operations" but this
+   implementation covers `tools/call` only. Extending to `resources/read`,
+   `prompts/get`, and other operations is straightforward (same pre-execution
+   pattern, keyed on method + params) and is deferred to follow-up.
 
 ## 10. What's NOT in Scope (Pun Intended)
 
@@ -437,7 +470,12 @@ The key difference: this proposal brings scope challenge support **into the SDK*
 - [TS SDK Issue #1151 — Server SDK support for scope challenges](https://github.com/modelcontextprotocol/typescript-sdk/issues/1151)
 - [TS SDK Issue #1294 — Server SDK support for signaling token expiry](https://github.com/modelcontextprotocol/typescript-sdk/issues/1294)
 - [TS SDK Issue #1582 — Scope overwrite during progressive auth](https://github.com/modelcontextprotocol/typescript-sdk/issues/1582)
-- [TS SDK PR #1618 — Fix: accumulate scopes across challenges](https://github.com/modelcontextprotocol/typescript-sdk/pull/1618)
+- [TS SDK PR #1618 — Fix: accumulate scopes across challenges (superseded)](https://github.com/modelcontextprotocol/typescript-sdk/pull/1618)
+- [TS SDK PR #1657 — Client-side scope accumulation on 401/403](https://github.com/modelcontextprotocol/typescript-sdk/pull/1657)
+- [SEP-2350 — Clarify client-side scope accumulation in step-up authorization (merged)](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2350)
+- [Python SDK PR #2676 — SEP-2350 implementation](https://github.com/modelcontextprotocol/python-sdk/pull/2676)
+- [RFC 6750 §3.1 — Bearer error responses](https://datatracker.ietf.org/doc/html/rfc6750#section-3.1)
+- [RFC 7235 — HTTP Authentication](https://datatracker.ietf.org/doc/html/rfc7235)
 - [github/github-mcp-server — scope_challenge.go](https://github.com/github/github-mcp-server/blob/main/pkg/http/middleware/scope_challenge.go)
 - [github/github-mcp-server — scopes package](https://github.com/github/github-mcp-server/tree/main/pkg/scopes)
 - [SEP-1488 — securitySchemes in Tool Metadata](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1488)

--- a/docs/serving/authorization.md
+++ b/docs/serving/authorization.md
@@ -21,7 +21,8 @@ import {
 } from '@modelcontextprotocol/express';
 import { toNodeHandler } from '@modelcontextprotocol/node';
 import type { AuthInfo, OAuthMetadata } from '@modelcontextprotocol/server';
-import { createMcpHandler, McpServer } from '@modelcontextprotocol/server';
+import { createMcpHandler, McpServer, requireScopes } from '@modelcontextprotocol/server';
+import * as z from 'zod/v4';
 
 const mcpServerUrl = new URL('https://api.example.com/mcp');
 const verifier: OAuthTokenVerifier = { verifyAccessToken };
@@ -33,7 +34,13 @@ const auth = requireBearerAuth({
 });
 
 const app = createMcpExpressApp({ host: '0.0.0.0', allowedHosts: ['api.example.com'] });
-const node = toNodeHandler(createMcpHandler(buildServer));
+const node = toNodeHandler(
+    createMcpHandler(buildServer, {
+        scopeChallenge: {
+            resourceMetadataUrl: getOAuthProtectedResourceMetadataUrl(mcpServerUrl)
+        }
+    })
+);
 app.all('/mcp', auth, (req, res) => void node(req, res, req.body));
 ```
 
@@ -118,22 +125,34 @@ The per-request factory itself receives the same value as `ctx.authInfo`, so it 
 
 ## Enforce per-tool scopes
 
-`requiredScopes` gates the whole endpoint. For a scope only some tools need, check inside the handler — the handler is the only place that knows which tool is executing.
+`requiredScopes` gates the whole endpoint. For scope step-up on an individual tool, set its `scopeChallenge` callback and configure `scopeChallenge.resourceMetadataUrl` on `createMcpHandler` (or a directly constructed Streamable HTTP transport). The callback receives the full parsed request and verified `authInfo`. Return `undefined` to continue, or return the exact, complete scope set to send `403 insufficient_scope` before invocation or SSE. Throwing or rejecting fails closed.
 
-```ts source="../../examples/guides/serving/authorization.examples.ts#perToolScopes_handler"
-server.registerTool('purge-notes', { description: 'Delete every note' }, async ctx => {
-    if (!ctx.http?.authInfo?.scopes.includes('notes:write')) {
-        return { content: [{ type: 'text', text: 'insufficient_scope: purge-notes requires notes:write' }], isError: true };
-    }
-    return { content: [{ type: 'text', text: 'All notes deleted' }] };
-});
+Use `requireScopes` for a static exact all-of check. Use a callback when the required scope set depends on the request:
+
+```ts source="../../examples/guides/serving/authorization.examples.ts#perToolScopes_challenge"
+server.registerTool('purge-notes', { scopeChallenge: requireScopes('notes:write') }, async () => ({
+    content: [{ type: 'text', text: 'All notes deleted' }]
+}));
+
+server.registerTool(
+    'read-repository',
+    {
+        inputSchema: z.object({ visibility: z.enum(['public', 'private']) }),
+        scopeChallenge: ({ request, authInfo }) => {
+            const visibility = (request.params as { arguments?: { visibility?: unknown } }).arguments?.visibility;
+            if (visibility !== 'public' && visibility !== 'private') return;
+
+            const scopes = visibility === 'private' ? (['repo:read'] as const) : (['public_repo'] as const);
+            return scopes.every(scope => authInfo?.scopes.includes(scope))
+                ? undefined
+                : { scopes, errorDescription: `${visibility} repository access is required` };
+        }
+    },
+    async ({ visibility }) => ({ content: [{ type: 'text', text: `Read ${visibility} repository` }] })
+);
 ```
 
-A caller holding only `mcp` gets an ordinary tool result with `isError: true`, so the model reads the refusal and moves on instead of losing the connection.
-
-::: info
-Responding `403 insufficient_scope` at the HTTP layer instead triggers the client transport's automatic scope step-up (SEP-2350) — see [Authenticate a user with OAuth](../clients/oauth.md).
-:::
+Scope interpretation belongs to your callback; the SDK does not infer hierarchies, alternatives, or missing scopes. Challenged tools remain visible in `tools/list`.
 
 ## Recap
 
@@ -141,5 +160,5 @@ Responding `403 insufficient_scope` at the HTTP layer instead triggers the clien
 - `requireBearerAuth` plus a `verifyAccessToken` you write turn an Express-mounted MCP route into an OAuth resource server; the SDK never issues tokens.
 - Missing, invalid, or expired tokens get `401 invalid_token`; a token missing a `requiredScopes` entry gets `403 insufficient_scope`; both carry a `WWW-Authenticate: Bearer` challenge.
 - `mcpAuthMetadataRouter` publishes the RFC 9728 document that challenge points at, plus a mirror of the AS metadata.
-- Verified auth flows `req.auth` → `ctx.http.authInfo`; per-tool scopes are a check inside the handler that returns `isError: true`.
+- Verified auth flows `req.auth` → `ctx.http.authInfo`; per-tool callbacks can trigger HTTP `403` scope step-up before invocation.
 - The v1 Authorization Server helpers are frozen in `@modelcontextprotocol/server-legacy/auth`.

--- a/docs/serving/authorization.md
+++ b/docs/serving/authorization.md
@@ -1,6 +1,6 @@
 ---
 shape: how-to
-description: 'Require a bearer token on a server you run: verification, protected-resource metadata, and per-tool scopes.'
+description: 'Require a bearer token on a server you run: verification, protected-resource metadata, and per-operation scopes.'
 ---
 
 # Require authorization
@@ -123,15 +123,23 @@ server.registerTool('whoami', { description: 'Report the authenticated caller' }
 The per-request factory itself receives the same value as `ctx.authInfo`, so it can register a different tool set per caller before any handler runs.
 :::
 
-## Enforce per-tool scopes
+## Enforce per-operation scopes
 
-`requiredScopes` gates the whole endpoint. For scope step-up on an individual tool, set its `scopeChallenge` callback and configure `scopeChallenge.resourceMetadataUrl` on `createMcpHandler` (or a directly constructed Streamable HTTP transport). The callback receives the full parsed request and verified `authInfo`. Return `undefined` to continue, or return the exact, complete scope set to send `403 insufficient_scope` before invocation or SSE. Throwing or rejecting fails closed.
+`requiredScopes` gates the whole endpoint. For scope step-up on an individual tool call, resource read, or prompt retrieval, set `scopeChallenge` on its registration and configure `scopeChallenge.resourceMetadataUrl` on `createMcpHandler` (or a directly constructed Streamable HTTP transport). The callback receives the full parsed request and verified `authInfo`. Return `undefined` to continue, or return the exact, complete scope set to send `403 insufficient_scope` before invocation or SSE. Throwing or rejecting fails closed.
 
 Use `requireScopes` for a static exact all-of check. Use a callback when the required scope set depends on the request:
 
-```ts source="../../examples/guides/serving/authorization.examples.ts#perToolScopes_challenge"
+```ts source="../../examples/guides/serving/authorization.examples.ts#perOperationScopes_challenge"
 server.registerTool('purge-notes', { scopeChallenge: requireScopes('notes:write') }, async () => ({
     content: [{ type: 'text', text: 'All notes deleted' }]
+}));
+
+server.registerResource('private-notes', 'notes://private', { scopeChallenge: requireScopes('notes:read') }, async uri => ({
+    contents: [{ uri: uri.href, text: 'Private notes' }]
+}));
+
+server.registerPrompt('summarize-notes', { scopeChallenge: requireScopes('notes:read') }, async () => ({
+    messages: [{ role: 'user', content: { type: 'text', text: 'Summarize my private notes' } }]
 }));
 
 server.registerTool(
@@ -152,7 +160,11 @@ server.registerTool(
 );
 ```
 
-Scope interpretation belongs to your callback; the SDK does not infer hierarchies, alternatives, or missing scopes. Challenged tools remain visible in `tools/list`.
+Scope interpretation belongs to your callback; the SDK does not infer hierarchies, alternatives, or missing scopes. Challenged primitives remain visible in their list operations.
+
+::: warning
+The callback runs before the primitive's input schema is validated or transformed. Its `request` contains the JSON-parsed wire values, so dynamic authorization should validate or canonicalize any value whose schema changes its meaning before handler invocation. Scope names and `errorDescription` must use printable ASCII so they can be serialized safely in `WWW-Authenticate`.
+:::
 
 ## Recap
 
@@ -160,5 +172,5 @@ Scope interpretation belongs to your callback; the SDK does not infer hierarchie
 - `requireBearerAuth` plus a `verifyAccessToken` you write turn an Express-mounted MCP route into an OAuth resource server; the SDK never issues tokens.
 - Missing, invalid, or expired tokens get `401 invalid_token`; a token missing a `requiredScopes` entry gets `403 insufficient_scope`; both carry a `WWW-Authenticate: Bearer` challenge.
 - `mcpAuthMetadataRouter` publishes the RFC 9728 document that challenge points at, plus a mirror of the AS metadata.
-- Verified auth flows `req.auth` → `ctx.http.authInfo`; per-tool callbacks can trigger HTTP `403` scope step-up before invocation.
+- Verified auth flows `req.auth` → `ctx.http.authInfo`; per-operation callbacks can trigger HTTP `403` scope step-up before invocation.
 - The v1 Authorization Server helpers are frozen in `@modelcontextprotocol/server-legacy/auth`.

--- a/docs/serving/authorization.md
+++ b/docs/serving/authorization.md
@@ -121,7 +121,7 @@ The per-request factory itself receives the same value as `ctx.authInfo`, so it 
 
 `requiredScopes` gates the whole endpoint. For scope step-up on an individual tool call, resource read, or prompt retrieval, set `scopeChallenge` on its registration — no handler or transport configuration is needed. The callback receives the full parsed request and verified `authInfo`. Return `undefined` to continue, or return the exact, complete scope set to send `403 insufficient_scope` before invocation or SSE. Throwing or rejecting fails closed.
 
-The challenge's `WWW-Authenticate` header is built by the same formatter as `requireBearerAuth`'s own `401`/`403` answers, and its `resource_metadata` parameter comes from the verified `AuthInfo`: the gate stamps its configured `resourceMetadataUrl` onto the `AuthInfo` it returns, so the metadata URL is configured exactly once — on `requireBearerAuth`. Without a stamped value the parameter falls back to the well-known location for the token's RFC 8707 `resource` identifier, or is omitted.
+The challenge uses the same OAuth `insufficient_scope` JSON body and `WWW-Authenticate` formatter as `requireBearerAuth`'s own `403` answer. Its `resource_metadata` parameter comes from the verified `AuthInfo`: the gate stamps its configured `resourceMetadataUrl` onto the `AuthInfo` it returns, so the metadata URL is configured exactly once — on `requireBearerAuth`. Without a stamped value the parameter falls back to the well-known location for the token's RFC 8707 `resource` identifier, or is omitted.
 
 Use `requireScopes` for a static exact all-of check. Use a callback when the required scope set depends on the request:
 

--- a/docs/serving/authorization.md
+++ b/docs/serving/authorization.md
@@ -34,13 +34,7 @@ const auth = requireBearerAuth({
 });
 
 const app = createMcpExpressApp({ host: '0.0.0.0', allowedHosts: ['api.example.com'] });
-const node = toNodeHandler(
-    createMcpHandler(buildServer, {
-        scopeChallenge: {
-            resourceMetadataUrl: getOAuthProtectedResourceMetadataUrl(mcpServerUrl)
-        }
-    })
-);
+const node = toNodeHandler(createMcpHandler(buildServer));
 app.all('/mcp', auth, (req, res) => void node(req, res, req.body));
 ```
 
@@ -125,7 +119,9 @@ The per-request factory itself receives the same value as `ctx.authInfo`, so it 
 
 ## Enforce per-operation scopes
 
-`requiredScopes` gates the whole endpoint. For scope step-up on an individual tool call, resource read, or prompt retrieval, set `scopeChallenge` on its registration and configure `scopeChallenge.resourceMetadataUrl` on `createMcpHandler` (or a directly constructed Streamable HTTP transport). The callback receives the full parsed request and verified `authInfo`. Return `undefined` to continue, or return the exact, complete scope set to send `403 insufficient_scope` before invocation or SSE. Throwing or rejecting fails closed.
+`requiredScopes` gates the whole endpoint. For scope step-up on an individual tool call, resource read, or prompt retrieval, set `scopeChallenge` on its registration — no handler or transport configuration is needed. The callback receives the full parsed request and verified `authInfo`. Return `undefined` to continue, or return the exact, complete scope set to send `403 insufficient_scope` before invocation or SSE. Throwing or rejecting fails closed.
+
+The challenge's `WWW-Authenticate` header is built by the same formatter as `requireBearerAuth`'s own `401`/`403` answers, and its `resource_metadata` parameter comes from the verified `AuthInfo`: the gate stamps its configured `resourceMetadataUrl` onto the `AuthInfo` it returns, so the metadata URL is configured exactly once — on `requireBearerAuth`. Without a stamped value the parameter falls back to the well-known location for the token's RFC 8707 `resource` identifier, or is omitted.
 
 Use `requireScopes` for a static exact all-of check. Use a callback when the required scope set depends on the request:
 
@@ -172,5 +168,5 @@ The callback runs before the primitive's input schema is validated or transforme
 - `requireBearerAuth` plus a `verifyAccessToken` you write turn an Express-mounted MCP route into an OAuth resource server; the SDK never issues tokens.
 - Missing, invalid, or expired tokens get `401 invalid_token`; a token missing a `requiredScopes` entry gets `403 insufficient_scope`; both carry a `WWW-Authenticate: Bearer` challenge.
 - `mcpAuthMetadataRouter` publishes the RFC 9728 document that challenge points at, plus a mirror of the AS metadata.
-- Verified auth flows `req.auth` → `ctx.http.authInfo`; per-operation callbacks can trigger HTTP `403` scope step-up before invocation.
+- Verified auth flows `req.auth` → `ctx.http.authInfo`; per-operation callbacks can trigger HTTP `403` scope step-up before invocation, advertising the metadata URL the gate stamped onto `AuthInfo`.
 - The v1 Authorization Server helpers are frozen in `@modelcontextprotocol/server-legacy/auth`.

--- a/docs/serving/authorization.md
+++ b/docs/serving/authorization.md
@@ -163,7 +163,7 @@ server.registerTool(
 Scope interpretation belongs to your callback; the SDK does not infer hierarchies, alternatives, or missing scopes. Challenged primitives remain visible in their list operations.
 
 ::: warning
-The callback runs before the primitive's input schema is validated or transformed. Its `request` contains the JSON-parsed wire values, so dynamic authorization should validate or canonicalize any value whose schema changes its meaning before handler invocation. Scope names and `errorDescription` must use printable ASCII so they can be serialized safely in `WWW-Authenticate`.
+The callback runs before the primitive's input schema is validated or transformed. Its `request` contains the JSON-parsed wire values, so dynamic authorization should validate or canonicalize any value whose schema changes its meaning before handler invocation. Scope names must follow the OAuth `scope-token` grammar; `errorDescription`, when provided, must follow RFC 6750's `error-description` grammar.
 :::
 
 ## Recap

--- a/examples/guides/serving/authorization.examples.ts
+++ b/examples/guides/serving/authorization.examples.ts
@@ -35,13 +35,7 @@ const auth = requireBearerAuth({
 });
 
 const app = createMcpExpressApp({ host: '0.0.0.0', allowedHosts: ['api.example.com'] });
-const node = toNodeHandler(
-    createMcpHandler(buildServer, {
-        scopeChallenge: {
-            resourceMetadataUrl: getOAuthProtectedResourceMetadataUrl(mcpServerUrl)
-        }
-    })
-);
+const node = toNodeHandler(createMcpHandler(buildServer));
 app.all('/mcp', auth, (req, res) => void node(req, res, req.body));
 //#endregion requireBearerAuth_basic
 

--- a/examples/guides/serving/authorization.examples.ts
+++ b/examples/guides/serving/authorization.examples.ts
@@ -79,9 +79,17 @@ function buildServer(): McpServer {
     });
     //#endregion authInfo_handler
 
-    //#region perToolScopes_challenge
+    //#region perOperationScopes_challenge
     server.registerTool('purge-notes', { scopeChallenge: requireScopes('notes:write') }, async () => ({
         content: [{ type: 'text', text: 'All notes deleted' }]
+    }));
+
+    server.registerResource('private-notes', 'notes://private', { scopeChallenge: requireScopes('notes:read') }, async uri => ({
+        contents: [{ uri: uri.href, text: 'Private notes' }]
+    }));
+
+    server.registerPrompt('summarize-notes', { scopeChallenge: requireScopes('notes:read') }, async () => ({
+        messages: [{ role: 'user', content: { type: 'text', text: 'Summarize my private notes' } }]
     }));
 
     server.registerTool(
@@ -100,7 +108,7 @@ function buildServer(): McpServer {
         },
         async ({ visibility }) => ({ content: [{ type: 'text', text: `Read ${visibility} repository` }] })
     );
-    //#endregion perToolScopes_challenge
+    //#endregion perOperationScopes_challenge
 
     return server;
 }

--- a/examples/guides/serving/authorization.examples.ts
+++ b/examples/guides/serving/authorization.examples.ts
@@ -22,7 +22,8 @@ import {
 } from '@modelcontextprotocol/express';
 import { toNodeHandler } from '@modelcontextprotocol/node';
 import type { AuthInfo, OAuthMetadata } from '@modelcontextprotocol/server';
-import { createMcpHandler, McpServer } from '@modelcontextprotocol/server';
+import { createMcpHandler, McpServer, requireScopes } from '@modelcontextprotocol/server';
+import * as z from 'zod/v4';
 
 const mcpServerUrl = new URL('https://api.example.com/mcp');
 const verifier: OAuthTokenVerifier = { verifyAccessToken };
@@ -34,7 +35,13 @@ const auth = requireBearerAuth({
 });
 
 const app = createMcpExpressApp({ host: '0.0.0.0', allowedHosts: ['api.example.com'] });
-const node = toNodeHandler(createMcpHandler(buildServer));
+const node = toNodeHandler(
+    createMcpHandler(buildServer, {
+        scopeChallenge: {
+            resourceMetadataUrl: getOAuthProtectedResourceMetadataUrl(mcpServerUrl)
+        }
+    })
+);
 app.all('/mcp', auth, (req, res) => void node(req, res, req.body));
 //#endregion requireBearerAuth_basic
 
@@ -72,14 +79,28 @@ function buildServer(): McpServer {
     });
     //#endregion authInfo_handler
 
-    //#region perToolScopes_handler
-    server.registerTool('purge-notes', { description: 'Delete every note' }, async ctx => {
-        if (!ctx.http?.authInfo?.scopes.includes('notes:write')) {
-            return { content: [{ type: 'text', text: 'insufficient_scope: purge-notes requires notes:write' }], isError: true };
-        }
-        return { content: [{ type: 'text', text: 'All notes deleted' }] };
-    });
-    //#endregion perToolScopes_handler
+    //#region perToolScopes_challenge
+    server.registerTool('purge-notes', { scopeChallenge: requireScopes('notes:write') }, async () => ({
+        content: [{ type: 'text', text: 'All notes deleted' }]
+    }));
+
+    server.registerTool(
+        'read-repository',
+        {
+            inputSchema: z.object({ visibility: z.enum(['public', 'private']) }),
+            scopeChallenge: ({ request, authInfo }) => {
+                const visibility = (request.params as { arguments?: { visibility?: unknown } }).arguments?.visibility;
+                if (visibility !== 'public' && visibility !== 'private') return;
+
+                const scopes = visibility === 'private' ? (['repo:read'] as const) : (['public_repo'] as const);
+                return scopes.every(scope => authInfo?.scopes.includes(scope))
+                    ? undefined
+                    : { scopes, errorDescription: `${visibility} repository access is required` };
+            }
+        },
+        async ({ visibility }) => ({ content: [{ type: 'text', text: `Read ${visibility} repository` }] })
+    );
+    //#endregion perToolScopes_challenge
 
     return server;
 }

--- a/packages/core-internal/src/types/types.ts
+++ b/packages/core-internal/src/types/types.ts
@@ -752,6 +752,19 @@ export interface AuthInfo {
     resource?: URL;
 
     /**
+     * URL of the RFC 9728 Protected Resource Metadata document for the
+     * resource server that accepted this token.
+     *
+     * The bearer-auth helpers stamp their configured `resourceMetadataUrl`
+     * here when verification succeeds, so challenge responses built after
+     * authentication (for example per-operation `insufficient_scope` scope
+     * challenges) can advertise the same document as the authentication
+     * gate's own challenges without separate configuration. Verifiers may
+     * also populate it directly; a verifier-set value wins.
+     */
+    resourceMetadataUrl?: string;
+
+    /**
      * Additional data associated with the token.
      * This field should be used for any additional data that needs to be attached to the auth info.
      */

--- a/packages/middleware/node/src/streamableHttp.ts
+++ b/packages/middleware/node/src/streamableHttp.ts
@@ -11,7 +11,7 @@ import type { IncomingMessage, ServerResponse } from 'node:http';
 
 import { getRequestListener } from '@hono/node-server';
 import type { AuthInfo, JSONRPCMessage, MessageExtraInfo, RequestId, Transport } from '@modelcontextprotocol/core';
-import type { WebStandardStreamableHTTPServerTransportOptions } from '@modelcontextprotocol/server';
+import type { ToolScopeConfig, WebStandardStreamableHTTPServerTransportOptions } from '@modelcontextprotocol/server';
 import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/server';
 
 /**
@@ -150,6 +150,17 @@ export class NodeStreamableHTTPServerTransport implements Transport {
      */
     async send(message: JSONRPCMessage, options?: { relatedRequestId?: RequestId }): Promise<void> {
         return this._webStandardTransport.send(message, options);
+    }
+
+    /**
+     * Sets the scope resolver for pre-execution scope challenge checks.
+     * Delegates to the underlying {@linkcode WebStandardStreamableHTTPServerTransport}.
+     *
+     * This is auto-wired by `McpServer.connect()` when `scopeChallenge`
+     * is configured on the transport.
+     */
+    setScopeResolver(resolver: (toolName: string) => ToolScopeConfig | undefined): void {
+        this._webStandardTransport.setScopeResolver(resolver);
     }
 
     /**

--- a/packages/middleware/node/src/streamableHttp.ts
+++ b/packages/middleware/node/src/streamableHttp.ts
@@ -11,7 +11,7 @@ import type { IncomingMessage, ServerResponse } from 'node:http';
 
 import { getRequestListener } from '@hono/node-server';
 import type { AuthInfo, JSONRPCMessage, MessageExtraInfo, RequestId, Transport } from '@modelcontextprotocol/core';
-import type { ToolScopeConfig, WebStandardStreamableHTTPServerTransportOptions } from '@modelcontextprotocol/server';
+import type { ScopeResolver, WebStandardStreamableHTTPServerTransportOptions } from '@modelcontextprotocol/server';
 import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/server';
 
 /**
@@ -159,7 +159,7 @@ export class NodeStreamableHTTPServerTransport implements Transport {
      * This is auto-wired by `McpServer.connect()` when `scopeChallenge`
      * is configured on the transport.
      */
-    setScopeResolver(resolver: (toolName: string) => ToolScopeConfig | undefined): void {
+    setScopeResolver(resolver: ScopeResolver): void {
         this._webStandardTransport.setScopeResolver(resolver);
     }
 

--- a/packages/middleware/node/src/streamableHttp.ts
+++ b/packages/middleware/node/src/streamableHttp.ts
@@ -15,6 +15,7 @@ import type {
     JSONRPCMessage,
     MessageExtraInfo,
     RequestId,
+    ScopeChallengeHandler,
     Transport,
     WebStandardStreamableHTTPServerTransportOptions
 } from '@modelcontextprotocol/server';
@@ -167,6 +168,11 @@ export class NodeStreamableHTTPServerTransport implements Transport {
      */
     setSupportedProtocolVersions(versions: string[]): void {
         this._webStandardTransport.setSupportedProtocolVersions(versions);
+    }
+
+    /** Sets the scope challenge resolver used by the wrapped Web Standard transport. */
+    setScopeChallengeResolver(resolver: ScopeChallengeHandler): void {
+        this._webStandardTransport.setScopeChallengeResolver(resolver);
     }
 
     /**

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -21,7 +21,8 @@ export type {
     RegisteredResourceTemplate,
     RegisteredTool,
     ResourceMetadata,
-    ToolCallback
+    ToolCallback,
+    ToolScopeConfig
 } from './server/mcp.js';
 export { McpServer, ResourceTemplate } from './server/mcp.js';
 export type { HostHeaderValidationResult } from './server/middleware/hostHeaderValidation.js';
@@ -35,10 +36,13 @@ export type {
     EventId,
     EventStore,
     HandleRequestOptions,
+    ScopeAware,
+    ScopeChallengeConfig,
+    ScopeResolver,
     StreamId,
     WebStandardStreamableHTTPServerTransportOptions
 } from './server/streamableHttp.js';
-export { WebStandardStreamableHTTPServerTransport } from './server/streamableHttp.js';
+export { isScopeAware, WebStandardStreamableHTTPServerTransport } from './server/streamableHttp.js';
 
 // experimental exports
 export type { CreateTaskRequestHandler, TaskRequestHandler, ToolTaskHandler } from './experimental/tasks/interfaces.js';

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -65,7 +65,7 @@ export { InMemoryServerEventBus } from './server/serverEventBus';
 // StdioServerTransport and the serveStdio entry are exported from the './stdio' subpath — server stdio
 // has only type-level Node imports (erased at compile time), but matching the client's `./stdio` subpath
 // gives consumers a consistent shape across packages.
-export type { ScopeChallenge, ScopeChallengeConfig, ScopeChallengeHandler } from './server/scopeChallenge';
+export type { ScopeChallenge, ScopeChallengeHandler } from './server/scopeChallenge';
 export { requireScopes } from './server/scopeChallenge';
 export type {
     EventId,

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -65,6 +65,8 @@ export { InMemoryServerEventBus } from './server/serverEventBus';
 // StdioServerTransport and the serveStdio entry are exported from the './stdio' subpath — server stdio
 // has only type-level Node imports (erased at compile time), but matching the client's `./stdio` subpath
 // gives consumers a consistent shape across packages.
+export type { ScopeChallenge, ScopeChallengeConfig, ScopeChallengeHandler } from './server/scopeChallenge';
+export { requireScopes } from './server/scopeChallenge';
 export type {
     EventId,
     EventStore,

--- a/packages/server/src/server/createMcpHandler.ts
+++ b/packages/server/src/server/createMcpHandler.ts
@@ -837,20 +837,20 @@ export function createMcpHandler(factory: McpServerFactory, options: CreateMcpHa
                     }
                 }
             }
+        }
 
-            // Run scope preflight after Mcp-Param headers have been checked against the body.
-            if (options.scopeChallenge !== undefined) {
-                try {
-                    const result = await findScopeChallenge([route.message], authInfo, context => product.resolveScopeChallenge(context));
-                    if (result !== undefined) {
-                        void product.close().catch(reportError);
-                        return createScopeChallengeResponse(options.scopeChallenge, result.challenge, result.requestId);
-                    }
-                } catch (error) {
+        // Run scope preflight after Mcp-Param headers have been checked against the body.
+        if (route.messageKind === 'request' && product instanceof McpServer && options.scopeChallenge !== undefined) {
+            try {
+                const result = await findScopeChallenge([route.message], authInfo, context => product.resolveScopeChallenge(context));
+                if (result !== undefined) {
                     void product.close().catch(reportError);
-                    reportError(toError(error));
-                    return internalServerErrorResponse(route.message.id);
+                    return createScopeChallengeResponse(options.scopeChallenge, result.challenge, result.requestId);
                 }
+            } catch (error) {
+                void product.close().catch(reportError);
+                reportError(toError(error));
+                return internalServerErrorResponse(route.message.id);
             }
         }
 

--- a/packages/server/src/server/createMcpHandler.ts
+++ b/packages/server/src/server/createMcpHandler.ts
@@ -840,10 +840,10 @@ export function createMcpHandler(factory: McpServerFactory, options: CreateMcpHa
         // or the token's RFC 8707 resource identifier) and omitted otherwise.
         if (route.messageKind === 'request' && product instanceof McpServer) {
             try {
-                const result = await findScopeChallenge([route.message], authInfo, context => product.resolveScopeChallenge(context));
-                if (result !== undefined) {
+                const challenge = await findScopeChallenge([route.message], authInfo, context => product.resolveScopeChallenge(context));
+                if (challenge !== undefined) {
                     void product.close().catch(reportError);
-                    return createScopeChallengeResponse(result.challenge, result.requestId, scopeChallengeResourceMetadataUrl(authInfo));
+                    return createScopeChallengeResponse(challenge, scopeChallengeResourceMetadataUrl(authInfo));
                 }
             } catch (error) {
                 void product.close().catch(reportError);

--- a/packages/server/src/server/createMcpHandler.ts
+++ b/packages/server/src/server/createMcpHandler.ts
@@ -64,6 +64,8 @@ import { createListenRouter, DEFAULT_MAX_SUBSCRIPTIONS } from './listenRouter';
 import { McpServer } from './mcp';
 import type { PerRequestResponseMode } from './perRequestTransport';
 import { DEFAULT_MAX_REQUEST_BODY_SIZE, readRequestBody, requestBodyTooLargeMessage, resolveMaxRequestBodySize } from './requestBody';
+import type { ScopeChallengeConfig } from './scopeChallenge';
+import { createScopeChallengeResponse, findScopeChallenge } from './scopeChallenge';
 import type { Server } from './server';
 import { installModernOnlyHandlers, seedClientIdentityFromEnvelope, serverIdentityOf } from './server';
 import type { ServerEventBus, ServerNotifier } from './serverEventBus';
@@ -212,6 +214,8 @@ export interface CreateMcpHandlerOptions {
      * @default 4194304 (4 MiB)
      */
     maxRequestBodySize?: number;
+    /** Enables per-operation OAuth scope challenges. */
+    scopeChallenge?: ScopeChallengeConfig;
 }
 
 /**
@@ -323,7 +327,8 @@ function createLegacyStatelessFallback(
     factory: McpServerFactory,
     onerror?: (error: Error) => void,
     keepAliveMs?: number,
-    maxRequestBodySize?: number
+    maxRequestBodySize?: number,
+    scopeChallenge?: ScopeChallengeConfig
 ): LegacyHttpHandler {
     return async (request, options) => {
         if (request.method.toUpperCase() !== 'POST') {
@@ -338,7 +343,8 @@ function createLegacyStatelessFallback(
             const transport = new WebStandardStreamableHTTPServerTransport({
                 sessionIdGenerator: undefined,
                 ...(keepAliveMs !== undefined && { keepAliveMs }),
-                ...(maxRequestBodySize !== undefined && { maxRequestBodySize })
+                ...(maxRequestBodySize !== undefined && { maxRequestBodySize }),
+                ...(scopeChallenge !== undefined && { scopeChallenge })
             });
             await product.connect(transport);
 
@@ -715,7 +721,9 @@ export function createMcpHandler(factory: McpServerFactory, options: CreateMcpHa
     // The default posture is the stateless fallback; 'reject' is the only way
     // to turn legacy serving off (modern-only strict).
     const legacyHandler: LegacyHttpHandler | undefined =
-        legacy === 'reject' ? undefined : createLegacyStatelessFallback(factory, reportError, options.keepAliveMs, maxRequestBodySize);
+        legacy === 'reject'
+            ? undefined
+            : createLegacyStatelessFallback(factory, reportError, options.keepAliveMs, maxRequestBodySize, options.scopeChallenge);
 
     async function serveModern(route: InboundModernRoute, request: Request, authInfo: AuthInfo | undefined): Promise<Response> {
         const claimedRevision = route.classification.revision;
@@ -827,6 +835,21 @@ export function createMcpHandler(factory: McpServerFactory, options: CreateMcpHa
                         reportError(new Error(`Rejected inbound request (${rejection.cell}): ${rejection.message}`));
                         return rejectionResponse(rejection, route.message.id);
                     }
+                }
+            }
+
+            // Run scope preflight after Mcp-Param headers have been checked against the body.
+            if (options.scopeChallenge !== undefined) {
+                try {
+                    const result = await findScopeChallenge([route.message], authInfo, context => product.resolveScopeChallenge(context));
+                    if (result !== undefined) {
+                        void product.close().catch(reportError);
+                        return createScopeChallengeResponse(options.scopeChallenge, result.challenge, result.requestId);
+                    }
+                } catch (error) {
+                    void product.close().catch(reportError);
+                    reportError(toError(error));
+                    return internalServerErrorResponse(route.message.id);
                 }
             }
         }

--- a/packages/server/src/server/createMcpHandler.ts
+++ b/packages/server/src/server/createMcpHandler.ts
@@ -64,8 +64,7 @@ import { createListenRouter, DEFAULT_MAX_SUBSCRIPTIONS } from './listenRouter';
 import { McpServer } from './mcp';
 import type { PerRequestResponseMode } from './perRequestTransport';
 import { DEFAULT_MAX_REQUEST_BODY_SIZE, readRequestBody, requestBodyTooLargeMessage, resolveMaxRequestBodySize } from './requestBody';
-import type { ScopeChallengeConfig } from './scopeChallenge';
-import { createScopeChallengeResponse, findScopeChallenge } from './scopeChallenge';
+import { createScopeChallengeResponse, findScopeChallenge, scopeChallengeResourceMetadataUrl } from './scopeChallenge';
 import type { Server } from './server';
 import { installModernOnlyHandlers, seedClientIdentityFromEnvelope, serverIdentityOf } from './server';
 import type { ServerEventBus, ServerNotifier } from './serverEventBus';
@@ -214,8 +213,6 @@ export interface CreateMcpHandlerOptions {
      * @default 4194304 (4 MiB)
      */
     maxRequestBodySize?: number;
-    /** Enables per-operation OAuth scope challenges. */
-    scopeChallenge?: ScopeChallengeConfig;
 }
 
 /**
@@ -327,8 +324,7 @@ function createLegacyStatelessFallback(
     factory: McpServerFactory,
     onerror?: (error: Error) => void,
     keepAliveMs?: number,
-    maxRequestBodySize?: number,
-    scopeChallenge?: ScopeChallengeConfig
+    maxRequestBodySize?: number
 ): LegacyHttpHandler {
     return async (request, options) => {
         if (request.method.toUpperCase() !== 'POST') {
@@ -343,8 +339,7 @@ function createLegacyStatelessFallback(
             const transport = new WebStandardStreamableHTTPServerTransport({
                 sessionIdGenerator: undefined,
                 ...(keepAliveMs !== undefined && { keepAliveMs }),
-                ...(maxRequestBodySize !== undefined && { maxRequestBodySize }),
-                ...(scopeChallenge !== undefined && { scopeChallenge })
+                ...(maxRequestBodySize !== undefined && { maxRequestBodySize })
             });
             await product.connect(transport);
 
@@ -721,9 +716,7 @@ export function createMcpHandler(factory: McpServerFactory, options: CreateMcpHa
     // The default posture is the stateless fallback; 'reject' is the only way
     // to turn legacy serving off (modern-only strict).
     const legacyHandler: LegacyHttpHandler | undefined =
-        legacy === 'reject'
-            ? undefined
-            : createLegacyStatelessFallback(factory, reportError, options.keepAliveMs, maxRequestBodySize, options.scopeChallenge);
+        legacy === 'reject' ? undefined : createLegacyStatelessFallback(factory, reportError, options.keepAliveMs, maxRequestBodySize);
 
     async function serveModern(route: InboundModernRoute, request: Request, authInfo: AuthInfo | undefined): Promise<Response> {
         const claimedRevision = route.classification.revision;
@@ -839,13 +832,18 @@ export function createMcpHandler(factory: McpServerFactory, options: CreateMcpHa
             }
         }
 
-        // Run scope preflight after Mcp-Param headers have been checked against the body.
-        if (route.messageKind === 'request' && product instanceof McpServer && options.scopeChallenge !== undefined) {
+        // Run scope preflight after Mcp-Param headers have been checked against
+        // the body. Active whenever the factory's instance registers a
+        // per-primitive scopeChallenge callback — no handler-level
+        // configuration exists: the challenge's resource_metadata parameter is
+        // derived from the verified AuthInfo (stamped by the bearer-auth gate,
+        // or the token's RFC 8707 resource identifier) and omitted otherwise.
+        if (route.messageKind === 'request' && product instanceof McpServer) {
             try {
                 const result = await findScopeChallenge([route.message], authInfo, context => product.resolveScopeChallenge(context));
                 if (result !== undefined) {
                     void product.close().catch(reportError);
-                    return createScopeChallengeResponse(options.scopeChallenge, result.challenge, result.requestId);
+                    return createScopeChallengeResponse(result.challenge, result.requestId, scopeChallengeResourceMetadataUrl(authInfo));
                 }
             } catch (error) {
                 void product.close().catch(reportError);

--- a/packages/server/src/server/mcp.ts
+++ b/packages/server/src/server/mcp.ts
@@ -107,6 +107,10 @@ export class McpServer {
      * ```
      */
     async connect(transport: Transport): Promise<void> {
+        // Auto-wire scope resolver if the transport supports scope challenges
+        if ('setScopeResolver' in transport && typeof transport.setScopeResolver === 'function') {
+            transport.setScopeResolver((toolName: string) => this.getToolScopes(toolName));
+        }
         return await this.server.connect(transport);
     }
 
@@ -115,6 +119,51 @@ export class McpServer {
      */
     async close(): Promise<void> {
         await this.server.close();
+    }
+
+    /**
+     * Returns the scope configuration for a registered tool, if any.
+     * Checks tool-level scopes first, then falls back to server-level scope overrides.
+     * Used by the transport layer for pre-execution scope challenge checks.
+     */
+    getToolScopes(toolName: string): ToolScopeConfig | undefined {
+        return this._toolScopeOverrides[toolName] ?? this._registeredTools[toolName]?.scopes;
+    }
+
+    private _toolScopeOverrides: { [name: string]: ToolScopeConfig } = {};
+
+    /**
+     * Sets scope requirements for a tool independently of tool registration.
+     *
+     * This allows defining scopes separately — from a config file, a central
+     * mapping, or dynamically at runtime — rather than co-locating them with
+     * the tool definition. Scopes set here take precedence over any `scopes`
+     * provided during tool registration.
+     *
+     * @example Central scope mapping
+     * ```typescript
+     * // Define all scopes in one place
+     * const TOOL_SCOPES: Record<string, string[]> = {
+     *     'get_repo': ['repo:read'],
+     *     'create_issue': ['repo:write'],
+     *     'list_orgs': ['read:org'],
+     * };
+     *
+     * for (const [tool, scopes] of Object.entries(TOOL_SCOPES)) {
+     *     server.setToolScopes(tool, scopes);
+     * }
+     * ```
+     *
+     * @example With scope hierarchy
+     * ```typescript
+     * server.setToolScopes('get_repo', {
+     *     required: ['public_repo'],
+     *     accepted: ['public_repo', 'repo'],
+     * });
+     * ```
+     */
+    setToolScopes(toolName: string, scopes: string[] | ToolScopeConfig): void {
+        this._toolScopeOverrides[toolName] = Array.isArray(scopes) ? { required: scopes } : scopes;
     }
 
     private _toolHandlersInitialized = false;
@@ -872,6 +921,34 @@ export class McpServer {
             inputSchema?: InputArgs;
             outputSchema?: OutputArgs;
             annotations?: ToolAnnotations;
+            /**
+             * OAuth scopes required for this tool.
+             *
+             * When provided alongside a `ScopeChallengeConfig` on the transport,
+             * the transport checks the client's token scopes before executing the tool.
+             * If the token lacks required scopes, the transport returns HTTP 403 with a
+             * `WWW-Authenticate` header, triggering the client's step-up authorization flow.
+             *
+             * Can be a simple array of required scope strings, or an object with `required`
+             * and optional `accepted` arrays (for scope hierarchy support).
+             *
+             * @example Simple scopes
+             * ```typescript
+             * server.registerTool('get_repo', {
+             *     description: 'Get repository details',
+             *     scopes: ['repo:read'],
+             * }, handler);
+             * ```
+             *
+             * @example With scope hierarchy
+             * ```typescript
+             * server.registerTool('get_repo', {
+             *     description: 'Get repository details',
+             *     scopes: { required: ['public_repo'], accepted: ['public_repo', 'repo'] },
+             * }, handler);
+             * ```
+             */
+            scopes?: string[] | ToolScopeConfig;
             _meta?: Record<string, unknown>;
         },
         cb: ToolCallback<InputArgs>
@@ -905,9 +982,9 @@ export class McpServer {
             throw new Error(`Tool ${name} is already registered`);
         }
 
-        const { title, description, inputSchema, outputSchema, annotations, _meta } = config;
+        const { title, description, inputSchema, outputSchema, annotations, scopes, _meta } = config;
 
-        return this._createRegisteredTool(
+        const tool = this._createRegisteredTool(
             name,
             title,
             description,
@@ -918,6 +995,13 @@ export class McpServer {
             _meta,
             cb as ToolCallback<StandardSchemaWithJSON | undefined>
         );
+
+        // Normalize and attach scope metadata
+        if (scopes) {
+            tool.scopes = Array.isArray(scopes) ? { required: scopes } : scopes;
+        }
+
+        return tool;
     }
 
     /**
@@ -1164,6 +1248,7 @@ export type RegisteredTool = {
     outputSchema?: StandardSchemaWithJSON;
     annotations?: ToolAnnotations;
     execution?: ToolExecution;
+    scopes?: ToolScopeConfig;
     _meta?: Record<string, unknown>;
     handler: AnyToolHandler<StandardSchemaWithJSON | undefined>;
     /** @hidden */
@@ -1184,6 +1269,42 @@ export type RegisteredTool = {
     }): void;
     remove(): void;
 };
+
+/**
+ * Scope metadata for a tool, used for pre-execution scope challenge checks.
+ *
+ * When configured alongside a `ScopeChallengeConfig` on the transport,
+ * the transport will check the client's token scopes against these requirements
+ * before executing the tool. If the token lacks the required scopes, the transport
+ * returns HTTP 403 with a `WWW-Authenticate` header per RFC 6750 §3.1.
+ */
+export interface ToolScopeConfig {
+    /**
+     * The scopes recommended in the 403 scope challenge response.
+     *
+     * When the token lacks sufficient scopes, these are included in the
+     * `WWW-Authenticate` header's `scope` parameter (unioned with the
+     * token's existing scopes) so the client knows what to request
+     * during re-authorization.
+     */
+    required: string[];
+    /**
+     * All scopes that satisfy the requirement — if the token has ANY of
+     * these, the tool call proceeds without challenge.
+     *
+     * Use this for scope hierarchies where a broader scope implies a
+     * narrower one. For example, a tool that requires `repo:read` might
+     * also accept `repo` (which implies read access).
+     *
+     * Defaults to `required` if not provided.
+     *
+     * @example
+     * ```typescript
+     * { required: ['repo:read'], accepted: ['repo:read', 'repo'] }
+     * ```
+     */
+    accepted?: string[];
+}
 
 /**
  * Creates an executor that invokes the handler with the appropriate arguments.

--- a/packages/server/src/server/mcp.ts
+++ b/packages/server/src/server/mcp.ts
@@ -46,6 +46,7 @@ import { ExperimentalMcpServerTasks } from '../experimental/tasks/mcpServer.js';
 import { getCompleter, isCompletable } from './completable.js';
 import type { ServerOptions } from './server.js';
 import { Server } from './server.js';
+import { isScopeAware } from './streamableHttp.js';
 
 /**
  * High-level MCP server that provides a simpler API for working with resources, tools, and prompts.
@@ -107,9 +108,9 @@ export class McpServer {
      * ```
      */
     async connect(transport: Transport): Promise<void> {
-        // Auto-wire scope resolver if the transport supports scope challenges
-        if ('setScopeResolver' in transport && typeof transport.setScopeResolver === 'function') {
-            transport.setScopeResolver((toolName: string) => this.getToolScopes(toolName));
+        // Auto-wire scope resolver if the transport supports scope challenges.
+        if (isScopeAware(transport)) {
+            transport.setScopeResolver(toolName => this.getToolScopes(toolName));
         }
         return await this.server.connect(transport);
     }
@@ -974,6 +975,7 @@ export class McpServer {
             inputSchema?: StandardSchemaWithJSON | ZodRawShape;
             outputSchema?: StandardSchemaWithJSON | ZodRawShape;
             annotations?: ToolAnnotations;
+            scopes?: string[] | ToolScopeConfig;
             _meta?: Record<string, unknown>;
         },
         cb: ToolCallback<StandardSchemaWithJSON | undefined> | LegacyToolCallback<ZodRawShape>
@@ -1280,25 +1282,33 @@ export type RegisteredTool = {
  */
 export interface ToolScopeConfig {
     /**
-     * The scopes recommended in the 403 scope challenge response.
+     * Scopes required for this tool, with **AND** semantics — the token must
+     * contain every scope in this array for the call to proceed (unless
+     * `accepted` is provided, see below). These are the scopes advertised in
+     * the 403 `WWW-Authenticate` challenge's `scope` parameter when the token
+     * is insufficient.
      *
-     * When the token lacks sufficient scopes, these are included in the
-     * `WWW-Authenticate` header's `scope` parameter (unioned with the
-     * token's existing scopes) so the client knows what to request
-     * during re-authorization.
+     * @example Single scope
+     * ```typescript
+     * { required: ['repo:read'] }
+     * ```
+     *
+     * @example Multiple scopes (all must be present)
+     * ```typescript
+     * { required: ['repo:read', 'user:read'] }
+     * ```
      */
     required: string[];
     /**
-     * All scopes that satisfy the requirement — if the token has ANY of
-     * these, the tool call proceeds without challenge.
+     * Optional **OR** escape hatch for the satisfaction check. When provided,
+     * the satisfaction check switches from "token has all `required`" to
+     * "token has ANY of `accepted`". Use this for scope hierarchies where a
+     * broader scope subsumes a narrower one.
      *
-     * Use this for scope hierarchies where a broader scope implies a
-     * narrower one. For example, a tool that requires `repo:read` might
-     * also accept `repo` (which implies read access).
+     * Note: `accepted` only affects whether the request is allowed through —
+     * the scope challenge advertised on a 403 is still based on `required`.
      *
-     * Defaults to `required` if not provided.
-     *
-     * @example
+     * @example Hierarchy: `repo` (broad) satisfies `repo:read` (narrow)
      * ```typescript
      * { required: ['repo:read'], accepted: ['repo:read', 'repo'] }
      * ```

--- a/packages/server/src/server/mcp.ts
+++ b/packages/server/src/server/mcp.ts
@@ -163,12 +163,49 @@ export class McpServer {
 
     /** @internal */
     resolveScopeChallenge: ScopeChallengeHandler = context => {
-        if (context.request.method !== 'tools/call') return;
-        const toolName = (context.request.params as { name?: unknown } | undefined)?.name;
-        if (typeof toolName !== 'string') return;
-        const tool = this._registeredTools[toolName];
-        if (tool === undefined || !tool.enabled) return;
-        return tool.scopeChallenge?.(context);
+        switch (context.request.method) {
+            case 'tools/call': {
+                const toolName = (context.request.params as { name?: unknown } | undefined)?.name;
+                if (typeof toolName !== 'string') return;
+                const tool = this._registeredTools[toolName];
+                if (tool === undefined || !tool.enabled) return;
+                return tool.scopeChallenge?.(context);
+            }
+            case 'resources/read': {
+                const resourceUri = (context.request.params as { uri?: unknown } | undefined)?.uri;
+                if (typeof resourceUri !== 'string') return;
+
+                let uri: URL;
+                try {
+                    uri = new URL(resourceUri);
+                } catch {
+                    return;
+                }
+
+                const resource = this._registeredResources[uri.toString()];
+                if (resource !== undefined) {
+                    return resource.enabled ? resource.scopeChallenge?.(context) : undefined;
+                }
+
+                for (const template of Object.values(this._registeredResourceTemplates)) {
+                    const variables = template.resourceTemplate.uriTemplate.match(uri.toString());
+                    if (variables) {
+                        return template.enabled ? template.scopeChallenge?.(context) : undefined;
+                    }
+                }
+                return;
+            }
+            case 'prompts/get': {
+                const promptName = (context.request.params as { name?: unknown } | undefined)?.name;
+                if (typeof promptName !== 'string') return;
+                const prompt = this._registeredPrompts[promptName];
+                if (prompt === undefined || !prompt.enabled) return;
+                return prompt.scopeChallenge?.(context);
+            }
+            default: {
+                return;
+            }
+        }
     };
 
     private _toolHandlersInitialized = false;
@@ -517,6 +554,12 @@ export class McpServer {
             for (const template of Object.values(this._registeredResourceTemplates)) {
                 const variables = template.resourceTemplate.uriTemplate.match(uri.toString());
                 if (variables) {
+                    if (!template.enabled) {
+                        throw new ProtocolError(
+                            ProtocolErrorCode.InvalidParams,
+                            `Resource template ${template.resourceTemplate.uriTemplate} disabled`
+                        );
+                    }
                     return attachCacheHintFallback(await template.readCallback(uri, variables, ctx), template.cacheHint);
                 }
             }
@@ -603,31 +646,27 @@ export class McpServer {
     registerResource(
         name: string,
         uriOrTemplate: string,
-        config: ResourceMetadata & { cacheHint?: CacheHint },
+        config: ResourceMetadata & { cacheHint?: CacheHint; scopeChallenge?: ScopeChallengeHandler },
         readCallback: ReadResourceCallback
     ): RegisteredResource;
     registerResource(
         name: string,
         uriOrTemplate: ResourceTemplate,
-        config: ResourceMetadata & { cacheHint?: CacheHint },
+        config: ResourceMetadata & { cacheHint?: CacheHint; scopeChallenge?: ScopeChallengeHandler },
         readCallback: ReadResourceTemplateCallback
     ): RegisteredResourceTemplate;
     registerResource(
         name: string,
         uriOrTemplate: string | ResourceTemplate,
-        config: ResourceMetadata & { cacheHint?: CacheHint },
+        config: ResourceMetadata & { cacheHint?: CacheHint; scopeChallenge?: ScopeChallengeHandler },
         readCallback: ReadResourceCallback | ReadResourceTemplateCallback
     ): RegisteredResource | RegisteredResourceTemplate {
-        // The cache hint configures the encode-time cache fields of this
-        // resource's `resources/read` results (2026-07-28); it is not resource
-        // metadata and never appears on `resources/list` entries.
-        const cacheHint = config.cacheHint;
-        let metadata: ResourceMetadata = config;
+        // These options configure request handling and are not advertised as
+        // resource metadata by `resources/list`.
+        const { cacheHint, scopeChallenge, ...resourceMetadata } = config;
+        const metadata: ResourceMetadata = resourceMetadata;
         if (cacheHint !== undefined) {
             assertValidCacheHint(cacheHint, `resource ${name}`);
-            const rest = { ...config };
-            delete rest.cacheHint;
-            metadata = rest;
         }
 
         if (typeof uriOrTemplate === 'string') {
@@ -640,6 +679,7 @@ export class McpServer {
                 (config as BaseMetadata).title,
                 uriOrTemplate,
                 metadata,
+                scopeChallenge,
                 readCallback as ReadResourceCallback
             );
             if (cacheHint !== undefined) {
@@ -659,6 +699,7 @@ export class McpServer {
                 (config as BaseMetadata).title,
                 uriOrTemplate,
                 metadata,
+                scopeChallenge,
                 readCallback as ReadResourceTemplateCallback
             );
             if (cacheHint !== undefined) {
@@ -676,6 +717,7 @@ export class McpServer {
         title: string | undefined,
         uri: string,
         metadata: ResourceMetadata | undefined,
+        scopeChallenge: ScopeChallengeHandler | undefined,
         readCallback: ReadResourceCallback
     ): RegisteredResource {
         const registeredResource: RegisteredResource = {
@@ -683,6 +725,7 @@ export class McpServer {
             title,
             metadata,
             readCallback,
+            scopeChallenge,
             enabled: true,
             disable: () => registeredResource.update({ enabled: false }),
             enable: () => registeredResource.update({ enabled: true }),
@@ -696,6 +739,9 @@ export class McpServer {
                 if (updates.title !== undefined) registeredResource.title = updates.title;
                 if (updates.metadata !== undefined) registeredResource.metadata = updates.metadata;
                 if (updates.callback !== undefined) registeredResource.readCallback = updates.callback;
+                if (updates.scopeChallenge !== undefined) {
+                    registeredResource.scopeChallenge = updates.scopeChallenge === null ? undefined : updates.scopeChallenge;
+                }
                 if (updates.enabled !== undefined) registeredResource.enabled = updates.enabled;
                 this.sendResourceListChanged();
             }
@@ -709,6 +755,7 @@ export class McpServer {
         title: string | undefined,
         template: ResourceTemplate,
         metadata: ResourceMetadata | undefined,
+        scopeChallenge: ScopeChallengeHandler | undefined,
         readCallback: ReadResourceTemplateCallback
     ): RegisteredResourceTemplate {
         const registeredResourceTemplate: RegisteredResourceTemplate = {
@@ -716,6 +763,7 @@ export class McpServer {
             title,
             metadata,
             readCallback,
+            scopeChallenge,
             enabled: true,
             disable: () => registeredResourceTemplate.update({ enabled: false }),
             enable: () => registeredResourceTemplate.update({ enabled: true }),
@@ -729,6 +777,9 @@ export class McpServer {
                 if (updates.template !== undefined) registeredResourceTemplate.resourceTemplate = updates.template;
                 if (updates.metadata !== undefined) registeredResourceTemplate.metadata = updates.metadata;
                 if (updates.callback !== undefined) registeredResourceTemplate.readCallback = updates.callback;
+                if (updates.scopeChallenge !== undefined) {
+                    registeredResourceTemplate.scopeChallenge = updates.scopeChallenge === null ? undefined : updates.scopeChallenge;
+                }
                 if (updates.enabled !== undefined) registeredResourceTemplate.enabled = updates.enabled;
                 this.sendResourceListChanged();
             }
@@ -752,6 +803,7 @@ export class McpServer {
         argsSchema: StandardSchemaWithJSON | undefined,
         callback: PromptCallback<StandardSchemaWithJSON | undefined>,
         icons: Icon[] | undefined,
+        scopeChallenge: ScopeChallengeHandler | undefined,
         _meta: Record<string, unknown> | undefined
     ): RegisteredPrompt {
         // Track current schema and callback for handler regeneration
@@ -763,6 +815,7 @@ export class McpServer {
             description,
             argsSchema,
             icons,
+            scopeChallenge,
             _meta,
             handler: createPromptHandler(name, argsSchema, callback),
             enabled: true,
@@ -777,6 +830,9 @@ export class McpServer {
                 if (updates.title !== undefined) registeredPrompt.title = updates.title;
                 if (updates.description !== undefined) registeredPrompt.description = updates.description;
                 if (updates.icons !== undefined) registeredPrompt.icons = updates.icons;
+                if (updates.scopeChallenge !== undefined) {
+                    registeredPrompt.scopeChallenge = updates.scopeChallenge === null ? undefined : updates.scopeChallenge;
+                }
                 if (updates._meta !== undefined) registeredPrompt._meta = updates._meta;
 
                 // Track if we need to regenerate the handler
@@ -1067,6 +1123,8 @@ export class McpServer {
             description?: string;
             argsSchema?: Args;
             icons?: Icon[];
+            /** Determines whether this prompt retrieval needs an OAuth scope challenge. */
+            scopeChallenge?: ScopeChallengeHandler;
             _meta?: Record<string, unknown>;
         },
         cb: PromptCallback<Args>
@@ -1079,6 +1137,7 @@ export class McpServer {
             description?: string;
             argsSchema?: Args;
             icons?: Icon[];
+            scopeChallenge?: ScopeChallengeHandler;
             _meta?: Record<string, unknown>;
         },
         cb: LegacyPromptCallback<Args>
@@ -1090,6 +1149,7 @@ export class McpServer {
             description?: string;
             argsSchema?: StandardSchemaWithJSON | ZodRawShape;
             icons?: Icon[];
+            scopeChallenge?: ScopeChallengeHandler;
             _meta?: Record<string, unknown>;
         },
         cb: PromptCallback<StandardSchemaWithJSON> | LegacyPromptCallback<ZodRawShape>
@@ -1098,7 +1158,7 @@ export class McpServer {
             throw new Error(`Prompt ${name} is already registered`);
         }
 
-        const { title, description, argsSchema, icons, _meta } = config;
+        const { title, description, argsSchema, icons, scopeChallenge, _meta } = config;
 
         const registeredPrompt = this._createRegisteredPrompt(
             name,
@@ -1107,6 +1167,7 @@ export class McpServer {
             normalizeRawShapeSchema(argsSchema),
             cb as PromptCallback<StandardSchemaWithJSON | undefined>,
             icons,
+            scopeChallenge,
             _meta
         );
 
@@ -1391,6 +1452,7 @@ export type RegisteredResource = {
     metadata?: ResourceMetadata;
     /** Cache hint applied to this resource's `resources/read` results on the 2026-07-28 revision. */
     cacheHint?: CacheHint;
+    scopeChallenge?: ScopeChallengeHandler;
     readCallback: ReadResourceCallback;
     enabled: boolean;
     enable(): void;
@@ -1400,6 +1462,7 @@ export type RegisteredResource = {
         title?: string;
         uri?: string | null;
         metadata?: ResourceMetadata;
+        scopeChallenge?: ScopeChallengeHandler | null;
         callback?: ReadResourceCallback;
         enabled?: boolean;
     }): void;
@@ -1421,6 +1484,7 @@ export type RegisteredResourceTemplate = {
     metadata?: ResourceMetadata;
     /** Cache hint applied to this template's `resources/read` results on the 2026-07-28 revision. */
     cacheHint?: CacheHint;
+    scopeChallenge?: ScopeChallengeHandler;
     readCallback: ReadResourceTemplateCallback;
     enabled: boolean;
     enable(): void;
@@ -1430,6 +1494,7 @@ export type RegisteredResourceTemplate = {
         title?: string;
         template?: ResourceTemplate;
         metadata?: ResourceMetadata;
+        scopeChallenge?: ScopeChallengeHandler | null;
         callback?: ReadResourceTemplateCallback;
         enabled?: boolean;
     }): void;
@@ -1459,6 +1524,7 @@ export type RegisteredPrompt = {
     description?: string;
     argsSchema?: StandardSchemaWithJSON;
     icons?: Icon[];
+    scopeChallenge?: ScopeChallengeHandler;
     _meta?: Record<string, unknown>;
     /** @hidden */
     handler: PromptHandler;
@@ -1471,6 +1537,7 @@ export type RegisteredPrompt = {
         description?: string;
         argsSchema?: Args;
         icons?: Icon[];
+        scopeChallenge?: ScopeChallengeHandler | null;
         _meta?: Record<string, unknown>;
         callback?: PromptCallback<Args>;
         enabled?: boolean;

--- a/packages/server/src/server/mcp.ts
+++ b/packages/server/src/server/mcp.ts
@@ -47,6 +47,8 @@ import {
 import type * as z from 'zod/v4';
 
 import { getCompleter, isCompletable } from './completable';
+import type { ScopeChallengeHandler } from './scopeChallenge';
+import { supportsScopeChallengeResolver } from './scopeChallenge';
 import type { ServerOptions } from './server';
 import { Server } from './server';
 
@@ -146,6 +148,9 @@ export class McpServer {
      * ```
      */
     async connect(transport: Transport): Promise<void> {
+        if (supportsScopeChallengeResolver(transport)) {
+            transport.setScopeChallengeResolver(context => this.resolveScopeChallenge(context));
+        }
         return await this.server.connect(transport);
     }
 
@@ -155,6 +160,16 @@ export class McpServer {
     async close(): Promise<void> {
         await this.server.close();
     }
+
+    /** @internal */
+    resolveScopeChallenge: ScopeChallengeHandler = context => {
+        if (context.request.method !== 'tools/call') return;
+        const toolName = (context.request.params as { name?: unknown } | undefined)?.name;
+        if (typeof toolName !== 'string') return;
+        const tool = this._registeredTools[toolName];
+        if (tool === undefined || !tool.enabled) return;
+        return tool.scopeChallenge?.(context);
+    };
 
     private _toolHandlersInitialized = false;
 
@@ -811,6 +826,7 @@ export class McpServer {
         annotations: ToolAnnotations | undefined,
         icons: Icon[] | undefined,
         execution: ToolExecution | undefined,
+        scopeChallenge: ScopeChallengeHandler | undefined,
         _meta: Record<string, unknown> | undefined,
         handler: AnyToolHandler<StandardSchemaWithJSON | undefined>
     ): RegisteredTool {
@@ -856,6 +872,7 @@ export class McpServer {
             annotations,
             icons,
             execution,
+            scopeChallenge,
             _meta,
             handler: handler,
             executor: createToolExecutor(inputSchema, handler),
@@ -911,6 +928,9 @@ export class McpServer {
                 }
                 if (updates.annotations !== undefined) registeredTool.annotations = updates.annotations;
                 if (updates.icons !== undefined) registeredTool.icons = updates.icons;
+                if (updates.scopeChallenge !== undefined) {
+                    registeredTool.scopeChallenge = updates.scopeChallenge === null ? undefined : updates.scopeChallenge;
+                }
                 if (updates._meta !== undefined) registeredTool._meta = updates._meta;
                 if (updates.enabled !== undefined) registeredTool.enabled = updates.enabled;
                 this.sendToolListChanged();
@@ -959,6 +979,8 @@ export class McpServer {
             outputSchema?: OutputArgs;
             annotations?: ToolAnnotations;
             icons?: Icon[];
+            /** Determines whether this tool call needs an OAuth scope challenge. */
+            scopeChallenge?: ScopeChallengeHandler;
             _meta?: Record<string, unknown>;
         },
         cb: ToolCallback<InputArgs>
@@ -973,6 +995,7 @@ export class McpServer {
             outputSchema?: OutputArgs;
             annotations?: ToolAnnotations;
             icons?: Icon[];
+            scopeChallenge?: ScopeChallengeHandler;
             _meta?: Record<string, unknown>;
         },
         cb: LegacyToolCallback<InputArgs>
@@ -986,6 +1009,7 @@ export class McpServer {
             outputSchema?: StandardSchemaWithJSON | ZodRawShape;
             annotations?: ToolAnnotations;
             icons?: Icon[];
+            scopeChallenge?: ScopeChallengeHandler;
             _meta?: Record<string, unknown>;
         },
         cb: ToolCallback<StandardSchemaWithJSON | undefined> | LegacyToolCallback<ZodRawShape>
@@ -994,8 +1018,7 @@ export class McpServer {
             throw new Error(`Tool ${name} is already registered`);
         }
 
-        const { title, description, inputSchema, outputSchema, annotations, icons, _meta } = config;
-
+        const { title, description, inputSchema, outputSchema, annotations, icons, scopeChallenge, _meta } = config;
         return this._createRegisteredTool(
             name,
             title,
@@ -1005,6 +1028,7 @@ export class McpServer {
             annotations,
             icons,
             undefined,
+            scopeChallenge,
             _meta,
             cb as ToolCallback<StandardSchemaWithJSON | undefined>
         );
@@ -1278,6 +1302,7 @@ export type RegisteredTool = {
     annotations?: ToolAnnotations;
     icons?: Icon[];
     execution?: ToolExecution;
+    scopeChallenge?: ScopeChallengeHandler;
     _meta?: Record<string, unknown>;
     handler: AnyToolHandler<StandardSchemaWithJSON | undefined>;
     /** @hidden */
@@ -1293,6 +1318,7 @@ export type RegisteredTool = {
         outputSchema?: StandardSchemaWithJSON;
         annotations?: ToolAnnotations;
         icons?: Icon[];
+        scopeChallenge?: ScopeChallengeHandler | null;
         _meta?: Record<string, unknown>;
         callback?: ToolCallback<StandardSchemaWithJSON>;
         enabled?: boolean;

--- a/packages/server/src/server/middleware/bearerAuth.ts
+++ b/packages/server/src/server/middleware/bearerAuth.ts
@@ -50,6 +50,12 @@ export interface BearerAuthOptions {
      *
      * Typically built with `getOAuthProtectedResourceMetadataUrl`, exported
      * from this package.
+     *
+     * When verification succeeds the value is also stamped onto the returned
+     * {@link AuthInfo} (`authInfo.resourceMetadataUrl`, unless the verifier
+     * already set one), so challenges built after authentication — such as
+     * per-operation `insufficient_scope` scope challenges — advertise the
+     * same document without being configured separately.
      */
     resourceMetadataUrl?: string;
 }
@@ -62,18 +68,27 @@ function headerQuotedValue(value: string): string {
     return value.replaceAll(/[\\"]/g, String.raw`\$&`).replaceAll(/[^\u0020-\u007E]/g, ' ');
 }
 
-function buildWwwAuthenticateHeader(
+/**
+ * Build a `WWW-Authenticate: Bearer …` challenge header value (RFC 6750).
+ *
+ * The single formatter behind every challenge this package emits — the
+ * bearer-auth 401/403 answers and the per-operation scope-challenge 403 — so
+ * all challenges from one server agree on parameter order and quoting. Every
+ * parameter value is emitted as an HTTP quoted-string with `\` and `"`
+ * escaped and non-printable characters replaced.
+ */
+export function buildWwwAuthenticateHeader(
     errorCode: string,
     description: string,
-    requiredScopes: string[],
+    requiredScopes: readonly string[],
     resourceMetadataUrl: string | undefined
 ): string {
     let header = `Bearer error="${headerQuotedValue(errorCode)}", error_description="${headerQuotedValue(description)}"`;
     if (requiredScopes.length > 0) {
-        header += `, scope="${requiredScopes.join(' ')}"`;
+        header += `, scope="${headerQuotedValue(requiredScopes.join(' '))}"`;
     }
     if (resourceMetadataUrl) {
-        header += `, resource_metadata="${resourceMetadataUrl}"`;
+        header += `, resource_metadata="${headerQuotedValue(resourceMetadataUrl)}"`;
     }
     return header;
 }
@@ -118,6 +133,14 @@ export async function verifyBearerToken(authorizationHeader: string | null | und
         throw new OAuthError(OAuthErrorCode.InvalidToken, 'Token has no expiration time');
     } else if (authInfo.expiresAt < Date.now() / 1000) {
         throw new OAuthError(OAuthErrorCode.InvalidToken, 'Token has expired');
+    }
+
+    // Hand the gate's discovery configuration inward with the verified token,
+    // so challenges built after authentication (per-operation scope
+    // challenges) advertise the same metadata document. A verifier-set value
+    // wins over the gate's configuration.
+    if (options.resourceMetadataUrl !== undefined && authInfo.resourceMetadataUrl === undefined) {
+        return { ...authInfo, resourceMetadataUrl: options.resourceMetadataUrl };
     }
 
     return authInfo;

--- a/packages/server/src/server/middleware/oauthMetadata.ts
+++ b/packages/server/src/server/middleware/oauthMetadata.ts
@@ -89,7 +89,10 @@ export function buildOAuthProtectedResourceMetadata(options: AuthMetadataOptions
  * ```
  */
 export function getOAuthProtectedResourceMetadataUrl(serverUrl: URL): string {
-    return new URL(protectedResourceMetadataPath(serverUrl), serverUrl).href;
+    const metadataUrl = new URL(serverUrl);
+    metadataUrl.pathname = protectedResourceMetadataPath(serverUrl);
+    metadataUrl.hash = '';
+    return metadataUrl.href;
 }
 
 /** The RFC 9728 path-aware well-known path for a resource URL. */

--- a/packages/server/src/server/scopeChallenge.ts
+++ b/packages/server/src/server/scopeChallenge.ts
@@ -2,9 +2,9 @@ import type { AuthInfo, JSONRPCRequest, RequestId } from '@modelcontextprotocol/
 
 /** OAuth scopes to request before handling an MCP request. */
 export interface ScopeChallenge {
-    /** The exact, complete scope set to include in the challenge. Each scope must be printable ASCII without whitespace. */
+    /** The exact, complete scope set to include in the challenge. Each scope must satisfy the OAuth `scope-token` grammar. */
     scopes: readonly [string, ...string[]];
-    /** Optional printable-ASCII human-readable detail for the OAuth challenge. */
+    /** Optional human-readable detail satisfying the RFC 6750 `error-description` grammar. */
     errorDescription?: string;
 }
 
@@ -33,8 +33,8 @@ export function supportsScopeChallengeResolver(
 }
 
 function assertScope(scope: unknown, location: string): asserts scope is string {
-    if (typeof scope !== 'string' || !/^[\u0021-\u007E]+$/.test(scope)) {
-        throw new TypeError(`${location} must be a non-empty printable ASCII OAuth scope without whitespace`);
+    if (typeof scope !== 'string' || !/^[\u0021\u0023-\u005B\u005D-\u007E]+$/.test(scope)) {
+        throw new TypeError(`${location} must satisfy the OAuth scope-token grammar`);
     }
 }
 
@@ -48,8 +48,8 @@ function validateScopeChallenge(challenge: ScopeChallenge): ScopeChallenge {
     if (challenge.errorDescription !== undefined && typeof challenge.errorDescription !== 'string') {
         throw new TypeError('scope challenge errorDescription must be a string');
     }
-    if (challenge.errorDescription !== undefined && !/^[\u0020-\u007E]*$/.test(challenge.errorDescription)) {
-        throw new TypeError('scope challenge errorDescription must contain only printable ASCII characters');
+    if (challenge.errorDescription !== undefined && !/^[\u0020-\u0021\u0023-\u005B\u005D-\u007E]+$/.test(challenge.errorDescription)) {
+        throw new TypeError('scope challenge errorDescription must satisfy the RFC 6750 error-description grammar');
     }
     return challenge;
 }

--- a/packages/server/src/server/scopeChallenge.ts
+++ b/packages/server/src/server/scopeChallenge.ts
@@ -2,9 +2,9 @@ import type { AuthInfo, JSONRPCRequest, RequestId } from '@modelcontextprotocol/
 
 /** OAuth scopes to request before handling an MCP request. */
 export interface ScopeChallenge {
-    /** The exact, complete scope set to include in the challenge. */
+    /** The exact, complete scope set to include in the challenge. Each scope must be printable ASCII without whitespace. */
     scopes: readonly [string, ...string[]];
-    /** Optional human-readable detail for the OAuth challenge. */
+    /** Optional printable-ASCII human-readable detail for the OAuth challenge. */
     errorDescription?: string;
 }
 
@@ -33,8 +33,8 @@ export function supportsScopeChallengeResolver(
 }
 
 function assertScope(scope: unknown, location: string): asserts scope is string {
-    if (typeof scope !== 'string' || scope.length === 0 || /\s/.test(scope)) {
-        throw new TypeError(`${location} must be a non-empty OAuth scope without whitespace`);
+    if (typeof scope !== 'string' || !/^[\u0021-\u007E]+$/.test(scope)) {
+        throw new TypeError(`${location} must be a non-empty printable ASCII OAuth scope without whitespace`);
     }
 }
 
@@ -47,6 +47,9 @@ function validateScopeChallenge(challenge: ScopeChallenge): ScopeChallenge {
     }
     if (challenge.errorDescription !== undefined && typeof challenge.errorDescription !== 'string') {
         throw new TypeError('scope challenge errorDescription must be a string');
+    }
+    if (challenge.errorDescription !== undefined && !/^[\u0020-\u007E]*$/.test(challenge.errorDescription)) {
+        throw new TypeError('scope challenge errorDescription must contain only printable ASCII characters');
     }
     return challenge;
 }

--- a/packages/server/src/server/scopeChallenge.ts
+++ b/packages/server/src/server/scopeChallenge.ts
@@ -1,6 +1,7 @@
-import type { AuthInfo, JSONRPCRequest, RequestId } from '@modelcontextprotocol/core-internal';
+import type { AuthInfo, JSONRPCRequest } from '@modelcontextprotocol/core-internal';
+import { OAuthError, OAuthErrorCode } from '@modelcontextprotocol/core-internal';
 
-import { buildWwwAuthenticateHeader } from './middleware/bearerAuth';
+import { bearerAuthChallengeResponse } from './middleware/bearerAuth';
 import { getOAuthProtectedResourceMetadataUrl } from './middleware/oauthMetadata';
 
 /** OAuth scopes to request before handling an MCP request. */
@@ -77,11 +78,11 @@ export async function findScopeChallenge(
     requests: readonly JSONRPCRequest[],
     authInfo: AuthInfo | undefined,
     resolve: ScopeChallengeHandler
-): Promise<{ challenge: ScopeChallenge; requestId: RequestId } | undefined> {
+): Promise<ScopeChallenge | undefined> {
     for (const request of requests) {
         const challenge = await resolve({ request, ...(authInfo !== undefined && { authInfo }) });
         if (challenge !== undefined) {
-            return { challenge: validateScopeChallenge(challenge), requestId: request.id };
+            return validateScopeChallenge(challenge);
         }
     }
     return undefined;
@@ -109,32 +110,12 @@ export function scopeChallengeResourceMetadataUrl(authInfo: AuthInfo | undefined
 }
 
 /** @internal */
-export function createScopeChallengeResponse(
-    challenge: ScopeChallenge,
-    responseId: RequestId | null,
-    resourceMetadataUrl: string | undefined
-): Response {
-    // One formatter for every challenge this package emits: identical
-    // parameter order and quoting to the bearer-auth 401/403 answers.
-    const wwwAuthenticate = buildWwwAuthenticateHeader(
-        'insufficient_scope',
-        challenge.errorDescription ?? 'Insufficient scope',
-        challenge.scopes,
-        resourceMetadataUrl
-    );
-
-    return Response.json(
+export function createScopeChallengeResponse(challenge: ScopeChallenge, resourceMetadataUrl: string | undefined): Response {
+    return bearerAuthChallengeResponse(
+        new OAuthError(OAuthErrorCode.InsufficientScope, challenge.errorDescription ?? 'Insufficient scope'),
         {
-            jsonrpc: '2.0',
-            error: { code: -32_600, message: 'Insufficient scope' },
-            id: responseId
-        },
-        {
-            status: 403,
-            headers: {
-                'Content-Type': 'application/json',
-                'WWW-Authenticate': wwwAuthenticate
-            }
+            requiredScopes: [...challenge.scopes],
+            resourceMetadataUrl
         }
     );
 }

--- a/packages/server/src/server/scopeChallenge.ts
+++ b/packages/server/src/server/scopeChallenge.ts
@@ -92,9 +92,9 @@ export async function findScopeChallenge(
  * challenge, derived from the verified {@link AuthInfo}: the URL the
  * authentication gate stamped (`authInfo.resourceMetadataUrl`, set by the
  * bearer-auth helpers from their `resourceMetadataUrl` option), falling back
- * to the well-known location for the token's RFC 8707 `resource` identifier,
- * or `undefined` when neither is available (the `resource_metadata` parameter
- * is then omitted, matching the bearer-auth challenges).
+ * to the well-known location for an HTTP(S) RFC 8707 `resource` identifier, or
+ * `undefined` when neither is available (the `resource_metadata` parameter is
+ * then omitted, matching the bearer-auth challenges).
  *
  * @internal
  */
@@ -102,7 +102,7 @@ export function scopeChallengeResourceMetadataUrl(authInfo: AuthInfo | undefined
     if (authInfo?.resourceMetadataUrl !== undefined) {
         return authInfo.resourceMetadataUrl;
     }
-    if (authInfo?.resource !== undefined) {
+    if (authInfo?.resource?.protocol === 'https:' || authInfo?.resource?.protocol === 'http:') {
         return getOAuthProtectedResourceMetadataUrl(authInfo.resource);
     }
     return undefined;

--- a/packages/server/src/server/scopeChallenge.ts
+++ b/packages/server/src/server/scopeChallenge.ts
@@ -1,5 +1,8 @@
 import type { AuthInfo, JSONRPCRequest, RequestId } from '@modelcontextprotocol/core-internal';
 
+import { buildWwwAuthenticateHeader } from './middleware/bearerAuth';
+import { getOAuthProtectedResourceMetadataUrl } from './middleware/oauthMetadata';
+
 /** OAuth scopes to request before handling an MCP request. */
 export interface ScopeChallenge {
     /** The exact, complete scope set to include in the challenge. Each scope must satisfy the OAuth `scope-token` grammar. */
@@ -13,12 +16,6 @@ export type ScopeChallengeHandler = (context: {
     request: JSONRPCRequest;
     authInfo?: AuthInfo;
 }) => ScopeChallenge | undefined | Promise<ScopeChallenge | undefined>;
-
-/** Configuration for HTTP `insufficient_scope` challenges. */
-export interface ScopeChallengeConfig {
-    /** URL of the RFC 9728 protected resource metadata. */
-    resourceMetadataUrl: string;
-}
 
 /** @internal */
 export function supportsScopeChallengeResolver(
@@ -90,22 +87,41 @@ export async function findScopeChallenge(
     return undefined;
 }
 
-function quoteAuthParam(value: string): string {
-    return value.replaceAll('\\', '\\\\').replaceAll('"', String.raw`\"`);
+/**
+ * The RFC 9728 Protected Resource Metadata URL to advertise on a scope
+ * challenge, derived from the verified {@link AuthInfo}: the URL the
+ * authentication gate stamped (`authInfo.resourceMetadataUrl`, set by the
+ * bearer-auth helpers from their `resourceMetadataUrl` option), falling back
+ * to the well-known location for the token's RFC 8707 `resource` identifier,
+ * or `undefined` when neither is available (the `resource_metadata` parameter
+ * is then omitted, matching the bearer-auth challenges).
+ *
+ * @internal
+ */
+export function scopeChallengeResourceMetadataUrl(authInfo: AuthInfo | undefined): string | undefined {
+    if (authInfo?.resourceMetadataUrl !== undefined) {
+        return authInfo.resourceMetadataUrl;
+    }
+    if (authInfo?.resource !== undefined) {
+        return getOAuthProtectedResourceMetadataUrl(authInfo.resource);
+    }
+    return undefined;
 }
 
 /** @internal */
 export function createScopeChallengeResponse(
-    config: ScopeChallengeConfig,
     challenge: ScopeChallenge,
-    responseId: RequestId | null
+    responseId: RequestId | null,
+    resourceMetadataUrl: string | undefined
 ): Response {
-    const wwwAuthenticate =
-        'Bearer' +
-        ' error="insufficient_scope"' +
-        `, scope="${quoteAuthParam(challenge.scopes.join(' '))}"` +
-        `, resource_metadata="${quoteAuthParam(config.resourceMetadataUrl)}"` +
-        (challenge.errorDescription === undefined ? '' : `, error_description="${quoteAuthParam(challenge.errorDescription)}"`);
+    // One formatter for every challenge this package emits: identical
+    // parameter order and quoting to the bearer-auth 401/403 answers.
+    const wwwAuthenticate = buildWwwAuthenticateHeader(
+        'insufficient_scope',
+        challenge.errorDescription ?? 'Insufficient scope',
+        challenge.scopes,
+        resourceMetadataUrl
+    );
 
     return Response.json(
         {

--- a/packages/server/src/server/scopeChallenge.ts
+++ b/packages/server/src/server/scopeChallenge.ts
@@ -1,0 +1,121 @@
+import type { AuthInfo, JSONRPCRequest, RequestId } from '@modelcontextprotocol/core-internal';
+
+/** OAuth scopes to request before handling an MCP request. */
+export interface ScopeChallenge {
+    /** The exact, complete scope set to include in the challenge. */
+    scopes: readonly [string, ...string[]];
+    /** Optional human-readable detail for the OAuth challenge. */
+    errorDescription?: string;
+}
+
+/** Determines whether an MCP request needs an OAuth scope challenge. */
+export type ScopeChallengeHandler = (context: {
+    request: JSONRPCRequest;
+    authInfo?: AuthInfo;
+}) => ScopeChallenge | undefined | Promise<ScopeChallenge | undefined>;
+
+/** Configuration for HTTP `insufficient_scope` challenges. */
+export interface ScopeChallengeConfig {
+    /** URL of the RFC 9728 protected resource metadata. */
+    resourceMetadataUrl: string;
+}
+
+/** @internal */
+export function supportsScopeChallengeResolver(
+    transport: unknown
+): transport is { setScopeChallengeResolver(resolver: ScopeChallengeHandler): void } {
+    return (
+        typeof transport === 'object' &&
+        transport !== null &&
+        'setScopeChallengeResolver' in transport &&
+        typeof (transport as { setScopeChallengeResolver: unknown }).setScopeChallengeResolver === 'function'
+    );
+}
+
+function assertScope(scope: unknown, location: string): asserts scope is string {
+    if (typeof scope !== 'string' || scope.length === 0 || /\s/.test(scope)) {
+        throw new TypeError(`${location} must be a non-empty OAuth scope without whitespace`);
+    }
+}
+
+function validateScopeChallenge(challenge: ScopeChallenge): ScopeChallenge {
+    if (challenge === null || typeof challenge !== 'object' || !Array.isArray(challenge.scopes) || challenge.scopes.length === 0) {
+        throw new TypeError('scope challenge must contain at least one scope');
+    }
+    for (const [index, scope] of challenge.scopes.entries()) {
+        assertScope(scope, `scope challenge scopes[${index}]`);
+    }
+    if (challenge.errorDescription !== undefined && typeof challenge.errorDescription !== 'string') {
+        throw new TypeError('scope challenge errorDescription must be a string');
+    }
+    return challenge;
+}
+
+/**
+ * Creates a handler that requires every supplied scope exactly.
+ *
+ * Requests without authentication are left to the server's authentication gate.
+ */
+export function requireScopes(...scopes: readonly [string, ...string[]]): ScopeChallengeHandler {
+    if (scopes.length === 0) {
+        throw new TypeError('requireScopes must contain at least one scope');
+    }
+    for (const [index, scope] of scopes.entries()) {
+        assertScope(scope, `requireScopes scope[${index}]`);
+    }
+    const requiredScopes = [...scopes] as [string, ...string[]];
+    return ({ authInfo }) => {
+        if (authInfo === undefined) return;
+        const activeScopes = new Set(authInfo.scopes);
+        if (requiredScopes.every(scope => activeScopes.has(scope))) return;
+        return { scopes: requiredScopes };
+    };
+}
+
+/** @internal */
+export async function findScopeChallenge(
+    requests: readonly JSONRPCRequest[],
+    authInfo: AuthInfo | undefined,
+    resolve: ScopeChallengeHandler
+): Promise<{ challenge: ScopeChallenge; requestId: RequestId } | undefined> {
+    for (const request of requests) {
+        const challenge = await resolve({ request, ...(authInfo !== undefined && { authInfo }) });
+        if (challenge !== undefined) {
+            return { challenge: validateScopeChallenge(challenge), requestId: request.id };
+        }
+    }
+    return undefined;
+}
+
+function quoteAuthParam(value: string): string {
+    return value.replaceAll('\\', '\\\\').replaceAll('"', String.raw`\"`);
+}
+
+/** @internal */
+export function createScopeChallengeResponse(
+    config: ScopeChallengeConfig,
+    challenge: ScopeChallenge,
+    responseId: RequestId | null
+): Response {
+    const wwwAuthenticate =
+        'Bearer' +
+        ' error="insufficient_scope"' +
+        `, scope="${quoteAuthParam(challenge.scopes.join(' '))}"` +
+        `, resource_metadata="${quoteAuthParam(config.resourceMetadataUrl)}"` +
+        (challenge.errorDescription === undefined ? '' : `, error_description="${quoteAuthParam(challenge.errorDescription)}"`);
+
+    return Response.json(
+        {
+            jsonrpc: '2.0',
+            error: { code: -32_600, message: 'Insufficient scope' },
+            id: responseId
+        },
+        {
+            status: 403,
+            headers: {
+                'Content-Type': 'application/json',
+                'WWW-Authenticate': wwwAuthenticate
+            }
+        }
+    );
+}

--- a/packages/server/src/server/streamableHttp.ts
+++ b/packages/server/src/server/streamableHttp.ts
@@ -18,6 +18,8 @@ import {
     SUPPORTED_PROTOCOL_VERSIONS
 } from '@modelcontextprotocol/core';
 
+import type { ToolScopeConfig } from './mcp.js';
+
 export type StreamId = string;
 export type EventId = string;
 
@@ -65,6 +67,48 @@ interface StreamMapping {
     resolveJson?: (response: Response) => void;
     /** Cleanup function to close stream and remove mapping */
     cleanup: () => void;
+}
+
+/**
+ * Configuration for automatic scope challenge handling on tool calls.
+ *
+ * When provided to the transport, the transport checks the client's token scopes
+ * (from {@linkcode AuthInfo.scopes}) against tool-level scope requirements before
+ * executing the tool. If the token lacks required scopes, the transport returns
+ * HTTP 403 with a `WWW-Authenticate` header per RFC 6750 §3.1, triggering the
+ * client's step-up authorization flow.
+ *
+ * The server implementer is responsible for populating {@linkcode AuthInfo.scopes}
+ * with the token's active scopes in their auth middleware, and for declaring the
+ * required/accepted scopes on each tool at registration time. The SDK only provides
+ * the plumbing to compare them and emit the correct HTTP response.
+ *
+ * This is only meaningful for HTTP-based transports — stdio transports have no
+ * concept of HTTP status codes or OAuth flows.
+ *
+ * @example
+ * ```typescript
+ * const transport = new WebStandardStreamableHTTPServerTransport({
+ *     sessionIdGenerator: () => crypto.randomUUID(),
+ *     scopeChallenge: {
+ *         resourceMetadataUrl: 'https://api.example.com/.well-known/oauth-protected-resource',
+ *     }
+ * });
+ * ```
+ */
+export interface ScopeChallengeConfig {
+    /**
+     * The `resource_metadata` URL to include in `WWW-Authenticate` headers.
+     * Should point to the server's OAuth Protected Resource Metadata document
+     * per RFC 9728.
+     */
+    resourceMetadataUrl: string;
+
+    /**
+     * Optional custom error description generator.
+     * If not provided, a default description listing the required scopes is used.
+     */
+    buildErrorDescription?: (toolName: string, requiredScopes: string[]) => string;
 }
 
 /**
@@ -152,6 +196,19 @@ export interface WebStandardStreamableHTTPServerTransportOptions {
      * @default {@linkcode SUPPORTED_PROTOCOL_VERSIONS}
      */
     supportedProtocolVersions?: string[];
+
+    /**
+     * Configuration for automatic scope challenge handling.
+     *
+     * When provided alongside tools registered with `scopes` metadata, the transport
+     * will check the client's token scopes before executing `tools/call` requests.
+     * If the token lacks required scopes, HTTP 403 is returned with a `WWW-Authenticate`
+     * header, triggering the client's step-up authorization (upscoping) flow.
+     *
+     * Also requires a `scopeResolver` to be set — a function that looks up scope
+     * metadata for a given tool name. This is typically wired to `McpServer.getToolScopes()`.
+     */
+    scopeChallenge?: ScopeChallengeConfig;
 }
 
 /**
@@ -240,6 +297,8 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
     private _enableDnsRebindingProtection: boolean;
     private _retryInterval?: number;
     private _supportedProtocolVersions: string[];
+    private _scopeChallenge?: ScopeChallengeConfig;
+    private _scopeResolver?: (toolName: string) => ToolScopeConfig | undefined;
 
     sessionId?: string;
     onclose?: () => void;
@@ -257,6 +316,20 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
         this._enableDnsRebindingProtection = options.enableDnsRebindingProtection ?? false;
         this._retryInterval = options.retryInterval;
         this._supportedProtocolVersions = options.supportedProtocolVersions ?? SUPPORTED_PROTOCOL_VERSIONS;
+        this._scopeChallenge = options.scopeChallenge;
+    }
+
+    /**
+     * Sets the scope resolver function, which looks up scope metadata for a given tool name.
+     * This is typically wired to `McpServer.getToolScopes()`.
+     *
+     * @example
+     * ```typescript
+     * transport.setScopeResolver((toolName) => mcpServer.getToolScopes(toolName));
+     * ```
+     */
+    setScopeResolver(resolver: (toolName: string) => ToolScopeConfig | undefined): void {
+        this._scopeResolver = resolver;
     }
 
     /**
@@ -305,6 +378,64 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
                 }
             }
         );
+    }
+
+    /**
+     * Checks if a tools/call request has sufficient scopes.
+     * Returns an HTTP 403 response with WWW-Authenticate header if scopes are insufficient,
+     * or undefined if the request should proceed normally.
+     *
+     * This implements the MCP Scope Challenge Handling spec (§10.1):
+     * https://modelcontextprotocol.io/specification/draft/basic/authorization#scope-challenge-handling
+     */
+    private _checkScopeChallenge(messages: JSONRPCMessage[], authInfo?: AuthInfo): Response | undefined {
+        if (!this._scopeChallenge || !this._scopeResolver || !authInfo) {
+            return undefined;
+        }
+
+        const activeScopes = authInfo.scopes;
+
+        for (const message of messages) {
+            if (!isJSONRPCRequest(message) || message.method !== 'tools/call') {
+                continue;
+            }
+
+            const toolName = (message.params as { name?: string })?.name;
+            if (!toolName) {
+                continue;
+            }
+
+            const toolScopes = this._scopeResolver(toolName);
+            if (!toolScopes) {
+                continue;
+            }
+
+            const acceptedScopes = toolScopes.accepted ?? toolScopes.required;
+
+            // Check if the token has any of the accepted scopes
+            if (acceptedScopes.some(s => activeScopes.includes(s))) {
+                continue;
+            }
+
+            // Additive scoping: recommend the union of existing + required scopes.
+            // This ensures the client never loses scopes it already has when
+            // re-authorizing, matching the pattern from github/github-mcp-server.
+            const recommendedScopes = [...new Set([...activeScopes, ...toolScopes.required])];
+
+            const errorDescription = this._scopeChallenge.buildErrorDescription
+                ? this._scopeChallenge.buildErrorDescription(toolName, toolScopes.required)
+                : `Additional scopes required: ${toolScopes.required.join(', ')}`;
+
+            const wwwAuthenticate = `Bearer error="insufficient_scope", scope="${recommendedScopes.join(' ')}", resource_metadata="${this._scopeChallenge.resourceMetadataUrl}", error_description="${errorDescription}"`;
+
+            return this.createJsonErrorResponse(403, -32_600, `Insufficient scope for tool: ${toolName}`, {
+                headers: {
+                    'WWW-Authenticate': wwwAuthenticate
+                }
+            });
+        }
+
+        return undefined;
     }
 
     /**
@@ -697,6 +828,13 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
                 if (protocolError) {
                     return protocolError;
                 }
+            }
+
+            // Pre-execution scope challenge check for tools/call requests.
+            // This runs BEFORE the SSE stream opens so we can still return HTTP 403.
+            const scopeChallengeResponse = this._checkScopeChallenge(messages, options?.authInfo);
+            if (scopeChallengeResponse) {
+                return scopeChallengeResponse;
             }
 
             // check if it contains requests

--- a/packages/server/src/server/streamableHttp.ts
+++ b/packages/server/src/server/streamableHttp.ts
@@ -96,6 +96,34 @@ interface StreamMapping {
  * });
  * ```
  */
+/**
+ * Function that resolves scope requirements for a given tool name.
+ * Returns the tool's {@linkcode ToolScopeConfig} or `undefined` if the tool has
+ * no scope requirements (in which case the request is allowed through).
+ */
+export type ScopeResolver = (toolName: string) => ToolScopeConfig | undefined;
+
+/**
+ * Transports that support scope challenge handling implement this interface,
+ * allowing {@linkcode McpServer.connect} to auto-wire a {@linkcode ScopeResolver}
+ * sourced from the registered tools.
+ */
+export interface ScopeAware {
+    setScopeResolver(resolver: ScopeResolver): void;
+}
+
+/**
+ * Type guard for transports that implement {@linkcode ScopeAware}.
+ */
+export function isScopeAware(transport: unknown): transport is ScopeAware {
+    return (
+        typeof transport === 'object' &&
+        transport !== null &&
+        'setScopeResolver' in transport &&
+        typeof (transport as { setScopeResolver: unknown }).setScopeResolver === 'function'
+    );
+}
+
 export interface ScopeChallengeConfig {
     /**
      * The `resource_metadata` URL to include in `WWW-Authenticate` headers.
@@ -105,10 +133,36 @@ export interface ScopeChallengeConfig {
     resourceMetadataUrl: string;
 
     /**
+     * When `true`, the `WWW-Authenticate` `scope` parameter is the union of the
+     * token's currently active scopes and the tool's `required` scopes, rather
+     * than just the per-operation `required` scopes.
+     *
+     * Per RFC 6750 §3.1 and MCP SEP-2350, the recommended posture is to emit
+     * only the scopes required for the current operation and rely on the client
+     * to accumulate scopes across step-up challenges. Enable this option only
+     * if you need to defend against older clients that do not accumulate scopes
+     * client-side (i.e. they replace their requested scope set on each 403).
+     *
+     * @default false
+     */
+    includeGrantedScopes?: boolean;
+
+    /**
      * Optional custom error description generator.
      * If not provided, a default description listing the required scopes is used.
      */
     buildErrorDescription?: (toolName: string, requiredScopes: string[]) => string;
+}
+
+/**
+ * Quotes a value for use inside a `WWW-Authenticate` auth-param `quoted-string`
+ * per RFC 7235. Escapes `\` and `"` so the header parses unambiguously even when
+ * developer-supplied descriptions or scope strings contain quotes or commas.
+ *
+ * Does NOT add the surrounding quotes — call sites embed the result inside `"..."`.
+ */
+function quoteAuthParam(value: string): string {
+    return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
 }
 
 /**
@@ -298,7 +352,7 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
     private _retryInterval?: number;
     private _supportedProtocolVersions: string[];
     private _scopeChallenge?: ScopeChallengeConfig;
-    private _scopeResolver?: (toolName: string) => ToolScopeConfig | undefined;
+    private _scopeResolver?: ScopeResolver;
 
     sessionId?: string;
     onclose?: () => void;
@@ -328,7 +382,7 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
      * transport.setScopeResolver((toolName) => mcpServer.getToolScopes(toolName));
      * ```
      */
-    setScopeResolver(resolver: (toolName: string) => ToolScopeConfig | undefined): void {
+    setScopeResolver(resolver: ScopeResolver): void {
         this._scopeResolver = resolver;
     }
 
@@ -410,23 +464,36 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
                 continue;
             }
 
-            const acceptedScopes = toolScopes.accepted ?? toolScopes.required;
+            // Satisfaction check:
+            //   - If `accepted` is provided, ANY of those scopes in the token satisfies
+            //     the requirement (OR / hierarchy escape hatch).
+            //   - Otherwise, ALL `required` scopes must be present in the token (AND).
+            const satisfied = toolScopes.accepted
+                ? toolScopes.accepted.some(s => activeScopes.includes(s))
+                : toolScopes.required.every(s => activeScopes.includes(s));
 
-            // Check if the token has any of the accepted scopes
-            if (acceptedScopes.some(s => activeScopes.includes(s))) {
+            if (satisfied) {
                 continue;
             }
 
-            // Additive scoping: recommend the union of existing + required scopes.
-            // This ensures the client never loses scopes it already has when
-            // re-authorizing, matching the pattern from github/github-mcp-server.
-            const recommendedScopes = [...new Set([...activeScopes, ...toolScopes.required])];
+            // Per RFC 6750 §3.1 and MCP SEP-2350, the `scope` parameter advertises
+            // the scopes needed for the *current operation* — clients are expected
+            // to accumulate scopes across step-up challenges. Opt in via
+            // `includeGrantedScopes` to additionally union the token's active
+            // scopes (defensive against clients that don't accumulate).
+            const recommendedScopes = this._scopeChallenge.includeGrantedScopes
+                ? [...new Set([...activeScopes, ...toolScopes.required])]
+                : toolScopes.required;
 
             const errorDescription = this._scopeChallenge.buildErrorDescription
                 ? this._scopeChallenge.buildErrorDescription(toolName, toolScopes.required)
                 : `Additional scopes required: ${toolScopes.required.join(', ')}`;
 
-            const wwwAuthenticate = `Bearer error="insufficient_scope", scope="${recommendedScopes.join(' ')}", resource_metadata="${this._scopeChallenge.resourceMetadataUrl}", error_description="${errorDescription}"`;
+            const wwwAuthenticate =
+                `Bearer error="insufficient_scope"` +
+                `, scope="${quoteAuthParam(recommendedScopes.join(' '))}"` +
+                `, resource_metadata="${quoteAuthParam(this._scopeChallenge.resourceMetadataUrl)}"` +
+                `, error_description="${quoteAuthParam(errorDescription)}"`;
 
             return this.createJsonErrorResponse(403, -32_600, `Insufficient scope for tool: ${toolName}`, {
                 headers: {

--- a/packages/server/src/server/streamableHttp.ts
+++ b/packages/server/src/server/streamableHttp.ts
@@ -7,7 +7,7 @@
  * For Node.js Express/HTTP compatibility, use {@linkcode @modelcontextprotocol/node!NodeStreamableHTTPServerTransport | NodeStreamableHTTPServerTransport} which wraps this transport.
  */
 
-import type { AuthInfo, JSONRPCMessage, MessageExtraInfo, RequestId, Transport } from '@modelcontextprotocol/core-internal';
+import type { AuthInfo, JSONRPCMessage, JSONRPCRequest, MessageExtraInfo, RequestId, Transport } from '@modelcontextprotocol/core-internal';
 import {
     DEFAULT_NEGOTIATED_PROTOCOL_VERSION,
     isInitializeRequest,
@@ -20,6 +20,8 @@ import {
 } from '@modelcontextprotocol/core-internal';
 
 import { MAX_BATCH_SIZE, readRequestBody, requestBodyTooLargeMessage, resolveMaxRequestBodySize } from './requestBody';
+import type { ScopeChallengeConfig, ScopeChallengeHandler } from './scopeChallenge';
+import { createScopeChallengeResponse, findScopeChallenge } from './scopeChallenge';
 import { armSseKeepAlive, DEFAULT_SSE_KEEP_ALIVE_MS } from './sseKeepAlive';
 
 export type StreamId = string;
@@ -177,6 +179,9 @@ export interface WebStandardStreamableHTTPServerTransportOptions {
      * @default {@linkcode SUPPORTED_PROTOCOL_VERSIONS}
      */
     supportedProtocolVersions?: string[];
+
+    /** Enables OAuth scope challenges. `McpServer.connect()` supplies the resolver. */
+    scopeChallenge?: ScopeChallengeConfig;
 }
 
 /**
@@ -267,6 +272,8 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
     private _supportedProtocolVersions: string[];
     private _keepAliveMs: number;
     private _maxRequestBodySize: number;
+    private _scopeChallenge?: ScopeChallengeConfig;
+    private _scopeChallengeResolver?: ScopeChallengeHandler;
 
     sessionId?: string;
     onclose?: () => void;
@@ -286,6 +293,7 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
         this._supportedProtocolVersions = options.supportedProtocolVersions ?? SUPPORTED_PROTOCOL_VERSIONS;
         this._keepAliveMs = options.keepAliveMs ?? DEFAULT_SSE_KEEP_ALIVE_MS;
         this._maxRequestBodySize = resolveMaxRequestBodySize(options.maxRequestBodySize);
+        this._scopeChallenge = options.scopeChallenge;
     }
 
     private startKeepAlive(
@@ -302,6 +310,11 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
             }
         });
         return timer;
+    }
+
+    /** Sets the scope challenge resolver for parsed JSON-RPC requests. */
+    setScopeChallengeResolver(resolver: ScopeChallengeHandler): void {
+        this._scopeChallengeResolver = resolver;
     }
 
     /**
@@ -350,6 +363,17 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
                 }
             }
         );
+    }
+
+    private async _checkScopeChallenge(messages: JSONRPCMessage[], authInfo?: AuthInfo): Promise<Response | undefined> {
+        if (!this._scopeChallenge || !this._scopeChallengeResolver) {
+            return undefined;
+        }
+        const requests: JSONRPCRequest[] = messages.filter(message => isJSONRPCRequest(message));
+        const result = await findScopeChallenge(requests, authInfo, this._scopeChallengeResolver);
+        return result === undefined
+            ? undefined
+            : createScopeChallengeResponse(this._scopeChallenge, result.challenge, messages.length === 1 ? result.requestId : null);
     }
 
     /**
@@ -854,6 +878,18 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
 
             if (this._closed) {
                 return this.createJsonErrorResponse(404, -32_001, 'Session not found');
+            }
+
+            // Check before opening SSE so an insufficient token can receive HTTP 403.
+            let scopeChallengeResponse: Response | undefined;
+            try {
+                scopeChallengeResponse = await this._checkScopeChallenge(messages, options?.authInfo);
+            } catch (error) {
+                this.onerror?.(error as Error);
+                return this.createJsonErrorResponse(500, -32_603, 'Internal server error');
+            }
+            if (scopeChallengeResponse) {
+                return scopeChallengeResponse;
             }
 
             // check if it contains requests

--- a/packages/server/src/server/streamableHttp.ts
+++ b/packages/server/src/server/streamableHttp.ts
@@ -369,14 +369,8 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
             return undefined;
         }
         const requests: JSONRPCRequest[] = messages.filter(message => isJSONRPCRequest(message));
-        const result = await findScopeChallenge(requests, authInfo, this._scopeChallengeResolver);
-        return result === undefined
-            ? undefined
-            : createScopeChallengeResponse(
-                  result.challenge,
-                  messages.length === 1 ? result.requestId : null,
-                  scopeChallengeResourceMetadataUrl(authInfo)
-              );
+        const challenge = await findScopeChallenge(requests, authInfo, this._scopeChallengeResolver);
+        return challenge === undefined ? undefined : createScopeChallengeResponse(challenge, scopeChallengeResourceMetadataUrl(authInfo));
     }
 
     /**

--- a/packages/server/src/server/streamableHttp.ts
+++ b/packages/server/src/server/streamableHttp.ts
@@ -20,8 +20,8 @@ import {
 } from '@modelcontextprotocol/core-internal';
 
 import { MAX_BATCH_SIZE, readRequestBody, requestBodyTooLargeMessage, resolveMaxRequestBodySize } from './requestBody';
-import type { ScopeChallengeConfig, ScopeChallengeHandler } from './scopeChallenge';
-import { createScopeChallengeResponse, findScopeChallenge } from './scopeChallenge';
+import type { ScopeChallengeHandler } from './scopeChallenge';
+import { createScopeChallengeResponse, findScopeChallenge, scopeChallengeResourceMetadataUrl } from './scopeChallenge';
 import { armSseKeepAlive, DEFAULT_SSE_KEEP_ALIVE_MS } from './sseKeepAlive';
 
 export type StreamId = string;
@@ -179,9 +179,6 @@ export interface WebStandardStreamableHTTPServerTransportOptions {
      * @default {@linkcode SUPPORTED_PROTOCOL_VERSIONS}
      */
     supportedProtocolVersions?: string[];
-
-    /** Enables OAuth scope challenges. `McpServer.connect()` supplies the resolver. */
-    scopeChallenge?: ScopeChallengeConfig;
 }
 
 /**
@@ -272,7 +269,6 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
     private _supportedProtocolVersions: string[];
     private _keepAliveMs: number;
     private _maxRequestBodySize: number;
-    private _scopeChallenge?: ScopeChallengeConfig;
     private _scopeChallengeResolver?: ScopeChallengeHandler;
 
     sessionId?: string;
@@ -293,7 +289,6 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
         this._supportedProtocolVersions = options.supportedProtocolVersions ?? SUPPORTED_PROTOCOL_VERSIONS;
         this._keepAliveMs = options.keepAliveMs ?? DEFAULT_SSE_KEEP_ALIVE_MS;
         this._maxRequestBodySize = resolveMaxRequestBodySize(options.maxRequestBodySize);
-        this._scopeChallenge = options.scopeChallenge;
     }
 
     private startKeepAlive(
@@ -366,14 +361,22 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
     }
 
     private async _checkScopeChallenge(messages: JSONRPCMessage[], authInfo?: AuthInfo): Promise<Response | undefined> {
-        if (!this._scopeChallenge || !this._scopeChallengeResolver) {
+        // Active whenever a connected McpServer supplied a resolver (it
+        // resolves per-primitive scopeChallenge callbacks); the challenge's
+        // resource_metadata parameter is derived from the verified AuthInfo
+        // and omitted when unavailable.
+        if (!this._scopeChallengeResolver) {
             return undefined;
         }
         const requests: JSONRPCRequest[] = messages.filter(message => isJSONRPCRequest(message));
         const result = await findScopeChallenge(requests, authInfo, this._scopeChallengeResolver);
         return result === undefined
             ? undefined
-            : createScopeChallengeResponse(this._scopeChallenge, result.challenge, messages.length === 1 ? result.requestId : null);
+            : createScopeChallengeResponse(
+                  result.challenge,
+                  messages.length === 1 ? result.requestId : null,
+                  scopeChallengeResourceMetadataUrl(authInfo)
+              );
     }
 
     /**

--- a/packages/server/test/server/oauthMetadata.test.ts
+++ b/packages/server/test/server/oauthMetadata.test.ts
@@ -82,6 +82,12 @@ describe('getOAuthProtectedResourceMetadataUrl', () => {
             'https://api.example.com/.well-known/oauth-protected-resource'
         );
     });
+
+    it('preserves the resource identifier query', () => {
+        expect(getOAuthProtectedResourceMetadataUrl(new URL('https://api.example.com/mcp?tenant=acme'))).toBe(
+            'https://api.example.com/.well-known/oauth-protected-resource/mcp?tenant=acme'
+        );
+    });
 });
 
 describe('oauthMetadataResponse', () => {

--- a/packages/server/test/server/scopeChallenge.test.ts
+++ b/packages/server/test/server/scopeChallenge.test.ts
@@ -1,0 +1,504 @@
+import { randomUUID } from 'node:crypto';
+
+import type { AuthInfo, CallToolResult, JSONRPCMessage } from '@modelcontextprotocol/core';
+import * as z from 'zod/v4';
+
+import { McpServer } from '../../src/server/mcp.js';
+import { WebStandardStreamableHTTPServerTransport } from '../../src/server/streamableHttp.js';
+
+/**
+ * Helper to create a Web Standard Request
+ */
+function createRequest(
+    method: string,
+    body?: JSONRPCMessage | JSONRPCMessage[],
+    options?: {
+        sessionId?: string;
+        accept?: string;
+        contentType?: string;
+        extraHeaders?: Record<string, string>;
+    }
+): Request {
+    const headers: Record<string, string> = {};
+
+    if (options?.accept) {
+        headers['Accept'] = options.accept;
+    } else if (method === 'POST') {
+        headers['Accept'] = 'application/json, text/event-stream';
+    } else if (method === 'GET') {
+        headers['Accept'] = 'text/event-stream';
+    }
+
+    if (options?.contentType) {
+        headers['Content-Type'] = options.contentType;
+    } else if (body) {
+        headers['Content-Type'] = 'application/json';
+    }
+
+    if (options?.sessionId) {
+        headers['mcp-session-id'] = options.sessionId;
+        headers['mcp-protocol-version'] = '2025-11-25';
+    }
+
+    if (options?.extraHeaders) {
+        Object.assign(headers, options.extraHeaders);
+    }
+
+    return new Request('http://localhost/mcp', {
+        method,
+        headers,
+        body: body ? JSON.stringify(body) : undefined
+    });
+}
+
+const RESOURCE_METADATA_URL = 'https://auth.example.com/.well-known/oauth-protected-resource';
+
+function createToolCallMessage(toolName: string, args: Record<string, unknown> = {}, id: string | number = 'call-1'): JSONRPCMessage {
+    return {
+        jsonrpc: '2.0',
+        method: 'tools/call',
+        params: { name: toolName, arguments: args },
+        id
+    } as JSONRPCMessage;
+}
+
+const INITIALIZE_MESSAGE: JSONRPCMessage = {
+    jsonrpc: '2.0',
+    method: 'initialize',
+    params: {
+        clientInfo: { name: 'test-client', version: '1.0' },
+        protocolVersion: '2025-11-25',
+        capabilities: {}
+    },
+    id: 'init-1'
+} as JSONRPCMessage;
+
+describe('Scope Challenge / Step-Up Auth', () => {
+    let transport: WebStandardStreamableHTTPServerTransport;
+    let mcpServer: McpServer;
+
+    afterEach(async () => {
+        await transport.close();
+    });
+
+    async function initializeServer(): Promise<string> {
+        const request = createRequest('POST', INITIALIZE_MESSAGE);
+        const response = await transport.handleRequest(request);
+        expect(response.status).toBe(200);
+        const sessionId = response.headers.get('mcp-session-id');
+        expect(sessionId).toBeDefined();
+        return sessionId as string;
+    }
+
+    function setupServer(options: {
+        scopeChallenge?: {
+            resourceMetadataUrl: string;
+            buildErrorDescription?: (toolName: string, requiredScopes: string[]) => string;
+        };
+        tools?: Array<{
+            name: string;
+            scopes?: string[] | { required: string[]; accepted?: string[] };
+            schema?: z.ZodObject<{ name: z.ZodString }>;
+        }>;
+        toolScopeOverrides?: Record<string, string[] | { required: string[]; accepted?: string[] }>;
+    }): void {
+        mcpServer = new McpServer({ name: 'scope-test-server', version: '1.0.0' }, { capabilities: { logging: {} } });
+
+        const tools = options.tools ?? [
+            { name: 'public_tool' },
+            { name: 'read_repo', scopes: ['repo:read'] },
+            { name: 'write_repo', scopes: { required: ['repo:write'], accepted: ['repo:write', 'repo'] } }
+        ];
+
+        for (const tool of tools) {
+            mcpServer.registerTool(
+                tool.name,
+                {
+                    description: `Test tool: ${tool.name}`,
+                    inputSchema: tool.schema ?? z.object({ name: z.string() }),
+                    scopes: tool.scopes
+                },
+                async ({ name }): Promise<CallToolResult> => {
+                    return { content: [{ type: 'text', text: `Result from ${tool.name}: ${name}` }] };
+                }
+            );
+        }
+
+        if (options.toolScopeOverrides) {
+            for (const [toolName, scopes] of Object.entries(options.toolScopeOverrides)) {
+                mcpServer.setToolScopes(toolName, scopes);
+            }
+        }
+
+        transport = new WebStandardStreamableHTTPServerTransport({
+            sessionIdGenerator: () => randomUUID(),
+            scopeChallenge: options.scopeChallenge
+        });
+    }
+
+    describe('HTTP 403 scope challenge responses', () => {
+        beforeEach(async () => {
+            setupServer({
+                scopeChallenge: { resourceMetadataUrl: RESOURCE_METADATA_URL }
+            });
+            await mcpServer.connect(transport);
+        });
+
+        it('should return 403 when token lacks required scopes', async () => {
+            const sessionId = await initializeServer();
+
+            const authInfo: AuthInfo = {
+                token: 'test-token',
+                clientId: 'test-client',
+                scopes: ['user:read']
+            };
+
+            const request = createRequest('POST', createToolCallMessage('read_repo', { name: 'test' }), { sessionId });
+
+            const response = await transport.handleRequest(request, { authInfo });
+
+            expect(response.status).toBe(403);
+
+            const wwwAuth = response.headers.get('WWW-Authenticate');
+            expect(wwwAuth).toBeDefined();
+            expect(wwwAuth).toContain('error="insufficient_scope"');
+            expect(wwwAuth).toContain('scope="user:read repo:read"');
+            expect(wwwAuth).toContain(`resource_metadata="${RESOURCE_METADATA_URL}"`);
+
+            const body = (await response.json()) as { jsonrpc: string; error: { code: number; message: string } };
+            expect(body.jsonrpc).toBe('2.0');
+            expect(body.error.code).toBe(-32600);
+            expect(body.error.message).toContain('Insufficient scope');
+            expect(body.error.message).toContain('read_repo');
+        });
+
+        it('should pass when token has a required scope', async () => {
+            const sessionId = await initializeServer();
+
+            const authInfo: AuthInfo = {
+                token: 'test-token',
+                clientId: 'test-client',
+                scopes: ['repo:read']
+            };
+
+            const request = createRequest('POST', createToolCallMessage('read_repo', { name: 'test' }), { sessionId });
+
+            const response = await transport.handleRequest(request, { authInfo });
+
+            // Should NOT be 403 — tool should execute
+            expect(response.status).toBe(200);
+        });
+
+        it('should pass when token has an accepted (parent) scope', async () => {
+            const sessionId = await initializeServer();
+
+            const authInfo: AuthInfo = {
+                token: 'test-token',
+                clientId: 'test-client',
+                scopes: ['repo'] // parent scope — accepted by write_repo
+            };
+
+            const request = createRequest('POST', createToolCallMessage('write_repo', { name: 'test' }), { sessionId });
+
+            const response = await transport.handleRequest(request, { authInfo });
+
+            expect(response.status).toBe(200);
+        });
+
+        it('should pass through tools with no scope configuration', async () => {
+            const sessionId = await initializeServer();
+
+            const authInfo: AuthInfo = {
+                token: 'test-token',
+                clientId: 'test-client',
+                scopes: [] // no scopes at all
+            };
+
+            const request = createRequest('POST', createToolCallMessage('public_tool', { name: 'test' }), { sessionId });
+
+            const response = await transport.handleRequest(request, { authInfo });
+
+            expect(response.status).toBe(200);
+        });
+
+        it('should pass through non-tools/call requests', async () => {
+            const sessionId = await initializeServer();
+
+            const authInfo: AuthInfo = {
+                token: 'test-token',
+                clientId: 'test-client',
+                scopes: []
+            };
+
+            const listToolsMsg: JSONRPCMessage = {
+                jsonrpc: '2.0',
+                method: 'tools/list',
+                params: {},
+                id: 'list-1'
+            } as JSONRPCMessage;
+
+            const request = createRequest('POST', listToolsMsg, { sessionId });
+            const response = await transport.handleRequest(request, { authInfo });
+
+            expect(response.status).toBe(200);
+        });
+
+        it('should include recommended scopes as union of existing + required', async () => {
+            const sessionId = await initializeServer();
+
+            const authInfo: AuthInfo = {
+                token: 'test-token',
+                clientId: 'test-client',
+                scopes: ['user:read', 'user:write']
+            };
+
+            const request = createRequest('POST', createToolCallMessage('read_repo', { name: 'test' }), { sessionId });
+
+            const response = await transport.handleRequest(request, { authInfo });
+
+            expect(response.status).toBe(403);
+            const wwwAuth = response.headers.get('WWW-Authenticate')!;
+            // Should contain all existing scopes + the required one
+            expect(wwwAuth).toContain('user:read');
+            expect(wwwAuth).toContain('user:write');
+            expect(wwwAuth).toContain('repo:read');
+        });
+    });
+
+    describe('without scope challenge configured', () => {
+        beforeEach(async () => {
+            setupServer({}); // no scopeChallenge
+            await mcpServer.connect(transport);
+        });
+
+        it('should pass through all tools/call requests when scope challenge is not configured', async () => {
+            const sessionId = await initializeServer();
+
+            const authInfo: AuthInfo = {
+                token: 'test-token',
+                clientId: 'test-client',
+                scopes: []
+            };
+
+            const request = createRequest('POST', createToolCallMessage('read_repo', { name: 'test' }), { sessionId });
+
+            const response = await transport.handleRequest(request, { authInfo });
+
+            // Without scopeChallenge configured, scope check is skipped
+            expect(response.status).toBe(200);
+        });
+    });
+
+    describe('setToolScopes override', () => {
+        it('should use overridden scopes from setToolScopes instead of registration scopes', async () => {
+            setupServer({
+                scopeChallenge: { resourceMetadataUrl: RESOURCE_METADATA_URL },
+                tools: [{ name: 'read_repo', scopes: ['repo:read'] }],
+                toolScopeOverrides: {
+                    read_repo: ['admin:repo'] // Override: now requires admin:repo instead
+                }
+            });
+            await mcpServer.connect(transport);
+            const sessionId = await initializeServer();
+
+            // Token has repo:read (the original scope), but not admin:repo (the override)
+            const authInfo: AuthInfo = {
+                token: 'test-token',
+                clientId: 'test-client',
+                scopes: ['repo:read']
+            };
+
+            const request = createRequest('POST', createToolCallMessage('read_repo', { name: 'test' }), { sessionId });
+
+            const response = await transport.handleRequest(request, { authInfo });
+
+            // Should be 403 because the override requires admin:repo
+            expect(response.status).toBe(403);
+            const wwwAuth = response.headers.get('WWW-Authenticate')!;
+            expect(wwwAuth).toContain('admin:repo');
+        });
+
+        it('should allow setting scopes on tools that had no scopes at registration', async () => {
+            setupServer({
+                scopeChallenge: { resourceMetadataUrl: RESOURCE_METADATA_URL },
+                tools: [
+                    { name: 'public_tool' } // No scopes at registration
+                ],
+                toolScopeOverrides: {
+                    public_tool: ['admin:read'] // Now requires scopes
+                }
+            });
+            await mcpServer.connect(transport);
+            const sessionId = await initializeServer();
+
+            const authInfo: AuthInfo = {
+                token: 'test-token',
+                clientId: 'test-client',
+                scopes: []
+            };
+
+            const request = createRequest('POST', createToolCallMessage('public_tool', { name: 'test' }), { sessionId });
+
+            const response = await transport.handleRequest(request, { authInfo });
+
+            expect(response.status).toBe(403);
+        });
+    });
+
+    describe('custom error description', () => {
+        it('should use buildErrorDescription when provided', async () => {
+            setupServer({
+                scopeChallenge: {
+                    resourceMetadataUrl: RESOURCE_METADATA_URL,
+                    buildErrorDescription: (toolName, requiredScopes) => `Tool "${toolName}" needs: ${requiredScopes.join(', ')}`
+                }
+            });
+            await mcpServer.connect(transport);
+            const sessionId = await initializeServer();
+
+            const authInfo: AuthInfo = {
+                token: 'test-token',
+                clientId: 'test-client',
+                scopes: []
+            };
+
+            const request = createRequest('POST', createToolCallMessage('read_repo', { name: 'test' }), { sessionId });
+
+            const response = await transport.handleRequest(request, { authInfo });
+
+            expect(response.status).toBe(403);
+            const wwwAuth = response.headers.get('WWW-Authenticate')!;
+            expect(wwwAuth).toContain('Tool "read_repo" needs: repo:read');
+        });
+    });
+
+    describe('batch requests', () => {
+        beforeEach(async () => {
+            setupServer({
+                scopeChallenge: { resourceMetadataUrl: RESOURCE_METADATA_URL }
+            });
+            await mcpServer.connect(transport);
+        });
+
+        it('should reject the entire batch if any tools/call lacks scopes', async () => {
+            const sessionId = await initializeServer();
+
+            const authInfo: AuthInfo = {
+                token: 'test-token',
+                clientId: 'test-client',
+                scopes: []
+            };
+
+            const batch: JSONRPCMessage[] = [
+                createToolCallMessage('public_tool', { name: 'ok' }, 'call-1'),
+                createToolCallMessage('read_repo', { name: 'fail' }, 'call-2')
+            ];
+
+            const request = createRequest('POST', batch, { sessionId });
+            const response = await transport.handleRequest(request, { authInfo });
+
+            expect(response.status).toBe(403);
+        });
+    });
+
+    describe('McpServer scope API', () => {
+        it('getToolScopes returns undefined for tools without scopes', () => {
+            mcpServer = new McpServer({ name: 'test', version: '1.0.0' });
+            mcpServer.registerTool(
+                'no_scopes',
+                {
+                    description: 'No scopes',
+                    inputSchema: z.object({ x: z.string() })
+                },
+                async () => ({ content: [] })
+            );
+
+            expect(mcpServer.getToolScopes('no_scopes')).toBeUndefined();
+        });
+
+        it('getToolScopes returns normalized scopes from string[] registration', () => {
+            mcpServer = new McpServer({ name: 'test', version: '1.0.0' });
+            mcpServer.registerTool(
+                'scoped',
+                {
+                    description: 'Scoped',
+                    inputSchema: z.object({ x: z.string() }),
+                    scopes: ['repo:read', 'repo:write']
+                },
+                async () => ({ content: [] })
+            );
+
+            const scopes = mcpServer.getToolScopes('scoped');
+            expect(scopes).toEqual({ required: ['repo:read', 'repo:write'] });
+        });
+
+        it('getToolScopes returns full config from object registration', () => {
+            mcpServer = new McpServer({ name: 'test', version: '1.0.0' });
+            mcpServer.registerTool(
+                'scoped',
+                {
+                    description: 'Scoped',
+                    inputSchema: z.object({ x: z.string() }),
+                    scopes: { required: ['public_repo'], accepted: ['public_repo', 'repo'] }
+                },
+                async () => ({ content: [] })
+            );
+
+            const scopes = mcpServer.getToolScopes('scoped');
+            expect(scopes).toEqual({ required: ['public_repo'], accepted: ['public_repo', 'repo'] });
+        });
+
+        it('setToolScopes overrides registration scopes', () => {
+            mcpServer = new McpServer({ name: 'test', version: '1.0.0' });
+            mcpServer.registerTool(
+                'scoped',
+                {
+                    description: 'Scoped',
+                    inputSchema: z.object({ x: z.string() }),
+                    scopes: ['repo:read']
+                },
+                async () => ({ content: [] })
+            );
+
+            mcpServer.setToolScopes('scoped', ['admin:repo']);
+
+            const scopes = mcpServer.getToolScopes('scoped');
+            expect(scopes).toEqual({ required: ['admin:repo'] });
+        });
+
+        it('setToolScopes can set scopes on unregistered tool names', () => {
+            mcpServer = new McpServer({ name: 'test', version: '1.0.0' });
+            mcpServer.setToolScopes('future_tool', ['admin:read']);
+
+            // Returns the override even if tool isn't registered yet
+            const scopes = mcpServer.getToolScopes('future_tool');
+            expect(scopes).toEqual({ required: ['admin:read'] });
+        });
+    });
+
+    describe('auto-wiring', () => {
+        it('should auto-wire scope resolver on connect when transport supports it', async () => {
+            setupServer({
+                scopeChallenge: { resourceMetadataUrl: RESOURCE_METADATA_URL }
+            });
+
+            // Before connect, the transport has no resolver — scope checks should pass
+            // We verify this indirectly: after connect, scope checks work
+            await mcpServer.connect(transport);
+            const sessionId = await initializeServer();
+
+            const authInfo: AuthInfo = {
+                token: 'test-token',
+                clientId: 'test-client',
+                scopes: []
+            };
+
+            const request = createRequest('POST', createToolCallMessage('read_repo', { name: 'test' }), { sessionId });
+
+            const response = await transport.handleRequest(request, { authInfo });
+
+            // If auto-wiring didn't work, this would pass through
+            expect(response.status).toBe(403);
+        });
+    });
+});

--- a/packages/server/test/server/scopeChallenge.test.ts
+++ b/packages/server/test/server/scopeChallenge.test.ts
@@ -93,6 +93,7 @@ describe('Scope Challenge / Step-Up Auth', () => {
     function setupServer(options: {
         scopeChallenge?: {
             resourceMetadataUrl: string;
+            includeGrantedScopes?: boolean;
             buildErrorDescription?: (toolName: string, requiredScopes: string[]) => string;
         };
         tools?: Array<{
@@ -162,7 +163,10 @@ describe('Scope Challenge / Step-Up Auth', () => {
             const wwwAuth = response.headers.get('WWW-Authenticate');
             expect(wwwAuth).toBeDefined();
             expect(wwwAuth).toContain('error="insufficient_scope"');
-            expect(wwwAuth).toContain('scope="user:read repo:read"');
+            // Per RFC 6750 §3.1 and SEP-2350, advertise only the per-operation
+            // required scope by default — clients accumulate across step-ups.
+            expect(wwwAuth).toContain('scope="repo:read"');
+            expect(wwwAuth).not.toContain('user:read');
             expect(wwwAuth).toContain(`resource_metadata="${RESOURCE_METADATA_URL}"`);
 
             const body = (await response.json()) as { jsonrpc: string; error: { code: number; message: string } };
@@ -243,7 +247,7 @@ describe('Scope Challenge / Step-Up Auth', () => {
             expect(response.status).toBe(200);
         });
 
-        it('should include recommended scopes as union of existing + required', async () => {
+        it('should advertise only per-operation required scopes by default (RFC 6750 §3.1, SEP-2350)', async () => {
             const sessionId = await initializeServer();
 
             const authInfo: AuthInfo = {
@@ -258,10 +262,127 @@ describe('Scope Challenge / Step-Up Auth', () => {
 
             expect(response.status).toBe(403);
             const wwwAuth = response.headers.get('WWW-Authenticate')!;
-            // Should contain all existing scopes + the required one
+            // Only the operation's required scope is advertised; client accumulates.
+            expect(wwwAuth).toContain('scope="repo:read"');
+            expect(wwwAuth).not.toContain('user:read');
+            expect(wwwAuth).not.toContain('user:write');
+        });
+    });
+
+    describe('required scopes (AND semantics)', () => {
+        beforeEach(async () => {
+            setupServer({
+                scopeChallenge: { resourceMetadataUrl: RESOURCE_METADATA_URL },
+                tools: [{ name: 'multi_scope_tool', scopes: ['repo:read', 'user:read'] }]
+            });
+            await mcpServer.connect(transport);
+        });
+
+        it('should require ALL scopes in required[] to be present', async () => {
+            const sessionId = await initializeServer();
+
+            const authInfo: AuthInfo = {
+                token: 'test-token',
+                clientId: 'test-client',
+                scopes: ['repo:read'] // missing user:read
+            };
+
+            const request = createRequest('POST', createToolCallMessage('multi_scope_tool', { name: 'test' }), { sessionId });
+            const response = await transport.handleRequest(request, { authInfo });
+
+            expect(response.status).toBe(403);
+        });
+
+        it('should pass when ALL required scopes are present', async () => {
+            const sessionId = await initializeServer();
+
+            const authInfo: AuthInfo = {
+                token: 'test-token',
+                clientId: 'test-client',
+                scopes: ['repo:read', 'user:read', 'extra:scope']
+            };
+
+            const request = createRequest('POST', createToolCallMessage('multi_scope_tool', { name: 'test' }), { sessionId });
+            const response = await transport.handleRequest(request, { authInfo });
+
+            expect(response.status).toBe(200);
+        });
+    });
+
+    describe('includeGrantedScopes opt-in', () => {
+        beforeEach(async () => {
+            setupServer({
+                scopeChallenge: {
+                    resourceMetadataUrl: RESOURCE_METADATA_URL,
+                    includeGrantedScopes: true
+                }
+            });
+            await mcpServer.connect(transport);
+        });
+
+        it('should union active token scopes with required when includeGrantedScopes=true', async () => {
+            const sessionId = await initializeServer();
+
+            const authInfo: AuthInfo = {
+                token: 'test-token',
+                clientId: 'test-client',
+                scopes: ['user:read', 'user:write']
+            };
+
+            const request = createRequest('POST', createToolCallMessage('read_repo', { name: 'test' }), { sessionId });
+            const response = await transport.handleRequest(request, { authInfo });
+
+            expect(response.status).toBe(403);
+            const wwwAuth = response.headers.get('WWW-Authenticate')!;
             expect(wwwAuth).toContain('user:read');
             expect(wwwAuth).toContain('user:write');
             expect(wwwAuth).toContain('repo:read');
+        });
+
+        it('should deduplicate scopes in the union', async () => {
+            const sessionId = await initializeServer();
+
+            // Token already has repo:read; tool will also require repo:read (plus a missing scope)
+            // so the union has a natural duplicate to deduplicate.
+            mcpServer.setToolScopes('read_repo', ['repo:read', 'repo:write']);
+
+            const authInfo: AuthInfo = {
+                token: 'test-token',
+                clientId: 'test-client',
+                scopes: ['repo:read', 'user:read']
+            };
+
+            const request = createRequest('POST', createToolCallMessage('read_repo', { name: 'test' }), { sessionId });
+            const response = await transport.handleRequest(request, { authInfo });
+
+            expect(response.status).toBe(403);
+            const wwwAuth = response.headers.get('WWW-Authenticate')!;
+            const scopeMatch = wwwAuth.match(/scope="([^"]*)"/);
+            const scopes = (scopeMatch?.[1] ?? '').split(' ');
+            // No duplicates in the advertised scope value (RFC 6750 §3 — scope is a set).
+            expect(new Set(scopes).size).toBe(scopes.length);
+        });
+    });
+
+    describe('WWW-Authenticate header quoting', () => {
+        it('should escape embedded quotes and backslashes per RFC 7235', async () => {
+            setupServer({
+                scopeChallenge: {
+                    resourceMetadataUrl: RESOURCE_METADATA_URL,
+                    buildErrorDescription: () => 'Needs "repo:read", path\\to\\thing'
+                }
+            });
+            await mcpServer.connect(transport);
+
+            const sessionId = await initializeServer();
+            const authInfo: AuthInfo = { token: 't', clientId: 'c', scopes: [] };
+            const request = createRequest('POST', createToolCallMessage('read_repo'), { sessionId });
+            const response = await transport.handleRequest(request, { authInfo });
+
+            expect(response.status).toBe(403);
+            const wwwAuth = response.headers.get('WWW-Authenticate')!;
+            // Both `"` and `\` must be backslash-escaped to keep the header parseable.
+            expect(wwwAuth).toContain('error_description="Needs \\"repo:read\\", path\\\\to\\\\thing"');
         });
     });
 
@@ -368,7 +489,8 @@ describe('Scope Challenge / Step-Up Auth', () => {
 
             expect(response.status).toBe(403);
             const wwwAuth = response.headers.get('WWW-Authenticate')!;
-            expect(wwwAuth).toContain('Tool "read_repo" needs: repo:read');
+            // The quotes in `"read_repo"` are escaped per RFC 7235 quoted-string rules.
+            expect(wwwAuth).toContain('Tool \\"read_repo\\" needs: repo:read');
         });
     });
 
@@ -398,81 +520,6 @@ describe('Scope Challenge / Step-Up Auth', () => {
             const response = await transport.handleRequest(request, { authInfo });
 
             expect(response.status).toBe(403);
-        });
-    });
-
-    describe('McpServer scope API', () => {
-        it('getToolScopes returns undefined for tools without scopes', () => {
-            mcpServer = new McpServer({ name: 'test', version: '1.0.0' });
-            mcpServer.registerTool(
-                'no_scopes',
-                {
-                    description: 'No scopes',
-                    inputSchema: z.object({ x: z.string() })
-                },
-                async () => ({ content: [] })
-            );
-
-            expect(mcpServer.getToolScopes('no_scopes')).toBeUndefined();
-        });
-
-        it('getToolScopes returns normalized scopes from string[] registration', () => {
-            mcpServer = new McpServer({ name: 'test', version: '1.0.0' });
-            mcpServer.registerTool(
-                'scoped',
-                {
-                    description: 'Scoped',
-                    inputSchema: z.object({ x: z.string() }),
-                    scopes: ['repo:read', 'repo:write']
-                },
-                async () => ({ content: [] })
-            );
-
-            const scopes = mcpServer.getToolScopes('scoped');
-            expect(scopes).toEqual({ required: ['repo:read', 'repo:write'] });
-        });
-
-        it('getToolScopes returns full config from object registration', () => {
-            mcpServer = new McpServer({ name: 'test', version: '1.0.0' });
-            mcpServer.registerTool(
-                'scoped',
-                {
-                    description: 'Scoped',
-                    inputSchema: z.object({ x: z.string() }),
-                    scopes: { required: ['public_repo'], accepted: ['public_repo', 'repo'] }
-                },
-                async () => ({ content: [] })
-            );
-
-            const scopes = mcpServer.getToolScopes('scoped');
-            expect(scopes).toEqual({ required: ['public_repo'], accepted: ['public_repo', 'repo'] });
-        });
-
-        it('setToolScopes overrides registration scopes', () => {
-            mcpServer = new McpServer({ name: 'test', version: '1.0.0' });
-            mcpServer.registerTool(
-                'scoped',
-                {
-                    description: 'Scoped',
-                    inputSchema: z.object({ x: z.string() }),
-                    scopes: ['repo:read']
-                },
-                async () => ({ content: [] })
-            );
-
-            mcpServer.setToolScopes('scoped', ['admin:repo']);
-
-            const scopes = mcpServer.getToolScopes('scoped');
-            expect(scopes).toEqual({ required: ['admin:repo'] });
-        });
-
-        it('setToolScopes can set scopes on unregistered tool names', () => {
-            mcpServer = new McpServer({ name: 'test', version: '1.0.0' });
-            mcpServer.setToolScopes('future_tool', ['admin:read']);
-
-            // Returns the override even if tool isn't registered yet
-            const scopes = mcpServer.getToolScopes('future_tool');
-            expect(scopes).toEqual({ required: ['admin:read'] });
         });
     });
 

--- a/packages/server/test/server/scopeChallenge.test.ts
+++ b/packages/server/test/server/scopeChallenge.test.ts
@@ -1,0 +1,224 @@
+import { randomUUID } from 'node:crypto';
+
+import type { AuthInfo, JSONRPCMessage, JSONRPCRequest } from '@modelcontextprotocol/core-internal';
+import { describe, expect, it, vi } from 'vitest';
+import * as z from 'zod/v4';
+
+import { McpServer } from '../../src/server/mcp';
+import type { ScopeChallengeHandler } from '../../src/server/scopeChallenge';
+import { requireScopes } from '../../src/server/scopeChallenge';
+import { WebStandardStreamableHTTPServerTransport } from '../../src/server/streamableHttp';
+
+const RESOURCE_METADATA_URL = 'https://auth.example.com/.well-known/oauth-protected-resource';
+
+function toolCall(name = 'operate', args: Record<string, unknown> = {}, id: string | number = 'call-1'): JSONRPCRequest {
+    return {
+        jsonrpc: '2.0',
+        method: 'tools/call',
+        params: { name, arguments: args },
+        id
+    };
+}
+
+function auth(scopes: string[]): AuthInfo {
+    return { token: 'token', clientId: 'client', scopes };
+}
+
+describe('requireScopes', () => {
+    it('requires every supplied scope using exact matches', async () => {
+        const handler = requireScopes('repo:read', 'org:read');
+        const request = toolCall();
+
+        expect(await handler({ request, authInfo: auth(['repo:read']) })).toEqual({
+            scopes: ['repo:read', 'org:read']
+        });
+        expect(await handler({ request, authInfo: auth(['repo:read', 'org:read']) })).toBeUndefined();
+        expect(await handler({ request, authInfo: auth(['repo:read:all', 'org:read']) })).toEqual({
+            scopes: ['repo:read', 'org:read']
+        });
+    });
+
+    it('leaves unauthenticated requests to the authentication gate', async () => {
+        expect(await requireScopes('repo:read')({ request: toolCall() })).toBeUndefined();
+    });
+
+    it('rejects invalid static scope declarations', () => {
+        expect(() => (requireScopes as (...scopes: string[]) => ScopeChallengeHandler)()).toThrow('at least one');
+        expect(() => requireScopes('repo read')).toThrow('without whitespace');
+    });
+});
+
+interface LegacyHarness {
+    server: McpServer;
+    transport: WebStandardStreamableHTTPServerTransport;
+    calls: ReturnType<typeof vi.fn>;
+}
+
+async function createLegacyHarness(scopeChallenge: ScopeChallengeHandler): Promise<LegacyHarness> {
+    const calls = vi.fn();
+    const server = new McpServer({ name: 'scope-test', version: '1.0.0' });
+    server.registerTool(
+        'operate',
+        {
+            inputSchema: z.object({ mode: z.string().optional() }),
+            scopeChallenge
+        },
+        async args => {
+            calls(args);
+            return { content: [{ type: 'text', text: 'ok' }] };
+        }
+    );
+    server.registerTool('public', { inputSchema: z.object({}) }, async () => ({ content: [{ type: 'text', text: 'public' }] }));
+    const transport = new WebStandardStreamableHTTPServerTransport({
+        sessionIdGenerator: () => randomUUID(),
+        enableJsonResponse: true,
+        scopeChallenge: { resourceMetadataUrl: RESOURCE_METADATA_URL }
+    });
+    await server.connect(transport);
+    return { server, transport, calls };
+}
+
+async function initializeLegacy(transport: WebStandardStreamableHTTPServerTransport): Promise<string> {
+    const request = new Request('http://localhost/mcp', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Accept: 'application/json, text/event-stream' },
+        body: JSON.stringify({
+            jsonrpc: '2.0',
+            method: 'initialize',
+            params: {
+                clientInfo: { name: 'test-client', version: '1.0' },
+                protocolVersion: '2025-11-25',
+                capabilities: {}
+            },
+            id: 'init'
+        })
+    });
+    const response = await transport.handleRequest(request);
+    return response.headers.get('mcp-session-id')!;
+}
+
+function legacyRequest(body: JSONRPCMessage | JSONRPCMessage[], sessionId: string): Request {
+    return new Request('http://localhost/mcp', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            Accept: 'application/json, text/event-stream',
+            'mcp-session-id': sessionId,
+            'mcp-protocol-version': '2025-11-25'
+        },
+        body: JSON.stringify(body)
+    });
+}
+
+describe('legacy Streamable HTTP scope preflight', () => {
+    it('awaits the callback with the full request and auth info before dispatch', async () => {
+        const callback = vi.fn<ScopeChallengeHandler>(async ({ request, authInfo }) => {
+            await Promise.resolve();
+            const mode = (request.params as { arguments?: { mode?: unknown } }).arguments?.mode;
+            return mode === 'write' && !authInfo?.scopes.includes('repo:write')
+                ? { scopes: ['repo:write'], errorDescription: 'Write access is required' }
+                : undefined;
+        });
+        const harness = await createLegacyHarness(callback);
+        const sessionId = await initializeLegacy(harness.transport);
+        const response = await harness.transport.handleRequest(
+            legacyRequest(toolCall('operate', { mode: 'write', nested: { value: 42 } }), sessionId),
+            { authInfo: auth(['repo:read']) }
+        );
+
+        expect(response.status).toBe(403);
+        const challenge = response.headers.get('WWW-Authenticate');
+        expect(challenge).toContain('scope="repo:write"');
+        expect(challenge).toContain(`resource_metadata="${RESOURCE_METADATA_URL}"`);
+        expect(challenge).toContain('error_description="Write access is required"');
+        expect(callback).toHaveBeenCalledWith({
+            request: expect.objectContaining({
+                method: 'tools/call',
+                params: { name: 'operate', arguments: { mode: 'write', nested: { value: 42 } } }
+            }),
+            authInfo: auth(['repo:read'])
+        });
+        expect(harness.calls).not.toHaveBeenCalled();
+        await harness.transport.close();
+    });
+
+    it('rejects a whole batch on the first challenge before any member executes', async () => {
+        const callback = vi.fn<ScopeChallengeHandler>(requireScopes('repo:read'));
+        const harness = await createLegacyHarness(callback);
+        const sessionId = await initializeLegacy(harness.transport);
+        const response = await harness.transport.handleRequest(
+            legacyRequest(
+                [
+                    { jsonrpc: '2.0', method: 'tools/call', params: { name: 'public', arguments: {} }, id: 'public' },
+                    toolCall('operate', {}, 'scoped')
+                ],
+                sessionId
+            ),
+            { authInfo: auth([]) }
+        );
+
+        expect(response.status).toBe(403);
+        expect(((await response.json()) as { id: unknown }).id).toBeNull();
+        expect(callback).toHaveBeenCalledTimes(1);
+        expect(harness.calls).not.toHaveBeenCalled();
+        await harness.transport.close();
+    });
+
+    it('fails closed when a callback rejects or returns invalid scopes', async () => {
+        for (const callback of [
+            vi.fn<ScopeChallengeHandler>(async () => {
+                throw new Error('scope lookup failed');
+            }),
+            vi.fn<ScopeChallengeHandler>(() => ({ scopes: [] as unknown as [string, ...string[]] }))
+        ]) {
+            const harness = await createLegacyHarness(callback);
+            const onerror = vi.fn();
+            harness.transport.onerror = onerror;
+            const sessionId = await initializeLegacy(harness.transport);
+            const response = await harness.transport.handleRequest(legacyRequest(toolCall(), sessionId), {
+                authInfo: auth([])
+            });
+
+            expect(response.status).toBe(500);
+            expect(harness.calls).not.toHaveBeenCalled();
+            expect(onerror).toHaveBeenCalledOnce();
+            await harness.transport.close();
+        }
+    });
+
+    it('tracks callback changes across the registered-tool lifecycle', async () => {
+        const server = new McpServer({ name: 'scope-test', version: '1.0.0' });
+        const initial = requireScopes('repo:read');
+        const updated = requireScopes('repo:write');
+        const tool = server.registerTool('mutable', { scopeChallenge: initial }, async () => ({ content: [] }));
+
+        expect(await server.resolveScopeChallenge({ request: toolCall('mutable'), authInfo: auth([]) })).toEqual({
+            scopes: ['repo:read']
+        });
+        tool.disable();
+        expect(await server.resolveScopeChallenge({ request: toolCall('mutable'), authInfo: auth([]) })).toBeUndefined();
+        tool.enable();
+        tool.update({ scopeChallenge: updated });
+        expect(await server.resolveScopeChallenge({ request: toolCall('mutable'), authInfo: auth([]) })).toEqual({
+            scopes: ['repo:write']
+        });
+        tool.update({ scopeChallenge: null });
+        expect(await server.resolveScopeChallenge({ request: toolCall('mutable'), authInfo: auth([]) })).toBeUndefined();
+        tool.remove();
+        expect(await server.resolveScopeChallenge({ request: toolCall('mutable'), authInfo: auth([]) })).toBeUndefined();
+    });
+
+    it('escapes optional challenge auth parameters', async () => {
+        const harness = await createLegacyHarness(() => ({
+            scopes: ['repo:read'],
+            errorDescription: String.raw`Needs "repo:read", path\to\thing`
+        }));
+        const sessionId = await initializeLegacy(harness.transport);
+        const response = await harness.transport.handleRequest(legacyRequest(toolCall(), sessionId), {
+            authInfo: auth([])
+        });
+
+        expect(response.headers.get('WWW-Authenticate')).toContain(String.raw`error_description="Needs \"repo:read\", path\\to\\thing"`);
+        await harness.transport.close();
+    });
+});

--- a/packages/server/test/server/scopeChallenge.test.ts
+++ b/packages/server/test/server/scopeChallenge.test.ts
@@ -45,6 +45,7 @@ describe('requireScopes', () => {
     it('rejects invalid static scope declarations', () => {
         expect(() => (requireScopes as (...scopes: string[]) => ScopeChallengeHandler)()).toThrow('at least one');
         expect(() => requireScopes('repo read')).toThrow('without whitespace');
+        expect(() => requireScopes('repo:read🚀')).toThrow('printable ASCII');
     });
 });
 
@@ -169,7 +170,9 @@ describe('legacy Streamable HTTP scope preflight', () => {
             vi.fn<ScopeChallengeHandler>(async () => {
                 throw new Error('scope lookup failed');
             }),
-            vi.fn<ScopeChallengeHandler>(() => ({ scopes: [] as unknown as [string, ...string[]] }))
+            vi.fn<ScopeChallengeHandler>(() => ({ scopes: [] as unknown as [string, ...string[]] })),
+            vi.fn<ScopeChallengeHandler>(() => ({ scopes: ['repo:read🚀'] })),
+            vi.fn<ScopeChallengeHandler>(() => ({ scopes: ['repo:read'], errorDescription: 'Need 🚀 access' }))
         ]) {
             const harness = await createLegacyHarness(callback);
             const onerror = vi.fn();

--- a/packages/server/test/server/scopeChallenge.test.ts
+++ b/packages/server/test/server/scopeChallenge.test.ts
@@ -20,8 +20,8 @@ function toolCall(name = 'operate', args: Record<string, unknown> = {}, id: stri
     };
 }
 
-function auth(scopes: string[]): AuthInfo {
-    return { token: 'token', clientId: 'client', scopes };
+function auth(scopes: string[], resourceMetadataUrl?: string): AuthInfo {
+    return { token: 'token', clientId: 'client', scopes, ...(resourceMetadataUrl !== undefined && { resourceMetadataUrl }) };
 }
 
 describe('requireScopes', () => {
@@ -73,8 +73,7 @@ async function createLegacyHarness(scopeChallenge: ScopeChallengeHandler): Promi
     server.registerTool('public', { inputSchema: z.object({}) }, async () => ({ content: [{ type: 'text', text: 'public' }] }));
     const transport = new WebStandardStreamableHTTPServerTransport({
         sessionIdGenerator: () => randomUUID(),
-        enableJsonResponse: true,
-        scopeChallenge: { resourceMetadataUrl: RESOURCE_METADATA_URL }
+        enableJsonResponse: true
     });
     await server.connect(transport);
     return { server, transport, calls };
@@ -125,7 +124,7 @@ describe('legacy Streamable HTTP scope preflight', () => {
         const sessionId = await initializeLegacy(harness.transport);
         const response = await harness.transport.handleRequest(
             legacyRequest(toolCall('operate', { mode: 'write', nested: { value: 42 } }), sessionId),
-            { authInfo: auth(['repo:read']) }
+            { authInfo: auth(['repo:read'], RESOURCE_METADATA_URL) }
         );
 
         expect(response.status).toBe(403);
@@ -138,7 +137,7 @@ describe('legacy Streamable HTTP scope preflight', () => {
                 method: 'tools/call',
                 params: { name: 'operate', arguments: { mode: 'write', nested: { value: 42 } } }
             }),
-            authInfo: auth(['repo:read'])
+            authInfo: auth(['repo:read'], RESOURCE_METADATA_URL)
         });
         expect(harness.calls).not.toHaveBeenCalled();
         await harness.transport.close();
@@ -226,6 +225,34 @@ describe('legacy Streamable HTTP scope preflight', () => {
         });
 
         expect(response.headers.get('WWW-Authenticate')).toContain('error_description="Needs repo:read, path/to/thing"');
+        await harness.transport.close();
+    });
+
+    it('omits resource_metadata when the auth info carries no metadata URL', async () => {
+        const harness = await createLegacyHarness(requireScopes('repo:write'));
+        const sessionId = await initializeLegacy(harness.transport);
+        const response = await harness.transport.handleRequest(legacyRequest(toolCall(), sessionId), {
+            authInfo: auth(['repo:read'])
+        });
+
+        expect(response.status).toBe(403);
+        const challenge = response.headers.get('WWW-Authenticate');
+        expect(challenge).toContain('scope="repo:write"');
+        expect(challenge).not.toContain('resource_metadata');
+        await harness.transport.close();
+    });
+
+    it('derives resource_metadata from the RFC 8707 resource identifier when no URL was stamped', async () => {
+        const harness = await createLegacyHarness(requireScopes('repo:write'));
+        const sessionId = await initializeLegacy(harness.transport);
+        const response = await harness.transport.handleRequest(legacyRequest(toolCall(), sessionId), {
+            authInfo: { ...auth(['repo:read']), resource: new URL('https://api.example.com/mcp') }
+        });
+
+        expect(response.status).toBe(403);
+        expect(response.headers.get('WWW-Authenticate')).toContain(
+            'resource_metadata="https://api.example.com/.well-known/oauth-protected-resource/mcp"'
+        );
         await harness.transport.close();
     });
 });

--- a/packages/server/test/server/scopeChallenge.test.ts
+++ b/packages/server/test/server/scopeChallenge.test.ts
@@ -6,7 +6,7 @@ import * as z from 'zod/v4';
 
 import { McpServer } from '../../src/server/mcp';
 import type { ScopeChallengeHandler } from '../../src/server/scopeChallenge';
-import { requireScopes } from '../../src/server/scopeChallenge';
+import { createScopeChallengeResponse, requireScopes } from '../../src/server/scopeChallenge';
 import { WebStandardStreamableHTTPServerTransport } from '../../src/server/streamableHttp';
 
 const RESOURCE_METADATA_URL = 'https://auth.example.com/.well-known/oauth-protected-resource';
@@ -47,6 +47,25 @@ describe('requireScopes', () => {
         for (const scope of ['repo read', 'repo"read', String.raw`repo\read`, 'repo:read🚀']) {
             expect(() => requireScopes(scope)).toThrow('scope-token grammar');
         }
+    });
+});
+
+describe('createScopeChallengeResponse', () => {
+    it('uses an OAuth error body rather than a JSON-RPC Invalid Request error', async () => {
+        const response = createScopeChallengeResponse(
+            { scopes: ['repo:write'], errorDescription: 'Write access is required' },
+            RESOURCE_METADATA_URL
+        );
+
+        expect(response.status).toBe(403);
+        expect(response.headers.get('WWW-Authenticate')).toBe(
+            'Bearer error="insufficient_scope", error_description="Write access is required", scope="repo:write"' +
+                `, resource_metadata="${RESOURCE_METADATA_URL}"`
+        );
+        expect(await response.json()).toEqual({
+            error: 'insufficient_scope',
+            error_description: 'Write access is required'
+        });
     });
 });
 
@@ -159,7 +178,10 @@ describe('legacy Streamable HTTP scope preflight', () => {
         );
 
         expect(response.status).toBe(403);
-        expect(((await response.json()) as { id: unknown }).id).toBeNull();
+        expect(await response.json()).toEqual({
+            error: 'insufficient_scope',
+            error_description: 'Insufficient scope'
+        });
         expect(callback).toHaveBeenCalledTimes(1);
         expect(harness.calls).not.toHaveBeenCalled();
         await harness.transport.close();

--- a/packages/server/test/server/scopeChallenge.test.ts
+++ b/packages/server/test/server/scopeChallenge.test.ts
@@ -246,13 +246,25 @@ describe('legacy Streamable HTTP scope preflight', () => {
         const harness = await createLegacyHarness(requireScopes('repo:write'));
         const sessionId = await initializeLegacy(harness.transport);
         const response = await harness.transport.handleRequest(legacyRequest(toolCall(), sessionId), {
-            authInfo: { ...auth(['repo:read']), resource: new URL('https://api.example.com/mcp') }
+            authInfo: { ...auth(['repo:read']), resource: new URL('https://api.example.com/mcp?tenant=acme') }
         });
 
         expect(response.status).toBe(403);
         expect(response.headers.get('WWW-Authenticate')).toContain(
-            'resource_metadata="https://api.example.com/.well-known/oauth-protected-resource/mcp"'
+            'resource_metadata="https://api.example.com/.well-known/oauth-protected-resource/mcp?tenant=acme"'
         );
+        await harness.transport.close();
+    });
+
+    it('omits resource_metadata when an abstract RFC 8707 resource identifier cannot locate an RFC 9728 document', async () => {
+        const harness = await createLegacyHarness(requireScopes('repo:write'));
+        const sessionId = await initializeLegacy(harness.transport);
+        const response = await harness.transport.handleRequest(legacyRequest(toolCall(), sessionId), {
+            authInfo: { ...auth(['repo:read']), resource: new URL('urn:example:mcp') }
+        });
+
+        expect(response.status).toBe(403);
+        expect(response.headers.get('WWW-Authenticate')).not.toContain('resource_metadata');
         await harness.transport.close();
     });
 });

--- a/packages/server/test/server/scopeChallenge.test.ts
+++ b/packages/server/test/server/scopeChallenge.test.ts
@@ -44,8 +44,9 @@ describe('requireScopes', () => {
 
     it('rejects invalid static scope declarations', () => {
         expect(() => (requireScopes as (...scopes: string[]) => ScopeChallengeHandler)()).toThrow('at least one');
-        expect(() => requireScopes('repo read')).toThrow('without whitespace');
-        expect(() => requireScopes('repo:read🚀')).toThrow('printable ASCII');
+        for (const scope of ['repo read', 'repo"read', String.raw`repo\read`, 'repo:read🚀']) {
+            expect(() => requireScopes(scope)).toThrow('scope-token grammar');
+        }
     });
 });
 
@@ -172,6 +173,9 @@ describe('legacy Streamable HTTP scope preflight', () => {
             }),
             vi.fn<ScopeChallengeHandler>(() => ({ scopes: [] as unknown as [string, ...string[]] })),
             vi.fn<ScopeChallengeHandler>(() => ({ scopes: ['repo:read🚀'] })),
+            vi.fn<ScopeChallengeHandler>(() => ({ scopes: ['repo:read'], errorDescription: '' })),
+            vi.fn<ScopeChallengeHandler>(() => ({ scopes: ['repo:read'], errorDescription: 'Need "repo:read"' })),
+            vi.fn<ScopeChallengeHandler>(() => ({ scopes: ['repo:read'], errorDescription: String.raw`Need repo\read` })),
             vi.fn<ScopeChallengeHandler>(() => ({ scopes: ['repo:read'], errorDescription: 'Need 🚀 access' }))
         ]) {
             const harness = await createLegacyHarness(callback);
@@ -211,17 +215,17 @@ describe('legacy Streamable HTTP scope preflight', () => {
         expect(await server.resolveScopeChallenge({ request: toolCall('mutable'), authInfo: auth([]) })).toBeUndefined();
     });
 
-    it('escapes optional challenge auth parameters', async () => {
+    it('serializes an optional challenge description', async () => {
         const harness = await createLegacyHarness(() => ({
             scopes: ['repo:read'],
-            errorDescription: String.raw`Needs "repo:read", path\to\thing`
+            errorDescription: 'Needs repo:read, path/to/thing'
         }));
         const sessionId = await initializeLegacy(harness.transport);
         const response = await harness.transport.handleRequest(legacyRequest(toolCall(), sessionId), {
             authInfo: auth([])
         });
 
-        expect(response.headers.get('WWW-Authenticate')).toContain(String.raw`error_description="Needs \"repo:read\", path\\to\\thing"`);
+        expect(response.headers.get('WWW-Authenticate')).toContain('error_description="Needs repo:read, path/to/thing"');
         await harness.transport.close();
     });
 });

--- a/packages/server/test/server/scopeChallengeModern.test.ts
+++ b/packages/server/test/server/scopeChallengeModern.test.ts
@@ -86,6 +86,10 @@ describe('createMcpHandler scope preflight', () => {
         expect(response.headers.get('WWW-Authenticate')).toBe(
             'Bearer error="insufficient_scope", error_description="Insufficient scope", scope="repo:write"'
         );
+        expect(await response.json()).toEqual({
+            error: 'insufficient_scope',
+            error_description: 'Insufficient scope'
+        });
         expect(callback).toHaveBeenCalledWith({
             request: expect.objectContaining({
                 method: 'tools/call',

--- a/packages/server/test/server/scopeChallengeModern.test.ts
+++ b/packages/server/test/server/scopeChallengeModern.test.ts
@@ -18,7 +18,8 @@ const ENVELOPE = {
 };
 
 function request(method: string, params: Record<string, unknown>, extraHeaders: Record<string, string> = {}): Request {
-    const name = typeof params.name === 'string' ? params.name : undefined;
+    const candidateName = method === 'resources/read' ? params.uri : params.name;
+    const name = typeof candidateName === 'string' ? candidateName : undefined;
     return new Request('http://localhost/mcp', {
         method: 'POST',
         headers: {
@@ -171,5 +172,35 @@ describe('createMcpHandler scope preflight', () => {
 
         expect(response.status).toBe(200);
         expect(onCall).toHaveBeenCalledOnce();
+    });
+
+    it('challenges resource and prompt primitives before dispatch', async () => {
+        const onRead = vi.fn(async (uri: URL) => ({ contents: [{ uri: uri.href, text: 'secret' }] }));
+        const onPrompt = vi.fn(async () => ({
+            messages: [{ role: 'user' as const, content: { type: 'text' as const, text: 'secret' } }]
+        }));
+        const handler = createMcpHandler(
+            () => {
+                const server = new McpServer({ name: 'modern-scope', version: '1.0.0' });
+                server.registerResource('config', 'config://settings', { scopeChallenge: requireScopes('config:read') }, onRead);
+                server.registerPrompt('summarize', { scopeChallenge: requireScopes('prompt:read') }, onPrompt);
+                return server;
+            },
+            { scopeChallenge: { resourceMetadataUrl: RESOURCE_METADATA_URL } }
+        );
+
+        const resourceResponse = await handler.fetch(request('resources/read', { uri: 'config://settings' }), {
+            authInfo: auth([])
+        });
+        const promptResponse = await handler.fetch(request('prompts/get', { name: 'summarize', arguments: {} }), {
+            authInfo: auth([])
+        });
+
+        expect(resourceResponse.status).toBe(403);
+        expect(resourceResponse.headers.get('WWW-Authenticate')).toContain('scope="config:read"');
+        expect(promptResponse.status).toBe(403);
+        expect(promptResponse.headers.get('WWW-Authenticate')).toContain('scope="prompt:read"');
+        expect(onRead).not.toHaveBeenCalled();
+        expect(onPrompt).not.toHaveBeenCalled();
     });
 });

--- a/packages/server/test/server/scopeChallengeModern.test.ts
+++ b/packages/server/test/server/scopeChallengeModern.test.ts
@@ -6,6 +6,7 @@ import * as z from 'zod/v4';
 import { fromJsonSchema } from '../../src/fromJsonSchema';
 import { createMcpHandler } from '../../src/server/createMcpHandler';
 import { McpServer } from '../../src/server/mcp';
+import { requireBearerAuth } from '../../src/server/middleware/bearerAuth';
 import type { ScopeChallengeHandler } from '../../src/server/scopeChallenge';
 import { requireScopes } from '../../src/server/scopeChallenge';
 
@@ -38,11 +39,13 @@ function call(name: string, args: Record<string, unknown>, headers?: Record<stri
     return request('tools/call', { name, arguments: args }, headers);
 }
 
-function auth(scopes: string[]): AuthInfo {
-    return { token: 'token', clientId: 'client', scopes };
+function auth(scopes: string[], resourceMetadataUrl?: string): AuthInfo {
+    return { token: 'token', clientId: 'client', scopes, ...(resourceMetadataUrl !== undefined && { resourceMetadataUrl }) };
 }
 
 function createHandler(scopeChallenge: ScopeChallengeHandler, onCall = vi.fn(), responseMode?: 'json' | 'sse') {
+    // No handler-level scope-challenge configuration exists: registering the
+    // callback on the primitive is all it takes to arm the preflight.
     return createMcpHandler(
         () => {
             const server = new McpServer({ name: 'modern-scope', version: '1.0.0' });
@@ -59,10 +62,7 @@ function createHandler(scopeChallenge: ScopeChallengeHandler, onCall = vi.fn(), 
             );
             return server;
         },
-        {
-            ...(responseMode !== undefined && { responseMode }),
-            scopeChallenge: { resourceMetadataUrl: RESOURCE_METADATA_URL }
-        }
+        { ...(responseMode !== undefined && { responseMode }) }
     );
 }
 
@@ -80,8 +80,12 @@ describe('createMcpHandler scope preflight', () => {
         const response = await handler.fetch(incoming, { authInfo: auth(['repo:read']) });
 
         expect(response.status).toBe(403);
-        expect(response.headers.get('WWW-Authenticate')).toContain('scope="repo:write"');
-        expect(response.headers.get('WWW-Authenticate')).not.toContain('error_description');
+        // The bearer-auth formatter builds the header: error, then the default
+        // description, then the scope set; resource_metadata is omitted when
+        // the auth info carries no metadata URL.
+        expect(response.headers.get('WWW-Authenticate')).toBe(
+            'Bearer error="insufficient_scope", error_description="Insufficient scope", scope="repo:write"'
+        );
         expect(callback).toHaveBeenCalledWith({
             request: expect.objectContaining({
                 method: 'tools/call',
@@ -101,16 +105,13 @@ describe('createMcpHandler scope preflight', () => {
             properties: { region: { type: 'string', 'x-mcp-header': 'Region' } as Record<string, unknown> },
             required: ['region']
         });
-        const handler = createMcpHandler(
-            () => {
-                const server = new McpServer({ name: 'modern-scope', version: '1.0.0' });
-                server.registerTool('route', { inputSchema: routeSchema, scopeChallenge: callback }, async () => ({
-                    content: [{ type: 'text', text: 'ok' }]
-                }));
-                return server;
-            },
-            { scopeChallenge: { resourceMetadataUrl: RESOURCE_METADATA_URL } }
-        );
+        const handler = createMcpHandler(() => {
+            const server = new McpServer({ name: 'modern-scope', version: '1.0.0' });
+            server.registerTool('route', { inputSchema: routeSchema, scopeChallenge: callback }, async () => ({
+                content: [{ type: 'text', text: 'ok' }]
+            }));
+            return server;
+        });
 
         const response = await handler.fetch(call('route', { region: 'us-west1' }, { 'Mcp-Param-Region': 'eu' }), {
             authInfo: auth([])
@@ -122,16 +123,13 @@ describe('createMcpHandler scope preflight', () => {
     });
 
     it('keeps challenged tools discoverable and uses exact static all-of checks', async () => {
-        const handler = createMcpHandler(
-            () => {
-                const server = new McpServer({ name: 'modern-scope', version: '1.0.0' });
-                server.registerTool('scoped', { scopeChallenge: requireScopes('repo:read', 'org:read') }, async () => ({
-                    content: []
-                }));
-                return server;
-            },
-            { scopeChallenge: { resourceMetadataUrl: RESOURCE_METADATA_URL } }
-        );
+        const handler = createMcpHandler(() => {
+            const server = new McpServer({ name: 'modern-scope', version: '1.0.0' });
+            server.registerTool('scoped', { scopeChallenge: requireScopes('repo:read', 'org:read') }, async () => ({
+                content: []
+            }));
+            return server;
+        });
 
         const listResponse = await handler.fetch(request('tools/list', {}), { authInfo: auth([]) });
         expect(listResponse.status).toBe(200);
@@ -179,15 +177,12 @@ describe('createMcpHandler scope preflight', () => {
         const onPrompt = vi.fn(async () => ({
             messages: [{ role: 'user' as const, content: { type: 'text' as const, text: 'secret' } }]
         }));
-        const handler = createMcpHandler(
-            () => {
-                const server = new McpServer({ name: 'modern-scope', version: '1.0.0' });
-                server.registerResource('config', 'config://settings', { scopeChallenge: requireScopes('config:read') }, onRead);
-                server.registerPrompt('summarize', { scopeChallenge: requireScopes('prompt:read') }, onPrompt);
-                return server;
-            },
-            { scopeChallenge: { resourceMetadataUrl: RESOURCE_METADATA_URL } }
-        );
+        const handler = createMcpHandler(() => {
+            const server = new McpServer({ name: 'modern-scope', version: '1.0.0' });
+            server.registerResource('config', 'config://settings', { scopeChallenge: requireScopes('config:read') }, onRead);
+            server.registerPrompt('summarize', { scopeChallenge: requireScopes('prompt:read') }, onPrompt);
+            return server;
+        });
 
         const resourceResponse = await handler.fetch(request('resources/read', { uri: 'config://settings' }), {
             authInfo: auth([])
@@ -202,5 +197,72 @@ describe('createMcpHandler scope preflight', () => {
         expect(promptResponse.headers.get('WWW-Authenticate')).toContain('scope="prompt:read"');
         expect(onRead).not.toHaveBeenCalled();
         expect(onPrompt).not.toHaveBeenCalled();
+    });
+});
+
+describe('scope challenge resource_metadata derivation', () => {
+    it('advertises the metadata URL stamped onto the auth info', async () => {
+        const handler = createHandler(requireScopes('repo:write'));
+
+        const response = await handler.fetch(call('operate', {}), {
+            authInfo: auth(['repo:read'], RESOURCE_METADATA_URL)
+        });
+
+        expect(response.status).toBe(403);
+        expect(response.headers.get('WWW-Authenticate')).toBe(
+            'Bearer error="insufficient_scope", error_description="Insufficient scope", scope="repo:write"' +
+                `, resource_metadata="${RESOURCE_METADATA_URL}"`
+        );
+    });
+
+    it('carries the URL configured on requireBearerAuth through to the challenge header', async () => {
+        // The single configuration site: the bearer-auth gate stamps its
+        // resourceMetadataUrl onto the AuthInfo it returns, and the scope
+        // preflight reads it from there.
+        const gate = requireBearerAuth({
+            verifier: {
+                verifyAccessToken: async token => ({
+                    token,
+                    clientId: 'client',
+                    scopes: ['repo:read'],
+                    expiresAt: Math.floor(Date.now() / 1000) + 3600
+                })
+            },
+            resourceMetadataUrl: RESOURCE_METADATA_URL
+        });
+        const handler = createHandler(requireScopes('repo:write'));
+
+        const incoming = call('operate', {}, { Authorization: 'Bearer token-1' });
+        const gateResult = await gate(incoming);
+        expect(gateResult).not.toBeInstanceOf(Response);
+        const authInfo = gateResult as AuthInfo;
+        expect(authInfo.resourceMetadataUrl).toBe(RESOURCE_METADATA_URL);
+
+        const response = await handler.fetch(incoming, { authInfo });
+
+        expect(response.status).toBe(403);
+        expect(response.headers.get('WWW-Authenticate')).toContain(`resource_metadata="${RESOURCE_METADATA_URL}"`);
+    });
+
+    it('falls back to the well-known location for the RFC 8707 resource identifier', async () => {
+        const handler = createHandler(requireScopes('repo:write'));
+
+        const response = await handler.fetch(call('operate', {}), {
+            authInfo: { ...auth(['repo:read']), resource: new URL('https://api.example.com/mcp') }
+        });
+
+        expect(response.status).toBe(403);
+        expect(response.headers.get('WWW-Authenticate')).toContain(
+            'resource_metadata="https://api.example.com/.well-known/oauth-protected-resource/mcp"'
+        );
+    });
+
+    it('omits resource_metadata entirely when the auth info offers no URL', async () => {
+        const handler = createHandler(requireScopes('repo:write'));
+
+        const response = await handler.fetch(call('operate', {}), { authInfo: auth(['repo:read']) });
+
+        expect(response.status).toBe(403);
+        expect(response.headers.get('WWW-Authenticate')).not.toContain('resource_metadata');
     });
 });

--- a/packages/server/test/server/scopeChallengeModern.test.ts
+++ b/packages/server/test/server/scopeChallengeModern.test.ts
@@ -1,0 +1,175 @@
+import type { AuthInfo, JSONRPCRequest } from '@modelcontextprotocol/core-internal';
+import { CLIENT_CAPABILITIES_META_KEY, CLIENT_INFO_META_KEY, PROTOCOL_VERSION_META_KEY } from '@modelcontextprotocol/core-internal';
+import { describe, expect, it, vi } from 'vitest';
+import * as z from 'zod/v4';
+
+import { fromJsonSchema } from '../../src/fromJsonSchema';
+import { createMcpHandler } from '../../src/server/createMcpHandler';
+import { McpServer } from '../../src/server/mcp';
+import type { ScopeChallengeHandler } from '../../src/server/scopeChallenge';
+import { requireScopes } from '../../src/server/scopeChallenge';
+
+const MODERN = '2026-07-28';
+const RESOURCE_METADATA_URL = 'https://auth.example.com/.well-known/oauth-protected-resource';
+const ENVELOPE = {
+    [PROTOCOL_VERSION_META_KEY]: MODERN,
+    [CLIENT_INFO_META_KEY]: { name: 'scope-client', version: '1.0.0' },
+    [CLIENT_CAPABILITIES_META_KEY]: {}
+};
+
+function request(method: string, params: Record<string, unknown>, extraHeaders: Record<string, string> = {}): Request {
+    const name = typeof params.name === 'string' ? params.name : undefined;
+    return new Request('http://localhost/mcp', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            Accept: 'application/json, text/event-stream',
+            'mcp-protocol-version': MODERN,
+            'mcp-method': method,
+            ...(name !== undefined && { 'mcp-name': name }),
+            ...extraHeaders
+        },
+        body: JSON.stringify({ jsonrpc: '2.0', id: 7, method, params: { ...params, _meta: ENVELOPE } })
+    });
+}
+
+function call(name: string, args: Record<string, unknown>, headers?: Record<string, string>): Request {
+    return request('tools/call', { name, arguments: args }, headers);
+}
+
+function auth(scopes: string[]): AuthInfo {
+    return { token: 'token', clientId: 'client', scopes };
+}
+
+function createHandler(scopeChallenge: ScopeChallengeHandler, onCall = vi.fn(), responseMode?: 'json' | 'sse') {
+    return createMcpHandler(
+        () => {
+            const server = new McpServer({ name: 'modern-scope', version: '1.0.0' });
+            server.registerTool(
+                'operate',
+                {
+                    inputSchema: z.object({ mode: z.string().optional(), secret: z.string().optional() }),
+                    scopeChallenge
+                },
+                async args => {
+                    onCall(args);
+                    return { content: [{ type: 'text', text: 'ok' }] };
+                }
+            );
+            return server;
+        },
+        {
+            ...(responseMode !== undefined && { responseMode }),
+            scopeChallenge: { resourceMetadataUrl: RESOURCE_METADATA_URL }
+        }
+    );
+}
+
+describe('createMcpHandler scope preflight', () => {
+    it('passes the full parsed request and auth info to an async callback before invocation', async () => {
+        const callback = vi.fn<ScopeChallengeHandler>(async ({ request, authInfo }) => {
+            const args = (request.params as { arguments: { mode?: string } }).arguments;
+            return args.mode === 'write' && !authInfo?.scopes.includes('repo:write') ? { scopes: ['repo:write'] } : undefined;
+        });
+        const onCall = vi.fn();
+        const handler = createHandler(callback, onCall);
+        const incoming = call('operate', { mode: 'write', secret: 'high-cardinality-value' });
+
+        expect([...incoming.headers.keys()]).not.toContain('mcp-param-secret');
+        const response = await handler.fetch(incoming, { authInfo: auth(['repo:read']) });
+
+        expect(response.status).toBe(403);
+        expect(response.headers.get('WWW-Authenticate')).toContain('scope="repo:write"');
+        expect(response.headers.get('WWW-Authenticate')).not.toContain('error_description');
+        expect(callback).toHaveBeenCalledWith({
+            request: expect.objectContaining({
+                method: 'tools/call',
+                params: expect.objectContaining({
+                    arguments: { mode: 'write', secret: 'high-cardinality-value' }
+                })
+            }),
+            authInfo: auth(['repo:read'])
+        });
+        expect(onCall).not.toHaveBeenCalled();
+    });
+
+    it('runs the callback after Mcp-Param header/body parity checks', async () => {
+        const callback = vi.fn<ScopeChallengeHandler>(() => ({ scopes: ['route:read'] }));
+        const routeSchema = fromJsonSchema<{ region: string }>({
+            type: 'object',
+            properties: { region: { type: 'string', 'x-mcp-header': 'Region' } as Record<string, unknown> },
+            required: ['region']
+        });
+        const handler = createMcpHandler(
+            () => {
+                const server = new McpServer({ name: 'modern-scope', version: '1.0.0' });
+                server.registerTool('route', { inputSchema: routeSchema, scopeChallenge: callback }, async () => ({
+                    content: [{ type: 'text', text: 'ok' }]
+                }));
+                return server;
+            },
+            { scopeChallenge: { resourceMetadataUrl: RESOURCE_METADATA_URL } }
+        );
+
+        const response = await handler.fetch(call('route', { region: 'us-west1' }, { 'Mcp-Param-Region': 'eu' }), {
+            authInfo: auth([])
+        });
+
+        expect(response.status).toBe(400);
+        expect(((await response.json()) as { error: { code: number } }).error.code).toBe(-32_020);
+        expect(callback).not.toHaveBeenCalled();
+    });
+
+    it('keeps challenged tools discoverable and uses exact static all-of checks', async () => {
+        const handler = createMcpHandler(
+            () => {
+                const server = new McpServer({ name: 'modern-scope', version: '1.0.0' });
+                server.registerTool('scoped', { scopeChallenge: requireScopes('repo:read', 'org:read') }, async () => ({
+                    content: []
+                }));
+                return server;
+            },
+            { scopeChallenge: { resourceMetadataUrl: RESOURCE_METADATA_URL } }
+        );
+
+        const listResponse = await handler.fetch(request('tools/list', {}), { authInfo: auth([]) });
+        expect(listResponse.status).toBe(200);
+        const body = (await listResponse.json()) as { result: { tools: Array<{ name: string }> } };
+        expect(body.result.tools.map(tool => tool.name)).toContain('scoped');
+
+        const challengeResponse = await handler.fetch(call('scoped', {}), { authInfo: auth(['repo:read']) });
+        expect(challengeResponse.status).toBe(403);
+        expect(challengeResponse.headers.get('WWW-Authenticate')).toContain('scope="repo:read org:read"');
+    });
+
+    it('fails closed before SSE when the callback throws', async () => {
+        const onCall = vi.fn();
+        const handler = createHandler(
+            async () => {
+                throw new Error('scope lookup failed');
+            },
+            onCall,
+            'sse'
+        );
+
+        const response = await handler.fetch(call('operate', {}), { authInfo: auth([]) });
+
+        expect(response.status).toBe(500);
+        expect(response.headers.get('content-type')).toContain('application/json');
+        expect(onCall).not.toHaveBeenCalled();
+    });
+
+    it('continues when the callback returns undefined', async () => {
+        const callback = vi.fn<ScopeChallengeHandler>(({ request }: { request: JSONRPCRequest }) => {
+            const mode = (request.params as { arguments?: { mode?: unknown } }).arguments?.mode;
+            return mode === 'write' ? { scopes: ['repo:write'] } : undefined;
+        });
+        const onCall = vi.fn();
+        const handler = createHandler(callback, onCall);
+
+        const response = await handler.fetch(call('operate', { mode: 'read' }), { authInfo: auth([]) });
+
+        expect(response.status).toBe(200);
+        expect(onCall).toHaveBeenCalledOnce();
+    });
+});

--- a/packages/server/test/server/scopeChallengePrimitives.test.ts
+++ b/packages/server/test/server/scopeChallengePrimitives.test.ts
@@ -1,0 +1,198 @@
+import { randomUUID } from 'node:crypto';
+
+import type { AuthInfo, JSONRPCMessage, JSONRPCRequest } from '@modelcontextprotocol/core-internal';
+import { describe, expect, it, vi } from 'vitest';
+
+import { McpServer, ResourceTemplate } from '../../src/server/mcp';
+import type { ScopeChallengeHandler } from '../../src/server/scopeChallenge';
+import { requireScopes } from '../../src/server/scopeChallenge';
+import { WebStandardStreamableHTTPServerTransport } from '../../src/server/streamableHttp';
+
+const RESOURCE_METADATA_URL = 'https://auth.example.com/.well-known/oauth-protected-resource';
+
+function auth(scopes: string[]): AuthInfo {
+    return { token: 'token', clientId: 'client', scopes };
+}
+
+function readResource(uri: string, id: string | number = 'read-1'): JSONRPCRequest {
+    return { jsonrpc: '2.0', method: 'resources/read', params: { uri }, id };
+}
+
+function getPrompt(name: string, id: string | number = 'prompt-1'): JSONRPCRequest {
+    return { jsonrpc: '2.0', method: 'prompts/get', params: { name, arguments: {} }, id };
+}
+
+function request(body: JSONRPCMessage | JSONRPCMessage[], sessionId?: string): Request {
+    return new Request('http://localhost/mcp', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            Accept: 'application/json, text/event-stream',
+            ...(sessionId !== undefined && {
+                'mcp-session-id': sessionId,
+                'mcp-protocol-version': '2025-11-25'
+            })
+        },
+        body: JSON.stringify(body)
+    });
+}
+
+async function initialize(transport: WebStandardStreamableHTTPServerTransport): Promise<string> {
+    const response = await transport.handleRequest(
+        request({
+            jsonrpc: '2.0',
+            method: 'initialize',
+            params: {
+                clientInfo: { name: 'test-client', version: '1.0' },
+                protocolVersion: '2025-11-25',
+                capabilities: {}
+            },
+            id: 'init'
+        })
+    );
+    return response.headers.get('mcp-session-id')!;
+}
+
+async function createHarness(server: McpServer): Promise<{
+    transport: WebStandardStreamableHTTPServerTransport;
+    sessionId: string;
+}> {
+    const transport = new WebStandardStreamableHTTPServerTransport({
+        sessionIdGenerator: () => randomUUID(),
+        enableJsonResponse: true,
+        scopeChallenge: { resourceMetadataUrl: RESOURCE_METADATA_URL }
+    });
+    await server.connect(transport);
+    return { transport, sessionId: await initialize(transport) };
+}
+
+describe('scope challenges for resources and prompts', () => {
+    it('challenges static resources and prompts before their handlers run', async () => {
+        const server = new McpServer({ name: 'scope-primitives', version: '1.0.0' });
+        const read = vi.fn(async (uri: URL) => ({ contents: [{ uri: uri.href, text: 'secret' }] }));
+        const render = vi.fn(async () => ({
+            messages: [{ role: 'user' as const, content: { type: 'text' as const, text: 'secret' } }]
+        }));
+        server.registerResource(
+            'config',
+            'config://settings',
+            { mimeType: 'text/plain', scopeChallenge: requireScopes('config:read') },
+            read
+        );
+        server.registerPrompt('summarize', { scopeChallenge: requireScopes('prompt:read') }, render);
+        const { transport, sessionId } = await createHarness(server);
+
+        const resourceResponse = await transport.handleRequest(request(readResource('config://settings'), sessionId), {
+            authInfo: auth([])
+        });
+        const promptResponse = await transport.handleRequest(request(getPrompt('summarize'), sessionId), {
+            authInfo: auth([])
+        });
+
+        expect(resourceResponse.status).toBe(403);
+        expect(resourceResponse.headers.get('WWW-Authenticate')).toContain('scope="config:read"');
+        expect(promptResponse.status).toBe(403);
+        expect(promptResponse.headers.get('WWW-Authenticate')).toContain('scope="prompt:read"');
+        expect(read).not.toHaveBeenCalled();
+        expect(render).not.toHaveBeenCalled();
+        await transport.close();
+    });
+
+    it('routes a template resource request to its request-aware callback', async () => {
+        const callback = vi.fn<ScopeChallengeHandler>(({ request: incoming, authInfo }) => {
+            const uri = (incoming.params as { uri?: unknown }).uri;
+            const scopes = typeof uri === 'string' && uri.includes('/private/') ? (['repo:read'] as const) : (['public_repo'] as const);
+            return scopes.every(scope => authInfo?.scopes.includes(scope)) ? undefined : { scopes };
+        });
+        const read = vi.fn(async (uri: URL) => ({ contents: [{ uri: uri.href, text: 'repository' }] }));
+        const server = new McpServer({ name: 'scope-primitives', version: '1.0.0' });
+        server.registerResource(
+            'repository',
+            new ResourceTemplate('github://{owner}/{visibility}/{repo}', { list: undefined }),
+            { scopeChallenge: callback },
+            read
+        );
+        const { transport, sessionId } = await createHarness(server);
+
+        const privateResponse = await transport.handleRequest(request(readResource('github://octo/private/sdk'), sessionId), {
+            authInfo: auth(['public_repo'])
+        });
+        const publicResponse = await transport.handleRequest(request(readResource('github://octo/public/sdk'), sessionId), {
+            authInfo: auth(['public_repo'])
+        });
+
+        expect(privateResponse.status).toBe(403);
+        expect(privateResponse.headers.get('WWW-Authenticate')).toContain('scope="repo:read"');
+        expect(publicResponse.status).toBe(200);
+        expect(callback).toHaveBeenCalledWith({
+            request: expect.objectContaining({
+                method: 'resources/read',
+                params: { uri: 'github://octo/private/sdk' }
+            }),
+            authInfo: auth(['public_repo'])
+        });
+        expect(read).toHaveBeenCalledOnce();
+        await transport.close();
+    });
+
+    it('tracks callback updates and enabled state for every primitive', async () => {
+        const server = new McpServer({ name: 'scope-primitives', version: '1.0.0' });
+        const resource = server.registerResource(
+            'config',
+            'config://settings',
+            { scopeChallenge: requireScopes('config:read') },
+            async uri => ({ contents: [{ uri: uri.href, text: 'config' }] })
+        );
+        const template = server.registerResource(
+            'repository',
+            new ResourceTemplate('github://{owner}/{repo}', { list: undefined }),
+            { scopeChallenge: requireScopes('repo:read') },
+            async uri => ({ contents: [{ uri: uri.href, text: 'repository' }] })
+        );
+        const prompt = server.registerPrompt('summarize', { scopeChallenge: requireScopes('prompt:read') }, async () => ({
+            messages: []
+        }));
+
+        expect(await server.resolveScopeChallenge({ request: readResource('config://settings'), authInfo: auth([]) })).toEqual({
+            scopes: ['config:read']
+        });
+        expect(await server.resolveScopeChallenge({ request: readResource('github://octo/sdk'), authInfo: auth([]) })).toEqual({
+            scopes: ['repo:read']
+        });
+        expect(await server.resolveScopeChallenge({ request: getPrompt('summarize'), authInfo: auth([]) })).toEqual({
+            scopes: ['prompt:read']
+        });
+
+        resource.update({ scopeChallenge: requireScopes('config:admin') });
+        template.disable();
+        prompt.update({ scopeChallenge: null });
+
+        expect(await server.resolveScopeChallenge({ request: readResource('config://settings'), authInfo: auth([]) })).toEqual({
+            scopes: ['config:admin']
+        });
+        expect(await server.resolveScopeChallenge({ request: readResource('github://octo/sdk'), authInfo: auth([]) })).toBeUndefined();
+        expect(await server.resolveScopeChallenge({ request: getPrompt('summarize'), authInfo: auth([]) })).toBeUndefined();
+    });
+
+    it('leaves malformed and non-invocation requests to normal protocol handling', async () => {
+        const callback = vi.fn<ScopeChallengeHandler>(requireScopes('resource:read'));
+        const server = new McpServer({ name: 'scope-primitives', version: '1.0.0' });
+        server.registerResource('config', 'config://settings', { scopeChallenge: callback }, async uri => ({
+            contents: [{ uri: uri.href, text: 'config' }]
+        }));
+
+        expect(
+            await server.resolveScopeChallenge({
+                request: readResource('not a valid URI'),
+                authInfo: auth([])
+            })
+        ).toBeUndefined();
+        expect(
+            await server.resolveScopeChallenge({
+                request: { jsonrpc: '2.0', method: 'resources/list', params: {}, id: 'list' },
+                authInfo: auth([])
+            })
+        ).toBeUndefined();
+        expect(callback).not.toHaveBeenCalled();
+    });
+});

--- a/packages/server/test/server/scopeChallengePrimitives.test.ts
+++ b/packages/server/test/server/scopeChallengePrimitives.test.ts
@@ -8,8 +8,6 @@ import type { ScopeChallengeHandler } from '../../src/server/scopeChallenge';
 import { requireScopes } from '../../src/server/scopeChallenge';
 import { WebStandardStreamableHTTPServerTransport } from '../../src/server/streamableHttp';
 
-const RESOURCE_METADATA_URL = 'https://auth.example.com/.well-known/oauth-protected-resource';
-
 function auth(scopes: string[]): AuthInfo {
     return { token: 'token', clientId: 'client', scopes };
 }
@@ -59,8 +57,7 @@ async function createHarness(server: McpServer): Promise<{
 }> {
     const transport = new WebStandardStreamableHTTPServerTransport({
         sessionIdGenerator: () => randomUUID(),
-        enableJsonResponse: true,
-        scopeChallenge: { resourceMetadataUrl: RESOURCE_METADATA_URL }
+        enableJsonResponse: true
     });
     await server.connect(transport);
     return { transport, sessionId: await initialize(transport) };

--- a/test/conformance/src/everythingServer.ts
+++ b/test/conformance/src/everythingServer.ts
@@ -12,12 +12,14 @@ import { randomUUID } from 'node:crypto';
 import { localhostHostValidation } from '@modelcontextprotocol/express';
 import { NodeStreamableHTTPServerTransport, toNodeHandler } from '@modelcontextprotocol/node';
 import type {
+    AuthInfo,
     CallToolResult,
     EventId,
     EventStore,
     GetPromptResult,
     InputRequests,
     InputRequiredResult,
+    JSONRPCRequest,
     ReadResourceResult,
     ServerContext,
     StreamId
@@ -44,6 +46,28 @@ import * as z from 'zod/v4';
 // Server state
 const resourceSubscriptions = new Set<string>();
 const watchedResourceContent = 'Watched resource content';
+
+const SCOPE_CHALLENGE_LOW_TOKEN = 'mcp-conformance-scope-low';
+const SCOPE_CHALLENGE_FULL_TOKEN = 'mcp-conformance-scope-full';
+const SCOPE_CHALLENGE_BASELINE_SCOPE = 'mcp:conformance:baseline';
+const SCOPE_CHALLENGE_SCOPES = {
+    tool: ['mcp:conformance:tools:call', 'mcp:conformance:tools:test_simple_text'],
+    staticResource: ['mcp:conformance:resources:read', 'mcp:conformance:resources:static'],
+    templateResource: ['mcp:conformance:resources:read', 'mcp:conformance:resources:template:123'],
+    prompt: ['mcp:conformance:prompts:get', 'mcp:conformance:prompts:test_simple_prompt']
+} as const;
+
+type ConformanceScopeChallengeHandler = (context: {
+    request: JSONRPCRequest;
+    authInfo?: AuthInfo;
+}) => { scopes: readonly [string, ...string[]] } | undefined;
+
+function requireConformanceScopes(...scopes: readonly [string, ...string[]]): ConformanceScopeChallengeHandler {
+    return ({ authInfo }) => {
+        if (authInfo === undefined || scopes.every(scope => authInfo.scopes.includes(scope))) return;
+        return { scopes };
+    };
+}
 
 // Session management
 const transports: { [sessionId: string]: NodeStreamableHTTPServerTransport } = {};
@@ -244,17 +268,15 @@ function createMcpServer() {
     );
 
     // Simple text tool
-    mcpServer.registerTool(
-        'test_simple_text',
-        {
-            description: 'Tests simple text content response'
-        },
-        async (): Promise<CallToolResult> => {
-            return {
-                content: [{ type: 'text', text: 'This is a simple text response for testing.' }]
-            };
-        }
-    );
+    const simpleTextToolConfig = {
+        description: 'Tests simple text content response',
+        scopeChallenge: requireConformanceScopes(...SCOPE_CHALLENGE_SCOPES.tool)
+    };
+    mcpServer.registerTool('test_simple_text', simpleTextToolConfig, async (): Promise<CallToolResult> => {
+        return {
+            content: [{ type: 'text', text: 'This is a simple text response for testing.' }]
+        };
+    });
 
     // Image content tool
     mcpServer.registerTool(
@@ -1092,26 +1114,23 @@ function createMcpServer() {
     // ===== RESOURCES =====
 
     // Static text resource
-    mcpServer.registerResource(
-        'static-text',
-        'test://static-text',
-        {
-            title: 'Static Text Resource',
-            description: 'A static text resource for testing',
-            mimeType: 'text/plain'
-        },
-        async (): Promise<ReadResourceResult> => {
-            return {
-                contents: [
-                    {
-                        uri: 'test://static-text',
-                        mimeType: 'text/plain',
-                        text: 'This is the content of the static text resource.'
-                    }
-                ]
-            };
-        }
-    );
+    const staticTextResourceConfig = {
+        title: 'Static Text Resource',
+        description: 'A static text resource for testing',
+        mimeType: 'text/plain',
+        scopeChallenge: requireConformanceScopes(...SCOPE_CHALLENGE_SCOPES.staticResource)
+    };
+    mcpServer.registerResource('static-text', 'test://static-text', staticTextResourceConfig, async (): Promise<ReadResourceResult> => {
+        return {
+            contents: [
+                {
+                    uri: 'test://static-text',
+                    mimeType: 'text/plain',
+                    text: 'This is the content of the static text resource.'
+                }
+            ]
+        };
+    });
 
     // Static binary resource
     mcpServer.registerResource(
@@ -1136,14 +1155,16 @@ function createMcpServer() {
     );
 
     // Resource template
+    const resourceTemplateConfig = {
+        title: 'Resource Template',
+        description: 'A resource template with parameter substitution',
+        mimeType: 'application/json',
+        scopeChallenge: requireConformanceScopes(...SCOPE_CHALLENGE_SCOPES.templateResource)
+    };
     mcpServer.registerResource(
         'template',
         new ResourceTemplate('test://template/{id}/data', { list: undefined }),
-        {
-            title: 'Resource Template',
-            description: 'A resource template with parameter substitution',
-            mimeType: 'application/json'
-        },
+        resourceTemplateConfig,
         async (uri, variables): Promise<ReadResourceResult> => {
             const id = variables.id;
             return {
@@ -1202,26 +1223,24 @@ function createMcpServer() {
     // ===== PROMPTS =====
 
     // Simple prompt
-    mcpServer.registerPrompt(
-        'test_simple_prompt',
-        {
-            title: 'Simple Test Prompt',
-            description: 'A simple prompt without arguments'
-        },
-        async (): Promise<GetPromptResult> => {
-            return {
-                messages: [
-                    {
-                        role: 'user',
-                        content: {
-                            type: 'text',
-                            text: 'This is a simple prompt for testing.'
-                        }
+    const simplePromptConfig = {
+        title: 'Simple Test Prompt',
+        description: 'A simple prompt without arguments',
+        scopeChallenge: requireConformanceScopes(...SCOPE_CHALLENGE_SCOPES.prompt)
+    };
+    mcpServer.registerPrompt('test_simple_prompt', simplePromptConfig, async (): Promise<GetPromptResult> => {
+        return {
+            messages: [
+                {
+                    role: 'user',
+                    content: {
+                        type: 'text',
+                        text: 'This is a simple prompt for testing.'
                     }
-                ]
-            };
-        }
-    );
+                }
+            ]
+        };
+    });
 
     // Prompt with arguments
     mcpServer.registerPrompt(
@@ -1386,9 +1405,13 @@ function createMcpServer() {
 // `createMcpServer()` fixture definition the 2025 sessions use. Legacy traffic
 // never reaches this handler (see the routing in the POST handler below), so
 // the 2025 stateful session path is unchanged.
-const modernHandler = createMcpHandler(() => createMcpServer(), {
-    onerror: error => console.error('Modern-era MCP handler error:', error)
-});
+const PORT = process.env.PORT || 3000;
+const scopeChallengeResourceMetadataUrl = `http://localhost:${PORT}/.well-known/oauth-protected-resource/mcp`;
+const modernHandlerOptions = {
+    onerror: (error: Error) => console.error('Modern-era MCP handler error:', error),
+    scopeChallenge: { resourceMetadataUrl: scopeChallengeResourceMetadataUrl }
+};
+const modernHandler = createMcpHandler(() => createMcpServer(), modernHandlerOptions);
 const modernNodeHandler = toNodeHandler(modernHandler);
 
 /** Normalize a possibly-repeated HTTP header to its first value. */
@@ -1401,6 +1424,33 @@ function headerValue(value: string | string[] | undefined): string | undefined {
 const app = express();
 app.use(express.json());
 
+app.use((req, _res, next) => {
+    const authorization = req.header('authorization');
+    const token = authorization?.startsWith('Bearer ') ? authorization.slice('Bearer '.length) : undefined;
+    if (token === SCOPE_CHALLENGE_LOW_TOKEN) {
+        req.auth = {
+            token,
+            clientId: 'mcp-conformance-scope-challenge',
+            scopes: [SCOPE_CHALLENGE_BASELINE_SCOPE]
+        };
+    } else if (token === SCOPE_CHALLENGE_FULL_TOKEN) {
+        req.auth = {
+            token,
+            clientId: 'mcp-conformance-scope-challenge',
+            scopes: [
+                SCOPE_CHALLENGE_BASELINE_SCOPE,
+                ...new Set([
+                    ...SCOPE_CHALLENGE_SCOPES.tool,
+                    ...SCOPE_CHALLENGE_SCOPES.staticResource,
+                    ...SCOPE_CHALLENGE_SCOPES.templateResource,
+                    ...SCOPE_CHALLENGE_SCOPES.prompt
+                ])
+            ]
+        };
+    }
+    next();
+});
+
 // DNS rebinding protection: reject non-localhost Host headers
 app.use(localhostHostValidation());
 
@@ -1409,7 +1459,7 @@ app.use(
     cors({
         origin: '*',
         exposedHeaders: ['Mcp-Session-Id'],
-        allowedHeaders: ['Content-Type', 'mcp-session-id', 'last-event-id', 'mcp-protocol-version', 'mcp-method']
+        allowedHeaders: ['Authorization', 'Content-Type', 'mcp-session-id', 'last-event-id', 'mcp-protocol-version', 'mcp-method']
     })
 );
 
@@ -1560,7 +1610,6 @@ app.delete('/mcp', async (req: Request, res: Response) => {
 });
 
 // Start server
-const PORT = process.env.PORT || 3000;
 const httpServer = app.listen(PORT, () => {
     console.log(`MCP Conformance Test Server running on http://localhost:${PORT}`);
     console.log(`  - MCP endpoint: http://localhost:${PORT}/mcp`);

--- a/test/conformance/src/everythingServer.ts
+++ b/test/conformance/src/everythingServer.ts
@@ -1408,8 +1408,7 @@ function createMcpServer() {
 const PORT = process.env.PORT || 3000;
 const scopeChallengeResourceMetadataUrl = `http://localhost:${PORT}/.well-known/oauth-protected-resource/mcp`;
 const modernHandlerOptions = {
-    onerror: (error: Error) => console.error('Modern-era MCP handler error:', error),
-    scopeChallenge: { resourceMetadataUrl: scopeChallengeResourceMetadataUrl }
+    onerror: (error: Error) => console.error('Modern-era MCP handler error:', error)
 };
 const modernHandler = createMcpHandler(() => createMcpServer(), modernHandlerOptions);
 const modernNodeHandler = toNodeHandler(modernHandler);
@@ -1431,12 +1430,17 @@ app.use((req, _res, next) => {
         req.auth = {
             token,
             clientId: 'mcp-conformance-scope-challenge',
-            scopes: [SCOPE_CHALLENGE_BASELINE_SCOPE]
+            scopes: [SCOPE_CHALLENGE_BASELINE_SCOPE],
+            // Scope-challenge 403s derive their resource_metadata parameter
+            // from the verified AuthInfo (a real deployment's bearer-auth gate
+            // stamps this from its resourceMetadataUrl option).
+            resourceMetadataUrl: scopeChallengeResourceMetadataUrl
         };
     } else if (token === SCOPE_CHALLENGE_FULL_TOKEN) {
         req.auth = {
             token,
             clientId: 'mcp-conformance-scope-challenge',
+            resourceMetadataUrl: scopeChallengeResourceMetadataUrl,
             scopes: [
                 SCOPE_CHALLENGE_BASELINE_SCOPE,
                 ...new Set([


### PR DESCRIPTION
## Summary

- Add a per-primitive `scopeChallenge` callback for tools, static resources, resource templates, and prompts.
- Pass the full JSON-parsed request and optional verified `AuthInfo` so required scopes can depend on operation arguments or resource URIs.
- Add `requireScopes(...scopes)` for exact static all-of checks.
- Return RFC 6750 `403 insufficient_scope` responses before handler invocation or SSE setup.
- Apply identical preflight semantics to modern `createMcpHandler` requests and legacy Streamable HTTP requests/batches.
- Reuse the existing bearer-auth metadata configuration and `WWW-Authenticate` formatter rather than requiring duplicate handler/transport configuration.

## API

```ts
type ScopeChallenge = {
  scopes: readonly [string, ...string[]];
  errorDescription?: string;
};

type ScopeChallengeHandler = (context: {
  request: JSONRPCRequest;
  authInfo?: AuthInfo;
}) => ScopeChallenge | undefined | Promise<ScopeChallenge | undefined>;
```

Register the callback as `scopeChallenge` on `registerTool`, either `registerResource` form, or `registerPrompt`. No handler- or transport-level scope-challenge configuration is needed. Returning `undefined` continues; returning a challenge sends its exact, complete scope set. Throwing, rejecting, or returning an invalid scope set fails closed. Scope values must satisfy OAuth's `scope-token` grammar; an optional description must satisfy RFC 6750's `error-description` grammar.

`requireBearerAuth` and `verifyBearerToken` stamp their configured `resourceMetadataUrl` onto verified `AuthInfo`, so per-operation challenges advertise the same protected-resource metadata URL configured at the authentication gate. Verifier-provided metadata wins; otherwise an HTTP(S) RFC 8707 `resource` identifier supplies the RFC 9728 well-known fallback, preserving query components. The parameter is omitted when no valid source exists. All bearer challenges use the same formatter.

The SDK does not infer scope hierarchies, alternatives, unions, or missing scopes. Dynamic callbacks receive JSON-parsed wire values before primitive input schema validation/transformation.

## Cross-language conformance

The independent official scenario is in [modelcontextprotocol/conformance#481](https://github.com/modelcontextprotocol/conformance/pull/481), tracked by [conformance#480](https://github.com/modelcontextprotocol/conformance/issues/480).

- TypeScript SDK `main` at `dcc01028`: `SUCCESS=5`, `WARNING=12`, exit 1. All four upgraded-token retries succeeded; each primitive failed the expected HTTP 403, `WWW-Authenticate`, and single-challenge checks.
- This branch at `54e8deda`: `SUCCESS=17`, no failures or warnings, exit 0.

The official scenario is language-neutral and covers tools, static resources, resource templates, and prompts using portable fixture tokens and wire assertions.

## Validation

- `pnpm test:all`
- `pnpm build:all`
- `pnpm typecheck:all`
- `pnpm --filter @modelcontextprotocol/server check`
- `pnpm docs:examples`
- `pnpm docs:build`
- `pnpm sync:snippets --check`
- Official conformance #481 scenario: 17/17 at `54e8deda`
- GitHub CI across Node 20/22/24, Bun, Deno, examples, and client/server conformance