### PR TITLE
fix: support icons in registerTool config and tools/list response

### DIFF
--- a/.changeset/fix-register-tool-icons.md
+++ b/.changeset/fix-register-tool-icons.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/server': patch
+---
+
+Support `icons` in `McpServer.registerTool()` config and include it in `tools/list` responses. The MCP spec's `ToolSchema` includes `icons` via `IconsSchema`, but the high-level API did not accept or serialize it.

--- a/packages/server/src/server/mcp.ts
+++ b/packages/server/src/server/mcp.ts
@@ -146,6 +146,7 @@ export class McpServer {
                                 : EMPTY_OBJECT_JSON_SCHEMA,
                             annotations: tool.annotations,
                             execution: tool.execution,
+                            icons: tool.icons,
                             _meta: tool._meta
                         };
 
@@ -773,7 +774,8 @@ export class McpServer {
         annotations: ToolAnnotations | undefined,
         execution: ToolExecution | undefined,
         _meta: Record<string, unknown> | undefined,
-        handler: AnyToolHandler<StandardSchemaWithJSON | undefined>
+        handler: AnyToolHandler<StandardSchemaWithJSON | undefined>,
+        icons?: Tool['icons'],
     ): RegisteredTool {
         // Validate tool name according to SEP specification
         validateAndWarnToolName(name);
@@ -788,6 +790,7 @@ export class McpServer {
             outputSchema,
             annotations,
             execution,
+            icons,
             _meta,
             handler: handler,
             executor: createToolExecutor(inputSchema, handler),
@@ -870,6 +873,7 @@ export class McpServer {
             inputSchema?: InputArgs;
             outputSchema?: OutputArgs;
             annotations?: ToolAnnotations;
+            icons?: Tool['icons'];
             _meta?: Record<string, unknown>;
         },
         cb: ToolCallback<InputArgs>
@@ -878,7 +882,7 @@ export class McpServer {
             throw new Error(`Tool ${name} is already registered`);
         }
 
-        const { title, description, inputSchema, outputSchema, annotations, _meta } = config;
+        const { title, description, inputSchema, outputSchema, annotations, icons, _meta } = config;
 
         return this._createRegisteredTool(
             name,
@@ -889,7 +893,8 @@ export class McpServer {
             annotations,
             { taskSupport: 'forbidden' },
             _meta,
-            cb as ToolCallback<StandardSchemaWithJSON | undefined>
+            cb as ToolCallback<StandardSchemaWithJSON | undefined>,
+            icons,
         );
     }
 
@@ -1096,6 +1101,7 @@ export type RegisteredTool = {
     outputSchema?: StandardSchemaWithJSON;
     annotations?: ToolAnnotations;
     execution?: ToolExecution;
+    icons?: Tool['icons'];
     _meta?: Record<string, unknown>;
     handler: AnyToolHandler<StandardSchemaWithJSON | undefined>;
     /** @hidden */


### PR DESCRIPTION
## Summary

Fixes #1864

The MCP spec's `ToolSchema` includes `icons` (via `IconsSchema`), but `McpServer.registerTool()` has two gaps:

1. The `config` parameter type does not accept `icons`
2. The `tools/list` handler does not include `icons` in the tool definition

## Changes

- Add `icons?: Tool['icons']` to `registerTool` config type
- Add `icons` parameter to `_createRegisteredTool`
- Include `icons` in the `toolDefinition` built by the `tools/list` handler
- Add `icons` to the `RegisteredTool` type

## Usage

```typescript
server.registerTool(
  'my-tool',
  {
    description: 'A tool with an icon',
    icons: [{ src: 'https://example.com/icon.png', mimeType: 'image/png' }],
  },
  async () => ({ content: [{ type: 'text', text: 'hello' }] })
);
```