### PR TITLE
fix(express): add CJS exports to resolve ERR_PACKAGE_PATH_NOT_EXPORTED

### DIFF
--- a/packages/middleware/express/package.json
+++ b/packages/middleware/express/package.json
@@ -23,8 +23,12 @@
     ],
     "exports": {
         ".": {
-            "types": "./dist/index.d.mts",
-            "import": "./dist/index.mjs"
+            "types": {
+                "import": "./dist/index.d.mts",
+                "require": "./dist/index.d.cts"
+            },
+            "import": "./dist/index.mjs",
+            "require": "./dist/index.cjs"
         }
     },
     "files": [

--- a/packages/middleware/express/tsdown.config.ts
+++ b/packages/middleware/express/tsdown.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'tsdown';
 export default defineConfig({
     failOnWarn: 'ci-only',
     entry: ['src/index.ts'],
-    format: ['esm'],
+    format: ['esm', 'cjs'],
     outDir: 'dist',
     clean: true,
     sourcemap: true,


### PR DESCRIPTION
## Summary

Fixes #1858

The `@modelcontextprotocol/express` package only defines ESM (`.mjs`) entries in its `exports` field, which causes `ERR_PACKAGE_PATH_NOT_EXPORTED` for consumers using CommonJS (`require()`). This is a common scenario for TypeScript projects initialized with default `tsconfig.json` settings (e.g. `module: "commonjs"`).

## Changes

- **`tsdown.config.ts`**: Add `'cjs'` to the `format` array so tsdown generates both `.mjs` and `.cjs` output files
- **`package.json`**: Add `require` conditions to the `exports` field for both the main entry and type definitions

## Before

```json
"exports": {
    ".": {
        "types": "./dist/index.d.mts",
        "import": "./dist/index.mjs"
    }
}
```

## After

```json
"exports": {
    ".": {
        "types": {
            "import": "./dist/index.d.mts",
            "require": "./dist/index.d.cts"
        },
        "import": "./dist/index.mjs",
        "require": "./dist/index.cjs"
    }
}
```

## Test plan

- [x] `pnpm --filter @modelcontextprotocol/express build` succeeds, generating both ESM and CJS output
- [x] `pnpm --filter @modelcontextprotocol/express test` passes (17/17 tests)
- [ ] Verify a CJS consumer project can `require('@modelcontextprotocol/express')` without errors