### PR TITLE
fix(core): skip cancellation notification for initialize requests

### DIFF
--- a/.changeset/fix-initialize-cancellation.md
+++ b/.changeset/fix-initialize-cancellation.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/core': patch
+---
+
+Do not send `notifications/cancelled` for `initialize` requests. Per the MCP specification, clients must not cancel the `initialize` request; when the caller aborts or times out during `connect()`, the promise still rejects locally but the wire notification is no longer emitted.

--- a/packages/core/src/shared/protocol.ts
+++ b/packages/core/src/shared/protocol.ts
@@ -846,19 +846,23 @@ export abstract class Protocol<ContextT extends BaseContext> {
             const cancel = (reason: unknown) => {
                 this._progressHandlers.delete(messageId);
 
-                this._transport
-                    ?.send(
-                        {
-                            jsonrpc: '2.0',
-                            method: 'notifications/cancelled',
-                            params: {
-                                requestId: messageId,
-                                reason: String(reason)
-                            }
-                        },
-                        { relatedRequestId, resumptionToken, onresumptiontoken }
-                    )
-                    .catch(error => this._onerror(new Error(`Failed to send cancellation: ${error}`)));
+                // Per the MCP spec, the `initialize` request MUST NOT be cancelled by clients.
+                // Abort/timeout still rejects the promise locally; we just skip the wire notification.
+                if (request.method !== 'initialize') {
+                    this._transport
+                        ?.send(
+                            {
+                                jsonrpc: '2.0',
+                                method: 'notifications/cancelled',
+                                params: {
+                                    requestId: messageId,
+                                    reason: String(reason)
+                                }
+                            },
+                            { relatedRequestId, resumptionToken, onresumptiontoken }
+                        )
+                        .catch(error => this._onerror(new Error(`Failed to send cancellation: ${error}`)));
+                }
 
                 // Wrap the reason in an SdkError if it isn't already
                 const error = reason instanceof SdkError ? reason : new SdkError(SdkErrorCode.RequestTimeout, String(reason));

--- a/packages/core/test/shared/protocol.test.ts
+++ b/packages/core/test/shared/protocol.test.ts
@@ -305,6 +305,63 @@ describe('protocol tests', () => {
         expect(removeSpy).toHaveBeenCalledWith('abort', expect.any(Function));
     });
 
+    describe('initialize request cancellation', () => {
+        test('should not send notifications/cancelled when an initialize request is aborted', async () => {
+            await protocol.connect(transport);
+
+            const controller = new AbortController();
+            const mockSchema = z.object({ result: z.string() });
+            const reqPromise = testRequest(protocol, { method: 'initialize', params: {} }, mockSchema, {
+                signal: controller.signal
+            });
+
+            controller.abort('User cancelled');
+            await expect(reqPromise).rejects.toThrow();
+
+            const cancelledSends = sendSpy.mock.calls.filter(([message]) => {
+                const m = message as Partial<JSONRPCNotification>;
+                return m?.method === 'notifications/cancelled';
+            });
+            expect(cancelledSends).toHaveLength(0);
+        });
+
+        test('should not send notifications/cancelled when an initialize request times out', async () => {
+            await protocol.connect(transport);
+
+            const mockSchema = z.object({ result: z.string() });
+            await expect(
+                testRequest(protocol, { method: 'initialize', params: {} }, mockSchema, {
+                    timeout: 0
+                })
+            ).rejects.toThrow();
+
+            const cancelledSends = sendSpy.mock.calls.filter(([message]) => {
+                const m = message as Partial<JSONRPCNotification>;
+                return m?.method === 'notifications/cancelled';
+            });
+            expect(cancelledSends).toHaveLength(0);
+        });
+
+        test('should still send notifications/cancelled for non-initialize requests', async () => {
+            await protocol.connect(transport);
+
+            const controller = new AbortController();
+            const mockSchema = z.object({ result: z.string() });
+            const reqPromise = testRequest(protocol, { method: 'example', params: {} }, mockSchema, {
+                signal: controller.signal
+            });
+
+            controller.abort('User cancelled');
+            await expect(reqPromise).rejects.toThrow();
+
+            const cancelledSends = sendSpy.mock.calls.filter(([message]) => {
+                const m = message as Partial<JSONRPCNotification>;
+                return m?.method === 'notifications/cancelled';
+            });
+            expect(cancelledSends).toHaveLength(1);
+        });
+    });
+
     test('should not overwrite existing hooks when connecting transports', async () => {
         const oncloseMock = vi.fn();
         const onerrorMock = vi.fn();


### PR DESCRIPTION
## Summary

Fixes #998.

Per the MCP specification, clients must not cancel the `initialize` request:

> A client MUST NOT attempt to cancel its `initialize` request.
> (`cancellation.mdx §2`, mirrored in `packages/core/src/types/types.ts`)

Before this change, when `Client.connect()` received an `AbortSignal` that later aborted, or when the initialize request timed out, `Protocol._requestWithSchema` unconditionally sent `notifications/cancelled` to the server for the in-flight `initialize` request.

## Fix

In `cancel()` inside `_requestWithSchema` (`packages/core/src/shared/protocol.ts`), guard the outbound `notifications/cancelled` send on `request.method !== 'initialize'`. The abort/reject path is unchanged — the caller's promise still rejects with the supplied reason — only the wire notification is suppressed for `initialize`.

## Tests

Added three cases in `packages/core/test/shared/protocol.test.ts` under a new `initialize request cancellation` describe block:

- aborting an initialize request does not send `notifications/cancelled`
- timing out an initialize request does not send `notifications/cancelled`
- aborting a non-initialize request still sends `notifications/cancelled` (regression guard)

## Test plan

- [x] `pnpm typecheck:all`
- [x] `pnpm lint:all`
- [x] `pnpm test:all` (all packages green, 492/492 in core)
- [x] `pnpm build:all`