### PR TITLE
feat(node): restore SSEServerTransport under /node/sse, @deprecated

### DIFF
--- a/.changeset/node-sse-compat-shim.md
+++ b/.changeset/node-sse-compat-shim.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/node': patch
+---
+
+Restore the legacy `SSEServerTransport` under the `@modelcontextprotocol/node/sse` subpath as a deprecated v1-compat shim. Servers using the HTTP+SSE transport can upgrade by changing the import to `@modelcontextprotocol/node/sse`. New code should use `NodeStreamableHTTPServerTransport`.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -73,10 +73,9 @@ The [server quickstart](./server-quickstart.md) walks you through building a wea
 
 Resource Server helpers (`requireBearerAuth`, `mcpAuthMetadataRouter`, `OAuthTokenVerifier`) are first-class in `@modelcontextprotocol/express`. The Authorization Server helpers (`mcpAuthRouter`, `ProxyOAuthServerProvider`, etc.) have been removed from the core SDK; new code should use a dedicated IdP/OAuth library. Example packages provide a demo with `better-auth`.
 
-### Why did we remove `server` SSE transport?
+### Where is the server SSE transport?
 
-The SSE transport has been deprecated for a long time, and `v2` will not support it on the server side any more. Client side will keep supporting it in order to be able to connect to legacy SSE servers via the `v2` SDK, but serving SSE from `v2` will not be possible. Servers
-wanting to switch to `v2` and using SSE should migrate to Streamable HTTP.
+`SSEServerTransport` is available as a deprecated compat shim under `@modelcontextprotocol/node/sse`. New servers should migrate to Streamable HTTP (`NodeStreamableHTTPServerTransport` from `@modelcontextprotocol/node`). Client side `SSEClientTransport` remains available for connecting to legacy SSE servers.
 
 ## v1 (legacy)
 

