### PR TITLE
fix: return 404 instead of 400 for invalid session IDs in examples

### DIFF
--- a/examples/server/src/elicitationFormExample.ts
+++ b/examples/server/src/elicitationFormExample.ts
@@ -400,7 +400,7 @@ async function main() {
     const mcpGetHandler = async (req: Request, res: Response) => {
         const sessionId = req.headers['mcp-session-id'] as string | undefined;
         if (!sessionId || !transports[sessionId]) {
-            res.status(400).send('Invalid or missing session ID');
+            res.status(404).send('Invalid or missing session ID');
             return;
         }
 
@@ -415,7 +415,7 @@ async function main() {
     const mcpDeleteHandler = async (req: Request, res: Response) => {
         const sessionId = req.headers['mcp-session-id'] as string | undefined;
         if (!sessionId || !transports[sessionId]) {
-            res.status(400).send('Invalid or missing session ID');
+            res.status(404).send('Invalid or missing session ID');
             return;
         }
 

--- a/examples/server/src/elicitationUrlExample.ts
+++ b/examples/server/src/elicitationUrlExample.ts
@@ -644,7 +644,7 @@ app.post('/mcp', authMiddleware, mcpPostHandler);
 const mcpGetHandler = async (req: Request, res: Response) => {
     const sessionId = req.headers['mcp-session-id'] as string | undefined;
     if (!sessionId || !transports[sessionId]) {
-        res.status(400).send('Invalid or missing session ID');
+        res.status(404).send('Invalid or missing session ID');
         return;
     }
 
@@ -683,7 +683,7 @@ app.get('/mcp', authMiddleware, mcpGetHandler);
 const mcpDeleteHandler = async (req: Request, res: Response) => {
     const sessionId = req.headers['mcp-session-id'] as string | undefined;
     if (!sessionId || !transports[sessionId]) {
-        res.status(400).send('Invalid or missing session ID');
+        res.status(404).send('Invalid or missing session ID');
         return;
     }
 

--- a/examples/server/src/simpleStreamableHttp.ts
+++ b/examples/server/src/simpleStreamableHttp.ts
@@ -726,7 +726,7 @@ if (useOAuth && authMiddleware) {
 const mcpGetHandler = async (req: Request, res: Response) => {
     const sessionId = req.headers['mcp-session-id'] as string | undefined;
     if (!sessionId || !transports[sessionId]) {
-        res.status(400).send('Invalid or missing session ID');
+        res.status(404).send('Invalid or missing session ID');
         return;
     }
 
@@ -757,7 +757,7 @@ if (useOAuth && authMiddleware) {
 const mcpDeleteHandler = async (req: Request, res: Response) => {
     const sessionId = req.headers['mcp-session-id'] as string | undefined;
     if (!sessionId || !transports[sessionId]) {
-        res.status(400).send('Invalid or missing session ID');
+        res.status(404).send('Invalid or missing session ID');
         return;
     }
 

--- a/examples/server/src/simpleTaskInteractive.ts
+++ b/examples/server/src/simpleTaskInteractive.ts
@@ -696,7 +696,7 @@ app.post('/mcp', async (req: Request, res: Response) => {
 app.get('/mcp', async (req: Request, res: Response) => {
     const sessionId = req.headers['mcp-session-id'] as string | undefined;
     if (!sessionId || !transports[sessionId]) {
-        res.status(400).send('Invalid or missing session ID');
+        res.status(404).send('Invalid or missing session ID');
         return;
     }
 
@@ -708,7 +708,7 @@ app.get('/mcp', async (req: Request, res: Response) => {
 app.delete('/mcp', async (req: Request, res: Response) => {
     const sessionId = req.headers['mcp-session-id'] as string | undefined;
     if (!sessionId || !transports[sessionId]) {
-        res.status(400).send('Invalid or missing session ID');
+        res.status(404).send('Invalid or missing session ID');
         return;
     }
 

--- a/examples/server/src/standaloneSseWithGetStreamableHttp.ts
+++ b/examples/server/src/standaloneSseWithGetStreamableHttp.ts
@@ -120,7 +120,7 @@ app.post('/mcp', async (req: Request, res: Response) => {
 app.get('/mcp', async (req: Request, res: Response) => {
     const sessionId = req.headers['mcp-session-id'] as string | undefined;
     if (!sessionId || !transports[sessionId]) {
-        res.status(400).send('Invalid or missing session ID');
+        res.status(404).send('Invalid or missing session ID');
         return;
     }
 

--- a/test/conformance/src/everythingServer.ts
+++ b/test/conformance/src/everythingServer.ts
@@ -926,7 +926,7 @@ app.post('/mcp', async (req: Request, res: Response) => {
             await transport.handleRequest(req, res, req.body);
             return;
         } else {
-            res.status(400).json({
+            res.status(404).json({
                 jsonrpc: '2.0',
                 error: {
                     code: -32_000,
@@ -958,7 +958,7 @@ app.get('/mcp', async (req: Request, res: Response) => {
     const sessionId = req.headers['mcp-session-id'] as string | undefined;
 
     if (!sessionId || !transports[sessionId]) {
-        res.status(400).send('Invalid or missing session ID');
+        res.status(404).send('Invalid or missing session ID');
         return;
     }
 
@@ -985,7 +985,7 @@ app.delete('/mcp', async (req: Request, res: Response) => {
     const sessionId = req.headers['mcp-session-id'] as string | undefined;
 
     if (!sessionId || !transports[sessionId]) {
-        res.status(400).send('Invalid or missing session ID');
+        res.status(404).send('Invalid or missing session ID');
         return;
     }
 


### PR DESCRIPTION
## Summary

Fixes #389

The MCP spec states that servers **SHOULD** return HTTP 404 for requests with invalid session IDs, so clients know the session is gone and can start a new one:

> If a server receives requests bearing an invalid `Mcp-Session-Id`, it **SHOULD** respond with HTTP 404 Not Found to indicate the session does not (or no longer) exists.

The SDK's own transport implementation (`streamableHttp.ts`) already correctly returns 404 with error code `-32001` ("Session not found"). However, all the example servers and the conformance test server were returning 400 instead.

## Changes

- **Example servers** (5 files): Changed `res.status(400)` → `res.status(404)` for invalid/missing session ID responses
- **Conformance test server**: Same fix applied

## Files changed

- `examples/server/src/simpleStreamableHttp.ts`
- `examples/server/src/simpleTaskInteractive.ts`
- `examples/server/src/elicitationFormExample.ts`
- `examples/server/src/elicitationUrlExample.ts`
- `examples/server/src/standaloneSseWithGetStreamableHttp.ts`
- `test/conformance/src/everythingServer.ts`

All existing tests pass (28/28 in streamableHttp.test.ts).