### PR TITLE
fix: add root package export barrel

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,4 @@
+export * from './types.js';
+export * from './client/index.js';
+export * from './server/index.js';
+export * from './inMemory.js';

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+
+import { Client, ErrorCode, InMemoryTransport, LATEST_PROTOCOL_VERSION, McpError, Server } from '../src/index.js';
+
+describe('root package exports', () => {
+    it('re-exports the package root public API', () => {
+        expect(Client).toBeTypeOf('function');
+        expect(Server).toBeTypeOf('function');
+        expect(InMemoryTransport.createLinkedPair).toBeTypeOf('function');
+        expect(LATEST_PROTOCOL_VERSION).toBeTypeOf('string');
+
+        const error = new McpError(ErrorCode.InvalidRequest, 'bad request');
+        expect(error.code).toBe(ErrorCode.InvalidRequest);
+    });
+});


### PR DESCRIPTION
## Summary
- Add the missing root `src/index.ts` barrel so the existing package root export emits `dist/esm/index.js` and `dist/cjs/index.js`.
- Cover the root export surface used by the package entry point (`Client`, `Server`, `McpError`, protocol constants, and `InMemoryTransport`).

Fixes #971.

## Testing
- `npm run typecheck`
- `npm test -- test/index.test.ts`
- `npm run build`
- `npm run lint`
- `npm pack --json` plus temp-project CJS `require('@modelcontextprotocol/sdk')` and ESM `import ... from '@modelcontextprotocol/sdk'` smoke tests
- `git diff --check`
