### PR TITLE
feat(server): add keepAliveInterval for standalone GET SSE stream

### DIFF
--- a/.changeset/add-sse-keepalive.md
+++ b/.changeset/add-sse-keepalive.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/server': minor
+---
+
+Add optional `keepAliveInterval` to `WebStandardStreamableHTTPServerTransportOptions` that sends periodic SSE comments on the standalone GET stream to prevent reverse proxy idle timeout disconnections.

--- a/packages/server/src/server/streamableHttp.ts
+++ b/packages/server/src/server/streamableHttp.ts
@@ -548,35 +548,21 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
             // Create a ReadableStream with controller for SSE
             const encoder = new TextEncoder();
             let streamController!: ReadableStreamDefaultController<Uint8Array>;
-            let replayedStreamId!: string;
-
-            const mapping: StreamMapping = {
-                encoder,
-                cleanup: () => {
-                    if (mapping.keepAliveTimer) clearInterval(mapping.keepAliveTimer);
-                    this._streamMapping.delete(replayedStreamId);
-                    try {
-                        streamController.close();
-                    } catch {
-                        // Controller might already be closed
-                    }
-                }
-            };
+            let keepAliveTimer: ReturnType<typeof setInterval> | undefined;
 
             const readable = new ReadableStream<Uint8Array>({
                 start: controller => {
                     streamController = controller;
-                    mapping.controller = controller;
                 },
                 cancel: () => {
                     // Stream was cancelled by client
-                    if (mapping.keepAliveTimer) clearInterval(mapping.keepAliveTimer);
+                    if (keepAliveTimer) clearInterval(keepAliveTimer);
                     // Cleanup will be handled by the mapping
                 }
             });
 
             // Replay events - returns the streamId for backwards compatibility
