### PR TITLE
build: exclude src/examples from published dist (v1.x)

### DIFF
--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -6,5 +6,5 @@
         "outDir": "./dist/cjs"
     },
     "include": ["src/**/*"],
-    "exclude": ["**/*.test.ts", "src/__mocks__/**/*", "src/__fixtures__/**/*"]
+    "exclude": ["**/*.test.ts", "src/__mocks__/**/*", "src/__fixtures__/**/*", "src/examples/**/*"]
 }

--- a/tsconfig.prod.json
+++ b/tsconfig.prod.json
@@ -4,5 +4,5 @@
         "outDir": "./dist/esm"
     },
     "include": ["src/**/*"],
-    "exclude": ["**/*.test.ts", "src/__mocks__/**/*", "src/__fixtures__/**/*"]
+    "exclude": ["**/*.test.ts", "src/__mocks__/**/*", "src/__fixtures__/**/*", "src/examples/**/*"]
 }


### PR DESCRIPTION
## Summary

Stop compiling `src/examples/**` into `dist/` so the published npm tarball no longer includes example code.

## Motivation

Follow-up to #1579 / #1553, which removed a command-injection sink from the example OAuth clients (reported by @dolevmiz1 — thank you!). The reporter noted that the compiled examples were shipping in the published package via `files: ["dist"]` and reachable through the `./*` wildcard export. Examples are meant to be read and run from the repo via `tsx`, not imported from the package, so this excludes them from the build.

## Changes

- Add `src/examples/**/*` to the `exclude` list in `tsconfig.prod.json` and `tsconfig.cjs.json`.

`npm pack --dry-run` no longer lists any `examples/` paths. Examples remain in the repository and runnable with `npx tsx src/examples/...`.

(Not needed on `main`/v2, where examples live in a separate unpublished workspace.)

cc @dolevmiz1