### PR TITLE
fix: accept JSON-only Accept in streamable JSON mode

### DIFF
--- a/.changeset/fix-json-response-accept.md
+++ b/.changeset/fix-json-response-accept.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/sdk': patch
+---
+
+Allow streamable HTTP JSON response mode to accept POST requests whose `Accept` header only lists `application/json`.

--- a/src/server/webStandardStreamableHttp.ts
+++ b/src/server/webStandardStreamableHttp.ts
@@ -598,14 +598,15 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
         try {
             // Validate the Accept header
             const acceptHeader = req.headers.get('accept');
-            // The client MUST include an Accept header, listing both application/json and text/event-stream as supported content types.
-            if (!acceptHeader?.includes('application/json') || !acceptHeader.includes('text/event-stream')) {
-                this.onerror?.(new Error('Not Acceptable: Client must accept both application/json and text/event-stream'));
-                return this.createJsonErrorResponse(
-                    406,
-                    -32000,
-                    'Not Acceptable: Client must accept both application/json and text/event-stream'
-                );
+            const acceptsJson = acceptHeader?.includes('application/json') ?? false;
+            const acceptsEventStream = acceptHeader?.includes('text/event-stream') ?? false;
+
+            if (!acceptsJson || (!this._enableJsonResponse && !acceptsEventStream)) {
+                const message = this._enableJsonResponse
+                    ? 'Not Acceptable: Client must accept application/json'
+                    : 'Not Acceptable: Client must accept both application/json and text/event-stream';
+                this.onerror?.(new Error(message));
+                return this.createJsonErrorResponse(406, -32000, message);
             }
 
             const ct = req.headers.get('content-type');

--- a/test/server/streamableHttp.test.ts
+++ b/test/server/streamableHttp.test.ts
@@ -1115,6 +1115,29 @@ describe.each(zodTestMatrix)('$zodVersionLabel', (entry: ZodMatrixEntry) => {
             });
         });
 
+        it('should accept JSON-only Accept header in JSON response mode', async () => {
+            const toolsListMessage: JSONRPCMessage = {
+                jsonrpc: '2.0',
+                method: 'tools/list',
+                params: {},
+                id: 'json-req-1'
+            };
+
+            const response = await sendPostRequest(baseUrl, toolsListMessage, sessionId, { Accept: 'application/json' });
+
+            expect(response.status).toBe(200);
+            expect(response.headers.get('content-type')).toBe('application/json');
+
+            const result = await response.json();
+            expect(result).toMatchObject({
+                jsonrpc: '2.0',
+                result: expect.objectContaining({
+                    tools: expect.arrayContaining([expect.objectContaining({ name: 'greet' })])
+                }),
+                id: 'json-req-1'
+            });
+        });
+
         it('should return JSON response for batch requests', async () => {
             const batchMessages: JSONRPCMessage[] = [
                 { jsonrpc: '2.0', method: 'tools/list', params: {}, id: 'batch-1' },


### PR DESCRIPTION
## Summary

- allow streamable HTTP JSON response mode to accept POST requests with `Accept: application/json`
- keep the existing stricter `application/json` + `text/event-stream` requirement for streaming POST responses
- add regression coverage for JSON response mode with a JSON-only `Accept` header

Fixes #1944.

## Validation

- `npm test -- test/server/streamableHttp.test.ts`
- `npm run typecheck`
- `npx prettier --check src/server/webStandardStreamableHttp.ts test/server/streamableHttp.test.ts .changeset/fix-json-response-accept.md`
- `git diff --check`
- `npx tsc -p tsconfig.prod.json --pretty false`
- `npx tsc -p tsconfig.cjs.json --pretty false`

`npm run build` still fails on Windows before TypeScript starts because `build:esm` uses POSIX shell syntax (`mkdir -p ... && ...`). The direct ESM and CJS TypeScript build commands above both pass.