### PR TITLE
docs(examples): index missing server and client examples in README

### DIFF
--- a/examples/client/README.md
+++ b/examples/client/README.md
@@ -36,6 +36,9 @@ Most clients expect a server to be running. Start one from [`../server/README.md
 | Client credentials (M2M)                            | Machine-to-machine OAuth client credentials example.                                      | [`src/simpleClientCredentials.ts`](src/simpleClientCredentials.ts)                         |
 | URL elicitation client                              | Drives URL-mode elicitation flows (sensitive input in a browser).                         | [`src/elicitationUrlExample.ts`](src/elicitationUrlExample.ts)                             |
 | Task interactive client                             | Demonstrates task-based execution + interactive server→client requests.                   | [`src/simpleTaskInteractiveClient.ts`](src/simpleTaskInteractiveClient.ts)                 |
+| Bearer token provider                               | Minimal `AuthProvider` for pre-configured bearer tokens (gateway/proxy patterns).         | [`src/simpleTokenProvider.ts`](src/simpleTokenProvider.ts)                                 |
+| Dual-mode auth                                      | Same `authProvider` option used for host-managed tokens and full OAuth providers.         | [`src/dualModeAuth.ts`](src/dualModeAuth.ts)                                               |
+| Custom (non-spec) method                            | Sends a vendor-prefixed `acme/search` request and receives custom progress notifications. | [`src/customMethodExample.ts`](src/customMethodExample.ts)                                 |
 
 ## URL elicitation example (server + client)
 

--- a/examples/server/README.md
+++ b/examples/server/README.md
@@ -39,6 +39,9 @@ pnpm tsx src/simpleStreamableHttp.ts
 | Task interactive server                   | Task-based execution with interactive server→client requests.                                   | [`src/simpleTaskInteractive.ts`](src/simpleTaskInteractive.ts)                           |
 | Hono Streamable HTTP server               | Streamable HTTP server built with Hono instead of Express.                                      | [`src/honoWebStandardStreamableHttp.ts`](src/honoWebStandardStreamableHttp.ts)           |
 | SSE polling demo server                   | Legacy SSE server intended for polling demos.                                                   | [`src/ssePollingExample.ts`](src/ssePollingExample.ts)                                   |
+| ArkType schema validation                 | Minimal stdio server using ArkType (Standard Schema spec) for tool input schemas.               | [`src/arktypeExample.ts`](src/arktypeExample.ts)                                         |
+| Valibot schema validation                 | Minimal stdio server using Valibot + `@valibot/to-json-schema` for tool input schemas.          | [`src/valibotExample.ts`](src/valibotExample.ts)                                         |
+| Custom protocol version support           | Supports protocol versions not yet shipped in the SDK; first in list is the fallback.           | [`src/customProtocolVersion.ts`](src/customProtocolVersion.ts)                           |
 
 ## OAuth demo flags (Streamable HTTP server)
 


### PR DESCRIPTION
## Summary

Several runnable example files exist in `examples/server/src/` and `examples/client/src/` but are not listed in the example index tables in their respective `README.md` files. Users browsing the example READMEs cannot discover them without scanning the directories directly.

This PR adds one row per missing example to the existing tables. No code changes.

## Why

The README example index is the canonical entry point. Examples that are not listed effectively don't exist for new users — every other example has a row, and the missing ones cover commonly requested scenarios (custom schema validators, custom protocol versions, simple bearer auth).

## Changes

### `examples/server/README.md`
Added rows for:
- `src/arktypeExample.ts` — ArkType / Standard Schema input validation
- `src/valibotExample.ts` — Valibot + `@valibot/to-json-schema` validation
- `src/customProtocolVersion.ts` — supporting protocol versions not yet in the SDK

### `examples/client/README.md`
Added rows for:
- `src/simpleTokenProvider.ts` — minimal `AuthProvider` for pre-configured tokens
- `src/dualModeAuth.ts` — same `authProvider` option for host-managed and OAuth flows
- `src/customMethodExample.ts` — vendor-prefixed (`acme/search`) custom method client

## Excluded

Files that are intentionally not standalone runnable examples are not added:
- `serverGuide.examples.ts` / `clientGuide.examples.ts` — snippet sources synced into `docs/`
- `inMemoryEventStore.ts` — supporting module imported by the streamable HTTP examples
- `customMethodExample.ts` (server side) — spawned by the client example via stdio

## How to test

- View `examples/server/README.md` and `examples/client/README.md` and confirm the new rows render as part of the existing tables.
- Confirm all relative links in the new rows resolve to existing files.