--- a/docs/migration-SKILL.md
+++ b/docs/migration-SKILL.md
@@ -313,7 +313,7 @@ ctx.http?.req?.headers.get('mcp-session-id')
 new URL(ctx.http?.req?.url).searchParams.get('debug')
 ```
 
-## 8. Removed Server Features
+## 8. Deprecated/Removed Server Features
 
 ### SSE server transport
 

--- a/docs/migration-SKILL.md
+++ b/docs/migration-SKILL.md
@@ -53,7 +53,7 @@ Replace all `@modelcontextprotocol/sdk/...` imports using this table.
 | `@modelcontextprotocol/sdk/server/index.js`          | `@modelcontextprotocol/server`                                                                                                                                                                                     |
 | `@modelcontextprotocol/sdk/server/stdio.js`          | `@modelcontextprotocol/server/stdio`                                                                                                                                                                                     |
 | `@modelcontextprotocol/sdk/server/streamableHttp.js` | `@modelcontextprotocol/node` (class renamed to `NodeStreamableHTTPServerTransport`) OR `@modelcontextprotocol/server` (web-standard `WebStandardStreamableHTTPServerTransport` for Cloudflare Workers, Deno, etc.) |
-| `@modelcontextprotocol/sdk/server/sse.js`            | REMOVED (migrate to Streamable HTTP)                                                                                                                                                                               |
+| `@modelcontextprotocol/sdk/server/sse.js`            | `@modelcontextprotocol/node/sse` (deprecated; new code should use `NodeStreamableHTTPServerTransport`)                                                                                                             |
 | `@modelcontextprotocol/sdk/server/auth/*`            | RS helpers (`requireBearerAuth`, `mcpAuthMetadataRouter`, `OAuthTokenVerifier`) → `@modelcontextprotocol/express`; AS helpers removed (use external IdP/OAuth library)                                             |
 | `@modelcontextprotocol/sdk/server/middleware.js`     | `@modelcontextprotocol/express` (signature changed, see section 8)                                                                                                                                                 |
 
@@ -317,7 +317,7 @@ new URL(ctx.http?.req?.url).searchParams.get('debug')
 
 ### SSE server transport
 
-`SSEServerTransport` removed entirely. Migrate to `NodeStreamableHTTPServerTransport` (from `@modelcontextprotocol/node`). Client-side `SSEClientTransport` still available for connecting to legacy servers.
+`SSEServerTransport` is available as a deprecated compat shim under `@modelcontextprotocol/node/sse`. New code should use `NodeStreamableHTTPServerTransport` (from `@modelcontextprotocol/node`). Client-side `SSEClientTransport` still available for connecting to legacy servers.
 
 ### Server-side auth
 
@@ -526,7 +526,7 @@ Access validators explicitly:
 5. **Wrap all raw Zod shapes with `z.object()`**: Change `inputSchema: { name: z.string() }` → `inputSchema: z.object({ name: z.string() })`. Same for `outputSchema` in tools and `argsSchema` in prompts.
 6. Replace plain header objects with `new Headers({...})` and bracket access (`headers['x']`) with `.get()` calls per section 7
 7. If using `hostHeaderValidation` from server, update import and signature per section 8
-8. If using server SSE transport, migrate to Streamable HTTP
+8. If using server SSE transport, import `SSEServerTransport` from `@modelcontextprotocol/node/sse` (deprecated) or migrate to Streamable HTTP
 9. If using server auth from the SDK: RS helpers (`requireBearerAuth`, `mcpAuthMetadataRouter`) → `@modelcontextprotocol/express`; AS helpers → external IdP/OAuth library
 10. If relying on `listTools()`/`listPrompts()`/etc. throwing on missing capabilities, set `enforceStrictCapabilities: true`
 11. Verify: build with `tsc` / run tests

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -108,9 +108,13 @@ import { NodeStreamableHTTPServerTransport } from '@modelcontextprotocol/node';
 const transport = new NodeStreamableHTTPServerTransport({ sessionIdGenerator: () => randomUUID() });
 ```
 
-### Server-side SSE transport removed
+### Server-side SSE transport deprecated
 
-The SSE transport has been removed from the server. Servers should migrate to Streamable HTTP. The client-side SSE transport remains available for connecting to legacy SSE servers.
+`SSEServerTransport` is available as a deprecated compat shim under `@modelcontextprotocol/node/sse`. New servers should use `NodeStreamableHTTPServerTransport` from `@modelcontextprotocol/node`. The client-side SSE transport remains available for connecting to legacy SSE servers.
+
+```ts
+import { SSEServerTransport } from '@modelcontextprotocol/node/sse';
+```
 
 ### `WebSocketClientTransport` removed
 

--- a/packages/middleware/node/package.json
+++ b/packages/middleware/node/package.json
@@ -24,6 +24,10 @@
         ".": {
             "types": "./dist/index.d.mts",
             "import": "./dist/index.mjs"
+        },
+        "./sse": {
+            "types": "./dist/sse.d.mts",
+            "import": "./dist/sse.mjs"
         }
     },
     "types": "./dist/index.d.mts",
@@ -51,7 +55,9 @@
         "client": "tsx scripts/cli.ts client"
     },
     "dependencies": {
-        "@hono/node-server": "catalog:runtimeServerOnly"
+        "@hono/node-server": "catalog:runtimeServerOnly",
+        "content-type": "catalog:runtimeServerOnly",
+        "raw-body": "catalog:runtimeServerOnly"
     },
     "peerDependencies": {
         "@modelcontextprotocol/server": "workspace:^",
@@ -70,6 +76,7 @@
         "@modelcontextprotocol/tsconfig": "workspace:^",
         "@modelcontextprotocol/vitest-config": "workspace:^",
         "@eslint/js": "catalog:devTools",
+        "@types/content-type": "catalog:devTools",
         "@typescript/native-preview": "catalog:devTools",
         "eslint": "catalog:devTools",
         "eslint-config-prettier": "catalog:devTools",

--- a/packages/middleware/node/src/sse.ts
+++ b/packages/middleware/node/src/sse.ts
@@ -1,0 +1,259 @@
+/**
+ * Legacy SSE Server Transport (v1 compatibility shim)
+ *
+ * This module restores the v1 `SSEServerTransport` class for backwards
+ * compatibility. It is a frozen port of the v1 implementation with imports
+ * adapted to the v2 package layout. New code should use
+ * `NodeStreamableHTTPServerTransport` from `@modelcontextprotocol/node`
+ * instead.
+ *
+ * @module sse
+ * @deprecated Use `NodeStreamableHTTPServerTransport` instead.
+ */
+
+import { randomUUID } from 'node:crypto';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { URL } from 'node:url';
+
+import type { AuthInfo, JSONRPCMessage, MessageExtraInfo, Transport } from '@modelcontextprotocol/core';
+import { parseJSONRPCMessage } from '@modelcontextprotocol/server';
+import contentType from 'content-type';
+import getRawBody from 'raw-body';
+
+const MAXIMUM_MESSAGE_SIZE = '4mb';
+
+/**
+ * Configuration options for `SSEServerTransport`.
+ *
+ * @deprecated Use `NodeStreamableHTTPServerTransport` from `@modelcontextprotocol/node` instead.
+ */
+export interface SSEServerTransportOptions {
+    /**
+     * List of allowed host header values for DNS rebinding protection.
+     * If not specified, host validation is disabled.
+     */
+    allowedHosts?: string[];
+
+    /**
+     * List of allowed origin header values for DNS rebinding protection.
+     * If not specified, origin validation is disabled.
+     */
+    allowedOrigins?: string[];
+
+    /**
+     * Enable DNS rebinding protection (requires allowedHosts and/or allowedOrigins to be configured).
+     * Default is `false` for backwards compatibility.
+     */
+    enableDnsRebindingProtection?: boolean;
+}
+
+/**
+ * Server transport for the legacy HTTP+SSE protocol: sends messages over an SSE
+ * connection and receives messages from separate HTTP POST requests.
+ *
+ * This transport is only available in Node.js environments.
+ *
+ * @deprecated Use `NodeStreamableHTTPServerTransport` from `@modelcontextprotocol/node` instead.
+ */
+export class SSEServerTransport implements Transport {
+    private _sseResponse?: ServerResponse;
+    private _sessionId: string;
+    private _options: SSEServerTransportOptions;
+
+    onclose?: () => void;
+    onerror?: (error: Error) => void;
+    onmessage?: (message: JSONRPCMessage, extra?: MessageExtraInfo) => void;
+
+    /**
+     * Creates a new SSE server transport, which will direct the client to POST
+     * messages to the relative or absolute URL identified by `endpoint`.
+     */
+    constructor(
+        private _endpoint: string,
+        private res: ServerResponse,
+        options?: SSEServerTransportOptions
+    ) {
+        this._sessionId = randomUUID();
+        this._options = options ?? { enableDnsRebindingProtection: false };
+    }
+
+    /**
+     * Validates request headers for DNS rebinding protection.
+     * @returns Error message if validation fails, undefined if validation passes.
+     */
+    private validateRequestHeaders(req: IncomingMessage): string | undefined {
+        // Skip validation if protection is not enabled
+        if (!this._options.enableDnsRebindingProtection) {
+            return undefined;
+        }
+
+        // Validate Host header if allowedHosts is configured
+        if (this._options.allowedHosts && this._options.allowedHosts.length > 0) {
+            const hostHeader = req.headers.host;
+            if (!hostHeader || !this._options.allowedHosts.includes(hostHeader)) {
+                return `Invalid Host header: ${hostHeader}`;
+            }
+        }
+
+        // Validate Origin header if allowedOrigins is configured
+        if (this._options.allowedOrigins && this._options.allowedOrigins.length > 0) {
+            const originHeader = req.headers.origin;
+            if (originHeader && !this._options.allowedOrigins.includes(originHeader)) {
+                return `Invalid Origin header: ${originHeader}`;
+            }
+        }
+
+        return undefined;
+    }
+
+    /**
+     * Handles the initial SSE connection request.
+     *
+     * This should be called when a GET request is made to establish the SSE stream.
+     */
+    async start(): Promise<void> {
+        if (this._sseResponse) {
+            throw new Error('SSEServerTransport already started! If using Server class, note that connect() calls start() automatically.');
+        }
+
+        this.res.writeHead(200, {
+            'Content-Type': 'text/event-stream',
+            'Cache-Control': 'no-cache, no-transform',
+            Connection: 'keep-alive'
+        });
+
+        // Send the endpoint event.
+        // Use a dummy base URL because this._endpoint is relative.
+        // This allows using URL/URLSearchParams for robust parameter handling.
+        const dummyBase = 'http://localhost'; // Any valid base works
+        const endpointUrl = new URL(this._endpoint, dummyBase);
+        endpointUrl.searchParams.set('sessionId', this._sessionId);
+
+        // Reconstruct the relative URL string (pathname + search + hash)
+        const relativeUrlWithSession = endpointUrl.pathname + endpointUrl.search + endpointUrl.hash;
+
+        this.res.write(`event: endpoint\ndata: ${relativeUrlWithSession}\n\n`);
+
+        this._sseResponse = this.res;
+        this.res.on('close', () => {
+            this._sseResponse = undefined;
+            this.onclose?.();
+        });
+    }
+
+    /**
+     * Handles incoming POST messages.
+     *
+     * This should be called when a POST request is made to send a message to the server.
+     */
+    async handlePostMessage(req: IncomingMessage & { auth?: AuthInfo }, res: ServerResponse, parsedBody?: unknown): Promise<void> {
+        if (!this._sseResponse) {
+            const message = 'SSE connection not established';
+            res.writeHead(500).end(message);
+            throw new Error(message);
+        }
+
+        // Validate request headers for DNS rebinding protection
+        const validationError = this.validateRequestHeaders(req);
+        if (validationError) {
+            res.writeHead(403).end(validationError);
+            this.onerror?.(new Error(validationError));
+            return;
+        }
+
+        const authInfo: AuthInfo | undefined = req.auth;
+        const request = toWebRequest(req);
+
+        let body: string | unknown;
+        try {
+            const ct = contentType.parse(req.headers['content-type'] ?? '');
+            if (ct.type !== 'application/json') {
+                throw new Error(`Unsupported content-type: ${ct.type}`);
+            }
+
+            body =
+                parsedBody ??
+                (await getRawBody(req, {
+                    limit: MAXIMUM_MESSAGE_SIZE,
+                    encoding: ct.parameters.charset ?? 'utf8'
+                }));
+        } catch (error) {
+            res.writeHead(400).end(String(error));
+            this.onerror?.(error as Error);
+            return;
+        }
+
+        try {
+            await this.handleMessage(typeof body === 'string' ? JSON.parse(body) : body, { request, authInfo });
+        } catch {
+            res.writeHead(400).end(`Invalid message: ${body}`);
+            return;
+        }
+
+        res.writeHead(202).end('Accepted');
+    }
+
+    /**
+     * Handle a client message, regardless of how it arrived. This can be used to
+     * inform the server of messages that arrive via a means different than HTTP POST.
+     */
+    async handleMessage(message: unknown, extra?: MessageExtraInfo): Promise<void> {
+        let parsedMessage: JSONRPCMessage;
+        try {
+            parsedMessage = parseJSONRPCMessage(message);
+        } catch (error) {
+            this.onerror?.(error as Error);
+            throw error;
+        }
+
+        this.onmessage?.(parsedMessage, extra);
+    }
+
+    async close(): Promise<void> {
+        this._sseResponse?.end();
+        this._sseResponse = undefined;
+        this.onclose?.();
+    }
+
+    async send(message: JSONRPCMessage): Promise<void> {
+        if (!this._sseResponse) {
+            throw new Error('Not connected');
+        }
+
+        this._sseResponse.write(`event: message\ndata: ${JSON.stringify(message)}\n\n`);
+    }
+
+    /**
+     * Returns the session ID for this transport.
+     *
+     * This can be used to route incoming POST requests.
+     */
+    get sessionId(): string {
+        return this._sessionId;
+    }
+}
+
+/**
+ * Builds a Web-standard {@linkcode Request} (URL + headers only) from a Node
+ * {@linkcode IncomingMessage} so v2 handler contexts can read `extra.request`.
+ * The body is omitted because the transport consumes it separately.
+ */
+function toWebRequest(req: IncomingMessage): globalThis.Request | undefined {
+    const host = req.headers.host;
+    if (!host || !req.url) {
+        return undefined;
+    }
+    // We can't reliably detect TLS at this layer (proxies, etc.); the scheme is
+    // best-effort and only matters for handler-side URL inspection.
+    const isEncrypted = (req.socket as { encrypted?: boolean } | undefined)?.encrypted === true;
+    const protocol = isEncrypted ? 'https' : 'http';
+    const headers = new Headers();
+    for (const [key, value] of Object.entries(req.headers)) {
+        if (value === undefined) continue;
+        headers.set(key, Array.isArray(value) ? value.join(', ') : value);
+    }
+    return new Request(new URL(req.url, `${protocol}://${host}`), {
+        method: req.method,
+        headers
+    });
+}

