### PR TITLE
fix(client): avoid expired OAuth access tokens

### DIFF
--- a/.changeset/fresh-tokens-check.md
+++ b/.changeset/fresh-tokens-check.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/client': patch
+---
+
+Avoid returning expired OAuth access tokens from adapted auth providers.

--- a/packages/client/src/client/auth.ts
+++ b/packages/client/src/client/auth.ts
@@ -113,6 +113,12 @@ export async function handleOAuthUnauthorized(provider: OAuthClientProvider, ctx
     }
 }
 
+const OAUTH_TOKEN_EXPIRY_BUFFER_SECONDS = 60;
+
+function hasUsableOAuthAccessToken(tokens: OAuthTokens | undefined): tokens is OAuthTokens {
+    return tokens !== undefined && (tokens.expires_in === undefined || tokens.expires_in > OAUTH_TOKEN_EXPIRY_BUFFER_SECONDS);
+}
+
 /**
  * Adapts an `OAuthClientProvider` to the minimal `AuthProvider` interface that
  * transports consume. Called once at transport construction — the transport stores
@@ -123,7 +129,7 @@ export function adaptOAuthProvider(provider: OAuthClientProvider): AuthProvider 
     return {
         token: async () => {
             const tokens = await provider.tokens();
-            return tokens?.access_token;
+            return hasUsableOAuthAccessToken(tokens) ? tokens.access_token : undefined;
         },
         onUnauthorized: async ctx => handleOAuthUnauthorized(provider, ctx)
     };

--- a/packages/client/src/client/authExtensions.ts
+++ b/packages/client/src/client/authExtensions.ts
@@ -10,6 +10,36 @@ import type { CryptoKey, JWK } from 'jose';
 
 import type { AddClientAuthentication, OAuthClientProvider } from './auth.js';
 
+type SavedOAuthTokens = {
+    tokens: OAuthTokens;
+    expiresAt?: number;
+};
+
+function saveOAuthTokens(tokens: OAuthTokens): SavedOAuthTokens {
+    const savedTokens: SavedOAuthTokens = { tokens };
+
+    if (tokens.expires_in !== undefined) {
+        savedTokens.expiresAt = Date.now() + tokens.expires_in * 1000;
+    }
+
+    return savedTokens;
+}
+
+function readOAuthTokens(savedTokens: SavedOAuthTokens | undefined): OAuthTokens | undefined {
+    if (savedTokens === undefined) {
+        return undefined;
+    }
+
+    if (savedTokens.expiresAt === undefined) {
+        return savedTokens.tokens;
+    }
+
+    return {
+        ...savedTokens.tokens,
+        expires_in: Math.max(0, Math.ceil((savedTokens.expiresAt - Date.now()) / 1000))
+    };
+}
+
 /**
  * Helper to produce a `private_key_jwt` client authentication function.
  *
@@ -138,7 +168,7 @@ export interface ClientCredentialsProviderOptions {
  * ```
  */
 export class ClientCredentialsProvider implements OAuthClientProvider {
-    private _tokens?: OAuthTokens;
+    private _tokens?: SavedOAuthTokens;
     private _clientInfo: OAuthClientInformation;
     private _clientMetadata: OAuthClientMetadata;
 
@@ -173,11 +203,11 @@ export class ClientCredentialsProvider implements OAuthClientProvider {
     }
 
     tokens(): OAuthTokens | undefined {
-        return this._tokens;
+        return readOAuthTokens(this._tokens);
     }
 
     saveTokens(tokens: OAuthTokens): void {
-        this._tokens = tokens;
+        this._tokens = saveOAuthTokens(tokens);
     }
 
     redirectToAuthorization(): void {
@@ -266,7 +296,7 @@ export interface PrivateKeyJwtProviderOptions {
  * ```
  */
 export class PrivateKeyJwtProvider implements OAuthClientProvider {
-    private _tokens?: OAuthTokens;
+    private _tokens?: SavedOAuthTokens;
     private _clientInfo: OAuthClientInformation;
     private _clientMetadata: OAuthClientMetadata;
     addClientAuthentication: AddClientAuthentication;
@@ -309,11 +339,11 @@ export class PrivateKeyJwtProvider implements OAuthClientProvider {
     }
 
     tokens(): OAuthTokens | undefined {
-        return this._tokens;
+        return readOAuthTokens(this._tokens);
     }
 
     saveTokens(tokens: OAuthTokens): void {
-        this._tokens = tokens;
+        this._tokens = saveOAuthTokens(tokens);
     }
 
     redirectToAuthorization(): void {
@@ -371,7 +401,7 @@ export interface StaticPrivateKeyJwtProviderOptions {
  * uses it directly for authentication.
  */
 export class StaticPrivateKeyJwtProvider implements OAuthClientProvider {
-    private _tokens?: OAuthTokens;
+    private _tokens?: SavedOAuthTokens;
     private _clientInfo: OAuthClientInformation;
     private _clientMetadata: OAuthClientMetadata;
     addClientAuthentication: AddClientAuthentication;
@@ -412,11 +442,11 @@ export class StaticPrivateKeyJwtProvider implements OAuthClientProvider {
     }
 
     tokens(): OAuthTokens | undefined {
-        return this._tokens;
+        return readOAuthTokens(this._tokens);
     }
 
     saveTokens(tokens: OAuthTokens): void {
-        this._tokens = tokens;
+        this._tokens = saveOAuthTokens(tokens);
     }
 
     redirectToAuthorization(): void {
@@ -569,7 +599,7 @@ export interface CrossAppAccessProviderOptions {
  * ```
  */
 export class CrossAppAccessProvider implements OAuthClientProvider {
-    private _tokens?: OAuthTokens;
+    private _tokens?: SavedOAuthTokens;
     private _clientInfo: OAuthClientInformation;
     private _clientMetadata: OAuthClientMetadata;
     private _assertionCallback: AssertionCallback;
@@ -610,11 +640,11 @@ export class CrossAppAccessProvider implements OAuthClientProvider {
     }
 
     tokens(): OAuthTokens | undefined {
-        return this._tokens;
+        return readOAuthTokens(this._tokens);
     }
 
     saveTokens(tokens: OAuthTokens): void {
-        this._tokens = tokens;
+        this._tokens = saveOAuthTokens(tokens);
     }
 
     redirectToAuthorization(): void {

--- a/packages/client/test/client/auth.test.ts
+++ b/packages/client/test/client/auth.test.ts
@@ -5,6 +5,7 @@ import { expect, vi } from 'vitest';
 
 import type { OAuthClientProvider } from '../../src/client/auth.js';
 import {
+    adaptOAuthProvider,
     auth,
     buildDiscoveryUrls,
     determineScope,
@@ -62,6 +63,49 @@ describe('OAuth Authorization', () => {
     });
     afterEach(() => {
         mockedCorsIsPossible = false;
+    });
+
+    describe('adaptOAuthProvider', () => {
+        function providerWithTokens(tokens: OAuthTokens | undefined): OAuthClientProvider {
+            return {
+                get redirectUrl() {
+                    return undefined;
+                },
+                get clientMetadata(): OAuthClientMetadata {
+                    return { redirect_uris: [] };
+                },
+                clientInformation: () => ({ client_id: 'client-id' }),
+                tokens: () => tokens,
+                saveTokens: vi.fn(),
+                redirectToAuthorization: vi.fn(),
+                saveCodeVerifier: vi.fn(),
+                codeVerifier: vi.fn()
+            };
+        }
+
+        it('returns the access token when no expiration is supplied', async () => {
+            const provider = adaptOAuthProvider(providerWithTokens({ access_token: 'access-token', token_type: 'Bearer' }));
+
+            await expect(provider.token()).resolves.toBe('access-token');
+        });
+
+        it('returns the access token when it is outside the expiration buffer', async () => {
+            const provider = adaptOAuthProvider(providerWithTokens({ access_token: 'access-token', token_type: 'Bearer', expires_in: 61 }));
+
+            await expect(provider.token()).resolves.toBe('access-token');
+        });
+
+        it('does not return an access token that is expired or inside the expiration buffer', async () => {
+            const nearExpiryProvider = adaptOAuthProvider(
+                providerWithTokens({ access_token: 'near-expiry-token', token_type: 'Bearer', expires_in: 60 })
+            );
+            const expiredProvider = adaptOAuthProvider(
+                providerWithTokens({ access_token: 'expired-token', token_type: 'Bearer', expires_in: 0 })
+            );
+
+            await expect(nearExpiryProvider.token()).resolves.toBeUndefined();
+            await expect(expiredProvider.token()).resolves.toBeUndefined();
+        });
     });
 
     describe('extractWWWAuthenticateParams', () => {

--- a/packages/client/test/client/authExtensions.test.ts
+++ b/packages/client/test/client/authExtensions.test.ts
@@ -247,6 +247,53 @@ describe('auth-extensions providers (end-to-end with auth())', () => {
     });
 });
 
+describe('auth-extensions token expiration tracking', () => {
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('returns expires_in relative to when tokens were saved', () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+
+        const provider = new ClientCredentialsProvider({
+            clientId: 'my-client',
+            clientSecret: 'my-secret'
+        });
+
+        provider.saveTokens({
+            access_token: 'access-token',
+            token_type: 'Bearer',
+            expires_in: 120
+        });
+
+        expect(provider.tokens()?.expires_in).toBe(120);
+
+        vi.advanceTimersByTime(61_000);
+        expect(provider.tokens()?.expires_in).toBe(59);
+
+        vi.advanceTimersByTime(60_000);
+        expect(provider.tokens()?.expires_in).toBe(0);
+    });
+
+    it('preserves tokens without expiration metadata', () => {
+        const provider = new ClientCredentialsProvider({
+            clientId: 'my-client',
+            clientSecret: 'my-secret'
+        });
+
+        provider.saveTokens({
+            access_token: 'access-token',
+            token_type: 'Bearer'
+        });
+
+        expect(provider.tokens()).toEqual({
+            access_token: 'access-token',
+            token_type: 'Bearer'
+        });
+    });
+});
+
 describe('createPrivateKeyJwtAuth', () => {
     const baseOptions = {
         issuer: 'client-id',


### PR DESCRIPTION
## Summary
- have adapted OAuth auth providers return no bearer token when saved tokens are expired or within the 60-second expiry buffer
- track token save time in built-in OAuth extension providers so `expires_in` reflects remaining lifetime instead of the original token response duration
- add regression coverage for adapter expiry filtering and built-in provider lifetime tracking

Fixes #1954.

## Validation
- `pnpm --filter @modelcontextprotocol/client exec vitest run test/client/auth.test.ts test/client/authExtensions.test.ts`
- `pnpm --filter @modelcontextprotocol/client run typecheck`
- `pnpm --filter @modelcontextprotocol/client run lint`
- `pnpm --filter @modelcontextprotocol/client test`
- pre-push hook: `typecheck:all`, `build:all`, `lint:all`