### PR TITLE
feat(core): add deprecate() warn-once helper for v1-compat shims

### DIFF
--- a/.changeset/deprecate-helper.md
+++ b/.changeset/deprecate-helper.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/core': patch
+---
+
+Add internal `deprecate()` warn-once helper for v1-compat shims.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -49,3 +49,4 @@ export * from './validators/fromJsonSchema.js';
 
 // Core types only - implementations are exported via separate entry points
 export type { JsonSchemaType, JsonSchemaValidator, jsonSchemaValidator, JsonSchemaValidatorResult } from './validators/types.js';
+export { deprecate } from './util/deprecate.js';

--- a/packages/core/src/util/deprecate.ts
+++ b/packages/core/src/util/deprecate.ts
@@ -1,0 +1,22 @@
+const _warned = new Set<string>();
+
+/**
+ * Emits a one-time deprecation warning to stderr. Subsequent calls with the
+ * same `key` are no-ops for the lifetime of the process.
+ *
+ * Used by v1-compat shims to nudge consumers toward the v2-native API without
+ * spamming logs on hot paths (e.g. per-tool registration).
+ *
+ * @internal
+ */
+export function deprecate(key: string, msg: string): void {
+    if (_warned.has(key)) return;
+    _warned.add(key);
+    // eslint-disable-next-line no-console
+    console.warn(`[mcp-sdk] DEPRECATED: ${msg}`);
+}
+
+/** @internal exposed for tests */
+export function _resetDeprecationWarnings(): void {
+    _warned.clear();
+}

--- a/packages/core/test/util/deprecate.test.ts
+++ b/packages/core/test/util/deprecate.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { deprecate, _resetDeprecationWarnings } from '../../src/util/deprecate.js';
+
+describe('deprecate', () => {
+    afterEach(() => _resetDeprecationWarnings());
+    it('warns once per key', () => {
+        const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        deprecate('k', 'msg');
+        deprecate('k', 'msg');
+        deprecate('other', 'msg2');
+        expect(spy).toHaveBeenCalledTimes(2);
+        spy.mockRestore();
+    });
+});


### PR DESCRIPTION
Part of the v2 backwards-compatibility series — see [reviewer guide](https://gist.github.com/felixweinberger/d7a70e1b52db4a2a0851b98b453ebe3b).

Shared helper that emits one stderr deprecation warning per key per process. Used by all Layer-1 BC shims so hot paths (per-tool registration) don't spam.

## Motivation and Context

Shared helper that emits one stderr deprecation warning per key per process. Used by all Layer-1 BC shims so hot paths (per-tool registration) don't spam.

<details>
<summary>v1 vs v2 pattern & evidence</summary>

**v1 pattern:**
```ts
n/a — infrastructure for shims
```

**v2-native:**
```ts
n/a
```

**Evidence:** n/a

</details>

## How Has This Been Tested?
- packages/core/test/util/deprecate.test.ts — warn-once semantics
- Integration: validated bump-only against 5 OSS repos via the `v2-bc-integration` validation branch
- `pnpm typecheck:all && pnpm lint:all && pnpm test:all` green

## Breaking Changes
None — additive `@deprecated` shim. Removed in v3.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added or updated documentation as needed

## Additional context
Stacks on: none
