### PR TITLE
fix(auth): deduplicate concurrent token refresh requests

### DIFF
--- a/packages/client/src/client/auth.ts
+++ b/packages/client/src/client/auth.ts
@@ -389,12 +389,53 @@ export async function parseErrorResponse(input: Response | string): Promise<OAut
 }
 
 /**
+ * In-flight auth promises keyed by provider, used to deduplicate concurrent
+ * auth() calls. When multiple requests detect a 401 at the same time, only the
+ * first caller performs the actual token refresh; subsequent callers await the
+ * same promise. This prevents rotating refresh tokens from being used more than
+ * once, which would trigger RFC 6819 §5.2.2.3 replay detection and revoke the
+ * entire token family.
+ */
+const pendingAuthRequests = new Map<OAuthClientProvider, Promise<AuthResult>>();
+
+/**
  * Orchestrates the full auth flow with a server.
  *
  * This can be used as a single entry point for all authorization functionality,
  * instead of linking together the other lower-level functions in this module.
+ *
+ * Concurrent calls for the same provider are deduplicated: only one auth flow
+ * runs at a time, and all concurrent callers receive the same result. This is
+ * critical for OAuth servers that use rotating refresh tokens, where concurrent
+ * refresh requests would invalidate each other.
  */
 export async function auth(
+    provider: OAuthClientProvider,
+    options: {
+        serverUrl: string | URL;
+        authorizationCode?: string;
+        scope?: string;
+        resourceMetadataUrl?: URL;
+        fetchFn?: FetchLike;
+    }
+): Promise<AuthResult> {
+    // If there's already an in-flight auth for this provider, reuse it
+    const pending = pendingAuthRequests.get(provider);
+    if (pending) {
+        return await pending;
+    }
+
+    const authPromise = authWithErrorHandling(provider, options);
+    pendingAuthRequests.set(provider, authPromise);
+
+    try {
+        return await authPromise;
+    } finally {
+        pendingAuthRequests.delete(provider);
+    }
+}
+
+async function authWithErrorHandling(
     provider: OAuthClientProvider,
     options: {
         serverUrl: string | URL;

--- a/packages/client/test/client/auth.test.ts
+++ b/packages/client/test/client/auth.test.ts
@@ -3668,4 +3668,348 @@ describe('OAuth Authorization', () => {
             });
         });
     });
