### PR TITLE
fix(client): prevent duplicate Auth headers in SSE transport

### DIFF
--- a/.changeset/fix-sse-duplicate-headers.md
+++ b/.changeset/fix-sse-duplicate-headers.md
@@ -1,0 +1,7 @@
+---
+'@modelcontextprotocol/client': patch
+---
+
+fix(sse): avoid passing entire init object to custom fetch to prevent duplicate headers
+
+When `eventSourceInit.fetch` provides a custom fetch implementation, only pass `signal` from `init` rather than spreading the entire `init` object. This prevents duplicate `Authorization` headers caused by the `Headers` instance from `_commonHeaders()` being mixed with user-provided headers through object spread.

--- a/packages/client/src/client/sse.ts
+++ b/packages/client/src/client/sse.ts
@@ -127,8 +127,8 @@ export class SSEClientTransport implements Transport {
                     const headers = await this._commonHeaders();
                     headers.set('Accept', 'text/event-stream');
                     const response = await fetchImpl(url, {
-                        ...init,
-                        headers
+                        signal: init?.signal,
+                        headers,
                     });
 
                     if (response.status === 401) {

--- a/packages/client/src/client/sse.ts
+++ b/packages/client/src/client/sse.ts
@@ -128,7 +128,7 @@ export class SSEClientTransport implements Transport {
                     headers.set('Accept', 'text/event-stream');
                     const response = await fetchImpl(url, {
                         signal: init?.signal,
-                        headers,
+                        headers
                     });
 
                     if (response.status === 401) {


### PR DESCRIPTION
Fixes SSE client spreading entire init object + explicit headers causing Headers merge issue with duplicate Auth.

Closes #1872