### PR TITLE
fix(client): surface OAuth token persistence failures

### DIFF
--- a/.changeset/forty-mayflies-tease.md
+++ b/.changeset/forty-mayflies-tease.md
@@ -1,0 +1,5 @@
+---
+"@modelcontextprotocol/client": patch
+---
+
+fix(client): surface OAuth token persistence failures

--- a/packages/client/src/client/auth.ts
+++ b/packages/client/src/client/auth.ts
@@ -763,9 +763,10 @@ async function authInternal(
 
     // Handle token refresh or new authorization
     if (tokens?.refresh_token) {
+        let newTokens: OAuthTokens | undefined;
         try {
             // Attempt to refresh the token
-            const newTokens = await refreshAuthorization(authorizationServerUrl, {
+            newTokens = await refreshAuthorization(authorizationServerUrl, {
                 metadata,
                 clientInformation,
                 refreshToken: tokens.refresh_token,
@@ -773,9 +774,6 @@ async function authInternal(
                 addClientAuthentication: provider.addClientAuthentication,
                 fetchFn
             });
-
-            await provider.saveTokens(newTokens);
-            return 'AUTHORIZED';
         } catch (error) {
             // If this is a ServerError, or an unknown type, log it out and try to continue. Otherwise, escalate so we can fix things and retry.
             if (!(error instanceof OAuthError) || error.code === OAuthErrorCode.ServerError) {
@@ -784,6 +782,11 @@ async function authInternal(
                 // Refresh failed for another reason, re-throw
                 throw error;
             }
+        }
+
+        if (newTokens !== undefined) {
+            await provider.saveTokens(newTokens);
+            return 'AUTHORIZED';
         }
     }
 

--- a/packages/client/test/client/auth.test.ts
+++ b/packages/client/test/client/auth.test.ts
@@ -2591,6 +2591,73 @@ describe('OAuth Authorization', () => {
             expect(body.get('refresh_token')).toBe('refresh123');
         });
 
+        it('does not hide token persistence failures after refresh succeeds', async () => {
+            mockFetch.mockImplementation(url => {
+                const urlString = url.toString();
+
+                if (urlString.includes('/.well-known/oauth-protected-resource')) {
+                    return Promise.resolve({
+                        ok: true,
+                        status: 200,
+                        json: async () => ({
+                            resource: 'https://api.example.com/mcp-server',
+                            authorization_servers: ['https://auth.example.com']
+                        })
+                    });
+                } else if (urlString.includes('/.well-known/oauth-authorization-server')) {
+                    return Promise.resolve({
+                        ok: true,
+                        status: 200,
+                        json: async () => ({
+                            issuer: 'https://auth.example.com',
+                            authorization_endpoint: 'https://auth.example.com/authorize',
+                            token_endpoint: 'https://auth.example.com/token',
+                            response_types_supported: ['code'],
+                            code_challenge_methods_supported: ['S256']
+                        })
+                    });
+                } else if (urlString.includes('/token')) {
+                    return Promise.resolve({
+                        ok: true,
+                        status: 200,
+                        json: async () => ({
+                            access_token: 'new-access123',
+                            token_type: 'Bearer',
+                            expires_in: 3600,
+                            refresh_token: 'new-refresh123'
+                        })
+                    });
+                }
+
+                return Promise.resolve({ ok: false, status: 404 });
+            });
+
+            const saveError = new Error('token store unavailable');
+            (mockProvider.clientInformation as Mock).mockResolvedValue({
+                client_id: 'test-client',
+                client_secret: 'test-secret'
+            });
+            (mockProvider.tokens as Mock).mockResolvedValue({
+                access_token: 'old-access',
+                refresh_token: 'refresh123'
+            });
+            (mockProvider.saveTokens as Mock).mockRejectedValue(saveError);
+
+            await expect(
+                auth(mockProvider, {
+                    serverUrl: 'https://api.example.com/mcp-server'
+                })
+            ).rejects.toThrow('token store unavailable');
+
+            expect(mockProvider.saveTokens).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    access_token: 'new-access123',
+                    refresh_token: 'new-refresh123'
+                })
+            );
+            expect(mockProvider.redirectToAuthorization).not.toHaveBeenCalled();
+        });
+
         it('skips default PRM resource validation when custom validateResourceURL is provided', async () => {
             const mockValidateResourceURL = vi.fn().mockResolvedValue(undefined);
             const providerWithCustomValidation = {


### PR DESCRIPTION
﻿## Summary

Fixes #2034.

When OAuth refresh succeeds but `provider.saveTokens()` fails, `auth()` should surface that persistence failure. The authorization server may already have rotated the refresh token, so silently falling through to a new authorization flow can hide the only useful error and leave the client with stale credentials.

This keeps the existing fallback behavior for refresh request failures, but moves `saveTokens()` out of that catch block so store/I/O failures propagate normally.

## To verify

- `pnpm --filter @modelcontextprotocol/client exec vitest run test/client/auth.test.ts -t "does not hide token persistence failures"`
- `pnpm --filter @modelcontextprotocol/client exec vitest run test/client/auth.test.ts`
- `pnpm --filter @modelcontextprotocol/client typecheck`
- `pnpm --filter @modelcontextprotocol/client lint`
- `git diff --check`

The repository pre-push hook also ran workspace typecheck, build, and lint successfully.
