### PR TITLE
feat(core) privacy annotations for tools, a proposal in progress

### DIFF
--- a/examples/client/src/privacyAnnotationsClient.ts
+++ b/examples/client/src/privacyAnnotationsClient.ts
@@ -1,0 +1,129 @@
+/**
+ * Privacy Annotations Example Client
+ *
+ * Demonstrates SEP-0000: Privacy Annotations for Tool Metadata.
+ *
+ * This client:
+ * 1. Connects to the privacy annotations example server
+ * 2. Lists tools and inspects their privacyHint annotations
+ * 3. Calls tools with RequestPrivacy metadata (purpose, justifications, location)
+ * 4. Reads ResponsePrivacy from each tool call result
+ * 5. Demonstrates a cross-border scenario (client in DE, server in US)
+ *
+ * Run the server first:
+ *   npx tsx ../server/src/privacyAnnotationsExample.ts
+ *
+ * Then run this client:
+ *   npx tsx src/privacyAnnotationsClient.ts
+ */
+
+import { Client, StreamableHTTPClientTransport } from '@modelcontextprotocol/client';
+
+const SERVER_URL = process.env.MCP_SERVER_URL || 'http://localhost:3000/mcp';
+
+async function main(): Promise<void> {
+    console.log('Privacy Annotations Example Client');
+    console.log('==================================\n');
+
+    // Connect to server
+    const client = new Client({ name: 'privacy-client', version: '1.0.0' });
+    const transport = new StreamableHTTPClientTransport(new URL(SERVER_URL));
+    await client.connect(transport);
+    console.log('Connected to server.\n');
+
+    // --- Step 1: List tools and inspect privacy hints ---
+
+    console.log('=== Tool Privacy Hints ===\n');
+    const { tools } = await client.listTools();
+
+    for (const tool of tools) {
+        const hint = tool.annotations?.privacyHint;
+        console.log(`Tool: ${tool.name}`);
+        if (hint) {
+            console.log(`  Data categories: ${hint.dataCategories?.join(', ') ?? 'none'}`);
+            console.log(`  Countries:       ${hint.countries?.join(', ') ?? 'unspecified'}`);
+            console.log(`  Subdivisions:    ${hint.subdivisions?.join(', ') ?? 'unspecified'}`);
+        } else {
+            console.log('  No privacy hint declared');
+        }
+        console.log('');
+    }
+
+    // --- Step 2: Call get_patient_record with treatment purpose (US client) ---
+
+    console.log('=== Scenario 1: US client requesting patient record for treatment ===\n');
+
+    const patientResult = await client.callTool({
+        name: 'get_patient_record',
+        arguments: { patient_id: 'P-12345' },
+        _meta: {
+            privacy: {
+                purpose: 'treatment',
+                justifications: ['contract'],
+                minor: false,
+                country: 'US',
+                subdivision: 'US-CA'
+            }
+        }
+    });
+
+    console.log('Response content:', patientResult.content[0]?.type === 'text' ? patientResult.content[0].text : '(non-text)');
+    console.log('Response privacy:', JSON.stringify(patientResult._meta?.privacy, null, 2));
+    console.log('');
+
+    // --- Step 3: Call process_payment with payment purpose ---
+
+    console.log('=== Scenario 2: Processing a payment ===\n');
+
+    const paymentResult = await client.callTool({
+        name: 'process_payment',
+        arguments: { amount: 150, card_token: 'tok_abc123xyz789' },
+        _meta: {
+            privacy: {
+                purpose: 'payment_processing',
+                justifications: ['contract'],
+                country: 'US',
+                subdivision: 'US-CA'
+            }
+        }
+    });
+
+    console.log('Response content:', paymentResult.content[0]?.type === 'text' ? paymentResult.content[0].text : '(non-text)');
+    console.log('Response privacy:', JSON.stringify(paymentResult._meta?.privacy, null, 2));
+    console.log('');
+
+    // --- Step 4: Cross-border scenario — DE client calling global_search ---
+
+    console.log('=== Scenario 3: Cross-border — German client calling global search ===\n');
+
+    const searchResult = await client.callTool({
+        name: 'global_search',
+        arguments: { query: 'customer 42' },
+        _meta: {
+            privacy: {
+                purpose: 'support',
+                justifications: ['contract'],
+                country: 'DE',
+                subdivision: 'DE-BY'
+            }
+        }
+    });
+
+    console.log('Response content:', searchResult.content[0]?.type === 'text' ? searchResult.content[0].text : '(non-text)');
+    const searchPrivacy = searchResult._meta?.privacy;
+    console.log('Response privacy:', JSON.stringify(searchPrivacy, null, 2));
+
+    if (searchPrivacy) {
+        console.log('');
+        console.log('Cross-border analysis:');
+        console.log(`  Client location:  DE (Bavaria)`);
+        console.log(`  Server processed: ${searchPrivacy.countries?.join(', ')} (${searchPrivacy.subdivisions?.join(', ')})`);
+        console.log(`  Data categories:  ${searchPrivacy.dataCategories?.join(', ')}`);
+        console.log('  → A policy engine would evaluate EU→US transfer restrictions');
+    }
+
+    console.log('\n=== Done ===');
+    await client.close();
+}
+
+await main();

