### PR TITLE
fix(client): add missing Windows env vars to DEFAULT_INHERITED_ENV_VARS

### DIFF
--- a/.changeset/fix-default-inherited-env-vars-windows.md
+++ b/.changeset/fix-default-inherited-env-vars-windows.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/client': patch
+---
+
+Add missing Windows environment variables to `DEFAULT_INHERITED_ENV_VARS`: `PATHEXT`, `COMSPEC`, `PROGRAMFILES(X86)`, `PROGRAMW6432`, and `WINDIR`. Without `PATHEXT`, spawning common tools like `npm` or `git` from a stdio MCP server fails with `ENOENT` on Windows because Node can't resolve the `.cmd`/`.exe` extension.

--- a/packages/client/src/client/stdio.ts
+++ b/packages/client/src/client/stdio.ts
@@ -55,17 +55,22 @@ export const DEFAULT_INHERITED_ENV_VARS =
     process.platform === 'win32'
         ? [
               'APPDATA',
+              'COMSPEC',
               'HOMEDRIVE',
               'HOMEPATH',
               'LOCALAPPDATA',
               'PATH',
+              'PATHEXT',
               'PROCESSOR_ARCHITECTURE',
+              'PROGRAMFILES',
+              'PROGRAMFILES(X86)',
+              'PROGRAMW6432',
               'SYSTEMDRIVE',
               'SYSTEMROOT',
               'TEMP',
               'USERNAME',
               'USERPROFILE',
-              'PROGRAMFILES'
+              'WINDIR'
           ]
         : /* list inspired by the default env inheritance of sudo */
           ['HOME', 'LOGNAME', 'PATH', 'SHELL', 'TERM', 'USER'];

--- a/packages/client/test/client/stdio.test.ts
+++ b/packages/client/test/client/stdio.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os';
 import type { JSONRPCMessage } from '@modelcontextprotocol/core-internal';
 
 import type { StdioServerParameters } from '../../src/client/stdio';
-import { StdioClientTransport } from '../../src/client/stdio';
+import { DEFAULT_INHERITED_ENV_VARS, StdioClientTransport } from '../../src/client/stdio';
 
 // Configure default server parameters based on OS
 // Uses 'more' command for Windows and 'tee' command for Unix/Linux
@@ -150,3 +150,33 @@ test('_dispose releases the parent-side pipe handles even when a helper process 
     expect(proc.stdout?.destroyed).toBe(true);
     expect(proc.stdin?.destroyed).toBe(true);
 }, 10_000);
+
+test('DEFAULT_INHERITED_ENV_VARS matches the host platform', () => {
+    if (process.platform === 'win32') {
+        // Variables Windows tooling needs to resolve executables and shells.
+        // Missing PATHEXT or COMSPEC causes spawn ENOENT for npm/git/etc.
+        expect(DEFAULT_INHERITED_ENV_VARS).toEqual(
+            expect.arrayContaining([
+                'APPDATA',
+                'COMSPEC',
+                'HOMEDRIVE',
+                'HOMEPATH',
+                'LOCALAPPDATA',
+                'PATH',
+                'PATHEXT',
+                'PROCESSOR_ARCHITECTURE',
+                'PROGRAMFILES',
+                'PROGRAMFILES(X86)',
+                'PROGRAMW6432',
+                'SYSTEMDRIVE',
+                'SYSTEMROOT',
+                'TEMP',
+                'USERNAME',
+                'USERPROFILE',
+                'WINDIR'
+            ])
+        );
+    } else {
+        expect(DEFAULT_INHERITED_ENV_VARS).toEqual(['HOME', 'LOGNAME', 'PATH', 'SHELL', 'TERM', 'USER']);
+    }
+});


### PR DESCRIPTION
Closes #2037.

On Windows, `DEFAULT_INHERITED_ENV_VARS` is missing a few variables that common dev tooling needs. The most impactful one is `PATHEXT`: without it, `spawn('npm', ...)` (and `git`, `python`, anything else that ships as `.cmd`/`.exe`/`.bat`) fails with `ENOENT` even when `PATH` is set, because Node has no extensions to try.

Added to the win32 branch:

- `PATHEXT` — extensions Windows treats as executable. Fix for the `spawn npm ENOENT` symptom in the issue.
- `COMSPEC` — path to `cmd.exe`; needed by `spawn({ shell: true })` and anything that shells out.
- `PROGRAMFILES(X86)` and `PROGRAMW6432` — the other two Program Files paths. Tools that resolve install locations need at least one of these depending on whether the parent is 32-bit or 64-bit.
- `WINDIR` — used by some legacy tooling that doesn't accept `SYSTEMROOT`.

Also sorted the array so future additions are easier to eyeball.

### Test

Added a small assertion in `stdio.test.ts` that pins the expected list per platform, so a regression on either branch fails locally. `pnpm test` is green (365/365) and `pnpm lint`/`pnpm typecheck` are clean.

Changeset included as a patch bump on `@modelcontextprotocol/client`.