### PR TITLE
fix(server): support two-arg no-schema task handlers

### DIFF
--- a/.changeset/fair-tasks-share.md
+++ b/.changeset/fair-tasks-share.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/server': patch
+---
+
+fix(server): pass task context as the second argument for no-schema task handlers

--- a/packages/server/src/experimental/tasks/interfaces.ts
+++ b/packages/server/src/experimental/tasks/interfaces.ts
@@ -19,10 +19,6 @@ import type { BaseToolCallback } from '../../server/mcp.js';
 // Task Handler Types (for registerToolTask)
 // ============================================================================
 
-type TaskCallbackWithoutArgs<SendResultT extends Result, Ctx extends TaskServerContext | CreateTaskServerContext> =
-    | ((ctx: Ctx) => SendResultT | Promise<SendResultT>)
-    | ((_args: undefined, ctx: Ctx) => SendResultT | Promise<SendResultT>);
-
 /**
  * Handler for creating a task.
  * @experimental
@@ -32,7 +28,9 @@ export type CreateTaskRequestHandler<
     Args extends StandardSchemaWithJSON | undefined = undefined
 > = Args extends StandardSchemaWithJSON
     ? BaseToolCallback<SendResultT, CreateTaskServerContext, Args>
-    : TaskCallbackWithoutArgs<SendResultT, CreateTaskServerContext>;
+    :
+          | ((ctx: CreateTaskServerContext) => SendResultT | Promise<SendResultT>)
+          | ((_args: undefined, ctx: CreateTaskServerContext) => SendResultT | Promise<SendResultT>);
 
 /**
  * Handler for task operations (`get`, `getResult`).
@@ -43,7 +41,9 @@ export type TaskRequestHandler<
     Args extends StandardSchemaWithJSON | undefined = undefined
 > = Args extends StandardSchemaWithJSON
     ? BaseToolCallback<SendResultT, TaskServerContext, Args>
-    : TaskCallbackWithoutArgs<SendResultT, TaskServerContext>;
+    :
+          | ((ctx: TaskServerContext) => SendResultT | Promise<SendResultT>)
+          | ((_args: undefined, ctx: TaskServerContext) => SendResultT | Promise<SendResultT>);
 
 /**
  * Interface for task-based tool handlers.

--- a/packages/server/src/experimental/tasks/interfaces.ts
+++ b/packages/server/src/experimental/tasks/interfaces.ts
@@ -19,6 +19,10 @@ import type { BaseToolCallback } from '../../server/mcp.js';
 // Task Handler Types (for registerToolTask)
 // ============================================================================
 
+type TaskCallbackWithoutArgs<SendResultT extends Result, Ctx extends TaskServerContext | CreateTaskServerContext> =
+    | ((ctx: Ctx) => SendResultT | Promise<SendResultT>)
+    | ((_args: undefined, ctx: Ctx) => SendResultT | Promise<SendResultT>);
+
 /**
  * Handler for creating a task.
  * @experimental
@@ -26,17 +30,20 @@ import type { BaseToolCallback } from '../../server/mcp.js';
 export type CreateTaskRequestHandler<
     SendResultT extends Result,
     Args extends StandardSchemaWithJSON | undefined = undefined
-> = BaseToolCallback<SendResultT, CreateTaskServerContext, Args>;
+> = Args extends StandardSchemaWithJSON
+    ? BaseToolCallback<SendResultT, CreateTaskServerContext, Args>
+    : TaskCallbackWithoutArgs<SendResultT, CreateTaskServerContext>;
 
 /**
  * Handler for task operations (`get`, `getResult`).
  * @experimental
  */
