### PR TITLE
[v1.x] fix(server): emit JSON Schema 2020-12 in tools/list (SEP-1613)

### DIFF
--- a/.changeset/fix-sep-1613-emit-2020-12.md
+++ b/.changeset/fix-sep-1613-emit-2020-12.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/sdk': patch
+---
+
+Fix SEP-1613 regression: `tools/list` now advertises `$schema: "https://json-schema.org/draft/2020-12/schema"` for `inputSchema` and `outputSchema`. The 1.29.0 release wired `target: 'draft-2020-12'` support into the Zod→JSON-Schema converter but the `McpServer` call sites in `mcp.ts` still emitted draft-07 because they omitted the `target` option. Both call sites now pass `target: 'draft-2020-12'`. Zod v4 schemas emit native 2020-12 (including `prefixItems` for tuples); Zod v3 schemas remain draft-07-shaped internally — `$schema` is overridden to advertise 2020-12, which is correct for the keyword subset that `zod-to-json-schema` emits.

--- a/.changeset/fix-sep-1613-emit-2020-12.md
+++ b/.changeset/fix-sep-1613-emit-2020-12.md
@@ -2,4 +2,6 @@
 '@modelcontextprotocol/sdk': patch
 ---
 
-Fix SEP-1613 regression: `tools/list` now advertises `$schema: "https://json-schema.org/draft/2020-12/schema"` for `inputSchema` and `outputSchema`. The 1.29.0 release wired `target: 'draft-2020-12'` support into the Zod→JSON-Schema converter but the `McpServer` call sites in `mcp.ts` still emitted draft-07 because they omitted the `target` option. Both call sites now pass `target: 'draft-2020-12'`. Zod v4 schemas emit native 2020-12 (including `prefixItems` for tuples); Zod v3 schemas remain draft-07-shaped internally — `$schema` is overridden to advertise 2020-12, which is correct for the keyword subset that `zod-to-json-schema` emits.
+Fix SEP-1613 regression: `tools/list` now advertises `$schema: "https://json-schema.org/draft/2020-12/schema"` for `inputSchema` and `outputSchema`. The 1.29.0 release wired `target: 'draft-2020-12'` support into the Zod→JSON-Schema converter but the `McpServer` call sites in
+`mcp.ts` still emitted draft-07 because they omitted the `target` option. Both call sites now pass `target: 'draft-2020-12'`. Zod v4 schemas emit native 2020-12 (including `prefixItems` for tuples); Zod v3 schemas remain draft-07-shaped internally — `$schema` is overridden to
+advertise 2020-12, which is correct for the keyword subset that `zod-to-json-schema` emits.

--- a/src/server/mcp.ts
+++ b/src/server/mcp.ts
@@ -149,6 +149,7 @@ export class McpServer {
                                 const obj = normalizeObjectSchema(tool.inputSchema);
                                 return obj
                                     ? (toJsonSchemaCompat(obj, {
+                                          target: 'draft-2020-12',
                                           strictUnions: true,
                                           pipeStrategy: 'input'
                                       }) as Tool['inputSchema'])
@@ -163,6 +164,7 @@ export class McpServer {
                             const obj = normalizeObjectSchema(tool.outputSchema);
                             if (obj) {
                                 toolDefinition.outputSchema = toJsonSchemaCompat(obj, {
+                                    target: 'draft-2020-12',
                                     strictUnions: true,
                                     pipeStrategy: 'output'
                                 }) as Tool['outputSchema'];

--- a/src/server/zod-json-schema-compat.ts
+++ b/src/server/zod-json-schema-compat.ts
@@ -37,11 +37,22 @@ export function toJsonSchemaCompat(schema: AnyObjectSchema, opts?: CommonOpts): 
         }) as JsonSchema;
     }
 
-    // v3 branch — use vendored converter
-    return zodToJsonSchema(schema as z3.ZodTypeAny, {
+    // v3 branch — use vendored converter (emits draft-07)
+    const result = zodToJsonSchema(schema as z3.ZodTypeAny, {
         strictUnions: opts?.strictUnions ?? true,
         pipeStrategy: opts?.pipeStrategy ?? 'input'
     }) as JsonSchema;
+
+    // SEP-1613: advertise draft/2020-12 when requested. zod-to-json-schema has
+    // no native 2020-12 target, but its emitted keywords (type, properties,
+    // required, additionalProperties, oneOf, anyOf, allOf, enum, const) are
+    // semantically unchanged in 2020-12. Tuple emission via `items: [...]`
+    // remains draft-07-shaped — upgrade to Zod v4 for native prefixItems.
+    if (mapMiniTarget(opts?.target) === 'draft-2020-12') {
+        result.$schema = 'https://json-schema.org/draft/2020-12/schema';
+    }
+
+    return result;
 }
 
 export function getMethodLiteral(schema: AnyObjectSchema): string {

--- a/test/server/mcp.test.ts
+++ b/test/server/mcp.test.ts
@@ -6931,4 +6931,69 @@ describe.each(zodTestMatrix)('$zodVersionLabel', (entry: ZodMatrixEntry) => {
             taskStore.cleanup();
         });
     });
