### PR TITLE
feat(client): add initial access token support for Dynamic Client Registration

### DIFF
--- a/packages/client/src/client/auth.ts
+++ b/packages/client/src/client/auth.ts
@@ -351,6 +351,19 @@ export interface OAuthClientProvider {
      * re-discovery in case the authorization server has changed.
      */
     discoveryState?(): OAuthDiscoveryState | undefined | Promise<OAuthDiscoveryState | undefined>;
+
+    /**
+     * If implemented, provides an initial access token for OAuth 2.0 Dynamic
+     * Client Registration (RFC 7591 Section 3). When the authorization server
+     * requires pre-authorisation for client registration, this token is included
+     * as a Bearer token in the registration request.
+     *
+     * The token is per-authorisation-server, so implementations should return the
+     * appropriate token for the server being registered with.
+     *
+     * When not implemented or returning `undefined`, open registration is assumed.
+     */
+    dcrRegistrationAccessToken?(): string | undefined | Promise<string | undefined>;
 }
 
 /**
@@ -730,10 +743,13 @@ async function authInternal(
                 throw new Error('OAuth client information must be saveable for dynamic registration');
             }
 
+            const initialAccessToken = await provider.dcrRegistrationAccessToken?.();
+
             const fullInformation = await registerClient(authorizationServerUrl, {
                 metadata,
                 clientMetadata: provider.clientMetadata,
                 scope: resolvedScope,
+                initialAccessToken,
                 fetchFn
             });
 
@@ -1684,11 +1700,13 @@ export async function registerClient(
         metadata,
         clientMetadata,
         scope,
+        initialAccessToken,
         fetchFn
     }: {
         metadata?: AuthorizationServerMetadata;
         clientMetadata: OAuthClientMetadata;
         scope?: string;
+        initialAccessToken?: string;
         fetchFn?: FetchLike;
     }
 ): Promise<OAuthClientInformationFull> {
@@ -1704,11 +1722,17 @@ export async function registerClient(
         registrationUrl = new URL('/register', authorizationServerUrl);
     }
 
+    const headers: Record<string, string> = {
+        'Content-Type': 'application/json'
+    };
+
+    if (initialAccessToken) {
+        headers['Authorization'] = `Bearer ${initialAccessToken}`;
+    }
+
     const response = await (fetchFn ?? fetch)(registrationUrl, {
         method: 'POST',
-        headers: {
-            'Content-Type': 'application/json'
-        },
+        headers,
         body: JSON.stringify({
             ...clientMetadata,
             ...(scope === undefined ? {} : { scope })

--- a/packages/client/test/client/auth.test.ts
+++ b/packages/client/test/client/auth.test.ts
@@ -2132,6 +2132,58 @@ describe('OAuth Authorization', () => {
                 })
             ).rejects.toThrow('Dynamic client registration failed');
         });
+
+        it('includes Authorization header when initialAccessToken is provided', async () => {
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                status: 200,
+                json: async () => validClientInfo
+            });
+
+            await registerClient('https://auth.example.com', {
+                clientMetadata: validClientMetadata,
+                initialAccessToken: 'my-initial-token'
+            });
+
+            expect(mockFetch).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    href: 'https://auth.example.com/register'
+                }),
+                expect.objectContaining({
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        Authorization: 'Bearer my-initial-token'
+                    },
+                    body: JSON.stringify(validClientMetadata)
+                })
+            );
+        });
+
+        it('does not include Authorization header when initialAccessToken is not provided', async () => {
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                status: 200,
+                json: async () => validClientInfo
+            });
+
+            await registerClient('https://auth.example.com', {
+                clientMetadata: validClientMetadata
+            });
+
+            expect(mockFetch).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    href: 'https://auth.example.com/register'
+                }),
+                expect.objectContaining({
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json'
+                    },
+                    body: JSON.stringify(validClientMetadata)
+                })
+            );
+        });
     });
 
     describe('auth function', () => {


### PR DESCRIPTION
## Summary

Add support for OAuth 2.0 Dynamic Client Registration initial access tokens (RFC 7591 Section 3), enabling enterprise deployments that require pre-authorisation for client registration.

- Add optional `dcrRegistrationAccessToken()` method to `OAuthClientProvider` interface
- When implemented and returning a token, `registerClient()` includes an `Authorization: Bearer <token>` header in the DCR request
- When not implemented or returning `undefined`, open registration continues as before (fully backward compatible)

Closes #772

## Design decisions

Following maintainer feedback from the previous attempt (#773):

- **No environment variable fallback** in the SDK — DCR tokens are per-authorisation-server, so a single env var breaks when connecting to multiple servers. Users who want env var support implement it in their `OAuthClientProvider`.
- **No transport-level parameters** — token resolution is contained in `auth.ts` only.
- **Provider-based resolution** — the `OAuthClientProvider` is the right place to resolve per-server tokens, consistent with how other credentials are handled.

## Changes

- `packages/client/src/client/auth.ts`:
  - Added `dcrRegistrationAccessToken?()` to `OAuthClientProvider` interface
  - Added optional `initialAccessToken` parameter to `registerClient()`
  - Updated the `auth()` flow to call the provider method and pass the token to `registerClient()`
- `packages/client/test/client/auth.test.ts`:
  - Added tests for `Authorization` header inclusion when token is provided
  - Added test confirming no `Authorization` header when token is absent

## Test plan

- [x] All 352 existing tests pass (`pnpm --filter @modelcontextprotocol/client test`)
- [x] Build passes (`pnpm build:all`)
- [x] Typecheck passes (`pnpm typecheck:all`)
- [x] Lint passes (`pnpm lint:all`)
- [x] Lefthook pre-push hooks pass (Build + Typecheck + Lint)

## AI Disclosure

AI assistance (Claude) was used for issue research, reviewing the previous PR feedback, and code exploration. The implementation was written and reviewed by the author.