### PR TITLE
fix: handle EPIPE errors in StdioServerTransport gracefully

### DIFF
--- a/.changeset/fix-stdio-epipe-crash.md
+++ b/.changeset/fix-stdio-epipe-crash.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/server': patch
+---
+
+Handle EPIPE errors in StdioServerTransport gracefully instead of crashing. When a client disconnects abruptly, the transport now catches stdout write errors, forwards them to `onerror`, and closes cleanly.

--- a/packages/server/src/server/stdio.ts
+++ b/packages/server/src/server/stdio.ts
@@ -37,6 +37,10 @@ export class StdioServerTransport implements Transport {
     _onerror = (error: Error) => {
         this.onerror?.(error);
     };
+    _onstdouterror = (error: Error) => {
+        this.onerror?.(error);
+        void this.close();
+    };
 
     /**
      * Starts listening for messages on `stdin`.
@@ -51,6 +55,7 @@ export class StdioServerTransport implements Transport {
         this._started = true;
         this._stdin.on('data', this._ondata);
         this._stdin.on('error', this._onerror);
+        this._stdout.on('error', this._onstdouterror);
     }
 
     private processReadBuffer() {
@@ -72,6 +77,7 @@ export class StdioServerTransport implements Transport {
         // Remove our event listeners first
         this._stdin.off('data', this._ondata);
         this._stdin.off('error', this._onerror);
+        this._stdout.off('error', this._onstdouterror);
 
         // Check if we were the only data listener
         const remainingDataListeners = this._stdin.listenerCount('data');
@@ -87,12 +93,16 @@ export class StdioServerTransport implements Transport {
     }
 
     send(message: JSONRPCMessage): Promise<void> {
-        return new Promise(resolve => {
+        return new Promise((resolve, reject) => {
             const json = serializeMessage(message);
-            if (this._stdout.write(json)) {
-                resolve();
-            } else {
-                this._stdout.once('drain', resolve);
+            try {
+                if (this._stdout.write(json)) {
+                    resolve();
+                } else {
+                    this._stdout.once('drain', resolve);
+                }
+            } catch (error) {
+                reject(error);
             }
         });
     }

--- a/packages/server/test/server/stdio.test.ts
+++ b/packages/server/test/server/stdio.test.ts
@@ -102,3 +102,64 @@ test('should read multiple messages', async () => {
     await finished;
     expect(readMessages).toEqual(messages);
 });
+
+test('should handle stdout write errors gracefully', async () => {
+    const brokenOutput = new Writable({
+        write(_chunk, _encoding, callback) {
+            callback(new Error('write EPIPE'));
+        }
+    });
+
+    const server = new StdioServerTransport(input, brokenOutput);
+
+    const errors: Error[] = [];
+    server.onerror = error => {
+        errors.push(error);
+    };
+
+    let didClose = false;
+    server.onclose = () => {
+        didClose = true;
+    };
+
+    await server.start();
+
+    const message: JSONRPCMessage = {
+        jsonrpc: '2.0',
+        id: 1,
+        result: {}
+    };
+
+    // The send itself should resolve (write returns true before async error),
+    // but the error handler on the stream should fire and trigger close.
+    await server.send(message);
+
+    // Allow the async error callback to fire
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0]!.message).toContain('EPIPE');
+    expect(didClose).toBe(true);
+});
+
+test('should handle synchronous stdout write throws gracefully', async () => {
+    const throwingOutput = new Writable({
+        write() {
+            throw new Error('write EPIPE');
+        }
+    });
+
+    const server = new StdioServerTransport(input, throwingOutput);
+    server.onerror = () => {};
+
+    await server.start();
+
+    const message: JSONRPCMessage = {
+        jsonrpc: '2.0',
+        id: 1,
+        result: {}
+    };
+
+    // send() should reject instead of crashing the process
+    await expect(server.send(message)).rejects.toThrow('EPIPE');
+});


### PR DESCRIPTION
**Note: This PR was authored by Claude (AI), operated by @maxwellcalkin.**

Fixes #1564

## Problem

When an MCP client disconnects abruptly (closes stdio pipes before the server can write a response), `stdout.write()` throws an unhandled `EPIPE` error that crashes the entire Node.js process:

```
node:events:486
      throw er; // Unhandled 'error' event
      ^
Error: EPIPE: broken pipe, write
    at Socket._write (node:internal/net:75:18)
    ...
    at StdioServerTransport.send (...)
```

This happens because `StdioServerTransport` has no `error` event listener on the stdout stream, and `stdout.write()` in `send()` is not wrapped in error handling.

## Fix

Three changes to `StdioServerTransport`:

1. **Add `_onstdouterror` handler** — an arrow function (matching the existing pattern for `_ondata`/`_onerror`) that forwards stdout errors to `onerror` and triggers a clean `close()`.

2. **Register/unregister the listener** — `start()` adds `this._stdout.on('error', this._onstdouterror)`; `close()` removes it with `.off()`.

3. **Wrap `stdout.write()` in try/catch** in `send()` — if `write()` throws synchronously, the promise rejects instead of crashing the process.

This matches how the client-side `StdioClientTransport` already handles errors on `stdin` and `stdout`.

## Tests

Added two new tests:
- **"should handle stdout write errors gracefully"** — verifies that async write errors (callback with error) trigger `onerror` and `close()`
- **"should handle synchronous stdout write throws gracefully"** — verifies that synchronous `write()` throws are caught and the promise rejects

## Changeset

Included a patch changeset for `@modelcontextprotocol/server`.