### PR TITLE
fix: default undefined prompt arguments to empty object

### DIFF
--- a/.changeset/fix-prompt-optional-args.md
+++ b/.changeset/fix-prompt-optional-args.md
@@ -1,0 +1,5 @@
+---
+"@modelcontextprotocol/server": patch
+---
+
+Fix prompts/get rejecting omitted arguments when all argsSchema fields are optional

--- a/packages/server/src/server/mcp.ts
+++ b/packages/server/src/server/mcp.ts
@@ -1271,7 +1271,7 @@ function createPromptHandler(
         const typedCallback = callback as (args: unknown, ctx: ServerContext) => GetPromptResult | Promise<GetPromptResult>;
 
         return async (args, ctx) => {
-            const parseResult = await validateStandardSchema(argsSchema, args);
+            const parseResult = await validateStandardSchema(argsSchema, args ?? {});
             if (!parseResult.success) {
                 throw new ProtocolError(ProtocolErrorCode.InvalidParams, `Invalid arguments for prompt ${name}: ${parseResult.error}`);
             }

--- a/test/integration/test/server/mcp.test.ts
+++ b/test/integration/test/server/mcp.test.ts
@@ -4255,6 +4255,54 @@ describe('Zod v4', () => {
         });
 
         /***
+         * Test: prompts/get with omitted arguments when all argsSchema fields are optional (#1869)
+         */
+        test('should accept omitted arguments in prompts/get when all argsSchema fields are optional', async () => {
+            const mcpServer = new McpServer({
+                name: 'test server',
+                version: '1.0'
+            });
+
+            const client = new Client({
+                name: 'test client',
+                version: '1.0'
+            });
+
+            mcpServer.registerPrompt(
+                'echo',
+                {
+                    argsSchema: z.object({
+                        context: z.string().optional()
+                    })
+                },
+                ({ context }) => ({
+                    messages: [
+                        {
+                            role: 'user' as const,
+                            content: { type: 'text' as const, text: `context: ${context ?? 'none'}` }
+                        }
+                    ]
+                })
+            );
+
+            const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+            await Promise.all([client.connect(clientTransport), mcpServer.server.connect(serverTransport)]);
+
+            // Call prompts/get without arguments -- should not throw
+            const result = await client.request({
+                method: 'prompts/get',
+                params: { name: 'echo' }
+            });
+
+            expect(result.messages).toHaveLength(1);
+            expect(result.messages[0]!.content).toEqual({
+                type: 'text',
+                text: 'context: none'
+            });
+        });
+
+        /***
          * Test: Prompt Registration with _meta field
          */
         test('should register prompt with _meta field and include it in list response', async () => {


### PR DESCRIPTION
## Summary
- Fixes `prompts/get` rejecting requests with omitted `arguments` when all `argsSchema` fields are optional
- Mirrors the same `?? {}` defensive pattern that #1404 applied to the tools handler, now applied to the prompts handler in `createPromptHandler`
- Adds an integration test that calls `prompts/get` without `arguments` against a prompt with all-optional schema fields

Closes #1869