### PR TITLE
fix(server): accept empty {} annotations in tool() overload

### DIFF
--- a/.changeset/fix-empty-annotations-typed-handler.md
+++ b/.changeset/fix-empty-annotations-typed-handler.md
@@ -1,0 +1,6 @@
+---
+'@modelcontextprotocol/sdk': patch
+---
+
+Fix `tool(name, desc, schema, {}, cb)` overload where an empty annotations object made the callback unreachable. `isZodRawShapeCompat({})` returns `true` to accommodate no-arg-tool schemas, so an empty annotations slot was misclassified as a second schema and the handler position
+fell through to `{}`, producing `typedHandler is not a function` at dispatch time. The annotations-position parser now accepts `{}` after a schema has already been consumed.

--- a/src/server/mcp.ts
+++ b/src/server/mcp.ts
@@ -1017,8 +1017,16 @@ export class McpServer {
                 // We have a params schema as the first arg
                 inputSchema = rest.shift() as ZodRawShapeCompat;
 
-                // Check if the next arg is potentially annotations
-                if (rest.length > 1 && typeof rest[0] === 'object' && rest[0] !== null && !isZodRawShapeCompat(rest[0])) {
+                // Check if the next arg is potentially annotations.
+                // We already consumed the inputSchema above, so an empty object {} in this
+                // position is annotations, not a schema — even though isZodRawShapeCompat({})
+                // returns true to support the no-arg-tool case in the schema position.
+                if (
+                    rest.length > 1 &&
+                    typeof rest[0] === 'object' &&
+                    rest[0] !== null &&
+                    (Object.keys(rest[0] as object).length === 0 || !isZodRawShapeCompat(rest[0]))
+                ) {
                     // Case: tool(name, paramsSchema, annotations, cb)
                     // Or: tool(name, description, paramsSchema, annotations, cb)
                     annotations = rest.shift() as ToolAnnotations;

--- a/test/server/mcp.test.ts
+++ b/test/server/mcp.test.ts
@@ -1048,6 +1048,49 @@ describe.each(zodTestMatrix)('$zodVersionLabel', (entry: ZodMatrixEntry) => {
         });
 
         /***
+         * Test: Tool Registration with Params and EMPTY Annotations Object
+         *
+         * Regression: tool(name, desc, schema, {}, cb) was misclassifying the empty
+         * annotations object as a second schema (because isZodRawShapeCompat({}) returns
+         * true to support the no-arg-tool case in the schema position). The handler slot
+         * then received the empty object instead of the callback, producing
+         * "typedHandler is not a function" at dispatch time.
+         */
+        test('should register tool with description, params, and empty annotations object', async () => {
+            const mcpServer = new McpServer({
+                name: 'test server',
+                version: '1.0'
+            });
+            const client = new Client({
+                name: 'test client',
+                version: '1.0'
+            });
+
+            mcpServer.tool('test', 'A tool with empty annotations', { name: z.string() }, {}, async ({ name }) => ({
+                content: [{ type: 'text', text: `Hello, ${name}!` }]
+            }));
+
+            const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+            await Promise.all([client.connect(clientTransport), mcpServer.server.connect(serverTransport)]);
+
+            const list = await client.request({ method: 'tools/list' }, ListToolsResultSchema);
+            expect(list.tools).toHaveLength(1);
+            expect(list.tools[0].name).toBe('test');
+            expect(list.tools[0].description).toBe('A tool with empty annotations');
+            expect(list.tools[0].inputSchema).toMatchObject({
+                type: 'object',
+                properties: { name: { type: 'string' } }
+            });
+
+            const callResult = await client.request(
+                { method: 'tools/call', params: { name: 'test', arguments: { name: 'world' } } },
+                CallToolResultSchema
+            );
+            expect(callResult.content).toEqual([{ type: 'text', text: 'Hello, world!' }]);
+        });
+
+        /***
          * Test: Tool Argument Validation
          */
         test('should validate tool args', async () => {


### PR DESCRIPTION
## Summary

`server.tool(name, description, schema, {}, callback)` registers successfully but throws `typedHandler is not a function` at first call.

The overload parser at `src/server/mcp.ts:993` uses `isZodRawShapeCompat()` to disambiguate between a Zod raw shape and a `ToolAnnotations` object in the slot after the schema. `isZodRawShapeCompat({})` returns `true` (intentionally — to accept tools with no parameters in the schema slot), so an empty annotations object passed *after* a populated schema is misclassified as a second schema, the annotations branch is skipped, and `callback = rest[0]` ends up as `{}` instead of the function.

At dispatch time, `executeToolHandler` does:

\`\`\`ts
const typedHandler = handler;
return await Promise.resolve(typedHandler(args, extra));
\`\`\`

…which throws `TypeError: typedHandler is not a function`.

## Root cause

`src/server/mcp.ts:1021` (pre-fix):

\`\`\`ts
if (rest.length > 1 && typeof rest[0] === 'object' && rest[0] !== null && !isZodRawShapeCompat(rest[0])) {
    annotations = rest.shift() as ToolAnnotations;
}
\`\`\`

For empty `{}`, `!isZodRawShapeCompat({})` is `false`, so annotations are not consumed. The handler slot then receives `{}`.

## Fix

Once the schema slot has been filled above, an empty object in the next slot is unambiguously annotations (a populated raw shape would have at least one Zod value). The annotations check now accepts empty objects:

\`\`\`ts
if (
    rest.length > 1 &&
    typeof rest[0] === 'object' &&
    rest[0] !== null &&
    (Object.keys(rest[0] as object).length === 0 || !isZodRawShapeCompat(rest[0]))
) {
    annotations = rest.shift() as ToolAnnotations;
}
\`\`\`

Non-empty objects retain their existing protective check (a populated Zod raw shape in the annotations slot stays an error rather than being silently consumed as annotations).

## Test plan

- [x] New regression test in `test/server/mcp.test.ts` covering `tool(name, desc, schema, {}, cb)` — registers, lists, and calls successfully (passes against both Zod v3 and Zod v4 fixtures).
- [x] Full `test/server/mcp.test.ts` suite passes (234/234).
- [x] `npm run typecheck` passes.
- [x] `npx prettier --check` passes on touched files.
- [x] `npx eslint src/server/mcp.ts` passes.

## Real-world impact

Any tool registered with `server.tool(name, desc, schema, {}, cb)` is unreachable. Encountered this in a downstream MCP server where 6 write-tool registrations all used `{}` as a placeholder for "no annotations to declare yet" — every write call surfaced as `typedHandler is not a function` while reads (which used populated annotations) worked.

Affects v1.x line. Not present on `main` — the 2.0 rewrite uses a different dispatch path.