### PR TITLE
fix(core): remove duplicate zod dependency declaration

### DIFF
--- a/.changeset/fix-core-zod-dup-deps.md
+++ b/.changeset/fix-core-zod-dup-deps.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/core': patch
+---
+
+Remove `zod` from `dependencies` in `@modelcontextprotocol/core` and keep it only as a peer dependency to avoid duplicate installs that can cause TypeScript type incompatibilities.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -51,8 +51,7 @@
     "dependencies": {
         "ajv": "catalog:runtimeShared",
         "ajv-formats": "catalog:runtimeShared",
-        "json-schema-typed": "catalog:runtimeShared",
-        "zod": "catalog:runtimeShared"
+        "json-schema-typed": "catalog:runtimeShared"
     },
     "peerDependencies": {
         "@cfworker/json-schema": "catalog:runtimeShared",


### PR DESCRIPTION
## Summary
- remove zod from @modelcontextprotocol/core dependencies
- keep zod in peerDependencies to avoid duplicate installs that cause TS type incompatibility in some package managers
- add a changeset for the core package

Closes #2011

## Testing
- Unable to run local package checks in this environment because pnpm is not installed