+
+    describe('concurrent auth deduplication', () => {
+        it('deduplicates concurrent token refresh requests for the same provider', async () => {
+            let tokenRequestCount = 0;
+
+            mockFetch.mockImplementation(url => {
+                const urlString = url.toString();
+
+                if (urlString.includes('/.well-known/oauth-protected-resource')) {
+                    return Promise.resolve({
+                        ok: true,
+                        status: 200,
+                        json: async () => ({
+                            resource: 'https://api.example.com/mcp-server',
+                            authorization_servers: ['https://auth.example.com']
+                        })
+                    });
+                }
+
+                if (urlString.includes('/.well-known/oauth-authorization-server')) {
+                    return Promise.resolve({
+                        ok: true,
+                        status: 200,
+                        json: async () => ({
+                            issuer: 'https://auth.example.com',
+                            authorization_endpoint: 'https://auth.example.com/authorize',
+                            token_endpoint: 'https://auth.example.com/token',
+                            response_types_supported: ['code'],
+                            code_challenge_methods_supported: ['S256']
+                        })
+                    });
+                }
+
+                if (urlString.includes('/token')) {
+                    tokenRequestCount++;
+                    return Promise.resolve({
+                        ok: true,
+                        status: 200,
+                        json: async () => ({
+                            access_token: 'new-access-token',
+                            token_type: 'bearer',
+                            expires_in: 3600,
+                            refresh_token: 'new-refresh-token'
+                        })
+                    });
+                }
+
+                return Promise.reject(new Error(`Unexpected fetch call: ${urlString}`));
+            });
+
+            const concurrentProvider: OAuthClientProvider = {
+                get redirectUrl() {
+                    return 'http://localhost:3000/callback';
+                },
+                get clientMetadata() {
+                    return {
+                        redirect_uris: ['http://localhost:3000/callback'],
+                        client_name: 'Test Client'
+                    };
+                },
+                clientInformation: vi.fn().mockResolvedValue({
+                    client_id: 'client-id',
+                    client_secret: 'client-secret'
+                }),
+                tokens: vi.fn().mockResolvedValue({
+                    access_token: 'expired-access-token',
+                    token_type: 'bearer',
+                    refresh_token: 'current-refresh-token'
+                }),
+                saveTokens: vi.fn(),
+                redirectToAuthorization: vi.fn(),
+                saveCodeVerifier: vi.fn(),
+                codeVerifier: vi.fn()
+            };
+
+            // Fire 3 concurrent auth calls for the same provider
+            const results = await Promise.all([
+                auth(concurrentProvider, { serverUrl: 'https://api.example.com/mcp-server' }),
+                auth(concurrentProvider, { serverUrl: 'https://api.example.com/mcp-server' }),
+                auth(concurrentProvider, { serverUrl: 'https://api.example.com/mcp-server' })
+            ]);
+
+            // All should succeed
+            expect(results).toEqual(['AUTHORIZED', 'AUTHORIZED', 'AUTHORIZED']);
+
+            // Only ONE token refresh request should have been made
+            expect(tokenRequestCount).toBe(1);
+        });
+
+        it('allows new auth after previous one completes', async () => {
+            let tokenRequestCount = 0;
+
+            mockFetch.mockImplementation(url => {
+                const urlString = url.toString();
+
+                if (urlString.includes('/.well-known/oauth-protected-resource')) {
+                    return Promise.resolve({
+                        ok: true,
+                        status: 200,
+                        json: async () => ({
+                            resource: 'https://api.example.com/mcp-server',
+                            authorization_servers: ['https://auth.example.com']
+                        })
+                    });
+                }
+
+                if (urlString.includes('/.well-known/oauth-authorization-server')) {
+                    return Promise.resolve({
+                        ok: true,
+                        status: 200,
+                        json: async () => ({
+                            issuer: 'https://auth.example.com',
+                            authorization_endpoint: 'https://auth.example.com/authorize',
+                            token_endpoint: 'https://auth.example.com/token',
+                            response_types_supported: ['code'],
+                            code_challenge_methods_supported: ['S256']
+                        })
+                    });
+                }
+
+                if (urlString.includes('/token')) {
+                    tokenRequestCount++;
+                    return Promise.resolve({
+                        ok: true,
+                        status: 200,
+                        json: async () => ({
+                            access_token: `access-token-${tokenRequestCount}`,
+                            token_type: 'bearer',
+                            expires_in: 3600,
+                            refresh_token: `refresh-token-${tokenRequestCount}`
+                        })
+                    });
+                }
+
+                return Promise.reject(new Error(`Unexpected fetch call: ${urlString}`));
+            });
+
+            const sequentialProvider: OAuthClientProvider = {
+                get redirectUrl() {
+                    return 'http://localhost:3000/callback';
+                },
+                get clientMetadata() {
+                    return {
+                        redirect_uris: ['http://localhost:3000/callback'],
+                        client_name: 'Test Client'
+                    };
+                },
+                clientInformation: vi.fn().mockResolvedValue({
+                    client_id: 'client-id',
+                    client_secret: 'client-secret'
+                }),
+                tokens: vi.fn().mockResolvedValue({
+                    access_token: 'expired-access-token',
+                    token_type: 'bearer',
+                    refresh_token: 'current-refresh-token'
+                }),
+                saveTokens: vi.fn(),
+                redirectToAuthorization: vi.fn(),
+                saveCodeVerifier: vi.fn(),
+                codeVerifier: vi.fn()
+            };
+
+            // First auth call
+            const result1 = await auth(sequentialProvider, { serverUrl: 'https://api.example.com/mcp-server' });
+            expect(result1).toBe('AUTHORIZED');
+
+            // Second auth call (after first completes) should trigger a new refresh
+            const result2 = await auth(sequentialProvider, { serverUrl: 'https://api.example.com/mcp-server' });
+            expect(result2).toBe('AUTHORIZED');
+
+            // Two separate token requests should have been made
+            expect(tokenRequestCount).toBe(2);
+        });
+
+        it('propagates errors to all concurrent callers', async () => {
+            mockFetch.mockImplementation(url => {
+                const urlString = url.toString();
+
+                if (urlString.includes('/.well-known/oauth-protected-resource')) {
+                    return Promise.resolve({
+                        ok: true,
+                        status: 200,
+                        json: async () => ({
+                            resource: 'https://api.example.com/mcp-server',
+                            authorization_servers: ['https://auth.example.com']
+                        })
+                    });
+                }
+
+                if (urlString.includes('/.well-known/oauth-authorization-server')) {
+                    return Promise.resolve({
+                        ok: true,
+                        status: 200,
+                        json: async () => ({
+                            issuer: 'https://auth.example.com',
+                            authorization_endpoint: 'https://auth.example.com/authorize',
+                            token_endpoint: 'https://auth.example.com/token',
+                            response_types_supported: ['code'],
+                            code_challenge_methods_supported: ['S256']
+                        })
+                    });
+                }
+
+                if (urlString.includes('/token')) {
+                    return Promise.resolve({
+                        ok: false,
+                        status: 400,
+                        text: async () => JSON.stringify({
+                            error: 'invalid_grant',
+                            error_description: 'Refresh token has been revoked'
+                        })
+                    });
+                }
+
+                return Promise.reject(new Error(`Unexpected fetch call: ${urlString}`));
+            });
+
+            const errorProvider: OAuthClientProvider = {
+                get redirectUrl() {
+                    return 'http://localhost:3000/callback';
+                },
+                get clientMetadata() {
+                    return {
+                        redirect_uris: ['http://localhost:3000/callback'],
+                        client_name: 'Test Client'
+                    };
+                },
+                clientInformation: vi.fn().mockResolvedValue({
+                    client_id: 'client-id',
+                    client_secret: 'client-secret'
+                }),
+                tokens: vi.fn().mockResolvedValue({
+                    access_token: 'expired-access-token',
+                    token_type: 'bearer',
+                    refresh_token: 'revoked-refresh-token'
+                }),
+                saveTokens: vi.fn(),
+                redirectToAuthorization: vi.fn(),
+                saveCodeVerifier: vi.fn(),
+                codeVerifier: vi.fn(),
+                invalidateCredentials: vi.fn()
+            };
+
+            // Fire concurrent auth calls — all should get the same error handling result
+            // (invalid_grant triggers credential invalidation and retry, which leads to REDIRECT)
+            const results = await Promise.all([
+                auth(errorProvider, { serverUrl: 'https://api.example.com/mcp-server' }),
+                auth(errorProvider, { serverUrl: 'https://api.example.com/mcp-server' }),
+                auth(errorProvider, { serverUrl: 'https://api.example.com/mcp-server' })
+            ]);
+
+            // All callers should get the same result
+            expect(results[0]).toBe(results[1]);
+            expect(results[1]).toBe(results[2]);
+        });
+
+        it('does not deduplicate auth calls for different providers', async () => {
+            let tokenRequestCount = 0;
+
+            mockFetch.mockImplementation(url => {
+                const urlString = url.toString();
+
+                if (urlString.includes('/.well-known/oauth-protected-resource')) {
+                    return Promise.resolve({
+                        ok: true,
+                        status: 200,
+                        json: async () => ({
+                            resource: 'https://api.example.com/mcp-server',
+                            authorization_servers: ['https://auth.example.com']
+                        })
+                    });
+                }
+
+                if (urlString.includes('/.well-known/oauth-authorization-server')) {
+                    return Promise.resolve({
+                        ok: true,
+                        status: 200,
+                        json: async () => ({
+                            issuer: 'https://auth.example.com',
+                            authorization_endpoint: 'https://auth.example.com/authorize',
+                            token_endpoint: 'https://auth.example.com/token',
+                            response_types_supported: ['code'],
+                            code_challenge_methods_supported: ['S256']
+                        })
+                    });
+                }
+
+                if (urlString.includes('/token')) {
+                    tokenRequestCount++;
+                    return Promise.resolve({
+                        ok: true,
+                        status: 200,
+                        json: async () => ({
+                            access_token: `access-token-${tokenRequestCount}`,
+                            token_type: 'bearer',
+                            expires_in: 3600,
+                            refresh_token: `refresh-token-${tokenRequestCount}`
+                        })
+                    });
+                }
+
+                return Promise.reject(new Error(`Unexpected fetch call: ${urlString}`));
+            });
+
+            const makeProvider = (): OAuthClientProvider => ({
+                get redirectUrl() {
+                    return 'http://localhost:3000/callback';
+                },
+                get clientMetadata() {
+                    return {
+                        redirect_uris: ['http://localhost:3000/callback'],
+                        client_name: 'Test Client'
+                    };
+                },
+                clientInformation: vi.fn().mockResolvedValue({
+                    client_id: 'client-id',
+                    client_secret: 'client-secret'
+                }),
+                tokens: vi.fn().mockResolvedValue({
+                    access_token: 'expired-access-token',
+                    token_type: 'bearer',
+                    refresh_token: 'current-refresh-token'
+                }),
+                saveTokens: vi.fn(),
+                redirectToAuthorization: vi.fn(),
+                saveCodeVerifier: vi.fn(),
+                codeVerifier: vi.fn()
+            });
+
+            const providerA = makeProvider();
+            const providerB = makeProvider();
+
+            // Concurrent calls with different providers should NOT be deduplicated
+            const results = await Promise.all([
+                auth(providerA, { serverUrl: 'https://api.example.com/mcp-server' }),
+                auth(providerB, { serverUrl: 'https://api.example.com/mcp-server' })
+            ]);
+
+            expect(results).toEqual(['AUTHORIZED', 'AUTHORIZED']);
+
+            // Each provider should have triggered its own token refresh
+            expect(tokenRequestCount).toBe(2);
+        });
+    });
 });

