### PR TITLE
fix(auth): preserve resource URI without trailing slash (#1968)

### DIFF
--- a/.changeset/fix-oauth-resource-trailing-slash.md
+++ b/.changeset/fix-oauth-resource-trailing-slash.md
@@ -2,4 +2,8 @@
 '@modelcontextprotocol/sdk': patch
 ---
 
-Preserve the OAuth protected-resource URI without adding a trailing slash. Previously `selectResourceURL` returned `new URL(metadata.resource).href` which appended `/` to bare-domain URIs (e.g. `https://example.com` became `https://example.com/`), breaking OAuth interop with Microsoft Entra ID. Resolves #1968.
+Preserve the OAuth protected-resource URI without adding a trailing slash.
+Previously `selectResourceURL` returned `new URL(metadata.resource).href` which
+appended `/` to bare-domain URIs (e.g. `https://example.com` became
+`https://example.com/`), breaking OAuth interop with Microsoft Entra ID.
+Resolves #1968.

--- a/.changeset/fix-oauth-resource-trailing-slash.md
+++ b/.changeset/fix-oauth-resource-trailing-slash.md
@@ -2,8 +2,5 @@
 '@modelcontextprotocol/sdk': patch
 ---
 
-Preserve the OAuth protected-resource URI without adding a trailing slash.
-Previously `selectResourceURL` returned `new URL(metadata.resource).href` which
-appended `/` to bare-domain URIs (e.g. `https://example.com` became
-`https://example.com/`), breaking OAuth interop with Microsoft Entra ID.
-Resolves #1968.
+Preserve the OAuth protected-resource URI without adding a trailing slash. Previously `selectResourceURL` returned `new URL(metadata.resource).href` which appended `/` to bare-domain URIs (e.g. `https://example.com` became `https://example.com/`), breaking OAuth interop with
+Microsoft Entra ID. Resolves #1968.

--- a/.changeset/fix-oauth-resource-trailing-slash.md
+++ b/.changeset/fix-oauth-resource-trailing-slash.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/sdk': patch
+---
+
+Preserve the OAuth protected-resource URI without adding a trailing slash. Previously `selectResourceURL` returned `new URL(metadata.resource).href` which appended `/` to bare-domain URIs (e.g. `https://example.com` became `https://example.com/`), breaking OAuth interop with Microsoft Entra ID. Resolves #1968.

--- a/.changeset/fix-oauth-resource-trailing-slash.md
+++ b/.changeset/fix-oauth-resource-trailing-slash.md
@@ -2,5 +2,6 @@
 '@modelcontextprotocol/sdk': patch
 ---
 
-Preserve the OAuth protected-resource URI without adding a trailing slash. Previously `selectResourceURL` returned `new URL(metadata.resource).href` which appended `/` to bare-domain URIs (e.g. `https://example.com` became `https://example.com/`), breaking OAuth interop with
-Microsoft Entra ID. Resolves #1968.
+Preserve the exact OAuth resource indicator from protected resource metadata when building authorization and token requests. Previously a pathless `resource` such as `https://example.com` was normalized to `https://example.com/` via `URL.href`, which breaks authorization servers
+that require the `resource` parameter to match the published value exactly (Microsoft Entra ID rejects it with `AADSTS9010010`). The exported OAuth helpers (`startAuthorization`, `exchangeAuthorization`, `refreshAuthorization`, `fetchToken`) now also accept a `string` for
+`resource`; `selectResourceURL` still returns a `URL`, and a provider's `validateResourceURL` result is used unchanged. Fixes #1968.

--- a/src/client/auth.ts
+++ b/src/client/auth.ts
@@ -503,7 +503,7 @@ async function authInternal(
         });
     }
 
-    const resource: URL | undefined = await selectResourceURL(serverUrl, provider, resourceMetadata);
+    const resource: URL | string | undefined = await selectResourceURL(serverUrl, provider, resourceMetadata);
 
     // Apply scope selection strategy (SEP-835):
     // 1. WWW-Authenticate scope (passed via `scope` param)
