### PR TITLE
fix(server): allow streamable HTTP JSON without content type

### DIFF
--- a/.changeset/fix-streamable-http-content-type.md
+++ b/.changeset/fix-streamable-http-content-type.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/server': patch
+---
+
+Allow Streamable HTTP clients to send valid JSON POST requests without requiring `Content-Type: application/json`.

--- a/packages/middleware/node/test/streamableHttp.test.ts
+++ b/packages/middleware/node/test/streamableHttp.test.ts
@@ -286,6 +286,20 @@ describe('Zod v4', () => {
             expect(response.headers.get('mcp-session-id')).toBeDefined();
         });
 
+        it('should initialize from valid JSON without Content-Type header', async () => {
+            const response = await fetch(baseUrl, {
+                method: 'POST',
+                headers: {
+                    Accept: 'application/json, text/event-stream'
+                },
+                body: new TextEncoder().encode(JSON.stringify(TEST_MESSAGES.initialize))
+            });
+
+            expect(response.status).toBe(200);
+            expect(response.headers.get('content-type')).toBe('text/event-stream');
+            expect(response.headers.get('mcp-session-id')).toBeDefined();
+        });
+
         it('should reject second initialization request', async () => {
             // First initialize
             const sessionId = await initializeServer();
@@ -680,10 +694,9 @@ describe('Zod v4', () => {
             expectErrorResponse(errorData, -32_000, /Client must accept both application\/json and text\/event-stream/);
         });
 
-        it('should reject unsupported Content-Type', async () => {
+        it('should reject invalid JSON regardless of Content-Type', async () => {
             sessionId = await initializeServer();
 
-            // Try POST with text/plain Content-Type
             const response = await fetch(baseUrl, {
                 method: 'POST',
                 headers: {
@@ -694,9 +707,9 @@ describe('Zod v4', () => {
                 body: 'This is plain text'
             });
 
-            expect(response.status).toBe(415);
+            expect(response.status).toBe(400);
             const errorData = await response.json();
-            expectErrorResponse(errorData, -32_000, /Content-Type must be application\/json/);
+            expectErrorResponse(errorData, -32_700, /Parse error.*Invalid JSON/);
         });
 
         it('should handle JSON-RPC batch notification messages with 202 response', async () => {

--- a/packages/server/src/server/streamableHttp.ts
+++ b/packages/server/src/server/streamableHttp.ts
@@ -629,12 +629,6 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
                 );
             }
 
-            const ct = req.headers.get('content-type');
-            if (!ct || !ct.includes('application/json')) {
-                this.onerror?.(new Error('Unsupported Media Type: Content-Type must be application/json'));
-                return this.createJsonErrorResponse(415, -32_000, 'Unsupported Media Type: Content-Type must be application/json');
-            }
-
             const request = req;
 
             let rawMessage;

--- a/packages/server/test/server/streamableHttp.test.ts
+++ b/packages/server/test/server/streamableHttp.test.ts
@@ -301,7 +301,24 @@ describe('Zod v4', () => {
                 expectErrorResponse(errorData, -32_000, /Not Acceptable/);
             });
 
-            it('should reject request with wrong Content-Type header', async () => {
+            it('should accept valid JSON without Content-Type header', async () => {
+                const request = new Request('http://localhost/mcp', {
+                    method: 'POST',
+                    headers: {
+                        Accept: 'application/json, text/event-stream'
+                    },
+                    body: new TextEncoder().encode(JSON.stringify(TEST_MESSAGES.initialize))
+                });
+
+                expect(request.headers.get('content-type')).toBeNull();
+
+                const response = await transport.handleRequest(request);
+
+                expect(response.status).toBe(200);
+                expect(response.headers.get('mcp-session-id')).toBeDefined();
+            });
+
+            it('should not reject valid JSON based on Content-Type header', async () => {
                 const request = new Request('http://localhost/mcp', {
                     method: 'POST',
                     headers: {
@@ -312,9 +329,8 @@ describe('Zod v4', () => {
                 });
                 const response = await transport.handleRequest(request);
 
-                expect(response.status).toBe(415);
-                const errorData = await response.json();
-                expectErrorResponse(errorData, -32_000, /Unsupported Media Type/);
+                expect(response.status).toBe(200);
+                expect(response.headers.get('mcp-session-id')).toBeDefined();
             });
 
             it('should reject invalid JSON', async () => {
@@ -844,23 +860,21 @@ describe('Zod v4', () => {
             expect(error?.message).toContain('Not Acceptable');
         });
 
-        it('should call onerror for unsupported Content-Type', async () => {
+        it('should not call onerror for valid JSON without Content-Type', async () => {
             const request = new Request('http://localhost/mcp', {
                 method: 'POST',
                 headers: {
-                    Accept: 'application/json, text/event-stream',
-                    'Content-Type': 'text/plain'
+                    Accept: 'application/json, text/event-stream'
                 },
-                body: JSON.stringify(TEST_MESSAGES.initialize)
+                body: new TextEncoder().encode(JSON.stringify(TEST_MESSAGES.initialize))
             });
+
+            expect(request.headers.get('content-type')).toBeNull();
 
             const response = await transport.handleRequest(request);
 
-            expect(response.status).toBe(415);
-            expect(errors.length).toBeGreaterThan(0);
-            const error = errors[0];
-            expect(error).toBeDefined();
-            expect(error?.message).toContain('Unsupported Media Type');
+            expect(response.status).toBe(200);
+            expect(errors).toHaveLength(0);
         });
 
         it('should call onerror for server not initialized', async () => {


### PR DESCRIPTION
## Summary
- remove the Streamable HTTP request `Content-Type` requirement from the web-standard server transport
- keep invalid body handling in the existing `req.json()` parse-error path
- add server and Node wrapper regression coverage for valid JSON POSTs without `Content-Type`

Fixes #581.

## Testing
- `pnpm --filter @modelcontextprotocol/server test -- streamableHttp.test.ts`
- `pnpm --filter @modelcontextprotocol/node test -- streamableHttp.test.ts`
- `pnpm --filter @modelcontextprotocol/test-integration test -- test/server/cloudflareWorkers.test.ts` (locally runs the full integration project: 16 files / 423 tests)
- `nvm exec 20.20.2 pnpm --filter @modelcontextprotocol/test-integration test -- test/server/cloudflareWorkers.test.ts` (same full integration project under Node 20.20.2)
- `pnpm --filter @modelcontextprotocol/server typecheck`
- `pnpm --filter @modelcontextprotocol/server lint`
- `pnpm --filter @modelcontextprotocol/node typecheck`
- `pnpm --filter @modelcontextprotocol/node lint`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter @modelcontextprotocol/server build`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter @modelcontextprotocol/node build`
- `git diff --check`

## Notes
- Independent review found no blocking issues. It called out that accepting valid JSON with `Content-Type: text/plain` is consistent with the issue's proposed full guard removal and the Streamable HTTP spec's lack of a request `Content-Type` requirement.
- The repo pre-push hook was attempted. Full workspace typecheck completed, but the hook did not finish because `@modelcontextprotocol/test-helpers` lint currently fails on untouched `vitest` dependency classification, and the workspace `@modelcontextprotocol/node` build hit Node's default heap limit. The targeted node/server builds pass with `NODE_OPTIONS=--max-old-space-size=4096`.
