### PR TITLE
ci: only match open PRs in spec-sync existence check

### DIFF
--- a/.github/workflows/update-spec-types.yml
+++ b/.github/workflows/update-spec-types.yml
@@ -70,9 +70,11 @@ jobs:
 
                   This is an automated update triggered by the nightly cron job."
 
-                  if gh pr view update-spec-types &>/dev/null; then
-                    echo "PR already exists, updating description..."
-                    gh pr edit update-spec-types --body "$PR_BODY"
+                  # `gh pr view <branch>` matches closed PRs too, so check for an *open* PR explicitly.
+                  EXISTING_PR=$(gh pr list --head update-spec-types --state open --json number --jq '.[0].number // empty')
+                  if [ -n "$EXISTING_PR" ]; then
+                    echo "PR #$EXISTING_PR already exists, updating description..."
+                    gh pr edit "$EXISTING_PR" --body "$PR_BODY"
                   else
                     gh pr create \
                       --title "chore: update spec.types.ts from upstream" \


### PR DESCRIPTION
Only treat an **open** PR as "existing" when deciding whether to create or update the spec-sync PR.

## Motivation and Context
`gh pr view update-spec-types` succeeds for closed PRs too, so the job has been running `gh pr edit` against closed PR #1152 instead of creating a new one — the `update-spec-types` branch is pushed nightly but no open PR points at it (e.g. [run 24326554514](https://github.com/modelcontextprotocol/typescript-sdk/actions/runs/24326554514) logs `"PR already exists, updating description..."`). Switch to `gh pr list --state open` and edit by PR number.

## How Has This Been Tested?
Verified `gh pr list --head update-spec-types --state open --json number --jq '.[0].number // empty'` returns empty against the repo today (no open PR) and a number when an open PR exists. Workflow itself will be exercised on the next scheduled/dispatched run.

## Breaking Changes
None.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
Follow-up to #1866.