-            replayedStreamId = await this._eventStore.replayEventsAfter(lastEventId, {
+            const replayedStreamId = await this._eventStore.replayEventsAfter(lastEventId, {
                 send: async (eventId: string, message: JSONRPCMessage) => {
                     const success = this.writeSSEEvent(streamController, encoder, message, eventId);
                     if (!success) {
@@ -589,18 +575,32 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
                 }
             });
 
+            const mapping: StreamMapping = {
+                controller: streamController,
+                encoder,
+                cleanup: () => {
+                    if (keepAliveTimer) clearInterval(keepAliveTimer);
+                    this._streamMapping.delete(replayedStreamId);
+                    try {
+                        streamController.close();
+                    } catch {
+                        // Controller might already be closed
+                    }
+                }
+            };
             this._streamMapping.set(replayedStreamId, mapping);
 
             // Start keepalive timer for the replayed stream so reconnecting
             // clients remain protected from proxy idle timeouts
             if (this._keepAliveInterval !== undefined) {
-                mapping.keepAliveTimer = setInterval(() => {
+                keepAliveTimer = setInterval(() => {
                     try {
                         streamController.enqueue(encoder.encode(': keepalive\n\n'));
                     } catch {
-                        if (mapping.keepAliveTimer) clearInterval(mapping.keepAliveTimer);
+                        if (keepAliveTimer) clearInterval(keepAliveTimer);
                     }
                 }, this._keepAliveInterval);
+                mapping.keepAliveTimer = keepAliveTimer;
             }
 
             return new Response(readable, { headers });

--- a/packages/server/src/server/streamableHttp.ts
+++ b/packages/server/src/server/streamableHttp.ts
@@ -65,6 +65,8 @@ interface StreamMapping {
     resolveJson?: (response: Response) => void;
     /** Cleanup function to close stream and remove mapping */
     cleanup: () => void;
+    /** Per-stream keepalive timer; cleared by this stream's cleanup/cancel */
+    keepAliveTimer?: ReturnType<typeof setInterval>;
 }
 
 /**
@@ -249,7 +251,6 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
     private _enableDnsRebindingProtection: boolean;
     private _retryInterval?: number;
     private _keepAliveInterval?: number;
-    private _keepAliveTimer?: ReturnType<typeof setInterval>;
     private _supportedProtocolVersions: string[];
 
     sessionId?: string;
@@ -449,16 +450,30 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
         }
 
         const encoder = new TextEncoder();
-        let streamController: ReadableStreamDefaultController<Uint8Array>;
+        let streamController!: ReadableStreamDefaultController<Uint8Array>;
+
+        const mapping: StreamMapping = {
+            encoder,
+            cleanup: () => {
+                if (mapping.keepAliveTimer) clearInterval(mapping.keepAliveTimer);
+                this._streamMapping.delete(this._standaloneSseStreamId);
+                try {
+                    streamController.close();
+                } catch {
+                    // Controller might already be closed
+                }
+            }
+        };
 
         // Create a ReadableStream with a controller we can use to push SSE events
         const readable = new ReadableStream<Uint8Array>({
             start: controller => {
                 streamController = controller;
+                mapping.controller = controller;
             },
             cancel: () => {
                 // Stream was cancelled by client
-                this._clearKeepAliveTimer();
+                if (mapping.keepAliveTimer) clearInterval(mapping.keepAliveTimer);
                 this._streamMapping.delete(this._standaloneSseStreamId);
             }
         });
@@ -474,30 +489,17 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
             headers['mcp-session-id'] = this.sessionId;
         }
 
-        // Store the stream mapping with the controller for pushing data
-        this._streamMapping.set(this._standaloneSseStreamId, {
-            controller: streamController!,
-            encoder,
-            cleanup: () => {
-                this._streamMapping.delete(this._standaloneSseStreamId);
-                try {
-                    streamController!.close();
-                } catch {
-                    // Controller might already be closed
-                }
-            }
-        });
+        this._streamMapping.set(this._standaloneSseStreamId, mapping);
 
         // Start keepalive timer to send periodic SSE comments that prevent
         // reverse proxies from closing the connection due to idle timeouts
         if (this._keepAliveInterval !== undefined) {
-            this._clearKeepAliveTimer();
-            this._keepAliveTimer = setInterval(() => {
+            mapping.keepAliveTimer = setInterval(() => {
                 try {
-                    streamController!.enqueue(encoder.encode(': keepalive\n\n'));
+                    streamController.enqueue(encoder.encode(': keepalive\n\n'));
                 } catch {
                     // Controller is closed or errored, stop sending keepalives
-                    this._clearKeepAliveTimer();
+                    if (mapping.keepAliveTimer) clearInterval(mapping.keepAliveTimer);
                 }
             }, this._keepAliveInterval);
         }
@@ -545,26 +547,41 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
 
             // Create a ReadableStream with controller for SSE
             const encoder = new TextEncoder();
-            let streamController: ReadableStreamDefaultController<Uint8Array>;
+            let streamController!: ReadableStreamDefaultController<Uint8Array>;
+            let replayedStreamId!: string;
+
+            const mapping: StreamMapping = {
+                encoder,
+                cleanup: () => {
+                    if (mapping.keepAliveTimer) clearInterval(mapping.keepAliveTimer);
+                    this._streamMapping.delete(replayedStreamId);
+                    try {
+                        streamController.close();
+                    } catch {
+                        // Controller might already be closed
+                    }
+                }
+            };
 
             const readable = new ReadableStream<Uint8Array>({
                 start: controller => {
                     streamController = controller;
+                    mapping.controller = controller;
                 },
                 cancel: () => {
                     // Stream was cancelled by client
-                    this._clearKeepAliveTimer();
+                    if (mapping.keepAliveTimer) clearInterval(mapping.keepAliveTimer);
                     // Cleanup will be handled by the mapping
                 }
             });
 
             // Replay events - returns the streamId for backwards compatibility
-            const replayedStreamId = await this._eventStore.replayEventsAfter(lastEventId, {
+            replayedStreamId = await this._eventStore.replayEventsAfter(lastEventId, {
                 send: async (eventId: string, message: JSONRPCMessage) => {
-                    const success = this.writeSSEEvent(streamController!, encoder, message, eventId);
+                    const success = this.writeSSEEvent(streamController, encoder, message, eventId);
                     if (!success) {
                         try {
-                            streamController!.close();
+                            streamController.close();
                         } catch {
                             // Controller might already be closed
                         }
@@ -572,28 +589,16 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
                 }
             });
 
-            this._streamMapping.set(replayedStreamId, {
-                controller: streamController!,
-                encoder,
-                cleanup: () => {
-                    this._streamMapping.delete(replayedStreamId);
-                    try {
-                        streamController!.close();
-                    } catch {
-                        // Controller might already be closed
-                    }
-                }
-            });
+            this._streamMapping.set(replayedStreamId, mapping);
 
             // Start keepalive timer for the replayed stream so reconnecting
             // clients remain protected from proxy idle timeouts
             if (this._keepAliveInterval !== undefined) {
-                this._clearKeepAliveTimer();
-                this._keepAliveTimer = setInterval(() => {
+                mapping.keepAliveTimer = setInterval(() => {
                     try {
-                        streamController!.enqueue(encoder.encode(': keepalive\n\n'));
+                        streamController.enqueue(encoder.encode(': keepalive\n\n'));
                     } catch {
-                        this._clearKeepAliveTimer();
+                        if (mapping.keepAliveTimer) clearInterval(mapping.keepAliveTimer);
                     }
                 }, this._keepAliveInterval);
             }
@@ -938,21 +943,13 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
         return undefined;
     }
 
-    private _clearKeepAliveTimer(): void {
-        if (this._keepAliveTimer !== undefined) {
-            clearInterval(this._keepAliveTimer);
-            this._keepAliveTimer = undefined;
-        }
-    }
-
     async close(): Promise<void> {
         if (this._closed) {
             return;
         }
         this._closed = true;
-        this._clearKeepAliveTimer();
 
-        // Close all SSE connections
+        // Close all SSE connections (each cleanup() also clears its own keepAliveTimer)
         for (const { cleanup } of this._streamMapping.values()) {
             cleanup();
         }
@@ -985,7 +982,6 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
     closeStandaloneSSEStream(): void {
         const stream = this._streamMapping.get(this._standaloneSseStreamId);
         if (stream) {
-            this._clearKeepAliveTimer();
             stream.cleanup();
         }
     }

--- a/packages/server/src/server/streamableHttp.ts
+++ b/packages/server/src/server/streamableHttp.ts
@@ -552,6 +552,7 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
                 },
                 cancel: () => {
                     // Stream was cancelled by client
+                    this._clearKeepAliveTimer();
                     // Cleanup will be handled by the mapping
                 }
             });
@@ -582,6 +583,18 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
                     }
                 }
             });
+
+            // Start keepalive timer for the replayed stream so reconnecting
+            // clients remain protected from proxy idle timeouts
+            if (this._keepAliveInterval !== undefined) {
+                this._keepAliveTimer = setInterval(() => {
+                    try {
+                        streamController!.enqueue(encoder.encode(': keepalive\n\n'));
+                    } catch {
+                        this._clearKeepAliveTimer();
+                    }
+                }, this._keepAliveInterval);
+            }
 
             return new Response(readable, { headers });
         } catch (error) {

--- a/packages/server/src/server/streamableHttp.ts
+++ b/packages/server/src/server/streamableHttp.ts
@@ -587,6 +587,7 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
             // Start keepalive timer for the replayed stream so reconnecting
             // clients remain protected from proxy idle timeouts
             if (this._keepAliveInterval !== undefined) {
+                this._clearKeepAliveTimer();
                 this._keepAliveTimer = setInterval(() => {
                     try {
                         streamController!.enqueue(encoder.encode(': keepalive\n\n'));

--- a/packages/server/src/server/streamableHttp.ts
+++ b/packages/server/src/server/streamableHttp.ts
@@ -491,6 +491,7 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
         // Start keepalive timer to send periodic SSE comments that prevent
         // reverse proxies from closing the connection due to idle timeouts
         if (this._keepAliveInterval !== undefined) {
+            this._clearKeepAliveTimer();
             this._keepAliveTimer = setInterval(() => {
                 try {
                     streamController!.enqueue(encoder.encode(': keepalive\n\n'));
@@ -982,9 +983,9 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
      * Use this to implement polling behavior for server-initiated notifications.
      */
     closeStandaloneSSEStream(): void {
-        this._clearKeepAliveTimer();
         const stream = this._streamMapping.get(this._standaloneSseStreamId);
         if (stream) {
+            this._clearKeepAliveTimer();
             stream.cleanup();
         }
     }

--- a/packages/server/src/server/streamableHttp.ts
+++ b/packages/server/src/server/streamableHttp.ts
@@ -142,6 +142,15 @@ export interface WebStandardStreamableHTTPServerTransportOptions {
     retryInterval?: number;
 
     /**
+     * Interval in milliseconds for sending SSE keepalive comments on the standalone
+     * GET SSE stream. When set, the transport sends periodic SSE comments
+     * (`: keepalive`) to prevent reverse proxies from closing idle connections.
+     *
+     * Disabled by default (no keepalive comments are sent).
+     */
+    keepAliveInterval?: number;
+
+    /**
      * List of protocol versions that this transport will accept.
      * Used to validate the `mcp-protocol-version` header in incoming requests.
      *
@@ -239,6 +248,8 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
     private _allowedOrigins?: string[];
     private _enableDnsRebindingProtection: boolean;
     private _retryInterval?: number;
+    private _keepAliveInterval?: number;
+    private _keepAliveTimer?: ReturnType<typeof setInterval>;
     private _supportedProtocolVersions: string[];
 
     sessionId?: string;
@@ -256,6 +267,7 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
         this._allowedOrigins = options.allowedOrigins;
         this._enableDnsRebindingProtection = options.enableDnsRebindingProtection ?? false;
         this._retryInterval = options.retryInterval;
+        this._keepAliveInterval = options.keepAliveInterval;
         this._supportedProtocolVersions = options.supportedProtocolVersions ?? SUPPORTED_PROTOCOL_VERSIONS;
     }
 
@@ -446,6 +458,7 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
             },
             cancel: () => {
                 // Stream was cancelled by client
+                this._clearKeepAliveTimer();
                 this._streamMapping.delete(this._standaloneSseStreamId);
             }
         });
@@ -474,6 +487,19 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
                 }
             }
         });
+
+        // Start keepalive timer to send periodic SSE comments that prevent
+        // reverse proxies from closing the connection due to idle timeouts
+        if (this._keepAliveInterval !== undefined) {
+            this._keepAliveTimer = setInterval(() => {
+                try {
+                    streamController!.enqueue(encoder.encode(': keepalive\n\n'));
+                } catch {
+                    // Controller is closed or errored, stop sending keepalives
+                    this._clearKeepAliveTimer();
+                }
+            }, this._keepAliveInterval);
+        }
 
         return new Response(readable, { headers });
     }
@@ -897,11 +923,19 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
         return undefined;
     }
 
+    private _clearKeepAliveTimer(): void {
+        if (this._keepAliveTimer !== undefined) {
+            clearInterval(this._keepAliveTimer);
+            this._keepAliveTimer = undefined;
+        }
+    }
+
     async close(): Promise<void> {
         if (this._closed) {
             return;
         }
         this._closed = true;
+        this._clearKeepAliveTimer();
 
         // Close all SSE connections
         for (const { cleanup } of this._streamMapping.values()) {
@@ -934,6 +968,7 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
      * Use this to implement polling behavior for server-initiated notifications.
      */
     closeStandaloneSSEStream(): void {
+        this._clearKeepAliveTimer();
         const stream = this._streamMapping.get(this._standaloneSseStreamId);
         if (stream) {
             stream.cleanup();

--- a/packages/server/src/server/streamableHttp.ts
+++ b/packages/server/src/server/streamableHttp.ts
@@ -580,24 +580,11 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
             // replayEventsAfter resolves) — must be `let`.
             // eslint-disable-next-line prefer-const
             let replayedStreamId: string | undefined;
-
-            const mapping: StreamMapping = {
-                encoder,
-                cleanup: () => {
-                    if (mapping.keepAliveTimer) clearInterval(mapping.keepAliveTimer);
-                    this._streamMapping.delete(replayedStreamId!);
-                    try {
-                        streamController!.close();
-                    } catch {
-                        // Controller might already be closed
-                    }
-                }
-            };
+            let keepAliveTimer: ReturnType<typeof setInterval> | undefined;
 
             const readable = new ReadableStream<Uint8Array>({
                 start: controller => {
                     streamController = controller;
-                    mapping.controller = controller;
                 },
                 cancel: () => {
                     // Stream was cancelled by client — drop the mapping so a
@@ -607,7 +594,7 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
                     // a stale cancel from an earlier resume must not delete a
                     // successor resumed stream a re-poll has since registered.
                     if (replayedStreamId !== undefined && this._streamMapping.get(replayedStreamId)?.controller === streamController) {
-                        if (mapping.keepAliveTimer) clearInterval(mapping.keepAliveTimer);
+                        if (keepAliveTimer) clearInterval(keepAliveTimer);
                         this._streamMapping.delete(replayedStreamId);
                     }
                 }
@@ -629,7 +616,20 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
                 }
             });
 
-            mapping.replayedEventIds = replayedEventIds;
+            const mapping: StreamMapping = {
+                controller: streamController!,
+                encoder,
+                replayedEventIds,
+                cleanup: () => {
+                    if (keepAliveTimer) clearInterval(keepAliveTimer);
+                    this._streamMapping.delete(replayedStreamId!);
+                    try {
+                        streamController!.close();
+                    } catch {
+                        // Controller might already be closed
+                    }
+                }
+            };
             this._streamMapping.set(replayedStreamId!, mapping);
 
             // If this is a per-request stream and no in-flight request still
@@ -654,13 +654,14 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
             // Start keepalive timer for the replayed stream so reconnecting
             // clients remain protected from proxy idle timeouts
             if (this._keepAliveInterval !== undefined) {
-                mapping.keepAliveTimer = setInterval(() => {
+                keepAliveTimer = setInterval(() => {
                     try {
-                        streamController.enqueue(encoder.encode(': keepalive\n\n'));
+                        streamController!.enqueue(encoder.encode(': keepalive\n\n'));
                     } catch {
-                        if (mapping.keepAliveTimer) clearInterval(mapping.keepAliveTimer);
+                        if (keepAliveTimer) clearInterval(keepAliveTimer);
                     }
                 }, this._keepAliveInterval);
+                mapping.keepAliveTimer = keepAliveTimer;
             }
 
             return new Response(readable, { headers });

--- a/packages/server/src/server/streamableHttp.ts
+++ b/packages/server/src/server/streamableHttp.ts
@@ -72,6 +72,8 @@ interface StreamMapping {
     replayedEventIds?: Set<string>;
     /** Cleanup function to close stream and remove mapping */
     cleanup: () => void;
+    /** Per-stream keepalive timer; cleared by this stream's cleanup/cancel */
+    keepAliveTimer?: ReturnType<typeof setInterval>;
 }
 
 /**
@@ -256,7 +258,6 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
     private _enableDnsRebindingProtection: boolean;
     private _retryInterval?: number;
     private _keepAliveInterval?: number;
-    private _keepAliveTimer?: ReturnType<typeof setInterval>;
     private _supportedProtocolVersions: string[];
 
     sessionId?: string;
@@ -473,19 +474,33 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
         }
 
         const encoder = new TextEncoder();
-        let streamController: ReadableStreamDefaultController<Uint8Array>;
+        let streamController!: ReadableStreamDefaultController<Uint8Array>;
+
+        const mapping: StreamMapping = {
+            encoder,
+            cleanup: () => {
+                if (mapping.keepAliveTimer) clearInterval(mapping.keepAliveTimer);
+                this._streamMapping.delete(this._standaloneSseStreamId);
+                try {
+                    streamController.close();
+                } catch {
+                    // Controller might already be closed
+                }
+            }
+        };
 
         // Create a ReadableStream with a controller we can use to push SSE events
         const readable = new ReadableStream<Uint8Array>({
             start: controller => {
                 streamController = controller;
+                mapping.controller = controller;
             },
             cancel: () => {
                 // Stream was cancelled by client. Only drop the mapping when
                 // it still points at THIS controller — a stale cancel must not
                 // delete a successor stream registered by a later GET/resume.
                 if (this._streamMapping.get(this._standaloneSseStreamId)?.controller === streamController) {
-                    this._clearKeepAliveTimer();
+                    if (mapping.keepAliveTimer) clearInterval(mapping.keepAliveTimer);
                     this._streamMapping.delete(this._standaloneSseStreamId);
                 }
             }
@@ -502,30 +517,17 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
             headers['mcp-session-id'] = this.sessionId;
         }
 
-        // Store the stream mapping with the controller for pushing data
-        this._streamMapping.set(this._standaloneSseStreamId, {
-            controller: streamController!,
-            encoder,
-            cleanup: () => {
-                this._streamMapping.delete(this._standaloneSseStreamId);
-                try {
-                    streamController!.close();
-                } catch {
-                    // Controller might already be closed
-                }
-            }
-        });
+        this._streamMapping.set(this._standaloneSseStreamId, mapping);
 
         // Start keepalive timer to send periodic SSE comments that prevent
         // reverse proxies from closing the connection due to idle timeouts
         if (this._keepAliveInterval !== undefined) {
-            this._clearKeepAliveTimer();
-            this._keepAliveTimer = setInterval(() => {
+            mapping.keepAliveTimer = setInterval(() => {
                 try {
-                    streamController!.enqueue(encoder.encode(': keepalive\n\n'));
+                    streamController.enqueue(encoder.encode(': keepalive\n\n'));
                 } catch {
                     // Controller is closed or errored, stop sending keepalives
-                    this._clearKeepAliveTimer();
+                    if (mapping.keepAliveTimer) clearInterval(mapping.keepAliveTimer);
                 }
             }, this._keepAliveInterval);
         }
@@ -579,9 +581,23 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
             // eslint-disable-next-line prefer-const
             let replayedStreamId: string | undefined;
 
+            const mapping: StreamMapping = {
+                encoder,
+                cleanup: () => {
+                    if (mapping.keepAliveTimer) clearInterval(mapping.keepAliveTimer);
+                    this._streamMapping.delete(replayedStreamId!);
+                    try {
+                        streamController!.close();
+                    } catch {
+                        // Controller might already be closed
+                    }
+                }
+            };
+
             const readable = new ReadableStream<Uint8Array>({
                 start: controller => {
                     streamController = controller;
+                    mapping.controller = controller;
                 },
                 cancel: () => {
                     // Stream was cancelled by client — drop the mapping so a
@@ -591,7 +607,7 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
                     // a stale cancel from an earlier resume must not delete a
                     // successor resumed stream a re-poll has since registered.
                     if (replayedStreamId !== undefined && this._streamMapping.get(replayedStreamId)?.controller === streamController) {
-                        this._clearKeepAliveTimer();
+                        if (mapping.keepAliveTimer) clearInterval(mapping.keepAliveTimer);
                         this._streamMapping.delete(replayedStreamId);
                     }
                 }
@@ -605,7 +621,7 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
                     const success = this.writeSSEEvent(streamController!, encoder, message, eventId);
                     if (!success) {
                         try {
-                            streamController!.close();
+                            streamController.close();
                         } catch {
                             // Controller might already be closed
                         }
@@ -613,19 +629,8 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
                 }
             });
 
-            this._streamMapping.set(replayedStreamId, {
-                controller: streamController!,
-                encoder,
-                replayedEventIds,
-                cleanup: () => {
-                    this._streamMapping.delete(replayedStreamId!);
-                    try {
-                        streamController!.close();
-                    } catch {
-                        // Controller might already be closed
-                    }
-                }
-            });
+            mapping.replayedEventIds = replayedEventIds;
+            this._streamMapping.set(replayedStreamId!, mapping);
 
             // If this is a per-request stream and no in-flight request still
             // targets this streamId, the request was already retired by the
@@ -649,12 +654,11 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
             // Start keepalive timer for the replayed stream so reconnecting
             // clients remain protected from proxy idle timeouts
             if (this._keepAliveInterval !== undefined) {
-                this._clearKeepAliveTimer();
-                this._keepAliveTimer = setInterval(() => {
+                mapping.keepAliveTimer = setInterval(() => {
                     try {
-                        streamController!.enqueue(encoder.encode(': keepalive\n\n'));
+                        streamController.enqueue(encoder.encode(': keepalive\n\n'));
                     } catch {
-                        this._clearKeepAliveTimer();
+                        if (mapping.keepAliveTimer) clearInterval(mapping.keepAliveTimer);
                     }
                 }, this._keepAliveInterval);
             }
@@ -1015,21 +1019,13 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
         return undefined;
     }
 
-    private _clearKeepAliveTimer(): void {
-        if (this._keepAliveTimer !== undefined) {
-            clearInterval(this._keepAliveTimer);
-            this._keepAliveTimer = undefined;
-        }
-    }
-
     async close(): Promise<void> {
         if (this._closed) {
             return;
         }
         this._closed = true;
-        this._clearKeepAliveTimer();
 
-        // Close all SSE connections
+        // Close all SSE connections (each cleanup() also clears its own keepAliveTimer)
         for (const { cleanup } of this._streamMapping.values()) {
             cleanup();
         }
@@ -1062,7 +1058,6 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
     closeStandaloneSSEStream(): void {
         const stream = this._streamMapping.get(this._standaloneSseStreamId);
         if (stream) {
-            this._clearKeepAliveTimer();
             stream.cleanup();
         }
     }

--- a/packages/server/src/server/streamableHttp.ts
+++ b/packages/server/src/server/streamableHttp.ts
@@ -587,14 +587,15 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
                     streamController = controller;
                 },
                 cancel: () => {
-                    // Stream was cancelled by client — drop the mapping so a
-                    // subsequent reconnect with the same Last-Event-ID is not
-                    // refused with 409 by the conflict check above. Only delete
-                    // when the mapped entry is still THIS closure's controller:
-                    // a stale cancel from an earlier resume must not delete a
-                    // successor resumed stream a re-poll has since registered.
+                    // Always clear the closure-local keepalive timer; the
+                    // mapping may already have been removed by the early-close
+                    // block for completed requests, but the timer is still ours.
+                    if (keepAliveTimer) clearInterval(keepAliveTimer);
+                    // Drop the mapping so a subsequent reconnect with the same
+                    // Last-Event-ID is not refused with 409. Only delete when
+                    // the mapped entry is still THIS closure's controller: a
+                    // stale cancel must not delete a successor resumed stream.
                     if (replayedStreamId !== undefined && this._streamMapping.get(replayedStreamId)?.controller === streamController) {
-                        if (keepAliveTimer) clearInterval(keepAliveTimer);
                         this._streamMapping.delete(replayedStreamId);
                     }
                 }
@@ -652,8 +653,9 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
             }
 
             // Start keepalive timer for the replayed stream so reconnecting
-            // clients remain protected from proxy idle timeouts
-            if (this._keepAliveInterval !== undefined) {
+            // clients remain protected from proxy idle timeouts.
+            // Skip if the early-close block above already removed the mapping.
+            if (this._keepAliveInterval !== undefined && this._streamMapping.has(replayedStreamId!)) {
                 keepAliveTimer = setInterval(() => {
                     try {
                         streamController!.enqueue(encoder.encode(': keepalive\n\n'));

--- a/packages/server/src/server/streamableHttp.ts
+++ b/packages/server/src/server/streamableHttp.ts
@@ -648,6 +648,7 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
             // Start keepalive timer for the replayed stream so reconnecting
             // clients remain protected from proxy idle timeouts
             if (this._keepAliveInterval !== undefined) {
+                this._clearKeepAliveTimer();
                 this._keepAliveTimer = setInterval(() => {
                     try {
                         streamController!.enqueue(encoder.encode(': keepalive\n\n'));

--- a/packages/server/src/server/streamableHttp.ts
+++ b/packages/server/src/server/streamableHttp.ts
@@ -590,6 +590,7 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
                     // a stale cancel from an earlier resume must not delete a
                     // successor resumed stream a re-poll has since registered.
                     if (replayedStreamId !== undefined && this._streamMapping.get(replayedStreamId)?.controller === streamController) {
+                        this._clearKeepAliveTimer();
                         this._streamMapping.delete(replayedStreamId);
                     }
                 }
@@ -642,6 +643,18 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
                         // Controller might already be closed
                     }
                 }
+            }
+
+            // Start keepalive timer for the replayed stream so reconnecting
+            // clients remain protected from proxy idle timeouts
+            if (this._keepAliveInterval !== undefined) {
+                this._keepAliveTimer = setInterval(() => {
+                    try {
+                        streamController!.enqueue(encoder.encode(': keepalive\n\n'));
+                    } catch {
+                        this._clearKeepAliveTimer();
+                    }
+                }, this._keepAliveInterval);
             }
 
             return new Response(readable, { headers });

--- a/packages/server/src/server/streamableHttp.ts
+++ b/packages/server/src/server/streamableHttp.ts
@@ -149,6 +149,15 @@ export interface WebStandardStreamableHTTPServerTransportOptions {
     retryInterval?: number;
 
     /**
+     * Interval in milliseconds for sending SSE keepalive comments on the standalone
+     * GET SSE stream. When set, the transport sends periodic SSE comments
+     * (`: keepalive`) to prevent reverse proxies from closing idle connections.
+     *
+     * Disabled by default (no keepalive comments are sent).
+     */
+    keepAliveInterval?: number;
+
+    /**
      * List of protocol versions that this transport will accept.
      * Used to validate the `mcp-protocol-version` header in incoming requests.
      *
@@ -246,6 +255,8 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
     private _allowedOrigins?: string[];
     private _enableDnsRebindingProtection: boolean;
     private _retryInterval?: number;
+    private _keepAliveInterval?: number;
+    private _keepAliveTimer?: ReturnType<typeof setInterval>;
     private _supportedProtocolVersions: string[];
 
     sessionId?: string;
@@ -263,6 +274,7 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
         this._allowedOrigins = options.allowedOrigins;
         this._enableDnsRebindingProtection = options.enableDnsRebindingProtection ?? false;
         this._retryInterval = options.retryInterval;
+        this._keepAliveInterval = options.keepAliveInterval;
         this._supportedProtocolVersions = options.supportedProtocolVersions ?? SUPPORTED_PROTOCOL_VERSIONS;
     }
 
@@ -473,6 +485,7 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
                 // it still points at THIS controller — a stale cancel must not
                 // delete a successor stream registered by a later GET/resume.
                 if (this._streamMapping.get(this._standaloneSseStreamId)?.controller === streamController) {
+                    this._clearKeepAliveTimer();
                     this._streamMapping.delete(this._standaloneSseStreamId);
                 }
             }
@@ -502,6 +515,19 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
                 }
             }
         });
+
+        // Start keepalive timer to send periodic SSE comments that prevent
+        // reverse proxies from closing the connection due to idle timeouts
+        if (this._keepAliveInterval !== undefined) {
+            this._keepAliveTimer = setInterval(() => {
+                try {
+                    streamController!.enqueue(encoder.encode(': keepalive\n\n'));
+                } catch {
+                    // Controller is closed or errored, stop sending keepalives
+                    this._clearKeepAliveTimer();
+                }
+            }, this._keepAliveInterval);
+        }
 
         return new Response(readable, { headers });
     }
@@ -974,11 +1000,19 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
         return undefined;
     }
 
+    private _clearKeepAliveTimer(): void {
+        if (this._keepAliveTimer !== undefined) {
+            clearInterval(this._keepAliveTimer);
+            this._keepAliveTimer = undefined;
+        }
+    }
+
     async close(): Promise<void> {
         if (this._closed) {
             return;
         }
         this._closed = true;
+        this._clearKeepAliveTimer();
 
         // Close all SSE connections
         for (const { cleanup } of this._streamMapping.values()) {
@@ -1011,6 +1045,7 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
      * Use this to implement polling behavior for server-initiated notifications.
      */
     closeStandaloneSSEStream(): void {
+        this._clearKeepAliveTimer();
         const stream = this._streamMapping.get(this._standaloneSseStreamId);
         if (stream) {
             stream.cleanup();

--- a/packages/server/src/server/streamableHttp.ts
+++ b/packages/server/src/server/streamableHttp.ts
@@ -519,6 +519,7 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
         // Start keepalive timer to send periodic SSE comments that prevent
         // reverse proxies from closing the connection due to idle timeouts
         if (this._keepAliveInterval !== undefined) {
+            this._clearKeepAliveTimer();
             this._keepAliveTimer = setInterval(() => {
                 try {
                     streamController!.enqueue(encoder.encode(': keepalive\n\n'));
@@ -1059,9 +1060,9 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
      * Use this to implement polling behavior for server-initiated notifications.
      */
     closeStandaloneSSEStream(): void {
-        this._clearKeepAliveTimer();
         const stream = this._streamMapping.get(this._standaloneSseStreamId);
         if (stream) {
+            this._clearKeepAliveTimer();
             stream.cleanup();
         }
     }

--- a/packages/server/test/server/streamableHttp.test.ts
+++ b/packages/server/test/server/streamableHttp.test.ts
@@ -1081,5 +1081,57 @@ describe('Zod v4', () => {
 
             expect(vi.getTimerCount()).toBe(0);
         });
+
+        it('should maintain independent keepalive timers per concurrent stream', async () => {
+            // Minimal event store so a GET with last-event-id triggers replayEvents()
+            // and creates a second StreamMapping entry concurrently with the standalone GET.
+            const eventStore: EventStore = {
+                async storeEvent(streamId) {
+                    return `${streamId}_evt`;
+                },
+                async getStreamIdForEventId() {
+                    return 'replay-stream';
+                },
+                async replayEventsAfter() {
+                    return 'replay-stream';
+                }
+            };
+
+            mcpServer = new McpServer({ name: 'test-server', version: '1.0.0' });
+            transport = new WebStandardStreamableHTTPServerTransport({
+                sessionIdGenerator: () => randomUUID(),
+                keepAliveInterval: 50,
+                eventStore
+            });
+            await mcpServer.connect(transport);
+            const initRes = await transport.handleRequest(createRequest('POST', TEST_MESSAGES.initialize));
+            const sessionId = initRes.headers.get('mcp-session-id') as string;
+
+            // Stream A: standalone GET
+            const resA = await transport.handleRequest(createRequest('GET', undefined, { sessionId }));
+            expect(resA.status).toBe(200);
+            const readerA = resA.body!.getReader();
+            expect(vi.getTimerCount()).toBe(1);
+
+            // Stream B: GET with last-event-id -> replayEvents path, separate mapping key
+            const resB = await transport.handleRequest(
+                createRequest('GET', undefined, { sessionId, extraHeaders: { 'last-event-id': 'evt-1' } })
+            );
+            expect(resB.status).toBe(200);
+            const readerB = resB.body!.getReader();
+            expect(vi.getTimerCount()).toBe(2);
+
+            // Cancel stream B; its keepalive timer must be cleared without affecting A's
+            await readerB.cancel();
+            expect(vi.getTimerCount()).toBe(1);
+
+            // Stream A still receives keepalives after B is cancelled
+            vi.advanceTimersByTime(60);
+            const { value } = await readerA.read();
+            expect(new TextDecoder().decode(value)).toContain(': keepalive');
+
+            await readerA.cancel();
+            expect(vi.getTimerCount()).toBe(0);
+        });
     });
 });

--- a/packages/server/test/server/streamableHttp.test.ts
+++ b/packages/server/test/server/streamableHttp.test.ts
@@ -1074,12 +1074,12 @@ describe('Zod v4', () => {
             const getRes = await transport.handleRequest(getReq);
 
             expect(getRes.status).toBe(200);
+            expect(vi.getTimerCount()).toBe(1);
 
             // Close the transport, which should clear the interval
             await transport.close();
 
-            // Advancing timers after close should not throw
-            vi.advanceTimersByTime(200);
+            expect(vi.getTimerCount()).toBe(0);
         });
     });
 });

--- a/packages/server/test/server/streamableHttp.test.ts
+++ b/packages/server/test/server/streamableHttp.test.ts
@@ -993,4 +993,93 @@ describe('Zod v4', () => {
             expect(cleanupCalls).toEqual(['stream-1']);
         });
     });
+
+    describe('HTTPServerTransport - keepAliveInterval', () => {
+        let transport: WebStandardStreamableHTTPServerTransport;
+        let mcpServer: McpServer;
+
+        beforeEach(() => {
+            vi.useFakeTimers();
+        });
+
+        afterEach(async () => {
+            vi.useRealTimers();
+            await transport.close();
+        });
+
+        async function setupTransport(keepAliveInterval?: number): Promise<string> {
+            mcpServer = new McpServer({ name: 'test-server', version: '1.0.0' });
+
+            transport = new WebStandardStreamableHTTPServerTransport({
+                sessionIdGenerator: () => randomUUID(),
+                keepAliveInterval
+            });
+
+            await mcpServer.connect(transport);
+
+            const initReq = createRequest('POST', TEST_MESSAGES.initialize);
+            const initRes = await transport.handleRequest(initReq);
+            return initRes.headers.get('mcp-session-id') as string;
+        }
+
+        it('should send SSE keepalive comments periodically when keepAliveInterval is set', async () => {
+            const sessionId = await setupTransport(50);
+
+            const getReq = createRequest('GET', undefined, { sessionId });
+            const getRes = await transport.handleRequest(getReq);
+
+            expect(getRes.status).toBe(200);
+            expect(getRes.body).not.toBeNull();
+
+            const reader = getRes.body!.getReader();
+
+            // Advance past two intervals to accumulate keepalive comments
+            vi.advanceTimersByTime(120);
+
+            const { value } = await reader.read();
+            const text = new TextDecoder().decode(value);
+            expect(text).toContain(': keepalive');
+        });
+
+        it('should not send SSE comments when keepAliveInterval is not set', async () => {
+            const sessionId = await setupTransport(undefined);
+
+            const getReq = createRequest('GET', undefined, { sessionId });
+            const getRes = await transport.handleRequest(getReq);
+
+            expect(getRes.status).toBe(200);
+            expect(getRes.body).not.toBeNull();
+
+            const reader = getRes.body!.getReader();
+
+            // Advance time; no keepalive should be enqueued
+            vi.advanceTimersByTime(200);
+
+            // Close the transport to end the stream, then read whatever was buffered
+            await transport.close();
+
+            const chunks: string[] = [];
+            for (let result = await reader.read(); !result.done; result = await reader.read()) {
+                chunks.push(new TextDecoder().decode(result.value));
+            }
+
+            const allText = chunks.join('');
+            expect(allText).not.toContain(': keepalive');
+        });
+
+        it('should clear the keepalive interval when the transport is closed', async () => {
+            const sessionId = await setupTransport(50);
+
+            const getReq = createRequest('GET', undefined, { sessionId });
+            const getRes = await transport.handleRequest(getReq);
+
+            expect(getRes.status).toBe(200);
+
+            // Close the transport, which should clear the interval
+            await transport.close();
+
+            // Advancing timers after close should not throw
+            vi.advanceTimersByTime(200);
+        });
+    });
 });

--- a/packages/server/test/server/streamableHttp.test.ts
+++ b/packages/server/test/server/streamableHttp.test.ts
@@ -1487,12 +1487,12 @@ describe('Zod v4', () => {
             const getRes = await transport.handleRequest(getReq);
 
             expect(getRes.status).toBe(200);
+            expect(vi.getTimerCount()).toBe(1);
 
             // Close the transport, which should clear the interval
             await transport.close();
 
-            // Advancing timers after close should not throw
-            vi.advanceTimersByTime(200);
+            expect(vi.getTimerCount()).toBe(0);
         });
     });
 });

