### PR TITLE
fix(server): exit when MCP client closes stdin pipe

### DIFF
--- a/.changeset/fix-stdio-stdin-close-exit.md
+++ b/.changeset/fix-stdio-stdin-close-exit.md
@@ -1,0 +1,5 @@
+---
+"@modelcontextprotocol/server": patch
+---
+
+Exit server process when MCP client closes stdin pipe. Previously, `StdioServerTransport` failed to detect when a client closed its stdin pipe, causing server processes to accumulate as zombies. This adds `close` and `end` event listeners on stdin that trigger proper transport cleanup.

--- a/packages/server/src/server/stdio.ts
+++ b/packages/server/src/server/stdio.ts
@@ -49,6 +49,11 @@ export class StdioServerTransport implements Transport {
             // Ignore errors during close — stdin pipe ended
         });
     };
+    _onstdinend = () => {
+        this.close().catch(() => {
+            // Ignore errors during close — stdin pipe ended
+        });
+    };
 
     /**
      * Starts listening for messages on `stdin`.
@@ -64,6 +69,7 @@ export class StdioServerTransport implements Transport {
         this._stdin.on('data', this._ondata);
         this._stdin.on('error', this._onerror);
         this._stdin.on('close', this._onstdinclose);
+        this._stdin.on('end', this._onstdinend);
         this._stdout.on('error', this._onstdouterror);
     }
 
@@ -92,6 +98,7 @@ export class StdioServerTransport implements Transport {
         this._stdin.off('data', this._ondata);
         this._stdin.off('error', this._onerror);
         this._stdin.off('close', this._onstdinclose);
+        this._stdin.off('end', this._onstdinend);
         this._stdout.off('error', this._onstdouterror);
 
         // Check if we were the only data listener

--- a/packages/server/src/server/stdio.ts
+++ b/packages/server/src/server/stdio.ts
@@ -44,6 +44,11 @@ export class StdioServerTransport implements Transport {
             // Ignore errors during close — we're already in an error path
         });
     };
+    _onstdinclose = () => {
+        this.close().catch(() => {
+            // Ignore errors during close — stdin pipe ended
+        });
+    };
 
     /**
      * Starts listening for messages on `stdin`.
@@ -58,6 +63,7 @@ export class StdioServerTransport implements Transport {
         this._started = true;
         this._stdin.on('data', this._ondata);
         this._stdin.on('error', this._onerror);
+        this._stdin.on('close', this._onstdinclose);
         this._stdout.on('error', this._onstdouterror);
     }
 
@@ -85,6 +91,7 @@ export class StdioServerTransport implements Transport {
         // Remove our event listeners first
         this._stdin.off('data', this._ondata);
         this._stdin.off('error', this._onerror);
+        this._stdin.off('close', this._onstdinclose);
         this._stdout.off('error', this._onstdouterror);
 
         // Check if we were the only data listener

--- a/packages/server/test/server/stdio.test.ts
+++ b/packages/server/test/server/stdio.test.ts
@@ -194,18 +194,28 @@ test('should fire onclose when stdin emits close', async () => {
 });
 
 test('should fire onclose when stdin emits end', async () => {
-    const server = new StdioServerTransport(input, output);
+    // Use autoDestroy:false + emitClose:false so push(null) fires 'end' but NOT 'close',
+    // ensuring the test fails unless an 'end' listener is explicitly registered.
+    const endOnlyInput = new Readable({
+        autoDestroy: false,
+        emitClose: false,
+        read: () => {}
+    });
+    const server = new StdioServerTransport(endOnlyInput, output);
     server.onerror = error => { throw error; };
 
     let closeCount = 0;
+    let inputCloseCount = 0;
     server.onclose = () => { closeCount++; };
+    endOnlyInput.on('close', () => { inputCloseCount++; });
 
     await server.start();
-    input.push(null); // signals end-of-stream
+    endOnlyInput.push(null); // signals end-of-stream without emitting close
 
     // Allow microtasks to flush
     await new Promise(resolve => setTimeout(resolve, 0));
 
+    expect(inputCloseCount).toBe(0); // confirms close was NOT emitted
     expect(closeCount).toBe(1);
 });
 

--- a/packages/server/test/server/stdio.test.ts
+++ b/packages/server/test/server/stdio.test.ts
@@ -179,3 +179,46 @@ test('should fire onerror before onclose on stdout error', async () => {
 
     expect(events).toEqual(['error', 'close']);
 });
+
+test('should fire onclose when stdin emits close', async () => {
+    const server = new StdioServerTransport(input, output);
+    server.onerror = error => { throw error; };
+
+    let closeCount = 0;
+    server.onclose = () => { closeCount++; };
+
+    await server.start();
+    input.emit('close');
+
+    expect(closeCount).toBe(1);
+});
+
+test('should fire onclose when stdin emits end', async () => {
+    const server = new StdioServerTransport(input, output);
+    server.onerror = error => { throw error; };
+
+    let closeCount = 0;
+    server.onclose = () => { closeCount++; };
+
+    await server.start();
+    input.push(null); // signals end-of-stream
+
+    // Allow microtasks to flush
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(closeCount).toBe(1);
+});
+
+test('should not fire onclose twice when close() called after stdin close', async () => {
+    const server = new StdioServerTransport(input, output);
+    server.onerror = () => {};
+
+    let closeCount = 0;
+    server.onclose = () => { closeCount++; };
+
+    await server.start();
+    input.emit('close');
+    await server.close();
+
+    expect(closeCount).toBe(1);
+});

--- a/packages/server/test/server/stdio.test.ts
+++ b/packages/server/test/server/stdio.test.ts
@@ -182,10 +182,14 @@ test('should fire onerror before onclose on stdout error', async () => {
 
 test('should fire onclose when stdin emits close', async () => {
     const server = new StdioServerTransport(input, output);
-    server.onerror = error => { throw error; };
+    server.onerror = error => {
+        throw error;
+    };
 
     let closeCount = 0;
-    server.onclose = () => { closeCount++; };
+    server.onclose = () => {
+        closeCount++;
+    };
 
     await server.start();
     input.emit('close');
@@ -202,12 +206,18 @@ test('should fire onclose when stdin emits end', async () => {
         read: () => {}
     });
     const server = new StdioServerTransport(endOnlyInput, output);
-    server.onerror = error => { throw error; };
+    server.onerror = error => {
+        throw error;
+    };
 
     let closeCount = 0;
     let inputCloseCount = 0;
-    server.onclose = () => { closeCount++; };
-    endOnlyInput.on('close', () => { inputCloseCount++; });
+    server.onclose = () => {
+        closeCount++;
+    };
+    endOnlyInput.on('close', () => {
+        inputCloseCount++;
+    });
 
     await server.start();
     endOnlyInput.push(null); // signals end-of-stream without emitting close
@@ -224,7 +234,9 @@ test('should not fire onclose twice when close() called after stdin close', asyn
     server.onerror = () => {};
 
     let closeCount = 0;
-    server.onclose = () => { closeCount++; };
+    server.onclose = () => {
+        closeCount++;
+    };
 
     await server.start();
     input.emit('close');


### PR DESCRIPTION
## Problem

`StdioServerTransport` listens for `data` and `error` on stdin, but not for `close` or `end`. When an MCP client (e.g. Claude Code) closes its window or restarts, it drops its end of the stdio pipe. The server process never detects this and keeps running indefinitely.

This causes **unbounded zombie process accumulation** — every time the client restarts, a new server is spawned, and the old one never dies. Observed in production: 37 orphaned processes consuming 26,000+ CPU-seconds, machine became unresponsive.

This is especially severe on **Windows**, where `SIGTERM` is not reliably delivered to child processes when a parent exits, making stdin close the *only* cross-platform shutdown signal.

Related to #1568 (which fixed stdout EPIPE) but stdin close was left unhandled.
Tracked in issue #2002.

## Fix

Add a `close` listener on stdin in `start()` that calls `this.close()`, using the same arrow-function pattern as `_onstdouterror` for proper cleanup on `close()`.

## Tests

- `should fire onclose when stdin emits close`
- `should fire onclose when stdin emits end`
- `should not fire onclose twice when close() called after stdin close`