### PR TITLE
fix: inline $ref pointers in schemaToJson for self-contained tool schemas

### DIFF
--- a/packages/core/src/util/schema.ts
+++ b/packages/core/src/util/schema.ts
@@ -50,14 +50,16 @@ export function schemaToJson(schema: AnySchema, options?: { io?: 'input' | 'outp
             const { id: _id, ...rest } = meta as Record<string, unknown>;
             return Object.keys(rest).length > 0 ? rest : undefined;
         },
-        has(s: AnySchema) { return globalReg.has(s); },
+        has(s: AnySchema) {
+            return globalReg.has(s);
+        },
         _idmap: new Map<string, AnySchema>(),
-        _map: (globalReg as unknown as { _map: WeakMap<object, unknown> })._map,
+        _map: (globalReg as unknown as { _map: WeakMap<object, unknown> })._map
     };
     return z.toJSONSchema(schema, {
         ...options,
         reused: 'inline',
-        metadata: idStrippedRegistry as unknown as z.core.$ZodRegistry<Record<string, unknown>>,
+        metadata: idStrippedRegistry as unknown as z.core.$ZodRegistry<Record<string, unknown>>
     }) as Record<string, unknown>;
 }
 

--- a/packages/core/test/util/schemaToJson.test.ts
+++ b/packages/core/test/util/schemaToJson.test.ts
@@ -71,13 +71,13 @@ describe('schemaToJson', () => {
         // The id-stripping proxy must not drop these non-id metadata entries.
         const schema = z.object({
             name: z.string().describe('The user name'),
-            age: z.number().int().describe('Age in years'),
+            age: z.number().int().describe('Age in years')
         });
         const json = schemaToJson(schema);
 
         expect(json.properties).toMatchObject({
             name: { type: 'string', description: 'The user name' },
-            age: { type: 'integer', description: 'Age in years' },
+            age: { type: 'integer', description: 'Age in years' }
         });
     });
 });


### PR DESCRIPTION
## Problem

Fixes #1562.

`z.toJSONSchema()` can emit `$ref`/`$defs` in two independent ways:

1. **Reused sub-schemas** – when the same schema object appears in two or more places, Zod extracts it to `$defs` and emits `$ref` pointers. Controlled by the `reused` option.
2. **Schemas registered in `z.globalRegistry` with an `id`** – Zod reads the `_idmap` of the metadata registry and extracts any schema with an `id` to `$defs`, regardless of `reused`. This fires whenever a user calls `z.globalRegistry.add(schema, { id: 'Foo' })` or `.meta({ id: 'Foo' })`.

Tool `inputSchema` / `outputSchema` objects sent over MCP must be **fully self-contained JSON Schema objects**. LLMs and most downstream validators cannot resolve `$ref` pointers – especially `$ref: "#/$defs/Foo"` references that point into a sibling `$defs` block.

## Fix

Update `schemaToJson()` in `packages/core/src/util/schema.ts`:

1. Pass `reused: 'inline'` to prevent multiply-referenced sub-schemas from becoming `$ref` pointers.
2. Pass a **proxy metadata registry** that wraps `z.globalRegistry` but:
   - strips the `id` field from returned metadata (so the serialiser skips the id-based `$defs` extraction pass)
   - exposes an empty `_idmap`
   - forwards all other metadata (e.g. `.describe()` descriptions, `.meta()` annotations) unchanged

This means schemas annotated with `.describe('some description')` still emit a `description` field in the JSON Schema output, while schemas registered with an explicit `id` are inlined instead of becoming `$ref` pointers.

## Tests

Added `packages/core/test/util/schemaToJson.test.ts` with five tests:

- Shared schemas are inlined, not `$ref`/`$defs`
- No `$ref` for plain schemas
- Correct output for `z.object()`
- `io: 'input'` option is respected
- `.describe()` metadata is preserved after id-stripping

## Checklist

- [x] All existing tests pass (`pnpm test:all`)
- [x] TypeScript type-check passes (`pnpm typecheck:all`)
- [x] New tests added covering both the fix and the preserve-metadata invariant