### PR TITLE
build: configure tsdown to output both ESM and CJS

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -103,6 +103,9 @@
             ],
             "stdio": [
                 "dist/cjs/stdio.d.cts"
+            ],
+            "_shims": [
+                "dist/cjs/shimsNode.d.cts"
             ]
         }
     },

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -19,46 +19,90 @@
         "mcp",
         "client"
     ],
+    "main": "./dist/cjs/index.cjs",
+    "module": "./dist/esm/index.mjs",
+    "types": "./dist/cjs/index.d.cts",
     "exports": {
         ".": {
-            "types": "./dist/index.d.mts",
-            "import": "./dist/index.mjs"
+            "import": {
+                "types": "./dist/esm/index.d.mts",
+                "default": "./dist/esm/index.mjs"
+            },
+            "require": {
+                "types": "./dist/cjs/index.d.cts",
+                "default": "./dist/cjs/index.cjs"
+            }
         },
         "./stdio": {
-            "types": "./dist/stdio.d.mts",
-            "import": "./dist/stdio.mjs"
+            "import": {
+                "types": "./dist/esm/stdio.d.mts",
+                "default": "./dist/esm/stdio.mjs"
+            },
+            "require": {
+                "types": "./dist/cjs/stdio.d.cts",
+                "default": "./dist/cjs/stdio.cjs"
+            }
         },
         "./validators/cf-worker": {
-            "types": "./dist/validators/cfWorker.d.mts",
-            "import": "./dist/validators/cfWorker.mjs"
+            "import": {
+                "types": "./dist/esm/validators/cfWorker.d.mts",
+                "default": "./dist/esm/validators/cfWorker.mjs"
+            },
+            "require": {
+                "types": "./dist/cjs/validators/cfWorker.d.cts",
+                "default": "./dist/cjs/validators/cfWorker.cjs"
+            }
         },
         "./_shims": {
             "workerd": {
-                "types": "./dist/shimsWorkerd.d.mts",
-                "import": "./dist/shimsWorkerd.mjs"
+                "import": {
+                    "types": "./dist/esm/shimsWorkerd.d.mts",
+                    "default": "./dist/esm/shimsWorkerd.mjs"
+                },
+                "require": {
+                    "types": "./dist/cjs/shimsWorkerd.d.cts",
+                    "default": "./dist/cjs/shimsWorkerd.cjs"
+                }
             },
             "browser": {
-                "types": "./dist/shimsBrowser.d.mts",
-                "import": "./dist/shimsBrowser.mjs"
+                "import": {
+                    "types": "./dist/esm/shimsBrowser.d.mts",
+                    "default": "./dist/esm/shimsBrowser.mjs"
+                },
+                "require": {
+                    "types": "./dist/cjs/shimsBrowser.d.cts",
+                    "default": "./dist/cjs/shimsBrowser.cjs"
+                }
             },
             "node": {
-                "types": "./dist/shimsNode.d.mts",
-                "import": "./dist/shimsNode.mjs"
+                "import": {
+                    "types": "./dist/esm/shimsNode.d.mts",
+                    "default": "./dist/esm/shimsNode.mjs"
+                },
+                "require": {
+                    "types": "./dist/cjs/shimsNode.d.cts",
+                    "default": "./dist/cjs/shimsNode.cjs"
+                }
             },
             "default": {
-                "types": "./dist/shimsNode.d.mts",
-                "import": "./dist/shimsNode.mjs"
+                "import": {
+                    "types": "./dist/esm/shimsNode.d.mts",
+                    "default": "./dist/esm/shimsNode.mjs"
+                },
+                "require": {
+                    "types": "./dist/cjs/shimsNode.d.cts",
+                    "default": "./dist/cjs/shimsNode.cjs"
+                }
             }
         }
     },
