### PR TITLE
fix(sse): escape U+2028 / U+2029 in SSE data lines (V1)

### DIFF
--- a/.changeset/fix-sse-u2028-u2029-escaping.md
+++ b/.changeset/fix-sse-u2028-u2029-escaping.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/sdk': patch
+---
+
+Escape `U+2028` (LINE SEPARATOR) and `U+2029` (PARAGRAPH SEPARATOR) in `WebStandardStreamableHTTPServerTransport` and `SSEServerTransport` SSE `data:` lines. `JSON.stringify` leaves these codepoints unescaped, but many SSE client parsers treat them as line terminators and truncate the frame mid-JSON, which made tool calls silently hang on the client whenever a response contained either character.

--- a/.changeset/fix-sse-u2028-u2029-escaping.md
+++ b/.changeset/fix-sse-u2028-u2029-escaping.md
@@ -2,4 +2,5 @@
 '@modelcontextprotocol/sdk': patch
 ---
 
-Escape `U+2028` (LINE SEPARATOR) and `U+2029` (PARAGRAPH SEPARATOR) in `WebStandardStreamableHTTPServerTransport` and `SSEServerTransport` SSE `data:` lines. `JSON.stringify` leaves these codepoints unescaped, but many SSE client parsers treat them as line terminators and truncate the frame mid-JSON, which made tool calls silently hang on the client whenever a response contained either character.
+Escape `U+2028` (LINE SEPARATOR) and `U+2029` (PARAGRAPH SEPARATOR) in `WebStandardStreamableHTTPServerTransport` and `SSEServerTransport` SSE `data:` lines. `JSON.stringify` leaves these codepoints unescaped, but many SSE client parsers treat them as line terminators and
+truncate the frame mid-JSON, which made tool calls silently hang on the client whenever a response contained either character.

--- a/src/server/sse.ts
+++ b/src/server/sse.ts
@@ -215,7 +215,10 @@ export class SSEServerTransport implements Transport {
             throw new Error('Not connected');
         }
 
-        this._sseResponse.write(`event: message\ndata: ${JSON.stringify(message)}\n\n`);
+        const safeJson = JSON.stringify(message)
+            .replace(/\u2028/g, '\\u2028')
+            .replace(/\u2029/g, '\\u2029');
+        this._sseResponse.write(`event: message\ndata: ${safeJson}\n\n`);
     }
 
     /**

--- a/src/server/webStandardStreamableHttp.ts
+++ b/src/server/webStandardStreamableHttp.ts
@@ -558,7 +558,10 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
             if (eventId) {
                 eventData += `id: ${eventId}\n`;
             }
-            eventData += `data: ${JSON.stringify(message)}\n\n`;
+            const safeJson = JSON.stringify(message)
+                .replace(/\u2028/g, '\\u2028')
+                .replace(/\u2029/g, '\\u2029');
+            eventData += `data: ${safeJson}\n\n`;
             controller.enqueue(encoder.encode(eventData));
             return true;
         } catch (error) {

--- a/test/server/streamableHttp.test.ts
+++ b/test/server/streamableHttp.test.ts
@@ -380,6 +380,58 @@ describe.each(zodTestMatrix)('$zodVersionLabel', (entry: ZodMatrixEntry) => {
             });
         });
 
+        it('should escape U+2028 and U+2029 in SSE data lines', async () => {
+            mcpServer.tool(
+                'emit-line-separators',
+                'Emits a string containing U+2028 and U+2029',
+                {},
+                async (): Promise<CallToolResult> => {
+                    return {
+                        content: [
+                            {
+                                type: 'text',
+                                text: 'before\u2028middle\u2029after'
+                            }
+                        ]
+                    };
+                }
+            );
+
+            sessionId = await initializeServer();
+
+            const toolCallMessage: JSONRPCMessage = {
+                jsonrpc: '2.0',
+                method: 'tools/call',
+                params: { name: 'emit-line-separators', arguments: {} },
+                id: 'ls-1'
+            };
+
+            const response = await sendPostRequest(baseUrl, toolCallMessage, sessionId);
+            expect(response.status).toBe(200);
+
+            const rawEvent = await readSSEEvent(response);
+
+            // Literal U+2028/U+2029 MUST NOT appear on the wire — they
+            // must have been escaped to the JSON literals `\u2028` / `\u2029`.
+            expect(rawEvent).not.toContain('\u2028');
+            expect(rawEvent).not.toContain('\u2029');
+            expect(rawEvent).toContain('\\u2028');
+            expect(rawEvent).toContain('\\u2029');
+
+            // Content still round-trips after JSON.parse.
+            const eventLines = rawEvent.split('\n');
+            const dataLine = eventLines.find(line => line.startsWith('data:'));
+            expect(dataLine).toBeDefined();
+            const eventData = JSON.parse(dataLine!.substring(5));
+            expect(eventData).toMatchObject({
+                jsonrpc: '2.0',
+                id: 'ls-1',
+                result: {
+                    content: [{ type: 'text', text: 'before\u2028middle\u2029after' }]
+                }
+            });
+        });
+
         /***
          * Test: Tool With Request Info
          */

