### PR TITLE
fix(core): preserve relatedRequestId 0 in debounce guard

### DIFF
--- a/.changeset/fix-related-request-id-zero-debounce.md
+++ b/.changeset/fix-related-request-id-zero-debounce.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/core': patch
+---
+
+Preserve `relatedRequestId: 0` when deciding whether notifications can be debounced. Request id `0` is valid, so request-associated notifications with that id now bypass debounce like other related notifications.

--- a/packages/core-internal/src/shared/protocol.ts
+++ b/packages/core-internal/src/shared/protocol.ts
@@ -1610,7 +1610,8 @@ export abstract class Protocol<ContextT extends BaseContext> {
         const debouncedMethods = this._options?.debouncedNotificationMethods ?? [];
         // A notification can only be debounced if it's in the list AND it's "simple"
         // (i.e., has no parameters and no related request ID that could be lost).
-        const canDebounce = debouncedMethods.includes(notification.method) && !notification.params && !options?.relatedRequestId;
+        const canDebounce =
+            debouncedMethods.includes(notification.method) && !notification.params && options?.relatedRequestId === undefined;
 
         if (canDebounce) {
             // If a notification of this type is already scheduled, do nothing.

--- a/packages/core-internal/test/shared/protocol.test.ts
+++ b/packages/core-internal/test/shared/protocol.test.ts
@@ -656,6 +656,21 @@ describe('protocol tests', () => {
             expect(sendSpy).toHaveBeenCalledWith(expect.any(Object), { relatedRequestId: 'req-2' });
         });
 
+        it('should NOT debounce a notification that has relatedRequestId 0', async () => {
+            // ARRANGE
+            protocol = new TestProtocolImpl({ debouncedNotificationMethods: ['test/debounced_with_options'] });
+            await protocol.connect(transport);
+
+            // ACT
+            const firstNotification = protocol.notification({ method: 'test/debounced_with_options' }, { relatedRequestId: 0 });
+            const secondNotification = protocol.notification({ method: 'test/debounced_with_options' }, { relatedRequestId: 0 });
+            await Promise.all([firstNotification, secondNotification]);
+
+            // ASSERT
+            expect(sendSpy).toHaveBeenCalledTimes(2);
+            expect(sendSpy).toHaveBeenCalledWith(expect.any(Object), { relatedRequestId: 0 });
+        });
+
         it('should clear pending debounced notifications on connection close', async () => {
             // ARRANGE
             protocol = new TestProtocolImpl({ debouncedNotificationMethods: ['test/debounced'] });


### PR DESCRIPTION
## What changed

- Treat `relatedRequestId` as present unless it is `undefined` when deciding whether a notification can be debounced.
- Add a regression test for two same-tick debounced notifications with `relatedRequestId: 0`.
- Add a patch changeset for `@modelcontextprotocol/core`.

## Why

`0` is a valid MCP/JSON-RPC request id. The previous truthiness check treated `relatedRequestId: 0` as absent, so simple request-associated notifications could be coalesced by the debounce path while non-zero ids were sent immediately.

Fixes #2117.

## Tests

- `pnpm --filter @modelcontextprotocol/core exec vitest run test/shared/protocol.test.ts -t "relatedRequestId 0"` — passes
- `pnpm --filter @modelcontextprotocol/core exec vitest run test/shared/protocol.test.ts` — 151 tests pass
- `pnpm --filter @modelcontextprotocol/core test` — 553 tests pass
- `pnpm --filter @modelcontextprotocol/core typecheck` — passes
- `pnpm --filter @modelcontextprotocol/core lint` — passes
- `pnpm changeset status --since origin/main` — reports `@modelcontextprotocol/core` patch bump

## Compatibility / risk

Small behavior fix only: notifications already associated with non-zero request ids bypass debounce; this makes request id `0` follow the same path. Notifications without a related request id remain debounced as before.
