### PR TITLE
fix(server): sanitize internal error details in tool error responses

### DIFF
--- a/.changeset/tool-error-sanitization.md
+++ b/.changeset/tool-error-sanitization.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/server': minor
+---
+
+Add ToolError class for secure-by-default tool error handling. Unhandled errors from tool handlers are now sanitized to "Internal error" instead of exposing raw messages. Use `throw new ToolError('message')` when you want clients to see a specific error message.

--- a/docs/migration-SKILL.md
+++ b/docs/migration-SKILL.md
@@ -454,6 +454,36 @@ Type changes in handler context:
 
 > These task APIs are `@experimental` and may change without notice.
 
+## 12b. Tool Error Sanitization (Breaking Change)
+
+Tool handlers that `throw new Error('message')` now return `"Internal error"` to clients instead of the raw error message. This prevents accidental leakage of server internals (hostnames, connection strings, stack traces) through tool error responses.
+
+To send a user-visible error message, use the new `ToolError` class:
+
+```typescript
+import { ToolError } from '@modelcontextprotocol/server';
+
+// Generic errors are sanitized -- client sees: "Internal error"
+server.registerTool('db-query', {
+    description: 'Query the database',
+    inputSchema: z.object({ sql: z.string() })
+}, async ({ sql }) => {
+    throw new Error('Connection refused to 10.0.0.5:5432');
+});
+
+// ToolError messages pass through -- client sees: "Invalid query syntax"
+server.registerTool('safe-query', {
+    description: 'Query with validated input',
+    inputSchema: z.object({ sql: z.string() })
+}, async ({ sql }) => {
+    throw new ToolError('Invalid query syntax');
+});
+```
+
+`ProtocolError` messages (SDK validation errors) are still passed through unchanged.
+
+**Migration action:** If your v1 tool handlers rely on `throw new Error('user-visible message')` to communicate errors to clients, switch those throws to `throw new ToolError('user-visible message')`. No changes needed for tools that only throw errors for genuinely unexpected failures.
+
 ## 13. Client Behavioral Changes
 
 `Client.listPrompts()`, `listResources()`, `listResourceTemplates()`, `listTools()` now return empty results when the server lacks the corresponding capability (instead of sending the request). Set `enforceStrictCapabilities: true` in `ClientOptions` to throw an error instead.

