### PR TITLE
[v1.x backport] fix(server): validate wrapped outputSchema

### DIFF
--- a/src/server/mcp.ts
+++ b/src/server/mcp.ts
@@ -306,8 +306,9 @@ export class McpServer {
         }
 
         // if the tool has an output schema, validate structured content
-        const outputObj = normalizeObjectSchema(tool.outputSchema) as AnyObjectSchema;
-        const parseResult = await safeParseAsync(outputObj, result.structuredContent);
+        const outputObj = normalizeObjectSchema(tool.outputSchema);
+        const schemaToParse = outputObj ?? (tool.outputSchema as AnySchema);
+        const parseResult = await safeParseAsync(schemaToParse, result.structuredContent);
         if (!parseResult.success) {
             const error = 'error' in parseResult ? parseResult.error : 'Unknown error';
             const errorMessage = getParseErrorMessage(error);

--- a/test/server/mcp.test.ts
+++ b/test/server/mcp.test.ts
@@ -1295,6 +1295,74 @@ describe.each(zodTestMatrix)('$zodVersionLabel', (entry: ZodMatrixEntry) => {
             expect(JSON.parse(textContent.text)).toEqual(result.structuredContent);
         });
 
+        test('should support wrapped outputSchema variants', async () => {
+            const cases = [
+                {
+                    label: 'optional',
+                    outputSchema: z.object({ data: z.string() }).optional(),
+                    structuredContent: { data: 'hello' }
+                },
+                {
+                    label: 'nullable',
+                    outputSchema: z.object({ data: z.string() }).nullable(),
+                    structuredContent: { data: 'hello' }
+                },
+                {
+                    label: 'nullish',
+                    outputSchema: z.object({ data: z.string() }).nullish(),
+                    structuredContent: { data: 'hello' }
+                },
+                {
+                    label: 'union',
+                    outputSchema: z.union([z.object({ data: z.string() }), z.object({ value: z.string() })]),
+                    structuredContent: { data: 'hello' }
+                }
+            ] as const;
+
+            for (const { label, outputSchema, structuredContent } of cases) {
+                const mcpServer = new McpServer({
+                    name: `test server ${label}`,
+                    version: '1.0'
+                });
+
+                const client = new Client({
+                    name: `test client ${label}`,
+                    version: '1.0'
+                });
+
+                mcpServer.registerTool(
+                    `test-${label}`,
+                    {
+                        description: `Test tool with ${label} output schema`,
+                        outputSchema
+                    },
+                    async () => ({
+                        content: [],
+                        structuredContent
+                    })
+                );
+
+                const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+                await Promise.all([client.connect(clientTransport), mcpServer.server.connect(serverTransport)]);
+
+                try {
+                    await expect(
+                        client.callTool({
+                            name: `test-${label}`,
+                            arguments: {}
+                        })
+                    ).resolves.toMatchObject({
+                        content: [],
+                        structuredContent
+                    });
+                } finally {
+                    await client.close();
+                    await mcpServer.server.close();
+                }
+            }
+        });
+
         /***
          * Test: Tool with Output Schema Must Provide Structured Content
          */


### PR DESCRIPTION
Fixes #1308.

On `v1.x`, `validateToolOutput()` still assumes every `outputSchema` can be normalized to an object schema before validation. That holds for raw shapes and plain `z.object(...)`, but wrapped schemas like `.optional()`, `.nullable()`, `.nullish()`, and top-level `z.union(...)` normalize to `undefined`, so tool calls fail with `Cannot read properties of undefined (reading '_zod')`.

This keeps the existing normalization path for raw shapes / object schemas and falls back to the original schema when normalization does not return an object, matching how tool input validation already works on this branch. The regression test covers the wrapped schema variants across both Zod matrices.

Validation:
- `npx vitest run test/server/mcp.test.ts -t 'should support wrapped outputSchema variants'`
- `npx vitest run test/server/mcp.test.ts -t 'outputSchema'`
- `npx eslint src/server/mcp.ts`
- `npx prettier --check src/server/mcp.ts test/server/mcp.test.ts`