### PR TITLE
[SEP-2575][SEP-2567] 2026-06 stateless support: stdio + InMemory transports

### DIFF
--- a/.changeset/stateless-pipe-transports.md
+++ b/.changeset/stateless-pipe-transports.md
@@ -1,0 +1,6 @@
+---
+'@modelcontextprotocol/core': minor
+'@modelcontextprotocol/server': minor
+'@modelcontextprotocol/client': minor
+---
+2026-06 stateless support over stdio + InMemory transports (StreamDriver, serverStatelessRouter).

--- a/packages/client/src/client/stdio.ts
+++ b/packages/client/src/client/stdio.ts
@@ -107,8 +107,8 @@ export class StdioClientTransport implements Transport {
      * Sends one request and returns the server's messages for it. Backed by
      * `StreamDriver`; bypasses `Protocol.request()`.
      */
-    sendAndReceive(request: Omit<JSONRPCRequest, 'jsonrpc' | 'id'>): AsyncIterable<JSONRPCMessage> {
-        return this._driver.sendAndReceive(request);
+    sendAndReceive(request: Omit<JSONRPCRequest, 'jsonrpc' | 'id'>, opts?: { signal?: AbortSignal }): AsyncIterable<JSONRPCMessage> {
+        return this._driver.sendAndReceive(request, opts);
     }
 
     setProtocolVersion(version: string): void {

--- a/packages/client/src/client/stdio.ts
+++ b/packages/client/src/client/stdio.ts
@@ -3,8 +3,8 @@ import process from 'node:process';
 import type { Stream } from 'node:stream';
 import { PassThrough } from 'node:stream';
 
-import type { JSONRPCMessage, Transport } from '@modelcontextprotocol/core';
-import { ReadBuffer, SdkError, SdkErrorCode, serializeMessage } from '@modelcontextprotocol/core';
+import type { JSONRPCMessage, JSONRPCRequest, Transport } from '@modelcontextprotocol/core';
+import { isStatelessProtocolVersion, ReadBuffer, SdkError, SdkErrorCode, serializeMessage, StreamDriver } from '@modelcontextprotocol/core';
 import spawn from 'cross-spawn';
 
 export type StdioServerParameters = {
@@ -95,10 +95,25 @@ export class StdioClientTransport implements Transport {
     private _readBuffer: ReadBuffer = new ReadBuffer();
     private _serverParams: StdioServerParameters;
     private _stderrStream: PassThrough | null = null;
+    private _protocolVersion?: string;
+    /* eslint-disable-next-line unicorn/consistent-function-scoping */
+    private readonly _driver = new StreamDriver(m => this.send(m));
 
     onclose?: () => void;
     onerror?: (error: Error) => void;
     onmessage?: (message: JSONRPCMessage) => void;
+
+    /**
+     * Sends one request and returns the server's messages for it. Backed by
+     * `StreamDriver`; bypasses `Protocol.request()`.
+     */
+    sendAndReceive(request: Omit<JSONRPCRequest, 'jsonrpc' | 'id'>): AsyncIterable<JSONRPCMessage> {
+        return this._driver.sendAndReceive(request);
+    }
+
+    setProtocolVersion(version: string): void {
+        this._protocolVersion = version;
+    }
 
     constructor(server: StdioServerParameters) {
         this._serverParams = server;
@@ -195,6 +210,16 @@ export class StdioClientTransport implements Transport {
                     break;
                 }
 
+                // Default to StreamDriver until setProtocolVersion is called with
+                // a pre-2026 version. The discover/initialize probe goes via
+                // sendAndReceive, so the driver claims those.
+                if (
+                    (this._protocolVersion === undefined || isStatelessProtocolVersion(this._protocolVersion)) &&
+                    this._driver.onMessage(message)
+                ) {
+                    continue;
+                }
+
                 this.onmessage?.(message);
             } catch (error) {
                 this.onerror?.(error as Error);
@@ -203,6 +228,7 @@ export class StdioClientTransport implements Transport {
     }
 
     async close(): Promise<void> {
+        this._driver.close();
         if (this._process) {
             const processToClose = this._process;
             this._process = undefined;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,6 +7,7 @@ export * from './shared/metadataUtils.js';
 export * from './shared/protocol.js';
 export * from './shared/stateless.js';
 export * from './shared/stdio.js';
+export * from './shared/streamDriver.js';
 export * from './shared/toolNameValidation.js';
 export * from './shared/transport.js';
 export * from './shared/uriTemplate.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,6 +5,7 @@ export * from './shared/authUtils.js';
 export * from './shared/dispatcher.js';
 export * from './shared/metadataUtils.js';
 export * from './shared/protocol.js';
+export * from './shared/serverStatelessRouter.js';
 export * from './shared/stateless.js';
 export * from './shared/stdio.js';
 export * from './shared/streamDriver.js';

--- a/packages/core/src/shared/serverStatelessRouter.ts
+++ b/packages/core/src/shared/serverStatelessRouter.ts
@@ -1,0 +1,94 @@
+import { ZodError } from 'zod/v4';
+import type { JSONRPCMessage, JSONRPCRequest, RequestId } from '../types/index.js';
+import { isJSONRPCNotification, ProtocolError, ProtocolErrorCode } from '../types/index.js';
+import { errorResponse } from './dispatcher.js';
+import type { ListenContext, StatelessHandlers } from './stateless.js';
+import { isStatelessRequest } from './stateless.js';
+
+/**
+ * Per-message router for pipe-shaped server transports (stdio, in-memory).
+ * Call once per inbound message. Returns `true` if the message was claimed by
+ * the stateless path (so the caller should NOT pass it to legacy `onmessage`).
+ *
+ * Stateless requests are dispatched via {@linkcode StatelessHandlers};
+ * `notifications/cancelled` aborts a tracked in-flight request.
+ */
+export function routeServerStateless(
+    message: JSONRPCMessage,
+    handlers: StatelessHandlers,
+    inflight: Map<RequestId, AbortController>,
+    write: (m: JSONRPCMessage) => void,
+    ctx: ListenContext,
+    onerror?: (e: Error) => void
+): boolean {
+    if (isStatelessRequest(message)) {
+        const ac = new AbortController();
+        inflight.set(message.id, ac);
+        void handleOne(handlers, message, ac, write, ctx)
+            .catch(error => onerror?.(error instanceof Error ? error : new Error(String(error))))
+            .finally(() => inflight.delete(message.id));
+        return true;
+    }
+    if (isJSONRPCNotification(message) && message.method === 'notifications/cancelled') {
+        const requestId = (message.params as { requestId?: RequestId } | undefined)?.requestId;
+        const ac = requestId === undefined ? undefined : inflight.get(requestId);
+        if (ac) {
+            ac.abort();
+            return true;
+        }
+    }
+    return false;
+}
+
+async function handleOne(
+    handlers: StatelessHandlers,
+    req: JSONRPCRequest,
+    ac: AbortController,
+    write: (m: JSONRPCMessage) => void,
+    ctx: ListenContext
+): Promise<void> {
+    if (req.method === 'subscriptions/listen') {
+        let listenStream;
+        try {
+            listenStream = handlers.listen(req, ctx);
+        } catch (error) {
+            write(listenErrorResponse(req.id, error));
+            return;
+        }
+        const { stream, close } = listenStream;
+        ac.signal.addEventListener('abort', close, { once: true });
+        try {
+            for await (const m of stream) {
+                if (ac.signal.aborted) break;
+                write(m);
+            }
+            // Stream ended without a client-side abort (backend eviction or
+            // natural end). Write a terminal error so StreamDriver's listen
+            // queue closes instead of hanging indefinitely.
+            if (!ac.signal.aborted) {
+                write(errorResponse(req.id, ProtocolErrorCode.InternalError, 'Subscription stream ended'));
+            }
+        } catch (error) {
+            if (!ac.signal.aborted) {
+                write(listenErrorResponse(req.id, error));
+            }
+            throw error;
+        } finally {
+            ac.signal.removeEventListener('abort', close);
+            close();
+        }
+    } else {
+        const response = await handlers.dispatch(req, { signal: ac.signal, authInfo: ctx.authInfo, notify: write });
+        write(response);
+    }
+}
+
+function listenErrorResponse(id: RequestId, error: unknown) {
+    if (error instanceof ProtocolError) {
+        return errorResponse(id, error.code, error.message);
+    }
+    if (error instanceof ZodError) {
+        return errorResponse(id, ProtocolErrorCode.InvalidParams, error.message);
+    }
+    return errorResponse(id, ProtocolErrorCode.InternalError, error instanceof Error ? error.message : 'Subscription failed');
+}

--- a/packages/core/src/shared/streamDriver.ts
+++ b/packages/core/src/shared/streamDriver.ts
@@ -1,0 +1,132 @@
+import { isJSONRPCNotification, isJSONRPCResponse } from '../types/guards.js';
+import type { JSONRPCMessage, JSONRPCRequest, RequestId } from '../types/index.js';
+import { JSONRPC_VERSION, ProtocolErrorCode } from '../types/index.js';
+import { AsyncQueue } from '../util/asyncQueue.js';
+import { META_KEYS } from './stateless.js';
+
+/**
+ * Minimal request→response correlator for pipe-shaped client transports
+ * (stdio, in-memory) under the 2026-06 stateless model. Provides
+ * `sendAndReceive(request) → AsyncIterable<JSONRPCMessage>` so the Client can
+ * make stateless calls without going through `Protocol.request()` and its
+ * `_responseHandlers` map.
+ *
+ * The transport feeds every inbound message to {@linkcode onMessage}; the
+ * driver routes responses by `id` and notifications by `_meta.subscriptionId`
+ * (which is the originating request's id, per SEP-2575) to the matching
+ * iterator. Closing/breaking the iterator sends `notifications/cancelled`.
+ */
+export class StreamDriver {
+    // Seed in a range Protocol's `_requestMessageId` (which starts at 0) will
+    // not reach, so a stdio fallback that mixes a discover-probe (StreamDriver)
+    // with a legacy initialize (Protocol.request) on the same pipe cannot
+    // collide on id 0.
+    private _nextId = 0x40_00_00_00;
+    private readonly _pending = new Map<RequestId, AsyncQueue<JSONRPCMessage>>();
+
+    constructor(private readonly _send: (m: JSONRPCMessage) => Promise<void>) {}
+
+    /**
+     * Sends one request and returns an async-iterable of the messages the server
+     * emits for it: zero or more notifications, then exactly one response (which
+     * ends the iteration). For `subscriptions/listen`, the iteration continues
+     * until `break`/`return()` (which sends `notifications/cancelled`).
+     *
+     * The request is dispatched and registered in `_pending` immediately, before
+     * the first `next()`. Callers MUST consume the iterable (`for await` is
+     * sufficient: it calls `return()` on break/throw); obtaining it and never
+     * iterating leaks the `_pending` entry until {@linkcode close}.
+     */
+    sendAndReceive(request: Omit<JSONRPCRequest, 'jsonrpc' | 'id'>, opts?: { signal?: AbortSignal }): AsyncIterable<JSONRPCMessage> {
+        const id = this._nextId++;
+        const isListen = request.method === 'subscriptions/listen';
+        const queue = new AsyncQueue<JSONRPCMessage>(256);
+
+        const cleanup = () => {
+            this._pending.delete(id);
+            this._pending.delete(String(id));
+            opts?.signal?.removeEventListener('abort', onAbort);
+        };
+        const cancel = () => {
+            if (queue.closed) return;
+            this._send({ jsonrpc: JSONRPC_VERSION, method: 'notifications/cancelled', params: { requestId: id } }).catch(() => {});
+            queue.close();
+            cleanup();
+        };
+        const onAbort = () => cancel();
+        opts?.signal?.addEventListener('abort', onAbort, { once: true });
+
+        this._pending.set(id, queue);
+        // `_meta.subscriptionId` on inbound notifications equals the string form
+        // of the request id (SEP-2575). Register the same queue under that key
+        // so {@linkcode onMessage} can route notifications without a second map.
+        this._pending.set(String(id), queue);
+
+        this._send({ jsonrpc: JSONRPC_VERSION, id, ...request }).catch(error => {
+            // Surface send failure to the iterator instead of hanging forever.
+            queue.push({
+                jsonrpc: JSONRPC_VERSION,
+                id,
+                error: {
+                    code: ProtocolErrorCode.InternalError,
+                    message: `Transport send failed: ${error instanceof Error ? error.message : String(error)}`
+                }
+            });
+            queue.close();
+            cleanup();
+        });
+
+        const inner = queue.iterate();
+        return {
+            [Symbol.asyncIterator]: () => ({
+                async next(): Promise<IteratorResult<JSONRPCMessage>> {
+                    const r = await inner.next();
+                    if (r.done) {
+                        cleanup();
+                    } else if (!isListen && isJSONRPCResponse(r.value)) {
+                        // Non-listen: end after the response.
+                        queue.close();
+                        cleanup();
+                    }
+                    return r;
+                },
+                async return(): Promise<IteratorResult<JSONRPCMessage>> {
+                    cancel();
+                    return { value: undefined, done: true };
+                }
+            })
+        };
+    }
+
+    /**
+     * Feeds one inbound message to the driver. The transport calls this for
+     * every message received while in stateless mode. Returns `true` if the
+     * message was claimed (routed to a pending iterator).
+     */
+    onMessage(m: JSONRPCMessage): boolean {
+        if ('id' in m && m.id !== null && m.id !== undefined) {
+            const q = this._pending.get(m.id);
+            if (q) {
+                q.push(m);
+                return true;
+            }
+        }
+        if (isJSONRPCNotification(m)) {
+            const sid = (m.params?._meta as Record<string, unknown> | undefined)?.[META_KEYS.subscriptionId];
+            if (typeof sid === 'string') {
+                const q = this._pending.get(sid);
+                if (q) {
+                    q.push(m);
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /** Ends every pending iterator (e.g., on transport close). */
+    close(): void {
+        for (const q of this._pending.values()) q.close();
+        this._pending.clear();
+    }
+}

--- a/packages/core/src/util/inMemory.ts
+++ b/packages/core/src/util/inMemory.ts
@@ -1,6 +1,7 @@
 import { SdkError, SdkErrorCode } from '../errors/sdkErrors.js';
+import { StreamDriver } from '../shared/streamDriver.js';
 import type { Transport } from '../shared/transport.js';
-import type { AuthInfo, JSONRPCMessage, RequestId } from '../types/index.js';
+import type { AuthInfo, JSONRPCMessage, JSONRPCRequest, RequestId } from '../types/index.js';
 
 interface QueuedMessage {
     message: JSONRPCMessage;
@@ -18,10 +19,18 @@ export class InMemoryTransport implements Transport {
     private _messageQueue: QueuedMessage[] = [];
     private _closed = false;
 
+    /* eslint-disable-next-line unicorn/consistent-function-scoping */
+    private readonly _driver = new StreamDriver(m => this.send(m));
+
     onclose?: () => void;
     onerror?: (error: Error) => void;
     onmessage?: (message: JSONRPCMessage, extra?: { authInfo?: AuthInfo }) => void;
     sessionId?: string;
+
+    /** Client-side: backed by `StreamDriver`. */
+    sendAndReceive(request: Omit<JSONRPCRequest, 'jsonrpc' | 'id'>): AsyncIterable<JSONRPCMessage> {
+        return this._driver.sendAndReceive(request);
+    }
 
     /**
      * Creates a pair of linked in-memory transports that can communicate with each other. One should be passed to a {@linkcode @modelcontextprotocol/client!client/client.Client | Client} and one to a {@linkcode @modelcontextprotocol/server!server/server.Server | Server}.
@@ -38,13 +47,20 @@ export class InMemoryTransport implements Transport {
         // Process any messages that were queued before start was called
         while (this._messageQueue.length > 0) {
             const queuedMessage = this._messageQueue.shift()!;
-            this.onmessage?.(queuedMessage.message, queuedMessage.extra);
+            this._receive(queuedMessage.message, queuedMessage.extra);
         }
+    }
+
+    /** Receive path: route to the StreamDriver first; fall through to `onmessage` for unclaimed. */
+    private _receive(message: JSONRPCMessage, extra?: { authInfo?: AuthInfo }): void {
+        if (this._driver.onMessage(message)) return;
+        this.onmessage?.(message, extra);
     }
 
     async close(): Promise<void> {
         if (this._closed) return;
         this._closed = true;
+        this._driver.close();
 
         const other = this._otherTransport;
         this._otherTransport = undefined;
@@ -65,7 +81,7 @@ export class InMemoryTransport implements Transport {
         }
 
         if (this._otherTransport.onmessage) {
-            this._otherTransport.onmessage(message, { authInfo: options?.authInfo });
+            this._otherTransport._receive(message, { authInfo: options?.authInfo });
         } else {
             this._otherTransport._messageQueue.push({ message, extra: { authInfo: options?.authInfo } });
         }

--- a/packages/core/src/util/inMemory.ts
+++ b/packages/core/src/util/inMemory.ts
@@ -1,4 +1,6 @@
 import { SdkError, SdkErrorCode } from '../errors/sdkErrors.js';
+import { routeServerStateless } from '../shared/serverStatelessRouter.js';
+import type { StatelessHandlers } from '../shared/stateless.js';
 import { StreamDriver } from '../shared/streamDriver.js';
 import type { Transport } from '../shared/transport.js';
 import type { AuthInfo, JSONRPCMessage, JSONRPCRequest, RequestId } from '../types/index.js';
@@ -19,6 +21,9 @@ export class InMemoryTransport implements Transport {
     private _messageQueue: QueuedMessage[] = [];
     private _closed = false;
 
+    private _statelessHandlers?: StatelessHandlers;
+    private readonly _inflight = new Map<RequestId, AbortController>();
+
     /* eslint-disable-next-line unicorn/consistent-function-scoping */
     private readonly _driver = new StreamDriver(m => this.send(m));
 
@@ -28,8 +33,13 @@ export class InMemoryTransport implements Transport {
     sessionId?: string;
 
     /** Client-side: backed by `StreamDriver`. */
-    sendAndReceive(request: Omit<JSONRPCRequest, 'jsonrpc' | 'id'>): AsyncIterable<JSONRPCMessage> {
-        return this._driver.sendAndReceive(request);
+    sendAndReceive(request: Omit<JSONRPCRequest, 'jsonrpc' | 'id'>, opts?: { signal?: AbortSignal }): AsyncIterable<JSONRPCMessage> {
+        return this._driver.sendAndReceive(request, opts);
+    }
+
+    /** Server-side: installed by `Server.connect()`. */
+    setStatelessHandlers(h: StatelessHandlers): void {
+        this._statelessHandlers = h;
     }
 
     /**
@@ -51,8 +61,28 @@ export class InMemoryTransport implements Transport {
         }
     }
 
-    /** Receive path: route to the StreamDriver first; fall through to `onmessage` for unclaimed. */
+    /**
+     * Receive path. Per-message router (mirrors stdio): server-side stateless
+     * requests go to {@linkcode StatelessHandlers}; client-side
+     * {@linkcode StreamDriver} claims responses for pending iterators; unclaimed
+     * messages fall through to legacy `onmessage`.
+     */
     private _receive(message: JSONRPCMessage, extra?: { authInfo?: AuthInfo }): void {
+        if (
+            this._statelessHandlers &&
+            routeServerStateless(
+                message,
+                this._statelessHandlers,
+                this._inflight,
+                m => {
+                    this.send(m).catch(error => this.onerror?.(error as Error));
+                },
+                { authInfo: extra?.authInfo },
+                e => this.onerror?.(e)
+            )
+        ) {
+            return;
+        }
         if (this._driver.onMessage(message)) return;
         this.onmessage?.(message, extra);
     }
@@ -60,6 +90,8 @@ export class InMemoryTransport implements Transport {
     async close(): Promise<void> {
         if (this._closed) return;
         this._closed = true;
+        for (const ac of this._inflight.values()) ac.abort();
+        this._inflight.clear();
         this._driver.close();
 
         const other = this._otherTransport;

--- a/packages/core/test/shared/streamDriver.test.ts
+++ b/packages/core/test/shared/streamDriver.test.ts
@@ -1,0 +1,145 @@
+import type { JSONRPCMessage } from '../../src/types/index.js';
+import { JSONRPC_VERSION } from '../../src/types/index.js';
+import { META_KEYS } from '../../src/shared/stateless.js';
+import { StreamDriver } from '../../src/shared/streamDriver.js';
+
+async function collect(it: AsyncIterable<JSONRPCMessage>): Promise<JSONRPCMessage[]> {
+    const out: JSONRPCMessage[] = [];
+    for await (const m of it) out.push(m);
+    return out;
+}
+
+describe('StreamDriver', () => {
+    it('sendAndReceive yields the response and ends', async () => {
+        const sent: JSONRPCMessage[] = [];
+        const d = new StreamDriver(async m => {
+            sent.push(m);
+        });
+        const it = d.sendAndReceive({ method: 'tools/list', params: {} });
+        const id = (sent[0] as { id: number }).id;
+        d.onMessage({ jsonrpc: JSONRPC_VERSION, id, result: { tools: [] } });
+        const got = await collect(it);
+        expect(got).toEqual([{ jsonrpc: JSONRPC_VERSION, id, result: { tools: [] } }]);
+    });
+
+    it('routes notifications by _meta.subscriptionId then the response', async () => {
+        const sent: JSONRPCMessage[] = [];
+        const d = new StreamDriver(async m => {
+            sent.push(m);
+        });
+        const it = d.sendAndReceive({ method: 'tools/call', params: { name: 'x' } });
+        const id = (sent[0] as { id: number }).id;
+        // Server stamps `_meta.subscriptionId = String(request.id)` on all
+        // notifications it emits for this request.
+        d.onMessage({
+            jsonrpc: JSONRPC_VERSION,
+            method: 'notifications/progress',
+            params: { progress: 1, _meta: { [META_KEYS.subscriptionId]: String(id) } }
+        });
+        d.onMessage({ jsonrpc: JSONRPC_VERSION, id, result: { content: [] } });
+        const got = await collect(it);
+        expect(got).toHaveLength(2);
+        expect(got[0]).toMatchObject({ method: 'notifications/progress' });
+        expect(got[1]).toMatchObject({ result: { content: [] } });
+    });
+
+    it('routes the listen ack and subsequent events to the listen iterator', async () => {
+        const sent: JSONRPCMessage[] = [];
+        const d = new StreamDriver(async m => {
+            sent.push(m);
+        });
+        const it = d.sendAndReceive({ method: 'subscriptions/listen', params: { notifications: { toolsListChanged: true } } });
+        const id = (sent[0] as { id: number }).id;
+        const sid = String(id);
+        d.onMessage({
+            jsonrpc: JSONRPC_VERSION,
+            method: 'notifications/subscriptions/acknowledged',
+            params: { notifications: { toolsListChanged: true }, _meta: { [META_KEYS.subscriptionId]: sid } }
+        });
+        d.onMessage({
+            jsonrpc: JSONRPC_VERSION,
+            method: 'notifications/tools/list_changed',
+            params: { _meta: { [META_KEYS.subscriptionId]: sid } }
+        });
+        const iter = it[Symbol.asyncIterator]();
+        const first = await iter.next();
+        const second = await iter.next();
+        expect(first.value).toMatchObject({ method: 'notifications/subscriptions/acknowledged' });
+        expect(second.value).toMatchObject({ method: 'notifications/tools/list_changed' });
+        await iter.return?.();
+    });
+
+    it('isolates concurrent requests by id', async () => {
+        const sent: JSONRPCMessage[] = [];
+        const d = new StreamDriver(async m => {
+            sent.push(m);
+        });
+        const a = d.sendAndReceive({ method: 'tools/list', params: {} });
+        const b = d.sendAndReceive({ method: 'prompts/list', params: {} });
+        const idA = (sent[0] as { id: number }).id;
+        const idB = (sent[1] as { id: number }).id;
+        expect(idA).not.toBe(idB);
+        d.onMessage({ jsonrpc: JSONRPC_VERSION, id: idB, result: { prompts: [] } });
+        d.onMessage({ jsonrpc: JSONRPC_VERSION, id: idA, result: { tools: [] } });
+        await expect(collect(a)).resolves.toEqual([{ jsonrpc: JSONRPC_VERSION, id: idA, result: { tools: [] } }]);
+        await expect(collect(b)).resolves.toEqual([{ jsonrpc: JSONRPC_VERSION, id: idB, result: { prompts: [] } }]);
+    });
+
+    it('early break sends notifications/cancelled and clears the pending entry', async () => {
+        const sent: JSONRPCMessage[] = [];
+        const d = new StreamDriver(async m => {
+            sent.push(m);
+        });
+        const it = d.sendAndReceive({ method: 'tools/call', params: { name: 'x' } });
+        const id = (sent[0] as { id: number }).id;
+        const iter = it[Symbol.asyncIterator]();
+        await iter.return?.();
+        expect(sent.at(-1)).toMatchObject({ method: 'notifications/cancelled', params: { requestId: id } });
+        expect(d.onMessage({ jsonrpc: JSONRPC_VERSION, id, result: {} })).toBe(false);
+    });
+
+    it('surfaces send failure to the iterator instead of hanging', async () => {
+        const d = new StreamDriver(async () => {
+            throw new Error('write failed');
+        });
+        const it = d.sendAndReceive({ method: 'tools/list', params: {} });
+        const got = await collect(it);
+        expect(got).toHaveLength(1);
+        expect(got[0]).toMatchObject({ error: { message: expect.stringContaining('write failed') } });
+    });
+
+    it('onMessage returns false for unknown id and unknown subscriptionId', () => {
+        const d = new StreamDriver(async () => {});
+        expect(d.onMessage({ jsonrpc: JSONRPC_VERSION, id: 999, result: {} })).toBe(false);
+        expect(
+            d.onMessage({
+                jsonrpc: JSONRPC_VERSION,
+                method: 'notifications/x',
+                params: { _meta: { [META_KEYS.subscriptionId]: 'nope' } }
+            })
+        ).toBe(false);
+    });
+
+    it('close() ends every pending iterator', async () => {
+        const d = new StreamDriver(async () => {});
+        const a = d.sendAndReceive({ method: 'tools/list', params: {} });
+        const b = d.sendAndReceive({ method: 'prompts/list', params: {} });
+        d.close();
+        await expect(collect(a)).resolves.toEqual([]);
+        await expect(collect(b)).resolves.toEqual([]);
+    });
+
+    it('return() after natural end is a no-op (no second cancelled)', async () => {
+        const sent: JSONRPCMessage[] = [];
+        const d = new StreamDriver(async m => {
+            sent.push(m);
+        });
+        const it = d.sendAndReceive({ method: 'tools/list', params: {} });
+        const id = (sent[0] as { id: number }).id;
+        d.onMessage({ jsonrpc: JSONRPC_VERSION, id, result: {} });
+        await collect(it);
+        const iter = it[Symbol.asyncIterator]();
+        await iter.return?.();
+        expect(sent.filter(m => 'method' in m && m.method === 'notifications/cancelled')).toHaveLength(0);
+    });
+});

--- a/packages/server/src/server/stdio.ts
+++ b/packages/server/src/server/stdio.ts
@@ -1,7 +1,7 @@
 import type { Readable, Writable } from 'node:stream';
 
-import type { JSONRPCMessage, Transport } from '@modelcontextprotocol/core';
-import { ReadBuffer, serializeMessage } from '@modelcontextprotocol/core';
+import type { JSONRPCMessage, RequestId, StatelessHandlers, Transport } from '@modelcontextprotocol/core';
+import { ReadBuffer, routeServerStateless, serializeMessage } from '@modelcontextprotocol/core';
 import { process } from '@modelcontextprotocol/server/_shims';
 
 /**
@@ -21,6 +21,9 @@ export class StdioServerTransport implements Transport {
     private _started = false;
     private _closed = false;
 
+    private _statelessHandlers?: StatelessHandlers;
+    private readonly _inflight = new Map<RequestId, AbortController>();
+
     constructor(
         private _stdin: Readable = process.stdin,
         private _stdout: Writable = process.stdout
@@ -29,6 +32,15 @@ export class StdioServerTransport implements Transport {
     onclose?: () => void;
     onerror?: (error: Error) => void;
     onmessage?: (message: JSONRPCMessage) => void;
+
+    /**
+     * Installed by `Server.connect()`. When present, `processReadBuffer`
+     * routes 2026-06 requests via {@linkcode StatelessHandlers}; everything else
+     * falls through to legacy `onmessage`.
+     */
+    setStatelessHandlers(h: StatelessHandlers): void {
+        this._statelessHandlers = h;
+    }
 
     // Arrow functions to bind `this` properly, while maintaining function identity.
     _ondata = (chunk: Buffer) => {
@@ -69,6 +81,25 @@ export class StdioServerTransport implements Transport {
                     break;
                 }
 
+                // Per-message router. Stateless requests (carrying _meta.protocolVersion
+                // for a 2026-06 version) go to the dispatch/listen handlers; everything
+                // else flows to the legacy onmessage path (Protocol._onrequest).
+                if (
+                    this._statelessHandlers &&
+                    routeServerStateless(
+                        message,
+                        this._statelessHandlers,
+                        this._inflight,
+                        m => {
+                            this.send(m).catch(error => this.onerror?.(error as Error));
+                        },
+                        {},
+                        e => this.onerror?.(e)
+                    )
+                ) {
+                    continue;
+                }
+
                 this.onmessage?.(message);
             } catch (error) {
                 this.onerror?.(error as Error);
@@ -81,6 +112,8 @@ export class StdioServerTransport implements Transport {
             return;
         }
         this._closed = true;
+        for (const ac of this._inflight.values()) ac.abort();
+        this._inflight.clear();
 
         // Remove our event listeners first
         this._stdin.off('data', this._ondata);

--- a/test/integration/test/client/client.test.ts
+++ b/test/integration/test/client/client.test.ts
@@ -1,4 +1,4 @@
-import { Client, getSupportedElicitationModes } from '@modelcontextprotocol/client';
+import { getSupportedElicitationModes } from '@modelcontextprotocol/client';
 import type { Prompt, Resource, Tool, Transport } from '@modelcontextprotocol/core';
 import {
     InMemoryTransport,
@@ -9,6 +9,8 @@ import {
     SUPPORTED_PROTOCOL_VERSIONS
 } from '@modelcontextprotocol/core';
 import { McpServer, Server } from '@modelcontextprotocol/server';
+
+import { LegacyTestClient } from '../__fixtures__/testClient.js';
 
 /***
  * Test: Initialize with Matching Protocol Version
@@ -37,7 +39,7 @@ test('should initialize with matching protocol version', async () => {
         })
     };
 
-    const client = new Client(
+    const client = new LegacyTestClient(
         {
             name: 'test client',
             version: '1.0'
@@ -95,7 +97,7 @@ test('should initialize with supported older protocol version', async () => {
         })
     };
 
-    const client = new Client(
+    const client = new LegacyTestClient(
         {
             name: 'test client',
             version: '1.0'
@@ -144,7 +146,7 @@ test('should restore negotiated protocol version on transport when reconnecting 
         })
     };
 
-    const client = new Client({ name: 'test client', version: '1.0' });
+    const client = new LegacyTestClient({ name: 'test client', version: '1.0' });
     await client.connect(initialTransport);
 
     // Initial handshake should have set the protocol version on the transport
@@ -197,7 +199,7 @@ test('should reject unsupported protocol version', async () => {
         })
     };
 
-    const client = new Client(
+    const client = new LegacyTestClient(
         {
             name: 'test client',
             version: '1.0'
@@ -254,7 +256,7 @@ test('should connect new client to old, supported server version', async () => {
 
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
 
-    const client = new Client(
+    const client = new LegacyTestClient(
         {
             name: 'new client',
             version: '1.0'
@@ -314,7 +316,7 @@ test('should negotiate version when client is old, and newer server supports its
 
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
 
-    const client = new Client(
+    const client = new LegacyTestClient(
         {
             name: 'old client',
             version: '1.0'
@@ -375,7 +377,7 @@ test("should throw when client is old, and server doesn't support its version", 
 
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
 
-    const client = new Client(
+    const client = new LegacyTestClient(
         {
             name: 'old client',
             version: '1.0'
@@ -433,7 +435,7 @@ test('should respect server capabilities', async () => {
 
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
 
-    const client = new Client(
+    const client = new LegacyTestClient(
         {
             name: 'test client',
             version: '1.0'
@@ -507,7 +509,7 @@ test('should return empty lists for missing capabilities by default', async () =
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
 
     // Client with default settings (enforceStrictCapabilities not set)
-    const client = new Client(
+    const client = new LegacyTestClient(
         {
             name: 'test client',
             version: '1.0'
@@ -556,7 +558,7 @@ test('should respect client notification capabilities', async () => {
         }
     );
 
-    const client = new Client(
+    const client = new LegacyTestClient(
         {
             name: 'test client',
             version: '1.0'
@@ -578,7 +580,7 @@ test('should respect client notification capabilities', async () => {
     await expect(client.sendRootsListChanged()).resolves.not.toThrow();
 
     // Create a new client without the roots.listChanged capability
-    const clientWithoutCapability = new Client(
+    const clientWithoutCapability = new LegacyTestClient(
         {
             name: 'test client without capability',
             version: '1.0'
@@ -614,7 +616,7 @@ test('should respect server notification capabilities', async () => {
         }
     );
 
-    const client = new Client(
+    const client = new LegacyTestClient(
         {
             name: 'test client',
             version: '1.0'
@@ -640,7 +642,7 @@ test('should respect server notification capabilities', async () => {
  * Test: Only Allow setRequestHandler for Declared Capabilities
  */
 test('should only allow setRequestHandler for declared capabilities', () => {
-    const client = new Client(
+    const client = new LegacyTestClient(
         {
             name: 'test client',
             version: '1.0'
@@ -671,7 +673,7 @@ test('should only allow setRequestHandler for declared capabilities', () => {
 });
 
 test('should allow setRequestHandler for declared elicitation capability', () => {
-    const client = new Client(
+    const client = new LegacyTestClient(
         {
             name: 'test-client',
             version: '1.0.0'
@@ -723,7 +725,7 @@ test('should accept form-mode elicitation request when client advertises empty e
         }
     );
 
-    const client = new Client(
+    const client = new LegacyTestClient(
         {
             name: 'test client',
             version: '1.0'
@@ -784,7 +786,7 @@ test('should accept form-mode elicitation request when client advertises empty e
 });
 
 test('should reject form-mode elicitation when client only supports URL mode', async () => {
-    const client = new Client(
+    const client = new LegacyTestClient(
         {
             name: 'test-client',
             version: '1.0.0'
@@ -881,7 +883,7 @@ test('should reject missing-mode elicitation when client only supports URL mode'
         }
     );
 
-    const client = new Client(
+    const client = new LegacyTestClient(
         {
             name: 'test client',
             version: '1.0'
@@ -926,7 +928,7 @@ test('should reject missing-mode elicitation when client only supports URL mode'
 });
 
 test('should reject URL-mode elicitation when client only supports form mode', async () => {
-    const client = new Client(
+    const client = new LegacyTestClient(
         {
             name: 'test-client',
             version: '1.0.0'
@@ -1022,7 +1024,7 @@ test('should apply defaults for form-mode elicitation when applyDefaults is enab
         }
     );
 
-    const client = new Client(
+    const client = new LegacyTestClient(
         {
             name: 'test client',
             version: '1.0'
@@ -1098,7 +1100,7 @@ test('should handle client cancelling a request', async () => {
 
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
 
-    const client = new Client(
+    const client = new LegacyTestClient(
         {
             name: 'test client',
             version: '1.0'
@@ -1154,7 +1156,7 @@ test('should handle request timeout', async () => {
 
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
 
-    const client = new Client(
+    const client = new LegacyTestClient(
         {
             name: 'test client',
             version: '1.0'
@@ -1194,7 +1196,7 @@ test('should handle tool list changed notification with auto refresh', async () 
     );
 
     // Configure listChanged handler in constructor
-    const client = new Client(
+    const client = new LegacyTestClient(
         {
             name: 'test-client',
             version: '1.0.0'
@@ -1252,7 +1254,7 @@ test('should handle tool list changed notification with manual refresh', async (
     server.registerTool('initial-tool', {}, async () => ({ content: [] }));
 
     // Configure listChanged handler with manual refresh (autoRefresh: false)
-    const client = new Client(
+    const client = new LegacyTestClient(
         {
             name: 'test-client',
             version: '1.0.0'
@@ -1318,7 +1320,7 @@ test('should handle prompt list changed notification with auto refresh', async (
     );
 
     // Configure listChanged handler in constructor
-    const client = new Client(
+    const client = new LegacyTestClient(
         {
             name: 'test-client',
             version: '1.0.0'
@@ -1373,7 +1375,7 @@ test('should handle resource list changed notification with auto refresh', async
     }));
 
     // Configure listChanged handler in constructor
-    const client = new Client(
+    const client = new LegacyTestClient(
         {
             name: 'test-client',
             version: '1.0.0'
@@ -1442,7 +1444,7 @@ test('should handle multiple list changed handlers configured together', async (
     );
 
     // Configure multiple listChanged handlers in constructor
-    const client = new Client(
+    const client = new LegacyTestClient(
         {
             name: 'test-client',
             version: '1.0.0'
@@ -1518,7 +1520,7 @@ test('should not activate listChanged handler when server does not advertise cap
     }));
 
     // Configure listChanged handler that should NOT be activated
-    const client = new Client(
+    const client = new LegacyTestClient(
         { name: 'test-client', version: '1.0.0' },
         {
             listChanged: {
@@ -1567,7 +1569,7 @@ test('should activate listChanged handler when server advertises capability', as
     }));
 
     // Configure listChanged handler that SHOULD be activated
-    const client = new Client(
+    const client = new LegacyTestClient(
         { name: 'test-client', version: '1.0.0' },
         {
             listChanged: {
@@ -1616,7 +1618,7 @@ test('should not activate any handlers when server has no listChanged capabiliti
     }));
 
     // Configure listChanged handlers for all three types
-    const client = new Client(
+    const client = new LegacyTestClient(
         { name: 'test-client', version: '1.0.0' },
         {
             listChanged: {
@@ -1682,7 +1684,7 @@ test('should handle partial listChanged capability support', async () => {
         prompts: [{ name: 'prompt-1' }]
     }));
 
-    const client = new Client(
+    const client = new LegacyTestClient(
         { name: 'test-client', version: '1.0.0' },
         {
             listChanged: {
@@ -1775,7 +1777,7 @@ describe('outputSchema validation', () => {
             throw new Error('Unknown tool');
         });
 
-        const client = new Client(
+        const client = new LegacyTestClient(
             {
                 name: 'test-client',
                 version: '1.0.0'
@@ -1868,7 +1870,7 @@ describe('outputSchema validation', () => {
             throw new Error('Unknown tool');
         });
 
-        const client = new Client(
+        const client = new LegacyTestClient(
             {
                 name: 'test-client',
                 version: '1.0.0'
@@ -1958,7 +1960,7 @@ describe('outputSchema validation', () => {
             throw new Error('Unknown tool');
         });
 
-        const client = new Client(
+        const client = new LegacyTestClient(
             {
                 name: 'test-client',
                 version: '1.0.0'
@@ -2044,7 +2046,7 @@ describe('outputSchema validation', () => {
             throw new Error('Unknown tool');
         });
 
-        const client = new Client(
+        const client = new LegacyTestClient(
             {
                 name: 'test-client',
                 version: '1.0.0'
@@ -2157,7 +2159,7 @@ describe('outputSchema validation', () => {
             throw new Error('Unknown tool');
         });
 
-        const client = new Client(
+        const client = new LegacyTestClient(
             {
                 name: 'test-client',
                 version: '1.0.0'
@@ -2255,7 +2257,7 @@ describe('outputSchema validation', () => {
             throw new Error('Unknown tool');
         });
 
-        const client = new Client(
+        const client = new LegacyTestClient(
             {
                 name: 'test-client',
                 version: '1.0.0'
@@ -2335,7 +2337,7 @@ describe('Client sampling validation with tools', () => {
     test('should validate array content with tool_use when request includes tools', async () => {
         const server = new Server({ name: 'test server', version: '1.0' }, { capabilities: {} });
 
-        const client = new Client({ name: 'test client', version: '1.0' }, { capabilities: { sampling: { tools: {} } } });
+        const client = new LegacyTestClient({ name: 'test client', version: '1.0' }, { capabilities: { sampling: { tools: {} } } });
 
         // Handler returns array content with tool_use - should validate with CreateMessageResultWithToolsSchema
         client.setRequestHandler('sampling/createMessage', async () => ({
@@ -2362,7 +2364,7 @@ describe('Client sampling validation with tools', () => {
     test('should validate single content when request includes tools', async () => {
         const server = new Server({ name: 'test server', version: '1.0' }, { capabilities: {} });
 
-        const client = new Client({ name: 'test client', version: '1.0' }, { capabilities: { sampling: { tools: {} } } });
+        const client = new LegacyTestClient({ name: 'test client', version: '1.0' }, { capabilities: { sampling: { tools: {} } } });
 
         // Handler returns single content (text) - should still validate with CreateMessageResultWithToolsSchema
         client.setRequestHandler('sampling/createMessage', async () => ({
@@ -2386,7 +2388,7 @@ describe('Client sampling validation with tools', () => {
     test('should validate single content when request has no tools', async () => {
         const server = new Server({ name: 'test server', version: '1.0' }, { capabilities: {} });
 
-        const client = new Client({ name: 'test client', version: '1.0' }, { capabilities: { sampling: {} } });
+        const client = new LegacyTestClient({ name: 'test client', version: '1.0' }, { capabilities: { sampling: {} } });
 
         // Handler returns single content - should validate with CreateMessageResultSchema
         client.setRequestHandler('sampling/createMessage', async () => ({
@@ -2409,7 +2411,7 @@ describe('Client sampling validation with tools', () => {
     test('should reject array content when request has no tools', async () => {
         const server = new Server({ name: 'test server', version: '1.0' }, { capabilities: {} });
 
-        const client = new Client({ name: 'test client', version: '1.0' }, { capabilities: { sampling: {} } });
+        const client = new LegacyTestClient({ name: 'test client', version: '1.0' }, { capabilities: { sampling: {} } });
 
         // Handler returns array content - should fail validation with CreateMessageResultSchema
         client.setRequestHandler('sampling/createMessage', async () => ({
@@ -2432,7 +2434,7 @@ describe('Client sampling validation with tools', () => {
     test('should validate array content when request includes toolChoice', async () => {
         const server = new Server({ name: 'test server', version: '1.0' }, { capabilities: {} });
 
-        const client = new Client({ name: 'test client', version: '1.0' }, { capabilities: { sampling: { tools: {} } } });
+        const client = new LegacyTestClient({ name: 'test client', version: '1.0' }, { capabilities: { sampling: { tools: {} } } });
 
         // Handler returns array content with tool_use
         client.setRequestHandler('sampling/createMessage', async () => ({

--- a/test/integration/test/server.test.ts
+++ b/test/integration/test/server.test.ts
@@ -23,6 +23,8 @@ import type { Request, Response } from 'express';
 import supertest from 'supertest';
 import * as z from 'zod/v4';
 
+import { LegacyTestClient } from './__fixtures__/testClient.js';
+
 describe('Server with standard protocol methods', () => {
     /*
     Test that Server class works with standard protocol method handlers.
@@ -278,7 +280,7 @@ test('should respect client capabilities', async () => {
         }
     );
 
-    const client = new Client(
+    const client = new LegacyTestClient(
         {
             name: 'test client',
             version: '1.0'
@@ -338,7 +340,7 @@ test('should respect client elicitation capabilities', async () => {
         }
     );
 
-    const client = new Client(
+    const client = new LegacyTestClient(
         {
             name: 'test client',
             version: '1.0'
@@ -422,7 +424,7 @@ test('should use elicitInput with mode: "form" by default for backwards compatib
         }
     );
 
-    const client = new Client(
+    const client = new LegacyTestClient(
         {
             name: 'test client',
             version: '1.0'
@@ -499,7 +501,7 @@ test('should throw when elicitInput is called without client form capability', a
         }
     );
 
-    const client = new Client(
+    const client = new LegacyTestClient(
         {
             name: 'test client',
             version: '1.0'
@@ -548,7 +550,7 @@ test('should throw when elicitInput is called without client URL capability', as
         }
     );
 
-    const client = new Client(
+    const client = new LegacyTestClient(
         {
             name: 'test client',
             version: '1.0'
@@ -591,7 +593,7 @@ test('should include form mode when sending elicitation form requests', async ()
         }
     );
 
-    const client = new Client(
+    const client = new LegacyTestClient(
         {
             name: 'test client',
             version: '1.0'
@@ -654,7 +656,7 @@ test('should include url mode when sending elicitation URL requests', async () =
         }
     );
 
-    const client = new Client(
+    const client = new LegacyTestClient(
         {
             name: 'test client',
             version: '1.0'
@@ -710,7 +712,7 @@ test('should reject elicitInput when client response violates requested schema',
         }
     );
 
-    const client = new Client(
+    const client = new LegacyTestClient(
         {
             name: 'test client',
             version: '1.0'
@@ -769,7 +771,7 @@ test('should wrap unexpected validator errors during elicitInput', async () => {
         }
     );
 
-    const client = new Client(
+    const client = new LegacyTestClient(
         {
             name: 'test client',
             version: '1.0'
@@ -818,7 +820,7 @@ test('should forward notification options when using elicitation completion noti
         }
     );
 
-    const client = new Client(
+    const client = new LegacyTestClient(
         {
             name: 'test client',
             version: '1.0'
@@ -865,7 +867,7 @@ test('should create notifier that emits elicitation completion notification', as
         }
     );
 
-    const client = new Client(
+    const client = new LegacyTestClient(
         {
             name: 'test client',
             version: '1.0'
@@ -907,7 +909,7 @@ test('should throw when creating notifier if client lacks URL elicitation suppor
         }
     );
 
-    const client = new Client(
+    const client = new LegacyTestClient(
         {
             name: 'test client',
             version: '1.0'
@@ -946,7 +948,7 @@ test('should apply back-compat form capability injection when client sends empty
         }
     );
 
-    const client = new Client(
+    const client = new LegacyTestClient(
         {
             name: 'test client',
             version: '1.0'
@@ -987,7 +989,7 @@ test('should preserve form capability configuration when client enables applyDef
         }
     );
 
-    const client = new Client(
+    const client = new LegacyTestClient(
         {
             name: 'test client',
             version: '1.0'
@@ -1033,7 +1035,7 @@ test('should validate elicitation response against requested schema', async () =
         }
     );
 
-    const client = new Client(
+    const client = new LegacyTestClient(
         {
             name: 'test client',
             version: '1.0'
@@ -1111,7 +1113,7 @@ test('should reject elicitation response with invalid data', async () => {
         }
     );
 
-    const client = new Client(
+    const client = new LegacyTestClient(
         {
             name: 'test client',
             version: '1.0'
@@ -1181,7 +1183,7 @@ test('should allow elicitation reject and cancel without validation', async () =
         }
     );
 
-    const client = new Client(
+    const client = new LegacyTestClient(
         {
             name: 'test client',
             version: '1.0'
@@ -1310,7 +1312,7 @@ test('should handle server cancelling a request', async () => {
         }
     );
 
-    const client = new Client(
+    const client = new LegacyTestClient(
         {
             name: 'test client',
             version: '1.0'
@@ -1370,7 +1372,7 @@ test('should handle request timeout', async () => {
     );
 
     // Set up client that delays responses
-    const client = new Client(
+    const client = new LegacyTestClient(
         {
             name: 'test client',
             version: '1.0'
@@ -1439,7 +1441,7 @@ test('should respect log level for transport without sessionId', async () => {
         }
     );
 
-    const client = new Client({
+    const client = new LegacyTestClient({
         name: 'test client',
         version: '1.0'
     });
@@ -1489,7 +1491,7 @@ describe('createMessage validation', () => {
     test('should throw when tools are provided without sampling.tools capability', async () => {
         const server = new Server({ name: 'test server', version: '1.0' }, { capabilities: {} });
 
-        const client = new Client(
+        const client = new LegacyTestClient(
             { name: 'test client', version: '1.0' },
             { capabilities: { sampling: {} } } // No tools capability
         );
@@ -1515,7 +1517,7 @@ describe('createMessage validation', () => {
     test('should throw when toolChoice is provided without sampling.tools capability', async () => {
         const server = new Server({ name: 'test server', version: '1.0' }, { capabilities: {} });
 
-        const client = new Client(
+        const client = new LegacyTestClient(
             { name: 'test client', version: '1.0' },
             { capabilities: { sampling: {} } } // No tools capability
         );
@@ -1541,7 +1543,7 @@ describe('createMessage validation', () => {
     test('should throw when tool_result is mixed with other content', async () => {
         const server = new Server({ name: 'test server', version: '1.0' }, { capabilities: {} });
 
-        const client = new Client({ name: 'test client', version: '1.0' }, { capabilities: { sampling: { tools: {} } } });
+        const client = new LegacyTestClient({ name: 'test client', version: '1.0' }, { capabilities: { sampling: { tools: {} } } });
 
         client.setRequestHandler('sampling/createMessage', async () => ({
             model: 'test-model',
@@ -1574,7 +1576,7 @@ describe('createMessage validation', () => {
     test('should throw when tool_result has no matching tool_use in previous message', async () => {
         const server = new Server({ name: 'test server', version: '1.0' }, { capabilities: {} });
 
-        const client = new Client({ name: 'test client', version: '1.0' }, { capabilities: { sampling: { tools: {} } } });
+        const client = new LegacyTestClient({ name: 'test client', version: '1.0' }, { capabilities: { sampling: { tools: {} } } });
 
         client.setRequestHandler('sampling/createMessage', async () => ({
             model: 'test-model',
@@ -1601,7 +1603,7 @@ describe('createMessage validation', () => {
     test('should throw when tool_result IDs do not match tool_use IDs', async () => {
         const server = new Server({ name: 'test server', version: '1.0' }, { capabilities: {} });
 
-        const client = new Client({ name: 'test client', version: '1.0' }, { capabilities: { sampling: { tools: {} } } });
+        const client = new LegacyTestClient({ name: 'test client', version: '1.0' }, { capabilities: { sampling: { tools: {} } } });
 
         client.setRequestHandler('sampling/createMessage', async () => ({
             model: 'test-model',
@@ -1628,7 +1630,7 @@ describe('createMessage validation', () => {
     test('should allow text-only messages with tools (no tool_results)', async () => {
         const server = new Server({ name: 'test server', version: '1.0' }, { capabilities: {} });
 
-        const client = new Client({ name: 'test client', version: '1.0' }, { capabilities: { sampling: { tools: {} } } });
+        const client = new LegacyTestClient({ name: 'test client', version: '1.0' }, { capabilities: { sampling: { tools: {} } } });
 
         client.setRequestHandler('sampling/createMessage', async () => ({
             model: 'test-model',
@@ -1651,7 +1653,7 @@ describe('createMessage validation', () => {
     test('should allow valid matching tool_result/tool_use IDs', async () => {
         const server = new Server({ name: 'test server', version: '1.0' }, { capabilities: {} });
 
-        const client = new Client({ name: 'test client', version: '1.0' }, { capabilities: { sampling: { tools: {} } } });
+        const client = new LegacyTestClient({ name: 'test client', version: '1.0' }, { capabilities: { sampling: { tools: {} } } });
 
         client.setRequestHandler('sampling/createMessage', async () => ({
             model: 'test-model',
@@ -1678,7 +1680,7 @@ describe('createMessage validation', () => {
     test('should throw when user sends text instead of tool_result after tool_use', async () => {
         const server = new Server({ name: 'test server', version: '1.0' }, { capabilities: {} });
 
-        const client = new Client({ name: 'test client', version: '1.0' }, { capabilities: { sampling: { tools: {} } } });
+        const client = new LegacyTestClient({ name: 'test client', version: '1.0' }, { capabilities: { sampling: { tools: {} } } });
 
         client.setRequestHandler('sampling/createMessage', async () => ({
             model: 'test-model',
@@ -1706,7 +1708,7 @@ describe('createMessage validation', () => {
     test('should throw when only some tool_results are provided for parallel tool_use', async () => {
         const server = new Server({ name: 'test server', version: '1.0' }, { capabilities: {} });
 
-        const client = new Client({ name: 'test client', version: '1.0' }, { capabilities: { sampling: { tools: {} } } });
+        const client = new LegacyTestClient({ name: 'test client', version: '1.0' }, { capabilities: { sampling: { tools: {} } } });
 
         client.setRequestHandler('sampling/createMessage', async () => ({
             model: 'test-model',
@@ -1743,7 +1745,7 @@ describe('createMessage validation', () => {
     test('should validate tool_use/tool_result even without tools in current request', async () => {
         const server = new Server({ name: 'test server', version: '1.0' }, { capabilities: {} });
 
-        const client = new Client({ name: 'test client', version: '1.0' }, { capabilities: { sampling: { tools: {} } } });
+        const client = new LegacyTestClient({ name: 'test client', version: '1.0' }, { capabilities: { sampling: { tools: {} } } });
 
         client.setRequestHandler('sampling/createMessage', async () => ({
             model: 'test-model',
@@ -1771,7 +1773,7 @@ describe('createMessage validation', () => {
     test('should allow valid tool_use/tool_result without tools in current request', async () => {
         const server = new Server({ name: 'test server', version: '1.0' }, { capabilities: {} });
 
-        const client = new Client({ name: 'test client', version: '1.0' }, { capabilities: { sampling: { tools: {} } } });
+        const client = new LegacyTestClient({ name: 'test client', version: '1.0' }, { capabilities: { sampling: { tools: {} } } });
 
         client.setRequestHandler('sampling/createMessage', async () => ({
             model: 'test-model',
@@ -1799,7 +1801,7 @@ describe('createMessage validation', () => {
     test('should handle empty messages array', async () => {
         const server = new Server({ name: 'test server', version: '1.0' }, { capabilities: {} });
 
-        const client = new Client({ name: 'test client', version: '1.0' }, { capabilities: { sampling: {} } });
+        const client = new LegacyTestClient({ name: 'test client', version: '1.0' }, { capabilities: { sampling: {} } });
 
         client.setRequestHandler('sampling/createMessage', async () => ({
             model: 'test-model',
@@ -1830,7 +1832,7 @@ describe('createMessage backwards compatibility', () => {
     test('createMessage without tools returns single content (backwards compat)', async () => {
         const server = new Server({ name: 'test server', version: '1.0' }, { capabilities: {} });
 
-        const client = new Client({ name: 'test client', version: '1.0' }, { capabilities: { sampling: {} } });
+        const client = new LegacyTestClient({ name: 'test client', version: '1.0' }, { capabilities: { sampling: {} } });
 
         // Mock client returns single text content
         client.setRequestHandler('sampling/createMessage', async () => ({
@@ -1860,7 +1862,7 @@ describe('createMessage backwards compatibility', () => {
     test('createMessage with tools accepts request and returns result', async () => {
         const server = new Server({ name: 'test server', version: '1.0' }, { capabilities: {} });
 
-        const client = new Client({ name: 'test client', version: '1.0' }, { capabilities: { sampling: { tools: {} } } });
+        const client = new LegacyTestClient({ name: 'test client', version: '1.0' }, { capabilities: { sampling: { tools: {} } } });
 
         // Mock client returns text content (tool_use schema validation is tested in types.test.ts)
         client.setRequestHandler('sampling/createMessage', async () => ({
@@ -1904,7 +1906,7 @@ test('should respect log level for transport with sessionId', async () => {
         }
     );
 
-    const client = new Client({
+    const client = new LegacyTestClient({
         name: 'test client',
         version: '1.0'
     });
@@ -2137,7 +2139,7 @@ describe('Server registerCapabilities with logging', () => {
         const server = new Server({ name: 'test-server', version: '1.0.0' });
         server.registerCapabilities({ logging: {} });
 
-        const client = new Client({ name: 'test-client', version: '1.0.0' });
+        const client = new LegacyTestClient({ name: 'test-client', version: '1.0.0' });
         const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
 
         await server.connect(serverTransport);
@@ -2153,7 +2155,7 @@ describe('Server registerCapabilities with logging', () => {
     test('logging in constructor capabilities should register logging/setLevel handler', async () => {
         const server = new Server({ name: 'test-server', version: '1.0.0' }, { capabilities: { logging: {} } });
 
-        const client = new Client({ name: 'test-client', version: '1.0.0' });
+        const client = new LegacyTestClient({ name: 'test-client', version: '1.0.0' });
         const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
 
         await server.connect(serverTransport);

--- a/test/integration/test/server/elicitation.test.ts
+++ b/test/integration/test/server/elicitation.test.ts
@@ -7,11 +7,13 @@
  * Per the MCP spec, elicitation only supports object schemas, not primitives.
  */
 
-import { Client } from '@modelcontextprotocol/client';
+import type { Client } from '@modelcontextprotocol/client';
 import type { ElicitRequestFormParams } from '@modelcontextprotocol/core';
 import { AjvJsonSchemaValidator, InMemoryTransport } from '@modelcontextprotocol/core';
 import { CfWorkerJsonSchemaValidator } from '@modelcontextprotocol/core/validators/cfWorker';
 import { Server } from '@modelcontextprotocol/server';
+
+import { LegacyTestClient } from '../__fixtures__/testClient.js';
 
 const ajvProvider = new AjvJsonSchemaValidator();
 const cfWorkerProvider = new CfWorkerJsonSchemaValidator();
@@ -30,7 +32,7 @@ describe('Elicitation Flow', () => {
                 }
             );
 
-            client = new Client({ name: 'test-client', version: '1.0.0' }, { capabilities: { elicitation: {} } });
+            client = new LegacyTestClient({ name: 'test-client', version: '1.0.0' }, { capabilities: { elicitation: {} } });
 
             const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
 
@@ -50,7 +52,7 @@ describe('Elicitation Flow', () => {
                 }
             );
 
-            client = new Client({ name: 'test-client', version: '1.0.0' }, { capabilities: { elicitation: {} } });
+            client = new LegacyTestClient({ name: 'test-client', version: '1.0.0' }, { capabilities: { elicitation: {} } });
 
             const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
 
@@ -472,7 +474,7 @@ function testElicitationFlow(validatorProvider: typeof ajvProvider | typeof cfWo
             }
         );
 
-        const client = new Client(
+        const client = new LegacyTestClient(
             { name: 'test-client', version: '1.0.0' },
             {
                 capabilities: {

--- a/test/integration/test/server/mcp.test.ts
+++ b/test/integration/test/server/mcp.test.ts
@@ -1,9 +1,11 @@
-import { Client } from '@modelcontextprotocol/client';
+import type { Client } from '@modelcontextprotocol/client';
 import type { Notification, TextContent } from '@modelcontextprotocol/core';
 import { getDisplayName, InMemoryTransport, ProtocolErrorCode, UriTemplate, UrlElicitationRequiredError } from '@modelcontextprotocol/core';
 import { completable, McpServer, ResourceTemplate } from '@modelcontextprotocol/server';
 import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 import * as z from 'zod/v4';
+
+import { LegacyTestClient } from '../__fixtures__/testClient.js';
 
 describe('Zod v4', () => {
     describe('McpServer', () => {
@@ -32,7 +34,7 @@ describe('Zod v4', () => {
             );
 
             const notifications: Notification[] = [];
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -76,7 +78,7 @@ describe('Zod v4', () => {
             );
 
             const notifications: Notification[] = [];
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -146,7 +148,7 @@ describe('Zod v4', () => {
                 }
             );
 
-            const client = new Client({ name: 'test client', version: '1.0' }, { capabilities: { elicitation: {} } });
+            const client = new LegacyTestClient({ name: 'test client', version: '1.0' }, { capabilities: { elicitation: {} } });
 
             client.setRequestHandler('elicitation/create', async () => ({
                 action: 'accept',
@@ -196,7 +198,7 @@ describe('Zod v4', () => {
                 }
             );
 
-            const client = new Client({ name: 'test client', version: '1.0' }, { capabilities: { sampling: {} } });
+            const client = new LegacyTestClient({ name: 'test client', version: '1.0' }, { capabilities: { sampling: {} } });
 
             client.setRequestHandler('sampling/createMessage', async () => ({
                 model: 'test-model',
@@ -269,7 +271,7 @@ describe('Zod v4', () => {
                 message?: string;
             }> = [];
 
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -324,7 +326,7 @@ describe('Zod v4', () => {
                 name: 'test server',
                 version: '1.0'
             });
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -348,7 +350,7 @@ describe('Zod v4', () => {
                 name: 'test server',
                 version: '1.0'
             });
-            const client = new Client(
+            const client = new LegacyTestClient(
                 {
                     name: 'test client',
                     version: '1.0'
@@ -434,7 +436,7 @@ describe('Zod v4', () => {
                 version: '1.0'
             });
             const notifications: Notification[] = [];
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -498,7 +500,7 @@ describe('Zod v4', () => {
                 version: '1.0'
             });
             const notifications: Notification[] = [];
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -560,7 +562,7 @@ describe('Zod v4', () => {
                 version: '1.0'
             });
             const notifications: Notification[] = [];
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -650,7 +652,7 @@ describe('Zod v4', () => {
                 version: '1.0'
             });
             const notifications: Notification[] = [];
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -733,7 +735,7 @@ describe('Zod v4', () => {
                 version: '1.0'
             });
             const notifications: Notification[] = [];
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -794,7 +796,7 @@ describe('Zod v4', () => {
                 name: 'test server',
                 version: '1.0'
             });
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -815,7 +817,7 @@ describe('Zod v4', () => {
          */
         test('should respect tools.listChanged: false when explicitly set', async () => {
             const mcpServer = new McpServer({ name: 'test server', version: '1.0' }, { capabilities: { tools: { listChanged: false } } });
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -839,7 +841,7 @@ describe('Zod v4', () => {
                 { name: 'test server', version: '1.0' },
                 { capabilities: { resources: { listChanged: false } } }
             );
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -860,7 +862,7 @@ describe('Zod v4', () => {
          */
         test('should respect prompts.listChanged: false when explicitly set', async () => {
             const mcpServer = new McpServer({ name: 'test server', version: '1.0' }, { capabilities: { prompts: { listChanged: false } } });
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -884,7 +886,7 @@ describe('Zod v4', () => {
                 name: 'test server',
                 version: '1.0'
             });
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -926,7 +928,7 @@ describe('Zod v4', () => {
                 name: 'test server',
                 version: '1.0'
             });
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -979,7 +981,7 @@ describe('Zod v4', () => {
                 name: 'test server',
                 version: '1.0'
             });
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -1023,7 +1025,7 @@ describe('Zod v4', () => {
                 name: 'test server',
                 version: '1.0'
             });
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -1065,7 +1067,7 @@ describe('Zod v4', () => {
                 name: 'test server',
                 version: '1.0'
             });
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -1114,7 +1116,7 @@ describe('Zod v4', () => {
                 name: 'test server',
                 version: '1.0'
             });
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -1162,7 +1164,7 @@ describe('Zod v4', () => {
                 name: 'test server',
                 version: '1.0'
             });
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -1266,7 +1268,7 @@ describe('Zod v4', () => {
                 version: '1.0'
             });
 
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -1362,7 +1364,7 @@ describe('Zod v4', () => {
                 version: '1.0'
             });
 
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -1424,7 +1426,7 @@ describe('Zod v4', () => {
                 version: '1.0'
             });
 
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -1483,7 +1485,7 @@ describe('Zod v4', () => {
                 version: '1.0'
             });
 
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -1555,7 +1557,7 @@ describe('Zod v4', () => {
                 version: '1.0'
             });
 
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -1598,7 +1600,7 @@ describe('Zod v4', () => {
                 version: '1.0'
             });
 
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -1651,7 +1653,7 @@ describe('Zod v4', () => {
                 { capabilities: { logging: {} } }
             );
 
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -1698,7 +1700,7 @@ describe('Zod v4', () => {
                 version: '1.0'
             });
 
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -1752,7 +1754,7 @@ describe('Zod v4', () => {
                 version: '1.0'
             });
 
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -1790,7 +1792,7 @@ describe('Zod v4', () => {
                 version: '1.0'
             });
 
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -1830,7 +1832,7 @@ describe('Zod v4', () => {
                 version: '1.0'
             });
 
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -1872,7 +1874,7 @@ describe('Zod v4', () => {
                 version: '1.0'
             });
 
-            const client = new Client(
+            const client = new LegacyTestClient(
                 {
                     name: 'test client',
                     version: '1.0'
@@ -1925,7 +1927,7 @@ describe('Zod v4', () => {
                 name: 'test server',
                 version: '1.0'
             });
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -1969,7 +1971,7 @@ describe('Zod v4', () => {
                 name: 'test server',
                 version: '1.0'
             });
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -2056,7 +2058,7 @@ describe('Zod v4', () => {
                 name: 'test server',
                 version: '1.0'
             });
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -2092,7 +2094,7 @@ describe('Zod v4', () => {
                 version: '1.0'
             });
             const notifications: Notification[] = [];
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -2157,7 +2159,7 @@ describe('Zod v4', () => {
                 version: '1.0'
             });
             const notifications: Notification[] = [];
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -2227,7 +2229,7 @@ describe('Zod v4', () => {
                 version: '1.0'
             });
             const notifications: Notification[] = [];
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -2278,7 +2280,7 @@ describe('Zod v4', () => {
                 version: '1.0'
             });
             const notifications: Notification[] = [];
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -2331,7 +2333,7 @@ describe('Zod v4', () => {
                 version: '1.0'
             });
             const notifications: Notification[] = [];
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -2387,7 +2389,7 @@ describe('Zod v4', () => {
                 name: 'test server',
                 version: '1.0'
             });
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -2441,7 +2443,7 @@ describe('Zod v4', () => {
                 name: 'test server',
                 version: '1.0'
             });
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -2476,7 +2478,7 @@ describe('Zod v4', () => {
                 name: 'test server',
                 version: '1.0'
             });
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -2531,7 +2533,7 @@ describe('Zod v4', () => {
                 name: 'test server',
                 version: '1.0'
             });
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -2671,7 +2673,7 @@ describe('Zod v4', () => {
                 name: 'test server',
                 version: '1.0'
             });
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -2702,7 +2704,7 @@ describe('Zod v4', () => {
                 name: 'test server',
                 version: '1.0'
             });
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -2741,7 +2743,7 @@ describe('Zod v4', () => {
                 name: 'test server',
                 version: '1.0'
             });
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -2782,7 +2784,7 @@ describe('Zod v4', () => {
                 name: 'test server',
                 version: '1.0'
             });
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -2818,7 +2820,7 @@ describe('Zod v4', () => {
                 name: 'test server',
                 version: '1.0'
             });
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -2858,7 +2860,7 @@ describe('Zod v4', () => {
                 version: '1.0'
             });
 
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -2913,7 +2915,7 @@ describe('Zod v4', () => {
                 version: '1.0'
             });
 
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -2968,7 +2970,7 @@ describe('Zod v4', () => {
                 version: '1.0'
             });
 
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -3019,7 +3021,7 @@ describe('Zod v4', () => {
                 name: 'test server',
                 version: '1.0'
             });
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -3057,7 +3059,7 @@ describe('Zod v4', () => {
                 version: '1.0'
             });
             const notifications: Notification[] = [];
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -3131,7 +3133,7 @@ describe('Zod v4', () => {
                 version: '1.0'
             });
             const notifications: Notification[] = [];
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -3229,7 +3231,7 @@ describe('Zod v4', () => {
                 version: '1.0'
             });
             const notifications: Notification[] = [];
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -3286,7 +3288,7 @@ describe('Zod v4', () => {
                 version: '1.0'
             });
             const notifications: Notification[] = [];
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -3355,7 +3357,7 @@ describe('Zod v4', () => {
                 name: 'test server',
                 version: '1.0'
             });
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -3405,7 +3407,7 @@ describe('Zod v4', () => {
                 name: 'test server',
                 version: '1.0'
             });
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -3444,7 +3446,7 @@ describe('Zod v4', () => {
                 version: '1.0'
             });
 
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -3639,7 +3641,7 @@ describe('Zod v4', () => {
                 version: '1.0'
             });
 
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -3681,7 +3683,7 @@ describe('Zod v4', () => {
                 name: 'test server',
                 version: '1.0'
             });
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -3723,7 +3725,7 @@ describe('Zod v4', () => {
                 name: 'test server',
                 version: '1.0'
             });
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -3764,7 +3766,7 @@ describe('Zod v4', () => {
                 version: '1.0'
             });
 
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -3820,7 +3822,7 @@ describe('Zod v4', () => {
                 version: '1.0'
             });
 
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -3876,7 +3878,7 @@ describe('Zod v4', () => {
                 version: '1.0'
             });
 
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -3931,7 +3933,7 @@ describe('Zod v4', () => {
                 name: 'test server',
                 version: '1.0'
             });
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -3998,7 +4000,7 @@ describe('Zod v4', () => {
                 name: 'test server',
                 version: '1.0'
             });
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -4055,7 +4057,7 @@ describe('Zod v4', () => {
                 version: '1.0'
             });
 
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -4099,7 +4101,7 @@ describe('Zod v4', () => {
                 name: 'test server',
                 version: '1.0'
             });
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -4150,7 +4152,7 @@ describe('Zod v4', () => {
                 name: 'test server',
                 version: '1.0'
             });
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -4191,7 +4193,7 @@ describe('Zod v4', () => {
                 name: 'test server',
                 version: '1.0'
             });
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -4328,7 +4330,7 @@ describe('Zod v4', () => {
                 version: '1.0'
             });
 
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -4437,7 +4439,7 @@ describe('Zod v4', () => {
                 version: '1.0'
             });
 
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -4666,7 +4668,7 @@ describe('Zod v4', () => {
             );
 
             // Create client with elicitation capability
-            client = new Client(
+            client = new LegacyTestClient(
                 {
                     name: 'test-client',
                     version: '1.0.0'
@@ -4801,7 +4803,7 @@ describe('Zod v4', () => {
                 version: '1.0.0'
             });
 
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test-client',
                 version: '1.0.0'
             });
@@ -4862,7 +4864,7 @@ describe('Zod v4', () => {
                 version: '1.0.0'
             });
 
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test-client',
                 version: '1.0.0'
             });
@@ -4909,7 +4911,7 @@ describe('Zod v4', () => {
                 version: '1.0.0'
             });
 
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test-client',
                 version: '1.0.0'
             });
@@ -4966,7 +4968,7 @@ describe('Zod v4', () => {
                 version: '1.0.0'
             });
 
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test-client',
                 version: '1.0.0'
             });
@@ -5013,7 +5015,7 @@ describe('Zod v4', () => {
                 version: '1.0.0'
             });
 
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test-client',
                 version: '1.0.0'
             });
@@ -5063,7 +5065,7 @@ describe('Zod v4', () => {
                 version: '1.0.0'
             });
 
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test-client',
                 version: '1.0.0'
             });
@@ -5108,7 +5110,7 @@ describe('Zod v4', () => {
                 version: '1.0.0'
             });
 
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test-client',
                 version: '1.0.0'
             });
@@ -5148,7 +5150,7 @@ describe('Zod v4', () => {
                 version: '1.0.0'
             });
 
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test-client',
                 version: '1.0.0'
             });
@@ -5210,7 +5212,7 @@ describe('Zod v4', () => {
                 name: 'test server',
                 version: '1.0'
             });
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -5246,7 +5248,7 @@ describe('Zod v4', () => {
                 version: '1.0'
             });
             const notifications: Notification[] = [];
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -5323,7 +5325,7 @@ describe('Zod v4', () => {
                 name: 'test server',
                 version: '1.0'
             });
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -5390,7 +5392,7 @@ describe('Zod v4', () => {
                 name: 'test server',
                 version: '1.0'
             });
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -5448,7 +5450,7 @@ describe('Zod v4', () => {
                 name: 'test server',
                 version: '1.0'
             });
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -5585,7 +5587,7 @@ describe('Zod v4', () => {
                 version: '1.0'
             });
 
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -5694,7 +5696,7 @@ describe('Zod v4', () => {
                 version: '1.0'
             });
 
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test client',
                 version: '1.0'
             });
@@ -5924,7 +5926,7 @@ describe('Zod v4', () => {
             );
 
             // Create client with elicitation capability
-            client = new Client(
+            client = new LegacyTestClient(
                 {
                     name: 'test-client',
                     version: '1.0.0'
@@ -6059,7 +6061,7 @@ describe('Zod v4', () => {
                 version: '1.0.0'
             });
 
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test-client',
                 version: '1.0.0'
             });
@@ -6120,7 +6122,7 @@ describe('Zod v4', () => {
                 version: '1.0.0'
             });
 
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test-client',
                 version: '1.0.0'
             });
@@ -6167,7 +6169,7 @@ describe('Zod v4', () => {
                 version: '1.0.0'
             });
 
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test-client',
                 version: '1.0.0'
             });
@@ -6224,7 +6226,7 @@ describe('Zod v4', () => {
                 version: '1.0.0'
             });
 
-            const client = new Client({
+            const client = new LegacyTestClient({
                 name: 'test-client',
                 version: '1.0.0'
             });

--- a/test/integration/test/statelessAcceptance.test.ts
+++ b/test/integration/test/statelessAcceptance.test.ts
@@ -1,8 +1,11 @@
+import { Client } from '@modelcontextprotocol/client';
 import type { JSONRPCNotification } from '@modelcontextprotocol/core';
-import { META_KEYS, ProtocolErrorCode } from '@modelcontextprotocol/core';
+import { InMemoryTransport, isStatelessProtocolVersion, META_KEYS, ProtocolErrorCode } from '@modelcontextprotocol/core';
 import type { StatelessHandlers } from '@modelcontextprotocol/server';
 import { handleHttp, InMemorySubscriptions, McpServer, Server } from '@modelcontextprotocol/server';
 import { describe, expect, test } from 'vitest';
+
+import { LegacyTestClient } from './__fixtures__/testClient.js';
 
 const STATELESS_META = {
     [META_KEYS.protocolVersion]: 'DRAFT-2026-v1',
@@ -225,6 +228,68 @@ describe('handleHttp', () => {
             })
         );
         expect(res.status).toBe(400);
+    });
+});
+
+describe('Client over InMemory (stateless end-to-end)', () => {
+    test('connect auto-probes discover, negotiates stateless, callTool via sendAndReceive', async () => {
+        const [c, s] = InMemoryTransport.createLinkedPair();
+        const server = makeServer();
+        await server.connect(s);
+        const client = new Client({ name: 'c', version: '1' });
+        await client.connect(c);
+        expect(isStatelessProtocolVersion(client.getNegotiatedProtocolVersion()!)).toBe(true);
+        const r = await client.callTool({ name: 'echo', arguments: {} });
+        expect((r.content as { text: string }[])[0]?.text).toBe('ok');
+        await client.close();
+    });
+
+    test('LegacyTestClient negotiates legacy; server-to-client elicitation works', async () => {
+        const [c, s] = InMemoryTransport.createLinkedPair();
+        const server = makeServer();
+        await server.connect(s);
+        const client = new LegacyTestClient({ name: 'c', version: '1' }, { capabilities: { elicitation: {} } });
+        client.setRequestHandler('elicitation/create', async () => ({ action: 'accept', content: {} }));
+        await client.connect(c);
+        expect(isStatelessProtocolVersion(client.getNegotiatedProtocolVersion()!)).toBe(false);
+        const r = await client.callTool({ name: 'elicit', arguments: {} });
+        expect((r.content as { text: string }[])[0]?.text).toBe('accept');
+        await client.close();
+    });
+
+    test('R-2575: subscribe() over InMemory delivers ack and list_changed (stdio-shaped demux)', async () => {
+        const [c, s] = InMemoryTransport.createLinkedPair();
+        const server = makeServer();
+        await server.connect(s);
+        const client = new Client({ name: 'c', version: '1' });
+        await client.connect(c);
+
+        const seen: string[] = [];
+        const sub = client.subscribe({ toolsListChanged: true });
+        const it = sub[Symbol.asyncIterator]();
+        const ack = await it.next();
+        expect((ack.value as JSONRPCNotification).method).toBe('notifications/subscriptions/acknowledged');
+
+        await server.sendToolListChanged();
+        const evt = await it.next();
+        expect((evt.value as JSONRPCNotification).method).toBe('notifications/tools/list_changed');
+        seen.push((evt.value as JSONRPCNotification).method);
+
+        await it.return?.();
+        await client.close();
+        expect(seen).toEqual(['notifications/tools/list_changed']);
+    });
+
+    test('R-2322: MRTR auto-resume — stateless callTool that elicits', async () => {
+        const [c, s] = InMemoryTransport.createLinkedPair();
+        const server = makeServer();
+        await server.connect(s);
+        const client = new Client({ name: 'c', version: '1' }, { capabilities: { elicitation: { form: {} } } });
+        client.setRequestHandler('elicitation/create', async () => ({ action: 'accept', content: {} }));
+        await client.connect(c);
+        const r = await client.callTool({ name: 'elicit', arguments: {} });
+        expect((r.content as { text: string }[])[0]?.text).toBe('accept');
+        await client.close();
     });
 });
 

--- a/test/integration/test/zeroChangeConsumer.test.ts
+++ b/test/integration/test/zeroChangeConsumer.test.ts
@@ -1,0 +1,135 @@
+import { Client } from '@modelcontextprotocol/client';
+import type { CreateMessageResult } from '@modelcontextprotocol/core';
+import { InMemoryTransport, InputRequiredError, SdkError, SdkErrorCode } from '@modelcontextprotocol/core';
+import { McpServer } from '@modelcontextprotocol/server';
+import { describe, expect, it, vi } from 'vitest';
+import * as z from 'zod/v4';
+
+import { LegacyTestClient } from './__fixtures__/testClient.js';
+
+// Mirrors a server whose author wrote nothing version-aware. greet awaits
+// ctx.mcpReq.elicitInput like any 2025-11 server.
+function makeMcpServer() {
+    const mcp = new McpServer({ name: 'scratch', version: '0.0.1' });
+    mcp.registerTool('echo', { inputSchema: z.object({ text: z.string() }) }, async ({ text }) => ({
+        content: [{ type: 'text', text }]
+    }));
+    mcp.registerTool('greet', { inputSchema: z.object({}) }, async (_args, ctx) => {
+        const result = await ctx.mcpReq.elicitInput({
+            message: 'What is your name?',
+            requestedSchema: { type: 'object', properties: { name: { type: 'string' } }, required: ['name'] }
+        });
+        if (result.action !== 'accept' || !result.content?.name) {
+            return { content: [{ type: 'text', text: 'No name provided.' }] };
+        }
+        return { content: [{ type: 'text', text: `hello, ${result.content.name as string}` }] };
+    });
+    return mcp;
+}
+
+function makeClient(ctor: typeof Client) {
+    const client = new ctor({ name: 'cli', version: '0.0.1' }, { capabilities: { elicitation: { form: {} } } });
+    const handler = vi.fn(async () => ({ action: 'accept' as const, content: { name: 'Felix' } }));
+    client.setRequestHandler('elicitation/create', handler);
+    return { client, handler };
+}
+
+describe.each([
+    ['stateless (Client auto-discovers)', Client],
+    ['legacy (LegacyTestClient)', LegacyTestClient]
+] as const)('zero-change consumer over InMemory: %s', (_label, ctor) => {
+    async function setup() {
+        const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+        const mcp = makeMcpServer();
+        const { client, handler } = makeClient(ctor);
+        await mcp.connect(serverTransport);
+        await client.connect(clientTransport);
+        return { client, handler };
+    }
+
+    it('echo works', async () => {
+        const { client } = await setup();
+        const result = await client.callTool({ name: 'echo', arguments: { text: 'hi' } });
+        expect(result.content).toEqual([{ type: 'text', text: 'hi' }]);
+    });
+
+    it('greet: ctx.mcpReq.elicitInput resolves via the registered handler', async () => {
+        const { client, handler } = await setup();
+        const result = await client.callTool({ name: 'greet', arguments: {} });
+        expect(handler).toHaveBeenCalledOnce();
+        expect(result.content).toEqual([{ type: 'text', text: 'hello, Felix' }]);
+    });
+});
+
+describe('MRTR hardening (stateless only)', () => {
+    async function connect(mcp: McpServer, caps: Record<string, unknown>) {
+        const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+        const client = new Client({ name: 'cli', version: '0.0.1' }, { capabilities: caps });
+        await mcp.connect(serverTransport);
+        await client.connect(clientTransport);
+        return client;
+    }
+
+    it('two sequential elicitInput calls converge (accumulate fix)', async () => {
+        const mcp = new McpServer({ name: 's', version: '1' });
+        mcp.registerTool('two', { inputSchema: z.object({}) }, async (_args, ctx) => {
+            const a = await ctx.mcpReq.elicitInput({
+                message: 'a',
+                requestedSchema: { type: 'object', properties: { v: { type: 'string' } }, required: ['v'] }
+            });
+            const b = await ctx.mcpReq.elicitInput({
+                message: 'b',
+                requestedSchema: { type: 'object', properties: { v: { type: 'string' } }, required: ['v'] }
+            });
+            const av = a.action === 'accept' ? a.content?.v : '?';
+            const bv = b.action === 'accept' ? b.content?.v : '?';
+            return { content: [{ type: 'text', text: `${av as string},${bv as string}` }] };
+        });
+        const client = await connect(mcp, { elicitation: { form: {} } });
+        let n = 0;
+        client.setRequestHandler('elicitation/create', async () => ({ action: 'accept' as const, content: { v: `r${n++}` } }));
+        const result = await client.callTool({ name: 'two', arguments: {} });
+        expect(result.content).toEqual([{ type: 'text', text: 'r0,r1' }]);
+    });
+
+    it('client auto-resume throws after max rounds when server never converges', async () => {
+        const mcp = new McpServer({ name: 's', version: '1' });
+        let round = 0;
+        mcp.registerTool('loop', { inputSchema: z.object({}) }, async () => {
+            throw new InputRequiredError({
+                [`k-${round++}`]: {
+                    method: 'elicitation/create',
+                    params: { message: 'x', requestedSchema: { type: 'object', properties: {}, required: [] } }
+                }
+            });
+        });
+        const client = await connect(mcp, { elicitation: { form: {} } });
+        client.setRequestHandler('elicitation/create', async () => ({ action: 'accept', content: {} }));
+        await expect(client.callTool({ name: 'loop', arguments: {} })).rejects.toSatisfy(
+            (e: unknown) => e instanceof SdkError && e.code === SdkErrorCode.RequestTimeout && /MRTR exceeded \d+ rounds/.test(e.message)
+        );
+    });
+
+    it('requestSampling resolves via sampling/createMessage handler (throw-then-cache)', async () => {
+        const mcp = new McpServer({ name: 's', version: '1' });
+        mcp.registerTool('ask', { inputSchema: z.object({}) }, async (_args, ctx) => {
+            const r = await ctx.mcpReq.requestSampling({
+                messages: [{ role: 'user', content: { type: 'text', text: 'hi' } }],
+                maxTokens: 10
+            });
+            return { content: [{ type: 'text', text: (r.content as { text: string }).text }] };
+        });
+        const client = await connect(mcp, { sampling: {} });
+        const handler = vi.fn(
+            async (): Promise<CreateMessageResult> => ({
+                role: 'assistant',
+                content: { type: 'text', text: 'sampled!' },
+                model: 'stub'
+            })
+        );
+        client.setRequestHandler('sampling/createMessage', handler);
+        const result = await client.callTool({ name: 'ask', arguments: {} });
+        expect(handler).toHaveBeenCalledOnce();
+        expect(result.content).toEqual([{ type: 'text', text: 'sampled!' }]);
+    });
+});


### PR DESCRIPTION
> **2026-06 stateless stack** (`v2-stateless` label):
> | # | PR | |
> |---|---|---|
> | 1 | [#2128](https://github.com/modelcontextprotocol/typescript-sdk/pull/2128) | tasks-delete (mechanical) |
> | 2 | [#2129](https://github.com/modelcontextprotocol/typescript-sdk/pull/2129) | schema-sync (mechanical) |
> | 3 | [#2130](https://github.com/modelcontextprotocol/typescript-sdk/pull/2130) | Dispatcher extraction (zero-Δ refactor) |
> | 4 | [#2131](https://github.com/modelcontextprotocol/typescript-sdk/pull/2131) | **HTTP-stateless (the substantive review)** |
> | 5 | [#2132](https://github.com/modelcontextprotocol/typescript-sdk/pull/2132) | stdio/InMemory transports (additive) |
> | 6 | [#2133](https://github.com/modelcontextprotocol/typescript-sdk/pull/2133) | docs + changeset |
> | 7 | [#2134](https://github.com/modelcontextprotocol/typescript-sdk/pull/2134) | LegacyServer/LegacyClient extraction |
>
> ---


Extends 2026-06 stateless support to stdio + InMemory transports. Additive: `StreamDriver` (client-side correlation for pipe transports), `serverStatelessRouter` (server-side per-message router), `sendAndReceive` impls. Migrates 189 connection-model tests to `LegacyTestClient`.


## Motivation and Context
Same SEPs over non-HTTP transports.

## How Has This Been Tested?
`pnpm test:all` (1367). InMemory acceptance scenarios + `zeroChangeConsumer` (same handler under both protocols).

## Breaking Changes
None.

## Types of changes
- [x] New feature

## Checklist
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally