### PR TITLE
fix(server): reject initialize with mismatched MCP-Protocol-Version header

### DIFF
--- a/.changeset/fix-init-protocol-version-mismatch.md
+++ b/.changeset/fix-init-protocol-version-mismatch.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/server': patch
+---
+
+fix(server): reject initialize when MCP-Protocol-Version header disagrees with body protocolVersion

--- a/packages/server/src/server/streamableHttp.ts
+++ b/packages/server/src/server/streamableHttp.ts
@@ -675,6 +675,21 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
                     this.onerror?.(new Error('Invalid Request: Only one initialization request is allowed'));
                     return this.createJsonErrorResponse(400, -32_600, 'Invalid Request: Only one initialization request is allowed');
                 }
+                // When the MCP-Protocol-Version header is present on initialize, it must agree
+                // with the body's params.protocolVersion. The spec does not require this check,
+                // but a silent header/body mismatch lets middleware misconfiguration through
+                // (the body wins) and routes responses to a version the client never asked for.
+                // See issue #2108.
+                const headerProtocolVersion = req.headers.get('mcp-protocol-version');
+                if (headerProtocolVersion !== null) {
+                    const initRequest = messages.find(element => isInitializeRequest(element));
+                    const bodyProtocolVersion = initRequest?.params.protocolVersion;
+                    if (bodyProtocolVersion !== undefined && headerProtocolVersion !== bodyProtocolVersion) {
+                        const error = `Bad Request: MCP-Protocol-Version header (${headerProtocolVersion}) does not match initialize body protocolVersion (${bodyProtocolVersion})`;
+                        this.onerror?.(new Error(error));
+                        return this.createJsonErrorResponse(400, -32_600, error);
+                    }
+                }
                 this.sessionId = this.sessionIdGenerator?.();
                 this._initialized = true;
 

--- a/packages/server/test/server/streamableHttp.test.ts
+++ b/packages/server/test/server/streamableHttp.test.ts
@@ -752,6 +752,68 @@ describe('Zod v4', () => {
             const errorData = await response.json();
             expectErrorResponse(errorData, -32_000, /Unsupported protocol version/);
         });
+
+        it('should reject initialize when MCP-Protocol-Version header disagrees with body (header older)', async () => {
+            const request = new Request('http://localhost/mcp', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    Accept: 'application/json, text/event-stream',
+                    'mcp-protocol-version': '2025-03-26'
+                },
+                body: JSON.stringify(TEST_MESSAGES.initialize)
+            });
+
+            const response = await transport.handleRequest(request);
+
+            expect(response.status).toBe(400);
+            const errorData = await response.json();
+            expectErrorResponse(errorData, -32_600, /MCP-Protocol-Version header.*does not match initialize body protocolVersion/);
+        });
+
+        it('should reject initialize when MCP-Protocol-Version header disagrees with body (header newer)', async () => {
+            const request = new Request('http://localhost/mcp', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    Accept: 'application/json, text/event-stream',
+                    'mcp-protocol-version': '2025-11-25'
+                },
+                body: JSON.stringify(TEST_MESSAGES.initializeOldVersion)
+            });
+
+            const response = await transport.handleRequest(request);
+
+            expect(response.status).toBe(400);
+            const errorData = await response.json();
+            expectErrorResponse(errorData, -32_600, /MCP-Protocol-Version header.*does not match initialize body protocolVersion/);
+        });
+
+        it('should accept initialize when MCP-Protocol-Version header matches body', async () => {
+            const request = new Request('http://localhost/mcp', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    Accept: 'application/json, text/event-stream',
+                    'mcp-protocol-version': '2025-11-25'
+                },
+                body: JSON.stringify(TEST_MESSAGES.initialize)
+            });
+
+            const response = await transport.handleRequest(request);
+
+            expect(response.status).toBe(200);
+            expect(response.headers.get('mcp-session-id')).toBeDefined();
+        });
+
+        it('should accept initialize when MCP-Protocol-Version header is absent (existing behavior)', async () => {
+            const request = createRequest('POST', TEST_MESSAGES.initialize);
+
+            const response = await transport.handleRequest(request);
+
+            expect(response.status).toBe(200);
+            expect(response.headers.get('mcp-session-id')).toBeDefined();
+        });
     });
 
     describe('HTTPServerTransport - start() method', () => {


### PR DESCRIPTION
## Summary

Fixes #2108.

When the initial JSON-RPC `initialize` request to the Streamable HTTP server carries an `MCP-Protocol-Version` header that disagrees with `initialize.params.protocolVersion` in the body, the server currently accepts the request, lets the body win, and the resulting session uses a version the client never asked for in its HTTP header.

This PR adds an equality check at the top of the initialize branch in `WebStandardStreamableHTTPServerTransport.handleRequest`. If the header is present and does not match the body's `protocolVersion`, the request is rejected with `400 Bad Request` and JSON-RPC error code `-32600`. Header absent stays a soft case (existing behavior, since the spec allows the header to be omitted on initialize).

## Why this shape

- This is option A from the issue: defensive validation against silent mismatch.
- The check is local to the initialize branch so it does not change behavior for any non-initialize request (those still flow through the existing `validateProtocolVersion` after-init path).
- The existing `validateProtocolVersion` is left alone. Its JSDoc already documents that initialize defers to version negotiation; that remains true for the header-absent case. Adding the equality check next to the rest of the init-branch validation keeps the surface area minimal and the change reviewable in one block.
- The MCP `2025-11-25` spec does not explicitly mandate this consistency check, so the change is implementation-level hardening. SEP-2575 is heading toward a related requirement for `_meta["io.modelcontextprotocol/protocolVersion"]`, and this lays groundwork without front-running it.

## Test plan

New tests in `packages/server/test/server/streamableHttp.test.ts` under the existing `HTTPServerTransport - Protocol Version Validation` block:

- [x] Initialize rejected (400, `-32600`) when header is older than body (`header=2025-03-26`, `body=2025-11-25`).
- [x] Initialize rejected (400, `-32600`) when header is newer than body (`header=2025-11-25`, `body=2025-06-18`).
- [x] Initialize accepted (200) when header matches body.
- [x] Initialize accepted (200) when header is absent (existing behavior preserved).
- [x] `pnpm --filter @modelcontextprotocol/server typecheck` clean.
- [x] `pnpm --filter @modelcontextprotocol/server lint` clean.
- [x] `pnpm --filter @modelcontextprotocol/server test` 69 / 69 passed (4 new + 65 pre-existing in `streamableHttp.test.ts`).
- [x] `pnpm test:all` green across all packages (integration suite 423 / 423).

## Branch + changeset

Targeted at `main` per CONTRIBUTING ("v2 in development"). Changeset added at `.changeset/fix-init-protocol-version-mismatch.md` as a `@modelcontextprotocol/server` patch.

Happy to open a parallel PR against `v1.x` (where the equivalent code lives in `src/server/webStandardStreamableHttp.ts`, same shape) if a maintainer wants it backported.

## AI Assistance Disclosure

Implementation and tests drafted with Claude assistance. I reviewed every line, ran the suites locally, and am the human contributor accountable for this PR.
