### PR TITLE
fix: make in-memory event replay use stored stream ids

### DIFF
--- a/.changeset/hot-panthers-matter.md
+++ b/.changeset/hot-panthers-matter.md
@@ -1,0 +1,6 @@
+---
+"@modelcontextprotocol/examples-server": patch
+"@modelcontextprotocol/test-integration": patch
+---
+
+Fix in-memory event replay to preserve the stored event stream id when resuming task notifications.

--- a/examples/server/src/inMemoryEventStore.ts
+++ b/examples/server/src/inMemoryEventStore.ts
@@ -16,11 +16,10 @@ export class InMemoryEventStore implements EventStore {
     }
 
     /**
-     * Extracts the stream ID from an event ID
+     * Looks up the stream ID for an event ID
      */
     private getStreamIdFromEventId(eventId: string): string {
-        const parts = eventId.split('_');
-        return parts.length > 0 ? parts[0]! : '';
+        return this.events.get(eventId)?.streamId ?? '';
     }
 
     /**
@@ -53,10 +52,7 @@ export class InMemoryEventStore implements EventStore {
 
         let foundLastEvent = false;
 
-        // Sort events by eventId for chronological ordering
-        const sortedEvents = [...this.events.entries()].toSorted((a, b) => a[0].localeCompare(b[0]));
-
-        for (const [eventId, { streamId: eventStreamId, message }] of sortedEvents) {
+        for (const [eventId, { streamId: eventStreamId, message }] of this.events) {
             // Only include events from the same stream
             if (eventStreamId !== streamId) {
                 continue;

--- a/test/integration/test/taskResumability.test.ts
+++ b/test/integration/test/taskResumability.test.ts
@@ -26,12 +26,11 @@ class InMemoryEventStore implements EventStore {
         { send }: { send: (eventId: string, message: JSONRPCMessage) => Promise<void> }
     ): Promise<string> {
         if (!lastEventId || !this.events.has(lastEventId)) return '';
-        const streamId = lastEventId.split('_')[0] ?? '';
+        const streamId = this.events.get(lastEventId)?.streamId ?? '';
         if (!streamId) return '';
 
         let found = false;
-        const sorted = [...this.events.entries()].toSorted((a, b) => a[0].localeCompare(b[0]));
-        for (const [eventId, { streamId: sid, message }] of sorted) {
+        for (const [eventId, { streamId: sid, message }] of this.events) {
             if (sid !== streamId) continue;
             if (eventId === lastEventId) {
                 found = true;
@@ -139,6 +138,32 @@ describe('Zod v4', () => {
             await mcpServer.close().catch(() => {});
             await serverTransport.close().catch(() => {});
             server.close();
+        });
+
+        it('replays events for stream IDs that contain underscores', async () => {
+            const firstMessage: JSONRPCMessage = {
+                jsonrpc: '2.0',
+                method: 'notifications/message',
+                params: { level: 'info', data: 'first' }
+            };
+            const secondMessage: JSONRPCMessage = {
+                jsonrpc: '2.0',
+                method: 'notifications/message',
+                params: { level: 'info', data: 'second' }
+            };
+
+            const firstEventId = await eventStore.storeEvent('_GET_stream', firstMessage);
+            const secondEventId = await eventStore.storeEvent('_GET_stream', secondMessage);
+            const replayed: Array<{ eventId: string; message: JSONRPCMessage }> = [];
+
+            const streamId = await eventStore.replayEventsAfter(firstEventId, {
+                send: async (eventId, message) => {
+                    replayed.push({ eventId, message });
+                }
+            });
+
+            expect(streamId).toBe('_GET_stream');
+            expect(replayed).toEqual([{ eventId: secondEventId, message: secondMessage }]);
         });
 
         it('should store session ID when client connects', async () => {


### PR DESCRIPTION
Summary
- Look up the stream id from the stored event metadata instead of parsing the generated event id.
- Replay events in insertion order so events stored in the same millisecond are not reordered by the random id suffix.
- Add regression coverage for the standalone SSE stream id used by GET streams.

Fixes #943

Tests
- pnpm --filter @modelcontextprotocol/test-integration exec vitest run test/taskResumability.test.ts
- pnpm --filter @modelcontextprotocol/examples-server run typecheck
- pnpm --filter @modelcontextprotocol/examples-server run lint
- pnpm --filter @modelcontextprotocol/test-integration run lint
- Pre-push hook: full lint, build, and typecheck suite passed