### PR TITLE
fix: keep related request id zero from debouncing

### DIFF
--- a/.changeset/related-zero-debounce.md
+++ b/.changeset/related-zero-debounce.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/core': patch
+---
+
+Treat numeric related request ID `0` as present when deciding whether a notification can be debounced.

--- a/packages/core/src/shared/protocol.ts
+++ b/packages/core/src/shared/protocol.ts
@@ -832,7 +832,8 @@ export abstract class Protocol<ContextT extends BaseContext> {
         const debouncedMethods = this._options?.debouncedNotificationMethods ?? [];
         // A notification can only be debounced if it's in the list AND it's "simple"
         // (i.e., has no parameters and no related request ID that could be lost).
-        const canDebounce = debouncedMethods.includes(notification.method) && !notification.params && !options?.relatedRequestId;
+        const hasRelatedRequestId = options?.relatedRequestId !== undefined;
+        const canDebounce = debouncedMethods.includes(notification.method) && !notification.params && !hasRelatedRequestId;
 
         if (canDebounce) {
             // If a notification of this type is already scheduled, do nothing.

--- a/packages/core/test/shared/protocol.test.ts
+++ b/packages/core/test/shared/protocol.test.ts
@@ -654,6 +654,20 @@ describe('protocol tests', () => {
             expect(sendSpy).toHaveBeenCalledWith(expect.any(Object), { relatedRequestId: 'req-2' });
         });
 
+        it('should NOT debounce a notification that has relatedRequestId 0', async () => {
+            // ARRANGE
+            protocol = new TestProtocolImpl({ debouncedNotificationMethods: ['test/debounced_with_zero_id'] });
+            await protocol.connect(transport);
+
+            // ACT
+            await protocol.notification({ method: 'test/debounced_with_zero_id' }, { relatedRequestId: 0 });
+            await protocol.notification({ method: 'test/debounced_with_zero_id' }, { relatedRequestId: 0 });
+
+            // ASSERT
+            expect(sendSpy).toHaveBeenCalledTimes(2);
+            expect(sendSpy).toHaveBeenCalledWith(expect.any(Object), { relatedRequestId: 0 });
+        });
+
         it('should clear pending debounced notifications on connection close', async () => {
             // ARRANGE
             protocol = new TestProtocolImpl({ debouncedNotificationMethods: ['test/debounced'] });


### PR DESCRIPTION
## Summary
- treat numeric `relatedRequestId: 0` as present when deciding whether a notification can be debounced
- add regression coverage so related notifications for request id zero are sent immediately instead of being coalesced
- add a patch changeset for `@modelcontextprotocol/core`

Fixes #2117

## To verify
- `corepack pnpm --filter @modelcontextprotocol/core test -- --run packages/core/test/shared/protocol.test.ts`
- `corepack pnpm --filter @modelcontextprotocol/core typecheck`
- `corepack pnpm --filter @modelcontextprotocol/core lint`
- `git diff --check origin/main..HEAD`

The pre-push hook also passed the repo typecheck/build/lint tasks.