### PR TITLE
fix: use constant-time comparison for session ID validation

### DIFF
--- a/packages/server/src/server/streamableHttp.ts
+++ b/packages/server/src/server/streamableHttp.ts
@@ -20,8 +20,8 @@ import {
 
 /**
  * Constant-time string comparison to prevent timing side-channel attacks.
- * Uses Web Crypto API's subtle.timingSafeEqual when available (Node.js 20+),
- * otherwise falls back to a portable XOR-based comparison.
+ * Uses a portable XOR-based comparison that works across all Web Standards
+ * runtimes (Node.js, Cloudflare Workers, Deno, Bun).
  */
 function timingSafeCompare(a: string, b: string): boolean {
     if (a.length !== b.length) {
@@ -30,13 +30,12 @@ function timingSafeCompare(a: string, b: string): boolean {
     const encoder = new TextEncoder();
     const bufA = encoder.encode(a);
     const bufB = encoder.encode(b);
-    // Length check on encoded bytes (handles multi-byte characters)
     if (bufA.length !== bufB.length) {
         return false;
     }
     let result = 0;
-    for (let i = 0; i < bufA.length; i++) {
-        result |= bufA[i]! ^ bufB[i]!;
+    for (const [index, byte] of bufA.entries()) {
+        result |= byte ^ bufB[index]!;
     }
     return result === 0;
 }

--- a/packages/server/src/server/streamableHttp.ts
+++ b/packages/server/src/server/streamableHttp.ts
@@ -18,6 +18,29 @@ import {
     SUPPORTED_PROTOCOL_VERSIONS
 } from '@modelcontextprotocol/core';
 
+/**
+ * Constant-time string comparison to prevent timing side-channel attacks.
+ * Uses Web Crypto API's subtle.timingSafeEqual when available (Node.js 20+),
+ * otherwise falls back to a portable XOR-based comparison.
+ */
+function timingSafeCompare(a: string, b: string): boolean {
+    if (a.length !== b.length) {
+        return false;
+    }
+    const encoder = new TextEncoder();
+    const bufA = encoder.encode(a);
+    const bufB = encoder.encode(b);
+    // Length check on encoded bytes (handles multi-byte characters)
+    if (bufA.length !== bufB.length) {
+        return false;
+    }
+    let result = 0;
+    for (let i = 0; i < bufA.length; i++) {
+        result |= bufA[i]! ^ bufB[i]!;
+    }
+    return result === 0;
+}
+
 export type StreamId = string;
 export type EventId = string;
 
@@ -864,7 +887,7 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
             return this.createJsonErrorResponse(400, -32_000, 'Bad Request: Mcp-Session-Id header is required');
         }
 
-        if (sessionId !== this.sessionId) {
+        if (!timingSafeCompare(sessionId, this.sessionId!)) {
             // Reject requests with invalid session ID with 404 Not Found
             this.onerror?.(new Error('Session not found'));
             return this.createJsonErrorResponse(404, -32_001, 'Session not found');


### PR DESCRIPTION
## Summary

Replace direct string comparison (`!==`) with a portable constant-time XOR-based comparison for `mcp-session-id` header validation in the Streamable HTTP transport.

## Problem

The `validateSession()` method in `WebStandardStreamableHTTPServerTransport` uses JavaScript's `!==` operator to compare the session ID from the request header against the server's session ID:

```typescript
if (sessionId !== this.sessionId) {
    return this.createJsonErrorResponse(404, -32_001, 'Session not found');
}
```

Non-constant-time string comparison creates a timing side-channel (**CWE-208**) that could allow an attacker to brute-force session IDs character-by-character by measuring response time differences. While the practical exploitability over HTTP is limited by network jitter, using constant-time comparison is the industry-standard defense-in-depth practice (applied by OpenSSL, Django, Rails, Go stdlib, and the MCP Python SDK's own OAuth state validation).

## Fix

A portable `timingSafeCompare()` helper that works across all Web Standards runtimes (Node.js, Cloudflare Workers, Deno, Bun) without requiring Node.js-specific `crypto.timingSafeEqual`:

- Encodes both strings to `Uint8Array` via `TextEncoder`
- XOR-accumulates all byte differences
- Returns `true` only if accumulator is zero

## Cross-reference

- Security advisory: GHSA-4hcw-h88w-fq35
- The MCP Python SDK has the same pattern at `src/mcp/server/streamable_http.py:491` (separate fix needed)
- The Python SDK already uses `secrets.compare_digest()` for OAuth state validation (`src/mcp/client/auth/oauth2.py:363`), showing awareness of this class of issue