--- a/examples/server/src/privacyAnnotationsExample.ts
+++ b/examples/server/src/privacyAnnotationsExample.ts
@@ -1,0 +1,251 @@
+/**
+ * Privacy Annotations Example Server
+ *
+ * Demonstrates SEP-0000: Privacy Annotations for Tool Metadata.
+ *
+ * This server declares three tools with different privacy profiles:
+ * - get_patient_record: health + genetic data in US-CA
+ * - process_payment: financial + authentication data in US-CA + US-VA
+ * - global_search: personal data with global processing
+ *
+ * Each tool handler:
+ * 1. Reads the client's RequestPrivacy from _meta.privacy
+ * 2. Logs a privacy audit trail
+ * 3. Returns ResponsePrivacy declaring what data was actually accessed
+ *
+ * Run with: npx tsx src/privacyAnnotationsExample.ts
+ * Then connect with the privacy annotations client example.
+ */
+
+import { randomUUID } from 'node:crypto';
+
+import { NodeStreamableHTTPServerTransport } from '@modelcontextprotocol/node';
+import type { CallToolResult } from '@modelcontextprotocol/server';
+import { getRequestPrivacy, isInitializeRequest, McpServer } from '@modelcontextprotocol/server';
+import express from 'express';
+import * as z from 'zod/v4';
+
+// Create server
+const server = new McpServer({
+    name: 'privacy-annotations-example',
+    version: '1.0.0'
+});
+
+// --- Tool 1: Patient records (health + genetic data, US-CA) ---
+
+server.registerTool(
+    'get_patient_record',
+    {
+        title: 'Get Patient Record',
+        description: 'Retrieve a patient medical record by ID',
+        inputSchema: z.object({
+            patient_id: z.string().describe('The patient identifier')
+        }),
+        annotations: {
+            title: 'Get Patient Record',
+            readOnlyHint: true,
+            openWorldHint: false,
+            privacyHint: {
+                dataCategories: ['personal', 'health', 'genetic'],
+                countries: ['US'],
+                subdivisions: ['US-CA']
+            }
+        }
+    },
+    async ({ patient_id }, ctx): Promise<CallToolResult> => {
+        // Read the client's privacy context
+        const requestPrivacy = getRequestPrivacy(ctx);
+
+        console.log('[AUDIT] get_patient_record called', {
+            patientId: patient_id,
+            purpose: requestPrivacy?.purpose,
+            justifications: requestPrivacy?.justifications,
+            clientCountry: requestPrivacy?.country,
+            clientSubdivision: requestPrivacy?.subdivision,
+            minor: requestPrivacy?.minor
+        });
+
+        // Simulated patient record
+        const record = {
+            id: patient_id,
+            name: 'Jane Doe',
+            dob: '1985-03-15',
+            diagnoses: ['Type 2 Diabetes'],
+            geneticMarkers: ['BRCA1-negative']
+        };
+
+        return {
+            content: [
+                {
+                    type: 'text',
+                    text: JSON.stringify(record, null, 2)
+                }
+            ],
+            _meta: {
+                privacy: {
+                    dataCategories: ['personal', 'health', 'genetic'],
+                    countries: ['US'],
+                    subdivisions: ['US-CA'],
+                    minor: requestPrivacy?.minor ?? false
+                }
+            }
+        };
+    }
+);
+
+// --- Tool 2: Payment processing (financial data, multi-state) ---
+
+server.registerTool(
+    'process_payment',
+    {
+        title: 'Process Payment',
+        description: 'Process a credit card payment',
+        inputSchema: z.object({
+            amount: z.number().describe('Payment amount in USD'),
+            card_token: z.string().describe('Tokenized card reference')
+        }),
+        annotations: {
+            title: 'Process Payment',
+            readOnlyHint: false,
+            destructiveHint: true,
+            privacyHint: {
+                dataCategories: ['personal', 'financial', 'authentication'],
+                countries: ['US'],
+                subdivisions: ['US-CA', 'US-VA']
+            }
+        }
+    },
+    async ({ amount, card_token }, ctx): Promise<CallToolResult> => {
+        const requestPrivacy = getRequestPrivacy(ctx);
+
+        console.log('[AUDIT] process_payment called', {
+            amount,
+            purpose: requestPrivacy?.purpose,
+            justifications: requestPrivacy?.justifications,
+            clientCountry: requestPrivacy?.country
+        });
+
+        return {
+            content: [
+                {
+                    type: 'text',
+                    text: `Payment of $${amount} processed with token ${card_token.slice(0, 8)}...`
+                }
+            ],
+            _meta: {
+                privacy: {
+                    dataCategories: ['personal', 'financial'],
+                    countries: ['US'],
+                    subdivisions: ['US-CA']
+                }
+            }
+        };
+    }
+);
+
+// --- Tool 3: Global search (personal data, globally distributed) ---
+
+server.registerTool(
+    'global_search',
+    {
+        title: 'Global Search',
+        description: 'Search across distributed data stores',
+        inputSchema: z.object({
+            query: z.string().describe('Search query')
+        }),
+        annotations: {
+            title: 'Global Search',
+            readOnlyHint: true,
+            privacyHint: {
+                dataCategories: ['personal'],
+                countries: ['global']
+            }
+        }
+    },
+    async ({ query }, ctx): Promise<CallToolResult> => {
+        const requestPrivacy = getRequestPrivacy(ctx);
+
+        console.log('[AUDIT] global_search called', {
+            query,
+            purpose: requestPrivacy?.purpose,
+            justifications: requestPrivacy?.justifications,
+            clientCountry: requestPrivacy?.country,
+            clientSubdivision: requestPrivacy?.subdivision
+        });
+
+        // Simulate routing to a specific region
+        const processingRegion = { country: 'US', subdivision: 'US-VA' };
+
+        return {
+            content: [
+                {
+                    type: 'text',
+                    text: `Search results for "${query}" (processed in ${processingRegion.country}-${processingRegion.subdivision})`
+                }
+            ],
+            _meta: {
+                privacy: {
+                    dataCategories: ['personal', 'financial'],
+                    countries: [processingRegion.country],
+                    subdivisions: [processingRegion.subdivision]
+                }
+            }
+        };
+    }
+);
+
+// --- HTTP Transport Setup ---
+
+const PORT = process.env.MCP_PORT ? Number.parseInt(process.env.MCP_PORT, 10) : 3000;
+
+const app = express();
+app.use(express.json());
+
+const transports: Record<string, NodeStreamableHTTPServerTransport> = {};
+
+app.all('/mcp', async (req, res) => {
+    const sessionId = req.headers['mcp-session-id'] as string | undefined;
+
+    try {
+        let transport: NodeStreamableHTTPServerTransport;
+        if (sessionId && transports[sessionId]) {
+            transport = transports[sessionId];
+        } else if (!sessionId && isInitializeRequest(req.body)) {
+            transport = new NodeStreamableHTTPServerTransport({
+                sessionIdGenerator: () => randomUUID(),
+                onsessioninitialized: id => {
+                    transports[id] = transport;
+                }
+            });
+
+            transport.onclose = () => {
+                if (transport.sessionId) {
+                    delete transports[transport.sessionId];
+                }
+            };
+
+            await server.server.connect(transport);
+        } else {
+            res.status(400).json({ error: 'Bad request: no valid session' });
+            return;
+        }
+
+        await transport.handleRequest(req, res, req.body);
+    } catch (error) {
+        console.error('Error handling MCP request:', error);
+        if (!res.headersSent) {
+            res.status(500).json({ error: 'Internal server error' });
+        }
+    }
+});
+
+app.listen(PORT, () => {
+    console.log(`Privacy Annotations Example Server running on http://localhost:${PORT}/mcp`);
+    console.log('');
+    console.log('Tools registered:');
+    console.log('  - get_patient_record  [health, genetic]  US-CA');
+    console.log('  - process_payment     [financial, auth]   US-CA, US-VA');
+    console.log('  - global_search       [personal]          global');
+    console.log('');
+    console.log('Connect with: npx tsx ../client/src/privacyAnnotationsClient.ts');
+});

