### PR TITLE
fix(auth): propagate saveTokens errors during token refresh

### DIFF
--- a/packages/client/src/client/auth.ts
+++ b/packages/client/src/client/auth.ts
@@ -763,9 +763,10 @@ async function authInternal(
 
     // Handle token refresh or new authorization
     if (tokens?.refresh_token) {
+        let newTokens: OAuthTokens | undefined;
         try {
             // Attempt to refresh the token
-            const newTokens = await refreshAuthorization(authorizationServerUrl, {
+            newTokens = await refreshAuthorization(authorizationServerUrl, {
                 metadata,
                 clientInformation,
                 refreshToken: tokens.refresh_token,
@@ -773,17 +774,22 @@ async function authInternal(
                 addClientAuthentication: provider.addClientAuthentication,
                 fetchFn
             });
-
-            await provider.saveTokens(newTokens);
-            return 'AUTHORIZED';
         } catch (error) {
             // If this is a ServerError, or an unknown type, log it out and try to continue. Otherwise, escalate so we can fix things and retry.
             if (!(error instanceof OAuthError) || error.code === OAuthErrorCode.ServerError) {
-                // Could not refresh OAuth tokens
+                // Could not refresh OAuth tokens — fall through to new authorization
             } else {
                 // Refresh failed for another reason, re-throw
                 throw error;
             }
+        }
+
+        if (newTokens) {
+            // saveTokens errors must propagate — the AS may have already
+            // rotated the refresh token, so silently losing the new tokens
+            // would leave the client with an invalid refresh token.
+            await provider.saveTokens(newTokens);
+            return 'AUTHORIZED';
         }
     }
 

--- a/packages/client/test/client/auth.test.ts
+++ b/packages/client/test/client/auth.test.ts
@@ -1422,6 +1422,49 @@ describe('OAuth Authorization', () => {
             expect(prmCalls).toHaveLength(1);
             expect(prmCalls[0]![0].toString()).toBe(cachedPrmUrl);
         });
+
+        it('propagates saveTokens errors instead of silently swallowing them during refresh', async () => {
+            const saveTokensError = new Error('Filesystem write failed');
+            const provider = createMockProvider({
+                discoveryState: vi.fn().mockResolvedValue({
+                    authorizationServerUrl: 'https://auth.example.com',
+                    resourceMetadata: validResourceMetadata,
+                    authorizationServerMetadata: validAuthMetadata
+                }),
+                tokens: vi.fn().mockResolvedValue({
+                    access_token: 'old-access',
+                    refresh_token: 'refresh-token',
+                    token_type: 'bearer'
+                }),
+                saveTokens: vi.fn().mockRejectedValue(saveTokensError)
+            });
+
+            mockFetch.mockImplementation(url => {
+                const urlString = url.toString();
+
+                if (urlString.includes('/token')) {
+                    return Promise.resolve({
+                        ok: true,
+                        status: 200,
+                        json: async () => ({
+                            access_token: 'new-token',
+                            token_type: 'bearer',
+                            expires_in: 3600,
+                            refresh_token: 'new-refresh-token'
+                        })
+                    });
+                }
+
+                return Promise.reject(new Error(`Unexpected fetch: ${urlString}`));
+            });
+
+            // saveTokens failure must propagate — not be silently swallowed
+            await expect(auth(provider, { serverUrl: 'https://resource.example.com' })).rejects.toThrow('Filesystem write failed');
+
+            // Verify the refresh exchange itself succeeded (token endpoint was called)
+            const tokenCall = mockFetch.mock.calls.find(call => call[0].toString().includes('/token'));
+            expect(tokenCall).toBeDefined();
+        });
     });
 
     describe('selectClientAuthMethod', () => {


### PR DESCRIPTION
## Summary

Fixes #2034

`saveTokens()` errors during token refresh are silently caught and discarded, because `saveTokens()` sits inside the same `try/catch` that handles `refreshAuthorization()` network errors. When an authorization server uses **rotating refresh tokens**, this is destructive: the AS has already invalidated the old RT, so losing the new tokens leaves the client permanently locked out.

## Changes

- Move `newTokens` declaration outside the `try` block
- Move `saveTokens(newTokens)` **after** the `catch` block so it is no longer swallowed by the `refreshAuthorization` error handler
- Add a test that verifies `saveTokens` errors propagate to the caller

## Root cause

```typescript
// BEFORE (lines 766-786)
try {
    const newTokens = await refreshAuthorization(...);
    await provider.saveTokens(newTokens);  // ← inside try
    return 'AUTHORIZED';
} catch (error) {
    // This catches BOTH refreshAuthorization AND saveTokens errors
    if (!(error instanceof OAuthError) || ...) {
        // silently swallowed — saveTokens failure lost here
    }
}
```

```typescript
// AFTER
let newTokens;
try {
    newTokens = await refreshAuthorization(...);
} catch (error) {
    // Only catches refreshAuthorization errors now
}

if (newTokens) {
    await provider.saveTokens(newTokens);  // ← propagates naturally
    return 'AUTHORIZED';
}
```

## Test

Added test case: *"should propagate saveTokens errors after successful token refresh"* — verifies that a `saveTokens` rejection is not caught by the refresh error handler.

All 365 existing tests continue to pass.