### PR TITLE
fix: preserve elicit string pattern constraints

### DIFF
--- a/.changeset/elicit-string-pattern.md
+++ b/.changeset/elicit-string-pattern.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/core': patch
+---
+
+Preserve `pattern` constraints on elicitation string property schemas during request validation.

--- a/packages/core/src/types/schemas.ts
+++ b/packages/core/src/types/schemas.ts
@@ -1733,6 +1733,7 @@ export const StringSchemaSchema = z.object({
     description: z.string().optional(),
     minLength: z.number().optional(),
     maxLength: z.number().optional(),
+    pattern: z.string().optional(),
     format: z.enum(['email', 'uri', 'date', 'date-time']).optional(),
     default: z.string().optional()
 });

--- a/packages/core/test/spec.types.test.ts
+++ b/packages/core/test/spec.types.test.ts
@@ -868,6 +868,7 @@ type _K_EmbeddedResource = Assert<AssertExactKeys<SDKTypes.EmbeddedResource, Spe
 type _K_ResourceLink = Assert<AssertExactKeys<SDKTypes.ResourceLink, SpecTypes.ResourceLink>>;
 type _K_PromptMessage = Assert<AssertExactKeys<SDKTypes.PromptMessage, SpecTypes.PromptMessage>>;
 type _K_BooleanSchema = Assert<AssertExactKeys<SDKTypes.BooleanSchema, SpecTypes.BooleanSchema>>;
+// @ts-expect-error The written 2025-11-25 elicitation spec includes StringSchema.pattern, but generated spec types lag it.
 type _K_StringSchema = Assert<AssertExactKeys<SDKTypes.StringSchema, SpecTypes.StringSchema>>;
 type _K_NumberSchema = Assert<AssertExactKeys<SDKTypes.NumberSchema, SpecTypes.NumberSchema>>;
 type _K_UntitledSingleSelectEnumSchema = Assert<

--- a/packages/core/test/types.test.ts
+++ b/packages/core/test/types.test.ts
@@ -11,6 +11,7 @@ import {
     PromptMessageSchema,
     ResourceLinkSchema,
     SamplingMessageSchema,
+    StringSchemaSchema,
     SUPPORTED_PROTOCOL_VERSIONS,
     ToolChoiceSchema,
     ToolResultContentSchema,
@@ -986,6 +987,18 @@ describe('Types', () => {
     });
 
     describe('ElicitRequestFormParamsSchema', () => {
+        test('preserves string pattern constraints in property schemas', () => {
+            const stringResult = StringSchemaSchema.safeParse({
+                type: 'string',
+                pattern: '^[A-Za-z]+$'
+            });
+
+            expect(stringResult.success).toBe(true);
+            if (stringResult.success) {
+                expect(stringResult.data.pattern).toBe('^[A-Za-z]+$');
+            }
+        });
+
         test('accepts requestedSchema with extra JSON Schema metadata keys', () => {
             // Mirrors what z.toJSONSchema() emits — includes $schema, additionalProperties, etc.
             // See https://github.com/modelcontextprotocol/typescript-sdk/issues/1362
@@ -995,7 +1008,7 @@ describe('Types', () => {
                     $schema: 'https://json-schema.org/draft/2020-12/schema',
                     type: 'object',
                     properties: {
-                        name: { type: 'string' }
+                        name: { type: 'string', pattern: '^[A-Za-z]+$' }
                     },
                     required: ['name'],
                     additionalProperties: false
@@ -1008,6 +1021,9 @@ describe('Types', () => {
                 expect(result.data.requestedSchema.type).toBe('object');
                 expect(result.data.requestedSchema.$schema).toBe('https://json-schema.org/draft/2020-12/schema');
                 expect(result.data.requestedSchema.additionalProperties).toBe(false);
+                expect(result.data.requestedSchema.properties.name).toEqual(
+                    expect.objectContaining({ type: 'string', pattern: '^[A-Za-z]+$' })
+                );
             }
         });
     });


### PR DESCRIPTION
## Summary
- Preserve `pattern` on elicitation string property schemas instead of stripping it during validation.
- Cover both direct `StringSchemaSchema` parsing and nested `ElicitRequestFormParamsSchema` parsing.
- Document the temporary generated-spec type mismatch: the written 2025-11-25 elicitation spec includes `StringSchema.pattern`, while `spec.types.ts` is still missing it.

## Notes
This intentionally keeps the change narrow to the spec-backed string `pattern` field rather than making all primitive schemas permissive. It addresses the concrete `pattern` loss described in #1844 without broad passthrough behavior.

Spec reference: https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation

## Validation
- `pnpm --filter @modelcontextprotocol/core exec vitest run test/types.test.ts test/spec.types.test.ts`
- `pnpm --filter @modelcontextprotocol/core run typecheck`
- `pnpm --filter @modelcontextprotocol/core exec prettier --ignore-path ../../.prettierignore --check src/types/schemas.ts test/types.test.ts test/spec.types.test.ts`
- pre-push hook: `pnpm -r typecheck`, `pnpm -r build`, `pnpm sync:snippets --check && pnpm -r lint`
