### PR TITLE
docs(README): add `@modelcontextprotocol/fastify` to middleware listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This repository contains the TypeScript SDK implementation of the MCP specificat
 
 - MCP **server** libraries (tools/resources/prompts, Streamable HTTP, stdio, auth helpers)
 - MCP **client** libraries (transports, high-level helpers, OAuth helpers)
-- Optional **middleware packages** for specific runtimes/frameworks (Express, Hono, Node.js HTTP)
+- Optional **middleware packages** for specific runtimes/frameworks (Express, Hono, Fastify, Node.js HTTP)
 - Runnable **examples** (under [`examples/`](https://github.com/modelcontextprotocol/typescript-sdk/tree/main/examples))
 
 ## Packages
@@ -50,6 +50,7 @@ They are intentionally thin adapters: they should not introduce new MCP function
 - **`@modelcontextprotocol/node`**: Node.js Streamable HTTP transport wrapper for `IncomingMessage` / `ServerResponse`
 - **`@modelcontextprotocol/express`**: Express helpers (app defaults + Host header validation)
 - **`@modelcontextprotocol/hono`**: Hono helpers (app defaults + JSON body parsing hook + Host header validation)
+- **`@modelcontextprotocol/fastify`**: Fastify helpers (app defaults + Host header validation)
 
 ## Installation
 
@@ -75,7 +76,7 @@ deno add npm:@modelcontextprotocol/client
 
 ### Optional middleware packages
 
-The SDK also publishes optional “middleware” packages that help you **wire MCP into a specific runtime or web framework** (for example Express, Hono, or Node.js `http`).
+The SDK also publishes optional “middleware” packages that help you **wire MCP into a specific runtime or web framework** (for example Express, Hono, Fastify, or Node.js `http`).
 
 These packages are intentionally thin adapters and should not introduce additional MCP features or business logic. See [`packages/middleware/README.md`](packages/middleware/README.md) for details.
 
@@ -88,6 +89,9 @@ npm install @modelcontextprotocol/express express
 
 # Hono integration:
 npm install @modelcontextprotocol/hono hono
+
+# Fastify integration:
+npm install @modelcontextprotocol/fastify fastify
 ```
 
 ## Getting Started


### PR DESCRIPTION
## What

Add `@modelcontextprotocol/fastify` to the README in the three places where the other middleware packages are documented.

## Why

The fastify middleware package is published (`packages/middleware/fastify/package.json` has `private: false` and shares the same `2.0.0-alpha.2` version as node/express/hono) and has its own README, but the top-level README omits it everywhere — overview line, middleware section, and install commands. Looks like an oversight from when fastify was added rather than an intentional exclusion. See #2112 for the original observation.

## How

Three small additions, no removals:

1. Overview parenthetical: `(Express, Hono, Node.js HTTP)` → `(Express, Hono, Fastify, Node.js HTTP)`
2. Middleware package list: add the `@modelcontextprotocol/fastify` bullet after the hono entry, using the same description shape Express uses.
3. Installation block: add the `npm install @modelcontextprotocol/fastify fastify` snippet matching the hono entry.

## Behavior change

- Before: README documents `node`, `express`, `hono`. Fastify is invisible to anyone reading the top-level docs.
- After: README documents all four published middleware packages consistently.

## Breaking changes

None — docs only.

## Test plan

No code paths touched. Spot-checked rendered Markdown locally.

## Related

- Closes #2112

---

*Code drafted with Claude Code assistance; manually reviewed and tested.*