### PR TITLE
ci: skip lefthook on spec-sync bot push

### DIFF
--- a/.github/workflows/update-spec-types.yml
+++ b/.github/workflows/update-spec-types.yml
@@ -51,6 +51,9 @@ jobs:
               if: steps.check_changes.outputs.has_changes == 'true'
               env:
                   GH_TOKEN: ${{ github.token }}
+                  # Skip lefthook pre-push (typecheck/lint/build); spec drift that breaks
+                  # typecheck should still open a PR so it can be fixed there.
+                  LEFTHOOK: 0
               run: |
                   git config user.name "github-actions[bot]"
                   git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -58,7 +61,7 @@ jobs:
                   git checkout -B update-spec-types
                   git add packages/core/src/types/spec.types.ts
                   git commit -m "chore: update spec.types.ts from upstream"
-                  git push -f origin update-spec-types
+                  git push -f --no-verify origin update-spec-types
 
                   # Create PR if it doesn't exist, or update if it does
                   PR_BODY="This PR updates \`packages/core/src/types/spec.types.ts\` from the Model Context Protocol specification.


### PR DESCRIPTION
Skip lefthook's pre-push hooks when the spec-sync bot pushes its branch.

## Motivation and Context
`pnpm install` installs lefthook git hooks on the runner, so the bot's `git push` runs `typecheck:all`/`lint:all`/`build:all`. When upstream `schema.ts` drifts in a way that requires SDK changes, typecheck fails and **no PR is created** — the drift is silently dropped instead of surfaced. This happened in [run 23971433340](https://github.com/modelcontextprotocol/typescript-sdk/actions/runs/23971433340). The PR's own CI is the right place for those checks.

## How Has This Been Tested?
Workflow-only change; verified the diff. The next scheduled/dispatched run will exercise it.

## Breaking Changes
None.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
Belt-and-suspenders: sets `LEFTHOOK=0` and passes `--no-verify` so this stays robust if the hook manager changes.
