### PR TITLE
feat(core): BaseContext.ext / RequestEnv.ext plugin slot (SEP-2133 mechanism)

### DIFF
--- a/packages/core/src/exports/public/index.ts
+++ b/packages/core/src/exports/public/index.ts
@@ -52,7 +52,7 @@ export type {
     RequestOptions,
     ServerContext
 } from '../../shared/protocol.js';
-export { DEFAULT_REQUEST_TIMEOUT_MSEC } from '../../shared/protocol.js';
+export { DEFAULT_REQUEST_TIMEOUT_MSEC, readExt } from '../../shared/protocol.js';
 
 // Task manager types (NOT TaskManager class itself — internal)
 export type { RequestTaskStore, TaskContext, TaskManagerOptions, TaskRequestOptions } from '../../shared/taskManager.js';

--- a/packages/core/src/exports/public/index.ts
+++ b/packages/core/src/exports/public/index.ts
@@ -52,7 +52,7 @@ export type {
     RequestOptions,
     ServerContext
 } from '../../shared/protocol.js';
-export { DEFAULT_REQUEST_TIMEOUT_MSEC, readExt } from '../../shared/protocol.js';
+export { DEFAULT_REQUEST_TIMEOUT_MSEC } from '../../shared/protocol.js';
 
 // Task manager types (NOT TaskManager class itself — internal)
 export type { RequestTaskStore, TaskContext, TaskManagerOptions, TaskRequestOptions } from '../../shared/taskManager.js';

--- a/packages/core/src/shared/context.ts
+++ b/packages/core/src/shared/context.ts
@@ -181,7 +181,7 @@ export type BaseContext = {
 
     /**
      * Extension slot (SEP-2133 mechanism). Dispatch middleware registered via
-     * {@linkcode Protocol.use} populates keys here under the extension's reverse-DNS
+     * `use()` populates keys here under the extension's reverse-DNS
      * namespace; handlers read via the extension's typed accessor (e.g.
      * `taskContext(ctx)` for `tasksPlugin`). Core never reads or writes this field.
      *

--- a/packages/core/src/shared/context.ts
+++ b/packages/core/src/shared/context.ts
@@ -197,15 +197,6 @@ export type BaseContext = {
 };
 
 /**
- * Typed reader for an extension key on {@linkcode BaseContext.ext}. Extensions export
- * a thin wrapper around this (e.g. `taskContext(ctx)`) so handlers get a typed value
- * without casting at the call site.
- */
-export function readExt<T>(ctx: BaseContext, key: string): T | undefined {
-    return ctx.ext?.[key] as T | undefined;
-}
-
-/**
  * Context provided to server-side request handlers, extending {@linkcode BaseContext} with server-specific fields.
  */
 export type ServerContext = BaseContext & {

--- a/packages/core/src/shared/context.ts
+++ b/packages/core/src/shared/context.ts
@@ -180,11 +180,30 @@ export type BaseContext = {
     };
 
     /**
-     * Extension slot. Adapters and middleware populate keys here; handlers cast to the
-     * extension's declared type to read them. Core never reads or writes this field.
+     * Extension slot (SEP-2133 mechanism). Dispatch middleware registered via
+     * {@linkcode Protocol.use} populates keys here under the extension's reverse-DNS
+     * namespace; handlers read via the extension's typed accessor (e.g.
+     * `taskContext(ctx)` for `tasksPlugin`). Core never reads or writes this field.
+     *
+     * @example
+     * ```ts
+     * // In a DispatchMiddleware:
+     * env.ext = { ...env.ext, 'io.modelcontextprotocol/task': { id, store } };
+     * // In a handler:
+     * const task = taskContext(ctx); // typed read of ctx.ext['io.modelcontextprotocol/task']
+     * ```
      */
     ext?: Record<string, unknown>;
 };
+
+/**
+ * Typed reader for an extension key on {@linkcode BaseContext.ext}. Extensions export
+ * a thin wrapper around this (e.g. `taskContext(ctx)`) so handlers get a typed value
+ * without casting at the call site.
+ */
+export function readExt<T>(ctx: BaseContext, key: string): T | undefined {
+    return ctx.ext?.[key] as T | undefined;
+}
 
 /**
  * Context provided to server-side request handlers, extending {@linkcode BaseContext} with server-specific fields.


### PR DESCRIPTION
---

Adds `ext?: Record<string, unknown>` to `BaseContext` and `RequestEnv` — a generic slot plugins/drivers populate and handlers read via a typed helper. Core never reads or writes it.

## Motivation and Context
The mechanism SEP-2133 extensions use to inject per-request context without core knowing about them. `tasksPlugin` (F3) puts `ext.task`; `SessionCompat` puts `ext.sessionId`.

## How Has This Been Tested?
typecheck + lint clean. Type-only change.

## Breaking Changes
None.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
Depends on S1. Review guide: https://gist.github.com/felixweinberger/5a48e0f14d5aced39ed6a91b61940711.

---