### PR TITLE
fix(client): skip outputSchema validation when result is an error

### DIFF
--- a/.changeset/fix-client-skip-output-validation-on-error.md
+++ b/.changeset/fix-client-skip-output-validation-on-error.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/client': patch
+---
+
+Client `callTool` and `experimental.tasks.callToolStream` now skip `outputSchema` validation when a tool result has `isError: true`, matching server-side `validateToolOutput` behavior. Tools that return a structured error envelope (e.g. `{ error: { code, message } }`) are no longer rejected with `Structured content does not match the tool's output schema`. Fixes #1943.

--- a/packages/client/src/client/client.ts
+++ b/packages/client/src/client/client.ts
@@ -890,7 +890,7 @@ export class Client extends Protocol<ClientContext> {
             }
 
             // Only validate structured content if present (not when there's an error)
-            if (result.structuredContent) {
+            if (result.structuredContent && !result.isError) {
                 try {
                     // Validate the structured content against the schema
                     const validationResult = validator(result.structuredContent);

--- a/packages/client/src/experimental/tasks/client.ts
+++ b/packages/client/src/experimental/tasks/client.ts
@@ -136,7 +136,7 @@ export class ExperimentalClientTasks {
                 }
 
                 // Only validate structured content if present (not when there's an error)
-                if (result.structuredContent) {
+                if (result.structuredContent && !result.isError) {
                     try {
                         // Validate the structured content against the schema
                         const validationResult = validator(result.structuredContent);

--- a/test/integration/test/client/client.test.ts
+++ b/test/integration/test/client/client.test.ts
@@ -1,5 +1,5 @@
 import { Client, getSupportedElicitationModes } from '@modelcontextprotocol/client';
-import type { Prompt, Resource, Tool, Transport } from '@modelcontextprotocol/core';
+import type { CallToolResult, Prompt, Resource, Tool, Transport } from '@modelcontextprotocol/core';
 import {
     CallToolResultSchema,
     ElicitResultSchema,
@@ -2278,6 +2278,72 @@ describe('outputSchema validation', () => {
             /Structured content does not match the tool's output schema/
         );
     });
+
+    /***
+     * Test: Skip outputSchema validation when result is an error (mirrors server-side behavior)
+     */
+    test('should not validate structuredContent against outputSchema when isError is true', async () => {
+        const server = new Server(
+            {
+                name: 'test-server',
+                version: '1.0.0'
+            },
+            {
+                capabilities: {
+                    tools: {}
+                }
+            }
+        );
+
+        server.setRequestHandler('tools/list', async () => ({
+            tools: [
+                {
+                    name: 'test-tool',
+                    description: 'A test tool',
+                    inputSchema: {
+                        type: 'object',
+                        properties: {}
+                    },
+                    outputSchema: {
+                        type: 'object',
+                        properties: {
+                            result: { type: 'string' },
+                            count: { type: 'number' }
+                        },
+                        required: ['result', 'count']
+                    }
+                }
+            ]
+        }));
+
+        server.setRequestHandler('tools/call', async () => {
+            // Error envelope carrying a structuredContent shape that does NOT match outputSchema.
+            // Server-side validateToolOutput short-circuits on isError; client must behave the same.
+            return {
+                isError: true,
+                content: [{ type: 'text', text: 'NOT_FOUND' }],
+                structuredContent: { error: { code: 'NOT_FOUND', message: 'nope' } }
+            };
+        });
+
+        const client = new Client(
+            {
+                name: 'test-client',
+                version: '1.0.0'
+            },
+            { capabilities: { tasks: { requests: { tools: { call: {} } } } } }
+        );
+
+        const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+        await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
+
+        await client.listTools();
+
+        const result = await client.callTool({ name: 'test-tool' });
+        expect(result.isError).toBe(true);
+        expect(result.structuredContent).toEqual({ error: { code: 'NOT_FOUND', message: 'nope' } });
+    });
 });
 
 describe('Task-based execution', () => {
@@ -4081,6 +4147,85 @@ test('callToolStream() should not validate structuredContent when isError is tru
     if (messages[0]!.type === 'result') {
         expect(messages[0]!.result.isError).toBe(true);
         expect(messages[0]!.result.content).toEqual([{ type: 'text', text: 'Something went wrong' }]);
+    }
+
+    await client.close();
+    await server.close();
+});
+
+test('callToolStream() should not validate structuredContent when isError is true', async () => {
+    const server = new Server(
+        {
+            name: 'test-server',
+            version: '1.0.0'
+        },
+        {
+            capabilities: {
+                tools: {}
+            }
+        }
+    );
+
+    server.setRequestHandler('tools/list', async () => ({
+        tools: [
+            {
+                name: 'test-tool',
+                description: 'A test tool',
+                inputSchema: {
+                    type: 'object',
+                    properties: {}
+                },
+                outputSchema: {
+                    type: 'object',
+                    properties: {
+                        result: { type: 'string' }
+                    },
+                    required: ['result']
+                }
+            }
+        ]
+    }));
+
+    server.setRequestHandler('tools/call', async () => {
+        // Error envelope carrying a structuredContent shape that does NOT match outputSchema.
+        // Server-side validateToolOutput short-circuits on isError; client must behave the same.
+        return {
+            isError: true,
+            content: [{ type: 'text', text: 'NOT_FOUND' }],
+            structuredContent: { error: { code: 'NOT_FOUND', message: 'nope' } }
+        };
+    });
+
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+    const client = new Client(
+        {
+            name: 'test-client',
+            version: '1.0.0'
+        },
+        {
+            capabilities: { tasks: { requests: { tools: { call: {} } } } }
+        }
+    );
+
+    await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
+
+    await client.listTools();
+
+    const stream = client.experimental.tasks.callToolStream({ name: 'test-tool', arguments: {} });
+
+    const messages = [];
+    for await (const message of stream) {
+        messages.push(message);
+    }
+
+    // Should have received result (not error), with isError flag set and structuredContent preserved
+    expect(messages.length).toBe(1);
+    expect(messages[0]!.type).toBe('result');
+    if (messages[0]!.type === 'result') {
+        const result = messages[0]!.result as CallToolResult;
+        expect(result.isError).toBe(true);
+        expect(result.structuredContent).toEqual({ error: { code: 'NOT_FOUND', message: 'nope' } });
     }
 
     await client.close();


### PR DESCRIPTION
## Motivation and Context

Fixes #1943.

Client-side `callTool` validates `structuredContent` against `outputSchema` whenever it is present, regardless of `result.isError`. The server-side `validateToolOutput` correctly short-circuits on `isError` (`packages/server/src/server/mcp.ts:276`). The asymmetry makes any tool whose error envelope carries `structuredContent` (e.g. `{ error: { code, message } }`) unusable with `outputSchema` — the client throws `Structured content does not match the tool's output schema` before the caller can see the error payload.

Per @truffle-dev's triage on the issue, the same missing `!result.isError` guard exists in two places with the same comment:

- `packages/client/src/client/client.ts:893` (main `callTool`)
- `packages/client/src/experimental/tasks/client.ts:139` (`callToolStream`)

Fixing only the first leaves tasks-mode clients with the same bug. This PR fixes both.

## How Has This Been Tested?

Added two integration tests in `test/integration/test/client/client.test.ts`:

1. `should not validate structuredContent against outputSchema when isError is true` — covers `client.callTool`.
2. `callToolStream() should not validate structuredContent when isError is true` (with `structuredContent` present) — complements the existing test at line 4014, which only covers the `isError` + no-`structuredContent` case.

Both tests return an error envelope whose `structuredContent` does **not** match `outputSchema` and assert the call resolves with `isError: true` and the original `structuredContent` preserved. Without the fix, both throw `ProtocolError` with the "does not match the tool's output schema" message.

```sh
pnpm --filter @modelcontextprotocol/test-integration test -- client/client.test.ts
# Test Files  16 passed (16)
#      Tests  425 passed (425)
```

Typecheck and build also pass:

```sh
pnpm typecheck:all
pnpm build:all
```

## Breaking Changes

None. The fix aligns client behavior with server behavior and the existing comment on the guard.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed (changeset included)

## Additional context

The guard comment already read *"Only validate structured content if present (not when there's an error)"* — the `!result.isError` check was just missing. Server-side reference for contrast at `packages/server/src/server/mcp.ts:276`:

```ts
if (result.isError) {
    return;
}
```

Found while migrating [`@adcp/client`](https://github.com/adcontextprotocol/adcp-client) to use `registerTool` with structured error envelopes.