--- a/docs/migration-SKILL.md
+++ b/docs/migration-SKILL.md
@@ -503,6 +503,36 @@ The 2025-11 task side-channel through `Protocol` is removed (was always `@experi
 
 NOT removed (wire surface, kept for 2025-11-25 interop): task Zod schemas + inferred types (`Task`, `TaskStatus`, `TaskMetadata`, `RelatedTaskMetadata`, `CreateTaskResult`, `GetTask*`, `ListTasks*`, `CancelTask*`, `TaskStatusNotification*`, `TaskAugmentedRequestParams`), task members of the request/result/notification unions, the `tasks` capability key, `isTaskAugmentedRequestParams`, `RELATED_TASK_META_KEY`. Inbound `tasks/*` requests → `-32601`.
 
+## 12b. Tool Error Sanitization (Breaking Change)
+
+Tool handlers that `throw new Error('message')` now return `"Internal error"` to clients instead of the raw error message. This prevents accidental leakage of server internals (hostnames, connection strings, stack traces) through tool error responses.
+
+To send a user-visible error message, use the new `ToolError` class:
+
+```typescript
+import { ToolError } from '@modelcontextprotocol/server';
+
+// Generic errors are sanitized -- client sees: "Internal error"
+server.registerTool('db-query', {
+    description: 'Query the database',
+    inputSchema: z.object({ sql: z.string() })
+}, async ({ sql }) => {
+    throw new Error('Connection refused to 10.0.0.5:5432');
+});
+
+// ToolError messages pass through -- client sees: "Invalid query syntax"
+server.registerTool('safe-query', {
+    description: 'Query with validated input',
+    inputSchema: z.object({ sql: z.string() })
+}, async ({ sql }) => {
+    throw new ToolError('Invalid query syntax');
+});
+```
+
+Errors thrown from inside your handler — including a `ProtocolError` (a public export, so it could otherwise be constructed by handler code or a dependency) — are sanitized to `"Internal error"`, as are failures validating the tool's output against its `outputSchema`. Input-validation errors still pass through, since they report that the client sent invalid arguments. Use `ToolError` for any message you want the client to see, and avoid putting secrets in custom input-schema validation messages.
+
+**Migration action:** If your v1 tool handlers rely on `throw new Error('user-visible message')` to communicate errors to clients, switch those throws to `throw new ToolError('user-visible message')`. No changes needed for tools that only throw errors for genuinely unexpected failures.
+
 ## 13. Behavioral Changes
 
 ### Client

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -870,6 +870,26 @@ import { AjvJsonSchemaValidator } from '@modelcontextprotocol/server';
 import { CfWorkerJsonSchemaValidator } from '@modelcontextprotocol/server/validators/cf-worker';
 ```
 
+## Tool error sanitization
+
+Tool handlers that `throw new Error('message')` will now return `"Internal error"` to clients instead of the raw error message. This prevents accidental leakage of server internals (hostnames, connection strings, stack traces).
+
+To send a user-visible error message, use the new `ToolError` class:
+
+```typescript
+import { ToolError } from '@modelcontextprotocol/server';
+
+server.registerTool('my-tool', {}, async () => {
+    // Client sees: "Internal error"
+    throw new Error('DB connection failed at 10.0.0.5:5432');
+
+    // Client sees: "Invalid country"
+    throw new ToolError('Invalid country');
+});
+```
+
+`ProtocolError` messages (SDK validation errors) are still passed through unchanged.
+
 ## Unchanged APIs
 
 The following APIs are unchanged between v1 and v2 (only the import paths changed):

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -821,6 +821,28 @@ server.setRequestHandler('tools/call', async (request, ctx) => {
 
 > **Note:** These task APIs are marked `@experimental` and may change without notice.
 
+### Tool error sanitization
+
+Tool handlers that `throw new Error('message')` will now return `"Internal error"` to clients instead of the raw error message. This prevents accidental leakage of server internals (hostnames, connection strings, stack traces).
+
+To send a user-visible error message, use the new `ToolError` class:
+
+```typescript
+import { ToolError } from '@modelcontextprotocol/server';
+
+// Generic errors are sanitized -- client sees: "Internal error"
+server.registerTool('internal-tool', {}, async () => {
+    throw new Error('DB connection failed at 10.0.0.5:5432');
+});
+
+// ToolError messages pass through -- client sees: "Invalid country"
+server.registerTool('validated-tool', {}, async () => {
+    throw new ToolError('Invalid country');
+});
+```
+
+`ProtocolError` messages (SDK validation errors) are still passed through unchanged.
+
 ## Enhancements
 
 ### Automatic JSON Schema validator selection by runtime
@@ -869,26 +891,6 @@ import { DefaultJsonSchemaValidator } from '@modelcontextprotocol/server/_shims'
 import { AjvJsonSchemaValidator } from '@modelcontextprotocol/server';
 import { CfWorkerJsonSchemaValidator } from '@modelcontextprotocol/server/validators/cf-worker';
 ```
-
-## Tool error sanitization
-
-Tool handlers that `throw new Error('message')` will now return `"Internal error"` to clients instead of the raw error message. This prevents accidental leakage of server internals (hostnames, connection strings, stack traces).
-
-To send a user-visible error message, use the new `ToolError` class:
-
-```typescript
-import { ToolError } from '@modelcontextprotocol/server';
-
-server.registerTool('my-tool', {}, async () => {
-    // Client sees: "Internal error"
-    throw new Error('DB connection failed at 10.0.0.5:5432');
-
-    // Client sees: "Invalid country"
-    throw new ToolError('Invalid country');
-});
-```
-
-`ProtocolError` messages (SDK validation errors) are still passed through unchanged.
 
 ## Unchanged APIs
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -906,6 +906,28 @@ The 2025-11 experimental tasks side-channel woven through `Protocol` has been re
 
 There is no migration path for the removed surface; it was always `@experimental`. Task support is planned to return as an opt-in extension plugin per SEP-2663.
 
+### Tool error sanitization
+
+Tool handlers that `throw new Error('message')` will now return `"Internal error"` to clients instead of the raw error message. This prevents accidental leakage of server internals (hostnames, connection strings, stack traces).
+
+To send a user-visible error message, use the new `ToolError` class:
+
+```typescript
+import { ToolError } from '@modelcontextprotocol/server';
+
+// Generic errors are sanitized -- client sees: "Internal error"
+server.registerTool('internal-tool', {}, async () => {
+    throw new Error('DB connection failed at 10.0.0.5:5432');
+});
+
+// ToolError messages pass through -- client sees: "Invalid country"
+server.registerTool('validated-tool', {}, async () => {
+    throw new ToolError('Invalid country');
+});
+```
+
+Errors thrown from inside your handler — including a `ProtocolError` (a public export, so it could otherwise be constructed by handler code or a dependency) — are sanitized to `"Internal error"`, as are failures validating the tool's output against its `outputSchema`. Input-validation errors still pass through, since they report that the client sent invalid arguments. Use `ToolError` for any message you want the client to see, and avoid putting secrets in custom input-schema validation messages.
+
 ## Enhancements
 
 ### Automatic JSON Schema validator selection by runtime

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -23,7 +23,7 @@ export type {
     ResourceMetadata,
     ToolCallback
 } from './server/mcp.js';
-export { McpServer, ResourceTemplate } from './server/mcp.js';
+export { McpServer, ResourceTemplate, ToolError } from './server/mcp.js';
 export type { HostHeaderValidationResult } from './server/middleware/hostHeaderValidation.js';
 export { hostHeaderValidationResponse, localhostAllowedHostnames, validateHostHeader } from './server/middleware/hostHeaderValidation.js';
 export type { ServerOptions } from './server/server.js';

--- a/packages/server/src/server/mcp.ts
+++ b/packages/server/src/server/mcp.ts
@@ -46,20 +46,6 @@ import type { ServerOptions } from './server.js';
 import { Server } from './server.js';
 
 /**
- * High-level MCP server that provides a simpler API for working with resources, tools, and prompts.
- * For advanced usage (like sending notifications or setting custom request handlers), use the underlying
- * {@linkcode Server} instance available via the {@linkcode McpServer.server | server} property.
- *
- * @example
- * ```ts source="./mcp.examples.ts#McpServer_basicUsage"
- * const server = new McpServer({
- *     name: 'my-server',
- *     version: '1.0.0'
- * });
- * ```
- */
-
-/**
  * Error class for tool handlers to throw when they want to send a
  * user-visible error message to the client. Unlike regular errors,
  * ToolError messages are passed through to the client as-is.
@@ -74,6 +60,19 @@ export class ToolError extends Error {
     }
 }
 
+/**
+ * High-level MCP server that provides a simpler API for working with resources, tools, and prompts.
+ * For advanced usage (like sending notifications or setting custom request handlers), use the underlying
+ * {@linkcode Server} instance available via the {@linkcode McpServer.server | server} property.
+ *
+ * @example
+ * ```ts source="./mcp.examples.ts#McpServer_basicUsage"
+ * const server = new McpServer({
+ *     name: 'my-server',
+ *     version: '1.0.0'
+ * });
+ * ```
+ */
 export class McpServer {
     /**
      * The underlying {@linkcode Server} instance, useful for advanced operations like sending notifications.

--- a/packages/server/src/server/mcp.ts
+++ b/packages/server/src/server/mcp.ts
@@ -58,6 +58,22 @@ import { Server } from './server.js';
  * });
  * ```
  */
+
+/**
+ * Error class for tool handlers to throw when they want to send a
+ * user-visible error message to the client. Unlike regular errors,
+ * ToolError messages are passed through to the client as-is.
+ *
+ * Regular errors thrown from tool handlers are sanitized to "Internal
+ * error" to prevent leaking sensitive server internals.
+ */
+export class ToolError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'ToolError';
+    }
+}
+
 export class McpServer {
     /**
      * The underlying {@linkcode Server} instance, useful for advanced operations like sending notifications.
@@ -209,7 +225,16 @@ export class McpServer {
                 if (error instanceof ProtocolError && error.code === ProtocolErrorCode.UrlElicitationRequired) {
                     throw error; // Return the error to the caller without wrapping in CallToolResult
                 }
-                return this.createToolError(error instanceof Error ? error.message : String(error));
+                if (error instanceof ProtocolError) {
+                    // SDK-generated validation errors are safe to expose
+                    return this.createToolError(error.message);
+                }
+                if (error instanceof ToolError) {
+                    // Developer intentionally wants this message shown to client
+                    return this.createToolError(error.message);
+                }
+                // All other errors: sanitize to prevent leaking internals
+                return this.createToolError('Internal error');
             }
         });
 

--- a/packages/server/src/server/mcp.ts
+++ b/packages/server/src/server/mcp.ts
@@ -43,6 +43,21 @@ import type { ServerOptions } from './server.js';
 import { Server } from './server.js';
 
 /**
+ * Error class for tool handlers to throw when they want to send a
+ * user-visible error message to the client. Unlike regular errors,
+ * ToolError messages are passed through to the client as-is.
+ *
+ * Regular errors thrown from tool handlers are sanitized to "Internal
+ * error" to prevent leaking sensitive server internals.
+ */
+export class ToolError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'ToolError';
+    }
+}
+
+/**
  * High-level MCP server that provides a simpler API for working with resources, tools, and prompts.
  * For advanced usage (like sending notifications or setting custom request handlers), use the underlying
  * {@linkcode Server} instance available via the {@linkcode McpServer.server | server} property.
@@ -165,16 +180,36 @@ export class McpServer {
                 throw new ProtocolError(ProtocolErrorCode.InvalidParams, `Tool ${request.params.name} disabled`);
             }
 
+            // Input-validation errors describe the client's own request against a
+            // public schema, so they are safe to surface. Once we enter the handler,
+            // any failure — from the handler itself or from validating the handler's
+            // (server-side) output — may carry server internals and must be sanitized.
+            let pastInputValidation = false;
             try {
                 const args = await this.validateToolInput(tool, request.params.arguments, request.params.name);
+                pastInputValidation = true;
                 const result = await this.executeToolHandler(tool, args, ctx);
                 await this.validateToolOutput(tool, result, request.params.name);
                 return result;
             } catch (error) {
                 if (error instanceof ProtocolError && error.code === ProtocolErrorCode.UrlElicitationRequired) {
-                    throw error; // Return the error to the caller without wrapping in CallToolResult
+                    throw error; // Control-flow signal for URL elicitation, not an error response
                 }
-                return this.createToolError(error instanceof Error ? error.message : String(error));
+                if (error instanceof ToolError) {
+                    // Developer intentionally wants this message shown to the client
+                    return this.createToolError(error.message);
+                }
+                if (error instanceof ProtocolError && !pastInputValidation) {
+                    // SDK-raised input-validation error: describes the client's request
+                    // against a public schema. ProtocolError is a public export, so we
+                    // never trust one thrown once we are past input validation (it could
+                    // come from the handler or from validating its output).
+                    return this.createToolError(error.message);
+                }
+                // Everything else (handler throws — including a handler-thrown
+                // ProtocolError — output-validation failures over the handler's result,
+                // and non-Error throws) is sanitized to avoid leaking server internals.
+                return this.createToolError('Internal error');
             }
         });
 

--- a/test/integration/test/server/mcp.test.ts
+++ b/test/integration/test/server/mcp.test.ts
@@ -7076,6 +7076,7 @@ describe('Zod v4', () => {
             });
 
             // Should receive an error since cancelled tasks don't have results
+            expect(result.isError).toBe(true);
             expect(result).toHaveProperty('content');
             expect(result.content).toEqual([{ type: 'text' as const, text: 'Internal error' }]);
 

--- a/test/integration/test/server/mcp.test.ts
+++ b/test/integration/test/server/mcp.test.ts
@@ -8,7 +8,7 @@ import {
     UriTemplate,
     UrlElicitationRequiredError
 } from '@modelcontextprotocol/core';
-import { completable, McpServer, ResourceTemplate } from '@modelcontextprotocol/server';
+import { completable, McpServer, ResourceTemplate, ToolError } from '@modelcontextprotocol/server';
 import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 import * as z from 'zod/v4';
 
@@ -1799,7 +1799,112 @@ describe('Zod v4', () => {
             expect(result.content).toEqual([
                 {
                     type: 'text',
-                    text: 'Tool execution failed'
+                    text: 'Internal error'
+                }
+            ]);
+        });
+
+        test('should pass through ToolError message to client', async () => {
+            const mcpServer = new McpServer({
+                name: 'test server',
+                version: '1.0'
+            });
+
+            const client = new Client({
+                name: 'test client',
+                version: '1.0'
+            });
+
+            mcpServer.registerTool('toolerror-test', {}, async () => {
+                throw new ToolError('Invalid input: country not supported');
+            });
+
+            const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+            await Promise.all([client.connect(clientTransport), mcpServer.server.connect(serverTransport)]);
+
+            const result = await client.request({
+                method: 'tools/call',
+                params: {
+                    name: 'toolerror-test'
+                }
+            });
+
+            expect(result.isError).toBe(true);
+            expect(result.content).toEqual([
+                {
+                    type: 'text',
+                    text: 'Invalid input: country not supported'
+                }
+            ]);
+        });
+
+        test('should sanitize generic Error to Internal error', async () => {
+            const mcpServer = new McpServer({
+                name: 'test server',
+                version: '1.0'
+            });
+
+            const client = new Client({
+                name: 'test client',
+                version: '1.0'
+            });
+
+            mcpServer.registerTool('internal-error-test', {}, async () => {
+                throw new Error('Connection failed at 10.0.0.5:5432');
+            });
+
+            const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+            await Promise.all([client.connect(clientTransport), mcpServer.server.connect(serverTransport)]);
+
+            const result = await client.request({
+                method: 'tools/call',
+                params: {
+                    name: 'internal-error-test'
+                }
+            });
+
+            expect(result.isError).toBe(true);
+            expect(result.content).toEqual([
+                {
+                    type: 'text',
+                    text: 'Internal error'
+                }
+            ]);
+        });
+
+        test('should sanitize non-Error throws to Internal error', async () => {
+            const mcpServer = new McpServer({
+                name: 'test server',
+                version: '1.0'
+            });
+
+            const client = new Client({
+                name: 'test client',
+                version: '1.0'
+            });
+
+            mcpServer.registerTool('string-throw-test', {}, async () => {
+                throw 'some raw string error';
+            });
+
+            const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+            await Promise.all([client.connect(clientTransport), mcpServer.server.connect(serverTransport)]);
+
+            const result = await client.request({
+                method: 'tools/call',
+                params: {
+                    name: 'string-throw-test'
+                }
+            });
+
+            expect(result.isError).toBe(true);
+            expect(result.content).toEqual([
+                {
+                    type: 'text',
+                    text: 'Internal error'
                 }
             ]);
         });
@@ -6972,7 +7077,7 @@ describe('Zod v4', () => {
 
             // Should receive an error since cancelled tasks don't have results
             expect(result).toHaveProperty('content');
-            expect(result.content).toEqual([{ type: 'text' as const, text: expect.stringContaining('has no result stored') }]);
+            expect(result.content).toEqual([{ type: 'text' as const, text: 'Internal error' }]);
 
             // Wait for async operations to complete
             await waitForLatch();

--- a/test/integration/test/server/mcp.test.ts
+++ b/test/integration/test/server/mcp.test.ts
@@ -1,7 +1,14 @@
 import { Client } from '@modelcontextprotocol/client';
 import type { Notification, TextContent } from '@modelcontextprotocol/core';
-import { getDisplayName, InMemoryTransport, ProtocolErrorCode, UriTemplate, UrlElicitationRequiredError } from '@modelcontextprotocol/core';
-import { completable, McpServer, ResourceTemplate } from '@modelcontextprotocol/server';
+import {
+    getDisplayName,
+    InMemoryTransport,
+    ProtocolError,
+    ProtocolErrorCode,
+    UriTemplate,
+    UrlElicitationRequiredError
+} from '@modelcontextprotocol/core';
+import { completable, McpServer, ResourceTemplate, ToolError } from '@modelcontextprotocol/server';
 import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 import * as z from 'zod/v4';
 
@@ -1403,17 +1410,15 @@ describe('Zod v4', () => {
                 }
             });
 
+            // Output validation runs over the handler's own (server-side) result, so
+            // a failure is an internal server problem and is sanitized for the client.
             expect(result.isError).toBe(true);
-            expect(result.content).toEqual(
-                expect.arrayContaining([
-                    {
-                        type: 'text',
-                        text: expect.stringContaining(
-                            'Output validation error: Tool test has an output schema but no structured content was provided'
-                        )
-                    }
-                ])
-            );
+            expect(result.content).toEqual([
+                {
+                    type: 'text',
+                    text: 'Internal error'
+                }
+            ]);
         });
         /***
          * Test: Tool with Output Schema Must Provide Structured Content
@@ -1535,15 +1540,15 @@ describe('Zod v4', () => {
                 }
             });
 
+            // Output validation runs over the handler's own (server-side) result, so
+            // the failure detail is sanitized to avoid leaking it to the client.
             expect(result.isError).toBe(true);
-            expect(result.content).toEqual(
-                expect.arrayContaining([
-                    {
-                        type: 'text',
-                        text: expect.stringContaining('Output validation error: Invalid structured content for tool test')
-                    }
-                ])
-            );
+            expect(result.content).toEqual([
+                {
+                    type: 'text',
+                    text: 'Internal error'
+                }
+            ]);
         });
 
         /***
@@ -1776,7 +1781,201 @@ describe('Zod v4', () => {
             expect(result.content).toEqual([
                 {
                     type: 'text',
-                    text: 'Tool execution failed'
+                    text: 'Internal error'
+                }
+            ]);
+        });
+
+        test('should pass through ToolError message to client', async () => {
+            const mcpServer = new McpServer({
+                name: 'test server',
+                version: '1.0'
+            });
+
+            const client = new Client({
+                name: 'test client',
+                version: '1.0'
+            });
+
+            mcpServer.registerTool('toolerror-test', {}, async () => {
+                throw new ToolError('Invalid input: country not supported');
+            });
+
+            const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+            await Promise.all([client.connect(clientTransport), mcpServer.server.connect(serverTransport)]);
+
+            const result = await client.request({
+                method: 'tools/call',
+                params: {
+                    name: 'toolerror-test'
+                }
+            });
+
+            expect(result.isError).toBe(true);
+            expect(result.content).toEqual([
+                {
+                    type: 'text',
+                    text: 'Invalid input: country not supported'
+                }
+            ]);
+        });
+
+        test('should sanitize generic Error to Internal error', async () => {
+            const mcpServer = new McpServer({
+                name: 'test server',
+                version: '1.0'
+            });
+
+            const client = new Client({
+                name: 'test client',
+                version: '1.0'
+            });
+
+            mcpServer.registerTool('internal-error-test', {}, async () => {
+                throw new Error('Connection failed at 10.0.0.5:5432');
+            });
+
+            const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+            await Promise.all([client.connect(clientTransport), mcpServer.server.connect(serverTransport)]);
+
+            const result = await client.request({
+                method: 'tools/call',
+                params: {
+                    name: 'internal-error-test'
+                }
+            });
+
+            expect(result.isError).toBe(true);
+            expect(result.content).toEqual([
+                {
+                    type: 'text',
+                    text: 'Internal error'
+                }
+            ]);
+        });
+
+        test('should sanitize non-Error throws to Internal error', async () => {
+            const mcpServer = new McpServer({
+                name: 'test server',
+                version: '1.0'
+            });
+
+            const client = new Client({
+                name: 'test client',
+                version: '1.0'
+            });
+
+            mcpServer.registerTool('string-throw-test', {}, async () => {
+                throw 'some raw string error';
+            });
+
+            const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+            await Promise.all([client.connect(clientTransport), mcpServer.server.connect(serverTransport)]);
+
+            const result = await client.request({
+                method: 'tools/call',
+                params: {
+                    name: 'string-throw-test'
+                }
+            });
+
+            expect(result.isError).toBe(true);
+            expect(result.content).toEqual([
+                {
+                    type: 'text',
+                    text: 'Internal error'
+                }
+            ]);
+        });
+
+        test('should sanitize a ProtocolError thrown from inside the handler', async () => {
+            // ProtocolError is a public export, so a handler (or a dependency in its
+            // call stack) can construct one. It must NOT be trusted as client-safe:
+            // only SDK-raised validation errors pass through, handler-thrown ones are
+            // sanitized.
+            const mcpServer = new McpServer({
+                name: 'test server',
+                version: '1.0'
+            });
+
+            const client = new Client({
+                name: 'test client',
+                version: '1.0'
+            });
+
+            mcpServer.registerTool('handler-protocolerror-test', {}, async () => {
+                throw new ProtocolError(
+                    ProtocolErrorCode.InternalError,
+                    'Connection refused to postgres://admin:hunter2@10.0.0.5:5432/prod'
+                );
+            });
+
+            const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+            await Promise.all([client.connect(clientTransport), mcpServer.server.connect(serverTransport)]);
+
+            const result = await client.request({
+                method: 'tools/call',
+                params: {
+                    name: 'handler-protocolerror-test'
+                }
+            });
+
+            expect(result.isError).toBe(true);
+            expect(result.content).toEqual([
+                {
+                    type: 'text',
+                    text: 'Internal error'
+                }
+            ]);
+        });
+
+        test('should sanitize output-schema validation failures without leaking server data', async () => {
+            const mcpServer = new McpServer({
+                name: 'test server',
+                version: '1.0'
+            });
+
+            const client = new Client({
+                name: 'test client',
+                version: '1.0'
+            });
+
+            // A custom schema-validation message can embed server-side data, and the
+            // output being validated is the handler's own (server-side) value. Any
+            // output-validation failure must be sanitized, never echoed to the client.
+            mcpServer.registerTool(
+                'leaky-output',
+                {
+                    description: 'Tool whose output fails a custom-message validation',
+                    outputSchema: z.object({
+                        token: z.string().refine(() => false, 'token rejected: s3cr3t-server-api-key')
+                    })
+                },
+                async () => ({
+                    content: [{ type: 'text', text: 'ok' }],
+                    structuredContent: {
+                        token: 's3cr3t-server-api-key'
+                    }
+                })
+            );
+
+            const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+            await Promise.all([client.connect(clientTransport), mcpServer.server.connect(serverTransport)]);
+
+            const result = await client.callTool({
+                name: 'leaky-output'
+            });
+
+            expect(result.isError).toBe(true);
+            expect(result.content).toEqual([
+                {
+                    type: 'text',
+                    text: 'Internal error'
                 }
             ]);
         });


### PR DESCRIPTION
## Summary

Closes #1429

When a tool handler throws an unexpected error, the full error message is sent to the MCP client, potentially leaking sensitive server internals (hostnames, connection strings, stack traces).

This PR:
- Adds a `ToolError` class that tool authors can throw when they want a specific message shown to the client
- Sanitizes all other unhandled errors to `"Internal error"`
- Preserves `ProtocolError` messages (SDK-generated validation errors are safe to expose)

## Usage

```typescript
import { McpServer, ToolError } from '@modelcontextprotocol/server';

server.registerTool('my-tool', {}, async () => {
    // This message WILL be shown to the client
    throw new ToolError('Invalid input: country not supported');

    // This message will NOT be shown — client sees "Internal error"
    throw new Error('DB connection failed at 10.0.0.5:5432');
});
```

## Error handling behavior

| Error type | Client sees | Rationale |
|------------|-------------|-----------|
| `ToolError` | Developer's message | Intentional, developer-controlled |
| `ProtocolError` | SDK message | SDK-generated validation, safe to expose |
| `Error` | `"Internal error"` | May contain sensitive internals |
| Non-Error throw | `"Internal error"` | Unknown, sanitize defensively |

## Test plan

- [x] Generic `Error` is sanitized to `"Internal error"`
- [x] `ToolError` message passes through to client
- [x] Non-Error throw (string) is sanitized to `"Internal error"`
- [x] Existing `ProtocolError` validation tests still pass (129/129)
- [x] Task cancellation error sanitized correctly