### PR TITLE
`v2`: cf workers fix

### DIFF
--- a/docs/migration-SKILL.md
+++ b/docs/migration-SKILL.md
@@ -480,7 +480,10 @@ new McpServer(
 new McpServer({ name: 'server', version: '1.0.0' }, {});
 ```
 
-Access validators via `_shims` export: `import { DefaultJsonSchemaValidator } from '@modelcontextprotocol/server/_shims';`
+Access validators explicitly:
+- Runtime-aware default: `import { DefaultJsonSchemaValidator } from '@modelcontextprotocol/server/_shims';`
+- AJV (Node.js): `import { AjvJsonSchemaValidator } from '@modelcontextprotocol/server';`
+- CF Worker: `import { CfWorkerJsonSchemaValidator } from '@modelcontextprotocol/server/validators/cf-worker';`
 
 ## 15. Migration Steps (apply in this order)
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -835,7 +835,8 @@ This means Cloudflare Workers users no longer need to explicitly pass the valida
 **Before (v1) - Cloudflare Workers required explicit configuration:**
 
 ```typescript
-import { McpServer, CfWorkerJsonSchemaValidator } from '@modelcontextprotocol/server';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { CfWorkerJsonSchemaValidator } from '@modelcontextprotocol/sdk/validation/cfworker';
 
 const server = new McpServer(
     { name: 'my-server', version: '1.0.0' },
@@ -858,12 +859,15 @@ const server = new McpServer(
 );
 ```
 
-You can still explicitly override the validator if needed. The validators are available via the `_shims` export:
+You can still explicitly override the validator if needed:
 
 ```typescript
+// Runtime-aware default (auto-selects AjvJsonSchemaValidator or CfWorkerJsonSchemaValidator)
 import { DefaultJsonSchemaValidator } from '@modelcontextprotocol/server/_shims';
-// or
-import { AjvJsonSchemaValidator, CfWorkerJsonSchemaValidator } from '@modelcontextprotocol/server';
+
+// Specific validators
+import { AjvJsonSchemaValidator } from '@modelcontextprotocol/server';
+import { CfWorkerJsonSchemaValidator } from '@modelcontextprotocol/server/validators/cf-worker';
 ```
 
 ## Unchanged APIs

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -24,6 +24,10 @@
             "types": "./dist/index.d.mts",
             "import": "./dist/index.mjs"
         },
+        "./validators/cf-worker": {
+            "types": "./dist/validators/cfWorker.d.mts",
+            "import": "./dist/validators/cfWorker.mjs"
+        },
         "./_shims": {
             "workerd": {
                 "types": "./dist/shimsWorkerd.d.mts",
@@ -66,14 +70,6 @@
         "jose": "catalog:runtimeClientOnly",
         "pkce-challenge": "catalog:runtimeShared",
         "zod": "catalog:runtimeShared"
-    },
-    "peerDependencies": {
-        "@cfworker/json-schema": "catalog:runtimeShared"
-    },
-    "peerDependenciesMeta": {
-        "@cfworker/json-schema": {
-            "optional": true
-        }
     },
     "devDependencies": {
         "@modelcontextprotocol/core": "workspace:^",

--- a/packages/client/src/client/client.ts
+++ b/packages/client/src/client/client.ts
@@ -162,7 +162,7 @@ export type ClientOptions = ProtocolOptions & {
      * The validator is used to validate structured content returned by tools
      * against their declared output schemas.
      *
-     * @default {@linkcode DefaultJsonSchemaValidator} ({@linkcode index.AjvJsonSchemaValidator | AjvJsonSchemaValidator} on Node.js, {@linkcode index.CfWorkerJsonSchemaValidator | CfWorkerJsonSchemaValidator} on Cloudflare Workers)
+     * @default {@linkcode DefaultJsonSchemaValidator} ({@linkcode index.AjvJsonSchemaValidator | AjvJsonSchemaValidator} on Node.js, `CfWorkerJsonSchemaValidator` on Cloudflare Workers)
      */
     jsonSchemaValidator?: jsonSchemaValidator;
 

--- a/packages/client/src/validators/cfWorker.ts
+++ b/packages/client/src/validators/cfWorker.ts
@@ -1,0 +1,10 @@
+/**
+ * Cloudflare Workers JSON Schema validator, available as a sub-path export.
+ *
+ * @example
+ * ```ts
+ * import { CfWorkerJsonSchemaValidator } from '@modelcontextprotocol/client/validators/cf-worker';
+ * ```
+ */
+export { CfWorkerJsonSchemaValidator } from '@modelcontextprotocol/core';
+export type { CfWorkerSchemaDraft } from '@modelcontextprotocol/core';

--- a/packages/client/tsdown.config.ts
+++ b/packages/client/tsdown.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
     failOnWarn: 'ci-only',
     // 1. Entry Points
     //    Directly matches package.json include/exclude globs
-    entry: ['src/index.ts', 'src/shimsNode.ts', 'src/shimsWorkerd.ts', 'src/shimsBrowser.ts'],
+    entry: ['src/index.ts', 'src/shimsNode.ts', 'src/shimsWorkerd.ts', 'src/shimsBrowser.ts', 'src/validators/cfWorker.ts'],
 
     // 2. Output Configuration
     format: ['esm'],

--- a/packages/core/src/exports/public/index.ts
+++ b/packages/core/src/exports/public/index.ts
@@ -137,7 +137,6 @@ export { InMemoryTaskMessageQueue, InMemoryTaskStore } from '../../experimental/
 export type { StandardSchemaWithJSON } from '../../util/standardSchema.js';
 export { AjvJsonSchemaValidator } from '../../validators/ajvProvider.js';
 export type { CfWorkerSchemaDraft } from '../../validators/cfWorkerProvider.js';
-export { CfWorkerJsonSchemaValidator } from '../../validators/cfWorkerProvider.js';
 // fromJsonSchema is intentionally NOT exported here — the server and client packages
 // provide runtime-aware wrappers that default to the appropriate validator via _shims.
 export type { JsonSchemaType, JsonSchemaValidator, jsonSchemaValidator, JsonSchemaValidatorResult } from '../../validators/types.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -28,12 +28,11 @@ export * from './validators/fromJsonSchema.js';
  * Choose a validator based on your runtime environment:
  *
  * - {@linkcode AjvJsonSchemaValidator}: Best for Node.js (default, fastest)
- *   Import from: @modelcontextprotocol/sdk/validators/ajv
- *   Requires peer dependencies: ajv, ajv-formats
+ *   Bundled — no additional dependencies required.
  *
  * - {@linkcode CfWorkerJsonSchemaValidator}: Best for edge runtimes
- *   Import from: @modelcontextprotocol/sdk/validators/cfworker
- *   Requires peer dependency: @cfworker/json-schema
+ *   Import from: `@modelcontextprotocol/server/validators/cf-worker` or `@modelcontextprotocol/client/validators/cf-worker`
+ *   Bundled — no additional dependencies required.
  *
  * @example For Node.js with AJV
  * ```ts source="./index.examples.ts#validation_ajv"

--- a/packages/core/src/validators/ajvProvider.ts
+++ b/packages/core/src/validators/ajvProvider.ts
@@ -33,7 +33,7 @@ function createDefaultAjvInstance(): Ajv {
  * const validator = new AjvJsonSchemaValidator(ajv);
  * ```
  *
- * @see `CfWorkerJsonSchemaValidator` for an edge-runtime-compatible alternative (import from `@modelcontextprotocol/server/validators/cf-worker`)
+ * @see `CfWorkerJsonSchemaValidator` for an edge-runtime-compatible alternative (import from `@modelcontextprotocol/server/validators/cf-worker` or `@modelcontextprotocol/client/validators/cf-worker`)
  */
 export class AjvJsonSchemaValidator implements jsonSchemaValidator {
     private _ajv: Ajv;

--- a/packages/core/src/validators/ajvProvider.ts
+++ b/packages/core/src/validators/ajvProvider.ts
@@ -33,7 +33,7 @@ function createDefaultAjvInstance(): Ajv {
  * const validator = new AjvJsonSchemaValidator(ajv);
  * ```
  *
- * @see {@linkcode CfWorkerJsonSchemaValidator} for an edge-runtime-compatible alternative
+ * @see `CfWorkerJsonSchemaValidator` for an edge-runtime-compatible alternative (import from `@modelcontextprotocol/server/validators/cf-worker`)
  */
 export class AjvJsonSchemaValidator implements jsonSchemaValidator {
     private _ajv: Ajv;

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -24,6 +24,10 @@
             "types": "./dist/index.d.mts",
             "import": "./dist/index.mjs"
         },
+        "./validators/cf-worker": {
+            "types": "./dist/validators/cfWorker.d.mts",
+            "import": "./dist/validators/cfWorker.mjs"
+        },
         "./_shims": {
             "workerd": {
                 "types": "./dist/shimsWorkerd.d.mts",
@@ -61,14 +65,6 @@
     },
     "dependencies": {
         "zod": "catalog:runtimeShared"
-    },
-    "peerDependencies": {
-        "@cfworker/json-schema": "catalog:runtimeShared"
-    },
-    "peerDependenciesMeta": {
-        "@cfworker/json-schema": {
-            "optional": true
-        }
     },
     "devDependencies": {
         "@cfworker/json-schema": "catalog:runtimeShared",

--- a/packages/server/src/server/server.ts
+++ b/packages/server/src/server/server.ts
@@ -84,7 +84,7 @@ export type ServerOptions = ProtocolOptions & {
      * The validator is used to validate user input returned from elicitation
      * requests against the requested schema.
      *
-     * @default {@linkcode DefaultJsonSchemaValidator} ({@linkcode index.AjvJsonSchemaValidator | AjvJsonSchemaValidator} on Node.js, {@linkcode index.CfWorkerJsonSchemaValidator | CfWorkerJsonSchemaValidator} on Cloudflare Workers)
+     * @default {@linkcode DefaultJsonSchemaValidator} ({@linkcode index.AjvJsonSchemaValidator | AjvJsonSchemaValidator} on Node.js, `CfWorkerJsonSchemaValidator` on Cloudflare Workers)
      */
     jsonSchemaValidator?: jsonSchemaValidator;
 };

--- a/packages/server/src/validators/cfWorker.ts
+++ b/packages/server/src/validators/cfWorker.ts
@@ -1,0 +1,10 @@
+/**
+ * Cloudflare Workers JSON Schema validator, available as a sub-path export.
+ *
+ * @example
+ * ```ts
+ * import { CfWorkerJsonSchemaValidator } from '@modelcontextprotocol/server/validators/cf-worker';
+ * ```
+ */
+export { CfWorkerJsonSchemaValidator } from '@modelcontextprotocol/core';
+export type { CfWorkerSchemaDraft } from '@modelcontextprotocol/core';

--- a/packages/server/tsdown.config.ts
+++ b/packages/server/tsdown.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
     failOnWarn: 'ci-only',
     // 1. Entry Points
     //    Directly matches package.json include/exclude globs
-    entry: ['src/index.ts', 'src/shimsNode.ts', 'src/shimsWorkerd.ts'],
+    entry: ['src/index.ts', 'src/shimsNode.ts', 'src/shimsWorkerd.ts', 'src/validators/cfWorker.ts'],
 
     // 2. Output Configuration
     format: ['esm'],


### PR DESCRIPTION
fix: bundle `@cfworker/json-schema` inline and move to sub-path export

## Motivation and Context

Consumers of `@modelcontextprotocol/server` and `@modelcontextprotocol/client` on Node.js hit a runtime error when importing from the main entry:

```
Error: Cannot find package '@cfworker/json-schema' imported from
  …/@modelcontextprotocol/server/dist/src-*.mjs
```

**Root cause:** tsdown bundles `@modelcontextprotocol/core` into a single shared chunk. When it encounters `@cfworker/json-schema`, it checks the package's `package.json` — because it's listed in `peerDependencies`, tsdown externalizes it (leaves a bare `import { Validator } from "@cfworker/json-schema"` in the output). Meanwhile, `ajv` is NOT in `peerDependencies`, so tsdown bundles it inline. This asymmetry means any import of the main entry eagerly triggers the cfworker import, which fails on Node.js where the optional peer dep isn't installed.

**Why this wasn't an issue in v1.x:**
1. v1.x used `tsc` (per-file transpilation), not `tsdown` (bundling) — the cfworker import stayed in its own isolated file
2. v1.x did NOT export `CfWorkerJsonSchemaValidator` from the main entry — it was only accessible via a dedicated sub-path (`@modelcontextprotocol/sdk/validation/cfworker`)

The v2 monorepo restructuring inadvertently collapsed both of these safeguards.

## How Has This Been Tested?

- All 1,425 tests pass across 49 test files (`pnpm test:all`)
- Verified the built dist shared chunk no longer contains any bare `import from "@cfworker/json-schema"` — the code is now bundled inline (same as ajv)
- Verified the new sub-path exports resolve correctly in the build output

## Breaking Changes

`CfWorkerJsonSchemaValidator` is no longer exported from the main entry of `@modelcontextprotocol/server` or `@modelcontextprotocol/client`. It is now available via a dedicated sub-path:

```ts
// Before (broken on Node.js, removed):
import { CfWorkerJsonSchemaValidator } from '@modelcontextprotocol/server';

// After:
import { CfWorkerJsonSchemaValidator } from '@modelcontextprotocol/server/validators/cf-worker';
```

**Most users are unaffected** — the shims system (`shimsWorkerd.mjs`) still automatically selects `CfWorkerJsonSchemaValidator` as the default validator on CF Workers/browser runtimes without any explicit import. Only users who were explicitly importing the class need to update.

The `CfWorkerSchemaDraft` type remains available from the main entry (type-only exports have no runtime impact).

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

### Options considered

1. **Remove from `peerDependencies` (bundle inline like ajv)** — Minimal change, consistent with ajv precedent, no API break. Increases shared chunk by ~38KB (dead code on Node.js). Doesn't address the v1.x regression where cfworker code was isolated behind a sub-path.

2. **Dynamic import with top-level `await` + try/catch** — No bundle size increase, but top-level `await` in the shared chunk makes it an async module, which can cause issues with downstream bundlers, test runners, and runtimes that don't fully support async module graphs.

3. **Separate sub-path export (restore v1.x pattern)** — Matches v1.x design. Breaking change, but acceptable in alpha. Insufficient alone due to rolldown's shared chunk behavior (see below).

4. **Both validators as separate sub-path exports** — Move both `AjvJsonSchemaValidator` and `CfWorkerJsonSchemaValidator` to sub-paths. More churn for no functional benefit since ajv is already working fine.

5. **Move to `dependencies` (not `peerDependencies`)** — Forces all consumers to install `@cfworker/json-schema` even when they don't need it.

**Chosen: Option 1 + Option 3 combined** (see rationale below).

### Why two changes are needed, not one

Simply moving `CfWorkerJsonSchemaValidator` to a sub-path export is **insufficient** on its own. Rolldown merges all of `@modelcontextprotocol/core`'s bundled code into a single shared chunk (because all entry points — `index.ts`, `shimsNode.ts`, `shimsWorkerd.ts` — import from core via `noExternal`). Even after removing the re-export from the main entry, the shared chunk still contains the cfworker code (needed by `shimsWorkerd.ts`), and the bare external import remains at the top of that chunk — loaded by all entry points including `index.mjs`.

The fix therefore combines two changes:

1. **Remove `@cfworker/json-schema` from `peerDependencies`** — tsdown then bundles it inline (same treatment `ajv` already gets). No bare external import → no runtime error. This increases the shared chunk size by ~38KB (the inlined cfworker code), which is dead code on Node.js — parsed but never executed.
2. **Move `CfWorkerJsonSchemaValidator` to a sub-path export** (`./validators/cf-worker`) — removes it from the main entry's public API, restoring the v1.x pattern where CF Workers-specific code is explicitly opt-in.

### Files changed

| File | Change |
|---|---|
| `packages/core/src/exports/public/index.ts` | Removed `CfWorkerJsonSchemaValidator` value export (kept `CfWorkerSchemaDraft` type) |
| `packages/server/package.json` | Removed `peerDependencies`/`peerDependenciesMeta` for cfworker; added `./validators/cf-worker` export |
| `packages/client/package.json` | Same |
| `packages/server/tsdown.config.ts` | Added `src/validators/cfWorker.ts` entry point |
| `packages/client/tsdown.config.ts` | Added `src/validators/cfWorker.ts` entry point |
| `packages/server/src/validators/cfWorker.ts` | New sub-path entry re-exporting from core |
| `packages/client/src/validators/cfWorker.ts` | New sub-path entry re-exporting from core |