+
+    describe('tools/list emits JSON Schema 2020-12 ($schema dialect — SEP-1613)', () => {
+        const DIALECT_2020_12 = 'https://json-schema.org/draft/2020-12/schema';
+
+        test('inputSchema advertises draft/2020-12 $schema', async () => {
+            const mcpServer = new McpServer({ name: 'test server', version: '1.0' });
+            const client = new Client({ name: 'test client', version: '1.0' });
+
+            mcpServer.registerTool('echo', { inputSchema: { value: z.string() } }, async ({ value }) => ({
+                content: [{ type: 'text', text: value }]
+            }));
+
+            const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+            await Promise.all([client.connect(clientTransport), mcpServer.connect(serverTransport)]);
+
+            const result = await client.request({ method: 'tools/list' }, ListToolsResultSchema);
+            expect(result.tools[0].inputSchema.$schema).toBe(DIALECT_2020_12);
+        });
+
+        test('outputSchema advertises draft/2020-12 $schema', async () => {
+            const mcpServer = new McpServer({ name: 'test server', version: '1.0' });
+            const client = new Client({ name: 'test client', version: '1.0' });
+
+            mcpServer.registerTool(
+                'lookup',
+                {
+                    inputSchema: { id: z.string() },
+                    outputSchema: { id: z.string(), name: z.string() }
+                },
+                async ({ id }) => ({
+                    content: [{ type: 'text', text: id }],
+                    structuredContent: { id, name: 'x' }
+                })
+            );
+
+            const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+            await Promise.all([client.connect(clientTransport), mcpServer.connect(serverTransport)]);
+
+            const result = await client.request({ method: 'tools/list' }, ListToolsResultSchema);
+            expect(result.tools[0].outputSchema?.$schema).toBe(DIALECT_2020_12);
+        });
+
+        // Tuples are a 2020-12-only differentiator: draft-07 emits `items: [...]`,
+        // 2020-12 emits `prefixItems`. Zod v3 has no tuple → prefixItems path even
+        // under 2020-12 (it always emits draft-07-shaped items), so this assertion
+        // is meaningful only for Zod v4.
+        if (entry.isV4) {
+            test('Zod v4 tuples emit prefixItems under 2020-12', async () => {
+                const mcpServer = new McpServer({ name: 'test server', version: '1.0' });
+                const client = new Client({ name: 'test client', version: '1.0' });
+
+                mcpServer.registerTool('point', { inputSchema: { coords: z.tuple([z.number(), z.number()]) } }, async () => ({
+                    content: [{ type: 'text', text: 'ok' }]
+                }));
+
+                const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+                await Promise.all([client.connect(clientTransport), mcpServer.connect(serverTransport)]);
+
+                const result = await client.request({ method: 'tools/list' }, ListToolsResultSchema);
+                const coords = (result.tools[0].inputSchema.properties as Record<string, unknown>).coords as Record<string, unknown>;
+                expect(coords).toHaveProperty('prefixItems');
+                expect(coords).not.toHaveProperty('items');
+            });
+        }
+    });
 });


### PR DESCRIPTION
Fixes #2084.

## Summary

`McpServer`'s `tools/list` handler calls `toJsonSchemaCompat()` without a `target`, so `mapMiniTarget(undefined)` returns `'draft-7'` and every `inputSchema`/`outputSchema` advertises draft-07 instead of the 2020-12 dialect SEP-1613 requires.

The `target: 'draft-2020-12'` plumbing was added in #1135, but the `mcp.ts` call sites weren't updated to use it. This PR does that, plus an extra fix for the Zod v3 path that the 2-liner doesn't reach.

## What changed

**`src/server/mcp.ts`** — pass `target: 'draft-2020-12'` at both call sites. That's the 2-line patch from the issue. For Zod v4 it's the whole fix: `z4mini.toJSONSchema` then emits the right `$schema` and uses `prefixItems` for tuples.

**`src/server/zod-json-schema-compat.ts`** — the v3 branch needed more. `zod-to-json-schema` has no `draft-2020-12` target (only `jsonSchema7` and `jsonSchema2019-09`), so passing the option through is a silent no-op. The v3 branch now overrides `$schema` to `https://json-schema.org/draft/2020-12/schema` when 2020-12 is requested.

A caveat on the v3 override: the keywords `zod-to-json-schema` actually emits (`type`, `properties`, `required`, `additionalProperties`, `oneOf`/`anyOf`/`allOf`, `enum`, `const`) have identical semantics in draft-07 and 2020-12. The one keyword that diverges is tuples. `items: [...]` is a positional tuple in draft-07 but means "every item matches one of these schemas" in 2020-12. A Zod v3 tuple stamped as 2020-12 is therefore subtly wrong; an inline comment in the file flags this and points at Zod v4 for native `prefixItems`. IMO, leaving v3 stuck on draft-07 is worse than the caveat.

**`test/server/mcp.test.ts`**: three new tests in the existing `zodTestMatrix` block so they run on v3 and v4: inputSchema `$schema`, outputSchema `$schema`, and a v4-only tuple → `prefixItems` check.

**`.changeset/fix-sep-1613-emit-2020-12.md`**: patch-level changeset.

## Tests

- `npm test`: 1584 / 1584 pass
- `npm run typecheck`: clean
- `npm run lint`: clean

## On v2.0.0-alpha

`main` doesn't have this bug. `standardSchemaToJsonSchema` hardcodes `target: 'draft-2020-12'` at the conversion site, and v2 dropped Zod v3.

## Test plan

- [x] New tests fail on unpatched v1.x
- [x] New tests pass with the fix
- [x] Full `npm test` (1584 / 1584)
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] Changeset added
