### PR TITLE
fix: accept omitted optional prompt and tool arguments

### DIFF
--- a/.changeset/fix-optional-arguments-prompts-tools.md
+++ b/.changeset/fix-optional-arguments-prompts-tools.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/sdk': patch
+---
+
+Treat omitted `arguments` as an empty object when validating prompts and tools with optional argument schemas.

--- a/src/server/mcp.ts
+++ b/src/server/mcp.ts
@@ -271,7 +271,7 @@ export class McpServer {
         // If that fails, use the schema directly (for union/intersection/etc)
         const inputObj = normalizeObjectSchema(tool.inputSchema);
         const schemaToParse = inputObj ?? (tool.inputSchema as AnySchema);
-        const parseResult = await safeParseAsync(schemaToParse, args);
+        const parseResult = await safeParseAsync(schemaToParse, args ?? {});
         if (!parseResult.success) {
             const error = 'error' in parseResult ? parseResult.error : 'Unknown error';
             const errorMessage = getParseErrorMessage(error);
@@ -605,7 +605,7 @@ export class McpServer {
 
             if (prompt.argsSchema) {
                 const argsObj = normalizeObjectSchema(prompt.argsSchema) as AnyObjectSchema;
-                const parseResult = await safeParseAsync(argsObj, request.params.arguments);
+                const parseResult = await safeParseAsync(argsObj, request.params.arguments ?? {});
                 if (!parseResult.success) {
                     const error = 'error' in parseResult ? parseResult.error : 'Unknown error';
                     const errorMessage = getParseErrorMessage(error);

--- a/test/server/mcp.test.ts
+++ b/test/server/mcp.test.ts
@@ -1147,6 +1147,57 @@ describe.each(zodTestMatrix)('$zodVersionLabel', (entry: ZodMatrixEntry) => {
             );
         });
 
+        test('should accept omitted arguments for tools with optional args', async () => {
+            const mcpServer = new McpServer({
+                name: 'test server',
+                version: '1.0'
+            });
+            const client = new Client({
+                name: 'test client',
+                version: '1.0'
+            });
+
+            mcpServer.registerTool(
+                'test',
+                {
+                    inputSchema: {
+                        limit: z.number().optional(),
+                        offset: z.number().optional()
+                    }
+                },
+                async ({ limit, offset }) => ({
+                    content: [
+                        {
+                            type: 'text',
+                            text: `limit: ${limit ?? 'default'}, offset: ${offset ?? 'default'}`
+                        }
+                    ]
+                })
+            );
+
+            const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+            await Promise.all([client.connect(clientTransport), mcpServer.server.connect(serverTransport)]);
+
+            const result = await client.request(
+                {
+                    method: 'tools/call',
+                    params: {
+                        name: 'test'
+                    }
+                },
+                CallToolResultSchema
+            );
+
+            expect(result.isError).toBeUndefined();
+            expect(result.content).toEqual([
+                {
+                    type: 'text',
+                    text: 'limit: default, offset: default'
+                }
+            ]);
+        });
+
         /***
          * Test: Preventing Duplicate Tool Registration
          */
@@ -3575,6 +3626,62 @@ describe.each(zodTestMatrix)('$zodVersionLabel', (entry: ZodMatrixEntry) => {
                     GetPromptResultSchema
                 )
             ).rejects.toThrow(/Invalid arguments/);
+        });
+
+        test('should accept omitted arguments for prompts with optional args', async () => {
+            const mcpServer = new McpServer({
+                name: 'test server',
+                version: '1.0'
+            });
+
+            const client = new Client({
+                name: 'test client',
+                version: '1.0'
+            });
+
+            mcpServer.registerPrompt(
+                'test',
+                {
+                    argsSchema: {
+                        context: z.string().optional()
+                    }
+                },
+                async ({ context }) => ({
+                    messages: [
+                        {
+                            role: 'assistant',
+                            content: {
+                                type: 'text',
+                                text: `context: ${context ?? 'none'}`
+                            }
+                        }
+                    ]
+                })
+            );
+
+            const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+            await Promise.all([client.connect(clientTransport), mcpServer.server.connect(serverTransport)]);
+
+            const result = await client.request(
+                {
+                    method: 'prompts/get',
+                    params: {
+                        name: 'test'
+                    }
+                },
+                GetPromptResultSchema
+            );
+
+            expect(result.messages).toEqual([
+                {
+                    role: 'assistant',
+                    content: {
+                        type: 'text',
+                        text: 'context: none'
+                    }
+                }
+            ]);
         });
 
         /***


### PR DESCRIPTION
## Summary

- default omitted tool `arguments` to `{}` during input validation
- default omitted prompt `arguments` to `{}` during argument validation
- add regression tests for optional tool and prompt schemas called without `arguments`

Fixes #1869.

## Validation

- `npm test -- test/server/mcp.test.ts`
- `npm run typecheck`
- `npx prettier --check src/server/mcp.ts test/server/mcp.test.ts .changeset/fix-optional-arguments-prompts-tools.md`
- `git diff --check`
- `npx tsc -p tsconfig.prod.json --pretty false`
- `npx tsc -p tsconfig.cjs.json --pretty false`

`npm run build` still fails on Windows before TypeScript starts because `build:esm` uses POSIX shell syntax (`mkdir -p ... && ...`). The direct ESM and CJS TypeScript build commands above both pass.