### PR TITLE
fix(server): accept structurally compatible Zod v4 schemas

### DIFF
--- a/.changeset/fix-zod-44-registertool-types.md
+++ b/.changeset/fix-zod-44-registertool-types.md
@@ -1,5 +1,5 @@
 ---
-"@modelcontextprotocol/sdk": patch
+'@modelcontextprotocol/sdk': patch
 ---
 
 fix(server): accept structurally compatible Zod v4 schemas

--- a/.changeset/fix-zod-44-registertool-types.md
+++ b/.changeset/fix-zod-44-registertool-types.md
@@ -1,0 +1,5 @@
+---
+"@modelcontextprotocol/sdk": patch
+---
+
+fix(server): accept structurally compatible Zod v4 schemas

--- a/src/server/zod-compat.ts
+++ b/src/server/zod-compat.ts
@@ -10,7 +10,15 @@ import * as z3rt from 'zod/v3';
 import * as z4mini from 'zod/v4-mini';
 
 // --- Unified schema types ---
-export type AnySchema = z3.ZodTypeAny | z4.$ZodType;
+export interface ZodV4TypeLike<Output = unknown, Input = unknown> {
+    _zod: {
+        output: Output;
+        input: Input;
+        def?: unknown;
+    };
+}
+
+export type AnySchema = z3.ZodTypeAny | ZodV4TypeLike;
 export type AnyObjectSchema = z3.AnyZodObject | z4.$ZodObject | AnySchema;
 export type ZodRawShapeCompat = Record<string, AnySchema>;
 
@@ -30,6 +38,8 @@ export interface ZodV3Internal {
 
 export interface ZodV4Internal {
     _zod?: {
+        output?: unknown;
+        input?: unknown;
         def?: {
             type?: string;
             value?: unknown;
@@ -41,9 +51,9 @@ export interface ZodV4Internal {
 }
 
 // --- Type inference helpers ---
-export type SchemaOutput<S> = S extends z3.ZodTypeAny ? z3.infer<S> : S extends z4.$ZodType ? z4.output<S> : never;
+export type SchemaOutput<S> = S extends z3.ZodTypeAny ? z3.infer<S> : S extends ZodV4TypeLike<infer Output, unknown> ? Output : never;
 
-export type SchemaInput<S> = S extends z3.ZodTypeAny ? z3.input<S> : S extends z4.$ZodType ? z4.input<S> : never;
+export type SchemaInput<S> = S extends z3.ZodTypeAny ? z3.input<S> : S extends ZodV4TypeLike<unknown, infer Input> ? Input : never;
 
 /**
  * Infers the output type from a ZodRawShapeCompat (raw shape object).
@@ -54,7 +64,7 @@ export type ShapeOutput<Shape extends ZodRawShapeCompat> = {
 };
 
 // --- Runtime detection ---
-export function isZ4Schema(s: AnySchema): s is z4.$ZodType {
+export function isZ4Schema(s: AnySchema): s is ZodV4TypeLike {
     // Present on Zod 4 (Classic & Mini) schemas; absent on Zod 3
     const schema = s as unknown as ZodV4Internal;
     return !!schema._zod;
@@ -81,7 +91,7 @@ export function safeParse<S extends AnySchema>(
 ): { success: true; data: SchemaOutput<S> } | { success: false; error: unknown } {
     if (isZ4Schema(schema)) {
         // Mini exposes top-level safeParse
-        const result = z4mini.safeParse(schema, data);
+        const result = z4mini.safeParse(schema as z4.$ZodType, data);
         return result as { success: true; data: SchemaOutput<S> } | { success: false; error: unknown };
     }
     const v3Schema = schema as z3.ZodTypeAny;
@@ -95,7 +105,7 @@ export async function safeParseAsync<S extends AnySchema>(
 ): Promise<{ success: true; data: SchemaOutput<S> } | { success: false; error: unknown }> {
     if (isZ4Schema(schema)) {
         // Mini exposes top-level safeParseAsync
-        const result = await z4mini.safeParseAsync(schema, data);
+        const result = await z4mini.safeParseAsync(schema as z4.$ZodType, data);
         return result as { success: true; data: SchemaOutput<S> } | { success: false; error: unknown };
     }
     const v3Schema = schema as z3.ZodTypeAny;

--- a/test/issues/test_1987_zod_v4_type_identity.test.ts
+++ b/test/issues/test_1987_zod_v4_type_identity.test.ts
@@ -1,0 +1,36 @@
+import { McpServer } from '../../src/server/mcp.js';
+
+type ExternalZodV4Schema<Output, Input = Output> = {
+    _zod: {
+        output: Output;
+        input: Input;
+        def: { type: string };
+    };
+};
+
+function assertTypechecks(callback: () => void): void {
+    expect(typeof callback).toBe('function');
+}
+
+describe('Issue #1987: externally resolved Zod v4 schema types', () => {
+    it('accepts raw shapes whose fields come from another compatible Zod v4 module identity', () => {
+        assertTypechecks(() => {
+            const server = new McpServer({ name: 'test', version: '1.0.0' });
+            const name = {} as ExternalZodV4Schema<string>;
+            const age = {} as ExternalZodV4Schema<number | undefined, number | undefined>;
+
+            server.registerTool(
+                'example',
+                {
+                    inputSchema: { name, age }
+                },
+                async ({ name, age }) => {
+                    const upperName: string = name.toUpperCase();
+                    const maybeAge: number | undefined = age;
+
+                    return { content: [{ type: 'text', text: `${upperName} ${maybeAge ?? ''}` }] };
+                }
+            );
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Fixes #1987 on the `v1.x` branch by avoiding a type-identity leak from the SDK's own `zod/v4/core` import in the public Zod compatibility types.

`AnySchema` now accepts Zod v4 schemas structurally via the `_zod.input` / `_zod.output` contract. This preserves inference for `registerTool` raw shapes while allowing projects whose package manager resolves a different compatible Zod v4 copy than the SDK's copy.

## Validation

- Reproduced the issue in an external consumer with top-level `zod@4.4.1` and a nested SDK-resolved `zod@4.3.6`: `registerTool` failed with `ZodString` not assignable to `AnySchema`.
- Packed this branch and re-ran the same duplicate-Zod consumer repro: `npx tsc --noEmit` passed and callback args inferred correctly.
- `npm run typecheck`
- `npm run build`
- `npm test -- test/issues/test_1987_zod_v4_type_identity.test.ts test/server/mcp.test.ts test/server/completable.test.ts`
- `npm run lint`
