### PR TITLE
fix: validate wrapped Zod output schemas

### DIFF
--- a/.changeset/validate-wrapped-output-schemas.md
+++ b/.changeset/validate-wrapped-output-schemas.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/sdk': patch
+---
+
+Validate structured tool output against the registered output schema so wrapped Zod schemas are enforced correctly.

--- a/src/server/mcp.ts
+++ b/src/server/mcp.ts
@@ -306,8 +306,7 @@ export class McpServer {
         }
 
         // if the tool has an output schema, validate structured content
-        const outputObj = normalizeObjectSchema(tool.outputSchema) as AnyObjectSchema;
-        const parseResult = await safeParseAsync(outputObj, result.structuredContent);
+        const parseResult = await safeParseAsync(tool.outputSchema, result.structuredContent);
         if (!parseResult.success) {
             const error = 'error' in parseResult ? parseResult.error : 'Unknown error';
             const errorMessage = getParseErrorMessage(error);

--- a/test/server/mcp.test.ts
+++ b/test/server/mcp.test.ts
@@ -1295,6 +1295,54 @@ describe.each(zodTestMatrix)('$zodVersionLabel', (entry: ZodMatrixEntry) => {
             expect(JSON.parse(textContent.text)).toEqual(result.structuredContent);
         });
 
+        test('should validate structuredContent against wrapped and union outputSchema values', async () => {
+            const mcpServer = new McpServer({
+                name: 'test server',
+                version: '1.0'
+            });
+
+            const client = new Client({
+                name: 'test client',
+                version: '1.0'
+            });
+
+            const outputSchemas = {
+                optional: z.object({ data: z.string() }).optional(),
+                nullable: z.object({ data: z.string() }).nullable(),
+                nullish: z.object({ data: z.string() }).nullish(),
+                union: z.union([z.object({ data: z.string() }), z.object({ value: z.string() })])
+            };
+
+            for (const [name, outputSchema] of Object.entries(outputSchemas)) {
+                mcpServer.registerTool(
+                    name,
+                    {
+                        outputSchema
+                    },
+                    async () => ({
+                        content: [],
+                        structuredContent: {
+                            data: name
+                        }
+                    })
+                );
+            }
+
+            const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+            await Promise.all([client.connect(clientTransport), mcpServer.server.connect(serverTransport)]);
+
+            for (const name of Object.keys(outputSchemas)) {
+                const result = await client.callTool({
+                    name,
+                    arguments: {}
+                });
+
+                expect(result.isError).not.toBe(true);
+                expect(result.structuredContent).toEqual({ data: name });
+            }
+        });
+
         /***
          * Test: Tool with Output Schema Must Provide Structured Content
          */


### PR DESCRIPTION
## Summary

- validate tool `structuredContent` against the registered output schema directly instead of first normalizing it to a plain object schema
- add regression coverage for optional, nullable, nullish, and union Zod output schemas across the repo Zod v3/v4 test matrix
- add a patch changeset for `@modelcontextprotocol/sdk`

Fixes #1308.

Related prior work: this revives the behavior covered by closed, unmerged #1931, with the current fix scoped to preserving the registered schema wrapper and with Zod v3/v4 regression coverage.

## Validation

- `npx vitest run test/server/mcp.test.ts -t "wrapped and union"`
- `npx vitest run test/server/mcp.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npx prettier --check .changeset/validate-wrapped-output-schemas.md`
- `git diff --check`

Note: I also started `npm test`; it passed the changed server suite and several unrelated suites, then stopped producing output for more than 10 minutes in this environment, so I stopped that run and relied on the targeted/full server suite plus typecheck/lint/build.