### PR TITLE
fix(server): handle ZodEffects in normalizeObjectSchema and getObjectShape

### DIFF
--- a/.changeset/fix-zod-effects-normalize.md
+++ b/.changeset/fix-zod-effects-normalize.md
@@ -1,0 +1,6 @@
+---
+'@modelcontextprotocol/sdk': patch
+---
+
+Handle ZodEffects wrappers (`.superRefine()`, `.refine()`, `.transform()`) in `normalizeObjectSchema()` and `getObjectShape()`. Previously, schemas wrapped with these methods would fall back to `EMPTY_OBJECT_JSON_SCHEMA` in `tools/list` responses because `normalizeObjectSchema()`
+only checked for `.shape` (v3) or `_zod.def.shape` (v4), which ZodEffects/pipe types lack. The fix walks through the wrapper chain to find the inner ZodObject, ensuring correct JSON Schema generation for tool listings.

--- a/src/server/zod-compat.ts
+++ b/src/server/zod-compat.ts
@@ -23,6 +23,7 @@ export interface ZodV3Internal {
         values?: unknown[];
         shape?: Record<string, AnySchema> | (() => Record<string, AnySchema>);
         description?: string;
+        schema?: AnySchema; // present on ZodEffects (.refine/.superRefine/.transform)
     };
     shape?: Record<string, AnySchema> | (() => Record<string, AnySchema>);
     value?: unknown;
@@ -35,6 +36,7 @@ export interface ZodV4Internal {
             value?: unknown;
             values?: unknown[];
             shape?: Record<string, AnySchema> | (() => Record<string, AnySchema>);
+            in?: AnySchema; // present on pipe types (from .transform())
         };
     };
     value?: unknown;
@@ -103,6 +105,26 @@ export async function safeParseAsync<S extends AnySchema>(
     return result as { success: true; data: SchemaOutput<S> } | { success: false; error: unknown };
 }
 
+// --- ZodEffects unwrapping ---
+/**
+ * Unwrap ZodEffects wrappers (.superRefine(), .refine(), .transform()) to
+ * find the inner schema. ZodEffects chains store the wrapped schema in
+ * `_def.schema`. This walks the chain up to `maxDepth` levels to prevent
+ * infinite loops on malformed schemas.
+ *
+ * Returns the innermost non-ZodEffects schema, or the original schema if
+ * it is not a ZodEffects.
+ */
+function unwrapZodEffects(schema: AnySchema, maxDepth = 10): AnySchema {
+    let current = schema;
+    for (let i = 0; i < maxDepth; i++) {
+        const v3 = current as unknown as ZodV3Internal;
+        if (v3._def?.typeName !== 'ZodEffects' || !v3._def.schema) break;
+        current = v3._def.schema;
+    }
+    return current;
+}
+
 // --- Shape extraction ---
 export function getObjectShape(schema: AnyObjectSchema | undefined): Record<string, AnySchema> | undefined {
     if (!schema) return undefined;
@@ -113,9 +135,24 @@ export function getObjectShape(schema: AnyObjectSchema | undefined): Record<stri
     if (isZ4Schema(schema)) {
         const v4Schema = schema as unknown as ZodV4Internal;
         rawShape = v4Schema._zod?.def?.shape;
+
+        // If no shape found, check if it's a v4 pipe (from .transform())
+        if (!rawShape && v4Schema._zod?.def?.type === 'pipe' && v4Schema._zod?.def?.in) {
+            const inner = v4Schema._zod.def.in as unknown as ZodV4Internal;
+            rawShape = inner._zod?.def?.shape;
+        }
     } else {
         const v3Schema = schema as unknown as ZodV3Internal;
         rawShape = v3Schema.shape;
+
+        // If no shape found, check if this is a ZodEffects wrapping a ZodObject
+        if (!rawShape) {
+            const inner = unwrapZodEffects(schema as AnySchema);
+            if (inner !== schema) {
+                const innerV3 = inner as unknown as ZodV3Internal;
+                rawShape = innerV3.shape;
+            }
+        }
     }
 
     if (!rawShape) return undefined;
@@ -177,11 +214,37 @@ export function normalizeObjectSchema(schema: AnySchema | ZodRawShapeCompat | un
         if (def && (def.type === 'object' || def.shape !== undefined)) {
             return schema as AnyObjectSchema;
         }
+
+        // Check if it's a v4 pipe type (from .transform()) wrapping an object.
+        // In Zod v4, .transform() creates a pipe with def.in pointing to the
+        // input schema. Walk through pipes to find the inner object schema.
+        if (def?.type === 'pipe' && def.in) {
+            const inner = def.in as unknown as ZodV4Internal;
+            const innerDef = inner._zod?.def;
+            if (innerDef && (innerDef.type === 'object' || innerDef.shape !== undefined)) {
+                return schema as AnyObjectSchema;
+            }
+        }
     } else {
         // Check if it's a v3 object
         const v3Schema = schema as unknown as ZodV3Internal;
         if (v3Schema.shape !== undefined) {
             return schema as AnyObjectSchema;
+        }
+
+        // Check if it's a v3 ZodEffects wrapping an object schema.
+        // ZodEffects are created by .superRefine(), .refine(), .transform(), etc.
+        // They lack .shape but have _def.schema pointing to the inner schema.
+        // Walk the chain to find the inner ZodObject.
+        const inner = unwrapZodEffects(schema as AnySchema);
+        if (inner !== schema) {
+            const innerV3 = inner as unknown as ZodV3Internal;
+            if (innerV3.shape !== undefined) {
+                // Return the original ZodEffects schema — zodToJsonSchema() and
+                // z4mini.toJSONSchema() can traverse ZodEffects to extract the
+                // correct JSON Schema from the full chain.
+                return schema as AnyObjectSchema;
+            }
         }
     }
 

--- a/test/server/mcp.test.ts
+++ b/test/server/mcp.test.ts
@@ -5218,6 +5218,183 @@ describe.each(zodTestMatrix)('$zodVersionLabel', (entry: ZodMatrixEntry) => {
                 }
             ]);
         });
