### PR TITLE
fix(client): preserve OAuth resource metadata indicator

### DIFF
--- a/.changeset/fix-oauth-resource-indicator-preserve-metadata.md
+++ b/.changeset/fix-oauth-resource-indicator-preserve-metadata.md
@@ -1,0 +1,5 @@
+---
+"@modelcontextprotocol/client": patch
+---
+
+fix(client): preserve OAuth resource metadata indicator

--- a/packages/client/src/client/auth.ts
+++ b/packages/client/src/client/auth.ts
@@ -236,7 +236,7 @@ export interface OAuthClientProvider {
      *
      * Implementations must verify the returned resource matches the MCP server.
      */
-    validateResourceURL?(serverUrl: string | URL, resource?: string): Promise<URL | undefined>;
+    validateResourceURL?(serverUrl: string | URL, resource?: string): Promise<OAuthResourceIndicator | undefined>;
 
     /**
      * If implemented, provides a way for the client to invalidate (e.g. delete) the specified
@@ -384,6 +384,11 @@ function isClientAuthMethod(method: string): method is ClientAuthMethod {
 
 const AUTHORIZATION_CODE_RESPONSE_TYPE = 'code';
 const AUTHORIZATION_CODE_CHALLENGE_METHOD = 'S256';
+type OAuthResourceIndicator = string | URL;
+
+function serializeResourceIndicator(resource: OAuthResourceIndicator): string {
+    return typeof resource === 'string' ? resource : resource.href;
+}
 
 /**
  * Determines the best client authentication method to use based on server support and client configuration.
@@ -684,11 +689,11 @@ async function authInternal(
     // Save authorization server URL for providers that need it (e.g., CrossAppAccessProvider)
     await provider.saveAuthorizationServerUrl?.(String(authorizationServerUrl));
 
-    const resource: URL | undefined = await selectResourceURL(serverUrl, provider, resourceMetadata);
+    const resource: OAuthResourceIndicator | undefined = await selectResourceURL(serverUrl, provider, resourceMetadata);
 
     // Save resource URL for providers that need it (e.g., CrossAppAccessProvider)
     if (resource) {
-        await provider.saveResourceUrl?.(String(resource));
+        await provider.saveResourceUrl?.(serializeResourceIndicator(resource));
     }
 
     // Scope selection used consistently for DCR and the authorization request.
@@ -844,7 +849,7 @@ export async function selectResourceURL(
     serverUrl: string | URL,
     provider: OAuthClientProvider,
     resourceMetadata?: OAuthProtectedResourceMetadata
-): Promise<URL | undefined> {
+): Promise<OAuthResourceIndicator | undefined> {
     const defaultResource = resourceUrlFromServerUrl(serverUrl);
 
     // If provider has custom validation, delegate to it
@@ -861,8 +866,9 @@ export async function selectResourceURL(
     if (!checkResourceAllowed({ requestedResource: defaultResource, configuredResource: resourceMetadata.resource })) {
         throw new Error(`Protected resource ${resourceMetadata.resource} does not match expected ${defaultResource} (or origin)`);
     }
-    // Prefer the resource from metadata since it's what the server is telling us to request
-    return new URL(resourceMetadata.resource);
+    // Prefer the exact resource indicator from metadata since it's what the server is telling us to request.
+    // Constructing a URL would normalize pathless origins by appending "/", which can change the audience.
+    return resourceMetadata.resource;
 }
 
 /**
@@ -1376,7 +1382,7 @@ export async function startAuthorization(
         redirectUrl: string | URL;
         scope?: string;
         state?: string;
-        resource?: URL;
+        resource?: OAuthResourceIndicator;
     }
 ): Promise<{ authorizationUrl: URL; codeVerifier: string }> {
     let authorizationUrl: URL;
@@ -1424,7 +1430,7 @@ export async function startAuthorization(
     }
 
     if (resource) {
-        authorizationUrl.searchParams.set('resource', resource.href);
+        authorizationUrl.searchParams.set('resource', serializeResourceIndicator(resource));
     }
 
     return { authorizationUrl, codeVerifier };
@@ -1472,7 +1478,7 @@ export async function executeTokenRequest(
         tokenRequestParams: URLSearchParams;
         clientInformation?: OAuthClientInformationMixed;
         addClientAuthentication?: OAuthClientProvider['addClientAuthentication'];
-        resource?: URL;
+        resource?: OAuthResourceIndicator;
         fetchFn?: FetchLike;
     }
 ): Promise<OAuthTokens> {
@@ -1484,7 +1490,7 @@ export async function executeTokenRequest(
     });
 
     if (resource) {
-        tokenRequestParams.set('resource', resource.href);
+        tokenRequestParams.set('resource', serializeResourceIndicator(resource));
     }
 
     if (addClientAuthentication) {
@@ -1548,7 +1554,7 @@ export async function exchangeAuthorization(
         authorizationCode: string;
         codeVerifier: string;
         redirectUri: string | URL;
-        resource?: URL;
+        resource?: OAuthResourceIndicator;
         addClientAuthentication?: OAuthClientProvider['addClientAuthentication'];
         fetchFn?: FetchLike;
     }
@@ -1590,7 +1596,7 @@ export async function refreshAuthorization(
         metadata?: AuthorizationServerMetadata;
         clientInformation: OAuthClientInformationMixed;
         refreshToken: string;
-        resource?: URL;
+        resource?: OAuthResourceIndicator;
         addClientAuthentication?: OAuthClientProvider['addClientAuthentication'];
         fetchFn?: FetchLike;
     }
@@ -1651,7 +1657,7 @@ export async function fetchToken(
         fetchFn
     }: {
         metadata?: AuthorizationServerMetadata;
-        resource?: URL;
+        resource?: OAuthResourceIndicator;
         /** Authorization code for the default `authorization_code` grant flow */
         authorizationCode?: string;
         /** Optional scope parameter from auth() options */

--- a/packages/client/src/client/auth.ts
+++ b/packages/client/src/client/auth.ts
@@ -384,7 +384,7 @@ function isClientAuthMethod(method: string): method is ClientAuthMethod {
 
 const AUTHORIZATION_CODE_RESPONSE_TYPE = 'code';
 const AUTHORIZATION_CODE_CHALLENGE_METHOD = 'S256';
-type OAuthResourceIndicator = string | URL;
+export type OAuthResourceIndicator = string | URL;
 
 function serializeResourceIndicator(resource: OAuthResourceIndicator): string {
     return typeof resource === 'string' ? resource : resource.href;

--- a/packages/client/test/client/auth.test.ts
+++ b/packages/client/test/client/auth.test.ts
@@ -18,6 +18,7 @@ import {
     refreshAuthorization,
     registerClient,
     selectClientAuthMethod,
+    selectResourceURL,
     startAuthorization,
     validateClientMetadataUrl
 } from '../../src/client/auth.js';
@@ -1301,7 +1302,7 @@ describe('OAuth Authorization', () => {
             const tokenCall = mockFetch.mock.calls.find(call => call[0].toString().includes('/token'));
             expect(tokenCall).toBeDefined();
             const body = tokenCall![1].body as URLSearchParams;
-            expect(body.get('resource')).toBe('https://resource.example.com/');
+            expect(body.get('resource')).toBe('https://resource.example.com');
         });
 
         it('re-saves enriched state when partial cache is supplemented with fetched metadata', async () => {
@@ -1464,6 +1465,17 @@ describe('OAuth Authorization', () => {
         });
     });
 
+    describe('selectResourceURL', () => {
+        it('preserves the exact protected resource metadata resource indicator', async () => {
+            const resource = await selectResourceURL('https://api.example.com/mcp-server', {} as OAuthClientProvider, {
+                resource: 'https://api.example.com',
+                authorization_servers: ['https://auth.example.com']
+            });
+
+            expect(resource).toBe('https://api.example.com');
+        });
+    });
+
     describe('startAuthorization', () => {
         const validMetadata = {
             issuer: 'https://auth.example.com',
@@ -1506,6 +1518,17 @@ describe('OAuth Authorization', () => {
             expect(authorizationUrl.searchParams.get('redirect_uri')).toBe('http://localhost:3000/callback');
             expect(authorizationUrl.searchParams.get('resource')).toBe('https://api.example.com/mcp-server');
             expect(codeVerifier).toBe('test_verifier');
+        });
+
+        it('preserves string resource indicators exactly', async () => {
+            const { authorizationUrl } = await startAuthorization('https://auth.example.com', {
+                metadata: undefined,
+                clientInformation: validClientInfo,
+                redirectUrl: 'http://localhost:3000/callback',
+                resource: 'https://api.example.com'
+            });
+
+            expect(authorizationUrl.searchParams.get('resource')).toBe('https://api.example.com');
         });
 
         it('includes scope parameter when provided', async () => {
@@ -1684,6 +1707,26 @@ describe('OAuth Authorization', () => {
             expect(options.headers.get('Authorization')).toBe('Basic ' + btoa('client123:secret123'));
             expect(body.get('redirect_uri')).toBe('http://localhost:3000/callback');
             expect(body.get('resource')).toBe('https://api.example.com/mcp-server');
+        });
+
+        it('preserves string resource indicators exactly in token requests', async () => {
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                status: 200,
+                json: async () => validTokens
+            });
+
+            await exchangeAuthorization('https://auth.example.com', {
+                clientInformation: validClientInfo,
+                authorizationCode: 'code123',
+                codeVerifier: 'verifier123',
+                redirectUri: 'http://localhost:3000/callback',
+                resource: 'https://api.example.com'
+            });
+
+            const options = mockFetch.mock.calls[0]![1];
+            const body = options.body as URLSearchParams;
+            expect(body.get('resource')).toBe('https://api.example.com');
         });
 
         it('allows for string "expires_in" values', async () => {


### PR DESCRIPTION
## Summary

Fixes #1968 by preserving the exact RFC 8707 resource indicator string published in protected resource metadata after validation, instead of serializing it through `URL.href` and normalizing pathless origins to include a trailing slash.

This keeps `resource=https://example.com` distinct from `resource=https://example.com/` for authorization and token requests, which matters for OAuth providers that treat the resource/audience string literally.

## Validation

- `pnpm --filter @modelcontextprotocol/client test -- auth.test.ts`
- `pnpm --filter @modelcontextprotocol/client typecheck`
- `pnpm --filter @modelcontextprotocol/client lint`
- `pnpm --filter @modelcontextprotocol/client build`
- pre-push hook: full workspace typecheck, build, and lint
