### PR TITLE
feat(server): add icons field to registerTool()

### DIFF
--- a/.changeset/add-registerTool-icons.md
+++ b/.changeset/add-registerTool-icons.md
@@ -1,0 +1,5 @@
+---
+"@modelcontextprotocol/server": patch
+---
+
+feat(server): add `icons` field support to `registerTool()` and `registerToolTask()` — icons are now forwarded to the protocol layer and included in tool list responses

--- a/packages/server/src/experimental/tasks/mcpServer.ts
+++ b/packages/server/src/experimental/tasks/mcpServer.ts
@@ -5,7 +5,7 @@
  * @experimental
  */
 
-import type { StandardSchemaWithJSON, TaskToolExecution, ToolAnnotations, ToolExecution } from '@modelcontextprotocol/core';
+import type { Icon, StandardSchemaWithJSON, TaskToolExecution, ToolAnnotations, ToolExecution } from '@modelcontextprotocol/core';
 
 import type { AnyToolHandler, McpServer, RegisteredTool } from '../../server/mcp.js';
 import type { ToolTaskHandler } from './interfaces.js';
@@ -24,6 +24,7 @@ interface McpServerInternal {
         annotations: ToolAnnotations | undefined,
         execution: ToolExecution | undefined,
         _meta: Record<string, unknown> | undefined,
+        icons: Icon[] | undefined,
         handler: AnyToolHandler<StandardSchemaWithJSON | undefined>
     ): RegisteredTool;
 }
@@ -85,6 +86,7 @@ export class ExperimentalMcpServerTasks {
             annotations?: ToolAnnotations;
             execution?: TaskToolExecution;
             _meta?: Record<string, unknown>;
+            icons?: Icon[];
         },
         handler: ToolTaskHandler<undefined>
     ): RegisteredTool;
@@ -99,6 +101,7 @@ export class ExperimentalMcpServerTasks {
             annotations?: ToolAnnotations;
             execution?: TaskToolExecution;
             _meta?: Record<string, unknown>;
+            icons?: Icon[];
         },
         handler: ToolTaskHandler<InputArgs>
     ): RegisteredTool;
@@ -113,6 +116,7 @@ export class ExperimentalMcpServerTasks {
             annotations?: ToolAnnotations;
             execution?: TaskToolExecution;
             _meta?: Record<string, unknown>;
+            icons?: Icon[];
         },
         handler: ToolTaskHandler<InputArgs>
     ): RegisteredTool {
@@ -133,6 +137,7 @@ export class ExperimentalMcpServerTasks {
             config.annotations,
             execution,
             config._meta,
+            config.icons,
             handler as AnyToolHandler<StandardSchemaWithJSON | undefined>
         );
     }

--- a/packages/server/src/server/mcp.ts
+++ b/packages/server/src/server/mcp.ts
@@ -1,6 +1,7 @@
 import type {
     BaseMetadata,
     CallToolRequest,
+    Icon,
     CallToolResult,
     CompleteRequestPrompt,
     CompleteRequestResourceTemplate,
@@ -146,6 +147,7 @@ export class McpServer {
                                 : EMPTY_OBJECT_JSON_SCHEMA,
                             annotations: tool.annotations,
                             execution: tool.execution,
+                            icons: tool.icons,
                             _meta: tool._meta
                         };
 
@@ -773,6 +775,7 @@ export class McpServer {
         annotations: ToolAnnotations | undefined,
         execution: ToolExecution | undefined,
         _meta: Record<string, unknown> | undefined,
+        icons: Icon[] | undefined,
         handler: AnyToolHandler<StandardSchemaWithJSON | undefined>
     ): RegisteredTool {
         // Validate tool name according to SEP specification
@@ -789,6 +792,7 @@ export class McpServer {
             annotations,
             execution,
             _meta,
+            icons,
             handler: handler,
             executor: createToolExecutor(inputSchema, handler),
             enabled: true,
@@ -871,6 +875,7 @@ export class McpServer {
             outputSchema?: OutputArgs;
             annotations?: ToolAnnotations;
             _meta?: Record<string, unknown>;
+            icons?: Icon[];
         },
         cb: ToolCallback<InputArgs>
     ): RegisteredTool {
@@ -878,7 +883,7 @@ export class McpServer {
             throw new Error(`Tool ${name} is already registered`);
         }
 
-        const { title, description, inputSchema, outputSchema, annotations, _meta } = config;
+        const { title, description, inputSchema, outputSchema, annotations, _meta, icons } = config;
 
         return this._createRegisteredTool(
             name,
@@ -889,6 +894,7 @@ export class McpServer {
             annotations,
             { taskSupport: 'forbidden' },
             _meta,
+            icons,
             cb as ToolCallback<StandardSchemaWithJSON | undefined>
         );
     }
@@ -1097,6 +1103,7 @@ export type RegisteredTool = {
     annotations?: ToolAnnotations;
     execution?: ToolExecution;
     _meta?: Record<string, unknown>;
+    icons?: Icon[];
     handler: AnyToolHandler<StandardSchemaWithJSON | undefined>;
     /** @hidden */
     executor: ToolExecutor;
@@ -1111,6 +1118,7 @@ export type RegisteredTool = {
         outputSchema?: StandardSchemaWithJSON;
         annotations?: ToolAnnotations;
         _meta?: Record<string, unknown>;
+        icons?: Icon[];
         callback?: ToolCallback<StandardSchemaWithJSON>;
         enabled?: boolean;
     }): void;


### PR DESCRIPTION
Fixes registerTool() config type and _createRegisteredTool() omitting icons parameter; tools/list handler now includes icons in Tool serialization.

Closes #1864