--- a/packages/server/test/server/streamableHttp.test.ts
+++ b/packages/server/test/server/streamableHttp.test.ts
@@ -1494,5 +1494,57 @@ describe('Zod v4', () => {
 
             expect(vi.getTimerCount()).toBe(0);
         });
+
+        it('should maintain independent keepalive timers per concurrent stream', async () => {
+            // Minimal event store so a GET with last-event-id triggers replayEvents()
+            // and creates a second StreamMapping entry concurrently with the standalone GET.
+            const eventStore: EventStore = {
+                async storeEvent(streamId) {
+                    return `${streamId}_evt`;
+                },
+                async getStreamIdForEventId() {
+                    return 'replay-stream';
+                },
+                async replayEventsAfter() {
+                    return 'replay-stream';
+                }
+            };
+
+            mcpServer = new McpServer({ name: 'test-server', version: '1.0.0' });
+            transport = new WebStandardStreamableHTTPServerTransport({
+                sessionIdGenerator: () => randomUUID(),
+                keepAliveInterval: 50,
+                eventStore
+            });
+            await mcpServer.connect(transport);
+            const initRes = await transport.handleRequest(createRequest('POST', TEST_MESSAGES.initialize));
+            const sessionId = initRes.headers.get('mcp-session-id') as string;
+
+            // Stream A: standalone GET
+            const resA = await transport.handleRequest(createRequest('GET', undefined, { sessionId }));
+            expect(resA.status).toBe(200);
+            const readerA = resA.body!.getReader();
+            expect(vi.getTimerCount()).toBe(1);
+
+            // Stream B: GET with last-event-id -> replayEvents path, separate mapping key
+            const resB = await transport.handleRequest(
+                createRequest('GET', undefined, { sessionId, extraHeaders: { 'last-event-id': 'evt-1' } })
+            );
+            expect(resB.status).toBe(200);
+            const readerB = resB.body!.getReader();
+            expect(vi.getTimerCount()).toBe(2);
+
+            // Cancel stream B; its keepalive timer must be cleared without affecting A's
+            await readerB.cancel();
+            expect(vi.getTimerCount()).toBe(1);
+
+            // Stream A still receives keepalives after B is cancelled
+            vi.advanceTimersByTime(60);
+            const { value } = await readerA.read();
+            expect(new TextDecoder().decode(value)).toContain(': keepalive');
+
+            await readerA.cancel();
+            expect(vi.getTimerCount()).toBe(0);
+        });
     });
 });

