### PR TITLE
fix(server): handle ZodObject in RegisteredTool.update (#1960)

### DIFF
--- a/.changeset/fix-registered-tool-update-zod-object.md
+++ b/.changeset/fix-registered-tool-update-zod-object.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/sdk': patch
+---
+
+Fix `RegisteredTool.update` crash when given a Zod object schema. The update path now uses the same `getZodSchemaObject` helper as `_createRegisteredTool` so both paths handle `ZodObject` inputs cleanly. Resolves #1960.

--- a/.changeset/fix-registered-tool-update-zod-object.md
+++ b/.changeset/fix-registered-tool-update-zod-object.md
@@ -2,4 +2,6 @@
 '@modelcontextprotocol/sdk': patch
 ---
 
-Fix `RegisteredTool.update` crash when given a Zod object schema. The update path now uses the same `getZodSchemaObject` helper as `_createRegisteredTool` so both paths handle `ZodObject` inputs cleanly. Resolves #1960.
+Fix `RegisteredTool.update` crash when given a Zod object schema. The update
+path now uses the same `getZodSchemaObject` helper as `_createRegisteredTool`
+so both paths handle `ZodObject` inputs cleanly. Resolves #1960.

--- a/.changeset/fix-registered-tool-update-zod-object.md
+++ b/.changeset/fix-registered-tool-update-zod-object.md
@@ -2,6 +2,4 @@
 '@modelcontextprotocol/sdk': patch
 ---
 
-Fix `RegisteredTool.update` crash when given a Zod object schema. The update
-path now uses the same `getZodSchemaObject` helper as `_createRegisteredTool`
-so both paths handle `ZodObject` inputs cleanly. Resolves #1960.
+Fix `RegisteredTool.update` crash when given a Zod object schema. The update path now uses the same `getZodSchemaObject` helper as `_createRegisteredTool` so both paths handle `ZodObject` inputs cleanly. Resolves #1960.

--- a/src/server/mcp.ts
+++ b/src/server/mcp.ts
@@ -905,8 +905,8 @@ export class McpServer {
                 }
                 if (typeof updates.title !== 'undefined') registeredTool.title = updates.title;
                 if (typeof updates.description !== 'undefined') registeredTool.description = updates.description;
-                if (typeof updates.paramsSchema !== 'undefined') registeredTool.inputSchema = objectFromShape(updates.paramsSchema);
-                if (typeof updates.outputSchema !== 'undefined') registeredTool.outputSchema = objectFromShape(updates.outputSchema);
+                if (typeof updates.paramsSchema !== 'undefined') registeredTool.inputSchema = getZodSchemaObject(updates.paramsSchema);
+                if (typeof updates.outputSchema !== 'undefined') registeredTool.outputSchema = getZodSchemaObject(updates.outputSchema);
                 if (typeof updates.callback !== 'undefined') registeredTool.handler = updates.callback;
                 if (typeof updates.annotations !== 'undefined') registeredTool.annotations = updates.annotations;
                 if (typeof updates._meta !== 'undefined') registeredTool._meta = updates._meta;
@@ -1312,7 +1312,7 @@ export type RegisteredTool = {
     enabled: boolean;
     enable(): void;
     disable(): void;
-    update<InputArgs extends ZodRawShapeCompat, OutputArgs extends ZodRawShapeCompat>(updates: {
+    update<InputArgs extends ZodRawShapeCompat | AnySchema, OutputArgs extends ZodRawShapeCompat | AnySchema>(updates: {
         name?: string | null;
         title?: string;
         description?: string;

--- a/test/server/mcp.test.ts
+++ b/test/server/mcp.test.ts
@@ -407,7 +407,7 @@ describe.each(zodTestMatrix)('$zodVersionLabel', (entry: ZodMatrixEntry) => {
                 callback: async () => ({
                     content: [
                         {
-                            type: 'text',
+                            type: 'text' as const,
                             text: 'Updated response'
                         }
                     ]
@@ -535,6 +535,72 @@ describe.each(zodTestMatrix)('$zodVersionLabel', (entry: ZodMatrixEntry) => {
         });
 
         /***
+         * Test: Updating Tool with a ZodObject paramsSchema (regression for #1960).
+         * The create path accepts both raw shapes and ZodObject instances, but the
+         * update path used to call `objectFromShape` directly which crashed on
+         * ZodObject inputs (e.g. `z.object({...}).passthrough()`).
+         */
+        test('should update tool with ZodObject paramsSchema', async () => {
+            const mcpServer = new McpServer({
+                name: 'test server',
+                version: '1.0'
+            });
+            const client = new Client({
+                name: 'test client',
+                version: '1.0'
+            });
+
+            // Register the tool using a ZodObject (not a raw shape); this path
+            // already worked before the fix.
+            const initialSchema = z.object({ id: z.string() }).passthrough();
+            const tool = mcpServer.registerTool(
+                'test',
+                {
+                    description: 'test',
+                    inputSchema: initialSchema
+                },
+                async ({ id }) => ({
+                    content: [{ type: 'text', text: `Initial: ${id}` }]
+                })
+            );
+
+            // Update the tool with a fresh ZodObject. Before #1960's fix this
+            // threw `TypeError: Cannot read properties of null (reading '_zod')`.
+            const updatedSchema = z.object({ id: z.string(), value: z.number() }).passthrough();
+            expect(() =>
+                tool.update({
+                    paramsSchema: updatedSchema,
+                    callback: async ({ id, value }) => ({
+                        content: [{ type: 'text', text: `Updated: ${id}, ${value}` }]
+                    })
+                })
+            ).not.toThrow();
+
+            const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+            await Promise.all([client.connect(clientTransport), mcpServer.connect(serverTransport)]);
+
+            const listResult = await client.request({ method: 'tools/list' }, ListToolsResultSchema);
+            expect(listResult.tools[0].inputSchema).toMatchObject({
+                properties: {
+                    id: { type: 'string' },
+                    value: { type: 'number' }
+                }
+            });
+
+            const callResult = await client.request(
+                {
+                    method: 'tools/call',
+                    params: {
+                        name: 'test',
+                        arguments: { id: 'abc', value: 42 }
+                    }
+                },
+                CallToolResultSchema
+            );
+            expect(callResult.content).toEqual([{ type: 'text', text: 'Updated: abc, 42' }]);
+        });
+
+        /***
          * Test: Updating Tool with outputSchema
          */
         test('should update tool with outputSchema', async () => {
@@ -574,7 +640,7 @@ describe.each(zodTestMatrix)('$zodVersionLabel', (entry: ZodMatrixEntry) => {
                     sum: z.number()
                 },
                 callback: async () => ({
-                    content: [{ type: 'text', text: '' }],
+                    content: [{ type: 'text' as const, text: '' }],
                     structuredContent: {
                         result: 42,
                         sum: 100
@@ -661,7 +727,7 @@ describe.each(zodTestMatrix)('$zodVersionLabel', (entry: ZodMatrixEntry) => {
                 callback: async () => ({
                     content: [
                         {
-                            type: 'text',
+                            type: 'text' as const,
                             text: 'Updated response'
                         }
                     ]


### PR DESCRIPTION
Fixes #1960.

`RegisteredTool.update({ paramsSchema })` crashes with `TypeError: Cannot read properties of null (reading '_zod')` when `paramsSchema` is a ZodObject (e.g. `z.object({...}).passthrough()`) instead of a raw shape.

## Why

The create path in `_createRegisteredTool` uses `getZodSchemaObject()`, which handles both raw shapes and ZodObject instances:

```ts
function getZodSchemaObject(schema) {
    if (!schema) return undefined;
    if (isZodRawShapeCompat(schema)) return objectFromShape(schema);
    return schema;
}
```

The update path was calling `objectFromShape()` directly. `objectFromShape` does `Object.values(shape)`, which on a ZodObject iterates internal fields like `_cached` (which is `null`), and downstream `isZ4Schema(null)` accesses `null._zod` and throws.

## Fix

- In `RegisteredTool.update`, route `paramsSchema` and `outputSchema` through `getZodSchemaObject()` (the same helper the create path uses) instead of `objectFromShape()` directly.
- Widen the `update<InputArgs, OutputArgs>` generic constraints from `ZodRawShapeCompat` to `ZodRawShapeCompat | AnySchema`, matching `registerTool`. This resolves the type-level inconsistency mentioned in the issue.

Net diff is ~3 lines of code; no new public API.

## Test

Added `should update tool with ZodObject paramsSchema` in `test/server/mcp.test.ts`. It registers a tool with `z.object({...}).passthrough()`, updates it with a fresh ZodObject, and asserts `tool.update(...)` does not throw and the new schema is reflected in `tools/list` and the call result. The test runs under the existing `zodTestMatrix`, so it covers both Zod v3 and v4.

## Reproduction (before this PR)

```js
const schema = z.object({ id: z.string() }).passthrough();
const tool = server.registerTool('my_tool', { description: 'test', inputSchema: schema }, async () => ({ content: [{ type: 'text', text: 'ok' }] }));
tool.update({ paramsSchema: schema });
// TypeError: Cannot read properties of null (reading '_zod')
```

After the patch this is a no-op update with no crash.