### PR TITLE
[SEP-2356] File input support for tools and elicitation

### DIFF
--- a/packages/core/src/types/schemas.ts
+++ b/packages/core/src/types/schemas.ts
@@ -1725,6 +1725,27 @@ export const BooleanSchemaSchema = z.object({
 });
 
 /**
+ * Value of the `mcpFile` JSON Schema extension keyword. When present on a
+ * `{"type": "string", "format": "uri"}` property, it marks the property as a
+ * file input that clients SHOULD render as a native file picker. Selected
+ * files are encoded as RFC 2397 data URIs. See {@link StringSchema.mcpFile}.
+ */
+export const FileInputDescriptorSchema = z.object({
+    /**
+     * Media type patterns and/or file extensions the client SHOULD filter the
+     * picker to (HTML `accept` attribute grammar). If omitted, any file type
+     * is accepted.
+     */
+    accept: z.array(z.string()).optional(),
+    /**
+     * Maximum decoded file size in bytes that the server will accept inline as
+     * a data URI. Servers MUST reject larger payloads with the
+     * `"file_too_large"` structured error reason.
+     */
+    maxSize: z.number().int().optional()
+});
+
+/**
  * Primitive schema definition for string fields.
  */
 export const StringSchemaSchema = z.object({
@@ -1734,7 +1755,13 @@ export const StringSchemaSchema = z.object({
     minLength: z.number().optional(),
     maxLength: z.number().optional(),
     format: z.enum(['email', 'uri', 'date', 'date-time']).optional(),
-    default: z.string().optional()
+    default: z.string().optional(),
+    /**
+     * Marks this string as a file input when `format` is `"uri"`. Clients SHOULD
+     * render a native file picker and populate the field with an RFC 2397 data
+     * URI for the selected file.
+     */
+    mcpFile: FileInputDescriptorSchema.optional()
 });
 
 /**

--- a/packages/core/src/types/spec.types.ts
+++ b/packages/core/src/types/spec.types.ts
@@ -1771,6 +1771,40 @@ export interface Tool extends BaseMetadata, Icons {
     _meta?: MetaObject;
 }
 
+/**
+ * Value of the `mcpFile` JSON Schema extension keyword. When present on a
+ * `{"type": "string", "format": "uri"}` property, it marks the property as a
+ * file input that clients SHOULD render as a native file picker. Selected
+ * files are encoded as RFC 2397 data URIs.
+ *
+ * Both fields are advisory; servers MUST still validate inputs independently.
+ *
+ * For {@link Tool.inputSchema} properties, `mcpFile` is added directly inside
+ * the JSON Schema property definition. For elicitation forms, it appears on
+ * {@link StringSchema}.
+ *
+ * @category `tools/list`
+ */
+export interface FileInputDescriptor {
+    /**
+     * Media type patterns and/or file extensions the client SHOULD filter the
+     * picker to. Supports exact MIME types (`"image/png"`), wildcard subtypes
+     * (`"image/*"`), and dot-prefixed extensions (`".pdf"`) following the same
+     * grammar as the HTML `accept` attribute. Extension entries are picker hints
+     * only; server-side validation compares MIME types. If omitted, any file
+     * type is accepted.
+     */
+    accept?: string[];
+
+    /**
+     * Maximum decoded file size in bytes that the server will accept inline as a
+     * data URI. Servers MUST reject larger payloads with the `"file_too_large"`
+     * structured error reason. For files larger than this, servers obtain the
+     * file via URL-mode elicitation instead of this property.
+     */
+    maxSize?: number;
+}
+
 /* Tasks */
 
 /**
@@ -2882,6 +2916,12 @@ export interface StringSchema {
     maxLength?: number;
     format?: 'email' | 'uri' | 'date' | 'date-time';
     default?: string;
+    /**
+     * Marks this string as a file input when `format` is `"uri"`. Clients SHOULD
+     * render a native file picker and populate the field with an RFC 2397 data
+     * URI for the selected file. See {@link FileInputDescriptor}.
+     */
+    mcpFile?: FileInputDescriptor;
 }
 
 /**

--- a/packages/core/src/types/types.ts
+++ b/packages/core/src/types/types.ts
@@ -44,6 +44,7 @@ import type {
     EmbeddedResourceSchema,
     EmptyResultSchema,
     EnumSchemaSchema,
+    FileInputDescriptorSchema,
     GetPromptRequestParamsSchema,
     GetPromptRequestSchema,
     GetPromptResultSchema,
@@ -300,6 +301,7 @@ export type PromptListChangedNotification = Infer<typeof PromptListChangedNotifi
 /* Tools */
 export type ToolAnnotations = Infer<typeof ToolAnnotationsSchema>;
 export type ToolExecution = Infer<typeof ToolExecutionSchema>;
+export type FileInputDescriptor = Infer<typeof FileInputDescriptorSchema>;
 export type Tool = Infer<typeof ToolSchema>;
 export type ListToolsRequest = Infer<typeof ListToolsRequestSchema>;
 export type ListToolsResult = Infer<typeof ListToolsResultSchema>;

--- a/packages/core/test/spec.types.test.ts
+++ b/packages/core/test/spec.types.test.ts
@@ -244,6 +244,10 @@ const sdkTypeChecks = {
         sdk = spec;
         spec = sdk;
     },
+    FileInputDescriptor: (sdk: SDKTypes.FileInputDescriptor, spec: SpecTypes.FileInputDescriptor) => {
+        sdk = spec;
+        spec = sdk;
+    },
     Tool: (sdk: SDKTypes.Tool, spec: SpecTypes.Tool) => {
         sdk = spec;
         spec = sdk;
@@ -804,7 +808,7 @@ type Assert<T extends true> = T;
  *   Cursor, TaskStatus
  */
 
-// -- Simple types (96) --
+// -- Simple types (97) --
 
 type _K_RequestParams = Assert<AssertExactKeys<SDKTypes.RequestParams, SpecTypes.RequestParams>>;
 type _K_NotificationParams = Assert<AssertExactKeys<SDKTypes.NotificationParams, SpecTypes.NotificationParams>>;
@@ -846,6 +850,7 @@ type _K_ResourceTemplateReference = Assert<AssertExactKeys<SDKTypes.ResourceTemp
 // @ts-expect-error Genuine mismatch: SDK PromptReference is missing 'title' from spec
 type _K_PromptReference = Assert<AssertExactKeys<SDKTypes.PromptReference, SpecTypes.PromptReference>>;
 type _K_ToolAnnotations = Assert<AssertExactKeys<SDKTypes.ToolAnnotations, SpecTypes.ToolAnnotations>>;
+type _K_FileInputDescriptor = Assert<AssertExactKeys<SDKTypes.FileInputDescriptor, SpecTypes.FileInputDescriptor>>;
 type _K_Tool = Assert<AssertExactKeys<SDKTypes.Tool, SpecTypes.Tool>>;
 type _K_ListToolsResult = Assert<AssertExactKeys<SDKTypes.ListToolsResult, SpecTypes.ListToolsResult>>;
 type _K_CallToolResult = Assert<AssertExactKeys<SDKTypes.CallToolResult, SpecTypes.CallToolResult>>;
@@ -1086,7 +1091,7 @@ describe('Spec Types', () => {
     it('should define some expected types', () => {
         expect(specTypes).toContain('JSONRPCNotification');
         expect(specTypes).toContain('ElicitResult');
-        expect(specTypes).toHaveLength(176);
+        expect(specTypes).toHaveLength(177);
     });
 
     it('should have up to date list of missing sdk types', () => {

--- a/packages/core/test/types.test.ts
+++ b/packages/core/test/types.test.ts
@@ -15,7 +15,9 @@ import {
     ToolChoiceSchema,
     ToolResultContentSchema,
     ToolSchema,
-    ToolUseContentSchema
+    ToolUseContentSchema,
+    FileInputDescriptorSchema,
+    StringSchemaSchema
 } from '../src/types/index.js';
 
 describe('Types', () => {
@@ -1008,6 +1010,73 @@ describe('Types', () => {
                 expect(result.data.requestedSchema.type).toBe('object');
                 expect(result.data.requestedSchema.$schema).toBe('https://json-schema.org/draft/2020-12/schema');
                 expect(result.data.requestedSchema.additionalProperties).toBe(false);
+            }
+        });
+    });
+
+    describe('File inputs (SEP-2356)', () => {
+        test('FileInputDescriptor: validates full descriptor', () => {
+            const result = FileInputDescriptorSchema.safeParse({
+                accept: ['image/png', 'image/*', '.pdf'],
+                maxSize: 5242880
+            });
+            expect(result.success).toBe(true);
+            if (result.success) {
+                expect(result.data.accept).toEqual(['image/png', 'image/*', '.pdf']);
+                expect(result.data.maxSize).toBe(5242880);
+            }
+        });
+
+        test('FileInputDescriptor: validates empty descriptor', () => {
+            expect(FileInputDescriptorSchema.safeParse({}).success).toBe(true);
+        });
+
+        test('FileInputDescriptor: rejects non-integer maxSize', () => {
+            expect(FileInputDescriptorSchema.safeParse({ maxSize: 1.5 }).success).toBe(false);
+        });
+
+        test('StringSchema: accepts mcpFile keyword with format uri', () => {
+            const result = StringSchemaSchema.safeParse({
+                type: 'string',
+                format: 'uri',
+                title: 'Profile photo',
+                mcpFile: { accept: ['image/*'], maxSize: 2097152 }
+            });
+            expect(result.success).toBe(true);
+            if (result.success) {
+                expect(result.data.mcpFile?.accept).toEqual(['image/*']);
+                expect(result.data.mcpFile?.maxSize).toBe(2097152);
+            }
+        });
+
+        test('StringSchema: mcpFile is optional', () => {
+            expect(StringSchemaSchema.safeParse({ type: 'string', format: 'uri' }).success).toBe(true);
+        });
+
+        test('ElicitRequestFormParams: validates spec example with mcpFile property', () => {
+            const result = ElicitRequestFormParamsSchema.safeParse({
+                mode: 'form',
+                message: 'Please select a profile photo.',
+                requestedSchema: {
+                    type: 'object',
+                    properties: {
+                        photo: {
+                            type: 'string',
+                            format: 'uri',
+                            title: 'Profile photo',
+                            mcpFile: { accept: ['image/*'], maxSize: 2097152 }
+                        }
+                    },
+                    required: ['photo']
+                }
+            });
+            expect(result.success).toBe(true);
+            if (result.success) {
+                const photo = result.data.requestedSchema.properties.photo;
+                if (photo?.type !== 'string' || !('mcpFile' in photo)) {
+                    throw new Error('expected StringSchema');
+                }
+                expect(photo.mcpFile?.accept).toEqual(['image/*']);
             }
         });
     });


### PR DESCRIPTION
## Summary

Prototype implementation of the file input SEP for the TypeScript SDK. Adds types and runtime schemas for declarative file inputs on tools and elicitation forms, gated by a new `fileInputs` client capability.

**SEP:** modelcontextprotocol/modelcontextprotocol#2356

> [!NOTE]
> This is a draft prototype tracking the spec proposal. It will be updated as the SEP evolves and should not be merged until the spec PR lands.

## Changes

- **`spec.types.ts`** — mirrors the spec additions:
  - `ClientCapabilities.fileInputs?: object`
  - `Tool.inputFiles?: { [argName: string]: FileInputDescriptor }`
  - `ElicitRequestFormParams.requestedFiles?: { [fieldName: string]: FileInputDescriptor }`
  - `FileInputDescriptor` interface (`accept?: string[]`, `maxSize?: number`)
  - `StringArraySchema` added to `PrimitiveSchemaDefinition` union
- **`types.ts`** — corresponding Zod runtime schemas (`FileInputDescriptorSchema`, `StringArraySchemaSchema`, field additions on `ToolSchema`, `ElicitRequestFormParamsSchema`, `ClientCapabilitiesSchema`)
- Tests for schema parsing and spec-type mutual assignability