### PR TITLE
fix(server): add icons field to registerTool and registerToolTask

### DIFF
--- a/.changeset/add-tool-icons-support.md
+++ b/.changeset/add-tool-icons-support.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/server': patch
+---
+
+Added `icons` field support to `registerTool()` and `registerToolTask()` APIs, matching the `ToolSchema` spec definition. Icons are now included in `tools/list` responses.

--- a/packages/server/src/experimental/tasks/mcpServer.ts
+++ b/packages/server/src/experimental/tasks/mcpServer.ts
@@ -5,7 +5,7 @@
  * @experimental
  */
 
-import type { StandardSchemaWithJSON, TaskToolExecution, ToolAnnotations, ToolExecution } from '@modelcontextprotocol/core';
+import type { Icon, StandardSchemaWithJSON, TaskToolExecution, ToolAnnotations, ToolExecution } from '@modelcontextprotocol/core';
 
 import type { AnyToolHandler, McpServer, RegisteredTool } from '../../server/mcp.js';
 import type { ToolTaskHandler } from './interfaces.js';
@@ -21,6 +21,7 @@ interface McpServerInternal {
         description: string | undefined,
         inputSchema: StandardSchemaWithJSON | undefined,
         outputSchema: StandardSchemaWithJSON | undefined,
+        icons: Icon[] | undefined,
         annotations: ToolAnnotations | undefined,
         execution: ToolExecution | undefined,
         _meta: Record<string, unknown> | undefined,
@@ -82,6 +83,7 @@ export class ExperimentalMcpServerTasks {
             title?: string;
             description?: string;
             outputSchema?: OutputArgs;
+            icons?: Icon[];
             annotations?: ToolAnnotations;
             execution?: TaskToolExecution;
             _meta?: Record<string, unknown>;
@@ -96,6 +98,7 @@ export class ExperimentalMcpServerTasks {
             description?: string;
             inputSchema: InputArgs;
             outputSchema?: OutputArgs;
+            icons?: Icon[];
             annotations?: ToolAnnotations;
             execution?: TaskToolExecution;
             _meta?: Record<string, unknown>;
@@ -110,6 +113,7 @@ export class ExperimentalMcpServerTasks {
             description?: string;
             inputSchema?: InputArgs;
             outputSchema?: OutputArgs;
+            icons?: Icon[];
             annotations?: ToolAnnotations;
             execution?: TaskToolExecution;
             _meta?: Record<string, unknown>;
@@ -130,6 +134,7 @@ export class ExperimentalMcpServerTasks {
             config.description,
             config.inputSchema,
             config.outputSchema,
+            config.icons,
             config.annotations,
             execution,
             config._meta,

--- a/packages/server/src/server/mcp.ts
+++ b/packages/server/src/server/mcp.ts
@@ -8,6 +8,7 @@ import type {
     CreateTaskResult,
     CreateTaskServerContext,
     GetPromptResult,
+    Icon,
     Implementation,
     ListPromptsResult,
     ListResourcesResult,
@@ -144,6 +145,7 @@ export class McpServer {
                             inputSchema: tool.inputSchema
                                 ? (standardSchemaToJsonSchema(tool.inputSchema, 'input') as Tool['inputSchema'])
                                 : EMPTY_OBJECT_JSON_SCHEMA,
+                            icons: tool.icons,
                             annotations: tool.annotations,
                             execution: tool.execution,
                             _meta: tool._meta
@@ -770,6 +772,7 @@ export class McpServer {
         description: string | undefined,
         inputSchema: StandardSchemaWithJSON | undefined,
         outputSchema: StandardSchemaWithJSON | undefined,
+        icons: Icon[] | undefined,
         annotations: ToolAnnotations | undefined,
         execution: ToolExecution | undefined,
         _meta: Record<string, unknown> | undefined,
@@ -786,6 +789,7 @@ export class McpServer {
             description,
             inputSchema,
             outputSchema,
+            icons,
             annotations,
             execution,
             _meta,
@@ -822,6 +826,7 @@ export class McpServer {
                 }
 
                 if (updates.outputSchema !== undefined) registeredTool.outputSchema = updates.outputSchema;
+                if (updates.icons !== undefined) registeredTool.icons = updates.icons;
                 if (updates.annotations !== undefined) registeredTool.annotations = updates.annotations;
                 if (updates._meta !== undefined) registeredTool._meta = updates._meta;
                 if (updates.enabled !== undefined) registeredTool.enabled = updates.enabled;
@@ -869,6 +874,7 @@ export class McpServer {
             description?: string;
             inputSchema?: InputArgs;
             outputSchema?: OutputArgs;
+            icons?: Icon[];
             annotations?: ToolAnnotations;
             _meta?: Record<string, unknown>;
         },
@@ -878,7 +884,7 @@ export class McpServer {
             throw new Error(`Tool ${name} is already registered`);
         }
 
-        const { title, description, inputSchema, outputSchema, annotations, _meta } = config;
+        const { title, description, inputSchema, outputSchema, icons, annotations, _meta } = config;
 
         return this._createRegisteredTool(
             name,
@@ -886,6 +892,7 @@ export class McpServer {
             description,
             inputSchema,
             outputSchema,
+            icons,
             annotations,
             { taskSupport: 'forbidden' },
             _meta,
@@ -1094,6 +1101,7 @@ export type RegisteredTool = {
     description?: string;
     inputSchema?: StandardSchemaWithJSON;
     outputSchema?: StandardSchemaWithJSON;
+    icons?: Icon[];
     annotations?: ToolAnnotations;
     execution?: ToolExecution;
     _meta?: Record<string, unknown>;
@@ -1109,6 +1117,7 @@ export type RegisteredTool = {
         description?: string;
         paramsSchema?: StandardSchemaWithJSON;
         outputSchema?: StandardSchemaWithJSON;
+        icons?: Icon[];
         annotations?: ToolAnnotations;
         _meta?: Record<string, unknown>;
         callback?: ToolCallback<StandardSchemaWithJSON>;


### PR DESCRIPTION
## Summary

`registerTool()` and `registerToolTask()` do not accept the `icons` field, even though `ToolSchema` includes it via `IconsSchema.shape`. This adds `icons` support to both APIs and includes it in `tools/list` responses.

## Issue

Fixes #1864

## Changes

- Added `icons?: Icon[]` to the `registerTool()` config parameter type
- Added `icons` to `_createRegisteredTool()` signature and object construction
- Added `icons` to the `tools/list` handler's `toolDefinition` object
- Added `icons` to `RegisteredTool` type and its `update()` method
- Added `icons` to all `registerToolTask()` overload signatures and its call to `_createRegisteredTool()`

## Testing

- All 55 existing server tests pass
- Full monorepo build succeeds