### PR TITLE
feat(server): add replayInitialization for stateless serverless sessions

### DIFF
--- a/packages/core/src/shared/transport.ts
+++ b/packages/core/src/shared/transport.ts
@@ -128,7 +128,7 @@ export interface Transport {
      * {@linkcode @modelcontextprotocol/server!server/server.Server.connect | connect()} to
      * seed client capabilities and version info.
      */
-    oninitialized?: ((data: { clientCapabilities: ClientCapabilities; clientVersion: Implementation }) => void) | undefined;
+    oninitializationreplay?: ((data: { clientCapabilities: ClientCapabilities; clientVersion: Implementation }) => void) | undefined;
 
     /**
      * The session ID generated for this connection.

--- a/packages/core/src/shared/transport.ts
+++ b/packages/core/src/shared/transport.ts
@@ -1,4 +1,4 @@
-import type { JSONRPCMessage, MessageExtraInfo, RequestId } from '../types/index.js';
+import type { ClientCapabilities, Implementation, JSONRPCMessage, MessageExtraInfo, RequestId } from '../types/index.js';
 
 export type FetchLike = (url: string | URL, init?: RequestInit) => Promise<Response>;
 
@@ -115,6 +115,20 @@ export interface Transport {
      * The {@linkcode MessageExtraInfo.request | request} can be used to get the original request information (headers, etc.)
      */
     onmessage?: (<T extends JSONRPCMessage>(message: T, extra?: MessageExtraInfo) => void) | undefined;
+
+    /**
+     * Callback invoked when session initialization state is restored by the transport.
+     *
+     * For transports that support stateless session replay (e.g.,
+     * {@linkcode @modelcontextprotocol/server!server/streamableHttp.WebStandardStreamableHTTPServerTransport | WebStandardStreamableHTTPServerTransport}),
+     * this is called when a non-initialize request triggers session restoration
+     * via the transport's `replayInitialization` callback.
+     *
+     * The {@linkcode @modelcontextprotocol/server!server/server.Server | Server} hooks this during
+     * {@linkcode @modelcontextprotocol/server!server/server.Server.connect | connect()} to
+     * seed client capabilities and version info.
+     */
+    oninitialized?: ((data: { clientCapabilities: ClientCapabilities; clientVersion: Implementation }) => void) | undefined;
 
     /**
      * The session ID generated for this connection.

--- a/packages/core/src/util/inMemory.ts
+++ b/packages/core/src/util/inMemory.ts
@@ -18,7 +18,7 @@ export class InMemoryTransport implements Transport {
     onclose?: () => void;
     onerror?: (error: Error) => void;
     onmessage?: (message: JSONRPCMessage, extra?: { authInfo?: AuthInfo }) => void;
-    oninitialized?: (data: { clientCapabilities: ClientCapabilities; clientVersion: Implementation }) => void;
+    oninitializationreplay?: (data: { clientCapabilities: ClientCapabilities; clientVersion: Implementation }) => void;
     sessionId?: string;
 
     /**

--- a/packages/core/src/util/inMemory.ts
+++ b/packages/core/src/util/inMemory.ts
@@ -1,6 +1,6 @@
 import { SdkError, SdkErrorCode } from '../errors/sdkErrors.js';
 import type { Transport } from '../shared/transport.js';
-import type { AuthInfo, JSONRPCMessage, RequestId } from '../types/index.js';
+import type { AuthInfo, ClientCapabilities, Implementation, JSONRPCMessage, RequestId } from '../types/index.js';
 
 interface QueuedMessage {
     message: JSONRPCMessage;
@@ -18,6 +18,7 @@ export class InMemoryTransport implements Transport {
     onclose?: () => void;
     onerror?: (error: Error) => void;
     onmessage?: (message: JSONRPCMessage, extra?: { authInfo?: AuthInfo }) => void;
+    oninitialized?: (data: { clientCapabilities: ClientCapabilities; clientVersion: Implementation }) => void;
     sessionId?: string;
 
     /**

--- a/packages/middleware/node/src/streamableHttp.ts
+++ b/packages/middleware/node/src/streamableHttp.ts
@@ -10,7 +10,15 @@
 import type { IncomingMessage, ServerResponse } from 'node:http';
 
 import { getRequestListener } from '@hono/node-server';
-import type { AuthInfo, JSONRPCMessage, MessageExtraInfo, RequestId, Transport } from '@modelcontextprotocol/core';
+import type {
+    AuthInfo,
+    ClientCapabilities,
+    Implementation,
+    JSONRPCMessage,
+    MessageExtraInfo,
+    RequestId,
+    Transport
+} from '@modelcontextprotocol/core';
 import type { WebStandardStreamableHTTPServerTransportOptions } from '@modelcontextprotocol/server';
 import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/server';
 
@@ -128,6 +136,17 @@ export class NodeStreamableHTTPServerTransport implements Transport {
 
     get onmessage(): ((message: JSONRPCMessage, extra?: MessageExtraInfo) => void) | undefined {
         return this._webStandardTransport.onmessage;
+    }
+
+    /**
+     * Sets callback for session initialization replay.
+     */
+    set oninitialized(handler: ((data: { clientCapabilities: ClientCapabilities; clientVersion: Implementation }) => void) | undefined) {
+        this._webStandardTransport.oninitialized = handler;
+    }
+
+    get oninitialized(): ((data: { clientCapabilities: ClientCapabilities; clientVersion: Implementation }) => void) | undefined {
+        return this._webStandardTransport.oninitialized;
     }
 
     /**

--- a/packages/middleware/node/src/streamableHttp.ts
+++ b/packages/middleware/node/src/streamableHttp.ts
@@ -141,12 +141,14 @@ export class NodeStreamableHTTPServerTransport implements Transport {
     /**
      * Sets callback for session initialization replay.
      */
-    set oninitialized(handler: ((data: { clientCapabilities: ClientCapabilities; clientVersion: Implementation }) => void) | undefined) {
-        this._webStandardTransport.oninitialized = handler;
+    set oninitializationreplay(
+        handler: ((data: { clientCapabilities: ClientCapabilities; clientVersion: Implementation }) => void) | undefined
+    ) {
+        this._webStandardTransport.oninitializationreplay = handler;
     }
 
-    get oninitialized(): ((data: { clientCapabilities: ClientCapabilities; clientVersion: Implementation }) => void) | undefined {
-        return this._webStandardTransport.oninitialized;
+    get oninitializationreplay(): ((data: { clientCapabilities: ClientCapabilities; clientVersion: Implementation }) => void) | undefined {
+        return this._webStandardTransport.oninitializationreplay;
     }
 
     /**

--- a/packages/server/src/server/server.ts
+++ b/packages/server/src/server/server.ts
@@ -31,7 +31,8 @@ import type {
     ServerResult,
     TaskManagerOptions,
     ToolResultContent,
-    ToolUseContent
+    ToolUseContent,
+    Transport
 } from '@modelcontextprotocol/core';
 import {
     assertClientRequestTaskCapability,
@@ -138,6 +139,21 @@ export class Server extends Protocol<ServerContext> {
         if (this._capabilities.logging) {
             this._registerLoggingHandler();
         }
+    }
+
+    /**
+     * Attaches to the given transport, hooking the `oninitialized` callback
+     * to seed client capabilities and version info from replayed sessions.
+     */
+    override async connect(transport: Transport): Promise<void> {
+        const _oninitialized = transport.oninitialized;
+        transport.oninitialized = data => {
+            _oninitialized?.(data);
+            this._clientCapabilities ??= data.clientCapabilities;
+            this._clientVersion ??= data.clientVersion;
+        };
+
+        await super.connect(transport);
     }
 
     private _registerLoggingHandler(): void {

--- a/packages/server/src/server/server.ts
+++ b/packages/server/src/server/server.ts
@@ -142,13 +142,13 @@ export class Server extends Protocol<ServerContext> {
     }
 
     /**
-     * Attaches to the given transport, hooking the `oninitialized` callback
+     * Attaches to the given transport, hooking the `oninitializationreplay` callback
      * to seed client capabilities and version info from replayed sessions.
      */
     override async connect(transport: Transport): Promise<void> {
-        const _oninitialized = transport.oninitialized;
-        transport.oninitialized = data => {
-            _oninitialized?.(data);
+        const _oninitializationreplay = transport.oninitializationreplay;
+        transport.oninitializationreplay = data => {
+            _oninitializationreplay?.(data);
             this._clientCapabilities ??= data.clientCapabilities;
             this._clientVersion ??= data.clientVersion;
         };

--- a/packages/server/src/server/streamableHttp.ts
+++ b/packages/server/src/server/streamableHttp.ts
@@ -7,7 +7,15 @@
  * For Node.js Express/HTTP compatibility, use {@linkcode @modelcontextprotocol/node!NodeStreamableHTTPServerTransport | NodeStreamableHTTPServerTransport} which wraps this transport.
  */
 
-import type { AuthInfo, JSONRPCMessage, MessageExtraInfo, RequestId, Transport } from '@modelcontextprotocol/core';
+import type {
+    AuthInfo,
+    ClientCapabilities,
+    Implementation,
+    JSONRPCMessage,
+    MessageExtraInfo,
+    RequestId,
+    Transport
+} from '@modelcontextprotocol/core';
 import {
     DEFAULT_NEGOTIATED_PROTOCOL_VERSION,
     isInitializeRequest,
@@ -152,6 +160,30 @@ export interface WebStandardStreamableHTTPServerTransportOptions {
      * @default {@linkcode SUPPORTED_PROTOCOL_VERSIONS}
      */
     supportedProtocolVersions?: string[];
+
+    /**
+     * Callback to restore session state for stateless deployments.
+     *
+     * Called when a non-initialize request arrives and the transport is not yet
+     * initialized. The transport reads the session ID from the `mcp-session-id`
+     * request header and passes it to this callback.
+     *
+     * Return cached client capabilities and version info to adopt the session,
+     * or `undefined` to reject the request.
+     *
+     * This callback is never called for `initialize` requests — those follow
+     * the normal handshake path. Note that {@linkcode WebStandardStreamableHTTPServerTransportOptions.onsessioninitialized | onsessioninitialized}
+     * is NOT called during replay — it only fires for new session creation.
+     *
+     * @param sessionId - The session ID from the `mcp-session-id` request header.
+     * @returns Cached client state to restore, or `undefined` if the session is unknown.
+     */
+    replayInitialization?: (
+        sessionId: string
+    ) =>
+        | { clientCapabilities: ClientCapabilities; clientVersion: Implementation }
+        | undefined
+        | Promise<{ clientCapabilities: ClientCapabilities; clientVersion: Implementation } | undefined>;
 }
 
 /**
@@ -240,11 +272,14 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
     private _enableDnsRebindingProtection: boolean;
     private _retryInterval?: number;
     private _supportedProtocolVersions: string[];
+    private _replayInitialization?: WebStandardStreamableHTTPServerTransportOptions['replayInitialization'];
+    private _replayInProgress = false;
 
     sessionId?: string;
     onclose?: () => void;
     onerror?: (error: Error) => void;
     onmessage?: (message: JSONRPCMessage, extra?: MessageExtraInfo) => void;
+    oninitialized?: (data: { clientCapabilities: ClientCapabilities; clientVersion: Implementation }) => void;
 
     constructor(options: WebStandardStreamableHTTPServerTransportOptions = {}) {
         this.sessionIdGenerator = options.sessionIdGenerator;
@@ -257,6 +292,7 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
         this._enableDnsRebindingProtection = options.enableDnsRebindingProtection ?? false;
         this._retryInterval = options.retryInterval;
         this._supportedProtocolVersions = options.supportedProtocolVersions ?? SUPPORTED_PROTOCOL_VERSIONS;
+        this._replayInitialization = options.replayInitialization;
     }
 
     /**
@@ -349,6 +385,17 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
         const validationError = this.validateRequestHeaders(req);
         if (validationError) {
             return validationError;
+        }
+
+        // Attempt stateless session replay before dispatching to method handlers.
+        let replayError: Response | undefined;
+        try {
+            replayError = await this._tryReplayInitialization(req);
+        } catch {
+            return this.createJsonErrorResponse(500, -32_603, 'Internal error: session replay failed');
+        }
+        if (replayError) {
+            return replayError;
         }
 
         switch (req.method) {
@@ -841,13 +888,44 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
     }
 
     /**
+     * Attempts to restore session state via the `replayInitialization` callback.
+     * Called once in `handleRequest()` before method dispatch.
+     *
+     * No-op when already initialized, no callback provided, or no session ID header.
+     * On success, sets `sessionId` and `_initialized`, then invokes `oninitialized`
+     * so the server can seed client capabilities and version info.
+     */
+    private async _tryReplayInitialization(req: Request): Promise<Response | undefined> {
+        if (this._initialized || this._replayInProgress || !this._replayInitialization) return undefined;
+
+        const sessionId = req.headers.get('mcp-session-id');
+        if (!sessionId) return undefined;
+
+        this._replayInProgress = true;
+        try {
+            const result = await this._replayInitialization(sessionId);
+            if (!result) {
+                // Session unknown/expired — 404 tells the client to re-initialize per spec
+                this.onerror?.(new Error('Session not found'));
+                return this.createJsonErrorResponse(404, -32_001, 'Session not found');
+            }
+
+            this.sessionId = sessionId;
+            this._initialized = true;
+            this.oninitialized?.(result);
+            return undefined;
+        } finally {
+            this._replayInProgress = false;
+        }
+    }
+
+    /**
      * Validates session ID for non-initialization requests.
      * Returns `Response` error if invalid, `undefined` otherwise
      */
     private validateSession(req: Request): Response | undefined {
-        if (this.sessionIdGenerator === undefined) {
-            // If the sessionIdGenerator ID is not set, the session management is disabled
-            // and we don't need to validate the session ID
+        if (this.sessionIdGenerator === undefined && this.sessionId === undefined && !this._replayInitialization) {
+            // Session management is fully disabled (no generator, no adopted/replayed session, no replay callback)
             return undefined;
         }
         if (!this._initialized) {

--- a/packages/server/src/server/streamableHttp.ts
+++ b/packages/server/src/server/streamableHttp.ts
@@ -279,7 +279,7 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
     onclose?: () => void;
     onerror?: (error: Error) => void;
     onmessage?: (message: JSONRPCMessage, extra?: MessageExtraInfo) => void;
-    oninitialized?: (data: { clientCapabilities: ClientCapabilities; clientVersion: Implementation }) => void;
+    oninitializationreplay?: (data: { clientCapabilities: ClientCapabilities; clientVersion: Implementation }) => void;
 
     constructor(options: WebStandardStreamableHTTPServerTransportOptions = {}) {
         this.sessionIdGenerator = options.sessionIdGenerator;
@@ -892,7 +892,7 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
      * Called once in `handleRequest()` before method dispatch.
      *
      * No-op when already initialized, no callback provided, or no session ID header.
-     * On success, sets `sessionId` and `_initialized`, then invokes `oninitialized`
+     * On success, sets `sessionId` and `_initialized`, then invokes `oninitializationreplay`
      * so the server can seed client capabilities and version info.
      */
     private async _tryReplayInitialization(req: Request): Promise<Response | undefined> {
@@ -912,7 +912,7 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
 
             this.sessionId = sessionId;
             this._initialized = true;
-            this.oninitialized?.(result);
+            this.oninitializationreplay?.(result);
             return undefined;
         } finally {
             this._replayInProgress = false;

--- a/packages/server/test/server/server.test.ts
+++ b/packages/server/test/server/server.test.ts
@@ -1,4 +1,4 @@
-import type { JSONRPCMessage } from '@modelcontextprotocol/core';
+import type { ClientCapabilities, Implementation, JSONRPCMessage } from '@modelcontextprotocol/core';
 import { InMemoryTransport, LATEST_PROTOCOL_VERSION } from '@modelcontextprotocol/core';
 import { Server } from '../../src/server/server.js';
 
@@ -35,6 +35,103 @@ describe('Server', () => {
             await responsePromise;
 
             expect(setProtocolVersion).toHaveBeenCalledWith(LATEST_PROTOCOL_VERSION);
+
+            await server.close();
+        });
+    });
+
+    describe('connect — oninitialized hook', () => {
+        const testCapabilities: ClientCapabilities = { sampling: {} };
+        const testVersion: Implementation = { name: 'test-client', version: '2.0.0' };
+
+        it('should seed getClientCapabilities() when transport.oninitialized is called', async () => {
+            const server = new Server({ name: 'test', version: '1.0.0' }, { capabilities: {} });
+
+            const [, serverTransport] = InMemoryTransport.createLinkedPair();
+            await server.connect(serverTransport);
+
+            // Simulate transport calling oninitialized (as _tryReplayInitialization would)
+            serverTransport.oninitialized?.({
+                clientCapabilities: testCapabilities,
+                clientVersion: testVersion
+            });
+
+            expect(server.getClientCapabilities()).toEqual(testCapabilities);
+            expect(server.getClientVersion()).toEqual(testVersion);
+
+            await server.close();
+        });
+
+        it('should return undefined for getClientCapabilities() when oninitialized is not called', async () => {
+            const server = new Server({ name: 'test', version: '1.0.0' }, { capabilities: {} });
+
+            const [, serverTransport] = InMemoryTransport.createLinkedPair();
+            await server.connect(serverTransport);
+
+            expect(server.getClientCapabilities()).toBeUndefined();
+            expect(server.getClientVersion()).toBeUndefined();
+
+            await server.close();
+        });
+
+        it('should be overwritten by a real initialize handshake', async () => {
+            const server = new Server({ name: 'test', version: '1.0.0' }, { capabilities: {} });
+
+            const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+            await server.connect(serverTransport);
+
+            // First: seed via oninitialized
+            serverTransport.oninitialized?.({
+                clientCapabilities: testCapabilities,
+                clientVersion: testVersion
+            });
+
+            expect(server.getClientCapabilities()).toEqual(testCapabilities);
+
+            // Then: real initialize overwrites
+            const responsePromise = new Promise<JSONRPCMessage>(resolve => {
+                clientTransport.onmessage = msg => resolve(msg);
+            });
+            await clientTransport.start();
+
+            const realCapabilities: ClientCapabilities = { elicitation: { form: {} } };
+            const realVersion: Implementation = { name: 'real-client', version: '3.0.0' };
+
+            await clientTransport.send({
+                jsonrpc: '2.0',
+                id: 1,
+                method: 'initialize',
+                params: {
+                    protocolVersion: LATEST_PROTOCOL_VERSION,
+                    capabilities: realCapabilities,
+                    clientInfo: realVersion
+                }
+            } as JSONRPCMessage);
+
+            await responsePromise;
+
+            expect(server.getClientCapabilities()).toEqual(realCapabilities);
+            expect(server.getClientVersion()).toEqual(realVersion);
+
+            await server.close();
+        });
+
+        it('should chain with an existing transport.oninitialized callback', async () => {
+            const server = new Server({ name: 'test', version: '1.0.0' }, { capabilities: {} });
+
+            const [, serverTransport] = InMemoryTransport.createLinkedPair();
+
+            const existingCallback = vi.fn();
+            serverTransport.oninitialized = existingCallback;
+
+            await server.connect(serverTransport);
+
+            const data = { clientCapabilities: testCapabilities, clientVersion: testVersion };
+            serverTransport.oninitialized?.(data);
+
+            // Both the existing callback and the server's hook should have fired
+            expect(existingCallback).toHaveBeenCalledWith(data);
+            expect(server.getClientCapabilities()).toEqual(testCapabilities);
 
             await server.close();
         });

--- a/packages/server/test/server/server.test.ts
+++ b/packages/server/test/server/server.test.ts
@@ -40,18 +40,18 @@ describe('Server', () => {
         });
     });
 
-    describe('connect — oninitialized hook', () => {
+    describe('connect — oninitializationreplay hook', () => {
         const testCapabilities: ClientCapabilities = { sampling: {} };
         const testVersion: Implementation = { name: 'test-client', version: '2.0.0' };
 
-        it('should seed getClientCapabilities() when transport.oninitialized is called', async () => {
+        it('should seed getClientCapabilities() when transport.oninitializationreplay is called', async () => {
             const server = new Server({ name: 'test', version: '1.0.0' }, { capabilities: {} });
 
             const [, serverTransport] = InMemoryTransport.createLinkedPair();
             await server.connect(serverTransport);
 
-            // Simulate transport calling oninitialized (as _tryReplayInitialization would)
-            serverTransport.oninitialized?.({
+            // Simulate transport calling oninitializationreplay (as _tryReplayInitialization would)
+            serverTransport.oninitializationreplay?.({
                 clientCapabilities: testCapabilities,
                 clientVersion: testVersion
             });
@@ -62,7 +62,7 @@ describe('Server', () => {
             await server.close();
         });
 
-        it('should return undefined for getClientCapabilities() when oninitialized is not called', async () => {
+        it('should return undefined for getClientCapabilities() when oninitializationreplay is not called', async () => {
             const server = new Server({ name: 'test', version: '1.0.0' }, { capabilities: {} });
 
             const [, serverTransport] = InMemoryTransport.createLinkedPair();
@@ -80,8 +80,8 @@ describe('Server', () => {
             const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
             await server.connect(serverTransport);
 
-            // First: seed via oninitialized
-            serverTransport.oninitialized?.({
+            // First: seed via oninitializationreplay
+            serverTransport.oninitializationreplay?.({
                 clientCapabilities: testCapabilities,
                 clientVersion: testVersion
             });
@@ -116,18 +116,18 @@ describe('Server', () => {
             await server.close();
         });
 
-        it('should chain with an existing transport.oninitialized callback', async () => {
+        it('should chain with an existing transport.oninitializationreplay callback', async () => {
             const server = new Server({ name: 'test', version: '1.0.0' }, { capabilities: {} });
 
             const [, serverTransport] = InMemoryTransport.createLinkedPair();
 
             const existingCallback = vi.fn();
-            serverTransport.oninitialized = existingCallback;
+            serverTransport.oninitializationreplay = existingCallback;
 
             await server.connect(serverTransport);
 
             const data = { clientCapabilities: testCapabilities, clientVersion: testVersion };
-            serverTransport.oninitialized?.(data);
+            serverTransport.oninitializationreplay?.(data);
 
             // Both the existing callback and the server's hook should have fired
             expect(existingCallback).toHaveBeenCalledWith(data);

--- a/packages/server/test/server/streamableHttp.test.ts
+++ b/packages/server/test/server/streamableHttp.test.ts
@@ -1099,9 +1099,7 @@ describe('Zod v4', () => {
 
         it('should return 404 when callback returns undefined (session unknown)', async () => {
             const transport = new WebStandardStreamableHTTPServerTransport({
-                replayInitialization: () => {
-                    return;
-                }
+                replayInitialization: () => undefined
             });
 
             const mcpServer = new McpServer({ name: 'test', version: '1.0.0' });

--- a/packages/server/test/server/streamableHttp.test.ts
+++ b/packages/server/test/server/streamableHttp.test.ts
@@ -1038,13 +1038,13 @@ describe('Zod v4', () => {
             expect(transport.sessionId).toBe(REPLAY_SESSION_ID);
         });
 
-        it('should invoke oninitialized with replayed data', async () => {
+        it('should invoke oninitializationreplay with replayed data', async () => {
             const transport = new WebStandardStreamableHTTPServerTransport({
                 replayInitialization: () => REPLAY_DATA
             });
 
-            const oninitializedSpy = vi.fn();
-            transport.oninitialized = oninitializedSpy;
+            const oninitializationreplaySpy = vi.fn();
+            transport.oninitializationreplay = oninitializationreplaySpy;
 
             const mcpServer = new McpServer({ name: 'test', version: '1.0.0' });
             await mcpServer.connect(transport);
@@ -1055,10 +1055,10 @@ describe('Zod v4', () => {
             await transport.handleRequest(request);
 
             // The server's connect() chains its own hook, so verify the original was also called
-            expect(oninitializedSpy).toHaveBeenCalledWith(REPLAY_DATA);
+            expect(oninitializationreplaySpy).toHaveBeenCalledWith(REPLAY_DATA);
         });
 
-        it('should seed server capabilities via oninitialized hook', async () => {
+        it('should seed server capabilities via oninitializationreplay hook', async () => {
             const transport = new WebStandardStreamableHTTPServerTransport({
                 replayInitialization: () => REPLAY_DATA
             });

--- a/packages/server/test/server/streamableHttp.test.ts
+++ b/packages/server/test/server/streamableHttp.test.ts
@@ -993,4 +993,305 @@ describe('Zod v4', () => {
             expect(cleanupCalls).toEqual(['stream-1']);
         });
     });
+
+    describe('replayInitialization', () => {
+        const REPLAY_SESSION_ID = 'replayed-session-abc';
+        const REPLAY_CAPABILITIES = { sampling: {}, elicitation: { form: {} } };
+        const REPLAY_VERSION = { name: 'cached-client', version: '2.0.0' };
+        const REPLAY_DATA = {
+            clientCapabilities: REPLAY_CAPABILITIES,
+            clientVersion: REPLAY_VERSION
+        };
+
+        it('should call replayInitialization with session ID from header on non-init POST', async () => {
+            const replayFn = vi.fn().mockReturnValue(REPLAY_DATA);
+            const transport = new WebStandardStreamableHTTPServerTransport({
+                replayInitialization: replayFn
+            });
+
+            const mcpServer = new McpServer({ name: 'test', version: '1.0.0' });
+            await mcpServer.connect(transport);
+
+            const request = createRequest('POST', TEST_MESSAGES.toolsList, {
+                sessionId: REPLAY_SESSION_ID
+            });
+            await transport.handleRequest(request);
+
+            expect(replayFn).toHaveBeenCalledWith(REPLAY_SESSION_ID);
+        });
+
+        it('should set transport sessionId and _initialized after successful replay', async () => {
+            const transport = new WebStandardStreamableHTTPServerTransport({
+                replayInitialization: () => REPLAY_DATA
+            });
+
+            const mcpServer = new McpServer({ name: 'test', version: '1.0.0' });
+            await mcpServer.connect(transport);
+
+            expect(transport.sessionId).toBeUndefined();
+
+            const request = createRequest('POST', TEST_MESSAGES.toolsList, {
+                sessionId: REPLAY_SESSION_ID
+            });
+            await transport.handleRequest(request);
+
+            expect(transport.sessionId).toBe(REPLAY_SESSION_ID);
+        });
+
+        it('should invoke oninitialized with replayed data', async () => {
+            const transport = new WebStandardStreamableHTTPServerTransport({
+                replayInitialization: () => REPLAY_DATA
+            });
+
+            const oninitializedSpy = vi.fn();
+            transport.oninitialized = oninitializedSpy;
+
+            const mcpServer = new McpServer({ name: 'test', version: '1.0.0' });
+            await mcpServer.connect(transport);
+
+            const request = createRequest('POST', TEST_MESSAGES.toolsList, {
+                sessionId: REPLAY_SESSION_ID
+            });
+            await transport.handleRequest(request);
+
+            // The server's connect() chains its own hook, so verify the original was also called
+            expect(oninitializedSpy).toHaveBeenCalledWith(REPLAY_DATA);
+        });
+
+        it('should seed server capabilities via oninitialized hook', async () => {
+            const transport = new WebStandardStreamableHTTPServerTransport({
+                replayInitialization: () => REPLAY_DATA
+            });
+
+            const mcpServer = new McpServer({ name: 'test', version: '1.0.0' });
+            await mcpServer.connect(transport);
+
+            expect(mcpServer.server.getClientCapabilities()).toBeUndefined();
+
+            const request = createRequest('POST', TEST_MESSAGES.toolsList, {
+                sessionId: REPLAY_SESSION_ID
+            });
+            await transport.handleRequest(request);
+
+            expect(mcpServer.server.getClientCapabilities()).toEqual(REPLAY_CAPABILITIES);
+            expect(mcpServer.server.getClientVersion()).toEqual(REPLAY_VERSION);
+        });
+
+        it('should pass validateSession after successful replay', async () => {
+            const transport = new WebStandardStreamableHTTPServerTransport({
+                replayInitialization: () => REPLAY_DATA
+            });
+
+            const mcpServer = new McpServer({ name: 'test', version: '1.0.0' });
+            mcpServer.registerTool('greet', { inputSchema: z.object({ name: z.string() }) }, async ({ name }) => ({
+                content: [{ type: 'text', text: `Hello, ${name}!` }]
+            }));
+            await mcpServer.connect(transport);
+
+            const request = createRequest('POST', TEST_MESSAGES.toolsList, {
+                sessionId: REPLAY_SESSION_ID
+            });
+            const response = await transport.handleRequest(request);
+
+            // Should NOT be 400 "Server not initialized" or 404 "Session not found"
+            expect(response.status).toBe(200);
+        });
+
+        it('should return 404 when callback returns undefined (session unknown)', async () => {
+            const transport = new WebStandardStreamableHTTPServerTransport({
+                replayInitialization: () => {
+                    return;
+                }
+            });
+
+            const mcpServer = new McpServer({ name: 'test', version: '1.0.0' });
+            await mcpServer.connect(transport);
+
+            const request = createRequest('POST', TEST_MESSAGES.toolsList, {
+                sessionId: REPLAY_SESSION_ID
+            });
+            const response = await transport.handleRequest(request);
+
+            // Replay returned undefined → 404 tells client to re-initialize per spec
+            expect(response.status).toBe(404);
+            const data = await response.json();
+            expectErrorResponse(data, -32_001, /Session not found/);
+        });
+
+        it('should return 500 when callback throws', async () => {
+            const transport = new WebStandardStreamableHTTPServerTransport({
+                replayInitialization: () => {
+                    throw new Error('Redis connection failed');
+                }
+            });
+
+            const mcpServer = new McpServer({ name: 'test', version: '1.0.0' });
+            await mcpServer.connect(transport);
+
+            const request = createRequest('POST', TEST_MESSAGES.toolsList, {
+                sessionId: REPLAY_SESSION_ID
+            });
+            const response = await transport.handleRequest(request);
+
+            expect(response.status).toBe(500);
+            const data = await response.json();
+            expectErrorResponse(data, -32_603, /session replay failed/);
+        });
+
+        it('should not call callback when no replayInitialization is provided', async () => {
+            const transport = new WebStandardStreamableHTTPServerTransport({
+                sessionIdGenerator: () => randomUUID()
+            });
+
+            const mcpServer = new McpServer({ name: 'test', version: '1.0.0' });
+            await mcpServer.connect(transport);
+
+            // Without init, a non-init request should be rejected normally
+            const request = createRequest('POST', TEST_MESSAGES.toolsList, {
+                sessionId: 'some-session'
+            });
+            const response = await transport.handleRequest(request);
+
+            expect(response.status).toBe(400);
+        });
+
+        it('should not call callback for initialize requests', async () => {
+            const replayFn = vi.fn().mockReturnValue(REPLAY_DATA);
+            const transport = new WebStandardStreamableHTTPServerTransport({
+                sessionIdGenerator: () => randomUUID(),
+                replayInitialization: replayFn
+            });
+
+            const mcpServer = new McpServer({ name: 'test', version: '1.0.0' });
+            await mcpServer.connect(transport);
+
+            // Init request has no mcp-session-id header → callback is not called
+            const request = createRequest('POST', TEST_MESSAGES.initialize);
+            await transport.handleRequest(request);
+
+            expect(replayFn).not.toHaveBeenCalled();
+        });
+
+        it('should not call callback when transport is already initialized', async () => {
+            const replayFn = vi.fn().mockReturnValue(REPLAY_DATA);
+            const transport = new WebStandardStreamableHTTPServerTransport({
+                sessionIdGenerator: () => randomUUID(),
+                replayInitialization: replayFn
+            });
+
+            const mcpServer = new McpServer({ name: 'test', version: '1.0.0' });
+            await mcpServer.connect(transport);
+
+            // Normal init first
+            const initRequest = createRequest('POST', TEST_MESSAGES.initialize);
+            const initResponse = await transport.handleRequest(initRequest);
+            const sessionId = initResponse.headers.get('mcp-session-id')!;
+
+            // Subsequent request should NOT trigger replay
+            const toolsRequest = createRequest('POST', TEST_MESSAGES.toolsList, { sessionId });
+            await transport.handleRequest(toolsRequest);
+
+            expect(replayFn).not.toHaveBeenCalled();
+        });
+
+        it('should not call callback when mcp-session-id header is missing', async () => {
+            const replayFn = vi.fn().mockReturnValue(REPLAY_DATA);
+            const transport = new WebStandardStreamableHTTPServerTransport({
+                replayInitialization: replayFn
+            });
+
+            const mcpServer = new McpServer({ name: 'test', version: '1.0.0' });
+            await mcpServer.connect(transport);
+
+            // POST without session ID header
+            const request = createRequest('POST', TEST_MESSAGES.toolsList);
+            await transport.handleRequest(request);
+
+            expect(replayFn).not.toHaveBeenCalled();
+        });
+
+        it('should reject mismatched session ID after replay', async () => {
+            const transport = new WebStandardStreamableHTTPServerTransport({
+                replayInitialization: () => REPLAY_DATA
+            });
+
+            const mcpServer = new McpServer({ name: 'test', version: '1.0.0' });
+            await mcpServer.connect(transport);
+
+            // First request replays with REPLAY_SESSION_ID
+            const request1 = createRequest('POST', TEST_MESSAGES.toolsList, {
+                sessionId: REPLAY_SESSION_ID
+            });
+            await transport.handleRequest(request1);
+
+            // Second request with a different session ID should be rejected
+            const request2 = createRequest('POST', TEST_MESSAGES.toolsList, {
+                sessionId: 'wrong-session-id'
+            });
+            const response2 = await transport.handleRequest(request2);
+
+            expect(response2.status).toBe(404);
+            const data = await response2.json();
+            expectErrorResponse(data, -32_001, /Session not found/);
+        });
+
+        it('should work with GET requests', async () => {
+            const transport = new WebStandardStreamableHTTPServerTransport({
+                replayInitialization: () => REPLAY_DATA
+            });
+
+            const mcpServer = new McpServer({ name: 'test', version: '1.0.0' });
+            await mcpServer.connect(transport);
+
+            const request = createRequest('GET', undefined, {
+                sessionId: REPLAY_SESSION_ID
+            });
+            const response = await transport.handleRequest(request);
+
+            // Should open an SSE stream, not reject
+            expect(response.status).toBe(200);
+            expect(response.headers.get('content-type')).toBe('text/event-stream');
+            expect(transport.sessionId).toBe(REPLAY_SESSION_ID);
+        });
+
+        it('should work with DELETE requests', async () => {
+            const transport = new WebStandardStreamableHTTPServerTransport({
+                replayInitialization: () => REPLAY_DATA
+            });
+
+            const mcpServer = new McpServer({ name: 'test', version: '1.0.0' });
+            await mcpServer.connect(transport);
+
+            const request = createRequest('DELETE', undefined, {
+                sessionId: REPLAY_SESSION_ID
+            });
+            const response = await transport.handleRequest(request);
+
+            expect(response.status).toBe(200);
+        });
+
+        it('should support async callback', async () => {
+            const transport = new WebStandardStreamableHTTPServerTransport({
+                replayInitialization: async sessionId => {
+                    // Simulate async cache lookup
+                    await new Promise(resolve => setTimeout(resolve, 10));
+                    return sessionId === REPLAY_SESSION_ID ? REPLAY_DATA : undefined;
+                }
+            });
+
+            const mcpServer = new McpServer({ name: 'test', version: '1.0.0' });
+            mcpServer.registerTool('greet', { inputSchema: z.object({ name: z.string() }) }, async ({ name }) => ({
+                content: [{ type: 'text', text: `Hello, ${name}!` }]
+            }));
+            await mcpServer.connect(transport);
+
+            const request = createRequest('POST', TEST_MESSAGES.toolsList, {
+                sessionId: REPLAY_SESSION_ID
+            });
+            const response = await transport.handleRequest(request);
+
+            expect(response.status).toBe(200);
+            expect(mcpServer.server.getClientCapabilities()).toEqual(REPLAY_CAPABILITIES);
+        });
+    });
 });


### PR DESCRIPTION
## Summary

Add a `replayInitialization` callback to `WebStandardStreamableHTTPServerTransport` that restores session state on non-initialize requests in stateless serverless deployments.

Closes #1658, closes #1882, closes #776

## Motivation and Context

In stateless serverless deployments (Vercel, Lambda, Workers), each HTTP request creates a fresh `Server` + `Transport`. The `initialize` handshake sets private state (`_clientCapabilities`, `_clientVersion`, `sessionId`, `_initialized`) that is lost when the instance is garbage collected. This means:

- Tools that check capabilities (elicitation, sampling, roots) throw `CapabilityNotSupported` on any non-initialize request
- Session validation fails because the fresh transport doesn't recognize the session
- Developers must use `Reflect.set` hacks to write private fields — fragile and breaks on field renames

The `replayInitialization` callback lets developers restore session state from an external cache (Redis, KV, Postgres) without reaching into private fields:

```typescript
const transport = new WebStandardStreamableHTTPServerTransport({
  sessionIdGenerator: () => crypto.randomUUID(),     // init request: generates ID

  // Subsequent requests: transport reads mcp-session-id from the client's
  // request header and passes it here to look up cached state
  replayInitialization: async (sessionId) => {
    const cached = await sessionStore.get(sessionId);
    if (!cached) return undefined; // → 404, client re-initializes
    return {
      clientCapabilities: cached.capabilities,
      clientVersion: cached.clientVersion,
    };
  },
});
```

The replay is invisible to the client — it's an internal server-side optimization that restores state from a prior legitimate handshake.

## Changes

| File | Change |
|---|---|
| `packages/core/src/shared/transport.ts` | Add optional `oninitializationreplay` callback to `Transport` interface (same pattern as `onmessage`/`onclose`/`onerror`) |
| `packages/core/src/util/inMemory.ts` | Declare `oninitializationreplay` on `InMemoryTransport` |
| `packages/server/src/server/server.ts` | Override `connect()` to hook `transport.oninitializationreplay`, seeding `_clientCapabilities`/`_clientVersion` via `??=` |
| `packages/server/src/server/streamableHttp.ts` | Add `replayInitialization` option, `_tryReplayInitialization` helper (called once in `handleRequest` before method dispatch), fix `validateSession` to recognize replayed sessions, race condition guard |
| `packages/middleware/node/src/streamableHttp.ts` | Delegate `oninitializationreplay` getter/setter to inner transport |

Callback semantics:
- Returns data → session restored, request proceeds
- Returns `undefined` → **404** "Session not found" per spec (client re-initializes)
- Throws → **500** internal error

## How Has This Been Tested?

- 4 new server tests: `oninitializationreplay` hook seeding, overwrite by real init, callback chaining, undefined without call
- 13 new transport tests: callback invocation, session adoption, 404 on unknown session, 500 on throw, no-ops (no callback, no header, already initialized, init request), session mismatch, GET/DELETE replay, async callback
- All existing tests pass: `pnpm typecheck:all`, `pnpm test:all`, `pnpm lint:all`

## Breaking Changes

None. All new options are optional with `undefined` defaults. Existing behavior is identical when `replayInitialization` is not provided.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

**Spec compliance:** The spec says *"The server MAY terminate the session at any time, after which it MUST respond with HTTP 404 Not Found"* and *"When a client receives HTTP 404, it MUST start a new session."* When the callback returns `undefined` (session unknown/expired), the transport returns 404 — the protocol self-heals.