+
+        test('should list correct JSON Schema properties for z.superRefine() schemas', async () => {
+            const server = new McpServer({
+                name: 'test',
+                version: '1.0.0'
+            });
+
+            const client = new Client({
+                name: 'test-client',
+                version: '1.0.0'
+            });
+
+            // z.superRefine() wraps a ZodObject in ZodEffects, which lacks .shape
+            const superRefineSchema = z
+                .object({
+                    password: z.string(),
+                    confirmPassword: z.string()
+                })
+                .superRefine((data, ctx) => {
+                    if (data.password !== data.confirmPassword) {
+                        ctx.addIssue({
+                            code: z.ZodIssueCode.custom,
+                            message: 'Passwords do not match',
+                            path: ['confirmPassword']
+                        });
+                    }
+                });
+
+            server.registerTool('superrefine-test', { inputSchema: superRefineSchema }, async args => {
+                return {
+                    content: [{ type: 'text' as const, text: `Password set for ${args.password}` }]
+                };
+            });
+
+            const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+            await server.connect(serverTransport);
+            await client.connect(clientTransport);
+
+            // Verify tools/list returns correct JSON Schema (not empty)
+            const result = await client.request({ method: 'tools/list' }, ListToolsResultSchema);
+            expect(result.tools).toHaveLength(1);
+            expect(result.tools[0].inputSchema).toMatchObject({
+                type: 'object',
+                properties: {
+                    password: { type: 'string' },
+                    confirmPassword: { type: 'string' }
+                }
+            });
+
+            // Also verify the tool still works (parsing path)
+            const callResult = await client.callTool({
+                name: 'superrefine-test',
+                arguments: { password: 'secret', confirmPassword: 'secret' }
+            });
+            expect(callResult.content).toEqual([{ type: 'text', text: 'Password set for secret' }]);
+        });
+
+        test('should list correct JSON Schema properties for z.refine() schemas', async () => {
+            const server = new McpServer({
+                name: 'test',
+                version: '1.0.0'
+            });
+
+            const client = new Client({
+                name: 'test-client',
+                version: '1.0.0'
+            });
+
+            const refineSchema = z
+                .object({
+                    min: z.number(),
+                    max: z.number()
+                })
+                .refine(data => data.max > data.min, {
+                    message: 'max must be greater than min'
+                });
+
+            server.registerTool('refine-test', { inputSchema: refineSchema }, async args => {
+                return {
+                    content: [{ type: 'text' as const, text: `Range: ${args.min}-${args.max}` }]
+                };
+            });
+
+            const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+            await server.connect(serverTransport);
+            await client.connect(clientTransport);
+
+            const result = await client.request({ method: 'tools/list' }, ListToolsResultSchema);
+            expect(result.tools).toHaveLength(1);
+            expect(result.tools[0].inputSchema).toMatchObject({
+                type: 'object',
+                properties: {
+                    min: { type: 'number' },
+                    max: { type: 'number' }
+                }
+            });
+        });
+
+        test('should list correct JSON Schema for z.transform() schemas via tools/list', async () => {
+            const server = new McpServer({
+                name: 'test',
+                version: '1.0.0'
+            });
+
+            const client = new Client({
+                name: 'test-client',
+                version: '1.0.0'
+            });
+
+            const transformSchema = z
+                .object({
+                    input: z.string()
+                })
+                .transform(data => ({ ...data, upper: data.input.toUpperCase() }));
+
+            server.registerTool('transform-list-test', { inputSchema: transformSchema }, async args => {
+                return {
+                    content: [{ type: 'text' as const, text: args.upper }]
+                };
+            });
+
+            const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+            await server.connect(serverTransport);
+            await client.connect(clientTransport);
+
+            const result = await client.request({ method: 'tools/list' }, ListToolsResultSchema);
+            expect(result.tools).toHaveLength(1);
+            expect(result.tools[0].inputSchema).toMatchObject({
+                type: 'object',
+                properties: {
+                    input: { type: 'string' }
+                }
+            });
+        });
+
+        test('should list correct JSON Schema for nested ZodEffects chains', async () => {
+            const server = new McpServer({
+                name: 'test',
+                version: '1.0.0'
+            });
+
+            const client = new Client({
+                name: 'test-client',
+                version: '1.0.0'
+            });
+
+            // Chain: ZodObject -> .superRefine() -> .transform() (nested ZodEffects)
+            const nestedSchema = z
+                .object({
+                    value: z.string()
+                })
+                .superRefine((data, ctx) => {
+                    if (data.value.length === 0) {
+                        ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'Value required' });
+                    }
+                })
+                .transform(data => ({ ...data, validated: true }));
+
+            server.registerTool('nested-effects', { inputSchema: nestedSchema }, async args => {
+                return {
+                    content: [{ type: 'text' as const, text: `${args.value}: ${args.validated}` }]
+                };
+            });
+
+            const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+            await server.connect(serverTransport);
+            await client.connect(clientTransport);
+
+            const result = await client.request({ method: 'tools/list' }, ListToolsResultSchema);
+            expect(result.tools).toHaveLength(1);
+            expect(result.tools[0].inputSchema).toMatchObject({
+                type: 'object',
+                properties: {
+                    value: { type: 'string' }
+                }
+            });
+        });
     });
 
     describe('resource()', () => {


### PR DESCRIPTION
## Summary

Schemas wrapped with `.superRefine()`, `.refine()`, or `.transform()` become ZodEffects (v3) or pipe types (v4) that lack `.shape`, causing `normalizeObjectSchema()` to return `undefined` and `tools/list` to fall back to `EMPTY_OBJECT_JSON_SCHEMA`.

## Changes

- Adds `unwrapZodEffects()` helper that walks `_def.schema` chains (v3 ZodEffects) with a depth bound of 10 to prevent infinite loops
- Updates `normalizeObjectSchema()` to detect v3 ZodEffects and v4 pipe types wrapping ZodObjects, returning the original schema so `zodToJsonSchema()` / `toJSONSchema()` can extract correct JSON Schema
- Updates `getObjectShape()` to extract shape through ZodEffects/pipe wrappers for both Zod versions

## Tests

Adds 4 new tests verifying `tools/list` returns correct JSON Schema properties for `.superRefine()`, `.refine()`, `.transform()`, and nested ZodEffects chains. All tests run against both Zod v3 and v4.

All 1587 existing tests pass. Lint + Prettier clean.

## Impact

Fixes: tools registered with refined/transformed schemas now correctly advertise their input properties to MCP clients. Without this fix, any tool using Zod refinements loses its schema information in the `tools/list` response, making it impossible for clients to know what parameters the tool accepts.