### PR TITLE
fix: inject progressToken when resetTimeoutOnProgress is set (not only onprogress)

### DIFF
--- a/packages/core/src/shared/protocol.ts
+++ b/packages/core/src/shared/protocol.ts
@@ -832,8 +832,10 @@ export abstract class Protocol<ContextT extends BaseContext> {
                 id: messageId
             };
 
-            if (options?.onprogress) {
-                this._progressHandlers.set(messageId, options.onprogress);
+            if (options?.onprogress || options?.resetTimeoutOnProgress) {
+                if (options.onprogress) {
+                    this._progressHandlers.set(messageId, options.onprogress);
+                }
                 jsonrpcRequest.params = {
                     ...request.params,
                     _meta: {


### PR DESCRIPTION
## Problem

`resetTimeoutOnProgress: true` in `RequestOptions` has no effect unless `onprogress` is also provided, because `_meta.progressToken` is only injected when `onprogress` exists:

```typescript
// packages/core/src/shared/protocol.ts (before this PR)
if (options?.onprogress) {          // ← only path that injects progressToken
    this._progressHandlers.set(messageId, options.onprogress);
    jsonrpcRequest.params = { ..., _meta: { progressToken: messageId } };
}

this._setupTimeout(
  messageId, timeout, ...,
  options?.resetTimeoutOnProgress ?? false,  // ← flag is stored but never fires
);
```

The `_onprogress` handler (line ~668) matches incoming `notifications/progress` by `params.progressToken → messageId`. Without a token in the request, the server's notifications cannot be matched — `_resetTimeout` is never called — and the request times out at `DEFAULT_REQUEST_TIMEOUT_MSEC` regardless of how often the server sends progress.

**Reproduction**: Any tool call where the server sends periodic progress notifications and the client passes `{ resetTimeoutOnProgress: true }` without `onprogress` times out at 60s. Tracked in issue #245.

## Fix

Expand the injection condition from `if (options?.onprogress)` to `if (options?.onprogress || options?.resetTimeoutOnProgress)`. The `progressToken` is now injected in both cases, so the server's `notifications/progress` can be matched and `_resetTimeout` fires correctly.

The `onprogress` handler registration is unchanged — a no-op token injection (when only `resetTimeoutOnProgress` is set) does not register a progress handler, so no memory is wasted on empty callbacks.

```typescript
// after this PR
if (options?.onprogress || options?.resetTimeoutOnProgress) {
    if (options.onprogress) {
        this._progressHandlers.set(messageId, options.onprogress);
    }
    jsonrpcRequest.params = { ..., _meta: { progressToken: messageId } };
}
```

## Why this matters

MCP servers providing long-running HITL tools (human-in-the-loop, waiting for user input) rely on progress notifications to keep calls alive. Clients that set `resetTimeoutOnProgress: true` expect this to work. Prior to this fix, the flag was silently ignored unless the client also provided a callback, making it effectively unusable without reading the source.

Closes #245