### PR TITLE
fix(test): extend cloudflare workers retry to cover full request cycle

### DIFF
--- a/test/integration/test/server/cloudflareWorkers.test.ts
+++ b/test/integration/test/server/cloudflareWorkers.test.ts
@@ -197,7 +197,11 @@ export default {
                 // Re-throw assertion failures immediately — only retry transport errors.
                 if (error instanceof Error && 'matcherResult' in error) throw error;
                 lastError = error;
-                try { await client.close(); } catch { /* ignore cleanup errors */ }
+                try {
+                    await client.close();
+                } catch {
+                    /* ignore cleanup errors */
+                }
                 if (attempt < 4) await new Promise(resolve => setTimeout(resolve, 1000));
             }
         }

--- a/test/integration/test/server/cloudflareWorkers.test.ts
+++ b/test/integration/test/server/cloudflareWorkers.test.ts
@@ -179,13 +179,28 @@ export default {
     });
 
     it('should handle MCP requests', async () => {
-        const client = new Client({ name: 'test-client', version: '1.0.0' });
-        const transport = new StreamableHTTPClientTransport(new URL(`http://127.0.0.1:${PORT}/`));
-        await client.connect(transport);
-
-        const result = await client.callTool({ name: 'greet', arguments: { name: 'World' } });
-        expect(result.content).toEqual([{ type: 'text', text: 'Hello, World!' }]);
-
-        await client.close();
+        // Retry the full interaction — wrangler may report "Ready" before it can
+        // reliably handle all requests (initialize succeeds but subsequent calls
+        // can still get "Network connection lost." on slower runtimes like Node 20).
+        // Only transport/connection errors are retried; assertion failures re-throw immediately.
+        let lastError: unknown;
+        for (let attempt = 0; attempt < 5; attempt++) {
+            const client = new Client({ name: 'test-client', version: '1.0.0' });
+            const transport = new StreamableHTTPClientTransport(new URL(`http://127.0.0.1:${PORT}/`));
+            try {
+                await client.connect(transport);
+                const result = await client.callTool({ name: 'greet', arguments: { name: 'World' } });
+                expect(result.content).toEqual([{ type: 'text', text: 'Hello, World!' }]);
+                await client.close();
+                return;
+            } catch (error) {
+                // Re-throw assertion failures immediately — only retry transport errors.
+                if (error instanceof Error && 'matcherResult' in error) throw error;
+                lastError = error;
+                try { await client.close(); } catch { /* ignore cleanup errors */ }
+                if (attempt < 4) await new Promise(resolve => setTimeout(resolve, 1000));
+            }
+        }
+        throw lastError;
     }, 30_000);
 });


### PR DESCRIPTION
Found this while digging into the CI failures on #2026. The Cloudflare Workers test has been flaky on Node 20 with `Error: Network connection lost.`

**Root cause**

Wrangler/miniflare reports "Ready" before it can serve all request types reliably. The initialize handshake (`client.connect()`) goes through, but the subsequent `client.callTool()` can still fail.

Commit 5a2c8a69 added a retry loop for this, but it only covered `connect()`. A successful connect followed by a failing `callTool()` had no retry path.

**The fix**

The retry loop now wraps the full interaction: connect, callTool, assertion, and close. Any failure cleans up the client and retries with a 1-second backoff, up to 5 attempts. The 30s test timeout is unchanged.

**Why it's separate from #2026**

#2026 kept hitting this same failure even though its change (44 lines in `packages/middleware/node`) has nothing to do with the Cloudflare test. Splitting them out makes both cleaner to review. Once this lands, #2026 can rebase onto main and the Node 20 run should pass.