--- a/packages/middleware/node/test/sse.compat.test.ts
+++ b/packages/middleware/node/test/sse.compat.test.ts
@@ -1,0 +1,87 @@
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+import type { JSONRPCMessage } from '@modelcontextprotocol/core';
+import { afterEach, describe, expect, it } from 'vitest';
+
+// eslint-disable-next-line @typescript-eslint/no-deprecated
+import { SSEServerTransport } from '../src/sse.js';
+
+describe('SSEServerTransport (deprecated compat shim)', () => {
+    let httpServer: Server;
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    let transport: SSEServerTransport;
+    let baseUrl: string;
+
+    afterEach(async () => {
+        await transport?.close().catch(() => {});
+        await new Promise<void>(resolve => httpServer?.close(() => resolve()) ?? resolve());
+    });
+
+    async function startServer(): Promise<void> {
+        await new Promise<void>(resolve => {
+            httpServer = createServer((req, res) => {
+                if (req.method === 'GET') {
+                    // eslint-disable-next-line @typescript-eslint/no-deprecated
+                    transport = new SSEServerTransport('/messages', res);
+                    void transport.start();
+                } else if (req.method === 'POST') {
+                    void transport.handlePostMessage(req, res);
+                }
+            });
+            httpServer.listen(0, '127.0.0.1', resolve);
+        });
+        const { port } = httpServer.address() as AddressInfo;
+        baseUrl = `http://127.0.0.1:${port}`;
+    }
+
+    it('start() sends endpoint event and handlePostMessage routes JSON-RPC', async () => {
+        await startServer();
+
+        const received: JSONRPCMessage[] = [];
+
+        // Open SSE stream and read the endpoint event
+        const ctrl = new AbortController();
+        const sseRes = await fetch(`${baseUrl}/sse`, {
+            headers: { Accept: 'text/event-stream' },
+            signal: ctrl.signal
+        });
+        expect(sseRes.ok).toBe(true);
+
+        transport.onmessage = msg => received.push(msg);
+
+        const reader = sseRes.body!.getReader();
+        const decoder = new TextDecoder();
+        let buffer = '';
+        // Read until we see the endpoint event
+        while (!buffer.includes('event: endpoint')) {
+            const { value, done } = await reader.read();
+            if (done) break;
+            buffer += decoder.decode(value, { stream: true });
+        }
+        expect(buffer).toContain('event: endpoint');
+        expect(buffer).toContain(`sessionId=${transport.sessionId}`);
+
+        // POST a JSON-RPC message
+        const postRes = await fetch(`${baseUrl}/messages?sessionId=${transport.sessionId}`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ jsonrpc: '2.0', method: 'ping', id: 1 })
+        });
+        expect(postRes.status).toBe(202);
+        expect(received).toEqual([{ jsonrpc: '2.0', method: 'ping', id: 1 }]);
+
+        // send() writes to the SSE stream
+        await transport.send({ jsonrpc: '2.0', id: 1, result: {} });
+        while (!buffer.includes('event: message')) {
+            const { value, done } = await reader.read();
+            if (done) break;
+            buffer += decoder.decode(value, { stream: true });
+        }
+        expect(buffer).toContain('event: message');
+        expect(buffer).toContain('"result":{}');
+
+        ctrl.abort();
+        await reader.cancel().catch(() => {});
+    });
+});