--- a/packages/core/src/types/schemas.ts
+++ b/packages/core/src/types/schemas.ts
@@ -1227,6 +1227,165 @@ export const PromptListChangedNotificationSchema = NotificationSchema.extend({
     params: NotificationsParamsSchema.optional()
 });
 
+/* Privacy vocabulary */
+
+/**
+ * Data categories describing what kind of data a tool handles.
+ * Each category represents a grouping that receives distinct regulatory
+ * treatment in at least one major global privacy framework.
+ */
+export const DataCategorySchema = z.enum([
+    'personal',
+    'health',
+    'financial',
+    'biometric',
+    'genetic',
+    'demographic',
+    'political',
+    'religious',
+    'sexual',
+    'criminal',
+    'education',
+    'location',
+    'communications',
+    'authentication',
+    'behavioral'
+]);
+
+/**
+ * Processing purpose describing why data is being accessed.
+ * Values are drawn from processing purposes recognized across
+ * major global privacy frameworks.
+ */
+export const PurposeSchema = z.enum([
+    'service_delivery',
+    'treatment',
+    'payment_processing',
+    'fraud_prevention',
+    'identity_verification',
+    'legal_compliance',
+    'research',
+    'analytics',
+    'marketing',
+    'advertising',
+    'personalization',
+    'third_party_sharing',
+    'model_training',
+    'audit',
+    'support',
+    'employment',
+    'deletion',
+    'data_portability'
+]);
+
+/**
+ * Legal justification for data processing. Rooted in the legal bases
+ * recognized by major privacy frameworks, particularly GDPR Article 6(1).
+ */
+export const LegalJustificationSchema = z.enum([
+    'consent',
+    'explicit_consent',
+    'contract',
+    'legal_obligation',
+    'vital_interest',
+    'public_interest',
+    'legitimate_interest',
+    'employment',
+    'regulatory_mandate'
+]);
+
+/* Privacy annotation types */
+
+/**
+ * Privacy hint declared by a server on a tool definition.
+ * Describes the data categories this tool may handle and the
+ * server's data residency location(s).
+ */
+export const PrivacyHintSchema = z.object({
+    /**
+     * Data categories that this tool's responses may contain.
+     * Additive: multiple categories apply simultaneously.
+     */
+    dataCategories: z.array(DataCategorySchema).optional(),
+
+    /**
+     * The geographic location(s) where this server processes and/or
+     * stores data. Uses ISO 3166-1 alpha-2 country codes.
+     * Use ["global"] when the server cannot guarantee a specific location.
+     */
+    countries: z.array(z.string()).optional(),
+
+    /**
+     * The sub-national subdivision(s) where this server processes
+     * and/or stores data, using ISO 3166-2 codes.
+     */
+    subdivisions: z.array(z.string()).optional()
+});
+
+/**
+ * Privacy metadata declared by the client in a tools/call request.
+ * Communicates the caller's processing context — purpose, legal
+ * justification, and location.
+ */
+export const RequestPrivacySchema = z.object({
+    /**
+     * The purpose for which the data is being accessed or processed.
+     */
+    purpose: PurposeSchema.optional(),
+
+    /**
+     * The legal justification(s) under which processing is claimed.
+     * An array because a single activity may be justified under
+     * multiple bases simultaneously.
+     */
+    justifications: z.array(LegalJustificationSchema).optional(),
+
+    /**
+     * Indicates the data subject is known or believed to be a minor.
+     */
+    minor: z.boolean().optional(),
+
+    /**
+     * The country where the client (or end user) is located,
+     * using ISO 3166-1 alpha-2 codes.
+     */
+    country: z.string().optional(),
+
+    /**
+     * The sub-national subdivision where the client is located,
+     * using ISO 3166-2 codes.
+     */
+    subdivision: z.string().optional()
+});
+
+/**
+ * Privacy metadata returned by the server in a CallToolResult.
+ * Reports the actual privacy characteristics of a specific response.
+ */
+export const ResponsePrivacySchema = z.object({
+    /**
+     * Data categories actually present in this response.
+     */
+    dataCategories: z.array(DataCategorySchema).optional(),
+
+    /**
+     * The country where the server actually processed this request,
+     * using ISO 3166-1 alpha-2 codes.
+     */
+    countries: z.array(z.string()).optional(),
+
+    /**
+     * The sub-national subdivision where the server processed this
+     * request, using ISO 3166-2 codes.
+     */
+    subdivisions: z.array(z.string()).optional(),
+
+    /**
+     * Indicates that data in this response relates to a minor.
+     */
+    minor: z.boolean().optional()
+});
+
 /* Tools */
 /**
  * Additional properties describing a `Tool` to clients.
@@ -1279,7 +1438,19 @@ export const ToolAnnotationsSchema = z.object({
      *
      * Default: `true`
      */
