### PR TITLE
fix: avoid duplicate SSE close callbacks

### DIFF
--- a/.changeset/fix-v1x-sse-close-once.md
+++ b/.changeset/fix-v1x-sse-close-once.md
@@ -1,5 +1,5 @@
 ---
-"@modelcontextprotocol/sdk": patch
+'@modelcontextprotocol/sdk': patch
 ---
 
 fix: avoid duplicate SSE close callbacks

--- a/.changeset/fix-v1x-sse-close-once.md
+++ b/.changeset/fix-v1x-sse-close-once.md
@@ -1,0 +1,5 @@
+---
+"@modelcontextprotocol/sdk": patch
+---
+
+fix: avoid duplicate SSE close callbacks

--- a/src/server/sse.ts
+++ b/src/server/sse.ts
@@ -124,8 +124,10 @@ export class SSEServerTransport implements Transport {
 
         this._sseResponse = this.res;
         this.res.on('close', () => {
-            this._sseResponse = undefined;
-            this.onclose?.();
+            if (this._sseResponse !== undefined) {
+                this._sseResponse = undefined;
+                this.onclose?.();
+            }
         });
     }
 

--- a/test/server/sse.test.ts
+++ b/test/server/sse.test.ts
@@ -442,6 +442,39 @@ describe.each(zodTestMatrix)('$zodVersionLabel', (entry: ZodMatrixEntry) => {
                 await transport.close();
                 expect(transport.onclose).toHaveBeenCalled();
             });
+
+            it('should only call onclose once when close ends the SSE response', async () => {
+                const onclose = vi.fn();
+                const server = createServer(async (_req, res) => {
+                    const transport = new SSEServerTransport('/messages', res);
+                    transport.onclose = onclose;
+
+                    await transport.start();
+                    await transport.close();
+                });
+
+                const baseUrl = await listenOnRandomPort(server);
+
+                try {
+                    await new Promise<void>((resolve, reject) => {
+                        const req = http.request(baseUrl, { headers: { Accept: 'text/event-stream' } }, response => {
+                            response.resume();
+                            response.on('end', resolve);
+                            response.on('error', reject);
+                        });
+
+                        req.on('error', reject);
+                        req.end();
+                    });
+
+                    await new Promise(resolve => setTimeout(resolve, 50));
+                    expect(onclose).toHaveBeenCalledTimes(1);
+                } finally {
+                    await new Promise<void>((resolve, reject) => {
+                        server.close(error => (error ? reject(error) : resolve()));
+                    });
+                }
+            });
         });
 
         describe('send method', () => {


### PR DESCRIPTION
## Summary
- guard the SSE response close handler so programmatic close() does not fire onclose twice
- add a real HTTP regression test covering close() ending the SSE response

Fixes #321

## Validation
- npm test -- test/server/sse.test.ts -t "should only call onclose once"
- npm test -- test/server/sse.test.ts
- npm run typecheck
- npm run lint
- npm test
- npm run build