### PR TITLE
feat(server): server/discover handler; per-request clientCapabilities resolution (SEP-2575)

### DIFF
--- a/packages/core/src/types/schemas.ts
+++ b/packages/core/src/types/schemas.ts
@@ -545,11 +545,30 @@ export const InitializeResultSchema = ResultSchema.extend({
 });
 
 /**
+ * SEP-2575 `server/discover` result. Same shape as {@linkcode InitializeResultSchema} but
+ * without the negotiated `protocolVersion` field; the client asserts the version per request
+ * via `_meta` instead of via a stateful handshake. Stateless: the server writes no instance
+ * fields when handling this.
+ */
+export const ServerDiscoverResultSchema = InitializeResultSchema.omit({ protocolVersion: true });
+
+/**
  * This notification is sent from the client to the server after initialization has finished.
  */
 export const InitializedNotificationSchema = NotificationSchema.extend({
     method: z.literal('notifications/initialized'),
     params: NotificationsParamsSchema.optional()
+});
+
+/* Discover (SEP-2575) */
+/**
+ * SEP-2575 stateless capability discovery. The server responds with its capabilities,
+ * info, and instructions; no protocol-version negotiation occurs (the client asserts the
+ * version per request via `_meta`).
+ */
+export const ServerDiscoverRequestSchema = RequestSchema.extend({
+    method: z.literal('server/discover'),
+    params: BaseRequestParamsSchema.optional()
 });
 
 /* Ping */
