### PR TITLE
feat(client): add periodic ping support for connection health monitoring

### DIFF
--- a/packages/client/src/client/client.ts
+++ b/packages/client/src/client/client.ts
@@ -261,7 +261,7 @@ export class Client extends Protocol<ClientContext> {
         this._enforceStrictCapabilities = options?.enforceStrictCapabilities ?? false;
         this._pingConfig = {
             enabled: options?.ping?.enabled ?? false,
-            intervalMs: options?.ping?.intervalMs ?? 30000,
+            intervalMs: options?.ping?.intervalMs ?? 30_000
         };
 
         // Store list changed config for setup after connection (when we know server capabilities)

--- a/packages/client/test/client/ping.test.ts
+++ b/packages/client/test/client/ping.test.ts
@@ -71,7 +71,9 @@ describe('Client periodic ping', () => {
 
         // Mock the internal _requestWithSchema to track ping calls
         const originalRequest = (client as unknown as { _requestWithSchema: (...args: unknown[]) => Promise<unknown> })._requestWithSchema;
-        (client as unknown as { _requestWithSchema: (...args: unknown[]) => Promise<unknown> })._requestWithSchema = async (...args: unknown[]) => {
+        (client as unknown as { _requestWithSchema: (...args: unknown[]) => Promise<unknown> })._requestWithSchema = async (
+            ...args: unknown[]
+        ) => {
             const request = args[0] as { method: string };
             if (request?.method === 'ping') {
                 pingCalls++;
@@ -148,8 +150,11 @@ describe('Client periodic ping', () => {
         );
 
         let customPingCalls = 0;
-        const originalRequest = (customIntervalClient as unknown as { _requestWithSchema: (...args: unknown[]) => Promise<unknown> })._requestWithSchema;
-        (customIntervalClient as unknown as { _requestWithSchema: (...args: unknown[]) => Promise<unknown> })._requestWithSchema = async (...args: unknown[]) => {
+        const originalRequest = (customIntervalClient as unknown as { _requestWithSchema: (...args: unknown[]) => Promise<unknown> })
+            ._requestWithSchema;
+        (customIntervalClient as unknown as { _requestWithSchema: (...args: unknown[]) => Promise<unknown> })._requestWithSchema = async (
+            ...args: unknown[]
+        ) => {
             const request = args[0] as { method: string };
             if (request?.method === 'ping') {
                 customPingCalls++;
@@ -179,7 +184,9 @@ describe('Client periodic ping', () => {
 
         // Mock ping to fail
         const originalRequest = (client as unknown as { _requestWithSchema: (...args: unknown[]) => Promise<unknown> })._requestWithSchema;
-        (client as unknown as { _requestWithSchema: (...args: unknown[]) => Promise<unknown> })._requestWithSchema = async (...args: unknown[]) => {
+        (client as unknown as { _requestWithSchema: (...args: unknown[]) => Promise<unknown> })._requestWithSchema = async (
+            ...args: unknown[]
+        ) => {
             const request = args[0] as { method: string };
             if (request?.method === 'ping') {
                 throw new Error('Ping failed');


### PR DESCRIPTION
Fixes #1000

## Summary

This PR implements the missing periodic ping functionality for the MCP TypeScript SDK Client, as specified in the MCP protocol. The implementation allows automatic connection health monitoring by sending ping requests at a configurable interval.

## Changes

- Added `PingConfig` interface to configure periodic ping options
- Added `ping` configuration option to `ClientOptions`
- Implemented `_startPeriodicPing()` method to begin periodic ping after connection
- Implemented `_stopPeriodicPing()` method to stop periodic ping on close
- Override `close()` method to ensure periodic ping is stopped when disconnecting
- Default configuration: disabled (opt-in), 30 second interval when enabled
- Ping failures are reported via the `onerror` callback without stopping the interval

## Usage

```typescript
const client = new Client(
    { name: 'my-client', version: '1.0.0' },
    {
        ping: {
            enabled: true,
            intervalMs: 60000 // Ping every 60 seconds
        }
    }
);

// Handle ping errors
client.onerror = (error) => {
    if (error.message.includes('Periodic ping failed')) {
        console.warn('Connection health check failed:', error);
    }
};

await client.connect(transport);
// Periodic pings will start automatically after connection
```

## Testing

Added comprehensive test suite covering:
- Periodic ping disabled by default
- Periodic ping starts when enabled after connection
- Periodic ping stops on client close
- Custom interval configuration
- Graceful error handling with onerror callback
- Configuration defaults

## Diff Stats

```
 packages/client/src/client/client.ts     |  90 +++++++++++++
 packages/client/test/client/ping.test.ts | 214 +++++++++++++++++++++++++++++++
 2 files changed, 304 insertions(+)
```