### PR TITLE
[v1.x backport] SEP-990 Cross-App Access

### DIFF
--- a/src/client/auth-extensions.ts
+++ b/src/client/auth-extensions.ts
@@ -7,7 +7,8 @@
 
 import type { JWK } from 'jose';
 import { OAuthClientInformation, OAuthClientMetadata, OAuthTokens } from '../shared/auth.js';
-import { AddClientAuthentication, OAuthClientProvider } from './auth.js';
+import type { FetchLike } from '../shared/transport.js';
+import { AddClientAuthentication, OAuthClientProvider, OAuthDiscoveryState } from './auth.js';
 
 /**
  * Helper to produce a private_key_jwt client authentication function.
@@ -414,6 +415,245 @@ export class StaticPrivateKeyJwtProvider implements OAuthClientProvider {
     prepareTokenRequest(scope?: string): URLSearchParams {
         const params = new URLSearchParams({ grant_type: 'client_credentials' });
         if (scope) params.set('scope', scope);
+        return params;
+    }
+}
+
+/**
+ * Context provided to the assertion callback in {@linkcode CrossAppAccessProvider}.
+ * Contains orchestrator-discovered information needed for JWT Authorization Grant requests.
+ */
+export interface CrossAppAccessContext {
+    /**
+     * The authorization server URL of the target MCP server.
+     * Discovered via RFC 9728 protected resource metadata.
+     */
+    authorizationServerUrl: string;
+
+    /**
+     * The resource URL of the target MCP server.
+     * Discovered via RFC 9728 protected resource metadata.
+     */
+    resourceUrl: string;
+
+    /**
+     * Optional scope being requested for the MCP server.
+     */
+    scope?: string;
+
+    /**
+     * Fetch function to use for HTTP requests (e.g., for IdP token exchange).
+     */
+    fetchFn: FetchLike;
+}
+
+/**
+ * Callback function type that provides a JWT Authorization Grant (ID-JAG).
+ *
+ * The callback receives context about the target MCP server (authorization server URL,
+ * resource URL, scope) and should return a JWT Authorization Grant that will be used
+ * to obtain an access token from the MCP server.
+ */
+export type AssertionCallback = (context: CrossAppAccessContext) => string | Promise<string>;
+
+/**
+ * Options for creating a {@linkcode CrossAppAccessProvider}.
+ */
+export interface CrossAppAccessProviderOptions {
+    /**
+     * Callback function that provides a JWT Authorization Grant (ID-JAG).
+     *
+     * The callback receives the MCP server's authorization server URL, resource URL,
+     * and requested scope, and should return a JWT Authorization Grant obtained from
+     * the enterprise IdP via RFC 8693 token exchange.
+     *
+     * You can use the utility functions from the `crossAppAccess` module
+     * for standard flows, or implement custom logic.
+     *
+     * @example
+     * ```ts
+     * assertion: async (ctx) => {
+     *     const result = await discoverAndRequestJwtAuthGrant({
+     *         idpUrl: 'https://idp.example.com',
+     *         audience: ctx.authorizationServerUrl,
+     *         resource: ctx.resourceUrl,
+     *         idToken: await getIdToken(),
+     *         clientId: 'my-idp-client',
+     *         clientSecret: 'my-idp-secret',
+     *         scope: ctx.scope,
+     *         fetchFn: ctx.fetchFn
+     *     });
+     *     return result.jwtAuthGrant;
+     * }
+     * ```
+     */
+    assertion: AssertionCallback;
+
+    /**
+     * The `client_id` registered with the MCP server's authorization server.
+     */
+    clientId: string;
+
+    /**
+     * The `client_secret` for authenticating with the MCP server's authorization server.
+     */
+    clientSecret: string;
+
+    /**
+     * Optional client name for metadata.
+     */
+    clientName?: string;
+
+    /**
+     * Custom fetch implementation. Defaults to global fetch.
+     */
+    fetchFn?: FetchLike;
+}
+
+/**
+ * OAuth provider for Cross-App Access (Enterprise Managed Authorization) using JWT Authorization Grant.
+ *
+ * This provider implements the Enterprise Managed Authorization flow (SEP-990) where:
+ * 1. User authenticates with an enterprise IdP and the client obtains an ID Token
+ * 2. Client exchanges the ID Token for a JWT Authorization Grant (ID-JAG) via RFC 8693 token exchange
+ * 3. Client uses the JAG to obtain an access token from the MCP server via RFC 7523 JWT bearer grant
+ *
+ * The provider handles steps 2-3 automatically, with the JAG acquisition delegated to
+ * a callback function that you provide. This allows flexibility in how you obtain and
+ * cache ID Tokens from the IdP.
+ *
+ * @see https://github.com/modelcontextprotocol/ext-auth/blob/main/specification/draft/enterprise-managed-authorization.mdx
+ *
+ * @example
+ * ```ts
+ * const provider = new CrossAppAccessProvider({
+ *     assertion: async (ctx) => {
+ *         const result = await discoverAndRequestJwtAuthGrant({
+ *             idpUrl: 'https://idp.example.com',
+ *             audience: ctx.authorizationServerUrl,
+ *             resource: ctx.resourceUrl,
+ *             idToken: await getIdToken(), // Your function to get ID token
+ *             clientId: 'my-idp-client',
+ *             clientSecret: 'my-idp-secret',
+ *             scope: ctx.scope,
+ *             fetchFn: ctx.fetchFn
+ *         });
+ *         return result.jwtAuthGrant;
+ *     },
+ *     clientId: 'my-mcp-client',
+ *     clientSecret: 'my-mcp-secret'
+ * });
+ *
+ * const transport = new StreamableHTTPClientTransport(serverUrl, {
+ *     authProvider: provider
+ * });
+ * ```
+ */
+export class CrossAppAccessProvider implements OAuthClientProvider {
+    private _tokens?: OAuthTokens;
+    private _clientInfo: OAuthClientInformation;
+    private _clientMetadata: OAuthClientMetadata;
+    private _assertionCallback: AssertionCallback;
+    private _fetchFn: FetchLike;
+    private _discoveryState?: OAuthDiscoveryState;
+    private _scope?: string;
+
+    constructor(options: CrossAppAccessProviderOptions) {
+        this._clientInfo = {
+            client_id: options.clientId,
+            client_secret: options.clientSecret
+        };
+        this._clientMetadata = {
+            client_name: options.clientName ?? 'cross-app-access-client',
+            redirect_uris: [],
+            grant_types: ['urn:ietf:params:oauth:grant-type:jwt-bearer'],
+            token_endpoint_auth_method: 'client_secret_basic'
+        };
+        this._assertionCallback = options.assertion;
+        this._fetchFn = options.fetchFn ?? fetch;
+    }
+
+    get redirectUrl(): undefined {
+        return undefined;
+    }
+
+    get clientMetadata(): OAuthClientMetadata {
+        return this._clientMetadata;
+    }
+
+    clientInformation(): OAuthClientInformation {
+        return this._clientInfo;
+    }
+
+    saveClientInformation(info: OAuthClientInformation): void {
+        this._clientInfo = info;
+    }
+
+    tokens(): OAuthTokens | undefined {
+        return this._tokens;
+    }
+
+    saveTokens(tokens: OAuthTokens): void {
+        this._tokens = tokens;
+    }
+
+    redirectToAuthorization(): void {
+        throw new Error('redirectToAuthorization is not used for jwt-bearer flow');
+    }
+
+    saveCodeVerifier(): void {
+        // Not used for jwt-bearer
+    }
+
+    codeVerifier(): string {
+        throw new Error('codeVerifier is not used for jwt-bearer flow');
+    }
+
+    saveDiscoveryState(state: OAuthDiscoveryState): void {
+        this._discoveryState = state;
+    }
+
+    discoveryState(): OAuthDiscoveryState | undefined {
+        return this._discoveryState;
+    }
+
+    async prepareTokenRequest(scope?: string): Promise<URLSearchParams> {
+        const authServerUrl = this._discoveryState?.authorizationServerUrl;
+        const resourceUrl = this._discoveryState?.resourceMetadata?.resource;
+
+        if (!authServerUrl) {
+            throw new Error('Authorization server URL not available. Ensure auth() has been called first.');
+        }
+
+        if (!resourceUrl) {
+            throw new Error(
+                'Resource URL not available — server may not implement RFC 9728 ' +
+                    'Protected Resource Metadata (required for Cross-App Access), or ' +
+                    'auth() has not been called'
+            );
+        }
+
+        // Store scope for assertion callback
+        this._scope = scope;
+
+        // Call the assertion callback to get the JWT Authorization Grant
+        const jwtAuthGrant = await this._assertionCallback({
+            authorizationServerUrl: authServerUrl,
+            resourceUrl: resourceUrl,
+            scope: this._scope,
+            fetchFn: this._fetchFn
+        });
+
+        // Return params for JWT bearer grant per RFC 7523
+        const params = new URLSearchParams({
+            grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+            assertion: jwtAuthGrant
+        });
+
+        if (scope) {
+            params.set('scope', scope);
+        }
+
         return params;
     }
 }

