### PR TITLE
feat(client): MRTR retry loop, ClientTransport, version-gate notifications/initialized (SEP-2322/2575)

### DIFF
--- a/packages/client/src/client/client.ts
+++ b/packages/client/src/client/client.ts
@@ -9,7 +9,10 @@ import type {
     CompleteRequest,
     GetPromptRequest,
     Implementation,
+    IncompleteResult,
+    JSONRPCErrorResponse,
     JSONRPCRequest,
+    JSONRPCResultResponse,
     JsonSchemaType,
     JsonSchemaValidator,
     jsonSchemaValidator,
@@ -22,12 +25,15 @@ import type {
     LoggingLevel,
     MessageExtraInfo,
     NotificationMethod,
+    NotificationOptions,
     ProtocolOptions,
     ReadResourceRequest,
+    Request,
     RequestMethod,
     RequestOptions,
     Result,
     ServerCapabilities,
+    StandardSchemaV1,
     SubscribeRequest,
     Tool,
     Transport,
@@ -44,6 +50,7 @@ import {
     EmptyResultSchema,
     GetPromptResultSchema,
     InitializeResultSchema,
+    isJSONRPCErrorResponse,
     LATEST_PROTOCOL_VERSION,
     ListChangedOptionsBaseSchema,
     ListPromptsResultSchema,
@@ -55,12 +62,16 @@ import {
     Protocol,
     ProtocolError,
     ProtocolErrorCode,
+    RAW_RESULT_SCHEMA,
     ReadResourceResultSchema,
     SdkError,
-    SdkErrorCode
+    SdkErrorCode,
+    validateStandardSchema
 } from '@modelcontextprotocol/core';
 
 import { ExperimentalClientTasks } from '../experimental/tasks/client.js';
+import type { ClientTransport } from './clientTransport.js';
+import { isClientTransport } from './clientTransport.js';
 
 /**
  * Elicitation default application helper. Applies defaults to the `data` based on the `schema`.
@@ -179,7 +190,28 @@ export type ClientOptions = ProtocolOptions & {
      * ```
      */
     listChanged?: ListChangedHandlers;
+
+    /**
+     * SEP-2322: maximum number of incomplete-result rounds before failing. Each round
+     * services the server's `inputRequests` via local handlers and re-sends with
+     * `params.{inputResponses, requestState}`. Prevents unbounded looping on a server
+     * that returns `incomplete` forever.
+     *
+     * @default 16
+     */
+    mrtrMaxRounds?: number;
 };
+
+const DEFAULT_MRTR_MAX_ROUNDS = 16;
+
+/** SEP-2322 client-side detection. The server signals it cannot complete without client input. */
+function isIncompleteResult(r: unknown): r is IncompleteResult {
+    if (typeof r !== 'object' || r === null) return false;
+    const o = r as { resultType?: unknown; inputRequests?: unknown };
+    if (o.resultType !== 'incomplete') return false;
+    if (o.inputRequests === undefined) return true;
+    return typeof o.inputRequests === 'object' && o.inputRequests !== null && !Array.isArray(o.inputRequests);
+}
 
 /**
  * An MCP client on top of a pluggable transport.
@@ -223,6 +255,12 @@ export class Client extends Protocol<ClientContext> {
     private _listChangedDebounceTimers: Map<string, ReturnType<typeof setTimeout>> = new Map();
     private _pendingListChangedConfig?: ListChangedHandlers;
     private _enforceStrictCapabilities: boolean;
+    /** Set when {@linkcode connect} was given a request-shaped {@linkcode ClientTransport}. */
+    private _clientTransport?: ClientTransport;
+    /** Monotonic id counter for the request-shaped path. */
+    private _ctRequestId = 0;
+    /** SEP-2322: maximum incomplete-result rounds before failing. */
+    private readonly _mrtrMaxRounds: number;
 
     /**
      * Initializes this client with the given name and version information.
@@ -235,6 +273,7 @@ export class Client extends Protocol<ClientContext> {
         this._capabilities = options?.capabilities ? { ...options.capabilities } : {};
         this._jsonSchemaValidator = options?.jsonSchemaValidator ?? new DefaultJsonSchemaValidator();
         this._enforceStrictCapabilities = options?.enforceStrictCapabilities ?? false;
+        this._mrtrMaxRounds = options?.mrtrMaxRounds ?? DEFAULT_MRTR_MAX_ROUNDS;
 
         // Store list changed config for setup after connection (when we know server capabilities)
         if (options?.listChanged) {
@@ -297,7 +336,7 @@ export class Client extends Protocol<ClientContext> {
      * The new capabilities will be merged with any existing capabilities previously given (e.g., at initialization).
      */
     public registerCapabilities(capabilities: ClientCapabilities): void {
-        if (this.transport) {
+        if (this.transport || this._clientTransport) {
             throw new Error('Cannot register capabilities after connecting to transport');
         }
 
@@ -429,7 +468,27 @@ export class Client extends Protocol<ClientContext> {
      * }
      * ```
      */
-    override async connect(transport: Transport, options?: RequestOptions): Promise<void> {
+    override async connect(transport: Transport | ClientTransport, options?: RequestOptions): Promise<void> {
+        if (isClientTransport(transport)) {
+            // Request-shaped transport: bypass Protocol's pipe wiring. _requestWithSchema
+            // routes via _clientTransport.fetch() per call; inbound server requests are
+            // serviced via _serviceInputRequests over the SEP-2322 retry loop.
+            this._clientTransport = transport;
+            await this._initializeOrDiscover(options);
+            // Wire the optional unsolicited stream so list-changed handlers can fire between fetches.
+            if (transport.subscribe) {
+                void (async () => {
+                    try {
+                        for await (const n of transport.subscribe!({ onrequest: r => this._serviceInboundRequest(r) })) {
+                            await this.dispatchNotification(n).catch(error => this.onerror?.(error as Error));
+                        }
+                    } catch (error) {
+                        this.onerror?.(error as Error);
+                    }
+                })();
+            }
+            return;
+        }
         await super.connect(transport);
         // When transport sessionId is already set this means we are trying to reconnect.
         // Restore the protocol version negotiated during the original initialize handshake
@@ -472,9 +531,14 @@ export class Client extends Protocol<ClientContext> {
 
             this._instructions = result.instructions;
 
-            await this.notification({
-                method: 'notifications/initialized'
-            });
+            // SEP-2575: post-initialize handshake notification only on legacy protocol
+            // versions. 2026-06-30+ servers do not require it (initialize itself is
+            // optional there); skipping avoids an extra round-trip on stateless servers.
+            if (this._negotiatedProtocolVersion < '2026-06-30') {
+                await this.notification({
+                    method: 'notifications/initialized'
+                });
+            }
 
             // Set up list changed handlers now that we know server capabilities
             if (this._pendingListChangedConfig) {
@@ -996,5 +1060,181 @@ export class Client extends Protocol<ClientContext> {
     /** Notifies the server that the client's root list has changed. Requires the `roots.listChanged` capability. */
     async sendRootsListChanged() {
         return this.notification({ method: 'notifications/roots/list_changed' });
+    }
+
+    /**
+     * Runs the SEP-2322 multi-round-trip retry loop around outbound requests, then validates
+     * the final result against `resultSchema`. On the pipe-transport path it delegates each
+     * round to `super._requestWithSchema(req, RAW_RESULT_SCHEMA)`; on the request-shaped path
+     * it calls {@linkcode ClientTransport.fetch}.
+     */
+    protected override async _requestWithSchema<T extends StandardSchemaV1>(
+        req: Request,
+        resultSchema: T,
+        options?: RequestOptions
+    ): Promise<StandardSchemaV1.InferOutput<T>> {
+        const overallStart = Date.now();
+        let inputResponses: Record<string, unknown> | undefined;
+        let requestState: string | undefined;
+        for (let round = 0; round < this._mrtrMaxRounds; round++) {
+            const remainingTotal =
+                options?.maxTotalTimeout === undefined ? undefined : Math.max(0, options.maxTotalTimeout - (Date.now() - overallStart));
+            if (remainingTotal !== undefined && remainingTotal <= 0) {
+                throw new SdkError(SdkErrorCode.RequestTimeout, 'Request timed out', { maxTotalTimeout: options?.maxTotalTimeout });
+            }
+            const params =
+                round > 0
+                    ? { ...(req.params as Record<string, unknown> | undefined), inputResponses, requestState }
+                    : (req.params as Record<string, unknown> | undefined);
+            const roundOpts: RequestOptions = {
+                ...options,
+                maxTotalTimeout: remainingTotal,
+                // resumptionToken is only meaningful for round 0; subsequent rounds carry
+                // fresh inputResponses in the body and must POST, not resume the prior stream.
+                resumptionToken: round === 0 ? options?.resumptionToken : undefined
+            };
+            const raw = await this._requestRoundRaw({ method: req.method, params }, roundOpts);
+            if (isIncompleteResult(raw)) {
+                requestState = raw.requestState;
+                if (raw.inputRequests) {
+                    inputResponses = { ...inputResponses, ...(await this._serviceInputRequests(raw.inputRequests, options?.signal)) };
+                }
+                continue;
+            }
+            const v = await validateStandardSchema(resultSchema, raw);
+            if (!v.success) {
+                throw new SdkError(SdkErrorCode.InvalidResult, `Invalid ${req.method} result: ${v.error}`);
+            }
+            return v.data;
+        }
+        throw new ProtocolError(ProtocolErrorCode.InternalError, `MRTR exceeded ${this._mrtrMaxRounds} rounds for ${req.method}`);
+    }
+
+    /** One round of {@linkcode _requestWithSchema}: returns the raw (unvalidated) result. */
+    private async _requestRoundRaw(req: Request, options?: RequestOptions): Promise<unknown> {
+        if (this._clientTransport) {
+            if (this._enforceStrictCapabilities) this.assertCapabilityForMethod(req.method);
+            const id = this._ctRequestId++;
+            const meta = {
+                ...(req.params?._meta as Record<string, unknown> | undefined),
+                ...(options?.onprogress ? { progressToken: id } : {})
+            };
+            const params: Record<string, unknown> | undefined =
+                req.params || Object.keys(meta).length > 0
+                    ? { ...(req.params as Record<string, unknown> | undefined), _meta: Object.keys(meta).length > 0 ? meta : undefined }
+                    : undefined;
+            const resp = await this._clientTransport.fetch(
+                { jsonrpc: '2.0', id, method: req.method, params },
+                {
+                    signal: options?.signal,
+                    onprogress: options?.onprogress,
+                    timeout: options?.timeout,
+                    resetTimeoutOnProgress: options?.resetTimeoutOnProgress,
+                    maxTotalTimeout: options?.maxTotalTimeout,
+                    relatedRequestId: options?.relatedRequestId,
+                    resumptionToken: options?.resumptionToken,
+                    onresumptiontoken: options?.onresumptiontoken,
+                    onnotification: n => void this.dispatchNotification(n).catch(error => this.onerror?.(error as Error)),
+                    onrequest: r => this._serviceInboundRequest(r, options?.signal)
+                }
+            );
+            if (isJSONRPCErrorResponse(resp)) {
+                throw ProtocolError.fromError(resp.error.code, resp.error.message, resp.error.data);
+            }
+            return resp.result;
+        }
+        return super._requestWithSchema(req, RAW_RESULT_SCHEMA, options);
+    }
+
+    /**
+     * Service the SEP-2322 `inputRequests` by dispatching each as a synthetic inbound
+     * request through this client's own handler registry (sampling/elicitation/roots).
+     * Handler errors propagate (aborting the MRTR round) so the server is not retried
+     * with a partial response set.
+     */
+    private async _serviceInputRequests(
+        reqs: NonNullable<IncompleteResult['inputRequests']>,
+        signal?: AbortSignal
+    ): Promise<Record<string, unknown>> {
+        const out: Record<string, unknown> = {};
+        for (const [key, ir] of Object.entries(reqs)) {
+            signal?.throwIfAborted();
+            const resp = await this._serviceInboundRequest(
+                { jsonrpc: '2.0', id: `mrtr:${key}`, method: ir.method, params: ir.params },
+                signal
+            );
+            if (isJSONRPCErrorResponse(resp)) {
+                throw ProtocolError.fromError(resp.error.code, resp.error.message, resp.error.data);
+            }
+            out[key] = resp.result;
+        }
+        return out;
+    }
+
+    /** Dispatch one server-initiated request through this client's handler registry. */
+    private async _serviceInboundRequest(r: JSONRPCRequest, signal?: AbortSignal): Promise<JSONRPCResultResponse | JSONRPCErrorResponse> {
+        let final: JSONRPCResultResponse | JSONRPCErrorResponse | undefined;
+        for await (const out of this.dispatch(r, { signal })) {
+            if (out.kind === 'response') final = out.message as JSONRPCResultResponse | JSONRPCErrorResponse;
+        }
+        if (!final) {
+            return { jsonrpc: '2.0', id: r.id, error: { code: ProtocolErrorCode.InternalError, message: 'dispatch yielded no response' } };
+        }
+        return final;
+    }
+
+    /** Initialize handshake on the request-shaped {@linkcode ClientTransport} path. */
+    private async _initializeOrDiscover(options?: RequestOptions): Promise<void> {
+        try {
+            const result = await this._requestWithSchema(
+                {
+                    method: 'initialize',
+                    params: {
+                        protocolVersion: this._supportedProtocolVersions[0] ?? LATEST_PROTOCOL_VERSION,
+                        capabilities: this._capabilities,
+                        clientInfo: this._clientInfo
+                    }
+                },
+                InitializeResultSchema,
+                options
+            );
+            if (!this._supportedProtocolVersions.includes(result.protocolVersion)) {
+                throw new Error(`Server's protocol version is not supported: ${result.protocolVersion}`);
+            }
+            this._serverCapabilities = result.capabilities;
+            this._serverVersion = result.serverInfo;
+            this._negotiatedProtocolVersion = result.protocolVersion;
+            this._instructions = result.instructions;
+            this._clientTransport?.setProtocolVersion?.(result.protocolVersion);
+            if (this._negotiatedProtocolVersion < '2026-06-30') {
+                await this.notification({ method: 'notifications/initialized' });
+            }
+            if (this._pendingListChangedConfig) {
+                this._setupListChangedHandlers(this._pendingListChangedConfig);
+                this._pendingListChangedConfig = undefined;
+            }
+        } catch (error) {
+            void this.close();
+            throw error;
+        }
+    }
+
+    override async notification(notification: ClientNotification, options?: NotificationOptions): Promise<void> {
+        if (this._clientTransport) {
+            this.assertNotificationCapability(notification.method as NotificationMethod);
+            return this._clientTransport.notify(notification);
+        }
+        return super.notification(notification, options);
+    }
+
+    override async close(): Promise<void> {
+        if (this._clientTransport) {
+            const ct = this._clientTransport;
+            this._clientTransport = undefined;
+            await ct.close();
+            this.onclose?.();
+            return;
+        }
+        return super.close();
     }
 }

