### PR TITLE
chore(ci): switch publish to OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
             # requires npm >=11.5.1, which Node 24's bundled npm only satisfies from
             # ~24.6 onward. Install a recent-enough npm so we don't depend on which Node patch resolves.
             - name: Ensure npm CLI supports OIDC trusted publishing
-              run: npm install -g npm@^11.5.1
+              run: npm install -g npm@11.5.1
 
             - name: Publish to npm
               uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
 
             # pnpm@10 delegates `pnpm publish` to the npm CLI; OIDC trusted publishing
             # requires npm >=11.5.1, which Node 24's bundled npm only satisfies from
-            # ~24.6 onward. Pin explicitly so we don't depend on the resolved Node patch.
+            # ~24.6 onward. Install a recent-enough npm so we don't depend on which Node patch resolves.
             - name: Ensure npm CLI supports OIDC trusted publishing
               run: npm install -g npm@^11.5.1
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,12 @@ jobs:
             - name: Install dependencies
               run: pnpm install
 
+            # pnpm@10 delegates `pnpm publish` to the npm CLI; OIDC trusted publishing
+            # requires npm >=11.5.1, which Node 24's bundled npm only satisfies from
+            # ~24.6 onward. Pin explicitly so we don't depend on the resolved Node patch.
+            - name: Ensure npm CLI supports OIDC trusted publishing
+              run: npm install -g npm@^11.5.1
+
             - name: Publish to npm
               uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1
               with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,6 @@ jobs:
                   node-version: 24
                   cache: pnpm
                   cache-dependency-path: pnpm-lock.yaml
-                  registry-url: 'https://registry.npmjs.org'
 
             - name: Install dependencies
               run: pnpm install
@@ -74,6 +73,4 @@ jobs:
                   publish: pnpm run ci:publish
               env:
                   GITHUB_TOKEN: ${{ github.token }}
-                  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
                   NPM_CONFIG_PROVENANCE: 'true'


### PR DESCRIPTION
Drops `NPM_TOKEN`/`NODE_AUTH_TOKEN` from `release.yml`'s publish job. npm CLI auto-detects GitHub Actions OIDC and exchanges for a short-lived publish credential — no long-lived secret to rotate.

## Motivation and Context

Trusted publishing is npm's recommended path and what the token-creation UI itself nudges toward.

`id-token: write` was already added in #1836 for provenance — the workflow is OIDC-ready. This just removes the token plumbing.

Also drops `registry-url` from `setup-node` — it writes a `.npmrc` containing `${NODE_AUTH_TOKEN}`, which interferes with OIDC auto-detect when the env var is empty. npm defaults to `registry.npmjs.org` without it.

## How Has This Been Tested?

Workflow YAML only. The publish path can't be tested without merging.

## Breaking Changes

None.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

After this merges, the `NPM_TOKEN` secret in the `release` environment can be deleted entirely.