-export type TaskRequestHandler<SendResultT extends Result, Args extends StandardSchemaWithJSON | undefined = undefined> = BaseToolCallback<
-    SendResultT,
-    TaskServerContext,
-    Args
->;
+export type TaskRequestHandler<
+    SendResultT extends Result,
+    Args extends StandardSchemaWithJSON | undefined = undefined
+> = Args extends StandardSchemaWithJSON
+    ? BaseToolCallback<SendResultT, TaskServerContext, Args>
+    : TaskCallbackWithoutArgs<SendResultT, TaskServerContext>;
 
 /**
  * Interface for task-based tool handlers.

--- a/packages/server/src/server/mcp.ts
+++ b/packages/server/src/server/mcp.ts
@@ -1206,7 +1206,12 @@ function createToolExecutor(
             if (inputSchema) {
                 return taskHandler.createTask(args, taskCtx);
             }
-            // When no inputSchema, call with just ctx (the handler expects (ctx) signature)
+
+            if (taskHandler.createTask.length >= 2) {
+                return taskHandler.createTask(undefined, taskCtx);
+            }
+
+            // When no inputSchema, preserve the existing context-only handler signature.
             return (taskHandler.createTask as (ctx: CreateTaskServerContext) => CreateTaskResult | Promise<CreateTaskResult>)(taskCtx);
         };
     }

--- a/packages/server/test/server/mcp.tasks.test.ts
+++ b/packages/server/test/server/mcp.tasks.test.ts
@@ -1,0 +1,88 @@
+import type { CreateTaskServerContext, JSONRPCMessage, TaskServerContext } from '@modelcontextprotocol/core';
+import { InMemoryTaskStore, InMemoryTransport, LATEST_PROTOCOL_VERSION } from '@modelcontextprotocol/core';
+import { describe, expect, it, vi } from 'vitest';
+import { McpServer } from '../../src/index.js';
+import type { ToolTaskHandler } from '../../src/index.js';
+
+describe('registerToolTask', () => {
+    it('passes task context as the second argument for no-schema task handlers', async () => {
+        const server = new McpServer(
+            { name: 'task-test', version: '1.0.0' },
+            {
+                capabilities: {
+                    tasks: {
+                        requests: { tools: { call: {} } },
+                        taskStore: new InMemoryTaskStore()
+                    }
+                }
+            }
+        );
+
+        let receivedArgs: unknown = 'not-called';
+        let receivedCtx: CreateTaskServerContext | undefined;
+
+        const handler = {
+            createTask: async (_args: undefined, ctx: CreateTaskServerContext) => {
+                receivedArgs = _args;
+                receivedCtx = ctx;
+                const task = await ctx.task.store.createTask({ ttl: ctx.task.requestedTtl });
+                return { task };
+            },
+            getTask: async (_args: undefined, ctx: TaskServerContext) => ({
+                taskId: ctx.task.id ?? 'unused',
+                status: 'working' as const,
+                ttl: null,
+                createdAt: new Date(0).toISOString(),
+                lastUpdatedAt: new Date(0).toISOString()
+            }),
+            getTaskResult: async () => ({
+                content: [{ type: 'text' as const, text: 'done' }]
+            })
+        } satisfies ToolTaskHandler<undefined>;
+
+        server.experimental.tasks.registerToolTask('no-schema-task', { description: 'Create a task without input arguments' }, handler);
+
+        const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+        await server.connect(serverTransport);
+        await clientTransport.start();
+
+        const responses: JSONRPCMessage[] = [];
+        clientTransport.onmessage = message => responses.push(message);
+
+        await clientTransport.send({
+            jsonrpc: '2.0',
+            id: 1,
+            method: 'initialize',
+            params: {
+                protocolVersion: LATEST_PROTOCOL_VERSION,
+                capabilities: {},
+                clientInfo: { name: 'task-client', version: '1.0.0' }
+            }
+        } as JSONRPCMessage);
+        await clientTransport.send({ jsonrpc: '2.0', method: 'notifications/initialized' } as JSONRPCMessage);
+        await clientTransport.send({
+            jsonrpc: '2.0',
+            id: 2,
+            method: 'tools/call',
+            params: {
+                name: 'no-schema-task',
+                task: { ttl: 600 }
+            }
+        } as JSONRPCMessage);
+
+        await vi.waitFor(() => expect(responses.some(response => 'id' in response && response.id === 2)).toBe(true));
+
+        expect(receivedArgs).toBeUndefined();
+        expect(receivedCtx?.task.store).toBeDefined();
+        expect(receivedCtx?.task.requestedTtl).toBe(600);
+
+        const response = responses.find(message => 'id' in message && message.id === 2) as {
+            error?: unknown;
+            result?: { task: { ttl?: number | null } };
+        };
+        expect(response.error).toBeUndefined();
+        expect(response.result?.task.ttl).toBe(600);
+
+        await server.close();
+    });
+});


### PR DESCRIPTION
## What changed

Fixes #1471 by allowing no-input-schema task handlers to receive task context as the second argument when they are written in the common `(_args, ctx)` form.

The executor still preserves the existing context-only `(ctx)` path for no-schema handlers, so current TypeScript users are not forced into a breaking runtime change. The public task handler types now accept either no-schema shape, while schema-backed handlers remain `(args, ctx)` as before.

## Why

`registerToolTask` currently calls no-schema `createTask` handlers with a single context argument. JavaScript users, or users bypassing types, can naturally write `async createTask(_args, ctx)`, which previously received `ctx` as `undefined` and failed before creating a task.

## Validation

- `pnpm --filter @modelcontextprotocol/server exec vitest run test/server/mcp.tasks.test.ts`
- `pnpm --filter @modelcontextprotocol/server typecheck`
- `pnpm --filter @modelcontextprotocol/server lint`
- pre-push hook: `pnpm -r typecheck`, `pnpm -r build`, `pnpm sync:snippets --check`, `pnpm -r lint`
