### PR TITLE
feat(core): export Protocol class + ProtocolSpec generic for typed custom vocabularies

### DIFF
--- a/.changeset/export-protocol-spec.md
+++ b/.changeset/export-protocol-spec.md
@@ -3,4 +3,4 @@
 '@modelcontextprotocol/server': minor
 ---
 
-Export the abstract `Protocol` class (was reachable in v1 via deep imports) and add `Protocol<ContextT, SpecT extends ProtocolSpec = McpSpec>` for typed custom-method vocabularies. Subclasses supplying a concrete `ProtocolSpec` get method-name autocomplete and result-type correlation on the typed `setRequestHandler`/`setNotificationHandler` overloads (handler param types come from the `paramsSchema` argument; `ProtocolSpec['params']` is informational).
+Export the abstract `Protocol` class (was reachable in v1 via deep imports) and add `Protocol<ContextT, SpecT extends ProtocolSpec = McpSpec>` for typed custom-method vocabularies. Subclasses supplying a concrete `ProtocolSpec` get method-name autocomplete on the typed `setRequestHandler`/`setNotificationHandler` overloads, and result-type correlation on `setRequestHandler` (handler param types come from the `paramsSchema` argument; `ProtocolSpec['params']` is informational).

--- a/.changeset/export-protocol-spec.md
+++ b/.changeset/export-protocol-spec.md
@@ -1,0 +1,6 @@
+---
+'@modelcontextprotocol/client': minor
+'@modelcontextprotocol/server': minor
+---
+
+Export the abstract `Protocol` class (was reachable in v1 via deep imports) and add `Protocol<ContextT, SpecT extends ProtocolSpec = McpSpec>` for typed custom-method vocabularies. Subclasses supplying a concrete `ProtocolSpec` get method-name autocomplete and params/result correlation on the typed `setRequestHandler`/`setNotificationHandler` overloads.

--- a/.changeset/export-protocol-spec.md
+++ b/.changeset/export-protocol-spec.md
@@ -3,4 +3,4 @@
 '@modelcontextprotocol/server': minor
 ---
 
-Export the abstract `Protocol` class (was reachable in v1 via deep imports) and add `Protocol<ContextT, SpecT extends ProtocolSpec = McpSpec>` for typed custom-method vocabularies. Subclasses supplying a concrete `ProtocolSpec` get method-name autocomplete and params/result correlation on the typed `setRequestHandler`/`setNotificationHandler` overloads.
+Export the abstract `Protocol` class (was reachable in v1 via deep imports) and add `Protocol<ContextT, SpecT extends ProtocolSpec = McpSpec>` for typed custom-method vocabularies. Subclasses supplying a concrete `ProtocolSpec` get method-name autocomplete and result-type correlation on the typed `setRequestHandler`/`setNotificationHandler` overloads (handler param types come from the `paramsSchema` argument; `ProtocolSpec['params']` is informational).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ The SDK is organized into three main layers:
 The SDK has a two-layer export structure to separate internal code from the public API:
 
 - **`@modelcontextprotocol/core`** (main entry, `packages/core/src/index.ts`) — Internal barrel. Exports everything (including Zod schemas, Protocol class, stdio utils). Only consumed by sibling packages within the monorepo (`private: true`).
-- **`@modelcontextprotocol/core/public`** (`packages/core/src/exports/public/index.ts`) — Curated public API. Exports only TypeScript types, error classes, constants, and guards. Re-exported by client and server packages.
+- **`@modelcontextprotocol/core/public`** (`packages/core/src/exports/public/index.ts`) — Curated public API. Exports TypeScript types, error classes, constants, guards, and the `Protocol` class. Re-exported by client and server packages.
 - **`@modelcontextprotocol/client`** and **`@modelcontextprotocol/server`** (`packages/*/src/index.ts`) — Final public surface. Package-specific exports (named explicitly) plus re-exports from `core/public`.
 
 When modifying exports:

--- a/packages/client/src/client/client.ts
+++ b/packages/client/src/client/client.ts
@@ -345,8 +345,13 @@ export class Client extends Protocol<ClientContext> {
         method: M,
         handler: (request: RequestTypeMap[M], ctx: ClientContext) => ResultTypeMap[M] | Promise<ResultTypeMap[M]>
     ): void;
