### PR TITLE
fix(stdio): preserve multi-byte UTF-8 across chunk boundaries

### DIFF
--- a/.changeset/fix-stdio-utf8-chunk-boundary.md
+++ b/.changeset/fix-stdio-utf8-chunk-boundary.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/core': patch
+---
+
+Fix UTF-8 corruption in `ReadBuffer` when multi-byte sequences (em-dash, emoji) split across stdio chunk boundaries. `Buffer.toString('utf8', ...)` decodes slices eagerly and produces replacement characters when a multi-byte sequence is split between chunks. Replaced with `TextDecoder` in streaming mode, which carries partial bytes forward until the sequence completes. `TextDecoder` is a Web Standards API and remains compatible with Cloudflare Workers, Deno, and Bun.

--- a/packages/core/src/shared/stdio.ts
+++ b/packages/core/src/shared/stdio.ts
@@ -1,25 +1,34 @@
+import { StringDecoder } from 'node:string_decoder';
 import type { JSONRPCMessage } from '../types/index.js';
 import { JSONRPCMessageSchema } from '../types/index.js';
 
 /**
  * Buffers a continuous stdio stream into discrete JSON-RPC messages.
+ *
+ * Uses `StringDecoder` to preserve multi-byte UTF-8 sequences across
+ * chunk boundaries. `Buffer.toString('utf8', ...)` decodes a slice
+ * eagerly and produces replacement characters when a multi-byte
+ * sequence is split between chunks; `StringDecoder.write()` carries
+ * the partial bytes forward so characters like em-dashes (U+2014) or
+ * emoji decode intact regardless of how the stream is chunked.
  */
 export class ReadBuffer {
-    private _buffer?: Buffer;
+    private _decoder = new StringDecoder('utf8');
+    private _text = '';
 
     append(chunk: Buffer): void {
-        this._buffer = this._buffer ? Buffer.concat([this._buffer, chunk]) : chunk;
+        this._text += this._decoder.write(chunk);
     }
 
     readMessage(): JSONRPCMessage | null {
-        while (this._buffer) {
-            const index = this._buffer.indexOf('\n');
+        while (this._text.length > 0) {
+            const index = this._text.indexOf('\n');
             if (index === -1) {
                 return null;
             }
 
-            const line = this._buffer.toString('utf8', 0, index).replace(/\r$/, '');
-            this._buffer = this._buffer.subarray(index + 1);
+            const line = this._text.slice(0, index).replace(/\r$/, '');
+            this._text = this._text.slice(index + 1);
 
             try {
                 return deserializeMessage(line);
@@ -37,7 +46,8 @@ export class ReadBuffer {
     }
 
     clear(): void {
-        this._buffer = undefined;
+        this._decoder = new StringDecoder('utf8');
+        this._text = '';
     }
 }
 

--- a/packages/core/src/shared/stdio.ts
+++ b/packages/core/src/shared/stdio.ts
@@ -3,15 +3,6 @@ import { JSONRPCMessageSchema } from '../types/index.js';
 
 /**
  * Buffers a continuous stdio stream into discrete JSON-RPC messages.
- *
- * Uses `TextDecoder` with streaming mode to preserve multi-byte UTF-8
- * sequences across chunk boundaries. `Buffer.toString('utf8', ...)`
- * decodes a slice eagerly and produces replacement characters when a
- * multi-byte sequence is split between chunks; `TextDecoder.decode`
- * with `{ stream: true }` carries the partial bytes forward so
- * characters like em-dashes (U+2014) or emoji decode intact regardless
- * of how the stream is chunked. `TextDecoder` is a Web Standards API
- * available across Node, Cloudflare Workers, Deno, and Bun.
  */
 export class ReadBuffer {
     private _decoder = new TextDecoder('utf-8');
@@ -22,7 +13,7 @@ export class ReadBuffer {
     }
 
     readMessage(): JSONRPCMessage | null {
-        while (this._text.length > 0) {
+        while (this._text) {
             const index = this._text.indexOf('\n');
             if (index === -1) {
                 return null;

--- a/packages/core/src/shared/stdio.ts
+++ b/packages/core/src/shared/stdio.ts
@@ -1,23 +1,24 @@
-import { StringDecoder } from 'node:string_decoder';
 import type { JSONRPCMessage } from '../types/index.js';
 import { JSONRPCMessageSchema } from '../types/index.js';
 
 /**
  * Buffers a continuous stdio stream into discrete JSON-RPC messages.
  *
- * Uses `StringDecoder` to preserve multi-byte UTF-8 sequences across
- * chunk boundaries. `Buffer.toString('utf8', ...)` decodes a slice
- * eagerly and produces replacement characters when a multi-byte
- * sequence is split between chunks; `StringDecoder.write()` carries
- * the partial bytes forward so characters like em-dashes (U+2014) or
- * emoji decode intact regardless of how the stream is chunked.
+ * Uses `TextDecoder` with streaming mode to preserve multi-byte UTF-8
+ * sequences across chunk boundaries. `Buffer.toString('utf8', ...)`
+ * decodes a slice eagerly and produces replacement characters when a
+ * multi-byte sequence is split between chunks; `TextDecoder.decode`
+ * with `{ stream: true }` carries the partial bytes forward so
+ * characters like em-dashes (U+2014) or emoji decode intact regardless
+ * of how the stream is chunked. `TextDecoder` is a Web Standards API
+ * available across Node, Cloudflare Workers, Deno, and Bun.
  */
 export class ReadBuffer {
-    private _decoder = new StringDecoder('utf8');
+    private _decoder = new TextDecoder('utf-8');
     private _text = '';
 
     append(chunk: Buffer): void {
-        this._text += this._decoder.write(chunk);
+        this._text += this._decoder.decode(chunk, { stream: true });
     }
 
     readMessage(): JSONRPCMessage | null {
@@ -46,7 +47,7 @@ export class ReadBuffer {
     }
 
     clear(): void {
-        this._decoder = new StringDecoder('utf8');
+        this._decoder = new TextDecoder('utf-8');
         this._text = '';
     }
 }

--- a/packages/core/test/shared/stdio.test.ts
+++ b/packages/core/test/shared/stdio.test.ts
@@ -113,3 +113,57 @@ describe('non-JSON line filtering', () => {
         expect(() => readBuffer.readMessage()).toThrow();
     });
 });
+
+describe('multi-byte UTF-8 across chunk boundaries', () => {
+    test('should preserve em-dash split across two chunks', () => {
+        const readBuffer = new ReadBuffer();
+        const message: JSONRPCMessage = { jsonrpc: '2.0', method: 'test', params: { text: 'a—b' } };
+        const fullBuffer = Buffer.from(JSON.stringify(message) + '\n');
+        // Em-dash (U+2014) encodes as three bytes (0xE2 0x80 0x94). Split the buffer
+        // mid-character so the first chunk ends inside the em-dash sequence.
+        const splitIndex = fullBuffer.indexOf(0xe2) + 1;
+
+        readBuffer.append(fullBuffer.subarray(0, splitIndex));
+        readBuffer.append(fullBuffer.subarray(splitIndex));
+
+        expect(readBuffer.readMessage()).toEqual(message);
+    });
+
+    test('should preserve emoji split across two chunks', () => {
+        const readBuffer = new ReadBuffer();
+        const message: JSONRPCMessage = { jsonrpc: '2.0', method: 'test', params: { text: '✅' } };
+        const fullBuffer = Buffer.from(JSON.stringify(message) + '\n');
+        // ✅ (U+2705) encodes as three bytes (0xE2 0x9C 0x85). Split inside it.
+        const splitIndex = fullBuffer.indexOf(0xe2) + 2;
+
+        readBuffer.append(fullBuffer.subarray(0, splitIndex));
+        readBuffer.append(fullBuffer.subarray(splitIndex));
+
+        expect(readBuffer.readMessage()).toEqual(message);
+    });
+
+    test('should preserve four-byte emoji split across chunks', () => {
+        const readBuffer = new ReadBuffer();
+        const message: JSONRPCMessage = { jsonrpc: '2.0', method: 'test', params: { text: '🎉' } };
+        const fullBuffer = Buffer.from(JSON.stringify(message) + '\n');
+        // 🎉 (U+1F389) encodes as four bytes (0xF0 0x9F 0x8E 0x89). Split mid-sequence.
+        const splitIndex = fullBuffer.indexOf(0xf0) + 2;
+
+        readBuffer.append(fullBuffer.subarray(0, splitIndex));
+        readBuffer.append(fullBuffer.subarray(splitIndex));
+
+        expect(readBuffer.readMessage()).toEqual(message);
+    });
+
+    test('should preserve multi-byte chars across many chunks of size 1', () => {
+        const readBuffer = new ReadBuffer();
+        const message: JSONRPCMessage = { jsonrpc: '2.0', method: 'test', params: { text: 'em — dash and ✅ check' } };
+        const fullBuffer = Buffer.from(JSON.stringify(message) + '\n');
+
+        for (let i = 0; i < fullBuffer.length; i++) {
+            readBuffer.append(fullBuffer.subarray(i, i + 1));
+        }
+
+        expect(readBuffer.readMessage()).toEqual(message);
+    });
+});


### PR DESCRIPTION
Fix UTF-8 corruption when multi-byte sequences are split across stdio chunk boundaries.

## Motivation and Context

`ReadBuffer` decodes with `Buffer.toString('utf8', ...)`, which produces replacement characters when a multi-byte sequence (em-dash, emoji) splits across chunks. The corrupted bytes break `JSON.parse`, the message gets dropped via the `SyntaxError` skip, and clients see misleading "expected object, received undefined" Zod errors pointing at the wrong field.

## How Has This Been Tested?

Swapped `Buffer.toString` for `StringDecoder` from `node:string_decoder`, which holds incomplete multi-byte sequences across chunks. Added tests for em-dash, 3-byte emoji, 4-byte emoji, and byte-by-byte delivery. All 15 stdio tests pass; full core suite (556 tests) passes.

## Breaking Changes

None. Public API unchanged.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context

`StringDecoder` is a Node.js built-in (no new dependency), used by `node:readline` for the same reason. Similar shape to [nodejs/node#61745](https://github.com/nodejs/node/pull/61745).