--- a/packages/server/test/server/streamableHttp.test.ts
+++ b/packages/server/test/server/streamableHttp.test.ts
@@ -1526,7 +1526,10 @@ describe('Zod v4', () => {
             const readerA = resA.body!.getReader();
             expect(vi.getTimerCount()).toBe(1);
 
-            // Stream B: GET with last-event-id -> replayEvents path, separate mapping key
+            // Stream B: GET with last-event-id -> replayEvents path, separate mapping key.
+            // Simulate an in-flight request for the replay stream so the
+            // early-close-for-completed-requests block keeps the stream open.
+            (transport as any)._requestToStreamMapping.set('fake-req', 'replay-stream');
             const resB = await transport.handleRequest(
                 createRequest('GET', undefined, { sessionId, extraHeaders: { 'last-event-id': 'evt-1' } })
             );

--- a/packages/server/test/server/streamableHttp.test.ts
+++ b/packages/server/test/server/streamableHttp.test.ts
@@ -1406,4 +1406,93 @@ describe('Zod v4', () => {
             expect(cleanupCalls).toEqual(['stream-1']);
         });
     });
+
+    describe('HTTPServerTransport - keepAliveInterval', () => {
+        let transport: WebStandardStreamableHTTPServerTransport;
+        let mcpServer: McpServer;
+
+        beforeEach(() => {
+            vi.useFakeTimers();
+        });
+
+        afterEach(async () => {
+            vi.useRealTimers();
+            await transport.close();
+        });
+
+        async function setupTransport(keepAliveInterval?: number): Promise<string> {
+            mcpServer = new McpServer({ name: 'test-server', version: '1.0.0' });
+
+            transport = new WebStandardStreamableHTTPServerTransport({
+                sessionIdGenerator: () => randomUUID(),
+                keepAliveInterval
+            });
+
+            await mcpServer.connect(transport);
+
+            const initReq = createRequest('POST', TEST_MESSAGES.initialize);
+            const initRes = await transport.handleRequest(initReq);
+            return initRes.headers.get('mcp-session-id') as string;
+        }
+
+        it('should send SSE keepalive comments periodically when keepAliveInterval is set', async () => {
+            const sessionId = await setupTransport(50);
+
+            const getReq = createRequest('GET', undefined, { sessionId });
+            const getRes = await transport.handleRequest(getReq);
+
+            expect(getRes.status).toBe(200);
+            expect(getRes.body).not.toBeNull();
+
+            const reader = getRes.body!.getReader();
+
+            // Advance past two intervals to accumulate keepalive comments
+            vi.advanceTimersByTime(120);
+
+            const { value } = await reader.read();
+            const text = new TextDecoder().decode(value);
+            expect(text).toContain(': keepalive');
+        });
+
+        it('should not send SSE comments when keepAliveInterval is not set', async () => {
+            const sessionId = await setupTransport(undefined);
+
+            const getReq = createRequest('GET', undefined, { sessionId });
+            const getRes = await transport.handleRequest(getReq);
+
+            expect(getRes.status).toBe(200);
+            expect(getRes.body).not.toBeNull();
+
+            const reader = getRes.body!.getReader();
+
+            // Advance time; no keepalive should be enqueued
+            vi.advanceTimersByTime(200);
+
+            // Close the transport to end the stream, then read whatever was buffered
+            await transport.close();
+
+            const chunks: string[] = [];
+            for (let result = await reader.read(); !result.done; result = await reader.read()) {
+                chunks.push(new TextDecoder().decode(result.value));
+            }
+
+            const allText = chunks.join('');
+            expect(allText).not.toContain(': keepalive');
+        });
+
+        it('should clear the keepalive interval when the transport is closed', async () => {
+            const sessionId = await setupTransport(50);
+
+            const getReq = createRequest('GET', undefined, { sessionId });
+            const getRes = await transport.handleRequest(getReq);
+
+            expect(getRes.status).toBe(200);
+
+            // Close the transport, which should clear the interval
+            await transport.close();
+
+            // Advancing timers after close should not throw
+            vi.advanceTimersByTime(200);
+        });
+    });
 });


