### PR TITLE
fix: handle cancelled notifications for request id zero

### DIFF
--- a/.changeset/fuzzy-birds-cancel.md
+++ b/.changeset/fuzzy-birds-cancel.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/core': patch
+---
+
+Fix `notifications/cancelled` handling for request ID `0`. Previously the cancellation guard treated `0` as missing and left the first request from a protocol instance uncancellable.

--- a/packages/core/src/shared/protocol.ts
+++ b/packages/core/src/shared/protocol.ts
@@ -409,11 +409,12 @@ export abstract class Protocol<ContextT extends BaseContext> {
     protected abstract buildContext(ctx: BaseContext, transportInfo?: MessageExtraInfo): ContextT;
 
     private async _oncancel(notification: CancelledNotification): Promise<void> {
-        if (!notification.params.requestId) {
+        const requestId = notification.params.requestId;
+        if (requestId === undefined) {
             return;
         }
         // Handle request cancellation
-        const controller = this._requestHandlerAbortControllers.get(notification.params.requestId);
+        const controller = this._requestHandlerAbortControllers.get(requestId);
         controller?.abort(notification.params.reason);
     }
 

--- a/packages/core/test/shared/protocol.test.ts
+++ b/packages/core/test/shared/protocol.test.ts
@@ -2319,6 +2319,43 @@ describe('Request Cancellation vs Task Cancellation', () => {
             expect(wasAborted).toBe(true);
         });
 
+        test('should abort request handler when cancelling request ID 0', async () => {
+            await protocol.connect(transport);
+
+            let wasAborted = false;
+            protocol.setRequestHandler('ping', async (_request, ctx) => {
+                await new Promise(resolve => setTimeout(resolve, 100));
+                wasAborted = ctx.mcpReq.signal.aborted;
+                return {};
+            });
+
+            if (transport.onmessage) {
+                transport.onmessage({
+                    jsonrpc: '2.0',
+                    id: 0,
+                    method: 'ping',
+                    params: {}
+                });
+            }
+
+            await new Promise(resolve => setTimeout(resolve, 10));
+
+            if (transport.onmessage) {
+                transport.onmessage({
+                    jsonrpc: '2.0',
+                    method: 'notifications/cancelled',
+                    params: {
+                        requestId: 0,
+                        reason: 'User cancelled'
+                    }
+                });
+            }
+
+            await new Promise(resolve => setTimeout(resolve, 150));
+
+            expect(wasAborted).toBe(true);
+        });
+
         test('should NOT automatically cancel associated tasks when notifications/cancelled is received', async () => {
             await protocol.connect(transport);
 


### PR DESCRIPTION
## Title
fix: handle cancelled notifications for request id zero

## Linked issue
Closes #2115

## Summary
- treats only an omitted `requestId` as missing when handling `notifications/cancelled`
- preserves valid request ID `0` so the first request from a protocol instance can be cancelled
- adds regression coverage for cancelling an in-flight request with ID `0`
- adds a patch changeset for `@modelcontextprotocol/core`

## Validation
- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm --filter @modelcontextprotocol/core test -- --run packages/core/test/shared/protocol.test.ts`  
  Result: core test suite passed, 21 files / 553 tests
- `corepack pnpm --filter @modelcontextprotocol/core typecheck`
- `corepack pnpm --filter @modelcontextprotocol/core lint`
- `corepack pnpm exec prettier --check .changeset/fuzzy-birds-cancel.md`

## Notes
No behavior changes for other request IDs. This only avoids treating numeric ID `0` as falsy/missing.
