### PR TITLE
fix: widen elicitInput requestedSchema type for Zod compatibility

### DIFF
--- a/.changeset/widen-elicit-requested-schema.md
+++ b/.changeset/widen-elicit-requested-schema.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/core': patch
+---
+
+Widen `requestedSchema` type in `ElicitRequestFormParams` to accept additional JSON Schema fields (e.g., `$schema`, `additionalProperties`) that tools like Zod's `.toJSONSchema()` produce. This removes the need for users to cast through `unknown` when passing Zod-generated schemas to `elicitInput()`.

--- a/packages/core/src/types/spec.types.ts
+++ b/packages/core/src/types/spec.types.ts
@@ -2795,6 +2795,7 @@ export interface ElicitRequestFormParams extends TaskAugmentedRequestParams {
      * Only top-level properties are allowed, without nesting.
      */
     requestedSchema: {
+        [key: string]: unknown;
         $schema?: string;
         type: 'object';
         properties: {

--- a/packages/core/src/types/types.ts
+++ b/packages/core/src/types/types.ts
@@ -2024,11 +2024,13 @@ export const ElicitRequestFormParamsSchema = TaskAugmentedRequestParamsSchema.ex
      * A restricted subset of JSON Schema.
      * Only top-level properties are allowed, without nesting.
      */
-    requestedSchema: z.object({
-        type: z.literal('object'),
-        properties: z.record(z.string(), PrimitiveSchemaDefinitionSchema),
-        required: z.array(z.string()).optional()
-    })
+    requestedSchema: z
+        .object({
+            type: z.literal('object'),
+            properties: z.record(z.string(), PrimitiveSchemaDefinitionSchema),
+            required: z.array(z.string()).optional()
+        })
+        .passthrough()
 });
 
 /**


### PR DESCRIPTION
## Summary

Widens the `requestedSchema` type in `elicitInput` to accept standard JSON Schema output from Zod's `.toJSONSchema()`, fixing the type incompatibility reported in #1362.

**The problem**: Zod v4's `.toJSONSchema()` returns objects with extra standard JSON Schema fields (`$schema`, `additionalProperties`, etc.). The SDK's `requestedSchema` type was a closed object that rejected these at the type level, forcing users to cast through `unknown`.

**The fix** (minimal, two changes):
- `types.ts`: Added `.passthrough()` to the Zod schema so extra fields pass runtime validation
- `spec.types.ts`: Added `[key: string]: unknown` index signature to match the widened Zod type

Required fields (`type: 'object'`, `properties`) remain strictly typed.

## Test plan

- [x] All 440 core tests pass
- [x] All 386 integration tests pass
- [x] Lint passes
- [x] Typecheck passes (including `spec.types.test.ts` mutual-assignability checks)
- [x] Changeset included (patch for `@modelcontextprotocol/core`)

Fixes #1362.

Co-Authored-By: Claude Opus 4.6 (1M context) <tadao@travisfixes.com>