### PR TITLE
fix: accept omitted prompt arguments

### DIFF
--- a/.changeset/fix-omitted-prompt-arguments.md
+++ b/.changeset/fix-omitted-prompt-arguments.md
@@ -1,0 +1,5 @@
+---
+"@modelcontextprotocol/server": patch
+---
+
+Fix prompts/get rejecting omitted arguments when all prompt schema fields are optional.

--- a/.changeset/fix-omitted-prompt-arguments.md
+++ b/.changeset/fix-omitted-prompt-arguments.md
@@ -1,5 +1,5 @@
 ---
-"@modelcontextprotocol/server": patch
+'@modelcontextprotocol/server': patch
 ---
 
 Fix prompts/get rejecting omitted arguments when all prompt schema fields are optional.

--- a/packages/server/src/server/mcp.ts
+++ b/packages/server/src/server/mcp.ts
@@ -1339,7 +1339,7 @@ function createPromptHandler(
         const typedCallback = callback as (args: unknown, ctx: ServerContext) => GetPromptResult | Promise<GetPromptResult>;
 
         return async (args, ctx) => {
-            const parseResult = await validateStandardSchema(argsSchema, args);
+            const parseResult = await validateStandardSchema(argsSchema, args ?? {});
             if (!parseResult.success) {
                 throw new ProtocolError(ProtocolErrorCode.InvalidParams, `Invalid arguments for prompt ${name}: ${parseResult.error}`);
             }

--- a/test/integration/test/server/cloudflareWorkers.test.ts
+++ b/test/integration/test/server/cloudflareWorkers.test.ts
@@ -8,18 +8,39 @@
 import type { ChildProcess } from 'node:child_process';
 import { execSync, spawn } from 'node:child_process';
 import * as fs from 'node:fs';
+import { createServer } from 'node:net';
 import * as os from 'node:os';
 import path from 'node:path';
 
 import { Client, StreamableHTTPClientTransport } from '@modelcontextprotocol/client';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
-const PORT = 8787;
-
 interface TestEnv {
     tempDir: string;
+    port: number;
     process: ChildProcess;
     cleanup: () => Promise<void>;
+}
+
+async function getAvailablePort(): Promise<number> {
+    return await new Promise((resolve, reject) => {
+        const server = createServer();
+        server.on('error', reject);
+        server.listen(0, '127.0.0.1', () => {
+            const address = server.address();
+            server.close(() => {
+                if (address && typeof address === 'object') {
+                    resolve(address.port);
+                } else {
+                    reject(new Error('Unable to allocate an available port'));
+                }
+            });
+        });
+    });
+}
+
+async function delay(ms: number): Promise<void> {
+    await new Promise(resolve => setTimeout(resolve, ms));
 }
 
 describe('Cloudflare Workers compatibility (no nodejs_compat)', () => {
@@ -27,6 +48,7 @@ describe('Cloudflare Workers compatibility (no nodejs_compat)', () => {
 
     beforeAll(async () => {
         const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cf-worker-test-'));
+        const port = await getAvailablePort();
 
         // Pack server package
         const serverPkgPath = path.resolve(__dirname, '../../../../packages/server');
@@ -82,10 +104,10 @@ export default {
         fs.writeFileSync(path.join(tempDir, 'server.ts'), serverSource);
 
         // Install dependencies
-        execSync('npm install', { cwd: tempDir, stdio: 'pipe', timeout: 60_000 });
+        execSync('npm install --prefer-offline --no-audit --no-fund', { cwd: tempDir, stdio: 'pipe', timeout: 180_000 });
 
         // Start wrangler dev server
-        const proc = spawn('npx', ['wrangler', 'dev', '--local', '--port', String(PORT)], {
+        const proc = spawn('npx', ['wrangler', 'dev', '--local', '--port', String(port)], {
             cwd: tempDir,
             shell: true,
             stdio: 'pipe'
@@ -140,8 +162,8 @@ export default {
             }
         };
 
-        env = { tempDir, process: proc, cleanup };
-    }, 120_000);
+        env = { tempDir, port, process: proc, cleanup };
+    }, 240_000);
 
     afterAll(async () => {
         await env?.cleanup();
@@ -150,28 +172,25 @@ export default {
     it('should handle MCP requests', async () => {
         expect(env).not.toBeNull();
 
-        // Retry connection — wrangler may report "Ready" before it can handle requests
-        let client!: Client;
+        // Retry the full round trip — wrangler may report "Ready" before it can
+        // consistently serve the first few requests.
         let lastError: unknown;
-        for (let attempt = 0; attempt < 5; attempt++) {
+        for (let attempt = 0; attempt < 8; attempt++) {
+            const client = new Client({ name: 'test-client', version: '1.0.0' });
+            const transport = new StreamableHTTPClientTransport(new URL(`http://127.0.0.1:${env!.port}/`));
             try {
-                client = new Client({ name: 'test-client', version: '1.0.0' });
-                const transport = new StreamableHTTPClientTransport(new URL(`http://127.0.0.1:${PORT}/`));
                 await client.connect(transport);
-                lastError = undefined;
-                break;
+                const result = await client.callTool({ name: 'greet', arguments: { name: 'World' } });
+                expect(result.content).toEqual([{ type: 'text', text: 'Hello, World!' }]);
+                await client.close();
+                return;
             } catch (error) {
                 lastError = error;
-                await new Promise(resolve => setTimeout(resolve, 1000));
+                await client.close().catch(() => {});
+                await delay(1000);
             }
         }
-        if (lastError) {
-            throw lastError;
-        }
 
-        const result = await client.callTool({ name: 'greet', arguments: { name: 'World' } });
-        expect(result.content).toEqual([{ type: 'text', text: 'Hello, World!' }]);
-
-        await client.close();
+        throw lastError;
     }, 30_000);
 });

--- a/test/integration/test/server/cloudflareWorkers.test.ts
+++ b/test/integration/test/server/cloudflareWorkers.test.ts
@@ -8,39 +8,18 @@
 import type { ChildProcess } from 'node:child_process';
 import { execSync, spawn } from 'node:child_process';
 import * as fs from 'node:fs';
-import { createServer } from 'node:net';
 import * as os from 'node:os';
 import path from 'node:path';
 
 import { Client, StreamableHTTPClientTransport } from '@modelcontextprotocol/client';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
+const PORT = 8787;
+
 interface TestEnv {
     tempDir: string;
-    port: number;
     process: ChildProcess;
     cleanup: () => Promise<void>;
-}
-
-async function getAvailablePort(): Promise<number> {
-    return await new Promise((resolve, reject) => {
-        const server = createServer();
-        server.on('error', reject);
-        server.listen(0, '127.0.0.1', () => {
-            const address = server.address();
-            server.close(() => {
-                if (address && typeof address === 'object') {
-                    resolve(address.port);
-                } else {
-                    reject(new Error('Unable to allocate an available port'));
-                }
-            });
-        });
-    });
-}
-
-async function delay(ms: number): Promise<void> {
-    await new Promise(resolve => setTimeout(resolve, ms));
 }
 
 describe('Cloudflare Workers compatibility (no nodejs_compat)', () => {
@@ -48,7 +27,6 @@ describe('Cloudflare Workers compatibility (no nodejs_compat)', () => {
 
     beforeAll(async () => {
         const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cf-worker-test-'));
-        const port = await getAvailablePort();
 
         // Pack server package
         const serverPkgPath = path.resolve(__dirname, '../../../../packages/server');
@@ -104,10 +82,10 @@ export default {
         fs.writeFileSync(path.join(tempDir, 'server.ts'), serverSource);
 
         // Install dependencies
-        execSync('npm install --prefer-offline --no-audit --no-fund', { cwd: tempDir, stdio: 'pipe', timeout: 180_000 });
+        execSync('npm install', { cwd: tempDir, stdio: 'pipe', timeout: 60_000 });
 
         // Start wrangler dev server
-        const proc = spawn('npx', ['wrangler', 'dev', '--local', '--port', String(port)], {
+        const proc = spawn('npx', ['wrangler', 'dev', '--local', '--port', String(PORT)], {
             cwd: tempDir,
             shell: true,
             stdio: 'pipe'
@@ -162,8 +140,8 @@ export default {
             }
         };
 
-        env = { tempDir, port, process: proc, cleanup };
-    }, 240_000);
+        env = { tempDir, process: proc, cleanup };
+    }, 120_000);
 
     afterAll(async () => {
         await env?.cleanup();
@@ -172,25 +150,28 @@ export default {
     it('should handle MCP requests', async () => {
         expect(env).not.toBeNull();
 
-        // Retry the full round trip — wrangler may report "Ready" before it can
-        // consistently serve the first few requests.
+        // Retry connection — wrangler may report "Ready" before it can handle requests
+        let client!: Client;
         let lastError: unknown;
-        for (let attempt = 0; attempt < 8; attempt++) {
-            const client = new Client({ name: 'test-client', version: '1.0.0' });
-            const transport = new StreamableHTTPClientTransport(new URL(`http://127.0.0.1:${env!.port}/`));
+        for (let attempt = 0; attempt < 5; attempt++) {
             try {
+                client = new Client({ name: 'test-client', version: '1.0.0' });
+                const transport = new StreamableHTTPClientTransport(new URL(`http://127.0.0.1:${PORT}/`));
                 await client.connect(transport);
-                const result = await client.callTool({ name: 'greet', arguments: { name: 'World' } });
-                expect(result.content).toEqual([{ type: 'text', text: 'Hello, World!' }]);
-                await client.close();
-                return;
+                lastError = undefined;
+                break;
             } catch (error) {
                 lastError = error;
-                await client.close().catch(() => {});
-                await delay(1000);
+                await new Promise(resolve => setTimeout(resolve, 1000));
             }
         }
+        if (lastError) {
+            throw lastError;
+        }
 
-        throw lastError;
+        const result = await client.callTool({ name: 'greet', arguments: { name: 'World' } });
+        expect(result.content).toEqual([{ type: 'text', text: 'Hello, World!' }]);
+
+        await client.close();
     }, 30_000);
 });

--- a/test/integration/test/server/mcp.test.ts
+++ b/test/integration/test/server/mcp.test.ts
@@ -4254,6 +4254,59 @@ describe('Zod v4', () => {
             ]);
         });
 
+        test('should accept omitted prompt arguments when all schema fields are optional', async () => {
+            const mcpServer = new McpServer({
+                name: 'test server',
+                version: '1.0'
+            });
+
+            const client = new Client({
+                name: 'test client',
+                version: '1.0'
+            });
+
+            mcpServer.registerPrompt(
+                'echo',
+                {
+                    argsSchema: z.object({
+                        context: z.string().optional()
+                    })
+                },
+                ({ context }) => ({
+                    messages: [
+                        {
+                            role: 'user',
+                            content: {
+                                type: 'text',
+                                text: `context: ${context ?? 'none'}`
+                            }
+                        }
+                    ]
+                })
+            );
+
+            const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+            await Promise.all([client.connect(clientTransport), mcpServer.server.connect(serverTransport)]);
+
+            const result = await client.request({
+                method: 'prompts/get',
+                params: {
+                    name: 'echo'
+                }
+            });
+
+            expect(result.messages).toEqual([
+                {
+                    role: 'user',
+                    content: {
+                        type: 'text',
+                        text: 'context: none'
+                    }
+                }
+            ]);
+        });
+
         /***
          * Test: Prompt Registration with _meta field
          */


### PR DESCRIPTION
## Summary
- default omitted `prompts/get` arguments to `{}` before prompt argument schema validation
- add a regression test for a prompt whose schema fields are all optional
- add a server patch changeset

## Root cause
`prompts/get` passes `request.params.arguments` through to the registered prompt handler. When `arguments` is omitted, `createPromptHandler` validated `undefined` against the prompt's object schema, so all-optional object schemas still failed at the top level. The tools path already normalizes omitted arguments with `args ?? {}`; this applies the same behavior to prompts.

Addresses the main-branch prompt portion of #1869. I did not include `v1.x` backport changes in this PR.

Related prior work: this revives the same main-branch behavior targeted by closed, unmerged #1921.

## Validation
- Added regression test and verified it failed before the handler fix.
- `pnpm --dir test/integration exec vitest run test/server/mcp.test.ts -t "should accept omitted prompt arguments"`
- `pnpm --dir test/integration exec vitest run test/server/mcp.test.ts`
- `pnpm --filter @modelcontextprotocol/server typecheck`
- `pnpm --filter @modelcontextprotocol/server lint`
- `pnpm --filter @modelcontextprotocol/test-integration lint`
- Full pre-push hook: typecheck passed; repo-wide lint/build did not complete due unrelated existing issues:
  - `@modelcontextprotocol/test-helpers` lint reports existing `vitest` extraneous dependency errors in `test/helpers/src/helpers/http.ts` and `test/helpers/src/helpers/oauth.ts`.
  - `@modelcontextprotocol/node` build OOMs with the default Node heap, but passes with `NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter @modelcontextprotocol/node build`.

CI note: Node 20 `test (20)` currently fails in unrelated `test/server/cloudflareWorkers.test.ts` with a Miniflare `Network connection lost`; the changed `test/server/mcp.test.ts` suite passed in that same run. I do not have permission to rerun the failed job.