### PR TITLE
docs(client): clarify private_key_jwt custom claim precedence

### DIFF
--- a/packages/client/src/client/authExtensions.ts
+++ b/packages/client/src/client/authExtensions.ts
@@ -236,8 +236,8 @@ export interface PrivateKeyJwtProviderOptions {
 
     /**
      * Optional custom claims to include in the JWT assertion.
-     * These are merged with the standard claims (`iss`, `sub`, `aud`, `exp`, `iat`, `jti`),
-     * with custom claims taking precedence for any overlapping keys.
+     * These are merged with the standard claims (`iss`, `sub`, `aud`, `exp`, `iat`, `jti`).
+     * Standard claims are set explicitly by the SDK and cannot be overridden by custom claims.
      *
      * Useful for including additional claims that help scope the access token
      * with finer granularity than what scopes alone allow.

--- a/packages/client/test/client/authExtensions.test.ts
+++ b/packages/client/test/client/authExtensions.test.ts
@@ -448,6 +448,41 @@ describe('createPrivateKeyJwtAuth', () => {
         expect(decoded.sub).toBe('client-id');
     });
 
+    it('keeps standard JWT claims authoritative over custom claim overlaps', async () => {
+        const addClientAuth = createPrivateKeyJwtAuth({
+            issuer: 'client-id',
+            subject: 'client-id',
+            privateKey: 'a-string-secret-at-least-256-bits-long',
+            alg: 'HS256',
+            audience: 'https://aud.example.com',
+            claims: {
+                iss: 'override-issuer',
+                sub: 'override-subject',
+                aud: 'https://override.example.com',
+                exp: 1,
+                iat: 1,
+                jti: 'override-jti',
+                tenant_id: 'org-123'
+            }
+        });
+
+        const params = new URLSearchParams();
+        await addClientAuth(new Headers(), params, 'https://auth.example.com/token', undefined);
+
+        const assertion = params.get('client_assertion');
+        expect(assertion).toBeTruthy();
+
+        const jose = await import('jose');
+        const decoded = jose.decodeJwt(assertion!);
+        expect(decoded.iss).toBe('client-id');
+        expect(decoded.sub).toBe('client-id');
+        expect(decoded.aud).toBe('https://aud.example.com');
+        expect(decoded.exp).not.toBe(1);
+        expect(decoded.iat).not.toBe(1);
+        expect(decoded.jti).not.toBe('override-jti');
+        expect(decoded.tenant_id).toBe('org-123');
+    });
+
     it('passes custom claims through PrivateKeyJwtProvider', async () => {
         const provider = new PrivateKeyJwtProvider({
             clientId: 'client-id',


### PR DESCRIPTION
## Summary

- clarify that `PrivateKeyJwtProviderOptions.claims` adds custom JWT claims but does not override SDK-controlled standard claims
- add regression coverage for overlapping `iss`, `sub`, `aud`, `exp`, `iat`, and `jti` custom claims

Refs #1914.

## Validation

- `git diff --check`
- `pnpm --filter @modelcontextprotocol/client test -- test/client/authExtensions.test.ts`
- pre-push hook: `pnpm -r build`, `pnpm -r typecheck`, `pnpm sync:snippets --check && pnpm -r lint`