-    openWorldHint: z.boolean().optional()
+    openWorldHint: z.boolean().optional(),
+
+    /**
+     * Privacy metadata describing the data categories this tool may
+     * handle and the server's data residency location(s).
+     *
+     * Like other ToolAnnotation fields, this is a hint. It is not
+     * guaranteed to provide a faithful description of data handling
+     * behavior. Clients SHOULD NOT rely on privacyHint from untrusted
+     * servers for security-critical decisions without independent
+     * verification.
+     */
+    privacyHint: PrivacyHintSchema.optional()
 });
 
 /**
@@ -1362,9 +1533,20 @@ export const ListToolsResultSchema = PaginatedResultSchema.extend({
 });
 
 /**
+ * Extended response metadata for tool call results, adding privacy fields.
+ */
+export const CallToolResultMetaSchema = RequestMetaSchema.extend({
+    /**
+     * Privacy metadata for this tool call result, declared by the server.
+     */
+    privacy: ResponsePrivacySchema.optional()
+});
+
+/**
  * The server's response to a tool call.
  */
 export const CallToolResultSchema = ResultSchema.extend({
+    _meta: CallToolResultMetaSchema.optional(),
     /**
      * A list of content objects that represent the result of the tool call.
      *
@@ -1407,9 +1589,20 @@ export const CompatibilityCallToolResultSchema = CallToolResultSchema.or(
 );
 
 /**
+ * Extended request metadata for tool call requests, adding privacy fields.
+ */
+export const CallToolRequestMetaSchema = RequestMetaSchema.extend({
+    /**
+     * Privacy metadata for this tool call, declared by the client.
+     */
+    privacy: RequestPrivacySchema.optional()
+});
+
+/**
  * Parameters for a `tools/call` request.
  */
 export const CallToolRequestParamsSchema = TaskAugmentedRequestParamsSchema.extend({
+    _meta: CallToolRequestMetaSchema.optional(),
     /**
      * The name of the tool to call.
      */

--- a/packages/core/src/types/types.ts
+++ b/packages/core/src/types/types.ts
@@ -12,8 +12,10 @@ import type {
     BaseRequestParamsSchema,
     BlobResourceContentsSchema,
     BooleanSchemaSchema,
+    CallToolRequestMetaSchema,
     CallToolRequestParamsSchema,
     CallToolRequestSchema,
+    CallToolResultMetaSchema,
     CallToolResultSchema,
     CancelledNotificationParamsSchema,
     CancelledNotificationSchema,
@@ -34,6 +36,7 @@ import type {
     CreateMessageResultWithToolsSchema,
     CreateTaskResultSchema,
     CursorSchema,
+    DataCategorySchema,
     ElicitationCompleteNotificationParamsSchema,
     ElicitationCompleteNotificationSchema,
     ElicitRequestFormParamsSchema,
@@ -65,6 +68,7 @@ import type {
     JSONRPCRequestSchema,
     JSONRPCResponseSchema,
     JSONRPCResultResponseSchema,
+    LegalJustificationSchema,
     LegacyTitledEnumSchemaSchema,
     ListPromptsRequestSchema,
     ListPromptsResultSchema,
@@ -91,6 +95,7 @@ import type {
     PaginatedRequestSchema,
     PaginatedResultSchema,
     PingRequestSchema,
+    PrivacyHintSchema,
     PrimitiveSchemaDefinitionSchema,
     ProgressNotificationParamsSchema,
     ProgressNotificationSchema,
@@ -101,12 +106,14 @@ import type {
     PromptMessageSchema,
     PromptReferenceSchema,
     PromptSchema,
+    PurposeSchema,
     ReadResourceRequestParamsSchema,
     ReadResourceRequestSchema,
     ReadResourceResultSchema,
     RelatedTaskMetadataSchema,
     RequestIdSchema,
     RequestMetaSchema,
+    RequestPrivacySchema,
     RequestSchema,
     ResourceContentsSchema,
     ResourceLinkSchema,
@@ -117,6 +124,7 @@ import type {
     ResourceTemplateSchema,
     ResourceUpdatedNotificationParamsSchema,
     ResourceUpdatedNotificationSchema,
+    ResponsePrivacySchema,
     ResultSchema,
     RoleSchema,
     RootSchema,
@@ -296,6 +304,16 @@ export type ContentBlock = Infer<typeof ContentBlockSchema>;
 export type PromptMessage = Infer<typeof PromptMessageSchema>;
 export type GetPromptResult = Infer<typeof GetPromptResultSchema>;
 export type PromptListChangedNotification = Infer<typeof PromptListChangedNotificationSchema>;
+
+/* Privacy */
+export type DataCategory = Infer<typeof DataCategorySchema>;
+export type Purpose = Infer<typeof PurposeSchema>;
+export type LegalJustification = Infer<typeof LegalJustificationSchema>;
+export type PrivacyHint = Infer<typeof PrivacyHintSchema>;
+export type RequestPrivacy = Infer<typeof RequestPrivacySchema>;
+export type ResponsePrivacy = Infer<typeof ResponsePrivacySchema>;
+export type CallToolRequestMeta = Infer<typeof CallToolRequestMetaSchema>;
+export type CallToolResultMeta = Infer<typeof CallToolResultMetaSchema>;
 
 /* Tools */
 export type ToolAnnotations = Infer<typeof ToolAnnotationsSchema>;

--- a/packages/core/test/spec.types.test.ts
+++ b/packages/core/test/spec.types.test.ts
@@ -845,6 +845,7 @@ type _K_Notification = Assert<AssertExactKeys<SDKTypes.Notification, SpecTypes.N
 type _K_ResourceTemplateReference = Assert<AssertExactKeys<SDKTypes.ResourceTemplateReference, SpecTypes.ResourceTemplateReference>>;
 // @ts-expect-error Genuine mismatch: SDK PromptReference is missing 'title' from spec
 type _K_PromptReference = Assert<AssertExactKeys<SDKTypes.PromptReference, SpecTypes.PromptReference>>;
+// @ts-expect-error SEP-0000: SDK ToolAnnotations adds 'privacyHint' (not yet in spec)
 type _K_ToolAnnotations = Assert<AssertExactKeys<SDKTypes.ToolAnnotations, SpecTypes.ToolAnnotations>>;
 type _K_Tool = Assert<AssertExactKeys<SDKTypes.Tool, SpecTypes.Tool>>;
 type _K_ListToolsResult = Assert<AssertExactKeys<SDKTypes.ListToolsResult, SpecTypes.ListToolsResult>>;

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -23,7 +23,7 @@ export type {
     ResourceMetadata,
     ToolCallback
 } from './server/mcp.js';
-export { McpServer, ResourceTemplate } from './server/mcp.js';
+export { getRequestPrivacy, McpServer, ResourceTemplate } from './server/mcp.js';
 export type { HostHeaderValidationResult } from './server/middleware/hostHeaderValidation.js';
 export { hostHeaderValidationResponse, localhostAllowedHostnames, validateHostHeader } from './server/middleware/hostHeaderValidation.js';
 export type { ServerOptions } from './server/server.js';

--- a/packages/server/src/server/mcp.ts
+++ b/packages/server/src/server/mcp.ts
@@ -1,6 +1,7 @@
 import type {
     BaseMetadata,
     CallToolRequest,
+    CallToolRequestMeta,
     CallToolResult,
     CompleteRequestPrompt,
     CompleteRequestResourceTemplate,
@@ -16,6 +17,7 @@ import type {
     Prompt,
     PromptReference,
     ReadResourceResult,
+    RequestPrivacy,
     Resource,
     ResourceTemplateReference,
     Result,
@@ -44,6 +46,19 @@ import { ExperimentalMcpServerTasks } from '../experimental/tasks/mcpServer.js';
 import { getCompleter, isCompletable } from './completable.js';
 import type { ServerOptions } from './server.js';
 import { Server } from './server.js';
+
+/**
+ * Extract the {@link RequestPrivacy} from a tool handler's context.
+ *
+ * Tool handler callbacks receive a generic `ServerContext` whose `mcpReq._meta`
+ * is typed as `RequestMeta`. This helper provides typed access to the `privacy`
+ * field that clients may include in `tools/call` requests.
+ *
+ * @returns The client-declared privacy metadata, or `undefined` if not present.
+ */
+export function getRequestPrivacy(ctx: ServerContext): RequestPrivacy | undefined {
+    return (ctx.mcpReq._meta as CallToolRequestMeta | undefined)?.privacy;
+}
 
 /**
  * High-level MCP server that provides a simpler API for working with resources, tools, and prompts.

--- a/test/integration/test/server/mcp.test.ts
+++ b/test/integration/test/server/mcp.test.ts
@@ -8,7 +8,7 @@ import {
     UriTemplate,
     UrlElicitationRequiredError
 } from '@modelcontextprotocol/core';
-import { completable, McpServer, ResourceTemplate } from '@modelcontextprotocol/server';
+import { completable, getRequestPrivacy, McpServer, ResourceTemplate } from '@modelcontextprotocol/server';
 import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 import * as z from 'zod/v4';
 
@@ -1175,6 +1175,280 @@ describe('Zod v4', () => {
                 readOnlyHint: true,
                 openWorldHint: false
             });
+        });
+
+        /***
+         * Test: Privacy Annotations
+         */
+        test('should register tool with privacyHint in annotations', async () => {
+            const mcpServer = new McpServer({ name: 'test server', version: '1.0' });
+            const client = new Client({ name: 'test client', version: '1.0' });
+
+            mcpServer.registerTool(
+                'get_patient_record',
+                {
+                    description: 'Retrieve a patient record',
+                    inputSchema: z.object({ patient_id: z.string() }),
+                    annotations: {
+                        title: 'Get Patient Record',
+                        readOnlyHint: true,
+                        privacyHint: {
+                            dataCategories: ['personal', 'health', 'genetic'],
+                            countries: ['US'],
+                            subdivisions: ['US-CA']
+                        }
+                    }
+                },
+                async ({ patient_id }) => ({
+                    content: [{ type: 'text', text: `Record for ${patient_id}` }]
+                })
+            );
+
+            const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+            await Promise.all([client.connect(clientTransport), mcpServer.server.connect(serverTransport)]);
+
+            const result = await client.request({ method: 'tools/list' });
+            expect(result.tools).toHaveLength(1);
+            expect(result.tools[0]!.annotations).toEqual({
+                title: 'Get Patient Record',
+                readOnlyHint: true,
+                privacyHint: {
+                    dataCategories: ['personal', 'health', 'genetic'],
+                    countries: ['US'],
+                    subdivisions: ['US-CA']
+                }
+            });
+        });
+
+        test('should pass RequestPrivacy through _meta on tool call', async () => {
+            const mcpServer = new McpServer({ name: 'test server', version: '1.0' });
+            const client = new Client({ name: 'test client', version: '1.0' });
+
+            let receivedPrivacy: unknown;
+
+            mcpServer.registerTool(
+                'test_tool',
+                {
+                    inputSchema: z.object({ query: z.string() })
+                },
+                async ({ query }, ctx) => {
+                    receivedPrivacy = getRequestPrivacy(ctx);
+                    return { content: [{ type: 'text', text: query }] };
+                }
+            );
+
+            const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+            await Promise.all([client.connect(clientTransport), mcpServer.server.connect(serverTransport)]);
+
+            await client.callTool({
+                name: 'test_tool',
+                arguments: { query: 'test' },
+                _meta: {
+                    privacy: {
+                        purpose: 'treatment',
+                        justifications: ['contract'],
+                        minor: false,
+                        country: 'US',
+                        subdivision: 'US-CA'
+                    }
+                }
+            });
+
+            expect(receivedPrivacy).toEqual({
+                purpose: 'treatment',
+                justifications: ['contract'],
+                minor: false,
+                country: 'US',
+                subdivision: 'US-CA'
+            });
+        });
+
+        test('should return ResponsePrivacy in tool call result _meta', async () => {
+            const mcpServer = new McpServer({ name: 'test server', version: '1.0' });
+            const client = new Client({ name: 'test client', version: '1.0' });
+
+            mcpServer.registerTool(
+                'test_tool',
+                {
+                    inputSchema: z.object({ query: z.string() })
+                },
+                async ({ query }) => ({
+                    content: [{ type: 'text', text: query }],
+                    _meta: {
+                        privacy: {
+                            dataCategories: ['personal', 'health'],
+                            countries: ['US'],
+                            subdivisions: ['US-CA'],
+                            minor: false
+                        }
+                    }
+                })
+            );
+
+            const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+            await Promise.all([client.connect(clientTransport), mcpServer.server.connect(serverTransport)]);
+
+            const result = await client.callTool({
+                name: 'test_tool',
+                arguments: { query: 'test' }
+            });
+
+            expect(result._meta?.privacy).toEqual({
+                dataCategories: ['personal', 'health'],
+                countries: ['US'],
+                subdivisions: ['US-CA'],
+                minor: false
+            });
+        });
+
+        test('should handle full privacy round-trip: hint + request + response', async () => {
+            const mcpServer = new McpServer({ name: 'test server', version: '1.0' });
+            const client = new Client({ name: 'test client', version: '1.0' });
+
+            let receivedPrivacy: unknown;
+
+            mcpServer.registerTool(
+                'get_patient_record',
+                {
+                    inputSchema: z.object({ patient_id: z.string() }),
+                    annotations: {
+                        readOnlyHint: true,
+                        privacyHint: {
+                            dataCategories: ['personal', 'health'],
+                            countries: ['US'],
+                            subdivisions: ['US-CA']
+                        }
+                    }
+                },
+                async ({ patient_id }, ctx) => {
+                    receivedPrivacy = getRequestPrivacy(ctx);
+                    return {
+                        content: [{ type: 'text', text: `Record for ${patient_id}` }],
+                        _meta: {
+                            privacy: {
+                                dataCategories: ['personal', 'health'],
+                                countries: ['US'],
+                                subdivisions: ['US-CA']
+                            }
+                        }
+                    };
+                }
+            );
+
+            const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+            await Promise.all([client.connect(clientTransport), mcpServer.server.connect(serverTransport)]);
+
+            // Verify privacy hint on tool listing
+            const tools = await client.request({ method: 'tools/list' });
+            expect(tools.tools[0]!.annotations?.privacyHint).toEqual({
+                dataCategories: ['personal', 'health'],
+                countries: ['US'],
+                subdivisions: ['US-CA']
+            });
+
+            // Call tool with request privacy
+            const result = await client.callTool({
+                name: 'get_patient_record',
+                arguments: { patient_id: 'P-123' },
+                _meta: {
+                    privacy: {
+                        purpose: 'treatment',
+                        justifications: ['contract'],
+                        country: 'DE',
+                        subdivision: 'DE-BY'
+                    }
+                }
+            });
+
+            // Verify request privacy was received by handler
+            expect(receivedPrivacy).toEqual({
+                purpose: 'treatment',
+                justifications: ['contract'],
+                country: 'DE',
+                subdivision: 'DE-BY'
+            });
+
+            // Verify response privacy
+            expect(result._meta?.privacy).toEqual({
+                dataCategories: ['personal', 'health'],
+                countries: ['US'],
+                subdivisions: ['US-CA']
+            });
+        });
+
+        test('should work without privacy annotations (backward compatibility)', async () => {
+            const mcpServer = new McpServer({ name: 'test server', version: '1.0' });
+            const client = new Client({ name: 'test client', version: '1.0' });
+
+            mcpServer.registerTool(
+                'simple_tool',
+                {
+                    annotations: { readOnlyHint: true }
+                },
+                async () => ({
+                    content: [{ type: 'text', text: 'result' }]
+                })
+            );
+
+            const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+            await Promise.all([client.connect(clientTransport), mcpServer.server.connect(serverTransport)]);
+
+            const tools = await client.request({ method: 'tools/list' });
+            expect(tools.tools[0]!.annotations?.privacyHint).toBeUndefined();
+
+            const result = await client.callTool({ name: 'simple_tool' });
+            expect(result._meta?.privacy).toBeUndefined();
+        });
+
+        test('should handle partial privacy objects', async () => {
+            const mcpServer = new McpServer({ name: 'test server', version: '1.0' });
+            const client = new Client({ name: 'test client', version: '1.0' });
+
+            let receivedPrivacy: unknown;
+
+            mcpServer.registerTool(
+                'test_tool',
+                {
+                    inputSchema: z.object({ q: z.string() }),
+                    annotations: {
+                        privacyHint: {
+                            dataCategories: ['financial']
+                        }
+                    }
+                },
+                async ({ q }, ctx) => {
+                    receivedPrivacy = getRequestPrivacy(ctx);
+                    return {
+                        content: [{ type: 'text', text: q }],
+                        _meta: {
+                            privacy: {
+                                dataCategories: ['financial']
+                            }
+                        }
+                    };
+                }
+            );
+
+            const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+            await Promise.all([client.connect(clientTransport), mcpServer.server.connect(serverTransport)]);
+
+            const tools = await client.request({ method: 'tools/list' });
+            expect(tools.tools[0]!.annotations?.privacyHint).toEqual({
+                dataCategories: ['financial']
+            });
+
+            const result = await client.callTool({
+                name: 'test_tool',
+                arguments: { q: 'test' },
+                _meta: {
+                    privacy: {
+                        purpose: 'payment_processing'
+                    }
+                }
+            });
+
+            expect(receivedPrivacy).toEqual({ purpose: 'payment_processing' });
+            expect(result._meta?.privacy).toEqual({ dataCategories: ['financial'] });
         });
 
         /***


### PR DESCRIPTION
This change introduces new optional non-breaking privacy annotations on tool definitions, tool requests, and tool responses.

## Motivation and Context

Inform clients and servers of the potential privacy implications - universally without attachment to a specific governing framework - of making or serving a request as requested.

## How Has This Been Tested?

Not yet. Just a simple sample server and client script. Will do.

## Breaking Changes

Nope!

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context

Inspired by SEP-1913 and a conversation with Dan.