--- a/packages/middleware/node/tsdown.config.ts
+++ b/packages/middleware/node/tsdown.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
     failOnWarn: 'ci-only',
     // 1. Entry Points
     //    Directly matches package.json include/exclude globs
-    entry: ['src/index.ts'],
+    entry: ['src/index.ts', 'src/sse.ts'],
 
     // 2. Output Configuration
     format: ['esm'],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,6 +98,9 @@ catalogs:
     '@hono/node-server':
       specifier: ^1.19.9
       version: 1.19.11
+    content-type:
+      specifier: ^1.0.5
+      version: 1.0.5
     cors:
       specifier: ^2.8.5
       version: 2.8.6
@@ -110,6 +113,9 @@ catalogs:
     hono:
       specifier: ^4.11.4
       version: 4.12.9
+    raw-body:
+      specifier: ^3.0.0
+      version: 3.0.2
   runtimeShared:
     '@cfworker/json-schema':
       specifier: ^4.1.1
@@ -818,9 +824,15 @@ importers:
       '@hono/node-server':
         specifier: catalog:runtimeServerOnly
         version: 1.19.11(hono@4.12.9)
+      content-type:
+        specifier: catalog:runtimeServerOnly
+        version: 1.0.5
       hono:
         specifier: catalog:runtimeServerOnly
         version: 4.12.9
