### PR TITLE
feat(compat): re-export StreamableHTTPServerTransport + EventStore types from /node

### DIFF
--- a/.changeset/node-transport-v1-aliases.md
+++ b/.changeset/node-transport-v1-aliases.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/node': patch
+---
+
+Add v1-compat re-exports: `StreamableHTTPServerTransport` (alias for `NodeStreamableHTTPServerTransport`) and the `EventStore` / `EventId` / `StreamId` types, so v1 imports from `@modelcontextprotocol/sdk/server/streamableHttp.js` map cleanly onto `@modelcontextprotocol/node`.

--- a/packages/middleware/node/src/index.ts
+++ b/packages/middleware/node/src/index.ts
@@ -1,8 +1,10 @@
+import { NodeStreamableHTTPServerTransport } from './streamableHttp.js';
+
 export * from './streamableHttp.js';
 
-// v1-compat re-exports.
-export {
-    /** @deprecated Use {@linkcode NodeStreamableHTTPServerTransport}. */
-    NodeStreamableHTTPServerTransport as StreamableHTTPServerTransport
-} from './streamableHttp.js';
+/** @deprecated Use {@linkcode NodeStreamableHTTPServerTransport}. */
+export const StreamableHTTPServerTransport = NodeStreamableHTTPServerTransport;
+/** @deprecated Use {@linkcode NodeStreamableHTTPServerTransport}. */
+export type StreamableHTTPServerTransport = NodeStreamableHTTPServerTransport;
+
 export type { EventId, EventStore, StreamId } from '@modelcontextprotocol/server';

--- a/packages/middleware/node/src/index.ts
+++ b/packages/middleware/node/src/index.ts
@@ -1,1 +1,8 @@
 export * from './streamableHttp.js';
+
+// v1-compat re-exports.
+export {
+    /** @deprecated Use {@linkcode NodeStreamableHTTPServerTransport}. */
+    NodeStreamableHTTPServerTransport as StreamableHTTPServerTransport
+} from './streamableHttp.js';
+export type { EventId, EventStore, StreamId } from '@modelcontextprotocol/server';

--- a/packages/middleware/node/test/compat.test.ts
+++ b/packages/middleware/node/test/compat.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, expectTypeOf, it } from 'vitest';
+
+import { NodeStreamableHTTPServerTransport, StreamableHTTPServerTransport } from '../src/index.js';
+import type { EventId, EventStore, StreamId } from '../src/index.js';
+
+describe('v1 compat exports from @modelcontextprotocol/node', () => {
+    it('StreamableHTTPServerTransport aliases NodeStreamableHTTPServerTransport', () => {
+        expect(StreamableHTTPServerTransport).toBe(NodeStreamableHTTPServerTransport);
+        expectTypeOf<StreamableHTTPServerTransport>().toEqualTypeOf<NodeStreamableHTTPServerTransport>();
+    });
+
+    it('re-exports EventStore / EventId / StreamId types', () => {
+        // Type-level assertions: these compile only if the types are exported.
+        expectTypeOf<EventId>().toBeString();
+        expectTypeOf<StreamId>().toBeString();
+        expectTypeOf<EventStore>().toHaveProperty('storeEvent');
+        expectTypeOf<EventStore>().toHaveProperty('replayEventsAfter');
+    });
+});


### PR DESCRIPTION
Part of the v2 backwards-compatibility series — see [reviewer guide](https://gist.github.com/felixweinberger/d7a70e1b52db4a2a0851b98b453ebe3b).

v2 renamed `StreamableHTTPServerTransport` → `NodeStreamableHTTPServerTransport`. v2 already kept the *Options* type alias (incoherent). This adds the class alias + `EventStore`/`EventId`/`StreamId` re-exports.

## Motivation and Context

v2 renamed `StreamableHTTPServerTransport` → `NodeStreamableHTTPServerTransport`. v2 already kept the *Options* type alias (incoherent). This adds the class alias + `EventStore`/`EventId`/`StreamId` re-exports.

<details>
<summary>v1 vs v2 pattern & evidence</summary>

**v1 pattern:**
```ts
`import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js'`
```

**v2-native:**
```ts
`import { NodeStreamableHTTPServerTransport } from '@modelcontextprotocol/node'`
```

**Evidence:** GitHub code search: ~1,700 files.

</details>

## How Has This Been Tested?
- Import-compiles test
- Integration: validated bump-only against 5 OSS repos via the `v2-bc-integration` validation branch
- `pnpm typecheck:all && pnpm lint:all && pnpm test:all` green

## Breaking Changes
None.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added or updated documentation as needed

## Additional context
Stacks on: none

