### PR TITLE
fix(client): add Accept header in SSEClientTransport.send()

### DIFF
--- a/packages/client/src/client/sse.ts
+++ b/packages/client/src/client/sse.ts
@@ -251,6 +251,7 @@ export class SSEClientTransport implements Transport {
         try {
             const headers = await this._commonHeaders();
             headers.set('content-type', 'application/json');
+            headers.set('accept', 'application/json, text/event-stream');
             const init = {
                 ...this._requestInit,
                 method: 'POST',


### PR DESCRIPTION
## Problem

SSEClientTransport's send() method was missing the Accept header when making POST requests to MCP servers. This caused compatibility issues with MCP servers that strictly require the `Accept: application/json, text/event-stream` header for Streamable HTTP transport.

## Solution

Added the Accept header in SSEClientTransport.send() method to match the behavior of StreamableHTTPClientTransport:

```typescript
headers.set('accept', 'application/json, text/event-stream');
```

## Testing

- Verified the fix resolves connectivity issues with Zhipu's MCP server (https://open.bigmodel.cn)
- Before: Server returned error "Accept header must include both application/json and text/event-stream"
- After: Server accepts the request and returns proper SSE response

## Comparison

| Transport | Before | After |
|-----------|--------|-------|
| StreamableHTTPClientTransport | ✅ Accept header present | ✅ No change |
| SSEClientTransport | ❌ Missing Accept header | ✅ Accept header added |

This aligns the two transports and improves MCP server compatibility.