### PR TITLE
fix: surface input validation errors for task-augmented tool calls

### DIFF
--- a/packages/server/src/server/mcp.ts
+++ b/packages/server/src/server/mcp.ts
@@ -216,6 +216,14 @@ export class McpServer {
                 if (error instanceof ProtocolError && error.code === ProtocolErrorCode.UrlElicitationRequired) {
                     throw error; // Return the error to the caller without wrapping in CallToolResult
                 }
+                if (
+                    request.params.task &&
+                    error instanceof ProtocolError &&
+                    error.code === ProtocolErrorCode.InvalidParams &&
+                    error.message.startsWith(`MCP error ${ProtocolErrorCode.InvalidParams}: Input validation error:`)
+                ) {
+                    throw error; // Propagate input schema validation failures as protocol errors for task-augmented calls
+                }
                 return this.createToolError(error instanceof Error ? error.message : String(error));
             }
         });

--- a/test/integration/test/server/mcp.test.ts
+++ b/test/integration/test/server/mcp.test.ts
@@ -6623,6 +6623,105 @@ describe('Zod v4', () => {
             taskStore.cleanup();
         });
 
+        test('should surface input validation errors for task-augmented tool calls', async () => {
+            const taskStore = new InMemoryTaskStore();
+
+            const mcpServer = new McpServer(
+                {
+                    name: 'test server',
+                    version: '1.0'
+                },
+                {
+                    capabilities: {
+                        tools: {},
+                        tasks: {
+                            requests: {
+                                tools: {
+                                    call: {}
+                                }
+                            }
+                        }
+                    },
+                    taskStore
+                }
+            );
+
+            const client = new Client(
+                {
+                    name: 'test client',
+                    version: '1.0'
+                },
+                {
+                    capabilities: {
+                        tasks: {
+                            requests: {
+                                tools: {
+                                    call: {}
+                                }
+                            }
+                        }
+                    }
+                }
+            );
+
+            mcpServer.experimental.tasks.registerToolTask(
+                'task-tool-validation',
+                {
+                    description: 'A task tool with validated input',
+                    inputSchema: z.object({
+                        duration: z.number().min(500)
+                    }),
+                    execution: {
+                        taskSupport: 'required'
+                    }
+                },
+                {
+                    createTask: async ({ duration }, ctx) => {
+                        const task = await ctx.task.store.createTask({ ttl: duration, pollInterval: 100 });
+                        return { task };
+                    },
+                    getTask: async (_args, ctx) => {
+                        const task = await ctx.task.store.getTask(ctx.task.id);
+                        if (!task) {
+                            throw new Error('Task not found');
+                        }
+                        return task;
+                    },
+                    getTaskResult: async (_data, ctx) => {
+                        const result = await ctx.task.store.getTaskResult(ctx.task.id);
+                        return result as CallToolResult;
+                    }
+                }
+            );
+
+            const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+            await Promise.all([client.connect(clientTransport), mcpServer.connect(serverTransport)]);
+
+            try {
+                await client.request({
+                    method: 'tools/call',
+                    params: {
+                        name: 'task-tool-validation',
+                        arguments: { duration: 100 },
+                        task: { ttl: 60_000 }
+                    }
+                });
+
+                expect.unreachable('Expected task-augmented validation error to be thrown');
+            } catch (error) {
+                expect(error).toMatchObject({
+                    code: ProtocolErrorCode.InvalidParams,
+                    message: expect.stringContaining('Too small: expected number to be >=500')
+                });
+                expect(error).not.toMatchObject({
+                    message: expect.stringContaining('Invalid task creation result')
+                });
+            } finally {
+                taskStore.cleanup();
+            }
+        });
+
         test('should handle task failures during automatic polling', async () => {
             const taskStore = new InMemoryTaskStore();
             const { releaseLatch, waitForLatch } = createLatch();


### PR DESCRIPTION
## Problem

When a task-augmented `tools/call` request fails input schema validation, the error is caught in `McpServer._setupToolHandlers` and converted to a `CallToolResult` with `isError: true`. This result then fails `CreateTaskResultSchema` validation in `server.ts`, producing a misleading `"Invalid task creation result"` error that completely masks the actual validation failure.

### Example

```json
{
  "method": "tools/call",
  "params": {
    "name": "batch_process",
    "arguments": { "itemCount": 5, "processingTimeMs": 100 },
    "task": { "ttl": 60000 }
  }
}
```

**Before** — client receives:
```json
{ "code": -32602, "message": "Invalid task creation result: ..." }
```

**After** — client receives the real error:
```json
{ "code": -32602, "message": "Input validation error: Invalid arguments for tool batch_process: Too small: expected number to be >=500" }
```

## Fix

In `mcp.ts`, the catch block now re-throws `InvalidParams` `ProtocolError`s that originated from input validation (identified by the `"Input validation error:"` message prefix set in `validateToolInput`) when the request is task-augmented. This is targeted to avoid changing semantics for non-validation errors.

## Testing

Added a regression test in `test/integration/test/server/mcp.test.ts` that:
- Registers a task-based tool with `z.number().min(500)` validation
- Calls it with an invalid argument (`duration: 100`) and task augmentation
- Asserts the client receives `code: -32602` with the real validation message
- Asserts the error does NOT say `"Invalid task creation result"`

Fixes #1385