### PR TITLE
fix: widen elicitInput requestedSchema to accept Zod JSON Schema output

### DIFF
--- a/.changeset/zod-elicit-schema-compat.md
+++ b/.changeset/zod-elicit-schema-compat.md
@@ -1,0 +1,13 @@
+---
+"@modelcontextprotocol/core": patch
+---
+
+Allow standard JSON Schema fields in elicitInput requestedSchema
+
+Widen the `requestedSchema` type on `ElicitRequestFormParams` to accept extra
+fields such as `$schema` and `additionalProperties` that tools like Zod's
+`.toJSONSchema()` produce. Previously these required an `as` cast even though
+the runtime accepted them fine.
+
+- Add `.passthrough()` to the Zod schema for `requestedSchema`
+- Add `additionalProperties?: boolean` and an index signature to the spec type

--- a/packages/core/src/types/spec.types.ts
+++ b/packages/core/src/types/spec.types.ts
@@ -2796,11 +2796,13 @@ export interface ElicitRequestFormParams extends TaskAugmentedRequestParams {
      */
     requestedSchema: {
         $schema?: string;
+        additionalProperties?: boolean;
         type: 'object';
         properties: {
             [key: string]: PrimitiveSchemaDefinition;
         };
         required?: string[];
+        [key: string]: unknown;
     };
 }
 

--- a/packages/core/src/types/types.ts
+++ b/packages/core/src/types/types.ts
@@ -2028,7 +2028,7 @@ export const ElicitRequestFormParamsSchema = TaskAugmentedRequestParamsSchema.ex
         type: z.literal('object'),
         properties: z.record(z.string(), PrimitiveSchemaDefinitionSchema),
         required: z.array(z.string()).optional()
-    })
+    }).passthrough()
 });
 
 /**


### PR DESCRIPTION
## Summary
- Adds `.passthrough()` to `ElicitRequestFormParamsSchema` so Zod validation accepts extra JSON Schema fields
- Adds index signature to `ElicitRequestFormParams` spec type for TypeScript compatibility
- Standard JSON Schema output from `z.object().toJSONSchema()` now works without type casting

Fixes #1362

## Context
Zod's `.toJSONSchema()` produces valid JSON Schema with fields like `$schema` and `additionalProperties` that the current type rejects at the TypeScript level, even though runtime behavior is correct. Rather than allowlisting individual fields, `.passthrough()` and an index signature handle any standard JSON Schema output generically.

## Test plan
- [x] All 386 existing integration tests pass
- [x] Build succeeds across all packages
- [x] Verified Zod `.toJSONSchema()` output matches widened type