### PR TITLE
fix: accept null arguments in tools/call and return -32602 for validation errors

### DIFF
--- a/.changeset/fix-null-arguments-internal-error.md
+++ b/.changeset/fix-null-arguments-internal-error.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/core': patch
+---
+
+Accept null arguments in tools/call requests and return -32602 (InvalidParams) instead of -32603 (InternalError) for request validation failures. Clients that serialize missing fields as null (common in Go, Java, C# JSON libraries) no longer get an opaque internal error when calling tools.

--- a/packages/core/src/shared/protocol.ts
+++ b/packages/core/src/shared/protocol.ts
@@ -388,7 +388,10 @@ export abstract class Protocol<ContextT extends BaseContext> {
                 const schema = getRequestSchema(method as RequestMethod);
                 this._requestHandlers.set(method, (request, ctx) => {
                     // Validate request params via Zod (strips jsonrpc/id, so we pass original to handler)
-                    schema.parse(request);
+                    const result = schema.safeParse(request);
+                    if (!result.success) {
+                        throw new ProtocolError(ProtocolErrorCode.InvalidParams, `Invalid ${method} request: ${result.error.message}`);
+                    }
                     return handler(request, ctx);
                 });
             },

--- a/packages/core/src/types/schemas.ts
+++ b/packages/core/src/types/schemas.ts
@@ -1417,7 +1417,7 @@ export const CallToolRequestParamsSchema = TaskAugmentedRequestParamsSchema.exte
     /**
      * Arguments to pass to the tool.
      */
-    arguments: z.record(z.string(), z.unknown()).optional()
+    arguments: z.preprocess(val => val ?? undefined, z.record(z.string(), z.unknown()).optional())
 });
 
 /**

--- a/packages/core/test/types.test.ts
+++ b/packages/core/test/types.test.ts
@@ -1,4 +1,5 @@
 import {
+    CallToolRequestSchema,
     CallToolResultSchema,
     ClientCapabilitiesSchema,
     CompleteRequestSchema,
@@ -982,6 +983,58 @@ describe('Types', () => {
                 expect(result.data.sampling?.context).toBeDefined();
                 expect(result.data.sampling?.tools).toBeDefined();
             }
+        });
+    });
+
+    describe('CallToolRequest arguments handling', () => {
+        test('should accept tools/call with arguments as object', () => {
+            const request = {
+                method: 'tools/call',
+                params: {
+                    name: 'echo',
+                    arguments: { message: 'hello' }
+                }
+            };
+            const result = CallToolRequestSchema.safeParse(request);
+            expect(result.success).toBe(true);
+        });
+
+        test('should accept tools/call with arguments omitted', () => {
+            const request = {
+                method: 'tools/call',
+                params: {
+                    name: 'echo'
+                }
+            };
+            const result = CallToolRequestSchema.safeParse(request);
+            expect(result.success).toBe(true);
+            if (result.success) {
+                expect(result.data.params.arguments).toBeUndefined();
+            }
+        });
+
+        test('should accept tools/call with arguments as null', () => {
+            const request = {
+                method: 'tools/call',
+                params: {
+                    name: 'echo',
+                    arguments: null
+                }
+            };
+            const result = CallToolRequestSchema.safeParse(request);
+            expect(result.success).toBe(true);
+        });
+
+        test('should accept tools/call with arguments as empty object', () => {
+            const request = {
+                method: 'tools/call',
+                params: {
+                    name: 'echo',
+                    arguments: {}
+                }
+            };
+            const result = CallToolRequestSchema.safeParse(request);
+            expect(result.success).toBe(true);
         });
     });
 


### PR DESCRIPTION
## Summary

- `CallToolRequestParamsSchema` rejects `null` arguments with `-32603` (InternalError) and a raw Zod error message. Fixed by adding `z.preprocess()` to coerce `null` to `undefined` before validation, preserving the existing type signature.
- The protocol request handler uses `schema.parse()` which throws on validation failure. The thrown ZodError lacks a numeric `code`, so the error handler defaults to `-32603`. Changed to `schema.safeParse()` with an explicit `ProtocolError(InvalidParams)` on failure, returning `-32602` as the JSON-RPC spec requires.

## Motivation

Clients that serialize missing fields as `null` (common in Go, Java, and C# JSON libraries) get an opaque internal error when calling any tool without arguments. Tested against `@modelcontextprotocol/server-everything`: all 13 tools fail this way.

## Changes

| File | Change |
|------|--------|
| `schemas.ts:1420` | `z.preprocess(val => val ?? undefined, ...)` on `arguments` field |
| `protocol.ts:390-397` | `schema.parse()` → `schema.safeParse()` + `ProtocolError(InvalidParams)` |
| `types.test.ts` | 4 new tests: null, undefined, empty, and normal arguments |

## Test plan

- [x] `pnpm run test:all` passes (1,536 tests, 0 failures)
- [x] `pnpm -r typecheck` passes (no type changes, preprocess preserves existing signature)
- [x] `pnpm -r lint` passes (prettier formatting applied)
- [x] Verified against `@modelcontextprotocol/server-everything` over raw stdio: null arguments now accepted

Fixes #2012