### PR TITLE
fix(server): handle undefined args in prompts handler

### DIFF
--- a/.changeset/fix-prompts-handle-undefined-args.md
+++ b/.changeset/fix-prompts-handle-undefined-args.md
@@ -1,0 +1,7 @@
+---
+'@modelcontextprotocol/server': patch
+---
+
+fix(server): handle undefined args in prompt handlers with all-optional schemas
+
+When a prompt has an argsSchema where all fields are optional, the LLM may omit the arguments entirely (undefined). `validateStandardSchema(undefined)` fails validation. Fix by using `args ?? {}` as the defensive fallback, matching the pattern already applied to tool handlers in PR #1404.

--- a/packages/server/src/server/mcp.ts
+++ b/packages/server/src/server/mcp.ts
@@ -1271,7 +1271,7 @@ function createPromptHandler(
         const typedCallback = callback as (args: unknown, ctx: ServerContext) => GetPromptResult | Promise<GetPromptResult>;
 
         return async (args, ctx) => {
-            const parseResult = await validateStandardSchema(argsSchema, args);
+            const parseResult = await validateStandardSchema(argsSchema, args ?? {});
             if (!parseResult.success) {
                 throw new ProtocolError(ProtocolErrorCode.InvalidParams, `Invalid arguments for prompt ${name}: ${parseResult.error}`);
             }


### PR DESCRIPTION
Fixes prompts handler validating undefined args when all fields optional, mirrors PR #1404 pattern for tools.

Closes #1869