### PR TITLE
Reject standalone GET in stateless streamable HTTP mode

### DIFF
--- a/packages/server/src/server/streamableHttp.ts
+++ b/packages/server/src/server/streamableHttp.ts
@@ -402,6 +402,17 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
      * Handles `GET` requests for SSE stream
      */
     private async handleGetRequest(req: Request): Promise<Response> {
+        // Stateless transports cannot safely own a standalone GET SSE stream.
+        // In stateless mode, each HTTP request must use a fresh transport
+        // instance, so allowing GET here would create transport-local stream
+        // state with no durable owner across requests.
+        if (this.sessionIdGenerator === undefined) {
+            return this.createJsonErrorResponse(405, -32_000, 'Method not allowed.', {
+                headers: {
+                    Allow: 'POST'
+                }
+            });
+        }
         // The client MUST include an Accept header, listing text/event-stream as a supported content type.
         const acceptHeader = req.headers.get('accept');
         if (!acceptHeader?.includes('text/event-stream')) {


### PR DESCRIPTION
## Summary
Reject standalone `GET /mcp` in stateless `WebStandardStreamableHTTPServerTransport` mode by returning `405 Method Not Allowed` with `Allow: POST`.

## Motivation and Context
In stateless mode (`sessionIdGenerator === undefined`), the transport requires a fresh transport instance per HTTP request. However, `handleGetRequest()` still permits creation of a standalone SSE stream (`_GET_stream`), which is transport-local state with no durable owner across requests.

This change aligns the implementation with the SDK’s own examples:
- `simpleStatelessStreamableHttp.ts` rejects `GET /mcp` with `405`
- `jsonResponseStreamableHttp.ts` also rejects `GET /mcp` with `405`

## How Has This Been Tested?
Tested in a real application using `@modelcontextprotocol/sdk` `1.29.0` in stateless mode.

Scenarios tested:
- Fresh transport per HTTP request with `sessionIdGenerator: undefined`
- Concurrent long-running tool calls with client disconnects
- Before this change:
  - standalone `GET /mcp` streams accumulated
- After this change:
  - standalone `GET /mcp` is rejected with `405`
  - the same workload no longer accumulated long-lived GET streams

## Breaking Changes
Potentially, yes for stateless servers that currently rely on standalone `GET /mcp` for out-of-band server-to-client notifications while a request is in flight.

This change makes stateless mode effectively POST-only for Streamable HTTP. Stateful servers are unchanged.

I'm not entirely sure whether this aligns with the stateless transport goals going forward, but offering this change in case this is actually a bug; can add tests for this if someone thinks this is the right fix.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed
