### PR TITLE
fix: replay in-memory events for underscore stream ids

### DIFF
--- a/.changeset/fix-inmemory-event-store-sse-resume.md
+++ b/.changeset/fix-inmemory-event-store-sse-resume.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/sdk': patch
+---
+
+Fix `InMemoryEventStore` replay for stream IDs that contain underscores, including the standalone Streamable HTTP SSE stream.

--- a/src/examples/shared/inMemoryEventStore.ts
+++ b/src/examples/shared/inMemoryEventStore.ts
@@ -20,8 +20,7 @@ export class InMemoryEventStore implements EventStore {
      * Extracts the stream ID from an event ID
      */
     private getStreamIdFromEventId(eventId: string): string {
-        const parts = eventId.split('_');
-        return parts.length > 0 ? parts[0] : '';
+        return this.events.get(eventId)?.streamId ?? '';
     }
 
     /**

--- a/test/integration-tests/taskResumability.test.ts
+++ b/test/integration-tests/taskResumability.test.ts
@@ -9,6 +9,37 @@ import { InMemoryEventStore } from '../../src/examples/shared/inMemoryEventStore
 import { zodTestMatrix, type ZodMatrixEntry } from '../../src/__fixtures__/zodTestMatrix.js';
 import { listenOnRandomPort } from '../helpers/http.js';
 
+describe('InMemoryEventStore', () => {
+    it('replays events for stream IDs that contain underscores', async () => {
+        const dateNow = vi.spyOn(Date, 'now');
+        dateNow.mockReturnValueOnce(1000).mockReturnValueOnce(1001);
+        const random = vi.spyOn(Math, 'random');
+        random.mockReturnValueOnce(0.1).mockReturnValueOnce(0.2);
+
+        try {
+            const eventStore = new InMemoryEventStore();
+            const streamId = '_GET_stream';
+            const firstMessage = { jsonrpc: '2.0' as const, method: 'first' };
+            const secondMessage = { jsonrpc: '2.0' as const, method: 'second' };
+            const firstEventId = await eventStore.storeEvent(streamId, firstMessage);
+            const secondEventId = await eventStore.storeEvent(streamId, secondMessage);
+            const replayed: Array<{ eventId: string; message: unknown }> = [];
+
+            const replayedStreamId = await eventStore.replayEventsAfter(firstEventId, {
+                send: async (eventId, message) => {
+                    replayed.push({ eventId, message });
+                }
+            });
+
+            expect(replayedStreamId).toBe(streamId);
+            expect(replayed).toEqual([{ eventId: secondEventId, message: secondMessage }]);
+        } finally {
+            dateNow.mockRestore();
+            random.mockRestore();
+        }
+    });
+});
+
 describe.each(zodTestMatrix)('$zodVersionLabel', (entry: ZodMatrixEntry) => {
     const { z } = entry;
     describe('Transport resumability', () => {


### PR DESCRIPTION
Fixes #943.

## Summary

- read the stream ID for an event from `InMemoryEventStore`'s stored event metadata instead of parsing the generated event ID
- add a regression test covering `_GET_stream`, the standalone Streamable HTTP SSE stream ID
- add a patch changeset for `@modelcontextprotocol/sdk`

This keeps replay working for stream IDs that contain or start with underscores.

## Validation

- `npm test -- test/integration-tests/taskResumability.test.ts`
- `npm run typecheck`
- `npx prettier --check src/examples/shared/inMemoryEventStore.ts test/integration-tests/taskResumability.test.ts .changeset/fix-inmemory-event-store-sse-resume.md`
- PowerShell equivalent of `npm run build` compiler steps:
  - `npx tsc -p tsconfig.prod.json --pretty false`
  - `npx tsc -p tsconfig.cjs.json --pretty false`
- `git diff --check`

Note: `npm run build` itself uses POSIX shell syntax (`mkdir -p ... && ...`) and does not start under Windows PowerShell, so I ran the equivalent compiler commands directly.