### PR TITLE
fix(server): surface parse/validation transport errors via onerror in streamable HTTP

### DIFF
--- a/packages/server/src/server/streamableHttp.ts
+++ b/packages/server/src/server/streamableHttp.ts
@@ -635,7 +635,8 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
             if (options?.parsedBody === undefined) {
                 try {
                     rawMessage = await req.json();
-                } catch {
+                } catch (error) {
+                    this.onerror?.(error instanceof Error ? error : new Error(String(error)));
                     return this.createJsonErrorResponse(400, -32_700, 'Parse error: Invalid JSON');
                 }
             } else {
@@ -649,7 +650,8 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
                 messages = Array.isArray(rawMessage)
                     ? rawMessage.map(msg => JSONRPCMessageSchema.parse(msg))
                     : [JSONRPCMessageSchema.parse(rawMessage)];
-            } catch {
+            } catch (error) {
+                this.onerror?.(error instanceof Error ? error : new Error(String(error)));
                 return this.createJsonErrorResponse(400, -32_700, 'Parse error: Invalid JSON-RPC message');
             }
 

--- a/packages/server/test/server/streamableHttp.test.ts
+++ b/packages/server/test/server/streamableHttp.test.ts
@@ -333,6 +333,44 @@ describe('Zod v4', () => {
                 expectErrorResponse(errorData, -32_700, /Parse error.*Invalid JSON/);
             });
 
+            it('should call onerror for invalid JSON', async () => {
+                const errorSpy = vi.fn();
+                transport.onerror = errorSpy;
+
+                const request = new Request('http://localhost/mcp', {
+                    method: 'POST',
+                    headers: {
+                        Accept: 'application/json, text/event-stream',
+                        'Content-Type': 'application/json'
+                    },
+                    body: 'not valid json'
+                });
+
+                const response = await transport.handleRequest(request);
+
+                expect(response.status).toBe(400);
+                expect(errorSpy).toHaveBeenCalledTimes(1);
+            });
+
+            it('should call onerror for invalid JSON-RPC message', async () => {
+                const errorSpy = vi.fn();
+                transport.onerror = errorSpy;
+
+                const request = new Request('http://localhost/mcp', {
+                    method: 'POST',
+                    headers: {
+                        Accept: 'application/json, text/event-stream',
+                        'Content-Type': 'application/json'
+                    },
+                    body: JSON.stringify({ bad: 'shape' })
+                });
+
+                const response = await transport.handleRequest(request);
+
+                expect(response.status).toBe(400);
+                expect(errorSpy).toHaveBeenCalledTimes(1);
+            });
+
             it('should accept notifications without session and return 202', async () => {
                 sessionId = await initializeServer();
 


### PR DESCRIPTION
## Summary
This PR fixes missing `onerror` propagation in `StreamableHTTPServerTransport` when request parsing/validation fails.

## What changed
- Updated `packages/server/src/server/streamableHttp.ts`:
  - call `this.onerror?.(...)` when `req.json()` fails
  - call `this.onerror?.(...)` when `JSONRPCMessageSchema.parse(...)` fails
- Added regression tests in `packages/server/test/server/streamableHttp.test.ts` to verify both paths trigger `onerror`

## Why
Previously, these transport-level errors could be handled in HTTP responses but were not reported through `onerror`, making observability and custom error handling inconsistent.

## Validation
- `pnpm --filter @modelcontextprotocol/server test -- test/server/streamableHttp.test.ts`
- Targeted lint/format checks for modified files

Closes #1395