### PR TITLE
feat(server): BackchannelCompat + Server.buildContext via ctx.mcpReq.send (R4)

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -31,6 +31,7 @@ export { Server } from './server/server.js';
 // StdioServerTransport is exported from the './stdio' subpath — server stdio has only type-level Node
 // imports (erased at compile time), but matching the client's `./stdio` subpath gives consumers a
 // consistent shape across packages.
+export { BackchannelCompat } from './server/backchannelCompat.js';
 export type { Dispatchable, HandleHttpOptions, HandleHttpRequestExtra } from './server/handleHttp.js';
 export { handleHttp } from './server/handleHttp.js';
 export type { SessionCompatOptions, SessionValidation } from './server/sessionCompat.js';

--- a/packages/server/src/server/backchannelCompat.ts
+++ b/packages/server/src/server/backchannelCompat.ts
@@ -16,8 +16,7 @@ import { DEFAULT_REQUEST_TIMEOUT_MSEC, isJSONRPCErrorResponse, ProtocolError, Sd
  * `sampling/createMessage` requests to the client mid-tool-call by writing them as
  * SSE events on the open POST response stream and waiting for the client to POST
  * the response back. This class owns the per-session `{requestId -> resolver}`
- * map that correlation requires, plus the standalone-GET writer registry used for
- * unsolicited server notifications.
+ * map that correlation requires.
  *
  * It exists so this stateful behaviour is in one removable file once MRTR
  * (SEP-2322) is the protocol floor and `env.send` becomes a hard error in
@@ -25,15 +24,17 @@ import { DEFAULT_REQUEST_TIMEOUT_MSEC, isJSONRPCErrorResponse, ProtocolError, Sd
  */
 export class BackchannelCompat {
     private _pending = new Map<string, Map<number, { resolve: (r: Result) => void; reject: (e: Error) => void }>>();
-    private _standaloneWriters = new Map<string, (msg: JSONRPCMessage) => void>();
     private _nextId = 0;
 
     /**
      * Returns an `env.send` implementation bound to the given session and POST-stream writer.
      * The returned function writes the outbound JSON-RPC request to `writeSSE` and resolves when
      * {@linkcode handleResponse} is called for the same id on the same session.
+     *
+     * `writeSSE` returns `false` when the underlying stream is closed; the returned promise then
+     * rejects immediately with `SendFailed` instead of waiting for the timeout.
      */
-    makeEnvSend(sessionId: string, writeSSE: (msg: JSONRPCMessage) => void): (req: Request, opts?: RequestOptions) => Promise<Result> {
+    makeEnvSend(sessionId: string, writeSSE: (msg: JSONRPCMessage) => boolean): (req: Request, opts?: RequestOptions) => Promise<Result> {
         return (req: Request, opts?: RequestOptions): Promise<Result> => {
             return new Promise<Result>((resolve, reject) => {
                 if (opts?.signal?.aborted) {
@@ -45,18 +46,17 @@ export class BackchannelCompat {
                 const sessionMap = this._pending.get(sessionId) ?? new Map();
                 this._pending.set(sessionId, sessionMap);
 
-                const timeoutMs = opts?.timeout ?? DEFAULT_REQUEST_TIMEOUT_MSEC;
-                const timer = setTimeout(() => {
-                    sessionMap.delete(id);
-                    reject(new SdkError(SdkErrorCode.RequestTimeout, 'Request timed out', { timeout: timeoutMs }));
-                }, timeoutMs);
-
+                // eslint-disable-next-line prefer-const -- forward-referenced by cleanup() before assignment site
+                let timer: ReturnType<typeof setTimeout> | undefined;
                 const onAbort = () => {
+                    // Tell the client to stop processing, then reject locally.
+                    writeSSE({ jsonrpc: '2.0', method: 'notifications/cancelled', params: { requestId: id } });
                     settle.reject(opts!.signal!.reason instanceof Error ? opts!.signal!.reason : new Error(String(opts!.signal!.reason)));
                 };
                 const cleanup = () => {
-                    clearTimeout(timer);
+                    if (timer !== undefined) clearTimeout(timer);
                     sessionMap.delete(id);
+                    if (sessionMap.size === 0) this._pending.delete(sessionId);
                     opts?.signal?.removeEventListener('abort', onAbort);
                 };
                 const settle = {
@@ -71,13 +71,17 @@ export class BackchannelCompat {
                 };
                 sessionMap.set(id, settle);
 
+                const timeoutMs = opts?.timeout ?? DEFAULT_REQUEST_TIMEOUT_MSEC;
+                timer = setTimeout(
+                    () => settle.reject(new SdkError(SdkErrorCode.RequestTimeout, 'Request timed out', { timeout: timeoutMs })),
+                    timeoutMs
+                );
+
                 opts?.signal?.addEventListener('abort', onAbort, { once: true });
 
                 const wire: JSONRPCRequest = { jsonrpc: '2.0', id, method: req.method, params: req.params };
-                try {
-                    writeSSE(wire);
-                } catch (error) {
-                    settle.reject(error instanceof Error ? error : new Error(String(error)));
+                if (!writeSSE(wire)) {
+                    settle.reject(new SdkError(SdkErrorCode.SendFailed, 'Backchannel stream closed'));
                 }
             });
         };
@@ -100,49 +104,12 @@ export class BackchannelCompat {
         return true;
     }
 
-    /**
-     * Registers (or clears) the standalone GET subscription writer for a session, used to
-     * deliver server-initiated notifications outside any POST request.
-     */
-    setStandaloneWriter(sessionId: string, write: ((msg: JSONRPCMessage) => void) | undefined): void {
-        if (write) this._standaloneWriters.set(sessionId, write);
-        else this._standaloneWriters.delete(sessionId);
-    }
-
-    /**
-     * Clears the standalone writer only if `owner` is still the registered writer. Guards against a
-     * stale `cancel` callback (from a superseded reconnect) clearing the new stream.
-     */
-    clearStandaloneWriter(sessionId: string, owner: (msg: JSONRPCMessage) => void): void {
-        if (this._standaloneWriters.get(sessionId) === owner) this._standaloneWriters.delete(sessionId);
-    }
-
-    /** True if a standalone writer is registered for the session. */
-    hasStandaloneWriter(sessionId: string): boolean {
-        return this._standaloneWriters.has(sessionId);
-    }
-
-    /** Writes a message on the session's standalone GET stream, if one is open. */
-    writeStandalone(sessionId: string, msg: JSONRPCMessage): boolean {
-        const w = this._standaloneWriters.get(sessionId);
-        if (!w) return false;
-        try {
-            w(msg);
-            return true;
-        } catch {
-            this._standaloneWriters.delete(sessionId);
-            return false;
-        }
-    }
-
     /** Rejects all pending requests for a session and forgets it. */
     closeSession(sessionId: string): void {
         const sessionMap = this._pending.get(sessionId);
-        if (sessionMap) {
-            const err = new SdkError(SdkErrorCode.ConnectionClosed, 'Session closed');
-            for (const s of sessionMap.values()) s.reject(err);
-            this._pending.delete(sessionId);
-        }
-        this._standaloneWriters.delete(sessionId);
+        if (!sessionMap) return;
+        const err = new SdkError(SdkErrorCode.ConnectionClosed, 'Session closed');
+        for (const s of sessionMap.values()) s.reject(err);
+        this._pending.delete(sessionId);
     }
 }

--- a/packages/server/src/server/backchannelCompat.ts
+++ b/packages/server/src/server/backchannelCompat.ts
@@ -1,0 +1,148 @@
+import type {
+    JSONRPCErrorResponse,
+    JSONRPCMessage,
+    JSONRPCRequest,
+    JSONRPCResultResponse,
+    Request,
+    RequestOptions,
+    Result
+} from '@modelcontextprotocol/core';
+import { DEFAULT_REQUEST_TIMEOUT_MSEC, isJSONRPCErrorResponse, ProtocolError, SdkError, SdkErrorCode } from '@modelcontextprotocol/core';
+
+/**
+ * Isolated 2025-11 server-to-client request backchannel for `handleHttp`.
+ *
+ * The 2025-11 protocol allows a server to send `elicitation/create` and
+ * `sampling/createMessage` requests to the client mid-tool-call by writing them as
+ * SSE events on the open POST response stream and waiting for the client to POST
+ * the response back. This class owns the per-session `{requestId -> resolver}`
+ * map that correlation requires, plus the standalone-GET writer registry used for
+ * unsolicited server notifications.
+ *
+ * It exists so this stateful behaviour is in one removable file once MRTR
+ * (SEP-2322) is the protocol floor and `env.send` becomes a hard error in
+ * stateless paths.
+ */
+export class BackchannelCompat {
+    private _pending = new Map<string, Map<number, { resolve: (r: Result) => void; reject: (e: Error) => void }>>();
+    private _standaloneWriters = new Map<string, (msg: JSONRPCMessage) => void>();
+    private _nextId = 0;
+
+    /**
+     * Returns an `env.send` implementation bound to the given session and POST-stream writer.
+     * The returned function writes the outbound JSON-RPC request to `writeSSE` and resolves when
+     * {@linkcode handleResponse} is called for the same id on the same session.
+     */
+    makeEnvSend(sessionId: string, writeSSE: (msg: JSONRPCMessage) => void): (req: Request, opts?: RequestOptions) => Promise<Result> {
+        return (req: Request, opts?: RequestOptions): Promise<Result> => {
+            return new Promise<Result>((resolve, reject) => {
+                if (opts?.signal?.aborted) {
+                    reject(opts.signal.reason instanceof Error ? opts.signal.reason : new Error(String(opts.signal.reason)));
+                    return;
+                }
+
+                const id = this._nextId++;
+                const sessionMap = this._pending.get(sessionId) ?? new Map();
+                this._pending.set(sessionId, sessionMap);
+
+                const timeoutMs = opts?.timeout ?? DEFAULT_REQUEST_TIMEOUT_MSEC;
+                const timer = setTimeout(() => {
+                    sessionMap.delete(id);
+                    reject(new SdkError(SdkErrorCode.RequestTimeout, 'Request timed out', { timeout: timeoutMs }));
+                }, timeoutMs);
+
+                const onAbort = () => {
+                    settle.reject(opts!.signal!.reason instanceof Error ? opts!.signal!.reason : new Error(String(opts!.signal!.reason)));
+                };
+                const cleanup = () => {
+                    clearTimeout(timer);
+                    sessionMap.delete(id);
+                    opts?.signal?.removeEventListener('abort', onAbort);
+                };
+                const settle = {
+                    resolve: (r: Result) => {
+                        cleanup();
+                        resolve(r);
+                    },
+                    reject: (e: Error) => {
+                        cleanup();
+                        reject(e);
+                    }
+                };
+                sessionMap.set(id, settle);
+
+                opts?.signal?.addEventListener('abort', onAbort, { once: true });
+
+                const wire: JSONRPCRequest = { jsonrpc: '2.0', id, method: req.method, params: req.params };
+                try {
+                    writeSSE(wire);
+                } catch (error) {
+                    settle.reject(error instanceof Error ? error : new Error(String(error)));
+                }
+            });
+        };
+    }
+
+    /**
+     * Routes an incoming JSON-RPC response (from a client POST) to the waiting `env.send` promise.
+     * @returns true if a pending request matched and was settled.
+     */
+    handleResponse(sessionId: string, response: JSONRPCResultResponse | JSONRPCErrorResponse): boolean {
+        const sessionMap = this._pending.get(sessionId);
+        const id = typeof response.id === 'number' ? response.id : Number(response.id);
+        const settle = sessionMap?.get(id);
+        if (!settle) return false;
+        if (isJSONRPCErrorResponse(response)) {
+            settle.reject(ProtocolError.fromError(response.error.code, response.error.message, response.error.data));
+        } else {
+            settle.resolve(response.result);
+        }
+        return true;
+    }
+
+    /**
+     * Registers (or clears) the standalone GET subscription writer for a session, used to
+     * deliver server-initiated notifications outside any POST request.
+     */
+    setStandaloneWriter(sessionId: string, write: ((msg: JSONRPCMessage) => void) | undefined): void {
+        if (write) this._standaloneWriters.set(sessionId, write);
+        else this._standaloneWriters.delete(sessionId);
+    }
+
+    /**
+     * Clears the standalone writer only if `owner` is still the registered writer. Guards against a
+     * stale `cancel` callback (from a superseded reconnect) clearing the new stream.
+     */
+    clearStandaloneWriter(sessionId: string, owner: (msg: JSONRPCMessage) => void): void {
+        if (this._standaloneWriters.get(sessionId) === owner) this._standaloneWriters.delete(sessionId);
+    }
+
+    /** True if a standalone writer is registered for the session. */
+    hasStandaloneWriter(sessionId: string): boolean {
+        return this._standaloneWriters.has(sessionId);
+    }
+
+    /** Writes a message on the session's standalone GET stream, if one is open. */
+    writeStandalone(sessionId: string, msg: JSONRPCMessage): boolean {
+        const w = this._standaloneWriters.get(sessionId);
+        if (!w) return false;
+        try {
+            w(msg);
+            return true;
+        } catch {
+            this._standaloneWriters.delete(sessionId);
+            return false;
+        }
+    }
+
+    /** Rejects all pending requests for a session and forgets it. */
+    closeSession(sessionId: string): void {
+        const sessionMap = this._pending.get(sessionId);
+        if (sessionMap) {
+            const err = new SdkError(SdkErrorCode.ConnectionClosed, 'Session closed');
+            for (const s of sessionMap.values()) s.reject(err);
+            this._pending.delete(sessionId);
+        }
+        this._standaloneWriters.delete(sessionId);
+    }
+}

--- a/packages/server/src/server/handleHttp.ts
+++ b/packages/server/src/server/handleHttp.ts
@@ -33,7 +33,10 @@ export interface Dispatchable {
  *
  * `mcp.connect(transport)` is not called; each HTTP request flows through
  * `mcp.dispatch()` directly. Supply a `SessionCompat` via `options.session`
- * to serve clients that send `Mcp-Session-Id` (the pre-2026-06 stateful flow).
+ * to serve clients that send `Mcp-Session-Id` (the pre-2026-06 stateful flow),
+ * and a `BackchannelCompat` via `options.backchannel` to let handlers'
+ * `ctx.mcpReq.send` (e.g. `elicitInput`, `requestSampling`) reach those
+ * clients over the open POST SSE stream.
  */
 export function handleHttp(
     mcp: Dispatchable,

--- a/packages/server/src/server/server.ts
+++ b/packages/server/src/server/server.ts
@@ -153,8 +153,16 @@ export class Server extends Protocol<ServerContext> {
             mcpReq: {
                 ...ctx.mcpReq,
                 log: (level, data, logger) => this.sendLoggingMessage({ level, data, logger }),
-                elicitInput: (params, options) => this.elicitInput(params, options),
-                requestSampling: (params, options) => this.createMessage(params, options)
+                elicitInput: (params, options) =>
+                    ctx.mcpReq.send({ method: 'elicitation/create', params }, ElicitResultSchema, {
+                        ...options,
+                        relatedRequestId: ctx.mcpReq.id
+                    }),
+                requestSampling: (params, options) =>
+                    ctx.mcpReq.send({ method: 'sampling/createMessage', params }, CreateMessageResultSchema, {
+                        ...options,
+                        relatedRequestId: ctx.mcpReq.id
+                    }) as Promise<CreateMessageResult>
             },
             http: hasHttpInfo
                 ? {

--- a/packages/server/src/server/server.ts
+++ b/packages/server/src/server/server.ts
@@ -28,6 +28,7 @@ import type {
     Result,
     ServerCapabilities,
     ServerContext,
+    StandardSchemaV1,
     TaskManagerOptions,
     ToolResultContent,
     ToolUseContent
@@ -53,6 +54,13 @@ import {
 import { DefaultJsonSchemaValidator } from '@modelcontextprotocol/server/_shims';
 
 import { ExperimentalServerTasks } from '../experimental/tasks/server.js';
+
+/** Three-arg send used by `_createMessageVia`/`_elicitInputVia`; satisfied by both `_requestWithSchema` and `ctx.mcpReq.send`. */
+type SendWithSchema = <T extends StandardSchemaV1>(
+    request: { method: string; params?: Record<string, unknown> },
+    resultSchema: T,
+    options?: RequestOptions
+) => Promise<StandardSchemaV1.InferOutput<T>>;
 
 /**
  * Extended tasks capability that includes runtime configuration (store, messageQueue).
@@ -148,21 +156,18 @@ export class Server extends Protocol<ServerContext> {
     protected override buildContext(ctx: BaseContext, transportInfo?: MessageExtraInfo): ServerContext {
         // Only create http when there's actual HTTP transport info or auth info
         const hasHttpInfo = ctx.http || transportInfo?.request || transportInfo?.closeSSEStream || transportInfo?.closeStandaloneSSEStream;
+        const sendOpts = (options?: RequestOptions): RequestOptions => ({ ...options, relatedRequestId: ctx.mcpReq.id });
         return {
             ...ctx,
             mcpReq: {
                 ...ctx.mcpReq,
-                log: (level, data, logger) => this.sendLoggingMessage({ level, data, logger }),
-                elicitInput: (params, options) =>
-                    ctx.mcpReq.send({ method: 'elicitation/create', params }, ElicitResultSchema, {
-                        ...options,
-                        relatedRequestId: ctx.mcpReq.id
-                    }),
-                requestSampling: (params, options) =>
-                    ctx.mcpReq.send({ method: 'sampling/createMessage', params }, CreateMessageResultSchema, {
-                        ...options,
-                        relatedRequestId: ctx.mcpReq.id
-                    }) as Promise<CreateMessageResult>
+                log: async (level, data, logger) => {
+                    if (this._capabilities.logging && !this.isMessageIgnored(level, ctx.sessionId)) {
+                        await ctx.mcpReq.notify({ method: 'notifications/message', params: { level, data, logger } });
+                    }
+                },
+                elicitInput: (params, options) => this._elicitInputVia(ctx.mcpReq.send, params, sendOpts(options)),
+                requestSampling: (params, options) => this._createMessageVia(ctx.mcpReq.send, params, sendOpts(options))
             },
             http: hasHttpInfo
                 ? {
@@ -466,14 +471,23 @@ export class Server extends Protocol<ServerContext> {
         params: CreateMessageRequest['params'],
         options?: RequestOptions
     ): Promise<CreateMessageResult | CreateMessageResultWithTools> {
-        // Capability check - only required when tools/toolChoice are provided
+        return this._createMessageVia((r, schema, opts) => this._requestWithSchema(r, schema, opts), params, options);
+    }
+
+    /**
+     * Shared body for {@linkcode createMessage} and `ctx.mcpReq.requestSampling`: capability check,
+     * tool_use/tool_result pairing validation, and result-schema selection. The `send` argument
+     * routes to either the connected driver (instance method) or `ctx.mcpReq.send` (per-request).
+     */
+    private async _createMessageVia(
+        send: SendWithSchema,
+        params: CreateMessageRequest['params'],
+        options?: RequestOptions
+    ): Promise<CreateMessageResult | CreateMessageResultWithTools> {
         if ((params.tools || params.toolChoice) && !this._clientCapabilities?.sampling?.tools) {
             throw new SdkError(SdkErrorCode.CapabilityNotSupported, 'Client does not support sampling tools capability.');
         }
 
-        // Message structure validation - always validate tool_use/tool_result pairs.
-        // These may appear even without tools/toolChoice in the current request when
-        // a previous sampling request returned tool_use and this is a follow-up with results.
         if (params.messages.length > 0) {
             const lastMessage = params.messages.at(-1)!;
             const lastContent = Array.isArray(lastMessage.content) ? lastMessage.content : [lastMessage.content];
@@ -515,11 +529,10 @@ export class Server extends Protocol<ServerContext> {
             }
         }
 
-        // Use different schemas based on whether tools are provided
         if (params.tools) {
-            return this._requestWithSchema({ method: 'sampling/createMessage', params }, CreateMessageResultWithToolsSchema, options);
+            return send({ method: 'sampling/createMessage', params }, CreateMessageResultWithToolsSchema, options);
         }
-        return this._requestWithSchema({ method: 'sampling/createMessage', params }, CreateMessageResultSchema, options);
+        return send({ method: 'sampling/createMessage', params }, CreateMessageResultSchema, options);
     }
 
     /**
@@ -530,6 +543,18 @@ export class Server extends Protocol<ServerContext> {
      * @returns The result of the elicitation request.
      */
     async elicitInput(params: ElicitRequestFormParams | ElicitRequestURLParams, options?: RequestOptions): Promise<ElicitResult> {
+        return this._elicitInputVia((r, schema, opts) => this._requestWithSchema(r, schema, opts), params, options);
+    }
+
+    /**
+     * Shared body for {@linkcode elicitInput} and `ctx.mcpReq.elicitInput`: form/url capability
+     * sub-field check, mode defaulting, and post-receipt JSON-schema validation of `content`.
+     */
+    private async _elicitInputVia(
+        send: SendWithSchema,
+        params: ElicitRequestFormParams | ElicitRequestURLParams,
+        options?: RequestOptions
+    ): Promise<ElicitResult> {
         const mode = (params.mode ?? 'form') as 'form' | 'url';
 
         switch (mode) {
@@ -537,29 +562,22 @@ export class Server extends Protocol<ServerContext> {
                 if (!this._clientCapabilities?.elicitation?.url) {
                     throw new SdkError(SdkErrorCode.CapabilityNotSupported, 'Client does not support url elicitation.');
                 }
-
                 const urlParams = params as ElicitRequestURLParams;
-                return this._requestWithSchema({ method: 'elicitation/create', params: urlParams }, ElicitResultSchema, options);
+                return send({ method: 'elicitation/create', params: urlParams }, ElicitResultSchema, options);
             }
             case 'form': {
                 if (!this._clientCapabilities?.elicitation?.form) {
                     throw new SdkError(SdkErrorCode.CapabilityNotSupported, 'Client does not support form elicitation.');
                 }
-
                 const formParams: ElicitRequestFormParams =
                     params.mode === 'form' ? (params as ElicitRequestFormParams) : { ...(params as ElicitRequestFormParams), mode: 'form' };
 
-                const result = await this._requestWithSchema(
-                    { method: 'elicitation/create', params: formParams },
-                    ElicitResultSchema,
-                    options
-                );
+                const result = await send({ method: 'elicitation/create', params: formParams }, ElicitResultSchema, options);
 
                 if (result.action === 'accept' && result.content && formParams.requestedSchema) {
                     try {
                         const validator = this._jsonSchemaValidator.getValidator(formParams.requestedSchema as JsonSchemaType);
                         const validationResult = validator(result.content);
-
                         if (!validationResult.valid) {
                             throw new ProtocolError(
                                 ProtocolErrorCode.InvalidParams,
@@ -567,9 +585,7 @@ export class Server extends Protocol<ServerContext> {
                             );
                         }
                     } catch (error) {
-                        if (error instanceof ProtocolError) {
-                            throw error;
-                        }
+                        if (error instanceof ProtocolError) throw error;
                         throw new ProtocolError(
                             ProtocolErrorCode.InternalError,
                             `Error validating elicitation response: ${error instanceof Error ? error.message : String(error)}`

--- a/packages/server/src/server/shttpHandler.ts
+++ b/packages/server/src/server/shttpHandler.ts
@@ -173,6 +173,11 @@ export function shttpHandler(
     const supportedProtocolVersions = options.supportedProtocolVersions ?? SUPPORTED_PROTOCOL_VERSIONS;
     const onerror = options.onerror;
 
+    // Reject any pending backchannel sends on session close (DELETE, idle/capacity eviction).
+    if (session && backchannel) {
+        session.addCloseListener(sid => backchannel.closeSession(sid));
+    }
+
     /**
      * Per-request abort controllers for `notifications/cancelled`. Keyed by
      * `(sessionId, requestId)` so concurrent sessions reusing the same JSON-RPC id don't collide.
@@ -541,7 +546,6 @@ export function shttpHandler(
         const protoErr = validateProtocolVersion(req);
         if (protoErr) return protoErr;
         try {
-            backchannel?.closeSession(v.sessionId!);
             await session.delete(v.sessionId!);
         } catch (error) {
             onerror?.(error as Error);

--- a/packages/server/src/server/shttpHandler.ts
+++ b/packages/server/src/server/shttpHandler.ts
@@ -361,12 +361,11 @@ export function shttpHandler(
                     authInfo: extra?.authInfo,
                     closeSSEStream: supportsPolling ? closeStream : undefined,
                     closeStandaloneSSEStream:
-                        supportsPolling && sessionId !== undefined
-                            ? () => {
-                                  session?.closeStandaloneStream(sessionId);
-                                  backchannel?.setStandaloneWriter(sessionId, undefined);
-                              }
-                            : undefined
+                        // No explicit backchannel writer clear: closeStandaloneStream closes the
+                        // controller, making the registered writer inert; a reconnecting GET overwrites
+                        // it via setStandaloneWriter. An unconditional clear here could race a
+                        // freshly-registered GET writer (r0-004).
+                        supportsPolling && sessionId !== undefined ? () => session?.closeStandaloneStream(sessionId) : undefined
                 };
                 const writeSSE = (msg: JSONRPCMessage) => void emit(controller, encoder, streamId, msg);
                 const env: ShttpRequestEnv = {

--- a/packages/server/src/server/shttpHandler.ts
+++ b/packages/server/src/server/shttpHandler.ts
@@ -361,13 +361,11 @@ export function shttpHandler(
                     authInfo: extra?.authInfo,
                     closeSSEStream: supportsPolling ? closeStream : undefined,
                     closeStandaloneSSEStream:
-                        // No explicit backchannel writer clear: closeStandaloneStream closes the
-                        // controller, making the registered writer inert; a reconnecting GET overwrites
-                        // it via setStandaloneWriter. An unconditional clear here could race a
-                        // freshly-registered GET writer (r0-004).
                         supportsPolling && sessionId !== undefined ? () => session?.closeStandaloneStream(sessionId) : undefined
                 };
-                const writeSSE = (msg: JSONRPCMessage) => void emit(controller, encoder, streamId, msg);
+                // Backchannel writes go straight to writeSSEEvent (synchronous boolean) so a closed
+                // stream surfaces as `false` immediately instead of hanging until the timeout.
+                const writeSSE = (msg: JSONRPCMessage): boolean => writeSSEEvent(controller, encoder, msg);
                 const env: ShttpRequestEnv = {
                     ...baseEnv,
                     _transportExtra: transportExtra,
@@ -456,18 +454,14 @@ export function shttpHandler(
         const encoder = new TextEncoder();
         const headers: Record<string, string> = { ...SSE_HEADERS, 'mcp-session-id': sessionId };
         let registeredController: ReadableStreamDefaultController<Uint8Array> | undefined;
-        let registeredWriter: ((msg: JSONRPCMessage) => void) | undefined;
         const readable = new ReadableStream<Uint8Array>({
             start: controller => {
                 registeredController = controller;
                 session.setStandaloneStream(sessionId, controller);
-                registeredWriter = (msg: JSONRPCMessage) => void emit(controller, encoder, streamId, msg);
-                backchannel?.setStandaloneWriter(sessionId, registeredWriter);
                 void writePrimingEvent(controller, encoder, streamId, clientProtocolVersion).catch(error => onerror?.(error as Error));
             },
             cancel: () => {
                 if (registeredController) session.clearStandaloneStream(sessionId, registeredController);
-                if (registeredWriter) backchannel?.clearStandaloneWriter(sessionId, registeredWriter);
             }
         });
         return new Response(readable, { headers });
@@ -495,7 +489,6 @@ export function shttpHandler(
         const encoder = new TextEncoder();
         const headers: Record<string, string> = { ...SSE_HEADERS, 'mcp-session-id': sessionId };
         let registeredController: ReadableStreamDefaultController<Uint8Array> | undefined;
-        let registeredWriter: ((msg: JSONRPCMessage) => void) | undefined;
         let cancelled = false;
         const readable = new ReadableStream<Uint8Array>({
             start: controller => {
@@ -532,7 +525,6 @@ export function shttpHandler(
             cancel: () => {
                 cancelled = true;
                 if (registeredController) session.clearStandaloneStream(sessionId, registeredController);
-                if (registeredWriter) backchannel?.clearStandaloneWriter(sessionId, registeredWriter);
             }
         });
         return new Response(readable, { headers });

--- a/packages/server/src/server/shttpHandler.ts
+++ b/packages/server/src/server/shttpHandler.ts
@@ -19,6 +19,7 @@ import {
     SUPPORTED_PROTOCOL_VERSIONS
 } from '@modelcontextprotocol/core';
 
+import type { BackchannelCompat } from './backchannelCompat.js';
 import type { SessionCompat } from './sessionCompat.js';
 import type { EventId, EventStore } from './streamableHttp.js';
 
@@ -53,6 +54,15 @@ export interface ShttpHandlerOptions {
      * the handler is stateless: GET/DELETE return 405.
      */
     session?: SessionCompat;
+
+    /**
+     * Pre-2026-06 server-to-client request backchannel. When provided alongside `session`,
+     * a handler's `ctx.mcpReq.send` (e.g. `elicitInput`, `requestSampling`) writes the
+     * outbound request onto the open POST's SSE stream and the client's POSTed-back
+     * response resolves the awaited promise. When omitted, `ctx.mcpReq.send` rejects
+     * with `NotConnected` on this path.
+     */
+    backchannel?: BackchannelCompat;
 
     /**
      * Event store for SSE resumability via `Last-Event-ID`. When configured, every
@@ -157,6 +167,7 @@ export function shttpHandler(
 ): (req: Request, extra?: ShttpRequestExtra) => Promise<Response> {
     const enableJsonResponse = options.enableJsonResponse ?? false;
     const session = options.session;
+    const backchannel = options.backchannel;
     const eventStore = options.eventStore;
     const retryInterval = options.retryInterval;
     const supportedProtocolVersions = options.supportedProtocolVersions ?? SUPPORTED_PROTOCOL_VERSIONS;
@@ -279,7 +290,8 @@ export function shttpHandler(
         }
 
         for (const r of responses) {
-            cb.onresponse?.(r);
+            const claimed = backchannel && sessionId !== undefined && backchannel.handleResponse(sessionId, r);
+            if (!claimed) cb.onresponse?.(r);
         }
 
         if (requests.length === 0) {
@@ -349,9 +361,19 @@ export function shttpHandler(
                     authInfo: extra?.authInfo,
                     closeSSEStream: supportsPolling ? closeStream : undefined,
                     closeStandaloneSSEStream:
-                        supportsPolling && sessionId !== undefined ? () => session?.closeStandaloneStream(sessionId) : undefined
+                        supportsPolling && sessionId !== undefined
+                            ? () => {
+                                  session?.closeStandaloneStream(sessionId);
+                                  backchannel?.setStandaloneWriter(sessionId, undefined);
+                              }
+                            : undefined
                 };
-                const env: ShttpRequestEnv = { ...baseEnv, _transportExtra: transportExtra };
+                const writeSSE = (msg: JSONRPCMessage) => void emit(controller, encoder, streamId, msg);
+                const env: ShttpRequestEnv = {
+                    ...baseEnv,
+                    _transportExtra: transportExtra,
+                    ...(backchannel && sessionId !== undefined ? { send: backchannel.makeEnvSend(sessionId, writeSSE) } : {})
+                };
                 void (async () => {
                     try {
                         await writePrimingEvent(controller, encoder, streamId, clientProtocolVersion);
@@ -435,14 +457,18 @@ export function shttpHandler(
         const encoder = new TextEncoder();
         const headers: Record<string, string> = { ...SSE_HEADERS, 'mcp-session-id': sessionId };
         let registeredController: ReadableStreamDefaultController<Uint8Array> | undefined;
+        let registeredWriter: ((msg: JSONRPCMessage) => void) | undefined;
         const readable = new ReadableStream<Uint8Array>({
             start: controller => {
                 registeredController = controller;
                 session.setStandaloneStream(sessionId, controller);
+                registeredWriter = (msg: JSONRPCMessage) => void emit(controller, encoder, streamId, msg);
+                backchannel?.setStandaloneWriter(sessionId, registeredWriter);
                 void writePrimingEvent(controller, encoder, streamId, clientProtocolVersion).catch(error => onerror?.(error as Error));
             },
             cancel: () => {
                 if (registeredController) session.clearStandaloneStream(sessionId, registeredController);
+                if (registeredWriter) backchannel?.clearStandaloneWriter(sessionId, registeredWriter);
             }
         });
         return new Response(readable, { headers });
@@ -470,6 +496,7 @@ export function shttpHandler(
         const encoder = new TextEncoder();
         const headers: Record<string, string> = { ...SSE_HEADERS, 'mcp-session-id': sessionId };
         let registeredController: ReadableStreamDefaultController<Uint8Array> | undefined;
+        let registeredWriter: ((msg: JSONRPCMessage) => void) | undefined;
         let cancelled = false;
         const readable = new ReadableStream<Uint8Array>({
             start: controller => {
@@ -506,6 +533,7 @@ export function shttpHandler(
             cancel: () => {
                 cancelled = true;
                 if (registeredController) session.clearStandaloneStream(sessionId, registeredController);
+                if (registeredWriter) backchannel?.clearStandaloneWriter(sessionId, registeredWriter);
             }
         });
         return new Response(readable, { headers });
@@ -522,6 +550,7 @@ export function shttpHandler(
         const protoErr = validateProtocolVersion(req);
         if (protoErr) return protoErr;
         try {
+            backchannel?.closeSession(v.sessionId!);
             await session.delete(v.sessionId!);
         } catch (error) {
             onerror?.(error as Error);

--- a/packages/server/test/server/backchannelCompat.test.ts
+++ b/packages/server/test/server/backchannelCompat.test.ts
@@ -1,0 +1,134 @@
+import type { JSONRPCMessage, JSONRPCRequest } from '@modelcontextprotocol/core';
+import { SdkError, SdkErrorCode } from '@modelcontextprotocol/core';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { BackchannelCompat } from '../../src/server/backchannelCompat.js';
+
+describe('BackchannelCompat', () => {
+    let bc: BackchannelCompat;
+    let written: JSONRPCMessage[];
+    const writeSSE = (msg: JSONRPCMessage) => {
+        written.push(msg);
+    };
+
+    beforeEach(() => {
+        bc = new BackchannelCompat();
+        written = [];
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    test('makeEnvSend writes outbound request and resolves on handleResponse', async () => {
+        const send = bc.makeEnvSend('s1', writeSSE);
+        const p = send({ method: 'elicitation/create', params: { message: 'hi' } });
+
+        expect(written).toHaveLength(1);
+        const wire = written[0] as JSONRPCRequest;
+        expect(wire.method).toBe('elicitation/create');
+        expect(typeof wire.id).toBe('number');
+
+        const claimed = bc.handleResponse('s1', { jsonrpc: '2.0', id: wire.id, result: { action: 'accept' } });
+        expect(claimed).toBe(true);
+        await expect(p).resolves.toEqual({ action: 'accept' });
+    });
+
+    test('handleResponse routes error response to rejection', async () => {
+        const send = bc.makeEnvSend('s1', writeSSE);
+        const p = send({ method: 'sampling/createMessage' });
+        const wire = written[0] as JSONRPCRequest;
+
+        bc.handleResponse('s1', { jsonrpc: '2.0', id: wire.id, error: { code: -32_000, message: 'nope' } });
+        await expect(p).rejects.toThrow('nope');
+    });
+
+    test('handleResponse returns false for unknown session/id', () => {
+        expect(bc.handleResponse('unknown', { jsonrpc: '2.0', id: 99, result: {} })).toBe(false);
+    });
+
+    test('per-session correlation: same id on different sessions does not collide', async () => {
+        const sendA = bc.makeEnvSend('A', writeSSE);
+        const sendB = bc.makeEnvSend('B', writeSSE);
+        const pA = sendA({ method: 'x' });
+        const pB = sendB({ method: 'x' });
+        const wA = written[0] as JSONRPCRequest;
+        const wB = written[1] as JSONRPCRequest;
+
+        bc.handleResponse('B', { jsonrpc: '2.0', id: wB.id, result: { from: 'B' } });
+        await expect(pB).resolves.toEqual({ from: 'B' });
+        bc.handleResponse('A', { jsonrpc: '2.0', id: wA.id, result: { from: 'A' } });
+        await expect(pA).resolves.toEqual({ from: 'A' });
+    });
+
+    test('timeout rejects with RequestTimeout', async () => {
+        const send = bc.makeEnvSend('s1', writeSSE);
+        const p = send({ method: 'x' }, { timeout: 100 });
+        const caught = p.catch(e => e);
+
+        vi.advanceTimersByTime(101);
+        const e = await caught;
+        expect(e).toBeInstanceOf(SdkError);
+        expect((e as SdkError).code).toBe(SdkErrorCode.RequestTimeout);
+        expect(bc.handleResponse('s1', { jsonrpc: '2.0', id: (written[0] as JSONRPCRequest).id, result: {} })).toBe(false);
+    });
+
+    test('abort rejects and cleans up', async () => {
+        const ctrl = new AbortController();
+        const send = bc.makeEnvSend('s1', writeSSE);
+        const p = send({ method: 'x' }, { signal: ctrl.signal });
+        const caught = p.catch(e => e);
+
+        ctrl.abort(new Error('cancelled'));
+        const e = await caught;
+        expect(e).toBeInstanceOf(Error);
+        expect((e as Error).message).toBe('cancelled');
+        expect(bc.handleResponse('s1', { jsonrpc: '2.0', id: (written[0] as JSONRPCRequest).id, result: {} })).toBe(false);
+    });
+
+    test('pre-aborted signal rejects immediately without writing', async () => {
+        const ctrl = new AbortController();
+        ctrl.abort(new Error('already'));
+        const send = bc.makeEnvSend('s1', writeSSE);
+        await expect(send({ method: 'x' }, { signal: ctrl.signal })).rejects.toThrow('already');
+        expect(written).toHaveLength(0);
+    });
+
+    test('writeSSE throw rejects the pending request', async () => {
+        const send = bc.makeEnvSend('s1', () => {
+            throw new Error('stream closed');
+        });
+        await expect(send({ method: 'x' })).rejects.toThrow('stream closed');
+    });
+
+    test('closeSession rejects all pending and clears standalone writer', async () => {
+        const send = bc.makeEnvSend('s1', writeSSE);
+        const p1 = send({ method: 'a' }).catch(e => e);
+        const p2 = send({ method: 'b' }).catch(e => e);
+        bc.setStandaloneWriter('s1', () => {});
+
+        bc.closeSession('s1');
+        expect((await p1).code).toBe(SdkErrorCode.ConnectionClosed);
+        expect((await p2).code).toBe(SdkErrorCode.ConnectionClosed);
+        expect(bc.hasStandaloneWriter('s1')).toBe(false);
+    });
+
+    test('standalone writer set/clear/write', () => {
+        const out: JSONRPCMessage[] = [];
+        const w = (m: JSONRPCMessage) => {
+            out.push(m);
+        };
+        bc.setStandaloneWriter('s1', w);
+        expect(bc.hasStandaloneWriter('s1')).toBe(true);
+        expect(bc.writeStandalone('s1', { jsonrpc: '2.0', method: 'n' } as JSONRPCMessage)).toBe(true);
+        expect(out).toHaveLength(1);
+
+        const stale = () => {};
+        bc.clearStandaloneWriter('s1', stale);
+        expect(bc.hasStandaloneWriter('s1')).toBe(true);
+        bc.clearStandaloneWriter('s1', w);
+        expect(bc.hasStandaloneWriter('s1')).toBe(false);
+        expect(bc.writeStandalone('s1', { jsonrpc: '2.0', method: 'n' } as JSONRPCMessage)).toBe(false);
+    });
+});

--- a/packages/server/test/server/backchannelCompat.test.ts
+++ b/packages/server/test/server/backchannelCompat.test.ts
@@ -7,8 +7,9 @@ import { BackchannelCompat } from '../../src/server/backchannelCompat.js';
 describe('BackchannelCompat', () => {
     let bc: BackchannelCompat;
     let written: JSONRPCMessage[];
-    const writeSSE = (msg: JSONRPCMessage) => {
+    const writeSSE = (msg: JSONRPCMessage): boolean => {
         written.push(msg);
+        return true;
     };
 
     beforeEach(() => {
@@ -74,17 +75,19 @@ describe('BackchannelCompat', () => {
         expect(bc.handleResponse('s1', { jsonrpc: '2.0', id: (written[0] as JSONRPCRequest).id, result: {} })).toBe(false);
     });
 
-    test('abort rejects and cleans up', async () => {
+    test('abort writes notifications/cancelled then rejects and cleans up', async () => {
         const ctrl = new AbortController();
         const send = bc.makeEnvSend('s1', writeSSE);
         const p = send({ method: 'x' }, { signal: ctrl.signal });
         const caught = p.catch(e => e);
+        const wireId = (written[0] as JSONRPCRequest).id;
 
         ctrl.abort(new Error('cancelled'));
         const e = await caught;
         expect(e).toBeInstanceOf(Error);
         expect((e as Error).message).toBe('cancelled');
-        expect(bc.handleResponse('s1', { jsonrpc: '2.0', id: (written[0] as JSONRPCRequest).id, result: {} })).toBe(false);
+        expect(written[1]).toMatchObject({ method: 'notifications/cancelled', params: { requestId: wireId } });
+        expect(bc.handleResponse('s1', { jsonrpc: '2.0', id: wireId, result: {} })).toBe(false);
     });
 
     test('pre-aborted signal rejects immediately without writing', async () => {
@@ -95,40 +98,20 @@ describe('BackchannelCompat', () => {
         expect(written).toHaveLength(0);
     });
 
-    test('writeSSE throw rejects the pending request', async () => {
-        const send = bc.makeEnvSend('s1', () => {
-            throw new Error('stream closed');
-        });
-        await expect(send({ method: 'x' })).rejects.toThrow('stream closed');
+    test('writeSSE returning false rejects with SendFailed', async () => {
+        const send = bc.makeEnvSend('s1', () => false);
+        const e = await send({ method: 'x' }).catch(err => err);
+        expect(e).toBeInstanceOf(SdkError);
+        expect((e as SdkError).code).toBe(SdkErrorCode.SendFailed);
     });
 
-    test('closeSession rejects all pending and clears standalone writer', async () => {
+    test('closeSession rejects all pending', async () => {
         const send = bc.makeEnvSend('s1', writeSSE);
         const p1 = send({ method: 'a' }).catch(e => e);
         const p2 = send({ method: 'b' }).catch(e => e);
-        bc.setStandaloneWriter('s1', () => {});
 
         bc.closeSession('s1');
         expect((await p1).code).toBe(SdkErrorCode.ConnectionClosed);
         expect((await p2).code).toBe(SdkErrorCode.ConnectionClosed);
-        expect(bc.hasStandaloneWriter('s1')).toBe(false);
-    });
-
-    test('standalone writer set/clear/write', () => {
-        const out: JSONRPCMessage[] = [];
-        const w = (m: JSONRPCMessage) => {
-            out.push(m);
-        };
-        bc.setStandaloneWriter('s1', w);
-        expect(bc.hasStandaloneWriter('s1')).toBe(true);
-        expect(bc.writeStandalone('s1', { jsonrpc: '2.0', method: 'n' } as JSONRPCMessage)).toBe(true);
-        expect(out).toHaveLength(1);
-
-        const stale = () => {};
-        bc.clearStandaloneWriter('s1', stale);
-        expect(bc.hasStandaloneWriter('s1')).toBe(true);
-        bc.clearStandaloneWriter('s1', w);
-        expect(bc.hasStandaloneWriter('s1')).toBe(false);
-        expect(bc.writeStandalone('s1', { jsonrpc: '2.0', method: 'n' } as JSONRPCMessage)).toBe(false);
     });
 });

--- a/test/conformance/expected-failures-handlehttp.yaml
+++ b/test/conformance/expected-failures-handlehttp.yaml
@@ -1,7 +1,4 @@
-# Baseline for the `handleHttp` conformance target.
-# Currently empty: all server scenarios pass on the dispatch() path. The
-# sampling/elicitation tools catch the NotConnected error and surface it in the
-# tool result, which satisfies the conformance check. R4 (BackchannelCompat) makes
-# them succeed for real.
+# Baseline for the `handleHttp` conformance target. Empty: all server scenarios
+# pass on the dispatch() path with `{session, backchannel}` configured.
 
 server: []

--- a/test/conformance/src/everythingServerHandleHttp.ts
+++ b/test/conformance/src/everythingServerHandleHttp.ts
@@ -29,10 +29,7 @@ const handler = toNodeHttpHandler(
     handleHttp(mcp, {
         session: new SessionCompat({
             onsessioninitialized: sid => console.log(`Session initialized with ID: ${sid}`),
-            onsessionclosed: sid => {
-                console.log(`Session ${sid} closed`);
-                backchannel.closeSession(sid);
-            }
+            onsessionclosed: sid => console.log(`Session ${sid} closed`)
         }),
         backchannel,
         eventStore: createEventStore(),

--- a/test/conformance/src/everythingServerHandleHttp.ts
+++ b/test/conformance/src/everythingServerHandleHttp.ts
@@ -14,7 +14,7 @@
 
 import { localhostHostValidation } from '@modelcontextprotocol/express';
 import { toNodeHttpHandler } from '@modelcontextprotocol/node';
-import { handleHttp, SessionCompat } from '@modelcontextprotocol/server';
+import { BackchannelCompat, handleHttp, SessionCompat } from '@modelcontextprotocol/server';
 import cors from 'cors';
 import express from 'express';
 
@@ -24,12 +24,17 @@ const mcp = createMcpServer({
     closeSSEForReconnectTest: ctx => ctx.http?.closeSSE?.()
 });
 
+const backchannel = new BackchannelCompat();
 const handler = toNodeHttpHandler(
     handleHttp(mcp, {
         session: new SessionCompat({
             onsessioninitialized: sid => console.log(`Session initialized with ID: ${sid}`),
-            onsessionclosed: sid => console.log(`Session ${sid} closed`)
+            onsessionclosed: sid => {
+                console.log(`Session ${sid} closed`);
+                backchannel.closeSession(sid);
+            }
         }),
+        backchannel,
         eventStore: createEventStore(),
         retryInterval: 5000,
         onerror: err => console.error('handleHttp error:', err)


### PR DESCRIPTION
`BackchannelCompat` — opt-in legacy server→client request backchannel for `handleHttp` (so a handler's `ctx.mcpReq.elicitInput()` works for 2025-11 clients over the POST's SSE). `Server.buildContext` binds `elicitInput`/`requestSampling`/`log` via `_createMessageVia`/`_elicitInputVia` so validation/capability checks apply on both `connect()` and `dispatch()` paths.

> Part of a 5-PR chain (depends on R3). Review guide: https://gist.github.com/felixweinberger/9e3357c04224d411ab3b20b227fd820c

## Motivation and Context
Completes `handleHttp`'s legacy-client story. `handleHttp(mcp, {session, backchannel})` serves 2025-11 clients fully.

## How Has This Been Tested?
Dual conformance 40/40 + 40/40, client conformance 289/289.

## Breaking Changes
None — additive.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
