### PR TITLE
fix(server): loosen Accept validation when enableJsonResponse is true

### DIFF
--- a/.changeset/fix-enable-json-response-accept-validation.md
+++ b/.changeset/fix-enable-json-response-accept-validation.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/server': patch
+---
+
+Fixed `StreamableHTTPServerTransport` rejecting `Accept: application/json` requests with 406 when `enableJsonResponse: true`. In JSON response mode the server never opens an SSE stream, so requiring `text/event-stream` in the Accept header is incorrect. The Accept check now only requires `application/json` when `enableJsonResponse` is true, and continues to require both media types in the default SSE streaming mode.

--- a/packages/server/src/server/streamableHttp.ts
+++ b/packages/server/src/server/streamableHttp.ts
@@ -619,14 +619,18 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
         try {
             // Validate the Accept header
             const acceptHeader = req.headers.get('accept');
-            // The client MUST include an Accept header, listing both application/json and text/event-stream as supported content types.
-            if (!acceptHeader?.includes('application/json') || !acceptHeader.includes('text/event-stream')) {
-                this.onerror?.(new Error('Not Acceptable: Client must accept both application/json and text/event-stream'));
-                return this.createJsonErrorResponse(
-                    406,
-                    -32_000,
-                    'Not Acceptable: Client must accept both application/json and text/event-stream'
-                );
+            // When enableJsonResponse is true the server responds with a plain JSON body, so text/event-stream
+            // is not needed and requiring it would break strict JSON-RPC clients (e.g. AdCP buyer agents).
+            // In SSE streaming mode (the default) the client must advertise both media types.
+            const acceptOk = this._enableJsonResponse
+                ? acceptHeader?.includes('application/json')
+                : acceptHeader?.includes('application/json') && acceptHeader.includes('text/event-stream');
+            if (!acceptOk) {
+                const msg = this._enableJsonResponse
+                    ? 'Not Acceptable: Client must accept application/json'
+                    : 'Not Acceptable: Client must accept both application/json and text/event-stream';
+                this.onerror?.(new Error(msg));
+                return this.createJsonErrorResponse(406, -32_000, msg);
             }
 
             const ct = req.headers.get('content-type');

--- a/packages/server/test/server/streamableHttp.test.ts
+++ b/packages/server/test/server/streamableHttp.test.ts
@@ -559,6 +559,23 @@ describe('Zod v4', () => {
                 id: 'call-1'
             });
         });
+
+        it('should accept JSON-only Accept header when enableJsonResponse is true', async () => {
+            const request = createRequest('POST', TEST_MESSAGES.initialize, { accept: 'application/json' });
+            const response = await transport.handleRequest(request);
+
+            expect(response.status).toBe(200);
+            expect(response.headers.get('content-type')).toBe('application/json');
+        });
+
+        it('should reject missing application/json in Accept header even when enableJsonResponse is true', async () => {
+            const request = createRequest('POST', TEST_MESSAGES.initialize, { accept: 'text/event-stream' });
+            const response = await transport.handleRequest(request);
+
+            expect(response.status).toBe(406);
+            const errorData = await response.json();
+            expectErrorResponse(errorData, -32_000, /Not Acceptable/);
+        });
     });
 
     describe('HTTPServerTransport - Session Callbacks', () => {


### PR DESCRIPTION
## Summary

\`WebStandardStreamableHTTPServerTransport\` returns 406 when a client sends \`Accept: application/json\` (without \`text/event-stream\`) even when the transport is constructed with \`enableJsonResponse: true\`.

That's the wrong check. With \`enableJsonResponse: true\`, the server responds with a plain JSON body and never opens an SSE stream. Requiring the client to advertise \`text/event-stream\` is unnecessary: the media type isn't used, and it breaks clients that send a minimal \`Accept: application/json\` (a standard JSON-RPC default). The AdCP ecosystem currently works around this with an Express middleware that rewrites the header before the transport sees it.

\`handlePostRequest\` now reads \`this._enableJsonResponse\` when validating the Accept header:

- \`enableJsonResponse: true\` → require only \`application/json\`
- \`enableJsonResponse: false\` (default) → require both \`application/json\` and \`text/event-stream\`, same as before

This change doesn't touch the GET handler or the SSE response path. \`NodeStreamableHTTPServerTransport\` is covered as well since it delegates request handling to \`WebStandardStreamableHTTPServerTransport\`.

## Test plan

- \`pnpm --filter @modelcontextprotocol/server test\`: 57 tests pass (up from 55)
- \`pnpm --filter @modelcontextprotocol/server typecheck\`: clean
- New in \`test/server/streamableHttp.test.ts\` inside the existing \`enableJsonResponse\` describe block: a regression test confirms \`Accept: application/json\` alone now returns 200 (previously 406); a second test confirms \`Accept: text/event-stream\` alone still returns 406.

Fixes #1944