--- a/packages/client/test/client/auth.test.ts
+++ b/packages/client/test/client/auth.test.ts
@@ -3875,10 +3875,11 @@ describe('OAuth Authorization', () => {
                     return Promise.resolve({
                         ok: false,
                         status: 400,
-                        text: async () => JSON.stringify({
-                            error: 'invalid_grant',
-                            error_description: 'Refresh token has been revoked'
-                        })
+                        text: async () =>
+                            JSON.stringify({
+                                error: 'invalid_grant',
+                                error_description: 'Refresh token has been revoked'
+                            })
                     });
                 }
 


### PR DESCRIPTION
## Summary

- **Fix race condition** in `auth()` where concurrent 401 handlers each independently refresh the same token, causing rotating refresh tokens to be reused and triggering RFC 6819 §5.2.2.3 replay detection
- **Add promise-based deduplication** using a `Map<OAuthClientProvider, Promise<AuthResult>>` — when a refresh is already in-flight for a provider, concurrent callers await the existing promise instead of starting a new one
- **Add 4 tests** covering: concurrent deduplication (single token request), sequential calls (separate requests), error propagation to all callers, and independent providers not being deduplicated

## Problem

When two or more requests for the same OAuth MCP server arrive in parallel:

1. Both detect a 401 and call `auth()`
2. Both independently call `refreshAuthorization()` with the same refresh token
3. With rotating refresh tokens (Atlassian, Asana, etc.), the first refresh consumes the token and issues a new one
4. The second refresh replays the now-consumed token, triggering the authorization server's replay detection
5. The server revokes the entire token family, permanently breaking the connection

## Solution

Store the in-flight `auth()` promise in a module-level `Map` keyed by provider instance. If a concurrent call arrives for the same provider, it awaits the existing promise. The entry is cleaned up in a `finally` block so subsequent refreshes proceed normally.

This is the same pattern used by `msal-browser` and `axios-auth-refresh`.

## Test plan

- [x] New test: concurrent auth calls result in exactly 1 token refresh request
- [x] New test: sequential auth calls each trigger their own refresh
- [x] New test: errors propagate correctly to all concurrent callers
- [x] New test: different providers are not deduplicated
- [x] All 260 existing client tests pass
- [x] TypeScript typecheck passes

Closes #1760