### PR TITLE
fix: continue OAuth discovery after non-JSON metadata

### DIFF
--- a/packages/client/src/client/auth.ts
+++ b/packages/client/src/client/auth.ts
@@ -1262,10 +1262,15 @@ export async function discoverAuthorizationServerMetadata(
             );
         }
 
+        let metadata: unknown;
+        try {
+            metadata = await response.json();
+        } catch {
+            continue;
+        }
+
         // Parse and validate based on type
-        return type === 'oauth'
-            ? OAuthMetadataSchema.parse(await response.json())
-            : OpenIdProviderDiscoveryMetadataSchema.parse(await response.json());
+        return type === 'oauth' ? OAuthMetadataSchema.parse(metadata) : OpenIdProviderDiscoveryMetadataSchema.parse(metadata);
     }
 
     return undefined;

--- a/packages/client/test/client/auth.test.ts
+++ b/packages/client/test/client/auth.test.ts
@@ -924,6 +924,31 @@ describe('OAuth Authorization', () => {
             expect(metadata).toEqual(validOpenIdMetadata);
         });
 
+        it('continues when a successful metadata response is not JSON', async () => {
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                status: 200,
+                json: async () => {
+                    throw new SyntaxError('Unexpected token <');
+                }
+            });
+
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                status: 200,
+                json: async () => validOpenIdMetadata
+            });
+
+            const metadata = await discoverAuthorizationServerMetadata('https://auth.example.com/tenant1');
+
+            expect(metadata).toEqual(validOpenIdMetadata);
+
+            const calls = mockFetch.mock.calls;
+            expect(calls.length).toBe(2);
+            expect(calls[0]![0].toString()).toBe('https://auth.example.com/.well-known/oauth-authorization-server/tenant1');
+            expect(calls[1]![0].toString()).toBe('https://auth.example.com/.well-known/openid-configuration/tenant1');
+        });
+
         it('continues on 502 and tries next URL', async () => {
             // First URL (OAuth) returns 502 (reverse proxy with no route)
             mockFetch.mockResolvedValueOnce({


### PR DESCRIPTION
## Summary
- continue authorization server discovery when a 200 OK metadata response is not JSON
- keep the existing 4xx/502 fallback behavior and non-502 5xx failure behavior
- add a regression test for falling through from the OAuth metadata URL to the OIDC metadata URL

Fixes #2126

## To verify
- pnpm --filter @modelcontextprotocol/client test -- test/client/auth.test.ts
- pnpm --filter @modelcontextprotocol/client typecheck
- pnpm --filter @modelcontextprotocol/client lint