### PR TITLE
fix: use getLiteralValue for Zod v3 method literal extraction

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -53,15 +53,7 @@ import {
 } from '../types.js';
 import { AjvJsonSchemaValidator } from '../validation/ajv-provider.js';
 import type { JsonSchemaType, JsonSchemaValidator, jsonSchemaValidator } from '../validation/types.js';
-import {
-    AnyObjectSchema,
-    SchemaOutput,
-    getObjectShape,
-    isZ4Schema,
-    safeParse,
-    type ZodV3Internal,
-    type ZodV4Internal
-} from '../server/zod-compat.js';
+import { AnyObjectSchema, SchemaOutput, getLiteralValue, getObjectShape, safeParse } from '../server/zod-compat.js';
 import type { RequestHandlerExtra } from '../shared/protocol.js';
 import { ExperimentalClientTasks } from '../experimental/tasks/client.js';
 import { assertToolsCallTaskCapability, assertClientRequestTaskCapability } from '../experimental/tasks/helpers.js';
@@ -339,18 +331,7 @@ export class Client<
             throw new Error('Schema is missing a method literal');
         }
 
-        // Extract literal value using type-safe property access
-        let methodValue: unknown;
-        if (isZ4Schema(methodSchema)) {
-            const v4Schema = methodSchema as unknown as ZodV4Internal;
-            const v4Def = v4Schema._zod?.def;
-            methodValue = v4Def?.value ?? v4Schema.value;
-        } else {
-            const v3Schema = methodSchema as unknown as ZodV3Internal;
-            const legacyDef = v3Schema._def;
-            methodValue = legacyDef?.value ?? v3Schema.value;
-        }
-
+        const methodValue = getLiteralValue(methodSchema);
         if (typeof methodValue !== 'string') {
             throw new Error('Schema method literal must be a string');
         }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -44,15 +44,7 @@ import {
 } from '../types.js';
 import { AjvJsonSchemaValidator } from '../validation/ajv-provider.js';
 import type { JsonSchemaType, jsonSchemaValidator } from '../validation/types.js';
-import {
-    AnyObjectSchema,
-    getObjectShape,
-    isZ4Schema,
-    safeParse,
-    SchemaOutput,
-    type ZodV3Internal,
-    type ZodV4Internal
-} from './zod-compat.js';
+import { AnyObjectSchema, getLiteralValue, getObjectShape, safeParse, SchemaOutput } from './zod-compat.js';
 import { RequestHandlerExtra } from '../shared/protocol.js';
 import { ExperimentalServerTasks } from '../experimental/tasks/server.js';
 import { assertToolsCallTaskCapability, assertClientRequestTaskCapability } from '../experimental/tasks/helpers.js';
@@ -228,18 +220,7 @@ export class Server<
             throw new Error('Schema is missing a method literal');
         }
 
-        // Extract literal value using type-safe property access
-        let methodValue: unknown;
-        if (isZ4Schema(methodSchema)) {
-            const v4Schema = methodSchema as unknown as ZodV4Internal;
-            const v4Def = v4Schema._zod?.def;
-            methodValue = v4Def?.value ?? v4Schema.value;
-        } else {
-            const v3Schema = methodSchema as unknown as ZodV3Internal;
-            const legacyDef = v3Schema._def;
-            methodValue = legacyDef?.value ?? v3Schema.value;
-        }
-
+        const methodValue = getLiteralValue(methodSchema);
         if (typeof methodValue !== 'string') {
             throw new Error('Schema method literal must be a string');
         }


### PR DESCRIPTION
## Summary

Fix `"Schema method literal must be a string"` error when constructing `McpServer` with late Zod v3 releases (e.g., `zod@3.25.1`) where the literal value is stored under `_def.values[0]` instead of `_def.value`.

Closes #1380

## Root cause

`Server.setRequestHandler` and `Client.setRequestHandler` had inline Zod literal extraction that only checked `_def.value` and `.value`. In `zod@3.25.x`, the literal is stored under `_def.values[0]` instead. The existing `getLiteralValue()` helper in `zod-compat.ts` already handles this fallback correctly, but it wasn't being used in these two locations.

## Changes

- `src/server/index.ts`: Replace inline v3/v4 literal extraction with `getLiteralValue()` call
- `src/client/index.ts`: Same replacement

This is a v1.x backport as discussed in #1380 — the issue resolves itself in v2 with the Zod v3 removal.

## Test plan

- [x] All 1579 tests pass across 48 test files (`npm test`)
- [x] Build passes (`npm run build`)

## AI Disclosure

AI assistance (Claude) was used for issue research and codebase exploration. The implementation was written and reviewed by the author.