### PR TITLE
fix(server): include request URL in RequestInfo

### DIFF
--- a/packages/core/src/types/types.ts
+++ b/packages/core/src/types/types.ts
@@ -2397,6 +2397,11 @@ type Infer<Schema extends z.ZodTypeAny> = Flatten<z.infer<Schema>>;
  */
 export interface RequestInfo {
     /**
+     * The full request URL.
+     */
+    url: string;
+
+    /**
      * The headers of the request.
      */
     headers: Headers;

--- a/packages/middleware/node/test/streamableHttp.test.ts
+++ b/packages/middleware/node/test/streamableHttp.test.ts
@@ -370,7 +370,10 @@ describe('Zod v4', () => {
                 id: 'call-1'
             };
 
-            const response = await sendPostRequest(baseUrl, toolCallMessage, sessionId);
+            const requestUrl = new URL(baseUrl);
+            requestUrl.searchParams.set('tenant', 'acme-corp');
+
+            const response = await sendPostRequest(requestUrl, toolCallMessage, sessionId);
             expect(response.status).toBe(200);
 
             const text = await readSSEEvent(response);
@@ -409,6 +412,7 @@ describe('Zod v4', () => {
                     // Convert Headers object to plain object for JSON serialization
                     // Headers is a Web API class that doesn't serialize with JSON.stringify
                     const serializedRequestInfo = {
+                        url: ctx.http?.req?.url,
                         headers: Object.fromEntries(ctx.http?.req?.headers ?? new Headers())
                     };
                     return {
@@ -432,7 +436,10 @@ describe('Zod v4', () => {
                 id: 'call-1'
             };
 
-            const response = await sendPostRequest(baseUrl, toolCallMessage, sessionId);
+            const requestUrl = new URL(baseUrl);
+            requestUrl.searchParams.set('tenant', 'acme-corp');
+
+            const response = await sendPostRequest(requestUrl, toolCallMessage, sessionId);
             expect(response.status).toBe(200);
 
             const text = await readSSEEvent(response);
@@ -455,6 +462,7 @@ describe('Zod v4', () => {
 
             const requestInfo = JSON.parse(eventData.result.content[1].text);
             expect(requestInfo).toMatchObject({
+                url: requestUrl.toString(),
                 headers: {
                     'content-type': 'application/json',
                     accept: 'application/json, text/event-stream',

--- a/packages/server/src/server/streamableHttp.ts
+++ b/packages/server/src/server/streamableHttp.ts
@@ -628,6 +628,7 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
 
             // Build request info from headers
             const requestInfo: RequestInfo = {
+                url: req.url,
                 headers: req.headers
             };
 


### PR DESCRIPTION
## Summary
- add the full request URL to `RequestInfo`
- populate it when building HTTP request context for server handlers
- extend the request-info regression test to verify query parameters are preserved

Fixes #1530.

## Testing
- `pnpm --filter @modelcontextprotocol/node test -- --run -t "should pass request info to tool callback"`
- `pnpm --filter @modelcontextprotocol/core typecheck && pnpm --filter @modelcontextprotocol/server typecheck && pnpm --filter @modelcontextprotocol/node typecheck`
- `pnpm --filter @modelcontextprotocol/core lint && pnpm --filter @modelcontextprotocol/server lint && pnpm --filter @modelcontextprotocol/node lint`