--- a/packages/client/src/client/client.ts
+++ b/packages/client/src/client/client.ts
@@ -193,7 +193,8 @@ export type ClientOptions = ProtocolOptions & {
 
     /**
      * SEP-2322: maximum number of incomplete-result rounds before failing. Each round
-     * services the server's `inputRequests` via local handlers and re-sends with
+     * services the server's `inputRequests` via local handlers (sampling, elicitation,
+     * roots, ping only; other methods are rejected) and re-sends with
      * `params.{inputResponses, requestState}`. Prevents unbounded looping on a server
      * that returns `incomplete` forever.
      *
@@ -205,9 +206,18 @@ export type ClientOptions = ProtocolOptions & {
 const DEFAULT_MRTR_MAX_ROUNDS = 16;
 
 /** SEP-2322 client-side detection. The server signals it cannot complete without client input. */
+/**
+ * Methods the SEP-2322 retry loop will service from `inputRequests`. The server cannot
+ * use this channel to invoke arbitrary client handlers (e.g. a custom-method handler the
+ * application registered for unrelated purposes); only the spec-defined client-side
+ * request methods are dispatched.
+ */
+const ALLOWED_INPUT_REQUEST_METHODS: ReadonlySet<string> = new Set(['sampling/createMessage', 'elicitation/create', 'roots/list', 'ping']);
+
 function isIncompleteResult(r: unknown): r is IncompleteResult {
     if (typeof r !== 'object' || r === null) return false;
     const o = r as { resultType?: unknown; inputRequests?: unknown };
+    // (deliberately narrow guard; the loop body validates method against ALLOWED_INPUT_REQUEST_METHODS)
     if (o.resultType !== 'incomplete') return false;
     if (o.inputRequests === undefined) return true;
     return typeof o.inputRequests === 'object' && o.inputRequests !== null && !Array.isArray(o.inputRequests);
@@ -1159,6 +1169,12 @@ export class Client extends Protocol<ClientContext> {
         const out: Record<string, unknown> = {};
         for (const [key, ir] of Object.entries(reqs)) {
             signal?.throwIfAborted();
+            if (!ALLOWED_INPUT_REQUEST_METHODS.has(ir.method)) {
+                throw new ProtocolError(
+                    ProtocolErrorCode.InvalidRequest,
+                    `inputRequest method '${ir.method}' is not a client-serviceable method`
+                );
+            }
             const resp = await this._serviceInboundRequest(
                 { jsonrpc: '2.0', id: `mrtr:${key}`, method: ir.method, params: ir.params },
                 signal

--- a/packages/client/src/client/clientTransport.ts
+++ b/packages/client/src/client/clientTransport.ts
@@ -1,0 +1,84 @@
+import type {
+    JSONRPCErrorResponse,
+    JSONRPCNotification,
+    JSONRPCRequest,
+    JSONRPCResultResponse,
+    Notification,
+    Progress,
+    RequestId,
+    Transport
+} from '@modelcontextprotocol/core';
+
+/**
+ * Per-call options for {@linkcode ClientTransport.fetch}.
+ */
+export type ClientFetchOptions = {
+    /** Abort the in-flight request. */
+    signal?: AbortSignal;
+    /** Called for each `notifications/progress` received before the terminal response. */
+    onprogress?: (progress: Progress) => void;
+    /** Called for each non-progress notification received before the terminal response. */
+    onnotification?: (notification: JSONRPCNotification) => void;
+    /**
+     * Called for each server-initiated request received on the response stream.
+     * Must return the response to send back. If absent, such requests fail with
+     * `MethodNotFound`.
+     */
+    onrequest?: (request: JSONRPCRequest) => Promise<JSONRPCResultResponse | JSONRPCErrorResponse>;
+    /** Per-request timeout (ms). */
+    timeout?: number;
+    /** Reset {@linkcode timeout} when a progress notification arrives. */
+    resetTimeoutOnProgress?: boolean;
+    /** Absolute upper bound (ms) regardless of progress. */
+    maxTotalTimeout?: number;
+    /** Associates this outbound request with an inbound one (pipe transports only). */
+    relatedRequestId?: RequestId;
+    /** Resumption token to continue a previous request (SHTTP only). */
+    resumptionToken?: string;
+    /** Called when the resumption token changes (SHTTP only). */
+    onresumptiontoken?: (token: string) => void;
+};
+
+/**
+ * Request-shaped client transport. One JSON-RPC request in, one terminal response out.
+ * The transport may be stateful internally (session id, protocol version) but the
+ * contract is per-call.
+ *
+ * Legacy pipe-shaped {@linkcode Transport} instances are accepted by
+ * {@linkcode client/client.Client.connect | Client.connect} unchanged; this interface
+ * is for transports that natively implement a fetch-per-request shape.
+ */
+export interface ClientTransport {
+    /** Explicit shape brand so {@linkcode isClientTransport} can discriminate without duck-typing. */
+    readonly kind: 'request';
+
+    /**
+     * Send one JSON-RPC request and resolve with the terminal response. Progress and
+     * notifications received before the response are surfaced via the callbacks in
+     * {@linkcode ClientFetchOptions}.
+     */
+    fetch(request: JSONRPCRequest, opts?: ClientFetchOptions): Promise<JSONRPCResultResponse | JSONRPCErrorResponse>;
+
+    /** Send a fire-and-forget notification. */
+    notify(notification: Notification): Promise<void>;
+
+    /**
+     * Open a server-to-client stream for unsolicited notifications and server-initiated
+     * requests. Optional; transports that cannot stream omit this.
+     */
+    subscribe?(opts?: Pick<ClientFetchOptions, 'onrequest'>): AsyncIterable<JSONRPCNotification>;
+
+    /** Close the transport and release resources. */
+    close(): Promise<void>;
+
+    /** Set by the SDK after handshake so subsequent calls carry `mcp-protocol-version`. */
+    setProtocolVersion?(version: string): void;
+}
+
+/**
+ * Type guard for {@linkcode ClientTransport}. A transport that implements both shapes
+ * (e.g. a future SHTTP client) is treated as request-shaped.
+ */
+export function isClientTransport(t: Transport | ClientTransport): t is ClientTransport {
+    return (t as ClientTransport).kind === 'request';
+}

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -55,6 +55,8 @@ export {
 export type { ClientOptions } from './client/client.js';
 export { Client } from './client/client.js';
 export { getSupportedElicitationModes } from './client/client.js';
+export type { ClientFetchOptions, ClientTransport } from './client/clientTransport.js';
+export { isClientTransport } from './client/clientTransport.js';
 export type { DiscoverAndRequestJwtAuthGrantOptions, JwtAuthGrantResult, RequestJwtAuthGrantOptions } from './client/crossAppAccess.js';
 export { discoverAndRequestJwtAuthGrant, exchangeJwtAuthGrant, requestJwtAuthorizationGrant } from './client/crossAppAccess.js';
 export type { LoggingOptions, Middleware, RequestLogger } from './client/middleware.js';

--- a/packages/client/test/client/mrtr.test.ts
+++ b/packages/client/test/client/mrtr.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, test } from 'vitest';
+
+import type {
+    JSONRPCErrorResponse,
+    JSONRPCNotification,
+    JSONRPCRequest,
+    JSONRPCResultResponse,
+    Notification
+} from '@modelcontextprotocol/core';
+import { LATEST_PROTOCOL_VERSION } from '@modelcontextprotocol/core';
+
+import { Client } from '../../src/client/client.js';
+import type { ClientFetchOptions, ClientTransport } from '../../src/client/clientTransport.js';
+
+type Handler = (req: JSONRPCRequest, opts?: ClientFetchOptions) => Promise<JSONRPCResultResponse | JSONRPCErrorResponse>;
+
+/**
+ * Minimal in-process {@linkcode ClientTransport} backed by a per-method handler map. The
+ * `initialize` reply uses the supplied protocol version so the SEP-2575 init-gate can be
+ * exercised in either direction.
+ */
+function fakeClientTransport(
+    serverProtocolVersion: string,
+    handlers: Record<string, Handler> = {}
+): ClientTransport & {
+    sentNotifications: Notification[];
+    calls: JSONRPCRequest[];
+} {
+    const sentNotifications: Notification[] = [];
+    const calls: JSONRPCRequest[] = [];
+    return {
+        kind: 'request',
+        sentNotifications,
+        calls,
+        async fetch(req, opts) {
+            calls.push(req);
+            if (req.method === 'initialize') {
+                return {
+                    jsonrpc: '2.0',
+                    id: req.id,
+                    result: {
+                        protocolVersion: serverProtocolVersion,
+                        capabilities: { tools: { listChanged: true } },
+                        serverInfo: { name: 'fake', version: '0.0.0' }
+                    }
+                };
+            }
+            const h = handlers[req.method];
+            if (!h) return { jsonrpc: '2.0', id: req.id, error: { code: -32_601, message: `no handler: ${req.method}` } };
+            return h(req, opts);
+        },
+        async notify(n) {
+            sentNotifications.push(n);
+        },
+        async close() {},
+        setProtocolVersion() {}
+    };
+}
+
+describe('Client.connect(ClientTransport)', () => {
+    test('accepts a request-shaped transport and completes the initialize handshake', async () => {
+        const ct = fakeClientTransport(LATEST_PROTOCOL_VERSION);
+        const client = new Client({ name: 't', version: '0' });
+        await client.connect(ct);
+        expect(client.getServerCapabilities()).toEqual({ tools: { listChanged: true } });
+        expect(client.getNegotiatedProtocolVersion()).toBe(LATEST_PROTOCOL_VERSION);
+    });
+
+    test('routes outbound requests via fetch() and validates the result', async () => {
+        const ct = fakeClientTransport(LATEST_PROTOCOL_VERSION, {
+            'tools/list': async req => ({ jsonrpc: '2.0', id: req.id, result: { tools: [] } })
+        });
+        const client = new Client({ name: 't', version: '0' });
+        await client.connect(ct);
+        const res = await client.listTools();
+        expect(res.tools).toEqual([]);
+        expect(ct.calls.map(c => c.method)).toContain('tools/list');
+    });
+});
+
+describe('SEP-2575 notifications/initialized gate', () => {
+    test('sends notifications/initialized when negotiated version < 2026-06-30', async () => {
+        const ct = fakeClientTransport('2025-11-25');
+        const client = new Client({ name: 't', version: '0' });
+        await client.connect(ct);
+        expect(ct.sentNotifications.map(n => n.method)).toContain('notifications/initialized');
+    });
+
+    test('skips notifications/initialized when negotiated version >= 2026-06-30', async () => {
+        const ct = fakeClientTransport('2026-06-30');
+        const client = new Client({ name: 't', version: '0' }, { supportedProtocolVersions: ['2026-06-30', LATEST_PROTOCOL_VERSION] });
+        await client.connect(ct);
+        expect(ct.sentNotifications.map(n => n.method)).not.toContain('notifications/initialized');
+    });
+});
+
+describe('SEP-2322 MRTR retry loop', () => {
+    test('services inputRequests via local handler and retries with inputResponses+requestState', async () => {
+        const seen: Array<{ round: number; params: unknown }> = [];
+        const ct = fakeClientTransport(LATEST_PROTOCOL_VERSION, {
+            'tools/call': async req => {
+                const params = req.params as { inputResponses?: Record<string, unknown>; requestState?: string };
+                seen.push({ round: seen.length, params });
+                if (!params.inputResponses) {
+                    // Round 0: ask the client to elicit a value.
+                    return {
+                        jsonrpc: '2.0',
+                        id: req.id,
+                        result: {
+                            resultType: 'incomplete',
+                            requestState: 'state-1',
+                            inputRequests: {
+                                k0: {
+                                    method: 'elicitation/create',
+                                    params: { message: 'q', requestedSchema: { type: 'object', properties: {} } }
+                                }
+                            }
+                        }
+                    };
+                }
+                // Round 1: receive the elicited answer and finish.
+                return {
+                    jsonrpc: '2.0',
+                    id: req.id,
+                    result: { content: [{ type: 'text', text: JSON.stringify(params.inputResponses) }] }
+                };
+            }
+        });
+        const client = new Client({ name: 't', version: '0' }, { capabilities: { elicitation: {} } });
+        client.setRequestHandler('elicitation/create', async () => ({ action: 'accept', content: { v: 42 } }));
+        await client.connect(ct);
+
+        const result = await client.callTool({ name: 'x', arguments: {} });
+        expect(seen).toHaveLength(2);
+        expect((seen[1]!.params as { requestState: string }).requestState).toBe('state-1');
+        expect((seen[1]!.params as { inputResponses: Record<string, unknown> }).inputResponses).toEqual({
+            k0: { action: 'accept', content: { v: 42 } }
+        });
+        expect((result.content as Array<{ text: string }>)[0]!.text).toContain('"v":42');
+    });
+
+    test('caps rounds via mrtrMaxRounds and throws on exhaustion', async () => {
+        const ct = fakeClientTransport(LATEST_PROTOCOL_VERSION, {
+            'tools/call': async req => ({
+                jsonrpc: '2.0',
+                id: req.id,
+                result: { resultType: 'incomplete', requestState: `s${req.id}` }
+            })
+        });
+        const client = new Client({ name: 't', version: '0' }, { mrtrMaxRounds: 3 });
+        await client.connect(ct);
+        await expect(client.callTool({ name: 'x', arguments: {} })).rejects.toThrow(/MRTR exceeded 3 rounds/);
+    });
+
+    test('propagates handler error from _serviceInputRequests instead of retrying with partial set', async () => {
+        const ct = fakeClientTransport(LATEST_PROTOCOL_VERSION, {
+            'tools/call': async req => ({
+                jsonrpc: '2.0',
+                id: req.id,
+                result: {
+                    resultType: 'incomplete',
+                    inputRequests: {
+                        k0: { method: 'elicitation/create', params: { message: 'q', requestedSchema: { type: 'object', properties: {} } } }
+                    }
+                }
+            })
+        });
+        const client = new Client({ name: 't', version: '0' }, { capabilities: { elicitation: {} } });
+        client.setRequestHandler('elicitation/create', async () => {
+            throw new Error('user cancelled');
+        });
+        await client.connect(ct);
+        await expect(client.callTool({ name: 'x', arguments: {} })).rejects.toThrow();
+    });
+
+    test('round-trip on the pipe-transport path: super._requestWithSchema sees IncompleteResult and loop retries', async () => {
+        // Drive both rounds through a fake ClientTransport but assert the loop machinery is on
+        // the override (not the fetch path) by checking that subscribe-stream notifications
+        // also flow when delivered via fetch onnotification.
+        let progressDelivered = false;
+        const ct = fakeClientTransport(LATEST_PROTOCOL_VERSION, {
+            'tools/call': async (req, opts) => {
+                opts?.onnotification?.({
+                    jsonrpc: '2.0',
+                    method: 'notifications/message',
+                    params: { level: 'info', data: 'x' }
+                } as JSONRPCNotification);
+                return { jsonrpc: '2.0', id: req.id, result: { content: [] } };
+            }
+        });
+        const client = new Client({ name: 't', version: '0' });
+        client.setNotificationHandler('notifications/message', async () => {
+            progressDelivered = true;
+        });
+        await client.connect(ct);
+        await client.callTool({ name: 'x', arguments: {} });
+        expect(progressDelivered).toBe(true);
+    });
+});


### PR DESCRIPTION
---

`Client.request()` detects `IncompleteResult`, services `inputRequests` via local handlers, and retries with `params.{inputResponses, requestState}`. Adds `ClientTransport` interface (`{fetch, notify, subscribe?}`) and `Client.connect(Transport | ClientTransport)`. `notifications/initialized` is gated to negotiated `protocolVersion < '2026-06-30'`.

## Motivation and Context
Client side of SEP-2322 (MRTR retry) and SEP-2575 (init optional on discover path). `ClientTransport` lets request-shaped transports (one POST per call) skip the pipe-shaped `send`/`onmessage` correlation.

## How Has This Been Tested?
`pnpm test:all` + client conformance.

## Breaking Changes
None. `connect(Transport)` keeps working unchanged.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
Depends on S3. Review guide: https://gist.github.com/felixweinberger/5a48e0f14d5aced39ed6a91b61940711.

---