### PR TITLE
fix(tasks): retrieve stored result for failed tasks in requestStream

### DIFF
--- a/packages/core/src/shared/taskManager.ts
+++ b/packages/core/src/shared/taskManager.ts
@@ -308,7 +308,8 @@ export class TaskManager {
                             break;
                         }
                         case 'failed': {
-                            yield { type: 'error', error: new ProtocolError(ProtocolErrorCode.InternalError, `Task ${taskId} failed`) };
+                            const result = await this.getTaskResult({ taskId }, resultSchema, options);
+                            yield { type: 'result', result };
                             break;
                         }
                         case 'cancelled': {


### PR DESCRIPTION
When `requestStream()` encounters a task with `failed` status, it yields a hardcoded `ProtocolError("Task <id> failed")` instead of calling `tasks/result` to retrieve the error the server stored.

The `completed` branch (and `input_required`) already call `getTaskResult()` correctly. This change makes `failed` do the same, so the real stored result (including `isError: true` content) is returned to the caller instead of being discarded.

Fixes #1922