### PR TITLE
fix: handle 404 and 406 gracefully in SSE stream initialization

### DIFF
--- a/packages/client/src/client/streamableHttp.ts
+++ b/packages/client/src/client/streamableHttp.ts
@@ -282,9 +282,11 @@ export class StreamableHTTPClientTransport implements Transport {
 
                 await response.text?.().catch(() => {});
 
-                // 405 indicates that the server does not offer an SSE stream at GET endpoint
-                // This is an expected case that should not trigger an error
-                if (response.status === 405) {
+                // 404: Server has no GET handler for this endpoint (POST-only)
+                // 405: Server explicitly does not allow GET
+                // 406: Server rejects Accept header for GET
+                // All indicate the server does not offer an SSE stream at the GET endpoint
+                if (response.status === 404 || response.status === 405 || response.status === 406) {
                     return;
                 }
 


### PR DESCRIPTION
## Problem

`StreamableHTTPClientTransport._startOrAuthSse()` only handles HTTP 405 as a graceful exit from the GET SSE stream attempt. Many MCP servers return 404 (no GET handler) or 406 (Accept header rejected) instead, causing the client to throw and preventing POST-based communication that would otherwise work.

## Fix

Widen the status check in `_startOrAuthSse()` to treat 404, 405, and 406 identically — all three indicate the server does not offer an SSE stream at the GET endpoint.

**Change:** `packages/client/src/client/streamableHttp.ts` line 285: `response.status === 405` → `response.status === 404 || response.status === 405 || response.status === 406`

## Impact

Affects Gemini CLI (#5268, #2787), MCP Inspector (#1150), LibreChat, and any client consuming this SDK against servers that only support POST.

Closes #1635