### PR TITLE
fix(client/auth): use .set() for prompt=consent instead of .append() to avoid duplicating

### DIFF
--- a/packages/client/src/client/auth.ts
+++ b/packages/client/src/client/auth.ts
@@ -1420,14 +1420,11 @@ export async function startAuthorization(
         // if the request includes the OIDC-only "offline_access" scope,
         // we need to set the prompt to "consent" to ensure the user is prompted to grant offline access
         // https://openid.net/specs/openid-connect-core-1_0.html#OfflineAccess
-        // RFC 6749 §3.1: the authorization endpoint URI MAY include a query component which MUST be
-        // retained, and parameters MUST NOT be included more than once. OIDC Core §3.1.2.1 defines
-        // `prompt` as space-delimited, so merge into any existing value rather than appending a duplicate.
-        const existingPrompt = authorizationUrl.searchParams.get('prompt');
-        authorizationUrl.searchParams.set(
-            'prompt',
-            existingPrompt ? [...new Set([...existingPrompt.split(' '), 'consent'])].join(' ') : 'consent'
-        );
+        // Use .set() not .append(): RFC 6749 §3.1 forbids duplicate params, and the
+        // authorization_endpoint may already include a prompt value. Azure AD also rejects the
+        // OIDC space-delimited list form (AADSTS90023), so a single value is the only portable
+        // option; consent is required for offline_access per OIDC §11.
+        authorizationUrl.searchParams.set('prompt', 'consent');
     }
 
     if (resource) {

--- a/packages/client/src/client/auth.ts
+++ b/packages/client/src/client/auth.ts
@@ -1420,7 +1420,14 @@ export async function startAuthorization(
         // if the request includes the OIDC-only "offline_access" scope,
         // we need to set the prompt to "consent" to ensure the user is prompted to grant offline access
         // https://openid.net/specs/openid-connect-core-1_0.html#OfflineAccess
-        authorizationUrl.searchParams.append('prompt', 'consent');
+        // RFC 6749 §3.1: the authorization endpoint URI MAY include a query component which MUST be
+        // retained, and parameters MUST NOT be included more than once. OIDC Core §3.1.2.1 defines
+        // `prompt` as space-delimited, so merge into any existing value rather than appending a duplicate.
+        const existingPrompt = authorizationUrl.searchParams.get('prompt');
+        authorizationUrl.searchParams.set(
+            'prompt',
+            existingPrompt ? [...new Set([...existingPrompt.split(' '), 'consent'])].join(' ') : 'consent'
+        );
     }
 
     if (resource) {

--- a/packages/client/test/client/auth.test.ts
+++ b/packages/client/test/client/auth.test.ts
@@ -1557,6 +1557,23 @@ describe('OAuth Authorization', () => {
             expect(authorizationUrl.searchParams.get('prompt')).toBe('consent');
         });
 
+        it('merges consent into existing prompt parameter from authorization_endpoint instead of duplicating', async () => {
+            const { authorizationUrl } = await startAuthorization('https://auth.example.com', {
+                metadata: {
+                    issuer: 'https://auth.example.com',
+                    authorization_endpoint: 'https://auth.example.com/authorize?prompt=select_account',
+                    token_endpoint: 'https://auth.example.com/token',
+                    response_types_supported: ['code'],
+                    code_challenge_methods_supported: ['S256']
+                },
+                clientInformation: validClientInfo,
+                redirectUrl: 'http://localhost:3000/callback',
+                scope: 'read offline_access'
+            });
+
+            expect(authorizationUrl.searchParams.getAll('prompt')).toEqual(['select_account consent']);
+        });
+
         it.each([validMetadata, validOpenIdMetadata])('uses metadata authorization_endpoint when provided', async baseMetadata => {
             const { authorizationUrl } = await startAuthorization('https://auth.example.com', {
                 metadata: baseMetadata,

--- a/packages/client/test/client/auth.test.ts
+++ b/packages/client/test/client/auth.test.ts
@@ -1557,7 +1557,7 @@ describe('OAuth Authorization', () => {
             expect(authorizationUrl.searchParams.get('prompt')).toBe('consent');
         });
 
-        it('merges consent into existing prompt parameter from authorization_endpoint instead of duplicating', async () => {
+        it('overwrites existing prompt parameter from authorization_endpoint instead of duplicating', async () => {
             const { authorizationUrl } = await startAuthorization('https://auth.example.com', {
                 metadata: {
                     issuer: 'https://auth.example.com',
@@ -1571,7 +1571,7 @@ describe('OAuth Authorization', () => {
                 scope: 'read offline_access'
             });
 
-            expect(authorizationUrl.searchParams.getAll('prompt')).toEqual(['select_account consent']);
+            expect(authorizationUrl.searchParams.getAll('prompt')).toEqual(['consent']);
         });
 
         it.each([validMetadata, validOpenIdMetadata])('uses metadata authorization_endpoint when provided', async baseMetadata => {


### PR DESCRIPTION
## Problem

When the authorization server's `authorization_endpoint` metadata already includes a `prompt` query parameter, `startAuthorization` appends a second `prompt=consent` (when scope contains `offline_access`), producing a request with two `prompt` parameters. Azure AD rejects this with `AADSTS9000411: The parameter 'prompt' is duplicated`.

Real-world example: Anthropic's hosted Microsoft 365 MCP server publishes `authorization_endpoint: "https://login.microsoftonline.com/.../authorize?prompt=select_account"`. The resulting URL contains both `prompt=select_account` and `prompt=consent`.

## Spec

- **[RFC 6749 §3.1](https://www.rfc-editor.org/rfc/rfc6749#section-3.1)**: "Request and response parameters MUST NOT be included more than once."
- **[OIDC Core 1.0 §3.1.2.1](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest)** defines `prompt` as space-delimited, but Azure AD rejects that form too (`AADSTS90023: Unsupported 'prompt' value`) — it only accepts a single value.
- **[OIDC Core §11](https://openid.net/specs/openid-connect-core-1_0.html#OfflineAccess)**: when `offline_access` is requested, `prompt=consent` MUST be used. So `consent` is the value that needs to win.

## Fix

`.append()` → `.set()`. If the endpoint already carries a `prompt` value, `consent` overwrites it — this is the only portable choice given Azure's single-value constraint, and `consent` is the value OIDC §11 mandates for the `offline_access` flow this branch guards.

## References

- anthropics/claude-code#31089
- Introduced in #681