--- a/test/server/streamableHttp.test.ts
+++ b/test/server/streamableHttp.test.ts
@@ -381,21 +381,16 @@ describe.each(zodTestMatrix)('$zodVersionLabel', (entry: ZodMatrixEntry) => {
         });
 
         it('should escape U+2028 and U+2029 in SSE data lines', async () => {
-            mcpServer.tool(
-                'emit-line-separators',
-                'Emits a string containing U+2028 and U+2029',
-                {},
-                async (): Promise<CallToolResult> => {
-                    return {
-                        content: [
-                            {
-                                type: 'text',
-                                text: 'before\u2028middle\u2029after'
-                            }
-                        ]
-                    };
-                }
-            );
+            mcpServer.tool('emit-line-separators', 'Emits a string containing U+2028 and U+2029', {}, async (): Promise<CallToolResult> => {
+                return {
+                    content: [
+                        {
+                            type: 'text',
+                            text: 'before\u2028middle\u2029after'
+                        }
+                    ]
+                };
+            });
 
             sessionId = await initializeServer();
 


### PR DESCRIPTION
This PR has a `v2` equivalent https://github.com/modelcontextprotocol/typescript-sdk/pull/1925

Escape `U+2028` (LINE SEPARATOR) and `U+2029` (PARAGRAPH SEPARATOR) in SSE `data:` lines emitted by `WebStandardStreamableHTTPServerTransport`.


## Motivation and Context
`JSON.stringify` leaves `U+2028` / `U+2029` unescaped, they are valid inside JSON strings. But many SSE client parsers (including in Claude Desktop and ChatGPT) treat them as line terminators. When a tool response contains either codepoint, the receiver truncates the `data:` line mid-JSON, fails to parse silently, and the tool call appears to hang forever on the client side.
The SSE spec ([WHATWG HTML](https://html.spec.whatwg.org/multipage/server-sent-events.html#parsing-an-event-stream)) only defines LF/CR/CRLF as line terminators, so strictly this is a client parser bug. The Python SDK hit the same issue (modelcontextprotocol/python-sdk#1356) and shipped a fix in its client parser (`httpx-sse` 0.4.2).
Reproduced end-to-end against an mcp-use server whose Algolia-backed tool returned a candidate whose `skills` field contained a literal `U+2028` 

## How Has This Been Tested?
- New regression test in `packages/server/test/server/streamableHttp.test.ts`: registers a tool returning `"before\u2028middle\u2029after"`, asserts the literal codepoints do not appear on the wire, asserts the escaped forms do, and asserts `JSON.parse` of the `data:` line round-trips to the original string.
- `pnpm --filter @modelcontextprotocol/server test` → 41/41 in `streamableHttp.test.ts`, 56/56 across the package.
- `pnpm test:all` → green across all packages and the 422-test integration suite. (One pre-existing `better-sqlite3` native-binding failure in `examples/shared` on my machine is reproducible on clean `origin/main` and unrelated to this PR.)
- `pnpm lint:all` clean.
- Manually reproduced end-to-end against the affected mcp-use server: before → widget hangs at `isPending: true`; after → tool result surfaces and widget renders normally.
- 
## Breaking Changes
None. The escape is invisible to SSE-spec-compliant clients (`JSON.parse` reinflates `\u2028` / `\u2029` back to the original codepoints). Non-compliant clients that previously truncated on these codepoints now receive the full payload.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
Scope intentionally narrow: only the SSE framing in `WebStandardStreamableHTTPServerTransport.writeSSEEvent` is touched. The JSON-response path (`enableJsonResponse`) is unaffected 

Related:

- python-sdk issue: https://github.com/modelcontextprotocol/python-sdk/issues/1356
- `httpx-sse` client-side fix: https://github.com/florimondmanca/httpx-sse/issues/34