@@ -2079,6 +2098,7 @@ export const RootsListChangedNotificationSchema = NotificationSchema.extend({
 export const ClientRequestSchema = z.union([
     PingRequestSchema,
     InitializeRequestSchema,
+    ServerDiscoverRequestSchema,
     CompleteRequestSchema,
     SetLevelRequestSchema,
     GetPromptRequestSchema,
@@ -2159,6 +2179,7 @@ export const ServerResultSchema = z.union([
 const resultSchemas: Record<string, z.core.$ZodType> = {
     ping: EmptyResultSchema,
     initialize: InitializeResultSchema,
+    'server/discover': ServerDiscoverResultSchema,
     'completion/complete': CompleteResultSchema,
     'logging/setLevel': EmptyResultSchema,
     'prompts/get': GetPromptResultSchema,

--- a/packages/core/src/types/specTypeSchema.ts
+++ b/packages/core/src/types/specTypeSchema.ts
@@ -151,6 +151,8 @@ const SPEC_SCHEMA_KEYS = [
     'SamplingMessageSchema',
     'SamplingMessageContentBlockSchema',
     'ServerCapabilitiesSchema',
+    'ServerDiscoverRequestSchema',
+    'ServerDiscoverResultSchema',
     'ServerNotificationSchema',
     'ServerRequestSchema',
     'ServerResultSchema',

--- a/packages/core/src/types/types.ts
+++ b/packages/core/src/types/types.ts
@@ -125,6 +125,8 @@ import type {
     SamplingMessageContentBlockSchema,
     SamplingMessageSchema,
     ServerCapabilitiesSchema,
+    ServerDiscoverRequestSchema,
+    ServerDiscoverResultSchema,
     ServerNotificationSchema,
     ServerRequestSchema,
     ServerResultSchema,
@@ -259,6 +261,8 @@ export type InitializeRequestParams = Infer<typeof InitializeRequestParamsSchema
 export type InitializeRequest = Infer<typeof InitializeRequestSchema>;
 export type ServerCapabilities = Infer<typeof ServerCapabilitiesSchema>;
 export type InitializeResult = Infer<typeof InitializeResultSchema>;
+export type ServerDiscoverRequest = Infer<typeof ServerDiscoverRequestSchema>;
+export type ServerDiscoverResult = Infer<typeof ServerDiscoverResultSchema>;
 export type InitializedNotification = Infer<typeof InitializedNotificationSchema>;
 
 /* Ping */
@@ -420,6 +424,7 @@ export type NotificationTypeMap = MethodToTypeMap<ClientNotification | ServerNot
 export type ResultTypeMap = {
     ping: EmptyResult;
     initialize: InitializeResult;
+    'server/discover': ServerDiscoverResult;
     'completion/complete': CompleteResult;
     'logging/setLevel': EmptyResult;
     'prompts/get': GetPromptResult;

--- a/packages/server/src/server/server.ts
+++ b/packages/server/src/server/server.ts
@@ -36,6 +36,7 @@ import type {
 import {
     CallToolRequestSchema,
     CallToolResultSchema,
+    ClientCapabilitiesSchema,
     CreateMessageResultSchema,
     CreateMessageResultWithToolsSchema,
     ElicitResultSchema,
@@ -144,7 +145,13 @@ export class Server extends Protocol<ServerContext> {
         const sendOpts = (options?: RequestOptions): RequestOptions => ({ ...options, relatedRequestId: ctx.mcpReq.id });
         // SEP-2575: prefer per-request peer scope (lifted from `_meta` by S4) over the
         // singleton handshake state. Falls back to the singleton for the connect() path.
-        const reqCaps = ctx.mcpReq.clientCapabilities ?? this._clientCapabilities;
+        // Normalize the per-request value: it may arrive raw from a transport adapter
+        // (e.g. SessionCompat stores `initialize.params.capabilities` off the wire), and
+        // ElicitationCapabilitySchema's preprocess (e.g. `{}` -> `{form:{}}`) must run
+        // before the `_elicitInputVia` capability gate reads `caps.elicitation.form`.
+        const rawReqCaps = ctx.mcpReq.clientCapabilities;
+        const reqCaps =
+            rawReqCaps === undefined ? this._clientCapabilities : (ClientCapabilitiesSchema.safeParse(rawReqCaps).data ?? rawReqCaps);
         const reqLogLevel = ctx.mcpReq.logLevel;
         return {
             ...ctx,

--- a/packages/server/src/server/server.ts
+++ b/packages/server/src/server/server.ts
@@ -28,6 +28,7 @@ import type {
     Result,
     ServerCapabilities,
     ServerContext,
+    ServerDiscoverResult,
     StandardSchemaV1,
     ToolResultContent,
     ToolUseContent
@@ -116,6 +117,7 @@ export class Server extends Protocol<ServerContext> {
         this._jsonSchemaValidator = options?.jsonSchemaValidator ?? new DefaultJsonSchemaValidator();
 
         this.setRequestHandler('initialize', request => this._oninitialize(request));
+        this.setRequestHandler('server/discover', () => this._ondiscover());
         this.setNotificationHandler('notifications/initialized', () => this.oninitialized?.());
 
         if (this._capabilities.logging) {
@@ -140,17 +142,21 @@ export class Server extends Protocol<ServerContext> {
         // Only create http when there's actual HTTP transport info or auth info
         const hasHttpInfo = ctx.http || transportInfo?.request || transportInfo?.closeSSEStream || transportInfo?.closeStandaloneSSEStream;
         const sendOpts = (options?: RequestOptions): RequestOptions => ({ ...options, relatedRequestId: ctx.mcpReq.id });
+        // SEP-2575: prefer per-request peer scope (lifted from `_meta` by S4) over the
+        // singleton handshake state. Falls back to the singleton for the connect() path.
+        const reqCaps = ctx.mcpReq.clientCapabilities ?? this._clientCapabilities;
+        const reqLogLevel = ctx.mcpReq.logLevel;
         return {
             ...ctx,
             mcpReq: {
                 ...ctx.mcpReq,
                 log: async (level, data, logger) => {
-                    if (this._capabilities.logging && !this.isMessageIgnored(level, ctx.sessionId)) {
+                    if (this._capabilities.logging && !this.isMessageIgnored(level, ctx.sessionId, reqLogLevel)) {
                         await ctx.mcpReq.notify({ method: 'notifications/message', params: { level, data, logger } });
                     }
                 },
-                elicitInput: (params, options) => this._elicitInputVia(ctx.mcpReq.send, params, sendOpts(options)),
-                requestSampling: (params, options) => this._createMessageVia(ctx.mcpReq.send, params, sendOpts(options))
+                elicitInput: (params, options) => this._elicitInputVia(ctx.mcpReq.send, reqCaps, params, sendOpts(options)),
+                requestSampling: (params, options) => this._createMessageVia(ctx.mcpReq.send, reqCaps, params, sendOpts(options))
             },
             http: hasHttpInfo
                 ? {
@@ -186,8 +192,9 @@ export class Server extends Protocol<ServerContext> {
     private readonly LOG_LEVEL_SEVERITY = new Map(LoggingLevelSchema.options.map((level, index) => [level, index]));
 
     // Is a message with the given level ignored in the log level set for the given session id?
-    private isMessageIgnored = (level: LoggingLevel, sessionId?: string): boolean => {
-        const currentLevel = this._loggingLevels.get(sessionId);
+    private isMessageIgnored = (level: LoggingLevel, sessionId?: string, requestLevel?: LoggingLevel): boolean => {
+        // SEP-2575: per-request `_meta.logLevel` (S4) takes precedence over session-stored level.
+        const currentLevel = requestLevel ?? this._loggingLevels.get(sessionId);
         return currentLevel ? this.LOG_LEVEL_SEVERITY.get(level)! < this.LOG_LEVEL_SEVERITY.get(currentLevel)! : false;
     };
 
@@ -376,7 +383,8 @@ export class Server extends Protocol<ServerContext> {
             }
 
             case 'ping':
-            case 'initialize': {
+            case 'initialize':
+            case 'server/discover': {
                 // No specific capability required for these methods
                 break;
             }
@@ -395,8 +403,17 @@ export class Server extends Protocol<ServerContext> {
 
         this.transport?.setProtocolVersion?.(protocolVersion);
 
+        return { protocolVersion, ...this._ondiscover() };
+    }
+
+    /**
+     * SEP-2575 `server/discover` handler. Returns capabilities, server info and instructions
+     * without negotiating a protocol version (the client asserts the version per request via
+     * `_meta`). Stateless: writes no instance fields, so one Server can serve unlimited
+     * concurrent stateless clients on the dispatch() path.
+     */
+    private _ondiscover(): ServerDiscoverResult {
         return {
-            protocolVersion,
             capabilities: this.getCapabilities(),
             serverInfo: this._serverInfo,
             ...(this._instructions && { instructions: this._instructions })
@@ -454,7 +471,12 @@ export class Server extends Protocol<ServerContext> {
         params: CreateMessageRequest['params'],
         options?: RequestOptions
     ): Promise<CreateMessageResult | CreateMessageResultWithTools> {
-        return this._createMessageVia((r, schema, opts) => this._requestWithSchema(r, schema, opts), params, options);
+        return this._createMessageVia(
+            (r, schema, opts) => this._requestWithSchema(r, schema, opts),
+            this._clientCapabilities,
+            params,
+            options
+        );
     }
 
     /**
@@ -469,13 +491,14 @@ export class Server extends Protocol<ServerContext> {
      */
     private async _createMessageVia(
         send: SendWithSchema,
+        caps: ClientCapabilities | undefined,
         params: CreateMessageRequest['params'],
         options?: RequestOptions
     ): Promise<CreateMessageResult | CreateMessageResultWithTools> {
         // Base `sampling` capability is checked via assertCapabilityForMethod() (gated on
         // enforceStrictCapabilities, which defaults to false). Only the `sampling.tools`
         // sub-capability is enforced here unconditionally, matching the v1 createMessage body.
-        if ((params.tools || params.toolChoice) && !this._clientCapabilities?.sampling?.tools) {
+        if ((params.tools || params.toolChoice) && !caps?.sampling?.tools) {
             throw new SdkError(SdkErrorCode.CapabilityNotSupported, 'Client does not support sampling tools capability.');
         }
 
@@ -534,7 +557,12 @@ export class Server extends Protocol<ServerContext> {
      * @returns The result of the elicitation request.
      */
     async elicitInput(params: ElicitRequestFormParams | ElicitRequestURLParams, options?: RequestOptions): Promise<ElicitResult> {
-        return this._elicitInputVia((r, schema, opts) => this._requestWithSchema(r, schema, opts), params, options);
+        return this._elicitInputVia(
+            (r, schema, opts) => this._requestWithSchema(r, schema, opts),
+            this._clientCapabilities,
+            params,
+            options
+        );
     }
 
     /**
@@ -543,6 +571,7 @@ export class Server extends Protocol<ServerContext> {
      */
     private async _elicitInputVia(
         send: SendWithSchema,
+        caps: ClientCapabilities | undefined,
         params: ElicitRequestFormParams | ElicitRequestURLParams,
         options?: RequestOptions
     ): Promise<ElicitResult> {
@@ -550,14 +579,14 @@ export class Server extends Protocol<ServerContext> {
 
         switch (mode) {
             case 'url': {
-                if (!this._clientCapabilities?.elicitation?.url) {
+                if (!caps?.elicitation?.url) {
                     throw new SdkError(SdkErrorCode.CapabilityNotSupported, 'Client does not support url elicitation.');
                 }
                 const urlParams = params as ElicitRequestURLParams;
                 return send({ method: 'elicitation/create', params: urlParams }, ElicitResultSchema, options);
             }
             case 'form': {
-                if (!this._clientCapabilities?.elicitation?.form) {
+                if (!caps?.elicitation?.form) {
                     throw new SdkError(SdkErrorCode.CapabilityNotSupported, 'Client does not support form elicitation.');
                 }
                 const formParams: ElicitRequestFormParams =

--- a/packages/server/test/server/server.test.ts
+++ b/packages/server/test/server/server.test.ts
@@ -39,4 +39,58 @@ describe('Server', () => {
             await server.close();
         });
     });
+
+    describe('server/discover (SEP-2575)', () => {
+        it('returns capabilities/serverInfo/instructions without writing handshake state', async () => {
+            const server = new Server({ name: 'disc', version: '2.0.0' }, { capabilities: { tools: {} }, instructions: 'hello' });
+
+            const out: JSONRPCMessage[] = [];
+            for await (const o of server.dispatch({ jsonrpc: '2.0', id: 1, method: 'server/discover' })) {
+                out.push(o.message);
+            }
+            const last = out.at(-1) as { result?: unknown; error?: unknown };
+            expect(last.error).toBeUndefined();
+            expect(last.result).toMatchObject({
+                serverInfo: { name: 'disc', version: '2.0.0' },
+                capabilities: { tools: {} },
+                instructions: 'hello'
+            });
+            expect((last.result as Record<string, unknown>).protocolVersion).toBeUndefined();
+            expect(server.getClientCapabilities()).toBeUndefined();
+        });
+    });
+
+    describe('per-request clientCapabilities (SEP-2575)', () => {
+        it('ctx.mcpReq.elicitInput respects _meta.clientCapabilities over singleton', async () => {
+            const server = new Server({ name: 't', version: '1' }, { capabilities: { tools: {} } });
+            // No initialize: singleton _clientCapabilities is undefined.
+            let elicitErr: unknown;
+            server.setRequestHandler('tools/call', async (_req, ctx) => {
+                try {
+                    await ctx.mcpReq.elicitInput({ message: 'm', requestedSchema: { type: 'object', properties: {} } });
+                } catch (e) {
+                    elicitErr = e;
+                }
+                return { content: [] };
+            });
+
+            // First call: no _meta caps -> elicitInput should reject (no caps anywhere).
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            for await (const _o of server.dispatch({ jsonrpc: '2.0', id: 1, method: 'tools/call', params: { name: 'x' } }));
+            expect(elicitErr).toBeDefined();
+            elicitErr = undefined;
+
+            // Second call: _meta carries elicitation.form -> capability check passes
+            // (the actual send will reject NotConnected since there's no env.send, but
+            // that proves we got past the cap check).
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            for await (const _o of server.dispatch({
+                jsonrpc: '2.0',
+                id: 2,
+                method: 'tools/call',
+                params: { name: 'x', _meta: { 'io.modelcontextprotocol/clientCapabilities': { elicitation: { form: {} } } } }
+            }));
+            expect(String(elicitErr)).not.toMatch(/CapabilityNotSupported|does not support/i);
+        });
+    });
 });


### PR DESCRIPTION
---

Registers a `server/discover` handler (returns `serverInfo`/`capabilities`/`instructions` without state). `Server.buildContext` resolves capability checks against `ctx.mcpReq.clientCapabilities ?? this._clientCapabilities`.

## Motivation and Context
Completes the SEP-2575 server side: per-request peer scope + the `server/discover` method that replaces `initialize` for stateless clients.

## How Has This Been Tested?
`pnpm test:all` passes. New tests for discover + per-request capability resolution.

## Breaking Changes
None.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
Depends on S4. Review guide: https://gist.github.com/felixweinberger/5a48e0f14d5aced39ed6a91b61940711.

---
