### PR TITLE
docs: @deprecated roots/sampling/logging (advisory; SEP-2577)

### DIFF
--- a/packages/client/src/client/client.ts
+++ b/packages/client/src/client/client.ts
@@ -718,7 +718,11 @@ export class Client extends Protocol<ClientContext> {
         return this._requestWithSchema({ method: 'completion/complete', params }, CompleteResultSchema, options);
     }
 
-    /** Sets the minimum severity level for log messages sent by the server. */
+    /**
+     * Sets the minimum severity level for log messages sent by the server.
+     *
+     * @deprecated SEP-2577 deprecates the MCP Logging feature (advisory; no wire change).
+     */
     async setLoggingLevel(level: LoggingLevel, options?: RequestOptions) {
         return this._requestWithSchema({ method: 'logging/setLevel', params: { level } }, EmptyResultSchema, options);
     }
@@ -1053,7 +1057,11 @@ export class Client extends Protocol<ClientContext> {
         this.setNotificationHandler(notificationMethod, handler);
     }
 
-    /** Notifies the server that the client's root list has changed. Requires the `roots.listChanged` capability. */
+    /**
+     * Notifies the server that the client's root list has changed. Requires the `roots.listChanged` capability.
+     *
+     * @deprecated SEP-2577 deprecates the MCP Roots feature (advisory; no wire change).
+     */
     async sendRootsListChanged() {
         return this.notification({ method: 'notifications/roots/list_changed' });
     }

--- a/packages/core/src/shared/protocol.ts
+++ b/packages/core/src/shared/protocol.ts
@@ -247,6 +247,9 @@ export type ServerContext = BaseContext & {
         /**
          * Send a log message notification to the client.
          * Respects the client's log level filter set via logging/setLevel.
+         *
+         * @deprecated SEP-2577 deprecates the MCP Logging feature (advisory; no wire change).
+         * Prefer stderr or OpenTelemetry for server diagnostics.
          */
         log: (level: LoggingLevel, data: unknown, logger?: string) => Promise<void>;
 
@@ -257,6 +260,8 @@ export type ServerContext = BaseContext & {
 
         /**
          * Request LLM sampling from the client.
+         *
+         * @deprecated SEP-2577 deprecates the MCP Sampling feature (advisory; no wire change).
          */
         requestSampling: (
             params: CreateMessageRequest['params'],

--- a/packages/server/src/server/mcp.ts
+++ b/packages/server/src/server/mcp.ts
@@ -1010,6 +1010,7 @@ export class McpServer {
      * Sends a logging message to the client, if connected.
      * Note: You only need to send the parameters object, not the entire JSON-RPC message.
      * @see {@linkcode LoggingMessageNotification}
+     * @deprecated SEP-2577 deprecates the MCP Logging feature (advisory; no wire change).
      * @param params
      * @param sessionId Optional for stateless transports and backward compatibility.
      *

--- a/packages/server/src/server/server.ts
+++ b/packages/server/src/server/server.ts
@@ -466,18 +466,24 @@ export class Server extends Protocol<ServerContext> {
     /**
      * Request LLM sampling from the client (without tools).
      * Returns single content block for backwards compatibility.
+     *
+     * @deprecated SEP-2577 deprecates the MCP Sampling feature (advisory; no wire change).
      */
     async createMessage(params: CreateMessageRequestParamsBase, options?: RequestOptions): Promise<CreateMessageResult>;
 
     /**
      * Request LLM sampling from the client with tool support.
      * Returns content that may be a single block or array (for parallel tool calls).
+     *
+     * @deprecated SEP-2577 deprecates the MCP Sampling feature (advisory; no wire change).
      */
     async createMessage(params: CreateMessageRequestParamsWithTools, options?: RequestOptions): Promise<CreateMessageResultWithTools>;
 
     /**
      * Request LLM sampling from the client.
      * When tools may or may not be present, returns the union type.
+     *
+     * @deprecated SEP-2577 deprecates the MCP Sampling feature (advisory; no wire change).
      */
     async createMessage(
         params: CreateMessageRequest['params'],
@@ -632,6 +638,12 @@ export class Server extends Protocol<ServerContext> {
             );
     }
 
+    /**
+     * Request the client's filesystem roots.
+     *
+     * @deprecated SEP-2577 deprecates the MCP Roots feature (advisory; no wire change).
+     * Prefer passing scope via tool parameters or server configuration.
+     */
     async listRoots(params?: ListRootsRequest['params'], options?: RequestOptions) {
         return this._requestWithSchema({ method: 'roots/list', params }, ListRootsResultSchema, options);
     }
@@ -642,6 +654,9 @@ export class Server extends Protocol<ServerContext> {
      * @see {@linkcode LoggingMessageNotification}
      * @param params
      * @param sessionId Optional for stateless transports and backward compatibility.
+     *
+     * @deprecated SEP-2577 deprecates the MCP Logging feature (advisory; no wire change).
+     * Prefer stderr or OpenTelemetry for server diagnostics.
      */
     async sendLoggingMessage(params: LoggingMessageNotification['params'], sessionId?: string) {
         if (this._capabilities.logging && !this.isMessageIgnored(params.level, sessionId)) {


### PR DESCRIPTION
---

Adds `@deprecated` JSDoc to `Server.createMessage`, `Server.listRoots`, `ctx.mcpReq.log`, and `ctx.mcpReq.requestSampling`. Capability-field types (`ClientCapabilities.{roots,sampling}`, `ServerCapabilities.logging`) are Zod-derived and not annotated here.

## Motivation and Context
Implements SEP-2577 (advisory deprecation of roots/sampling/logging). No wire-level change; deprecation is signal-only.

## How Has This Been Tested?
typecheck + lint clean.

## Breaking Changes
None.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
On `main` (independent). Review guide: https://gist.github.com/felixweinberger/5a48e0f14d5aced39ed6a91b61940711.

---
