### PR TITLE
fix: sanitize internal error details in tool error responses

### DIFF
--- a/.changeset/sanitize-tool-errors.md
+++ b/.changeset/sanitize-tool-errors.md
@@ -1,0 +1,5 @@
+---
+"@modelcontextprotocol/server": patch
+---
+
+fix: sanitize internal error details in tool error responses

--- a/packages/server/src/server/mcp.ts
+++ b/packages/server/src/server/mcp.ts
@@ -246,7 +246,7 @@ export class McpServer {
                 if (error instanceof ToolError) {
                     return this.createToolError(error.message);
                 }
-                return this.createToolError("Internal error");
+                return this.createToolError('Internal error');
             }
         });
 

--- a/packages/server/src/server/mcp.ts
+++ b/packages/server/src/server/mcp.ts
@@ -51,6 +51,30 @@ import type { ServerOptions } from './server.js';
 import { Server } from './server.js';
 
 /**
+ * An error that tool handlers can throw to return a user-visible error message
+ * to the MCP client. Unlike generic errors (which are sanitized to prevent
+ * leaking internal details), ToolError messages are passed through to the client
+ * as-is in a CallToolResult with isError: true.
+ *
+ * @example
+ * ```ts
+ * server.registerTool('my-tool', {}, async () => {
+ *     // This message will be visible to the client
+ *     throw new ToolError('Invalid input: missing required field "name"');
+ * });
+ * ```
+ *
+ * Any other error thrown from a tool handler will result in a generic
+ * "Internal error" message being returned to the client.
+ */
+export class ToolError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'ToolError';
+    }
+}
+
+/**
  * High-level MCP server that provides a simpler API for working with resources, tools, and prompts.
  * For advanced usage (like sending notifications or setting custom request handlers), use the underlying
  * {@linkcode Server} instance available via the {@linkcode McpServer.server | server} property.
@@ -213,10 +237,16 @@ export class McpServer {
                 await this.validateToolOutput(tool, result, request.params.name);
                 return result;
             } catch (error) {
-                if (error instanceof ProtocolError && error.code === ProtocolErrorCode.UrlElicitationRequired) {
-                    throw error; // Return the error to the caller without wrapping in CallToolResult
+                if (error instanceof ProtocolError) {
+                    if (error.code === ProtocolErrorCode.UrlElicitationRequired) {
+                        throw error;
+                    }
+                    return this.createToolError(error.message);
                 }
-                return this.createToolError(error instanceof Error ? error.message : String(error));
+                if (error instanceof ToolError) {
+                    return this.createToolError(error.message);
+                }
+                return this.createToolError("Internal error");
             }
         });
 

--- a/test/integration/test/server/mcp.test.ts
+++ b/test/integration/test/server/mcp.test.ts
@@ -8,7 +8,7 @@ import {
     UriTemplate,
     UrlElicitationRequiredError
 } from '@modelcontextprotocol/core';
-import { completable, McpServer, ResourceTemplate } from '@modelcontextprotocol/server';
+import { completable, McpServer, ResourceTemplate, ToolError } from '@modelcontextprotocol/server';
 import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 import * as z from 'zod/v4';
 
@@ -1745,7 +1745,45 @@ describe('Zod v4', () => {
             expect(result.content).toEqual([
                 {
                     type: 'text',
-                    text: 'Tool execution failed'
+                    text: 'Internal error'
+                }
+            ]);
+        });
+
+        /***
+         * Test: ToolError should expose message to client
+         */
+        test('should expose ToolError message to client', async () => {
+            const mcpServer = new McpServer({
+                name: 'test server',
+                version: '1.0'
+            });
+
+            const client = new Client({
+                name: 'test client',
+                version: '1.0'
+            });
+
+            mcpServer.registerTool('tool-error-test', {}, async () => {
+                throw new ToolError('Invalid input: missing required field');
+            });
+
+            const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+            await Promise.all([client.connect(clientTransport), mcpServer.server.connect(serverTransport)]);
+
+            const result = await client.request({
+                method: 'tools/call',
+                params: {
+                    name: 'tool-error-test'
+                }
+            });
+
+            expect(result.isError).toBe(true);
+            expect(result.content).toEqual([
+                {
+                    type: 'text',
+                    text: 'Invalid input: missing required field'
                 }
             ]);
         });
@@ -6734,7 +6772,7 @@ describe('Zod v4', () => {
 
             // Should receive an error since cancelled tasks don't have results
             expect(result).toHaveProperty('content');
-            expect(result.content).toEqual([{ type: 'text' as const, text: expect.stringContaining('has no result stored') }]);
+            expect(result.content).toEqual([{ type: 'text' as const, text: 'Internal error' }]);
 
             // Wait for async operations to complete
             await waitForLatch();


### PR DESCRIPTION
## Summary

Fixes #1429

Unhandled exceptions thrown from tool handlers were previously exposed to MCP clients with their full error message, potentially leaking sensitive internal details (stack traces, hostnames, connection strings, etc.).

This PR:

- Introduces a new `ToolError` class that tool authors can throw when they intentionally want an error message returned to the client
- Sanitizes all other unhandled errors to a generic `"Internal error"` message
- Preserves `ProtocolError` messages (SDK-generated validation errors that are already safe)
- Continues to re-throw `UrlElicitationRequiredError` as before

### Usage

```typescript
import { McpServer, ToolError } from '@modelcontextprotocol/server';

server.registerTool('my-tool', {}, async () => {
    // This message WILL be visible to the client
    throw new ToolError('Invalid input: missing required field "name"');
});

server.registerTool('my-other-tool', {}, async () => {
    // This message will NOT be visible — client sees "Internal error"
    throw new Error('Connection to internal DB failed at 10.0.0.5:5432');
});
```

## Test plan

- [x] Updated existing test for generic `Error` to expect `"Internal error"` instead of the raw message
- [x] Added new test verifying `ToolError` messages are passed through to the client
- [x] Updated task cancellation test to expect sanitized error
- [x] All 384 integration tests pass (1 pre-existing Cloudflare Workers failure on Windows unrelated to this change)