### PR TITLE
fix(core): handle task failed result properly

### DIFF
--- a/.changeset/fix-task-failed-result.md
+++ b/.changeset/fix-task-failed-result.md
@@ -1,0 +1,5 @@
+---
+"@modelcontextprotocol/core": patch
+---
+
+Fix task requestStream to return underlying task result on failed status instead of generic error. Closes #1922

--- a/packages/core/src/shared/taskManager.ts
+++ b/packages/core/src/shared/taskManager.ts
@@ -308,7 +308,8 @@ export class TaskManager {
                             break;
                         }
                         case 'failed': {
-                            yield { type: 'error', error: new ProtocolError(ProtocolErrorCode.InternalError, `Task ${taskId} failed`) };
+                            const result = await this.getTaskResult({ taskId }, resultSchema, options);
+                            yield { type: 'result', result };
                             break;
                         }
                         case 'cancelled': {


### PR DESCRIPTION
Fixes task failed result handling in taskManager.

Closes #1922