-    public override setRequestHandler<P extends StandardSchemaV1>(
-        method: string,
+    public override setRequestHandler<M extends RequestMethod, P extends StandardSchemaV1>(
+        method: M,
+        paramsSchema: P,
+        handler: (params: StandardSchemaV1.InferOutput<P>, ctx: ClientContext) => ResultTypeMap[M] | Promise<ResultTypeMap[M]>
+    ): void;
+    public override setRequestHandler<M extends string, P extends StandardSchemaV1>(
+        method: M extends RequestMethod ? never : M,
         paramsSchema: P,
         handler: (params: StandardSchemaV1.InferOutput<P>, ctx: ClientContext) => Result | Promise<Result>
     ): void;

--- a/packages/core/src/exports/public/index.ts
+++ b/packages/core/src/exports/public/index.ts
@@ -38,17 +38,21 @@ export { checkResourceAllowed, resourceUrlFromServerUrl } from '../../shared/aut
 // Metadata utilities
 export { getDisplayName } from '../../shared/metadataUtils.js';
 
-// Protocol types (NOT the Protocol class itself or mergeCapabilities)
+// Protocol class (abstract — subclass for custom vocabularies) + types. NOT mergeCapabilities.
 export type {
     BaseContext,
     ClientContext,
+    McpSpec,
     NotificationOptions,
     ProgressCallback,
     ProtocolOptions,
+    ProtocolSpec,
     RequestOptions,
-    ServerContext
+    ServerContext,
+    SpecNotifications,
+    SpecRequests
 } from '../../shared/protocol.js';
-export { DEFAULT_REQUEST_TIMEOUT_MSEC } from '../../shared/protocol.js';
+export { DEFAULT_REQUEST_TIMEOUT_MSEC, Protocol } from '../../shared/protocol.js';
 export type { ZodLikeRequestSchema } from '../../util/compatSchema.js';
 
 // Task manager types (NOT TaskManager class itself — internal)

--- a/packages/core/src/exports/public/index.ts
+++ b/packages/core/src/exports/public/index.ts
@@ -38,7 +38,7 @@ export { checkResourceAllowed, resourceUrlFromServerUrl } from '../../shared/aut
 // Metadata utilities
 export { getDisplayName } from '../../shared/metadataUtils.js';
 
-// Protocol class (concrete; subclass for custom vocabularies via SpecT) + types. NOT mergeCapabilities.
+// Protocol class (abstract; subclass for custom vocabularies via SpecT) + types. NOT mergeCapabilities.
 export type {
     BaseContext,
     ClientContext,

--- a/packages/core/src/exports/public/index.ts
+++ b/packages/core/src/exports/public/index.ts
@@ -4,9 +4,9 @@
  * This module defines the stable, public-facing API surface. Client and server
  * packages re-export from here so that end users only see supported symbols.
  *
- * Internal utilities (Protocol class, stdio parsing, schema helpers, etc.)
- * remain available via the internal barrel (@modelcontextprotocol/core) for
- * use by client/server packages.
+ * Internal utilities (stdio parsing, schema helpers, etc.) remain available via
+ * the internal barrel (@modelcontextprotocol/core) for use by client/server
+ * packages.
  */
 
 // Auth error classes
@@ -38,7 +38,7 @@ export { checkResourceAllowed, resourceUrlFromServerUrl } from '../../shared/aut
 // Metadata utilities
 export { getDisplayName } from '../../shared/metadataUtils.js';
 
-// Protocol class (abstract — subclass for custom vocabularies) + types. NOT mergeCapabilities.
+// Protocol class (concrete; subclass for custom vocabularies via SpecT) + types. NOT mergeCapabilities.
 export type {
     BaseContext,
     ClientContext,

--- a/packages/core/src/shared/protocol.ts
+++ b/packages/core/src/shared/protocol.ts
@@ -352,6 +352,11 @@ export type SpecNotifications<SpecT extends ProtocolSpec> = string extends keyof
  * `Protocol` is abstract; `Client` and `Server` are the concrete role-specific implementations.
  * Subclasses (such as MCP-dialect protocols like MCP Apps) can supply a {@linkcode ProtocolSpec}
  * as the second type argument to get method-name autocomplete on their own vocabulary.
+ *
+ * @remarks
+ * Subclassing `Protocol` directly is supported for MCP-dialect frameworks. The protected
+ * surface (`buildContext`, `assertCapability*`, `_setRequestHandlerByMethod`) may evolve in
+ * minor versions; prefer `Client`/`Server` unless you need a custom method vocabulary.
  */
 export abstract class Protocol<ContextT extends BaseContext = BaseContext, SpecT extends ProtocolSpec = McpSpec> {
     private _transport?: Transport;

--- a/packages/core/src/shared/protocol.ts
+++ b/packages/core/src/shared/protocol.ts
@@ -310,7 +310,8 @@ type TimeoutInfo = {
  *
  * Supplying a concrete `ProtocolSpec` as `Protocol`'s second type argument gives method-name
  * autocomplete and params/result correlation on the typed overloads of `setRequestHandler`
- * and `setNotificationHandler`. The default leaves them string-keyed and untyped.
+ * and `setNotificationHandler`. `Protocol` defaults to {@linkcode McpSpec}; using the bare
+ * `ProtocolSpec` type leaves methods string-keyed and untyped.
  */
 export type ProtocolSpec = {
     requests?: Record<string, { params?: unknown; result: unknown }>;
@@ -1092,8 +1093,9 @@ export abstract class Protocol<ContextT extends BaseContext = BaseContext, SpecT
      *   Any method string; the supplied schema validates incoming `params`. Absent or undefined
      *   `params` are normalized to `{}` (after stripping `_meta`) before validation, so for
      *   no-params methods use `z.object({})`. `paramsSchema` may be any Standard Schema (Zod,
-     *   Valibot, ArkType, etc.). When `method` is listed in this instance's
-     *   {@linkcode ProtocolSpec}, params and result types are inferred from `SpecT`.
+     *   Valibot, ArkType, etc.). The handler's `params` type is inferred from the passed
+     *   `paramsSchema`; when `method` is listed in this instance's {@linkcode ProtocolSpec},
+     *   `paramsSchema`'s input and the handler's result type are constrained by `SpecT`.
      * - **Zod schema** — `setRequestHandler(RequestZodSchema, (request, ctx) => …)`. The method
      *   name is read from the schema's `method` literal; the handler receives the parsed request.
      */
@@ -1236,8 +1238,9 @@ export abstract class Protocol<ContextT extends BaseContext = BaseContext, SpecT
      * Mirrors {@linkcode setRequestHandler}: a two-arg spec-method form (handler receives the full
      * notification object), a three-arg form with a `paramsSchema` (handler receives validated
      * `params`), and a Zod-schema form (method read from the schema's `method` literal). When the
-     * three-arg form's `method` is listed in this instance's {@linkcode ProtocolSpec}, the params
-     * type is inferred from `SpecT`.
+     * three-arg form's `method` is listed in this instance's {@linkcode ProtocolSpec},
+     * `paramsSchema`'s input is constrained by `SpecT`; the handler's `params` type is always
+     * inferred from the passed schema.
      */
     setNotificationHandler<K extends SpecNotifications<SpecT>, P extends StandardSchemaV1<_Notifications<SpecT>[K]['params']>>(
         method: K,

--- a/packages/core/src/shared/protocol.ts
+++ b/packages/core/src/shared/protocol.ts
@@ -309,9 +309,12 @@ type TimeoutInfo = {
  * Declares the request and notification vocabulary a `Protocol` subclass speaks.
  *
  * Supplying a concrete `ProtocolSpec` as `Protocol`'s second type argument gives method-name
- * autocomplete and params/result correlation on the typed overloads of `setRequestHandler`
+ * autocomplete and result-type correlation on the typed overloads of `setRequestHandler`
  * and `setNotificationHandler`. `Protocol` defaults to {@linkcode McpSpec}; using the bare
  * `ProtocolSpec` type leaves methods string-keyed and untyped.
+ *
+ * Only `requests[K].result` is enforced by the type system; `params` shapes are informational
+ * (handler param types come from the `paramsSchema` you pass at the call site).
  */
 export type ProtocolSpec = {
     requests?: Record<string, { params?: unknown; result: unknown }>;

--- a/packages/core/src/shared/protocol.ts
+++ b/packages/core/src/shared/protocol.ts
@@ -1095,11 +1095,11 @@ export abstract class Protocol<ContextT extends BaseContext = BaseContext, SpecT
      *   no-params methods use `z.object({})`. `paramsSchema` may be any Standard Schema (Zod,
      *   Valibot, ArkType, etc.). The handler's `params` type is inferred from the passed
      *   `paramsSchema`; when `method` is listed in this instance's {@linkcode ProtocolSpec},
-     *   `paramsSchema`'s input and the handler's result type are constrained by `SpecT`.
+     *   the handler's result type is constrained to `SpecT`'s declared result.
      * - **Zod schema** — `setRequestHandler(RequestZodSchema, (request, ctx) => …)`. The method
      *   name is read from the schema's `method` literal; the handler receives the parsed request.
      */
-    setRequestHandler<K extends SpecRequests<SpecT>, P extends StandardSchemaV1<_Requests<SpecT>[K]['params']>>(
+    setRequestHandler<K extends SpecRequests<SpecT>, P extends StandardSchemaV1>(
         method: K,
         paramsSchema: P,
         handler: (
@@ -1111,8 +1111,8 @@ export abstract class Protocol<ContextT extends BaseContext = BaseContext, SpecT
         method: M,
         handler: (request: RequestTypeMap[M], ctx: ContextT) => Result | Promise<Result>
     ): void;
-    setRequestHandler<P extends StandardSchemaV1>(
-        method: string,
+    setRequestHandler<M extends string, P extends StandardSchemaV1>(
+        method: M extends SpecRequests<SpecT> ? never : M,
         paramsSchema: P,
         handler: (params: StandardSchemaV1.InferOutput<P>, ctx: ContextT) => Result | Promise<Result>
     ): void;
@@ -1237,12 +1237,10 @@ export abstract class Protocol<ContextT extends BaseContext = BaseContext, SpecT
      *
      * Mirrors {@linkcode setRequestHandler}: a two-arg spec-method form (handler receives the full
      * notification object), a three-arg form with a `paramsSchema` (handler receives validated
-     * `params`), and a Zod-schema form (method read from the schema's `method` literal). When the
-     * three-arg form's `method` is listed in this instance's {@linkcode ProtocolSpec},
-     * `paramsSchema`'s input is constrained by `SpecT`; the handler's `params` type is always
-     * inferred from the passed schema.
+     * `params`), and a Zod-schema form (method read from the schema's `method` literal). The
+     * handler's `params` type is always inferred from the passed schema.
      */
-    setNotificationHandler<K extends SpecNotifications<SpecT>, P extends StandardSchemaV1<_Notifications<SpecT>[K]['params']>>(
+    setNotificationHandler<K extends SpecNotifications<SpecT>, P extends StandardSchemaV1>(
         method: K,
         paramsSchema: P,
         handler: (params: StandardSchemaV1.InferOutput<P>) => void | Promise<void>
@@ -1251,8 +1249,8 @@ export abstract class Protocol<ContextT extends BaseContext = BaseContext, SpecT
         method: M,
         handler: (notification: NotificationTypeMap[M]) => void | Promise<void>
     ): void;
-    setNotificationHandler<P extends StandardSchemaV1>(
-        method: string,
+    setNotificationHandler<M extends string, P extends StandardSchemaV1>(
+        method: M extends SpecNotifications<SpecT> ? never : M,
         paramsSchema: P,
         handler: (params: StandardSchemaV1.InferOutput<P>) => void | Promise<void>
     ): void;

--- a/packages/core/src/shared/protocol.ts
+++ b/packages/core/src/shared/protocol.ts
@@ -306,10 +306,50 @@ type TimeoutInfo = {
 };
 
 /**
+ * Declares the request and notification vocabulary a `Protocol` subclass speaks.
+ *
+ * Supplying a concrete `ProtocolSpec` as `Protocol`'s second type argument gives method-name
+ * autocomplete and params/result correlation on the typed overloads of `setRequestHandler`
+ * and `setNotificationHandler`. The default leaves them string-keyed and untyped.
+ */
+export type ProtocolSpec = {
+    requests?: Record<string, { params?: unknown; result: unknown }>;
+    notifications?: Record<string, { params?: unknown }>;
+};
+
+/**
+ * The {@linkcode ProtocolSpec} that describes the standard MCP method vocabulary, derived from
+ * {@linkcode RequestTypeMap}, {@linkcode ResultTypeMap} and {@linkcode NotificationTypeMap}.
+ */
+export type McpSpec = {
+    requests: { [M in RequestMethod]: { params: RequestTypeMap[M]['params']; result: ResultTypeMap[M] } };
+    notifications: { [M in NotificationMethod]: { params: NotificationTypeMap[M]['params'] } };
+};
+
+type _Requests<SpecT extends ProtocolSpec> = NonNullable<SpecT['requests']>;
+type _Notifications<SpecT extends ProtocolSpec> = NonNullable<SpecT['notifications']>;
+
+/**
+ * Method-name keys from a {@linkcode ProtocolSpec}'s `requests` map, or `never` for the
+ * unconstrained default `ProtocolSpec`. Making the keys `never` for the default disables the
+ * spec-typed overloads on `setRequestHandler` until the caller supplies a concrete `SpecT`.
+ */
+export type SpecRequests<SpecT extends ProtocolSpec> = string extends keyof _Requests<SpecT> ? never : keyof _Requests<SpecT> & string;
+
+/** See {@linkcode SpecRequests}. */
+export type SpecNotifications<SpecT extends ProtocolSpec> = string extends keyof _Notifications<SpecT>
+    ? never
+    : keyof _Notifications<SpecT> & string;
+
+/**
  * Implements MCP protocol framing on top of a pluggable transport, including
  * features like request/response linking, notifications, and progress.
+ *
+ * `Protocol` is abstract; `Client` and `Server` are the concrete role-specific implementations.
+ * Subclasses (such as MCP-dialect protocols like MCP Apps) can supply a {@linkcode ProtocolSpec}
+ * as the second type argument to get method-name autocomplete on their own vocabulary.
  */
-export abstract class Protocol<ContextT extends BaseContext> {
+export abstract class Protocol<ContextT extends BaseContext = BaseContext, SpecT extends ProtocolSpec = McpSpec> {
     private _transport?: Transport;
     private _requestMessageId = 0;
     private _requestHandlers: Map<string, (request: JSONRPCRequest, ctx: ContextT) => Promise<Result>> = new Map();
@@ -1052,10 +1092,19 @@ export abstract class Protocol<ContextT extends BaseContext> {
      *   Any method string; the supplied schema validates incoming `params`. Absent or undefined
      *   `params` are normalized to `{}` (after stripping `_meta`) before validation, so for
      *   no-params methods use `z.object({})`. `paramsSchema` may be any Standard Schema (Zod,
-     *   Valibot, ArkType, etc.).
+     *   Valibot, ArkType, etc.). When `method` is listed in this instance's
+     *   {@linkcode ProtocolSpec}, params and result types are inferred from `SpecT`.
      * - **Zod schema** — `setRequestHandler(RequestZodSchema, (request, ctx) => …)`. The method
      *   name is read from the schema's `method` literal; the handler receives the parsed request.
      */
+    setRequestHandler<K extends SpecRequests<SpecT>, P extends StandardSchemaV1<_Requests<SpecT>[K]['params']>>(
+        method: K,
+        paramsSchema: P,
+        handler: (
+            params: StandardSchemaV1.InferOutput<P>,
+            ctx: ContextT
+        ) => _Requests<SpecT>[K]['result'] | Promise<_Requests<SpecT>[K]['result']>
+    ): void;
     setRequestHandler<M extends RequestMethod>(
         method: M,
         handler: (request: RequestTypeMap[M], ctx: ContextT) => Result | Promise<Result>
@@ -1186,8 +1235,15 @@ export abstract class Protocol<ContextT extends BaseContext> {
      *
      * Mirrors {@linkcode setRequestHandler}: a two-arg spec-method form (handler receives the full
      * notification object), a three-arg form with a `paramsSchema` (handler receives validated
-     * `params`), and a Zod-schema form (method read from the schema's `method` literal).
+     * `params`), and a Zod-schema form (method read from the schema's `method` literal). When the
+     * three-arg form's `method` is listed in this instance's {@linkcode ProtocolSpec}, the params
+     * type is inferred from `SpecT`.
      */
+    setNotificationHandler<K extends SpecNotifications<SpecT>, P extends StandardSchemaV1<_Notifications<SpecT>[K]['params']>>(
+        method: K,
+        paramsSchema: P,
+        handler: (params: StandardSchemaV1.InferOutput<P>) => void | Promise<void>
+    ): void;
     setNotificationHandler<M extends NotificationMethod>(
         method: M,
         handler: (notification: NotificationTypeMap[M]) => void | Promise<void>

--- a/packages/core/src/shared/protocol.ts
+++ b/packages/core/src/shared/protocol.ts
@@ -309,9 +309,9 @@ type TimeoutInfo = {
  * Declares the request and notification vocabulary a `Protocol` subclass speaks.
  *
  * Supplying a concrete `ProtocolSpec` as `Protocol`'s second type argument gives method-name
- * autocomplete and result-type correlation on the typed overloads of `setRequestHandler`
- * and `setNotificationHandler`. `Protocol` defaults to {@linkcode McpSpec}; using the bare
- * `ProtocolSpec` type leaves methods string-keyed and untyped.
+ * autocomplete on the typed overloads of `setRequestHandler` and `setNotificationHandler`, and
+ * result-type correlation on `setRequestHandler`. `Protocol` defaults to {@linkcode McpSpec};
+ * using the bare `ProtocolSpec` type leaves methods string-keyed and untyped.
  *
  * Only `requests[K].result` is enforced by the type system; `params` shapes are informational
  * (handler param types come from the `paramsSchema` you pass at the call site).

--- a/packages/core/test/shared/protocolSpec.test.ts
+++ b/packages/core/test/shared/protocolSpec.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+
+import type { BaseContext, ProtocolSpec, SpecRequests } from '../../src/shared/protocol.js';
+import { Protocol } from '../../src/shared/protocol.js';
+import { InMemoryTransport } from '../../src/util/inMemory.js';
+
+class TestProtocol<SpecT extends ProtocolSpec = ProtocolSpec> extends Protocol<BaseContext, SpecT> {
+    protected assertCapabilityForMethod(): void {}
+    protected assertNotificationCapability(): void {}
+    protected assertRequestHandlerCapability(): void {}
+    protected assertTaskCapability(): void {}
+    protected assertTaskHandlerCapability(): void {}
+    protected buildContext(ctx: BaseContext): BaseContext {
+        return ctx;
+    }
+}
+
+describe('ProtocolSpec typing', () => {
+    type AppSpec = {
+        requests: {
+            'ui/open-link': { params: { url: string }; result: { opened: boolean } };
+        };
+        notifications: {
+            'ui/size-changed': { params: { width: number; height: number } };
+        };
+    };
+
+    type _Assert<T extends true> = T;
+    type _Eq<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false;
+    type _t1 = _Assert<_Eq<SpecRequests<AppSpec>, 'ui/open-link'>>;
+    type _t2 = _Assert<_Eq<SpecRequests<ProtocolSpec>, never>>;
+    void (undefined as unknown as [_t1, _t2]);
+
+    it('typed-SpecT overload infers params/result; string fallback still works', async () => {
+        const [t1, t2] = InMemoryTransport.createLinkedPair();
+        const app = new TestProtocol<AppSpec>();
+        const host = new TestProtocol<AppSpec>();
+        await app.connect(t1);
+        await host.connect(t2);
+
+        host.setRequestHandler('ui/open-link', z.object({ url: z.string() }), p => {
+            const _typed: string = p.url;
+            void _typed;
+            return { opened: true };
+        });
+        const r = await app.request({ method: 'ui/open-link', params: { url: 'https://x' } }, z.object({ opened: z.boolean() }));
+        expect(r.opened).toBe(true);
+
+        host.setRequestHandler('not/in-spec', z.object({ n: z.number() }), p => ({ doubled: p.n * 2 }));
+        const r2 = await app.request({ method: 'not/in-spec', params: { n: 3 } }, z.object({ doubled: z.number() }));
+        expect(r2.doubled).toBe(6);
+    });
+
+    it('typed-SpecT overload types handler from passed schema, not SpecT (regression)', () => {
+        type Spec = { requests: { 'x/y': { params: { a: string; b: string }; result: { ok: boolean } } } };
+        const p = new TestProtocol<Spec>();
+        const Narrow = z.object({ a: z.string() });
+        p.setRequestHandler('x/y', Narrow, params => {
+            const _a: string = params.a;
+            // @ts-expect-error -- params is InferOutput<Narrow>, has no 'b' even though Spec does
+            const _b: string = params.b;
+            void _a;
+            void _b;
+            return { ok: true };
+        });
+    });
+});

--- a/packages/core/test/shared/protocolSpec.test.ts
+++ b/packages/core/test/shared/protocolSpec.test.ts
@@ -65,4 +65,17 @@ describe('ProtocolSpec typing', () => {
             return { ok: true };
         });
     });
+
+    it('typed-SpecT setRequestHandler enforces result type (no fallthrough to loose string overload)', () => {
+        const p = new TestProtocol<AppSpec>();
+        // @ts-expect-error -- result must be { opened: boolean }; string overload is `never`-guarded for spec methods
+        p.setRequestHandler('ui/open-link', z.object({ url: z.string() }), () => ({ ok: 'wrong-type' }));
+        // @ts-expect-error -- empty object doesn't satisfy { opened: boolean }
+        p.setRequestHandler('ui/open-link', z.object({ url: z.string() }), () => ({}));
+        // non-spec methods still allow loose Result
+        p.setRequestHandler('not/in-spec', z.object({}), () => ({ anything: 1 }));
+        // notifications: spec and non-spec both allow any schema and return void
+        p.setNotificationHandler('ui/size-changed', z.object({ width: z.number(), height: z.number() }), () => {});
+        p.setNotificationHandler('not/in-spec', z.object({ x: z.number() }), () => {});
+    });
 });

--- a/packages/server/src/server/server.ts
+++ b/packages/server/src/server/server.ts
@@ -232,8 +232,13 @@ export class Server extends Protocol<ServerContext> {
         method: M,
         handler: (request: RequestTypeMap[M], ctx: ServerContext) => ResultTypeMap[M] | Promise<ResultTypeMap[M]>
     ): void;
-    public override setRequestHandler<P extends StandardSchemaV1>(
-        method: string,
+    public override setRequestHandler<M extends RequestMethod, P extends StandardSchemaV1>(
+        method: M,
+        paramsSchema: P,
+        handler: (params: StandardSchemaV1.InferOutput<P>, ctx: ServerContext) => ResultTypeMap[M] | Promise<ResultTypeMap[M]>
+    ): void;
+    public override setRequestHandler<M extends string, P extends StandardSchemaV1>(
+        method: M extends RequestMethod ? never : M,
         paramsSchema: P,
         handler: (params: StandardSchemaV1.InferOutput<P>, ctx: ServerContext) => Result | Promise<Result>
     ): void;

--- a/packages/server/test/server/setRequestHandlerSchemaParity.test.ts
+++ b/packages/server/test/server/setRequestHandlerSchemaParity.test.ts
@@ -103,4 +103,12 @@ describe('Server.setRequestHandler — Zod-schema form parity', () => {
         });
         expect(res.result).toEqual({ reply: 'hi' });
     });
+
+    it('three-arg form on Server enforces spec-method result type (no fallthrough to loose overload)', () => {
+        const s = new Server({ name: 't', version: '1.0' }, { capabilities: { tools: {} } });
+        // @ts-expect-error -- result for 'ping' must be EmptyResult-compatible; loose overload is never-guarded for spec methods
+        s.setRequestHandler('ping', z.object({}), () => ({ ok: 'wrong-type' }) as { ok: string });
+        // non-spec methods still allow loose Result
+        s.setRequestHandler('acme/custom', z.object({}), () => ({ anything: 1 }));
+    });
 });


### PR DESCRIPTION
Part of the v2 BC series — see [reviewer guide](https://gist.github.com/felixweinberger/d7a70e1b52db4a2a0851b98b453ebe3b). Stacks on #1916 (which stacks on #1891).

Exports the abstract `Protocol` class (was reachable in v1 via deep imports; ext-apps subclasses it) and adds `Protocol<ContextT, SpecT extends ProtocolSpec = McpSpec>`. Supplying a concrete `ProtocolSpec` gives method-name autocomplete and params/result correlation on the typed `setRequestHandler`/`setNotificationHandler` overloads.

## Motivation and Context

v1 exposed `Protocol` via deep imports (`sdk/shared/protocol.js`). MCP-dialect protocols (e.g., MCP Apps) subclass it. v2 omitted it from the public surface — this restores it and adds a `ProtocolSpec` type-level vocabulary.

## How Has This Been Tested?

`packages/core/test/shared/protocolSpec.test.ts` — typed-SpecT inference, `SpecRequests<ProtocolSpec> = never`, params typed by passed schema (not SpecT).

## Breaking Changes

None — additive. `Protocol` stays abstract; the second generic defaults so existing `Protocol<ContextT>` references work unchanged.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Additional context

Stacks on #1916 → #1891.
