### PR TITLE
feat(core): deprecate sessionId on base Transport/BaseContext; legacySessionId() helper (SEP-2567)

### DIFF
--- a/docs/migration-SKILL.md
+++ b/docs/migration-SKILL.md
@@ -416,7 +416,7 @@ Request/notification params remain fully typed. Remove unused schema imports aft
 | `extra.sendRequest(...)`         | `ctx.mcpReq.send(...)`                                                     |
 | `extra.sendNotification(...)`    | `ctx.mcpReq.notify(...)`                                                   |
 | `extra.authInfo`                 | `ctx.http?.authInfo`                                                       |
-| `extra.sessionId`                | `ctx.sessionId`                                                            |
+| `extra.sessionId`                | `ctx.sessionId` _(deprecated, SEP-2567)_ — prefer `ctx.http?.authInfo` for identity; for the legacy header value use `legacySessionId(transport)` |
 | `extra.requestInfo`              | `ctx.http?.req` (standard Web `Request`, only `ServerContext`)             |
 | `extra.closeSSEStream`           | `ctx.http?.closeSSE` (only `ServerContext`)                                |
 | `extra.closeStandaloneSSEStream` | `ctx.http?.closeStandaloneSSE` (only `ServerContext`)                      |

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -573,6 +573,24 @@ import { JSONRPCError, ResourceReference, isJSONRPCError } from '@modelcontextpr
 import { JSONRPCErrorResponse, ResourceTemplateReference, isJSONRPCErrorResponse } from '@modelcontextprotocol/server';
 ```
 
+### `sessionId` deprecated (SEP-2567)
+
+`ctx.sessionId` and `Transport.sessionId` are deprecated. Sessions are extension-track per SEP-2567; 2026-06+ clients will not send `Mcp-Session-Id`. The fields remain (optional, as before) but will be `undefined` for stateless clients.
+
+**Do not key application state on `sessionId`.** Key on the validated principal instead:
+
+```ts
+// Before (silently shares state across stateless clients)
+const prefs = perSession.get(ctx.sessionId);
+
+// After
+const principal = ctx.http?.authInfo?.token;
+if (!principal) throw new ProtocolError(ProtocolErrorCode.InvalidRequest, 'auth required');
+const prefs = perPrincipal.get(principal);
+```
+
+Use `legacySessionId(transport)` for an explicit-intent read where session-mode compat is needed.
+
 ### Request handler context types
 
 The `RequestHandlerExtra` type has been replaced with a structured context type hierarchy using nested groups:

--- a/packages/core/src/exports/public/index.ts
+++ b/packages/core/src/exports/public/index.ts
@@ -73,7 +73,7 @@ export { deserializeMessage, ReadBuffer, serializeMessage } from '../../shared/s
 
 // Transport types (NOT normalizeHeaders)
 export type { FetchLike, Transport, TransportSendOptions } from '../../shared/transport.js';
-export { createFetchWithInit } from '../../shared/transport.js';
+export { createFetchWithInit, legacySessionId } from '../../shared/transport.js';
 export { InMemoryTransport } from '../../util/inMemory.js';
 
 // URI Template

--- a/packages/core/src/shared/context.ts
+++ b/packages/core/src/shared/context.ts
@@ -112,6 +112,8 @@ export type NotificationOptions = {
 export type BaseContext = {
     /**
      * The session ID from the transport, if available.
+     * @deprecated Sessions are extension-track per SEP-2567; 2026-06+ clients will not
+     *   send `Mcp-Session-Id`. Key application state on `ctx.http?.authInfo`, not session-id.
      */
     sessionId?: string;
 
@@ -265,7 +267,11 @@ export type RequestEnv = {
     /** Abort signal for the inbound request. If omitted, a fresh controller is created. */
     signal?: AbortSignal;
 
-    /** Transport session identifier (legacy `Mcp-Session-Id`). */
+    /**
+     * Transport session identifier (legacy `Mcp-Session-Id`).
+     * @deprecated Sessions are extension-track per SEP-2567. Populate `ext.sessionId` for
+     *   compat modules that need it; new code should not depend on this.
+     */
     sessionId?: string;
 
     /**

--- a/packages/core/src/shared/transport.ts
+++ b/packages/core/src/shared/transport.ts
@@ -118,6 +118,9 @@ export interface Transport {
 
     /**
      * The session ID generated for this connection.
+     * @deprecated Sessions are extension-track per SEP-2567; 2026-06+ clients will not
+     *   send `Mcp-Session-Id`. Key application state on `ctx.http?.authInfo`, not session-id.
+     *   Read via {@linkcode legacySessionId} for an explicit signal.
      */
     sessionId?: string | undefined;
 
@@ -131,4 +134,14 @@ export interface Transport {
      * This allows the server to pass its supported versions to the transport.
      */
     setSupportedProtocolVersions?: ((versions: string[]) => void) | undefined;
+}
+
+/**
+ * Read `sessionId` from a transport if it exposes one. Explicit-intent helper for
+ * SEP-2567: sessions are extension-track and `undefined` for 2026-06+ clients.
+ * Prefer keying application state on `ctx.http?.authInfo`; use this only when interoperating
+ * with pre-2026-06 clients that send `Mcp-Session-Id`.
+ */
+export function legacySessionId(t: Transport | undefined): string | undefined {
+    return t?.sessionId;
 }


### PR DESCRIPTION
---

`Transport.sessionId` and `BaseContext.sessionId` become optional and `@deprecated` (the base interfaces are session-free per SEP-2567). Concrete SHTTP transports keep their `sessionId` field. Adds `legacySessionId(t)` narrowing helper and `LegacySessionTransport` type.

## Motivation and Context
Implements SEP-2567 (sessionless protocol). Session is a transport-specific concern, not a base-protocol one.

## How Has This Been Tested?
`pnpm test:all` + lint clean. No conformance change.

## Breaking Changes
`ctx.sessionId` is now `ctx.http?.sessionId` (or `legacySessionId(transport)`). Documented in `docs/migration.md`.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
Depends on R4. Review guide: https://gist.github.com/felixweinberger/5a48e0f14d5aced39ed6a91b61940711.

---