### PR TITLE
fix: check AbortSignal in handleAutomaticTaskPolling to stop cancelled requests

### DIFF
--- a/.changeset/fix-automatic-task-polling-abort.md
+++ b/.changeset/fix-automatic-task-polling-abort.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/server': patch
+---
+
+Check AbortSignal in handleAutomaticTaskPolling to stop cancelled requests from polling indefinitely. Previously, if a client cancelled a tools/call request during automatic task polling, the poll loop continued consuming server resources until the task completed or the process died.

--- a/packages/server/src/server/mcp.ts
+++ b/packages/server/src/server/mcp.ts
@@ -326,6 +326,9 @@ export class McpServer {
         const pollInterval = task.pollInterval ?? 5000;
 
         while (task.status !== 'completed' && task.status !== 'failed' && task.status !== 'cancelled') {
+            if (ctx.mcpReq.signal.aborted) {
+                throw new ProtocolError(ProtocolErrorCode.RequestCancelled, 'Request cancelled during task polling');
+            }
             await new Promise(resolve => setTimeout(resolve, pollInterval));
             const updatedTask = await ctx.task.store.getTask(taskId);
             if (!updatedTask) {

--- a/packages/server/src/server/mcp.ts
+++ b/packages/server/src/server/mcp.ts
@@ -327,7 +327,7 @@ export class McpServer {
 
         while (task.status !== 'completed' && task.status !== 'failed' && task.status !== 'cancelled') {
             if (ctx.mcpReq.signal.aborted) {
-                throw new ProtocolError(ProtocolErrorCode.RequestCancelled, 'Request cancelled during task polling');
+                throw new ProtocolError(ProtocolErrorCode.InternalError, 'Request cancelled during task polling');
             }
             await new Promise(resolve => setTimeout(resolve, pollInterval));
             const updatedTask = await ctx.task.store.getTask(taskId);


### PR DESCRIPTION
## Summary

`handleAutomaticTaskPolling` polls a task store in a while loop without checking `ctx.mcpReq.signal.aborted`. Cancelled requests continue polling indefinitely, leaking server resources.

## Motivation and Context

The `taskManager.ts` implementation correctly checks the signal for the same polling pattern (line 856). This brings `handleAutomaticTaskPolling` in line with that behavior.

## How Has This Been Tested?

Existing tests pass. The change adds an early exit condition that only fires when the request's AbortSignal has been triggered (client cancellation).

Fixes #2018