--- a/src/client/auth.ts
+++ b/src/client/auth.ts
@@ -239,7 +239,7 @@ export class UnauthorizedError extends Error {
     }
 }
 
-type ClientAuthMethod = 'client_secret_basic' | 'client_secret_post' | 'none';
+export type ClientAuthMethod = 'client_secret_basic' | 'client_secret_post' | 'none';
 
 function isClientAuthMethod(method: string): method is ClientAuthMethod {
     return ['client_secret_basic', 'client_secret_post', 'none'].includes(method);
@@ -313,7 +313,7 @@ export function selectClientAuthMethod(clientInformation: OAuthClientInformation
  * @param params - URL search parameters to modify
  * @throws {Error} When required credentials are missing
  */
-function applyClientAuthentication(
+export function applyClientAuthentication(
     method: ClientAuthMethod,
     clientInformation: OAuthClientInformation,
     headers: Headers,

--- a/src/client/cross-app-access.ts
+++ b/src/client/cross-app-access.ts
@@ -1,0 +1,286 @@
+/**
+ * Cross-App Access (Enterprise Managed Authorization) Layer 2 utilities.
+ *
+ * Provides standalone functions for RFC 8693 Token Exchange and RFC 7523 JWT Authorization Grant
+ * flows as specified in the Enterprise Managed Authorization specification (SEP-990).
+ *
+ * @see https://github.com/modelcontextprotocol/ext-auth/blob/main/specification/draft/enterprise-managed-authorization.mdx
+ * @module
+ */
+
+import type { OAuthTokens } from '../shared/auth.js';
+import type { FetchLike } from '../shared/transport.js';
+import { IdJagTokenExchangeResponseSchema, OAuthTokensSchema } from '../shared/auth.js';
+
+import type { ClientAuthMethod } from './auth.js';
+import { applyClientAuthentication, discoverAuthorizationServerMetadata, parseErrorResponse } from './auth.js';
+
+/**
+ * Options for requesting a JWT Authorization Grant via RFC 8693 Token Exchange.
+ */
+export interface RequestJwtAuthGrantOptions {
+    /**
+     * The IdP's token endpoint URL where the token exchange request will be sent.
+     */
+    tokenEndpoint: string | URL;
+
+    /**
+     * The authorization server URL of the target MCP server (used as `audience` in the token exchange request).
+     */
+    audience: string | URL;
+
+    /**
+     * The resource identifier of the target MCP server (RFC 9728).
+     */
+    resource: string | URL;
+
+    /**
+     * The identity assertion (ID Token) from the enterprise IdP.
+     * This should be the OpenID Connect ID Token obtained during user authentication.
+     */
+    idToken: string;
+
+    /**
+     * The client ID registered with the IdP for token exchange.
+     */
+    clientId: string;
+
+    /**
+     * The client secret for authenticating with the IdP.
+     *
+     * Optional: the IdP may register the MCP client as a public client. RFC 8693 does
+     * not mandate confidential clients for token exchange. Omitting this parameter
+     * omits `client_secret` from the request body.
+     */
+    clientSecret?: string;
+
+    /**
+     * Optional space-separated list of scopes to request for the target MCP server.
+     */
+    scope?: string;
+
+    /**
+     * Custom fetch implementation. Defaults to global fetch.
+     */
+    fetchFn?: FetchLike;
+}
+
+/**
+ * Options for discovering the IdP's token endpoint and requesting a JWT Authorization Grant.
+ * Extends {@linkcode RequestJwtAuthGrantOptions} with IdP discovery.
+ */
+export interface DiscoverAndRequestJwtAuthGrantOptions extends Omit<RequestJwtAuthGrantOptions, 'tokenEndpoint'> {
+    /**
+     * The IdP's issuer URL for OAuth metadata discovery.
+     * Will be used to discover the token endpoint via `.well-known/oauth-authorization-server`.
+     */
+    idpUrl: string | URL;
+}
+
+/**
+ * Result from a successful JWT Authorization Grant token exchange.
+ */
+export interface JwtAuthGrantResult {
+    /**
+     * The JWT Authorization Grant (ID-JAG) that can be used to request an access token from the MCP server.
+     */
+    jwtAuthGrant: string;
+
+    /**
+     * Optional expiration time in seconds for the JWT Authorization Grant.
+     */
+    expiresIn?: number;
+
+    /**
+     * Optional scope granted by the IdP (may differ from requested scope).
+     */
+    scope?: string;
+}
+
+/**
+ * Requests a JWT Authorization Grant (ID-JAG) from an enterprise IdP using RFC 8693 Token Exchange.
+ *
+ * This function performs step 2 of the Enterprise Managed Authorization flow:
+ * exchanges an ID Token for a JWT Authorization Grant that can be used with the target MCP server.
+ *
+ * @param options - Configuration for the token exchange request
+ * @returns The JWT Authorization Grant and related metadata
+ * @throws {OAuthError} If the token exchange fails or returns an error response
+ *
+ * @example
+ * ```ts
+ * const result = await requestJwtAuthorizationGrant({
+ *     tokenEndpoint: 'https://idp.example.com/token',
+ *     audience: 'https://auth.chat.example/',
+ *     resource: 'https://mcp.chat.example/',
+ *     idToken: 'eyJhbGciOiJS...',
+ *     clientId: 'my-idp-client',
+ *     clientSecret: 'my-idp-secret',
+ *     scope: 'chat.read chat.history'
+ * });
+ *
+ * // Use result.jwtAuthGrant with the MCP server's authorization server
+ * ```
+ */
+export async function requestJwtAuthorizationGrant(options: RequestJwtAuthGrantOptions): Promise<JwtAuthGrantResult> {
+    const { tokenEndpoint, audience, resource, idToken, clientId, clientSecret, scope, fetchFn = fetch } = options;
+
+    // Prepare token exchange request per RFC 8693
+    const params = new URLSearchParams({
+        grant_type: 'urn:ietf:params:oauth:grant-type:token-exchange',
+        requested_token_type: 'urn:ietf:params:oauth:token-type:id-jag',
+        audience: String(audience),
+        resource: String(resource),
+        subject_token: idToken,
+        subject_token_type: 'urn:ietf:params:oauth:token-type:id_token',
+        client_id: clientId
+    });
+
+    // Only include client_secret when provided — sending an empty/undefined secret
+    // triggers `invalid_client` on strict IdPs that registered this as a public client.
+    if (clientSecret) {
+        params.set('client_secret', clientSecret);
+    }
+
+    if (scope) {
+        params.set('scope', scope);
+    }
+
+    const response = await fetchFn(String(tokenEndpoint), {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/x-www-form-urlencoded'
+        },
+        body: params.toString()
+    });
+
+    if (!response.ok) {
+        throw await parseErrorResponse(response);
+    }
+
+    const parseResult = IdJagTokenExchangeResponseSchema.safeParse(await response.json());
+    if (!parseResult.success) {
+        throw new Error(`Invalid token exchange response: ${parseResult.error.message}`);
+    }
+
+    return {
+        jwtAuthGrant: parseResult.data.access_token,
+        expiresIn: parseResult.data.expires_in,
+        scope: parseResult.data.scope
+    };
+}
+
+/**
+ * Discovers the IdP's token endpoint and requests a JWT Authorization Grant.
+ *
+ * This is a convenience wrapper around {@linkcode requestJwtAuthorizationGrant} that
+ * first performs OAuth metadata discovery to find the token endpoint.
+ *
+ * @param options - Configuration including IdP URL for discovery
+ * @returns The JWT Authorization Grant and related metadata
+ * @throws {OAuthError} If the token exchange fails or returns an error response
+ *
+ * @example
+ * ```ts
+ * const result = await discoverAndRequestJwtAuthGrant({
+ *     idpUrl: 'https://idp.example.com',
+ *     audience: 'https://auth.chat.example/',
+ *     resource: 'https://mcp.chat.example/',
+ *     idToken: await getIdToken(),
+ *     clientId: 'my-idp-client',
+ *     clientSecret: 'my-idp-secret'
+ * });
+ * ```
+ */
+export async function discoverAndRequestJwtAuthGrant(options: DiscoverAndRequestJwtAuthGrantOptions): Promise<JwtAuthGrantResult> {
+    const { idpUrl, fetchFn = fetch, ...restOptions } = options;
+
+    // Discover IdP's authorization server metadata
+    const metadata = await discoverAuthorizationServerMetadata(String(idpUrl), { fetchFn });
+
+    if (!metadata?.token_endpoint) {
+        throw new Error(`Failed to discover token endpoint for IdP: ${idpUrl}`);
+    }
+
+    // Perform token exchange
+    return requestJwtAuthorizationGrant({
+        ...restOptions,
+        tokenEndpoint: metadata.token_endpoint,
+        fetchFn
+    });
+}
+
+/**
+ * Exchanges a JWT Authorization Grant for an access token at the MCP server's authorization server.
+ *
+ * This function performs step 3 of the Enterprise Managed Authorization flow:
+ * uses the JWT Authorization Grant to obtain an access token from the MCP server.
+ *
+ * @param options - Configuration for the JWT grant exchange
+ * @returns OAuth tokens (access token, token type, etc.)
+ * @throws {OAuthError} If the exchange fails or returns an error response
+ *
+ * Defaults to `client_secret_basic` (HTTP Basic Authorization header), matching
+ * `CrossAppAccessProvider`'s declared `token_endpoint_auth_method` and the
+ * SEP-990 conformance test requirements. Use `authMethod: 'client_secret_post'` only
+ * when the authorization server explicitly requires it.
+ *
+ * @example
+ * ```ts
+ * const tokens = await exchangeJwtAuthGrant({
+ *     tokenEndpoint: 'https://auth.chat.example/token',
+ *     jwtAuthGrant: 'eyJhbGci...',
+ *     clientId: 'my-mcp-client',
+ *     clientSecret: 'my-mcp-secret'
+ * });
+ *
+ * // Use tokens.access_token to access the MCP server
+ * ```
+ */
+export async function exchangeJwtAuthGrant(options: {
+    tokenEndpoint: string | URL;
+    jwtAuthGrant: string;
+    clientId: string;
+    clientSecret?: string;
+    /**
+     * Client authentication method. Defaults to `'client_secret_basic'` to align with
+     * `CrossAppAccessProvider` and SEP-990 conformance requirements.
+     * Callers with no `clientSecret` should pass `'none'` for public-client auth.
+     */
+    authMethod?: ClientAuthMethod;
+    fetchFn?: FetchLike;
+}): Promise<OAuthTokens> {
+    const { tokenEndpoint, jwtAuthGrant, clientId, clientSecret, authMethod = 'client_secret_basic', fetchFn = fetch } = options;
+
+    // Prepare JWT bearer grant request per RFC 7523
+    const params = new URLSearchParams({
+        grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+        assertion: jwtAuthGrant
+    });
+
+    const headers = new Headers({
+        'Content-Type': 'application/x-www-form-urlencoded'
+    });
+
+    applyClientAuthentication(authMethod, { client_id: clientId, client_secret: clientSecret }, headers, params);
+
+    const response = await fetchFn(String(tokenEndpoint), {
+        method: 'POST',
+        headers,
+        body: params.toString()
+    });
+
+    if (!response.ok) {
+        throw await parseErrorResponse(response);
+    }
+
+    const responseBody = await response.json();
+
+    // Validate response using core schema
+    const parseResult = OAuthTokensSchema.safeParse(responseBody);
+    if (!parseResult.success) {
+        throw new Error(`Invalid token response: ${parseResult.error.message}`);
+    }
+
+    return parseResult.data;
+}

--- a/src/shared/auth.ts
+++ b/src/shared/auth.ts
@@ -139,6 +139,25 @@ export const OAuthTokensSchema = z
     .strip();
 
 /**
+ * RFC 8693 §2.2.1 Token Exchange response for ID-JAG tokens.
+ *
+ * `token_type` is intentionally optional: per RFC 8693 §2.2.1 it is informational when
+ * the issued token is not an access token, and per RFC 6749 §5.1 it is case-insensitive,
+ * so strict checking rejects conformant IdPs.
+ */
+export const IdJagTokenExchangeResponseSchema = z
+    .object({
+        issued_token_type: z.literal('urn:ietf:params:oauth:token-type:id-jag'),
+        access_token: z.string(),
+        token_type: z.string().optional(),
+        expires_in: z.coerce.number().optional(),
+        scope: z.string().optional()
+    })
+    .strip();
+
+export type IdJagTokenExchangeResponse = z.infer<typeof IdJagTokenExchangeResponseSchema>;
+
+/**
  * OAuth 2.1 error response
  */
 export const OAuthErrorResponseSchema = z.object({

--- a/test/client/cross-app-access.test.ts
+++ b/test/client/cross-app-access.test.ts
@@ -1,0 +1,326 @@
+import type { FetchLike } from '../../src/shared/transport.js';
+import { OAuthError } from '../../src/server/auth/errors.js';
+import { describe, expect, it, vi } from 'vitest';
+
+import { discoverAndRequestJwtAuthGrant, exchangeJwtAuthGrant, requestJwtAuthorizationGrant } from '../../src/client/cross-app-access.js';
+
+describe('crossAppAccess', () => {
+    describe('requestJwtAuthorizationGrant', () => {
+        it('successfully exchanges ID token for JWT Authorization Grant', async () => {
+            const mockFetch = vi.fn<FetchLike>().mockResolvedValue({
+                ok: true,
+                json: async () => ({
+                    issued_token_type: 'urn:ietf:params:oauth:token-type:id-jag',
+                    access_token: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...',
+                    token_type: 'N_A',
+                    expires_in: 300,
+                    scope: 'chat.read chat.history'
+                })
+            } as Response);
+
+            const result = await requestJwtAuthorizationGrant({
+                tokenEndpoint: 'https://idp.example.com/token',
+                audience: 'https://auth.chat.example/',
+                resource: 'https://mcp.chat.example/',
+                idToken: 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...',
+                clientId: 'my-idp-client',
+                clientSecret: 'my-idp-secret',
+                scope: 'chat.read chat.history',
+                fetchFn: mockFetch
+            });
+
+            expect(result.jwtAuthGrant).toBe('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...');
+            expect(result.expiresIn).toBe(300);
+            expect(result.scope).toBe('chat.read chat.history');
+
+            expect(mockFetch).toHaveBeenCalledOnce();
+            const [url, init] = mockFetch.mock.calls[0]!;
+            expect(url).toBe('https://idp.example.com/token');
+            expect(init?.method).toBe('POST');
+            expect(init?.headers).toEqual({
+                'Content-Type': 'application/x-www-form-urlencoded'
+            });
+
+            const body = new URLSearchParams(init?.body as string);
+            expect(body.get('grant_type')).toBe('urn:ietf:params:oauth:grant-type:token-exchange');
+            expect(body.get('requested_token_type')).toBe('urn:ietf:params:oauth:token-type:id-jag');
+            expect(body.get('audience')).toBe('https://auth.chat.example/');
+            expect(body.get('resource')).toBe('https://mcp.chat.example/');
+            expect(body.get('subject_token')).toBe('eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...');
+            expect(body.get('subject_token_type')).toBe('urn:ietf:params:oauth:token-type:id_token');
+            expect(body.get('client_id')).toBe('my-idp-client');
+            expect(body.get('client_secret')).toBe('my-idp-secret');
+            expect(body.get('scope')).toBe('chat.read chat.history');
+        });
+
+        it('works without optional scope parameter', async () => {
+            const mockFetch = vi.fn<FetchLike>().mockResolvedValue({
+                ok: true,
+                json: async () => ({
+                    issued_token_type: 'urn:ietf:params:oauth:token-type:id-jag',
+                    access_token: 'jag-token',
+                    token_type: 'N_A'
+                })
+            } as Response);
+
+            const result = await requestJwtAuthorizationGrant({
+                tokenEndpoint: 'https://idp.example.com/token',
+                audience: 'https://auth.chat.example/',
+                resource: 'https://mcp.chat.example/',
+                idToken: 'id-token',
+                clientId: 'client',
+                clientSecret: 'secret',
+                fetchFn: mockFetch
+            });
+
+            expect(result.jwtAuthGrant).toBe('jag-token');
+
+            const body = new URLSearchParams(mockFetch.mock.calls[0]![1]?.body as string);
+            expect(body.get('scope')).toBeNull();
+        });
+
+        it('omits client_secret from body when not provided (public client)', async () => {
+            const mockFetch = vi.fn<FetchLike>().mockResolvedValue({
+                ok: true,
+                json: async () => ({
+                    issued_token_type: 'urn:ietf:params:oauth:token-type:id-jag',
+                    access_token: 'jag-token',
+                    token_type: 'N_A'
+                })
+            } as Response);
+
+            await requestJwtAuthorizationGrant({
+                tokenEndpoint: 'https://idp.example.com/token',
+                audience: 'https://auth.chat.example/',
+                resource: 'https://mcp.chat.example/',
+                idToken: 'id-token',
+                clientId: 'public-client',
+                fetchFn: mockFetch
+            });
+
+            const body = new URLSearchParams(mockFetch.mock.calls[0]![1]?.body as string);
+            expect(body.get('client_id')).toBe('public-client');
+            expect(body.has('client_secret')).toBe(false);
+        });
+
+        it('throws error when issued_token_type is incorrect', async () => {
+            const mockFetch = vi.fn<FetchLike>().mockResolvedValue({
+                ok: true,
+                json: async () => ({
+                    issued_token_type: 'urn:ietf:params:oauth:token-type:access_token',
+                    access_token: 'token',
+                    token_type: 'N_A'
+                })
+            } as Response);
+
+            await expect(
+                requestJwtAuthorizationGrant({
+                    tokenEndpoint: 'https://idp.example.com/token',
+                    audience: 'https://auth.chat.example/',
+                    resource: 'https://mcp.chat.example/',
+                    idToken: 'id-token',
+                    clientId: 'client',
+                    clientSecret: 'secret',
+                    fetchFn: mockFetch
+                })
+            ).rejects.toThrow('Invalid token exchange response');
+        });
+
+        it('handles OAuth error responses', async () => {
+            const mockFetch = vi.fn<FetchLike>().mockResolvedValue(
+                new Response(
+                    JSON.stringify({
+                        error: 'invalid_grant',
+                        error_description: 'Audience validation failed'
+                    }),
+                    { status: 400 }
+                )
+            );
+
+            await expect(
+                requestJwtAuthorizationGrant({
+                    tokenEndpoint: 'https://idp.example.com/token',
+                    audience: 'https://auth.chat.example/',
+                    resource: 'https://mcp.chat.example/',
+                    idToken: 'id-token',
+                    clientId: 'client',
+                    clientSecret: 'secret',
+                    fetchFn: mockFetch
+                })
+            ).rejects.toThrow(OAuthError);
+        });
+
+        it('handles non-OAuth error responses', async () => {
+            const mockFetch = vi
+                .fn<FetchLike>()
+                .mockResolvedValue(new Response(JSON.stringify({ message: 'Internal server error' }), { status: 500 }));
+
+            await expect(
+                requestJwtAuthorizationGrant({
+                    tokenEndpoint: 'https://idp.example.com/token',
+                    audience: 'https://auth.chat.example/',
+                    resource: 'https://mcp.chat.example/',
+                    idToken: 'id-token',
+                    clientId: 'client',
+                    clientSecret: 'secret',
+                    fetchFn: mockFetch
+                })
+            ).rejects.toThrow(OAuthError);
+        });
+    });
+
+    describe('discoverAndRequestJwtAuthGrant', () => {
+        it('discovers token endpoint and performs token exchange', async () => {
+            const mockFetch = vi.fn<FetchLike>();
+
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({
+                    issuer: 'https://idp.example.com',
+                    authorization_endpoint: 'https://idp.example.com/authorize',
+                    token_endpoint: 'https://idp.example.com/token',
+                    jwks_uri: 'https://idp.example.com/jwks',
+                    response_types_supported: ['code'],
+                    grant_types_supported: ['urn:ietf:params:oauth:grant-type:token-exchange']
+                })
+            } as Response);
+
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({
+                    issued_token_type: 'urn:ietf:params:oauth:token-type:id-jag',
+                    access_token: 'jag-token',
+                    token_type: 'N_A',
+                    expires_in: 300
+                })
+            } as Response);
+
+            const result = await discoverAndRequestJwtAuthGrant({
+                idpUrl: 'https://idp.example.com',
+                audience: 'https://auth.chat.example/',
+                resource: 'https://mcp.chat.example/',
+                idToken: 'id-token',
+                clientId: 'client',
+                clientSecret: 'secret',
+                fetchFn: mockFetch
+            });
+
+            expect(result.jwtAuthGrant).toBe('jag-token');
+            expect(result.expiresIn).toBe(300);
+
+            expect(mockFetch).toHaveBeenCalledTimes(2);
+            expect(String(mockFetch.mock.calls[0]![0])).toContain('.well-known/oauth-authorization-server');
+            expect(String(mockFetch.mock.calls[1]![0])).toBe('https://idp.example.com/token');
+        });
+    });
+
+    describe('exchangeJwtAuthGrant', () => {
+        it('exchanges JAG for access token using client_secret_basic by default', async () => {
+            const mockFetch = vi.fn<FetchLike>().mockResolvedValue({
+                ok: true,
+                json: async () => ({
+                    access_token: 'mcp-access-token',
+                    token_type: 'Bearer',
+                    expires_in: 3600,
+                    scope: 'chat.read chat.history'
+                })
+            } as Response);
+
+            const result = await exchangeJwtAuthGrant({
+                tokenEndpoint: 'https://auth.chat.example/token',
+                jwtAuthGrant: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...',
+                clientId: 'my-mcp-client',
+                clientSecret: 'my-mcp-secret',
+                fetchFn: mockFetch
+            });
+
+            expect(result.access_token).toBe('mcp-access-token');
+            expect(result.token_type).toBe('Bearer');
+            expect(result.expires_in).toBe(3600);
+            expect(result.scope).toBe('chat.read chat.history');
+
+            expect(mockFetch).toHaveBeenCalledOnce();
+            const [url, init] = mockFetch.mock.calls[0]!;
+            expect(url).toBe('https://auth.chat.example/token');
+            expect(init?.method).toBe('POST');
+
+            const headers = new Headers(init?.headers as Headers);
+            const expectedCredentials = Buffer.from('my-mcp-client:my-mcp-secret').toString('base64');
+            expect(headers.get('Authorization')).toBe(`Basic ${expectedCredentials}`);
+
+            const body = new URLSearchParams(init?.body as string);
+            expect(body.get('grant_type')).toBe('urn:ietf:params:oauth:grant-type:jwt-bearer');
+            expect(body.get('assertion')).toBe('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...');
+            expect(body.has('client_id')).toBe(false);
+            expect(body.has('client_secret')).toBe(false);
+        });
+
+        it('supports client_secret_post when explicitly requested', async () => {
+            const mockFetch = vi.fn<FetchLike>().mockResolvedValue({
+                ok: true,
+                json: async () => ({
+                    access_token: 'mcp-access-token',
+                    token_type: 'Bearer'
+                })
+            } as Response);
+
+            await exchangeJwtAuthGrant({
+                tokenEndpoint: 'https://auth.chat.example/token',
+                jwtAuthGrant: 'jwt',
+                clientId: 'my-mcp-client',
+                clientSecret: 'my-mcp-secret',
+                authMethod: 'client_secret_post',
+                fetchFn: mockFetch
+            });
+
+            const [, init] = mockFetch.mock.calls[0]!;
+            const headers = new Headers(init?.headers as Headers);
+            expect(headers.get('Authorization')).toBeNull();
+
+            const body = new URLSearchParams(init?.body as string);
+            expect(body.get('client_id')).toBe('my-mcp-client');
+            expect(body.get('client_secret')).toBe('my-mcp-secret');
+        });
+
+        it('handles OAuth error responses', async () => {
+            const mockFetch = vi.fn<FetchLike>().mockResolvedValue(
+                new Response(
+                    JSON.stringify({
+                        error: 'invalid_grant',
+                        error_description: 'JWT signature verification failed'
+                    }),
+                    { status: 400 }
+                )
+            );
+
+            await expect(
+                exchangeJwtAuthGrant({
+                    tokenEndpoint: 'https://auth.chat.example/token',
+                    jwtAuthGrant: 'invalid-jwt',
+                    clientId: 'client',
+                    clientSecret: 'secret',
+                    fetchFn: mockFetch
+                })
+            ).rejects.toThrow(OAuthError);
+        });
+
+        it('validates token response with schema', async () => {
+            const mockFetch = vi.fn<FetchLike>().mockResolvedValue({
+                ok: true,
+                json: async () => ({
+                    token_type: 'Bearer'
+                })
+            } as Response);
+
+            await expect(
+                exchangeJwtAuthGrant({
+                    tokenEndpoint: 'https://auth.chat.example/token',
+                    jwtAuthGrant: 'jwt',
+                    clientId: 'client',
+                    clientSecret: 'secret',
+                    fetchFn: mockFetch
+                })
+            ).rejects.toThrow('Invalid token response');
+        });
+    });
+});


### PR DESCRIPTION
Backport Enterprise Managed Authorization (Cross-App Access) from v2 main (PR #1593) to the v1.x release line.

**New files:**
- `src/client/cross-app-access.ts` — standalone RFC 8693 token exchange and RFC 7523 JWT bearer grant utilities
- `test/client/cross-app-access.test.ts` — unit tests

**Modified files:**
- `src/shared/auth.ts` — add `IdJagTokenExchangeResponseSchema`
- `src/client/auth.ts` — export `ClientAuthMethod` and `applyClientAuthentication`
- `src/client/auth-extensions.ts` — add `CrossAppAccessProvider`, `CrossAppAccessContext`, `AssertionCallback` types

All existing tests pass. The `CrossAppAccessProvider` reads `authorizationServerUrl` and `resourceMetadata.resource` from the discovery state (no individual save methods).