### PR TITLE
fix(server): validate wrapped output schemas on v1

### DIFF
--- a/.changeset/fix-output-schema-wrappers.md
+++ b/.changeset/fix-output-schema-wrappers.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/sdk': patch
+---
+
+Fix v1.x server tool output validation for optional, nullable, nullish, and union Zod output schemas.

--- a/src/server/mcp.ts
+++ b/src/server/mcp.ts
@@ -305,9 +305,11 @@ export class McpServer {
             );
         }
 
-        // if the tool has an output schema, validate structured content
-        const outputObj = normalizeObjectSchema(tool.outputSchema) as AnyObjectSchema;
-        const parseResult = await safeParseAsync(outputObj, result.structuredContent);
+        // Try to normalize to object schema first (for raw shapes and object schemas)
+        // If that fails, use the schema directly (for union/optional/nullable/etc)
+        const outputObj = normalizeObjectSchema(tool.outputSchema);
+        const schemaToParse = outputObj ?? tool.outputSchema;
+        const parseResult = await safeParseAsync(schemaToParse, result.structuredContent);
         if (!parseResult.success) {
             const error = 'error' in parseResult ? parseResult.error : 'Unknown error';
             const errorMessage = getParseErrorMessage(error);

--- a/test/server/mcp.test.ts
+++ b/test/server/mcp.test.ts
@@ -1295,6 +1295,74 @@ describe.each(zodTestMatrix)('$zodVersionLabel', (entry: ZodMatrixEntry) => {
             expect(JSON.parse(textContent.text)).toEqual(result.structuredContent);
         });
 
+        test('should validate structuredContent against non-object-wrapper output schemas', async () => {
+            const mcpServer = new McpServer({
+                name: 'test server',
+                version: '1.0'
+            });
+
+            const client = new Client({
+                name: 'test client',
+                version: '1.0'
+            });
+
+            const schemaCases = [
+                {
+                    name: 'optional',
+                    outputSchema: z.object({ data: z.string() }).optional(),
+                    structuredContent: { data: 'hello' }
+                },
+                {
+                    name: 'nullable',
+                    outputSchema: z.object({ data: z.string() }).nullable(),
+                    structuredContent: { data: 'hello' }
+                },
+                {
+                    name: 'nullish',
+                    outputSchema: z.object({ data: z.string() }).nullish(),
+                    structuredContent: { data: 'hello' }
+                },
+                {
+                    name: 'union',
+                    outputSchema: z.union([z.object({ data: z.string() }), z.object({ value: z.string() })]),
+                    structuredContent: { value: 'hello' }
+                }
+            ];
+
+            for (const { name, outputSchema, structuredContent } of schemaCases) {
+                mcpServer.registerTool(
+                    `test-${name}`,
+                    {
+                        description: `Test tool with ${name} output schema`,
+                        outputSchema
+                    },
+                    async () => ({
+                        structuredContent,
+                        content: [
+                            {
+                                type: 'text',
+                                text: JSON.stringify(structuredContent)
+                            }
+                        ]
+                    })
+                );
+            }
+
+            const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+            await Promise.all([client.connect(clientTransport), mcpServer.server.connect(serverTransport)]);
+
+            for (const { name, structuredContent } of schemaCases) {
+                const result = await client.callTool({
+                    name: `test-${name}`,
+                    arguments: {}
+                });
+
+                expect(result.isError).not.toBe(true);
+                expect(result.structuredContent).toEqual(structuredContent);
+            }
+        });
+
         /***
          * Test: Tool with Output Schema Must Provide Structured Content
          */


### PR DESCRIPTION
## Summary

- mirror input validation's fallback behavior for tool output schemas on `v1.x`
- validate wrapped/non-object top-level Zod output schemas directly when `normalizeObjectSchema()` cannot produce an object schema
- add regression coverage across the Zod v3/v4 matrix for optional, nullable, nullish, and union output schemas

Fixes #1308 for the v1.x release line.

## Validation

- `npm test -- test/server/mcp.test.ts -t "non-object-wrapper"`
- `npm test -- test/server/mcp.test.ts`
- `npx prettier --check src/server/mcp.ts test/server/mcp.test.ts .changeset/fix-output-schema-wrappers.md`
- `npx eslint src/server/mcp.ts`
- `git diff --check`

Note: `npm run typecheck -- --pretty false` currently fails on unrelated existing v1.x test errors in `test/integration-tests/taskLifecycle.test.ts` and `test/shared/protocol.test.ts` (`Expected 2-3 arguments, but got 1`). No typecheck error points at the files changed in this PR.
