### PR TITLE
docs(client): clarify that custom JWT claims do not override standard claims

### DIFF
--- a/packages/client/src/client/authExtensions.ts
+++ b/packages/client/src/client/authExtensions.ts
@@ -236,8 +236,9 @@ export interface PrivateKeyJwtProviderOptions {
 
     /**
      * Optional custom claims to include in the JWT assertion.
-     * These are merged with the standard claims (`iss`, `sub`, `aud`, `exp`, `iat`, `jti`),
-     * with custom claims taking precedence for any overlapping keys.
+     * These are merged with the standard claims (`iss`, `sub`, `aud`, `exp`, `iat`, `jti`).
+     * Additional custom claims are included, but overlapping standard claims are
+     * still set explicitly by the SDK and therefore are not overridden.
      *
      * Useful for including additional claims that help scope the access token
      * with finer granularity than what scopes alone allow.

--- a/packages/client/test/client/authExtensions.test.ts
+++ b/packages/client/test/client/authExtensions.test.ts
@@ -448,6 +448,35 @@ describe('createPrivateKeyJwtAuth', () => {
         expect(decoded.sub).toBe('client-id');
     });
 
+    it('does not allow custom claims to override standard JWT claims', async () => {
+        const addClientAuth = createPrivateKeyJwtAuth({
+            issuer: 'client-id',
+            subject: 'client-id',
+            privateKey: 'a-string-secret-at-least-256-bits-long',
+            alg: 'HS256',
+            audience: 'https://aud.example.com',
+            claims: {
+                iss: 'override-issuer',
+                sub: 'override-subject',
+                aud: 'https://override.example.com',
+                tenant_id: 'org-123'
+            }
+        });
+
+        const params = new URLSearchParams();
+        await addClientAuth(new Headers(), params, 'https://auth.example.com/token', undefined);
+
+        const assertion = params.get('client_assertion');
+        expect(assertion).toBeTruthy();
+
+        const jose = await import('jose');
+        const decoded = jose.decodeJwt(assertion!);
+        expect(decoded.iss).toBe('client-id');
+        expect(decoded.sub).toBe('client-id');
+        expect(decoded.aud).toBe('https://aud.example.com');
+        expect(decoded.tenant_id).toBe('org-123');
+    });
+
     it('passes custom claims through PrivateKeyJwtProvider', async () => {
         const provider = new PrivateKeyJwtProvider({
             clientId: 'client-id',


### PR DESCRIPTION
## Summary

- clarify that `PrivateKeyJwtProviderOptions.claims` adds custom claims but does not override reserved standard JWT claims
- add a regression test proving the current runtime behavior

Closes #1914

## Motivation and Context

`packages/client/src/client/authExtensions.ts` currently says overlapping custom claims take precedence over the standard JWT claims.

The implementation does include additional custom claims, but it then re-applies the reserved claims via `SignJWT` setters (`setIssuer`, `setSubject`, `setAudience`, `setIssuedAt`, `setExpirationTime`, `setJti`). In practice, overlapping custom values are not preserved.

This PR keeps the runtime behavior unchanged and narrows the fix to docs + tests so the published contract matches the shipped behavior.

## How Has This Been Tested?

- `corepack pnpm --filter @modelcontextprotocol/client test -- --run packages/client/test/client/authExtensions.test.ts`
- `corepack pnpm --filter @modelcontextprotocol/client typecheck`
- `corepack pnpm --filter @modelcontextprotocol/client lint`

## Breaking Changes

None.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] I have read the MCP Documentation
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added or updated documentation as needed
