### PR TITLE
fix(client): preserve authorization server subpath in fallback URLs

### DIFF
--- a/.changeset/fix-auth-subpath-fallback.md
+++ b/.changeset/fix-auth-subpath-fallback.md
@@ -1,0 +1,5 @@
+---
+"@modelcontextprotocol/client": patch
+---
+
+fix(client): preserve authorization server subpath in fallback URLs

--- a/packages/client/src/client/auth.ts
+++ b/packages/client/src/client/auth.ts
@@ -1014,12 +1014,8 @@ async function fetchWithCorsRetry(url: URL, headers?: Record<string, string>, fe
  * `https://example.com/admin/authorize` (path preserved).
  */
 function buildFallbackUrl(authorizationServerUrl: string | URL, endpoint: string): URL {
-    const url = typeof authorizationServerUrl === 'string'
-        ? new URL(authorizationServerUrl)
-        : new URL(authorizationServerUrl.href);
-    const basePath = url.pathname.endsWith('/')
-        ? url.pathname.slice(0, -1)
-        : url.pathname;
+    const url = typeof authorizationServerUrl === 'string' ? new URL(authorizationServerUrl) : new URL(authorizationServerUrl.href);
+    const basePath = url.pathname.endsWith('/') ? url.pathname.slice(0, -1) : url.pathname;
     url.pathname = `${basePath}${endpoint}`;
     return url;
 }

--- a/packages/client/src/client/auth.ts
+++ b/packages/client/src/client/auth.ts
@@ -1006,6 +1006,25 @@ async function fetchWithCorsRetry(url: URL, headers?: Record<string, string>, fe
 }
 
 /**
+ * Builds a fallback endpoint URL by appending the endpoint path to the
+ * authorization server's existing pathname, instead of replacing it.
+ *
+ * `new URL('/authorize', 'https://example.com/admin')` produces
+ * `https://example.com/authorize` (path lost). This helper produces
+ * `https://example.com/admin/authorize` (path preserved).
+ */
+function buildFallbackUrl(authorizationServerUrl: string | URL, endpoint: string): URL {
+    const url = typeof authorizationServerUrl === 'string'
+        ? new URL(authorizationServerUrl)
+        : new URL(authorizationServerUrl.href);
+    const basePath = url.pathname.endsWith('/')
+        ? url.pathname.slice(0, -1)
+        : url.pathname;
+    url.pathname = `${basePath}${endpoint}`;
+    return url;
+}
+
+/**
  * Constructs the well-known path for auth-related metadata discovery
  */
 function buildWellKnownPath(
@@ -1372,7 +1391,7 @@ export async function startAuthorization(
             throw new Error(`Incompatible auth server: does not support code challenge method ${AUTHORIZATION_CODE_CHALLENGE_METHOD}`);
         }
     } else {
-        authorizationUrl = new URL('/authorize', authorizationServerUrl);
+        authorizationUrl = buildFallbackUrl(authorizationServerUrl, '/authorize');
     }
 
     // Generate PKCE challenge
@@ -1454,7 +1473,7 @@ export async function executeTokenRequest(
         fetchFn?: FetchLike;
     }
 ): Promise<OAuthTokens> {
-    const tokenUrl = metadata?.token_endpoint ? new URL(metadata.token_endpoint) : new URL('/token', authorizationServerUrl);
+    const tokenUrl = metadata?.token_endpoint ? new URL(metadata.token_endpoint) : buildFallbackUrl(authorizationServerUrl, '/token');
 
     const headers = new Headers({
         'Content-Type': 'application/x-www-form-urlencoded',
@@ -1701,7 +1720,7 @@ export async function registerClient(
 
         registrationUrl = new URL(metadata.registration_endpoint);
     } else {
-        registrationUrl = new URL('/register', authorizationServerUrl);
+        registrationUrl = buildFallbackUrl(authorizationServerUrl, '/register');
     }
 
     const response = await (fetchFn ?? fetch)(registrationUrl, {

--- a/packages/client/test/client/auth.test.ts
+++ b/packages/client/test/client/auth.test.ts
@@ -1621,6 +1621,59 @@ describe('OAuth Authorization', () => {
         );
     });
 
+    describe('fallback URL subpath preservation', () => {
+        const validClientInfo = {
+            client_id: 'client123',
+            client_secret: 'secret123',
+            redirect_uris: ['http://localhost:3000/callback'],
+            client_name: 'Test Client'
+        };
+
+        it('preserves authorization server subpath in fallback authorize URL', async () => {
+            const { authorizationUrl } = await startAuthorization('https://auth.example.com/admin', {
+                metadata: undefined,
+                clientInformation: validClientInfo,
+                redirectUrl: 'http://localhost:3000/callback'
+            });
+
+            expect(authorizationUrl.pathname).toBe('/admin/authorize');
+        });
+
+        it('preserves subpath in fallback token URL', async () => {
+            const mockFetch = vi.fn();
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                status: 200,
+                json: async () => ({
+                    access_token: 'access123',
+                    token_type: 'Bearer'
+                })
+            });
+
+            await exchangeAuthorization('https://auth.example.com/admin', {
+                metadata: undefined,
+                clientInformation: validClientInfo,
+                authorizationCode: 'code123',
+                codeVerifier: 'verifier123',
+                redirectUri: 'http://localhost:3000/callback',
+                fetchFn: mockFetch,
+            });
+
+            const fetchUrl = new URL(mockFetch.mock.calls[0][0]);
+            expect(fetchUrl.pathname).toBe('/admin/token');
+        });
+
+        it('still works for root-path authorization servers', async () => {
+            const { authorizationUrl } = await startAuthorization('https://auth.example.com', {
+                metadata: undefined,
+                clientInformation: validClientInfo,
+                redirectUrl: 'http://localhost:3000/callback'
+            });
+
+            expect(authorizationUrl.pathname).toBe('/authorize');
+        });
+    });
+
     describe('exchangeAuthorization', () => {
         const validTokens: OAuthTokens = {
             access_token: 'access123',

--- a/packages/client/test/client/auth.test.ts
+++ b/packages/client/test/client/auth.test.ts
@@ -1656,7 +1656,7 @@ describe('OAuth Authorization', () => {
                 authorizationCode: 'code123',
                 codeVerifier: 'verifier123',
                 redirectUri: 'http://localhost:3000/callback',
-                fetchFn: mockFetch,
+                fetchFn: mockFetch
             });
 
             const fetchUrl = new URL(mockFetch.mock.calls[0]![0] as string);

--- a/packages/client/test/client/auth.test.ts
+++ b/packages/client/test/client/auth.test.ts
@@ -1659,7 +1659,7 @@ describe('OAuth Authorization', () => {
                 fetchFn: mockFetch,
             });
 
-            const fetchUrl = new URL(mockFetch.mock.calls[0][0]);
+            const fetchUrl = new URL(mockFetch.mock.calls[0]![0] as string);
             expect(fetchUrl.pathname).toBe('/admin/token');
         });
 


### PR DESCRIPTION
## Summary

Closes #1716

When AS metadata discovery fails and the authorization server has a non-root path (e.g., `https://example.com/admin`), the fallback URL construction silently discards the path prefix, redirecting users to a nonexistent endpoint.

**Before:** `new URL('/authorize', 'https://example.com/admin')` → `https://example.com/authorize`
**After:** `buildFallbackUrl('https://example.com/admin', '/authorize')` → `https://example.com/admin/authorize`

## Changes

**`packages/client/src/client/auth.ts`**
- Added `buildFallbackUrl()` helper that appends the endpoint path to the server's existing pathname
- Updated three fallback locations: `/authorize` (startAuthorization), `/token` (executeTokenRequest), `/register` (registerClient)

## Test plan

- [x] Subpath preserved in fallback `/authorize` URL
- [x] Subpath preserved in fallback `/token` URL
- [x] Root-path server still produces correct URLs (no regression)
- [x] All 161 auth tests passing