-    "types": "./dist/index.d.mts",
     "typesVersions": {
         "*": {
             "validators/cf-worker": [
-                "dist/validators/cfWorker.d.mts"
+                "dist/cjs/validators/cfWorker.d.cts"
             ],
             "stdio": [
-                "dist/stdio.d.mts"
+                "dist/cjs/stdio.d.cts"
             ]
         }
     },

--- a/packages/client/test/client/barrelClean.test.ts
+++ b/packages/client/test/client/barrelClean.test.ts
@@ -6,7 +6,7 @@ import { fileURLToPath } from 'node:url';
 import { beforeAll, describe, expect, test } from 'vitest';
 
 const pkgDir = join(dirname(fileURLToPath(import.meta.url)), '../..');
-const distDir = join(pkgDir, 'dist');
+const distDir = join(pkgDir, 'dist/esm');
 const NODE_ONLY = /\b(child_process|cross-spawn|node:stream|node:child_process)\b/;
 
 function chunkImportsOf(entryPath: string): string[] {

--- a/packages/client/tsdown.config.ts
+++ b/packages/client/tsdown.config.ts
@@ -7,8 +7,16 @@ export default defineConfig({
     entry: ['src/index.ts', 'src/stdio.ts', 'src/shimsNode.ts', 'src/shimsWorkerd.ts', 'src/shimsBrowser.ts', 'src/validators/cfWorker.ts'],
 
     // 2. Output Configuration
-    format: ['esm'],
     outDir: 'dist',
+    format: {
+        esm: {
+            outDir: 'dist/esm'
+        },
+        cjs: {
+            outDir: 'dist/cjs'
+        }
+    },
+
     clean: true, // Recommended: Cleans 'dist' before building
     sourcemap: true,
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,22 +20,49 @@
         "mcp",
         "core"
     ],
+    "main": "./dist/cjs/index.cjs",
+    "module": "./dist/esm/index.mjs",
+    "types": "./dist/cjs/index.d.cts",
     "exports": {
         ".": {
-            "types": "./dist/index.d.ts",
-            "import": "./dist/index.mjs"
+            "import": {
+                "types": "./dist/esm/index.d.mts",
+                "default": "./dist/esm/index.mjs"
+            },
+            "require": {
+                "types": "./dist/cjs/index.d.cts",
+                "default": "./dist/cjs/index.cjs"
+            }
         },
         "./types": {
-            "types": "./src/exports/types/index.ts",
-            "import": "./src/exports/types/index.ts"
+            "import": {
+                "types": "./src/exports/types/index.ts",
+                "default": "./src/exports/types/index.ts"
+            },
+            "require": {
+                "types": "./src/exports/types/index.ts",
+                "default": "./src/exports/types/index.ts"
+            }
         },
         "./public": {
-            "types": "./src/exports/public/index.ts",
-            "import": "./src/exports/public/index.ts"
+            "import": {
+                "types": "./src/exports/public/index.ts",
+                "default": "./src/exports/public/index.ts"
+            },
+            "require": {
+                "types": "./src/exports/public/index.ts",
+                "default": "./src/exports/public/index.ts"
+            }
         },
         "./validators/cfWorker": {
-            "types": "./src/validators/cfWorkerProvider.ts",
-            "import": "./src/validators/cfWorkerProvider.ts"
+            "import": {
+                "types": "./src/validators/cfWorkerProvider.ts",
+                "default": "./src/validators/cfWorkerProvider.ts"
+            },
+            "require": {
+                "types": "./src/validators/cfWorkerProvider.ts",
+                "default": "./src/validators/cfWorkerProvider.ts"
+            }
         }
     },
     "scripts": {

--- a/packages/middleware/express/package.json
+++ b/packages/middleware/express/package.json
@@ -21,13 +21,21 @@
         "express",
         "middleware"
     ],
+    "main": "./dist/cjs/index.cjs",
+    "module": "./dist/esm/index.mjs",
+    "types": "./dist/cjs/index.d.cts",
     "exports": {
         ".": {
-            "types": "./dist/index.d.mts",
-            "import": "./dist/index.mjs"
+            "import": {
+                "types": "./dist/esm/index.d.mts",
+                "default": "./dist/esm/index.mjs"
+            },
+            "require": {
+                "types": "./dist/cjs/index.d.cts",
+                "default": "./dist/cjs/index.cjs"
+            }
         }
     },
-    "types": "./dist/index.d.mts",
     "files": [
         "dist"
     ],

--- a/packages/middleware/express/tsdown.config.ts
+++ b/packages/middleware/express/tsdown.config.ts
@@ -3,8 +3,15 @@ import { defineConfig } from 'tsdown';
 export default defineConfig({
     failOnWarn: 'ci-only',
     entry: ['src/index.ts'],
-    format: ['esm'],
     outDir: 'dist',
+    format: {
+        esm: {
+            outDir: 'dist/esm'
+        },
+        cjs: {
+            outDir: 'dist/cjs'
+        }
+    },
     clean: true,
     sourcemap: true,
     target: 'esnext',

--- a/packages/middleware/fastify/package.json
+++ b/packages/middleware/fastify/package.json
@@ -21,13 +21,21 @@
         "fastify",
         "middleware"
     ],
+    "main": "./dist/cjs/index.cjs",
+    "module": "./dist/esm/index.mjs",
+    "types": "./dist/cjs/index.d.cts",
     "exports": {
         ".": {
-            "types": "./dist/index.d.mts",
-            "import": "./dist/index.mjs"
+            "import": {
+                "types": "./dist/esm/index.d.mts",
+                "default": "./dist/esm/index.mjs"
+            },
+            "require": {
+                "types": "./dist/cjs/index.d.cts",
+                "default": "./dist/cjs/index.cjs"
+            }
         }
     },
-    "types": "./dist/index.d.mts",
     "files": [
         "dist"
     ],

--- a/packages/middleware/fastify/tsdown.config.ts
+++ b/packages/middleware/fastify/tsdown.config.ts
@@ -3,8 +3,15 @@ import { defineConfig } from 'tsdown';
 export default defineConfig({
     failOnWarn: 'ci-only',
     entry: ['src/index.ts'],
-    format: ['esm'],
     outDir: 'dist',
+    format: {
+        esm: {
+            outDir: 'dist/esm'
+        },
+        cjs: {
+            outDir: 'dist/cjs'
+        }
+    },
     clean: true,
     sourcemap: true,
     target: 'esnext',

--- a/packages/middleware/hono/package.json
+++ b/packages/middleware/hono/package.json
@@ -21,13 +21,21 @@
         "hono",
         "middleware"
     ],
+    "main": "./dist/cjs/index.cjs",
+    "module": "./dist/esm/index.mjs",
+    "types": "./dist/cjs/index.d.cts",
     "exports": {
         ".": {
-            "types": "./dist/index.d.mts",
-            "import": "./dist/index.mjs"
+            "import": {
+                "types": "./dist/esm/index.d.mts",
+                "default": "./dist/esm/index.mjs"
+            },
+            "require": {
+                "types": "./dist/cjs/index.d.cts",
+                "default": "./dist/cjs/index.cjs"
+            }
         }
     },
-    "types": "./dist/index.d.mts",
     "files": [
         "dist"
     ],

--- a/packages/middleware/hono/tsdown.config.ts
+++ b/packages/middleware/hono/tsdown.config.ts
@@ -3,8 +3,15 @@ import { defineConfig } from 'tsdown';
 export default defineConfig({
     failOnWarn: 'ci-only',
     entry: ['src/index.ts'],
-    format: ['esm'],
     outDir: 'dist',
+    format: {
+        esm: {
+            outDir: 'dist/esm'
+        },
+        cjs: {
+            outDir: 'dist/cjs'
+        }
+    },
     clean: true,
     sourcemap: true,
     target: 'esnext',

--- a/packages/middleware/node/package.json
+++ b/packages/middleware/node/package.json
@@ -20,17 +20,25 @@
         "node.js",
         "middleware"
     ],
+    "main": "./dist/cjs/index.cjs",
+    "module": "./dist/esm/index.mjs",
+    "types": "./dist/cjs/index.d.cts",
     "exports": {
         ".": {
-            "types": "./dist/index.d.mts",
-            "import": "./dist/index.mjs"
+            "import": {
+                "types": "./dist/esm/index.d.mts",
+                "default": "./dist/esm/index.mjs"
+            },
+            "require": {
+                "types": "./dist/cjs/index.d.cts",
+                "default": "./dist/cjs/index.cjs"
+            }
         }
     },
-    "types": "./dist/index.d.mts",
     "typesVersions": {
         "*": {
             "sse": [
-                "dist/sse.d.mts"
+                "dist/cjs/sse.d.cts"
             ]
         }
     },

--- a/packages/middleware/node/tsdown.config.ts
+++ b/packages/middleware/node/tsdown.config.ts
@@ -7,8 +7,16 @@ export default defineConfig({
     entry: ['src/index.ts'],
 
     // 2. Output Configuration
-    format: ['esm'],
     outDir: 'dist',
+    format: {
+        esm: {
+            outDir: 'dist/esm'
+        },
+        cjs: {
+            outDir: 'dist/cjs'
+        }
+    },
+
     clean: true, // Recommended: Cleans 'dist' before building
     sourcemap: true,
 

--- a/packages/middleware/node/tsdown.config.ts
+++ b/packages/middleware/node/tsdown.config.ts
@@ -29,6 +29,7 @@ export default defineConfig({
     //    Bundles d.ts files into a single output
     dts: {
         resolver: 'tsc',
+        parallel: true,
         // override just for DTS generation:
         compilerOptions: {
             baseUrl: '.',

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -106,6 +106,9 @@
             ],
             "stdio": [
                 "dist/cjs/stdio.d.cts"
+            ],
+            "_shims": [
+                "dist/cjs/shimsNode.d.cts"
             ]
         }
     },

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -19,49 +19,93 @@
         "mcp",
         "server"
     ],
+    "main": "./dist/cjs/index.cjs",
+    "module": "./dist/esm/index.mjs",
+    "types": "./dist/cjs/index.d.cts",
     "exports": {
         ".": {
-            "types": "./dist/index.d.mts",
-            "import": "./dist/index.mjs"
+            "import": {
+                "types": "./dist/esm/index.d.mts",
+                "default": "./dist/esm/index.mjs"
+            },
+            "require": {
+                "types": "./dist/cjs/index.d.cts",
+                "default": "./dist/cjs/index.cjs"
+            }
         },
         "./stdio": {
-            "types": "./dist/stdio.d.mts",
-            "import": "./dist/stdio.mjs"
+            "import": {
+                "types": "./dist/esm/stdio.d.mts",
+                "default": "./dist/esm/stdio.mjs"
+            },
+            "require": {
+                "types": "./dist/cjs/stdio.d.cts",
+                "default": "./dist/cjs/stdio.cjs"
+            }
         },
         "./validators/cf-worker": {
-            "types": "./dist/validators/cfWorker.d.mts",
-            "import": "./dist/validators/cfWorker.mjs"
+            "import": {
+                "types": "./dist/esm/validators/cfWorker.d.mts",
+                "default": "./dist/esm/validators/cfWorker.mjs"
+            },
+            "require": {
+                "types": "./dist/cjs/validators/cfWorker.d.cts",
+                "default": "./dist/cjs/validators/cfWorker.cjs"
+            }
         },
         "./_shims": {
             "workerd": {
-                "types": "./dist/shimsWorkerd.d.mts",
-                "import": "./dist/shimsWorkerd.mjs"
+                "import": {
+                    "types": "./dist/esm/shimsWorkerd.d.mts",
+                    "default": "./dist/esm/shimsWorkerd.mjs"
+                },
+                "require": {
+                    "types": "./dist/cjs/shimsWorkerd.d.cts",
+                    "default": "./dist/cjs/shimsWorkerd.cjs"
+                }
             },
             "browser": {
-                "types": "./dist/shimsWorkerd.d.mts",
-                "import": "./dist/shimsWorkerd.mjs"
+                "import": {
+                    "types": "./dist/esm/shimsWorkerd.d.mts",
+                    "default": "./dist/esm/shimsWorkerd.mjs"
+                },
+                "require": {
+                    "types": "./dist/cjs/shimsWorkerd.d.cts",
+                    "default": "./dist/cjs/shimsWorkerd.cjs"
+                }
             },
             "node": {
-                "types": "./dist/shimsNode.d.mts",
-                "import": "./dist/shimsNode.mjs"
+                "import": {
+                    "types": "./dist/esm/shimsNode.d.mts",
+                    "default": "./dist/esm/shimsNode.mjs"
+                },
+                "require": {
+                    "types": "./dist/cjs/shimsNode.d.cts",
+                    "default": "./dist/cjs/shimsNode.cjs"
+                }
             },
             "default": {
-                "types": "./dist/shimsNode.d.mts",
-                "import": "./dist/shimsNode.mjs"
+                "import": {
+                    "types": "./dist/esm/shimsNode.d.mts",
+                    "default": "./dist/esm/shimsNode.mjs"
+                },
+                "require": {
+                    "types": "./dist/cjs/shimsNode.d.cts",
+                    "default": "./dist/cjs/shimsNode.cjs"
+                }
             }
         }
     },
-    "types": "./dist/index.d.mts",
     "typesVersions": {
         "*": {
             "validators/cf-worker": [
-                "dist/validators/cfWorker.d.mts"
+                "dist/cjs/validators/cfWorker.d.cts"
             ],
             "zod-schemas": [
-                "dist/zodSchemas.d.mts"
+                "dist/cjs/zodSchemas.d.cts"
             ],
             "stdio": [
-                "dist/stdio.d.mts"
+                "dist/cjs/stdio.d.cts"
             ]
         }
     },

--- a/packages/server/test/server/barrelClean.test.ts
+++ b/packages/server/test/server/barrelClean.test.ts
@@ -6,7 +6,7 @@ import { fileURLToPath } from 'node:url';
 import { beforeAll, describe, expect, test } from 'vitest';
 
 const pkgDir = join(dirname(fileURLToPath(import.meta.url)), '../..');
-const distDir = join(pkgDir, 'dist');
+const distDir = join(pkgDir, 'dist/esm');
 const NODE_ONLY = /\b(child_process|cross-spawn|node:stream|node:child_process)\b/;
 
 function chunkImportsOf(entryPath: string): string[] {

--- a/packages/server/tsdown.config.ts
+++ b/packages/server/tsdown.config.ts
@@ -7,8 +7,16 @@ export default defineConfig({
     entry: ['src/index.ts', 'src/stdio.ts', 'src/shimsNode.ts', 'src/shimsWorkerd.ts', 'src/validators/cfWorker.ts'],
 
     // 2. Output Configuration
-    format: ['esm'],
     outDir: 'dist',
+    format: {
+        esm: {
+            outDir: 'dist/esm'
+        },
+        cjs: {
+            outDir: 'dist/cjs'
+        }
+    },
+
     clean: true, // Recommended: Cleans 'dist' before building
     sourcemap: true,
 


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context

The SDK v2 needs proper packaging for both ESM and CJS consumers.  

`tsdown` can easily do that, but was not properly configured.  
Each module system's output is isolated into its own `dist/{module-system}` subdir.

Fixes #971

## How Has This Been Tested?

- Executed all test cases.
- Packaged tarballs and installed them locally.
- Verified the outputted consumer files properly run, and that they properly bundle SDK declarations.

## Breaking Changes

There is no "obvious" breaking change that I can think of.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context

No AI-assistant was involved in the changes. If something's broken it's my fault.