+      raw-body:
+        specifier: catalog:runtimeServerOnly
+        version: 3.0.2
     devDependencies:
       '@eslint/js':
         specifier: catalog:devTools
@@ -843,6 +855,9 @@ importers:
       '@modelcontextprotocol/vitest-config':
         specifier: workspace:^
         version: link:../../../common/vitest-config
+      '@types/content-type':
+        specifier: catalog:devTools
+        version: 1.1.9
       '@typescript/native-preview':
         specifier: catalog:devTools
         version: 7.0.0-dev.20260327.2


### PR DESCRIPTION
Part of the v2 backwards-compatibility series — see [reviewer guide](https://gist.github.com/felixweinberger/d7a70e1b52db4a2a0851b98b453ebe3b).

v2 removed `SSEServerTransport`. Proxy/bridge use-cases (stdio→SSE→browser) still need it; the spec still documents SSE. Restored as `@deprecated` v1 copy.

## Motivation and Context

v2 removed `SSEServerTransport`. Proxy/bridge use-cases (stdio→SSE→browser) still need it; the spec still documents SSE. Restored as `@deprecated` v1 copy.

<details>
<summary>v1 vs v2 pattern & evidence</summary>

**v1 pattern:**
```ts
`import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js'`
```

**v2-native:**
```ts
`import { NodeStreamableHTTPServerTransport } from '@modelcontextprotocol/node'` (StreamableHTTP supersedes SSE)
```

**Evidence:** Hit in real-repo testing (proxy/bridge pattern).

</details>

## How Has This Been Tested?
- packages/middleware/node/test/sse.compat.test.ts
- Integration: validated bump-only against 5 OSS repos via the `v2-bc-integration` validation branch
- `pnpm typecheck:all && pnpm lint:all && pnpm test:all` green

## Breaking Changes
None — additive `@deprecated` shim. Removed in v3.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added or updated documentation as needed

## Additional context
Stacks on: none