@@ -633,7 +633,7 @@ export async function selectResourceURL(
     serverUrl: string | URL,
     provider: OAuthClientProvider,
     resourceMetadata?: OAuthProtectedResourceMetadata
-): Promise<URL | undefined> {
+): Promise<URL | string | undefined> {
     const defaultResource = resourceUrlFromServerUrl(serverUrl);
 
     // If provider has custom validation, delegate to it
@@ -650,8 +650,12 @@ export async function selectResourceURL(
     if (!checkResourceAllowed({ requestedResource: defaultResource, configuredResource: resourceMetadata.resource })) {
         throw new Error(`Protected resource ${resourceMetadata.resource} does not match expected ${defaultResource} (or origin)`);
     }
-    // Prefer the resource from metadata since it's what the server is telling us to request
-    return new URL(resourceMetadata.resource);
+    // Prefer the resource from metadata since it's what the server is telling us to request.
+    // Return the original string verbatim so we don't re-serialize through `URL.href`, which
+    // appends a trailing slash to bare-origin URIs (e.g. `https://example.com` becomes
+    // `https://example.com/`) and breaks providers that require an exact match against the
+    // configured resource indicator (RFC 8707), such as Microsoft Entra ID.
+    return resourceMetadata.resource;
 }
 
 /**
@@ -1126,7 +1130,7 @@ export async function startAuthorization(
         redirectUrl: string | URL;
         scope?: string;
         state?: string;
-        resource?: URL;
+        resource?: URL | string;
     }
 ): Promise<{ authorizationUrl: URL; codeVerifier: string }> {
     let authorizationUrl: URL;
@@ -1174,7 +1178,7 @@ export async function startAuthorization(
     }
 
     if (resource) {
-        authorizationUrl.searchParams.set('resource', resource.href);
+        authorizationUrl.searchParams.set('resource', String(resource));
     }
 
     return { authorizationUrl, codeVerifier };
@@ -1222,7 +1226,7 @@ async function executeTokenRequest(
         tokenRequestParams: URLSearchParams;
         clientInformation?: OAuthClientInformationMixed;
         addClientAuthentication?: OAuthClientProvider['addClientAuthentication'];
-        resource?: URL;
+        resource?: URL | string;
         fetchFn?: FetchLike;
     }
 ): Promise<OAuthTokens> {
@@ -1234,7 +1238,7 @@ async function executeTokenRequest(
     });
 
     if (resource) {
-        tokenRequestParams.set('resource', resource.href);
+        tokenRequestParams.set('resource', String(resource));
     }
 
     if (addClientAuthentication) {
@@ -1287,7 +1291,7 @@ export async function exchangeAuthorization(
         authorizationCode: string;
         codeVerifier: string;
         redirectUri: string | URL;
-        resource?: URL;
+        resource?: URL | string;
         addClientAuthentication?: OAuthClientProvider['addClientAuthentication'];
         fetchFn?: FetchLike;
     }
@@ -1329,7 +1333,7 @@ export async function refreshAuthorization(
         metadata?: AuthorizationServerMetadata;
         clientInformation: OAuthClientInformationMixed;
         refreshToken: string;
-        resource?: URL;
+        resource?: URL | string;
         addClientAuthentication?: OAuthClientProvider['addClientAuthentication'];
         fetchFn?: FetchLike;
     }
@@ -1388,7 +1392,7 @@ export async function fetchToken(
         fetchFn
     }: {
         metadata?: AuthorizationServerMetadata;
-        resource?: URL;
+        resource?: URL | string;
         /** Authorization code for the default authorization_code grant flow */
         authorizationCode?: string;
         fetchFn?: FetchLike;

--- a/src/client/auth.ts
+++ b/src/client/auth.ts
@@ -503,7 +503,13 @@ async function authInternal(
         });
     }
 
