### PR TITLE
fix: add required:[] to empty object JSON schemas for OpenAI strict mode compatibility

### DIFF
--- a/packages/core/src/util/schema.ts
+++ b/packages/core/src/util/schema.ts
@@ -26,7 +26,32 @@ export type SchemaOutput<T extends AnySchema> = z.output<T>;
  * Converts a Zod schema to JSON Schema.
  */
 export function schemaToJson(schema: AnySchema, options?: { io?: 'input' | 'output' }): Record<string, unknown> {
-    return z.toJSONSchema(schema, options) as Record<string, unknown>;
+    return normalizeEmptyObjectRequired(z.toJSONSchema(schema, options) as Record<string, unknown>) as Record<string, unknown>;
+}
+
+const LITERAL_JSON_SCHEMA_VALUE_KEYS = new Set(['const', 'default', 'enum', 'example', 'examples']);
+
+function normalizeEmptyObjectRequired(value: unknown): unknown {
+    if (Array.isArray(value)) {
+        return value.map(item => normalizeEmptyObjectRequired(item));
+    }
+
+    if (!value || typeof value !== 'object') {
+        return value;
+    }
+
+    const normalized = Object.fromEntries(
+        Object.entries(value).map(([key, child]) => [
+            key,
+            LITERAL_JSON_SCHEMA_VALUE_KEYS.has(key) ? child : normalizeEmptyObjectRequired(child)
+        ])
+    );
+
+    if (normalized.type === 'object' && Object.hasOwn(normalized, 'properties') && !Object.hasOwn(normalized, 'required')) {
+        normalized.required = [];
+    }
+
+    return normalized;
 }
 
 /**

--- a/packages/core/test/schema.test.ts
+++ b/packages/core/test/schema.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from 'vitest';
+import * as z from 'zod/v4';
+
+import { schemaToJson } from '../src/util/schema.js';
+
+describe('schemaToJson', () => {
+    test('adds empty required arrays for empty object schemas recursively', () => {
+        const schema = z.object({
+            nested: z.object({}).strict(),
+            configured: z.object({
+                name: z.string()
+            })
+        });
+
+        expect(schemaToJson(schema)).toEqual({
+            $schema: 'https://json-schema.org/draft/2020-12/schema',
+            type: 'object',
+            properties: {
+                nested: {
+                    type: 'object',
+                    properties: {},
+                    required: [],
+                    additionalProperties: false
+                },
+                configured: {
+                    type: 'object',
+                    properties: {
+                        name: {
+                            type: 'string'
+                        }
+                    },
+                    required: ['name'],
+                    additionalProperties: false
+                }
+            },
+            required: ['nested', 'configured'],
+            additionalProperties: false
+        });
+    });
+
+    test('does not normalize literal values in default fields', () => {
+        const schema = z.any().default({
+            type: 'object',
+            properties: {}
+        });
+
+        expect(schemaToJson(schema)).toEqual({
+            $schema: 'https://json-schema.org/draft/2020-12/schema',
+            default: {
+                type: 'object',
+                properties: {}
+            }
+        });
+    });
+});

--- a/test/integration/test/server/mcp.test.ts
+++ b/test/integration/test/server/mcp.test.ts
@@ -883,7 +883,83 @@ describe('Zod v4', () => {
                 properties: {
                     name: { type: 'string' },
                     value: { type: 'number' }
-                }
+                },
+                required: ['name', 'value']
+            });
+        });
+
+        test('should include required arrays for empty object schemas in tools/list', async () => {
+            const mcpServer = new McpServer({
+                name: 'test server',
+                version: '1.0'
+            });
+            const client = new Client({
+                name: 'test client',
+                version: '1.0'
+            });
+
+            mcpServer.registerTool(
+                'empty-input',
+                {
+                    inputSchema: z.object({}),
+                    outputSchema: z.object({
+                        nested: z.object({}).strict()
+                    })
+                },
+                async () => ({
+                    structuredContent: { nested: {} },
+                    content: [{ type: 'text', text: 'ok' }]
+                })
+            );
+
+            mcpServer.registerTool(
+                'with-field',
+                {
+                    inputSchema: z.object({ fieldName: z.string() })
+                },
+                async ({ fieldName }) => ({
+                    content: [{ type: 'text', text: fieldName }]
+                })
+            );
+
+            const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+            await Promise.all([client.connect(clientTransport), mcpServer.server.connect(serverTransport)]);
+
+            const result = await client.request({
+                method: 'tools/list'
+            });
+
+            const emptyInputTool = result.tools.find(tool => tool.name === 'empty-input');
+            expect(emptyInputTool).toBeDefined();
+            expect(emptyInputTool!.inputSchema).toMatchObject({
+                type: 'object',
+                properties: {},
+                required: []
+            });
+            expect(emptyInputTool!.outputSchema).toMatchObject({
+                type: 'object',
+                properties: {
+                    nested: {
+                        type: 'object',
+                        properties: {},
+                        required: [],
+                        additionalProperties: false
+                    }
+                },
+                required: ['nested']
+            });
+
+            const fieldTool = result.tools.find(tool => tool.name === 'with-field');
+            expect(fieldTool).toBeDefined();
+            expect(fieldTool!.inputSchema).toMatchObject({
+                type: 'object',
+                properties: {
+                    fieldName: {
+                        type: 'string'
+                    }
+                },
+                required: ['fieldName']
             });
         });
 


### PR DESCRIPTION
## Summary

Fixes #1659.

When registering a tool with an empty Zod object as `inputSchema` (e.g. `z.object({})`), the generated JSON schema omits the `required` field entirely:

```json
{ "type": "object", "properties": {}, "additionalProperties": false }
```

While this is valid JSON Schema, OpenAI's strict JSON schema mode requires `required` to always be present, even as an empty array. This causes tools without input parameters to fail OpenAI strict validation.

## Root Cause

`z.toJSONSchema(z.object({}))` only adds `required` when there are fields to list. For empty objects it omits the key entirely.

## Fix

Added a `normalizeEmptyObjectRequired()` post-processing step in `schemaToJson()` that recursively adds `required: []` to any JSON Schema object node that has `properties` but no `required`. The recursion correctly skips literal data fields (`default`, `const`, `enum`, `example`, `examples`) to avoid mutating non-schema embedded values.

The result for empty object schemas is now:
```json
{ "type": "object", "properties": {}, "required": [], "additionalProperties": false }
```

## Test Plan

- [x] New unit test in `packages/core/test/schema.test.ts`:
  - Verifies empty objects get `required: []`
  - Verifies nested empty objects get `required: []` recursively
  - Verifies non-empty objects keep their correct `required` values
  - Verifies literal `default: { type: 'object', properties: {} }` values are NOT mutated
- [x] Integration test in `test/integration/test/server/mcp.test.ts`:
  - Verifies `tools/list` returns `required: []` for tools with `z.object({})` inputSchema
  - Verifies nested empty objects in `outputSchema` also get `required: []`
  - Verifies tools with fields still return correct `required: ['fieldName']`
- [x] All 387 existing integration tests pass (`pnpm test:all`)
- [x] `pnpm check:all` passes (typecheck + lint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)