### PR TITLE
fix: align zod object schemas with stripped properties

### DIFF
--- a/.changeset/fix-zod-object-additional-properties-schema.md
+++ b/.changeset/fix-zod-object-additional-properties-schema.md
@@ -1,0 +1,6 @@
+---
+"@modelcontextprotocol/core": patch
+"@modelcontextprotocol/test-integration": patch
+---
+
+fix: align zod object schemas with stripped properties

--- a/packages/core/src/util/standardSchema.ts
+++ b/packages/core/src/util/standardSchema.ts
@@ -188,7 +188,11 @@ export function standardSchemaToJsonSchema(schema: StandardJSONSchemaV1, io: 'in
                 `Wrap your schema in z.object({...}) or equivalent.`
         );
     }
-    return { type: 'object', ...result };
+    const jsonSchema: Record<string, unknown> = { type: 'object', ...result };
+    if (jsonSchema.properties !== undefined && !('additionalProperties' in jsonSchema) && !('unevaluatedProperties' in jsonSchema)) {
+        jsonSchema.additionalProperties = false;
+    }
+    return jsonSchema;
 }
 
 // Validation

--- a/packages/core/test/util/standardSchema.test.ts
+++ b/packages/core/test/util/standardSchema.test.ts
@@ -39,4 +39,28 @@ describe('standardSchemaToJsonSchema', () => {
         expect(keys.filter(k => k === 'type')).toHaveLength(1);
         expect(result.type).toBe('object');
     });
+
+    test('marks default z.object schemas as not accepting additional properties', () => {
+        const schema = z.object({ message: z.string() });
+        const result = standardSchemaToJsonSchema(schema, 'input');
+
+        expect(result.additionalProperties).toBe(false);
+    });
+
+    test('preserves schemas that explicitly allow additional properties', () => {
+        const schema = z.object({ message: z.string() }).passthrough();
+        const result = standardSchemaToJsonSchema(schema, 'input');
+
+        expect(result.additionalProperties).toEqual({});
+    });
+
+    test('does not add root additionalProperties to union schemas', () => {
+        const schema = z.discriminatedUnion('action', [
+            z.object({ action: z.literal('create'), name: z.string() }),
+            z.object({ action: z.literal('delete'), id: z.string() })
+        ]);
+        const result = standardSchemaToJsonSchema(schema, 'input');
+
+        expect(result.additionalProperties).toBeUndefined();
+    });
 });

--- a/test/integration/test/server/mcp.test.ts
+++ b/test/integration/test/server/mcp.test.ts
@@ -934,6 +934,7 @@ describe('Zod v4', () => {
             expect(result.tools[0]!.name).toBe('test');
             expect(result.tools[0]!.inputSchema).toMatchObject({
                 type: 'object',
+                additionalProperties: false,
                 properties: {
                     name: { type: 'string' },
                     value: { type: 'number' }


### PR DESCRIPTION
## Summary
- mark converted default Zod object schemas with `additionalProperties: false` when Zod validation will strip unknown keys
- preserve explicit passthrough schemas and avoid adding a root `additionalProperties` to union schemas
- assert the advertised tool schema now matches runtime behavior for registered tools

Fixes #147.

## Validation
- `pnpm --filter @modelcontextprotocol/core test -- packages/core/test/util/standardSchema.test.ts`
- `pnpm --filter @modelcontextprotocol/server test -- test/integration/test/server/mcp.test.ts -t "should register tool with params"`
- `pnpm --filter @modelcontextprotocol/core typecheck`
- `pnpm --filter @modelcontextprotocol/core lint`
- `pnpm --filter @modelcontextprotocol/test-integration lint`
- pre-push: full `typecheck:all`, `build:all`, and `lint:all`