-    const resource: URL | string | undefined = await selectResourceURL(serverUrl, provider, resourceMetadata);
+    // Send the metadata's resource indicator verbatim: `selectResourceURL` returns a parsed
+    // `URL`, and `URL.href` appends "/" to a pathless indicator such as `https://example.com`,
+    // which exact-match authorization servers reject (#1968). A URL returned by the
+    // provider's own `validateResourceURL` is used as returned.
+    const selectedResource = await selectResourceURL(serverUrl, provider, resourceMetadata);
+    const resource: string | URL | undefined =
+        selectedResource && resourceMetadata && !provider.validateResourceURL ? resourceMetadata.resource : selectedResource;
 
     // Apply scope selection strategy (SEP-835):
     // 1. WWW-Authenticate scope (passed via `scope` param)
@@ -629,11 +635,22 @@ export function isHttpsUrl(value?: string): boolean {
     }
 }
 
+/**
+ * Selects the RFC 8707 resource indicator for an MCP server: the provider's
+ * {@linkcode OAuthClientProvider.validateResourceURL | validateResourceURL} result when
+ * implemented, otherwise the protected resource metadata's `resource` (checked against the
+ * server URL with `checkResourceAllowed`), or `undefined` when there is no metadata.
+ *
+ * The result is a parsed `URL`, so a pathless indicator such as `https://example.com` has
+ * the `href` `https://example.com/`. {@linkcode auth} therefore sends the metadata string
+ * verbatim instead of this URL's `href` (#1968); callers that emit the `resource`
+ * parameter themselves should do the same.
+ */
 export async function selectResourceURL(
     serverUrl: string | URL,
     provider: OAuthClientProvider,
     resourceMetadata?: OAuthProtectedResourceMetadata
-): Promise<URL | string | undefined> {
+): Promise<URL | undefined> {
     const defaultResource = resourceUrlFromServerUrl(serverUrl);
 
     // If provider has custom validation, delegate to it
@@ -650,12 +667,8 @@ export async function selectResourceURL(
     if (!checkResourceAllowed({ requestedResource: defaultResource, configuredResource: resourceMetadata.resource })) {
         throw new Error(`Protected resource ${resourceMetadata.resource} does not match expected ${defaultResource} (or origin)`);
     }
-    // Prefer the resource from metadata since it's what the server is telling us to request.
-    // Return the original string verbatim so we don't re-serialize through `URL.href`, which
-    // appends a trailing slash to bare-origin URIs (e.g. `https://example.com` becomes
-    // `https://example.com/`) and breaks providers that require an exact match against the
-    // configured resource indicator (RFC 8707), such as Microsoft Entra ID.
-    return resourceMetadata.resource;
+    // Prefer the resource from metadata since it's what the server is telling us to request
+    return new URL(resourceMetadata.resource);
 }
 
 /**
@@ -1112,6 +1125,10 @@ export async function discoverOAuthServerInfo(
     };
 }
 
+function resourceIndicatorToString(resource: string | URL): string {
+    return typeof resource === 'string' ? resource : resource.href;
+}
+
 /**
  * Begins the authorization flow with the given server, by generating a PKCE challenge and constructing the authorization URL.
  */
@@ -1130,7 +1147,7 @@ export async function startAuthorization(
         redirectUrl: string | URL;
         scope?: string;
         state?: string;
-        resource?: URL | string;
+        resource?: string | URL;
     }
 ): Promise<{ authorizationUrl: URL; codeVerifier: string }> {
     let authorizationUrl: URL;
@@ -1178,7 +1195,7 @@ export async function startAuthorization(
     }
 
     if (resource) {
-        authorizationUrl.searchParams.set('resource', String(resource));
+        authorizationUrl.searchParams.set('resource', resourceIndicatorToString(resource));
     }
 
     return { authorizationUrl, codeVerifier };
@@ -1226,7 +1243,7 @@ async function executeTokenRequest(
         tokenRequestParams: URLSearchParams;
         clientInformation?: OAuthClientInformationMixed;
         addClientAuthentication?: OAuthClientProvider['addClientAuthentication'];
-        resource?: URL | string;
+        resource?: string | URL;
         fetchFn?: FetchLike;
     }
 ): Promise<OAuthTokens> {
@@ -1238,7 +1255,7 @@ async function executeTokenRequest(
     });
 
     if (resource) {
-        tokenRequestParams.set('resource', String(resource));
+        tokenRequestParams.set('resource', resourceIndicatorToString(resource));
     }
 
     if (addClientAuthentication) {
@@ -1291,7 +1308,7 @@ export async function exchangeAuthorization(
         authorizationCode: string;
         codeVerifier: string;
         redirectUri: string | URL;
-        resource?: URL | string;
+        resource?: string | URL;
         addClientAuthentication?: OAuthClientProvider['addClientAuthentication'];
         fetchFn?: FetchLike;
     }
@@ -1333,7 +1350,7 @@ export async function refreshAuthorization(
         metadata?: AuthorizationServerMetadata;
         clientInformation: OAuthClientInformationMixed;
         refreshToken: string;
-        resource?: URL | string;
+        resource?: string | URL;
         addClientAuthentication?: OAuthClientProvider['addClientAuthentication'];
         fetchFn?: FetchLike;
     }
@@ -1392,7 +1409,7 @@ export async function fetchToken(
         fetchFn
     }: {
         metadata?: AuthorizationServerMetadata;
-        resource?: URL | string;
+        resource?: string | URL;
         /** Authorization code for the default authorization_code grant flow */
         authorizationCode?: string;
         fetchFn?: FetchLike;

--- a/test/client/auth.test.ts
+++ b/test/client/auth.test.ts
@@ -1153,11 +1153,12 @@ describe('OAuth Authorization', () => {
             );
             expect(discoveryCalls).toHaveLength(0);
 
-            // Verify the token request includes the resource parameter from cached metadata
+            // Verify the token request includes the resource parameter from cached metadata,
+            // preserved verbatim (no trailing slash added — see #1968).
             const tokenCall = mockFetch.mock.calls.find(call => call[0].toString().includes('/token'));
             expect(tokenCall).toBeDefined();
             const body = tokenCall![1].body as URLSearchParams;
-            expect(body.get('resource')).toBe('https://resource.example.com/');
+            expect(body.get('resource')).toBe('https://resource.example.com');
         });
 
         it('re-saves enriched state when partial cache is supplemented with fetched metadata', async () => {
@@ -2560,6 +2561,60 @@ describe('OAuth Authorization', () => {
             const authUrl: URL = redirectCall[0];
             // Should use the PRM's resource value, not the full requested URL
             expect(authUrl.searchParams.get('resource')).toBe('https://api.example.com/');
+        });
+
+        it('preserves bare-domain resource URI from PRM without adding a trailing slash', async () => {
+            // Regression test for #1968: `new URL("https://example.com").href` adds a trailing
+            // slash, which breaks providers (e.g. Microsoft Entra ID) that require an exact
+            // match between the OAuth `resource` parameter and the configured resource indicator.
+            mockFetch.mockImplementation(url => {
+                const urlString = url.toString();
+
+                if (urlString.includes('/.well-known/oauth-protected-resource')) {
+                    return Promise.resolve({
+                        ok: true,
+                        status: 200,
+                        json: async () => ({
+                            // Bare-origin resource URI with no trailing slash
+                            resource: 'https://api.example.com',
+                            authorization_servers: ['https://auth.example.com']
+                        })
+                    });
+                } else if (urlString.includes('/.well-known/oauth-authorization-server')) {
+                    return Promise.resolve({
+                        ok: true,
+                        status: 200,
+                        json: async () => ({
+                            issuer: 'https://auth.example.com',
+                            authorization_endpoint: 'https://auth.example.com/authorize',
+                            token_endpoint: 'https://auth.example.com/token',
+                            response_types_supported: ['code'],
+                            code_challenge_methods_supported: ['S256']
+                        })
+                    });
+                }
+
+                return Promise.resolve({ ok: false, status: 404 });
+            });
+
+            (mockProvider.clientInformation as Mock).mockResolvedValue({
+                client_id: 'test-client',
+                client_secret: 'test-secret'
+            });
+            (mockProvider.tokens as Mock).mockResolvedValue(undefined);
+            (mockProvider.saveCodeVerifier as Mock).mockResolvedValue(undefined);
+            (mockProvider.redirectToAuthorization as Mock).mockResolvedValue(undefined);
+
+            const result = await auth(mockProvider, {
+                serverUrl: 'https://api.example.com/mcp-server/endpoint'
+            });
+
+            expect(result).toBe('REDIRECT');
+
+            const redirectCall = (mockProvider.redirectToAuthorization as Mock).mock.calls[0];
+            const authUrl: URL = redirectCall[0];
+            // Resource indicator must round-trip exactly as published in PRM (no trailing slash)
+            expect(authUrl.searchParams.get('resource')).toBe('https://api.example.com');
         });
 
         it('excludes resource parameter when Protected Resource Metadata is not present', async () => {

--- a/test/client/auth.test.ts
+++ b/test/client/auth.test.ts
@@ -1365,6 +1365,16 @@ describe('OAuth Authorization', () => {
             expect(codeVerifier).toBe('test_verifier');
         });
 
+        it('preserves a string resource indicator without URL normalization', async () => {
+            const { authorizationUrl } = await startAuthorization('https://auth.example.com', {
+                clientInformation: validClientInfo,
+                redirectUrl: 'http://localhost:3000/callback',
+                resource: 'https://api.example.com'
+            });
+
+            expect(authorizationUrl.searchParams.get('resource')).toBe('https://api.example.com');
+        });
+
         it('includes scope parameter when provided', async () => {
             const { authorizationUrl } = await startAuthorization('https://auth.example.com', {
                 clientInformation: validClientInfo,
@@ -2563,10 +2573,11 @@ describe('OAuth Authorization', () => {
             expect(authUrl.searchParams.get('resource')).toBe('https://api.example.com/');
         });
 
-        it('preserves bare-domain resource URI from PRM without adding a trailing slash', async () => {
-            // Regression test for #1968: `new URL("https://example.com").href` adds a trailing
-            // slash, which breaks providers (e.g. Microsoft Entra ID) that require an exact
-            // match between the OAuth `resource` parameter and the configured resource indicator.
+        it('sends a pathless PRM resource verbatim on the authorization and token requests (#1968)', async () => {
+            // RFC 9728 publishes the resource identifier and RFC 8707 requires it to be
+            // sent unchanged. `new URL('https://example.com').href` is 'https://example.com/',
+            // and authorization servers that match the indicator exactly (Microsoft Entra
+            // ID: AADSTS9010010) reject the extra slash.
             mockFetch.mockImplementation(url => {
                 const urlString = url.toString();
 
@@ -2575,9 +2586,9 @@ describe('OAuth Authorization', () => {
                         ok: true,
                         status: 200,
                         json: async () => ({
-                            // Bare-origin resource URI with no trailing slash
-                            resource: 'https://api.example.com',
-                            authorization_servers: ['https://auth.example.com']
+                            resource: 'https://example.com',
+                            authorization_servers: ['https://auth.example.com'],
+                            scopes_supported: ['https://example.com/mcp:tools']
                         })
                     });
                 } else if (urlString.includes('/.well-known/oauth-authorization-server')) {
@@ -2592,6 +2603,12 @@ describe('OAuth Authorization', () => {
                             code_challenge_methods_supported: ['S256']
                         })
                     });
+                } else if (urlString.includes('/token')) {
+                    return Promise.resolve({
+                        ok: true,
+                        status: 200,
+                        json: async () => ({ access_token: 'access123', token_type: 'bearer', expires_in: 3600 })
+                    });
                 }
 
                 return Promise.resolve({ ok: false, status: 404 });
@@ -2604,17 +2621,25 @@ describe('OAuth Authorization', () => {
             (mockProvider.tokens as Mock).mockResolvedValue(undefined);
             (mockProvider.saveCodeVerifier as Mock).mockResolvedValue(undefined);
             (mockProvider.redirectToAuthorization as Mock).mockResolvedValue(undefined);
+            (mockProvider.codeVerifier as Mock).mockResolvedValue('verifier123');
+            (mockProvider.saveTokens as Mock).mockResolvedValue(undefined);
 
-            const result = await auth(mockProvider, {
-                serverUrl: 'https://api.example.com/mcp-server/endpoint'
+            // Authorization request: the redirect carries the metadata value byte for byte.
+            const redirectResult = await auth(mockProvider, { serverUrl: 'https://example.com/mcp' });
+            expect(redirectResult).toBe('REDIRECT');
+            const authUrl: URL = (mockProvider.redirectToAuthorization as Mock).mock.calls[0][0];
+            expect(authUrl.searchParams.get('resource')).toBe('https://example.com');
+
+            // Token request: the authorization-code exchange sends the same value.
+            const exchangeResult = await auth(mockProvider, {
+                serverUrl: 'https://example.com/mcp',
+                authorizationCode: 'code123'
             });
-
-            expect(result).toBe('REDIRECT');
-
-            const redirectCall = (mockProvider.redirectToAuthorization as Mock).mock.calls[0];
-            const authUrl: URL = redirectCall[0];
-            // Resource indicator must round-trip exactly as published in PRM (no trailing slash)
-            expect(authUrl.searchParams.get('resource')).toBe('https://api.example.com');
+            expect(exchangeResult).toBe('AUTHORIZED');
+            const tokenCall = mockFetch.mock.calls.find(call => call[0].toString().includes('/token'));
+            expect(tokenCall).toBeDefined();
+            const body = tokenCall![1].body as URLSearchParams;
+            expect(body.get('resource')).toBe('https://example.com');
         });
 
         it('excludes resource parameter when Protected Resource Metadata is not present', async () => {


### PR DESCRIPTION
## What

Fixes #1968.

When parsing OAuth protected resource metadata, `selectResourceURL` returned `new URL(resourceMetadata.resource)` and the auth + token request paths serialized that value via `URL.href`. For bare-origin URIs that round trip appends a trailing slash:

```js
new URL("https://example.com").href // "https://example.com/"
```

So a PRM document that publishes `"resource": "https://example.com"` ends up sending `resource=https%3A%2F%2Fexample.com%2F` on the wire. That changes the resource indicator from the value the server told us to use, and it breaks any AS that compares it against the configured audience exactly.

In particular Microsoft Entra ID rejects the call with:

```
AADSTS9010010: The resource parameter provided in the request doesn't match with the requested scopes.
```

(see also: modelcontextprotocol/inspector#927 for the symptom downstream.)

## How

- `selectResourceURL` now returns `URL | string | undefined` and returns `resourceMetadata.resource` verbatim from the PRM path. The custom-validation path still returns a `URL` because `validateResourceURL` is typed that way.
- `startAuthorization`, `executeTokenRequest`, `exchangeAuthorization`, `refreshAuthorization`, and `fetchToken` accept `resource?: URL | string` and serialize it via `String(resource)` instead of `resource.href`.
- The `validateResourceURL` provider hook signature is unchanged. `checkResourceAllowed` still validates the metadata value as a URL.

Diff is contained to `src/client/auth.ts`. Existing PRM-with-path coverage still passes (paths like `https://api.example.com/mcp-server` are unaffected — the `URL.href` round-trip only added a slash for bare origins).

## Tests

- Added a regression test that publishes `resource: "https://example.com"` in PRM and asserts the auth URL receives `resource=https://example.com` (no trailing slash).
- Updated the cached-discovery-state test, which previously asserted the buggy normalized form, to expect the un-normalized resource string.
- `npm test` passes locally (1580/1580).

---

Maintainer edit:

Backport of the #1968 fix to v1.x, aligned with the v2 change in #2581: selectResourceURL keeps its signature, auth() sends the protected resource metadata's resource string verbatim, and the OAuth helpers accept string | URL.
