### PR TITLE
[v1.x backport] fix(server): respect explicit listChanged: false in McpServer

### DIFF
--- a/.changeset/fix-listchanged-backport.md
+++ b/.changeset/fix-listchanged-backport.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/sdk': patch
+---
+
+Respected explicit `listChanged: false` capability settings in `McpServer`. Previously, registering a tool, resource, or prompt would unconditionally overwrite `listChanged` to `true`, ignoring any explicit `false` set at construction time.

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -464,7 +464,10 @@ export class Server<
         return this._clientVersion;
     }
 
-    private getCapabilities(): ServerCapabilities {
+    /**
+     * Returns the current server capabilities.
+     */
+    public getCapabilities(): ServerCapabilities {
         return this._capabilities;
     }
 

--- a/src/server/mcp.ts
+++ b/src/server/mcp.ts
@@ -131,7 +131,7 @@ export class McpServer {
 
         this.server.registerCapabilities({
             tools: {
-                listChanged: true
+                listChanged: this.server.getCapabilities().tools?.listChanged ?? true
             }
         });
 
@@ -493,7 +493,7 @@ export class McpServer {
 
         this.server.registerCapabilities({
             resources: {
-                listChanged: true
+                listChanged: this.server.getCapabilities().resources?.listChanged ?? true
             }
         });
 
@@ -573,7 +573,7 @@ export class McpServer {
 
         this.server.registerCapabilities({
             prompts: {
-                listChanged: true
+                listChanged: this.server.getCapabilities().prompts?.listChanged ?? true
             }
         });
 

--- a/test/server/mcp.test.ts
+++ b/test/server/mcp.test.ts
@@ -281,10 +281,7 @@ describe.each(zodTestMatrix)('$zodVersionLabel', (entry: ZodMatrixEntry) => {
          * Test: listChanged capability should respect explicit false setting
          */
         test('should respect tools.listChanged: false when explicitly set', async () => {
-            const mcpServer = new McpServer(
-                { name: 'test server', version: '1.0' },
-                { capabilities: { tools: { listChanged: false } } }
-            );
+            const mcpServer = new McpServer({ name: 'test server', version: '1.0' }, { capabilities: { tools: { listChanged: false } } });
             const client = new Client({
                 name: 'test client',
                 version: '1.0'
@@ -314,14 +311,9 @@ describe.each(zodTestMatrix)('$zodVersionLabel', (entry: ZodMatrixEntry) => {
                 version: '1.0'
             });
 
-            mcpServer.registerResource(
-                'test',
-                'test://resource',
-                {},
-                async () => ({
-                    contents: [{ uri: 'test://resource', text: 'Test', mimeType: 'text/plain' }]
-                })
-            );
+            mcpServer.registerResource('test', 'test://resource', {}, async () => ({
+                contents: [{ uri: 'test://resource', text: 'Test', mimeType: 'text/plain' }]
+            }));
 
             const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
             await Promise.all([client.connect(clientTransport), mcpServer.connect(serverTransport)]);
@@ -334,22 +326,15 @@ describe.each(zodTestMatrix)('$zodVersionLabel', (entry: ZodMatrixEntry) => {
          * Test: prompts.listChanged should respect explicit false setting
          */
         test('should respect prompts.listChanged: false when explicitly set', async () => {
-            const mcpServer = new McpServer(
-                { name: 'test server', version: '1.0' },
-                { capabilities: { prompts: { listChanged: false } } }
-            );
+            const mcpServer = new McpServer({ name: 'test server', version: '1.0' }, { capabilities: { prompts: { listChanged: false } } });
             const client = new Client({
                 name: 'test client',
                 version: '1.0'
             });
 
-            mcpServer.registerPrompt(
-                'test-prompt',
-                {},
-                async () => ({
-                    messages: [{ role: 'assistant', content: { type: 'text', text: 'Test' } }]
-                })
-            );
+            mcpServer.registerPrompt('test-prompt', {}, async () => ({
+                messages: [{ role: 'assistant', content: { type: 'text', text: 'Test' } }]
+            }));
 
             const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
             await Promise.all([client.connect(clientTransport), mcpServer.connect(serverTransport)]);

--- a/test/server/mcp.test.ts
+++ b/test/server/mcp.test.ts
@@ -252,6 +252,111 @@ describe.each(zodTestMatrix)('$zodVersionLabel', (entry: ZodMatrixEntry) => {
             expect(capabilities?.extensions).toBeDefined();
             expect(capabilities?.extensions?.['io.modelcontextprotocol/test-extension']).toEqual({ streaming: true });
         });
+
+        /***
+         * Test: listChanged capability should default to true when not specified
+         */
+        test('should default tools.listChanged to true when not explicitly set', async () => {
+            const mcpServer = new McpServer({
+                name: 'test server',
+                version: '1.0'
+            });
+            const client = new Client({
+                name: 'test client',
+                version: '1.0'
+            });
+
+            mcpServer.registerTool('test', {}, async () => ({
+                content: [{ type: 'text', text: 'Test' }]
+            }));
+
+            const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+            await Promise.all([client.connect(clientTransport), mcpServer.connect(serverTransport)]);
+
+            const capabilities = client.getServerCapabilities();
+            expect(capabilities?.tools?.listChanged).toBe(true);
+        });
+
+        /***
+         * Test: listChanged capability should respect explicit false setting
+         */
+        test('should respect tools.listChanged: false when explicitly set', async () => {
+            const mcpServer = new McpServer(
+                { name: 'test server', version: '1.0' },
+                { capabilities: { tools: { listChanged: false } } }
+            );
+            const client = new Client({
+                name: 'test client',
+                version: '1.0'
+            });
+
+            mcpServer.registerTool('test', {}, async () => ({
+                content: [{ type: 'text', text: 'Test' }]
+            }));
+
+            const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+            await Promise.all([client.connect(clientTransport), mcpServer.connect(serverTransport)]);
+
+            const capabilities = client.getServerCapabilities();
+            expect(capabilities?.tools?.listChanged).toBe(false);
+        });
+
+        /***
+         * Test: resources.listChanged should respect explicit false setting
+         */
+        test('should respect resources.listChanged: false when explicitly set', async () => {
+            const mcpServer = new McpServer(
+                { name: 'test server', version: '1.0' },
+                { capabilities: { resources: { listChanged: false } } }
+            );
+            const client = new Client({
+                name: 'test client',
+                version: '1.0'
+            });
+
+            mcpServer.registerResource(
+                'test',
+                'test://resource',
+                {},
+                async () => ({
+                    contents: [{ uri: 'test://resource', text: 'Test', mimeType: 'text/plain' }]
+                })
+            );
+
+            const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+            await Promise.all([client.connect(clientTransport), mcpServer.connect(serverTransport)]);
+
+            const capabilities = client.getServerCapabilities();
+            expect(capabilities?.resources?.listChanged).toBe(false);
+        });
+
+        /***
+         * Test: prompts.listChanged should respect explicit false setting
+         */
+        test('should respect prompts.listChanged: false when explicitly set', async () => {
+            const mcpServer = new McpServer(
+                { name: 'test server', version: '1.0' },
+                { capabilities: { prompts: { listChanged: false } } }
+            );
+            const client = new Client({
+                name: 'test client',
+                version: '1.0'
+            });
+
+            mcpServer.registerPrompt(
+                'test-prompt',
+                {},
+                async () => ({
+                    messages: [{ role: 'assistant', content: { type: 'text', text: 'Test' } }]
+                })
+            );
+
+            const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+            await Promise.all([client.connect(clientTransport), mcpServer.connect(serverTransport)]);
+
+            const capabilities = client.getServerCapabilities();
+            expect(capabilities?.prompts?.listChanged).toBe(false);
+        });
     });
 
     describe('ResourceTemplate', () => {


### PR DESCRIPTION
## Summary

Backport of #1513 to `v1.x`.

Constructing `McpServer` with `capabilities: { tools: { listChanged: false } }` had no effect. The three lazy-init methods (`setToolRequestHandlers`, `setResourceRequestHandlers`, `setPromptRequestHandlers`) each call `registerCapabilities` with a hardcoded `listChanged: true`, overwriting whatever the user passed at construction time. Stateless servers can't opt out of list-change notifications on `v1.x`.

**Root cause** (`src/server/mcp.ts:134`, `496`, `576`):
```diff
 this.server.registerCapabilities({
-    tools: { listChanged: true }
+    tools: { listChanged: this.server.getCapabilities().tools?.listChanged ?? true }
 });
```

Same fix applied to `resources` and `prompts`. `Server.getCapabilities()` changed from `private` to `public` so `McpServer` can read the current value. The `?? true` default keeps existing behavior for servers that don't set `listChanged` at all.

## Test plan

Added 4 tests to `test/server/mcp.test.ts`, run against both Zod v3 and v4 via `describe.each`:

- `should default tools.listChanged to true when not explicitly set`
- `should respect tools.listChanged: false when explicitly set`
- `should respect resources.listChanged: false when explicitly set`
- `should respect prompts.listChanged: false when explicitly set`

6 of 8 fail on pre-fix code (the default test passes on both Zod variants; the three false-respecting tests fail). All 8 pass after. Full suite: 1587/1587, no regressions.

Fixes #1819