### PR TITLE
fix: accept null introspection_endpoint in OAuthMetadataSchema

### DIFF
--- a/packages/core/src/shared/auth.ts
+++ b/packages/core/src/shared/auth.ts
@@ -62,7 +62,7 @@ export const OAuthMetadataSchema = z.looseObject({
     revocation_endpoint: SafeUrlSchema.optional(),
     revocation_endpoint_auth_methods_supported: z.array(z.string()).optional(),
     revocation_endpoint_auth_signing_alg_values_supported: z.array(z.string()).optional(),
-    introspection_endpoint: z.string().optional(),
+    introspection_endpoint: z.string().nullish(),
     introspection_endpoint_auth_methods_supported: z.array(z.string()).optional(),
     introspection_endpoint_auth_signing_alg_values_supported: z.array(z.string()).optional(),
     code_challenge_methods_supported: z.array(z.string()).optional(),


### PR DESCRIPTION
## Problem

Some OAuth authorization servers return `introspection_endpoint: null` in their `/.well-known/oauth-authorization-server` metadata rather than omitting the field entirely. This is valid per [RFC 7662](https://www.rfc-editor.org/rfc/rfc7662) — the field is optional and `null` should be treated the same as absent.

The current schema uses `z.string().optional()` which accepts `undefined` but rejects `null`, causing OAuth flow initiation to fail with:

```
Invalid input: expected string, received null
  path: ["introspection_endpoint"]
```

## Fix

Change `z.string().optional()` to `z.string().nullish()` for `introspection_endpoint`. This accepts `string | null | undefined`, correctly handling servers that explicitly set the field to `null`.

## Reproduction

Connect any MCP client to an OAuth server whose `/.well-known/oauth-authorization-server` returns `"introspection_endpoint": null`. The OAuth flow fails immediately at metadata validation before the authorization redirect is attempted.

Example metadata that triggers the bug:
```json
{
  "issuer": "https://example.com",
  "authorization_endpoint": "https://example.com/oauth/authorize",
  "token_endpoint": "https://example.com/oauth/token",
  "introspection_endpoint": null,
  "registration_endpoint": "https://example.com/oauth/register"
}
```