### PR TITLE
feat(compat): IsomorphicHeaders/FetchLike/RequestInfo deprecated type aliases

### DIFF
--- a/.changeset/compat-v1-type-aliases.md
+++ b/.changeset/compat-v1-type-aliases.md
@@ -1,0 +1,7 @@
+---
+'@modelcontextprotocol/core': patch
+'@modelcontextprotocol/client': patch
+'@modelcontextprotocol/server': patch
+---
+
+Add v1 type aliases to the public API surface for smoother migration: `IsomorphicHeaders` (→ `Headers`) and `RequestInfo` (→ `Request`). `FetchLike` retains its v1 name.

--- a/packages/core/src/exports/public/index.ts
+++ b/packages/core/src/exports/public/index.ts
@@ -142,3 +142,26 @@ export type { CfWorkerSchemaDraft } from '../../validators/cfWorkerProvider.js';
 // fromJsonSchema is intentionally NOT exported here — the server and client packages
 // provide runtime-aware wrappers that default to the appropriate validator via _shims.
 export type { JsonSchemaType, JsonSchemaValidator, jsonSchemaValidator, JsonSchemaValidatorResult } from '../../validators/types.js';
+
+// ────────────────────────────────────────────────────────────────────────────
+// v1 backwards-compatibility type aliases
+// ────────────────────────────────────────────────────────────────────────────
+
+// Note: a `ResourceTemplate = ResourceTemplateType` alias is intentionally NOT
+// exported here — it conflicts with the server's `ResourceTemplate` class under
+// tsdown bundling. The alias lives only in the `/sdk` meta-package's `types.js`.
+
+/**
+ * @deprecated Use the standard `Headers` web type. v2 transports surface
+ * request headers via `Headers` on `ctx.http?.req`.
+ */
+export type IsomorphicHeaders = Headers;
+
+/**
+ * @deprecated Use the standard `Request` web type. v2's {@linkcode ServerContext}
+ * exposes the originating HTTP request at `ctx.http?.req`.
+ */
+export type RequestInfo = Request;
+
+// `FetchLike` keeps its v1 name and is re-exported above from
+// '../../shared/transport.js' — no alias needed.

--- a/packages/core/src/exports/public/index.ts
+++ b/packages/core/src/exports/public/index.ts
@@ -161,7 +161,7 @@ export type IsomorphicHeaders = Headers;
  * @deprecated Use the standard `Request` web type. v2's {@linkcode ServerContext}
  * exposes the originating HTTP request at `ctx.http?.req`.
  */
-export type RequestInfo = Request;
+export type RequestInfo = globalThis.Request;
 
 // `FetchLike` keeps its v1 name and is re-exported above from
 // '../../shared/transport.js' — no alias needed.

--- a/packages/core/test/exports/public.compat.test.ts
+++ b/packages/core/test/exports/public.compat.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, expectTypeOf, test } from 'vitest';
+import type { FetchLike, IsomorphicHeaders, RequestInfo } from '../../src/exports/public/index.js';
+
+describe('v1 compat type aliases (core/public)', () => {
+    test('IsomorphicHeaders aliases the standard Headers type', () => {
+        expectTypeOf<IsomorphicHeaders>().toEqualTypeOf<Headers>();
+        const h: IsomorphicHeaders = new Headers({ 'content-type': 'application/json' });
+        expect(h.get('content-type')).toBe('application/json');
+    });
+
+    test('RequestInfo aliases the standard Request type', () => {
+        expectTypeOf<RequestInfo>().toEqualTypeOf<Request>();
+        const r: RequestInfo = new Request('http://localhost/mcp');
+        expect(r.url).toBe('http://localhost/mcp');
+    });
+
+    test('FetchLike is re-exported', () => {
+        const f: FetchLike = (url, init) => fetch(url, init);
+        expect(typeof f).toBe('function');
+    });
+});


### PR DESCRIPTION
Part of the v2 backwards-compatibility series — see [reviewer guide](https://gist.github.com/felixweinberger/d7a70e1b52db4a2a0851b98b453ebe3b).

v2 moved to Web-standard `Headers`/`Request`. This re-exports the v1 type names as `@deprecated` aliases.

## Motivation and Context

v2 moved to Web-standard `Headers`/`Request`. This re-exports the v1 type names as `@deprecated` aliases.

<details>
<summary>v1 vs v2 pattern & evidence</summary>

**v1 pattern:**
```ts
`const h: IsomorphicHeaders = req.headers`
```

**v2-native:**
```ts
`const h: Headers = req.headers`
```

**Evidence:** Low volume but zero-cost to shim.

</details>

## How Has This Been Tested?
- Import-compiles test
- Integration: validated bump-only against 5 OSS repos via the `v2-bc-integration` validation branch
- `pnpm typecheck:all && pnpm lint:all && pnpm test:all` green

## Breaking Changes
None — additive `@deprecated` shim.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added or updated documentation as needed

## Additional context
Stacks on: none

