### PR TITLE
chore(ci): switch publish to OIDC trusted publishing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,6 +62,9 @@ jobs:
 
             - run: npm ci
 
+            - name: Ensure npm CLI supports OIDC trusted publishing
+              run: npm install -g npm@11.5.1
+
             - name: Determine npm tag
               id: npm-tag
               run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,7 +59,6 @@ jobs:
               with:
                   node-version: 24
                   cache: npm
-                  registry-url: 'https://registry.npmjs.org'
 
             - run: npm ci
 
@@ -85,5 +84,3 @@ jobs:
                   fi
 
             - run: npm publish --provenance --access public ${{ steps.npm-tag.outputs.tag }}
-              env:
-                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
v1.x companion to #1838. Drops `NODE_AUTH_TOKEN` and `registry-url` — npm CLI auto-detects GitHub Actions OIDC. `id-token: write` was already present.

Requires a trusted publisher configured for `@modelcontextprotocol/sdk` on npmjs.com (workflow `main.yml`, environment `release`).