### PR TITLE
fix: prevent duplicate Authorization header in SSE client

### DIFF
--- a/.changeset/fix-sse-duplicate-auth-header.md
+++ b/.changeset/fix-sse-duplicate-auth-header.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/client': patch
+---
+
+Fix duplicate Authorization header when using both `requestInit.headers` and `eventSourceInit.fetch`. The SDK's internal SSE fetch wrapper no longer delegates to `eventSourceInit.fetch`, preventing case-mismatch header duplication that caused `Bearer X, Bearer X` values and 401 rejections from strict servers.

--- a/packages/client/src/client/sse.ts
+++ b/packages/client/src/client/sse.ts
@@ -119,7 +119,7 @@ export class SSEClientTransport implements Transport {
     }
 
     private _startOrAuth(): Promise<void> {
-        const fetchImpl = (this?._eventSourceInit?.fetch ?? this._fetch ?? fetch) as typeof fetch;
+        const fetchImpl = (this._fetch ?? fetch) as typeof fetch;
         return new Promise((resolve, reject) => {
             this._eventSource = new EventSource(this._url.href, {
                 ...this._eventSourceInit,

--- a/packages/client/test/client/sse.test.ts
+++ b/packages/client/test/client/sse.test.ts
@@ -288,7 +288,7 @@ describe('SSEClientTransport', () => {
                     }
                     return fetch(url.toString(), {
                         ...init,
-                        headers: { ...sdkHeaders, ...closureHeaders },
+                        headers: { ...sdkHeaders, ...closureHeaders }
                     });
                 };
             }
@@ -296,7 +296,7 @@ describe('SSEClientTransport', () => {
             const headers = { Authorization: authToken };
             transport = new SSEClientTransport(resourceBaseUrl, {
                 requestInit: { headers },
-                eventSourceInit: { fetch: buildSseEventSourceFetch(headers) },
+                eventSourceInit: { fetch: buildSseEventSourceFetch(headers) }
             });
 
             await transport.start();

--- a/packages/client/test/client/sse.test.ts
+++ b/packages/client/test/client/sse.test.ts
@@ -247,25 +247,61 @@ describe('SSEClientTransport', () => {
     });
 
     describe('header handling', () => {
-        it('uses custom fetch implementation from EventSourceInit to add auth headers', async () => {
-            const authToken = 'Bearer test-token';
-
-            // Create a fetch wrapper that adds auth header
-            const fetchWithAuth = (url: string | URL, init?: RequestInit) => {
-                const headers = new Headers(init?.headers);
-                headers.set('Authorization', authToken);
-                return fetch(url.toString(), { ...init, headers });
-            };
+        it('ignores eventSourceInit.fetch for the internal SSE fetch wrapper', async () => {
+            // eventSourceInit.fetch is no longer used as the HTTP transport inside the
+            // SDK's internal SSE fetch wrapper (to avoid duplicate header injection).
+            // Users should use the top-level 'fetch' option or requestInit.headers instead.
+            const spyFetch = vi.fn(fetch);
 
             transport = new SSEClientTransport(resourceBaseUrl, {
+                requestInit: { headers: { Authorization: 'Bearer test-token' } },
                 eventSourceInit: {
-                    fetch: fetchWithAuth
+                    fetch: spyFetch
                 }
             });
 
             await transport.start();
 
-            // Verify the auth header was received by the server
+            // eventSourceInit.fetch should NOT be called as fetchImpl
+            expect(spyFetch).not.toHaveBeenCalled();
+            // The auth header from requestInit.headers should still reach the server
+            expect(lastServerRequest.headers.authorization).toBe('Bearer test-token');
+        });
+
+        it('does not duplicate Authorization header when both requestInit.headers and eventSourceInit.fetch provide it', async () => {
+            const authToken = 'Bearer my-token';
+
+            // This pattern was common before the SDK fixed _commonHeaders to include requestInit.headers.
+            // The user's custom fetch merges closure headers with init.headers using plain object spread,
+            // which caused case-mismatch duplicates (authorization vs Authorization).
+            function buildSseEventSourceFetch(closureHeaders: Record<string, string>) {
+                return (url: string | URL, init?: RequestInit) => {
+                    const sdkHeaders: Record<string, string> = {};
+                    if (init?.headers) {
+                        if (init.headers instanceof Headers) {
+                            init.headers.forEach((value: string, key: string) => {
+                                sdkHeaders[key] = value;
+                            });
+                        } else {
+                            Object.assign(sdkHeaders, init.headers);
+                        }
+                    }
+                    return fetch(url.toString(), {
+                        ...init,
+                        headers: { ...sdkHeaders, ...closureHeaders },
+                    });
+                };
+            }
+
+            const headers = { Authorization: authToken };
+            transport = new SSEClientTransport(resourceBaseUrl, {
+                requestInit: { headers },
+                eventSourceInit: { fetch: buildSseEventSourceFetch(headers) },
+            });
+
+            await transport.start();
+
+            // The server should receive exactly one Authorization value, not "Bearer my-token, Bearer my-token"
             expect(lastServerRequest.headers.authorization).toBe(authToken);
         });
 


### PR DESCRIPTION
## Summary

Fixes #1872. When both `requestInit.headers` and `eventSourceInit.fetch` provide the same `Authorization` header, the server receives a duplicated value (`Bearer X, Bearer X`) due to a case mismatch between the `Headers` instance (lowercase `authorization`) and the user's closure headers (original case `Authorization`).

- Remove `eventSourceInit.fetch` from the `fetchImpl` resolution chain in `_startOrAuth()` -- the SDK's internal wrapper already fully controls the fetch call passed to EventSource, so `fetchImpl` should use the raw transport (`opts.fetch` or global `fetch`), not the user's header-injecting wrapper
- Update existing test that relied on `eventSourceInit.fetch` being used as `fetchImpl`
- Add regression test verifying no duplicate `Authorization` header when both `requestInit.headers` and `eventSourceInit.fetch` inject the same token

## Root cause

1. `_commonHeaders()` returns a `Headers` instance which lowercases keys (`authorization`)
2. `_startOrAuth()` used `eventSourceInit.fetch` as `fetchImpl`, calling it with the `Headers` instance
3. The user's custom fetch iterates the `Headers` into a plain object (lowercase keys), then merges closure headers (original case), producing both `authorization` and `Authorization` as separate keys
4. `new Headers({ authorization: X, Authorization: X })` joins them per HTTP spec into `X, X`

## Test plan

- [x] Existing SSE tests pass (362/362)
- [x] New regression test: when `requestInit.headers` and `eventSourceInit.fetch` both set `Authorization`, server receives exactly one value
- [x] Verified `eventSourceInit.fetch` is no longer called as `fetchImpl` (spy test)