### PR DESCRIPTION
## Summary

Adds an opt-in `keepAliveInterval` option to `WebStandardStreamableHTTPServerTransportOptions`. When set, the transport sends periodic SSE comments (`: keepalive\n\n`) on the standalone GET SSE stream to reset proxy idle timers and prevent silent disconnections.

SSE comments are ignored by spec-compliant clients but keep the connection alive through reverse proxies (nginx, Envoy, HAProxy, cloud load balancers) that enforce idle timeouts.

## Usage

```ts
const transport = new WebStandardStreamableHTTPServerTransport({
    sessionIdGenerator: () => crypto.randomUUID(),
    keepAliveInterval: 15_000 // send keepalive every 15 seconds
});
```

Omitting the option preserves existing behavior (no keepalive, fully backwards compatible).

## What changed

- `keepAliveInterval?: number` added to the options interface (milliseconds, disabled by default)
- `handleGetRequest` starts a `setInterval` that enqueues `: keepalive\n\n` to the stream controller
- Timer is cleared on client disconnect, `close()`, and `closeStandaloneSSEStream()`
- Controller enqueue is guarded against closed/errored state
- The `NodeStreamableHTTPServerTransport` wrapper picks this up automatically (it type-aliases and passes through the options)
- Three new tests covering: comments sent when enabled, no comments when disabled, cleanup on close

## Related issues

Ref #28 (server-side ping automation, P1)
Ref #876 (SSE connections drop after ~5 min idle behind proxies)

This is complementary to protocol-level ping approaches (like PR #1717). SSE comments operate at the transport layer and don't require JSON-RPC round-trips, making them a lightweight way to keep the connection alive independently of protocol-level health checks.