### PR TITLE
docs(client): clarify private_key_jwt reserved-claim behavior

### DIFF
--- a/packages/client/src/client/authExtensions.ts
+++ b/packages/client/src/client/authExtensions.ts
@@ -31,6 +31,13 @@ export function createPrivateKeyJwtAuth(options: {
     alg: string;
     audience?: string | URL;
     lifetimeSeconds?: number;
+    /**
+     * Additional custom JWT claims to include in the signed assertion.
+     *
+     * These are merged into the JWT payload, but the standard JWT claims
+     * (`iss`, `sub`, `aud`, `exp`, `iat`, `jti`) are always set explicitly by the SDK and
+     * will override any overlapping keys provided here.
+     */
     claims?: Record<string, unknown>;
 }): AddClientAuthentication {
     return async (_headers, params, url, metadata) => {


### PR DESCRIPTION
Fixes #1914.

Clarifies that `createPrivateKeyJwtAuth({ claims })` merges additional payload keys, but the SDK always sets the standard JWT claims (`iss`, `sub`, `aud`, `exp`, `iat`, `jti`) explicitly and they override any overlapping keys in `claims`.

Docs-only change; no runtime behavior changes.
