### PR TITLE
fix: resetTimeoutOnProgress does nothing without onprogress callback

### DIFF
--- a/src/shared/protocol.ts
+++ b/src/shared/protocol.ts
@@ -857,12 +857,6 @@ export abstract class Protocol<SendRequestT extends Request, SendNotificationT e
         const { progressToken, ...params } = notification.params;
         const messageId = Number(progressToken);
 
-        const handler = this._progressHandlers.get(messageId);
-        if (!handler) {
-            this._onerror(new Error(`Received a progress notification for an unknown token: ${JSON.stringify(notification)}`));
-            return;
-        }
-
         const responseHandler = this._responseHandlers.get(messageId);
         const timeoutInfo = this._timeoutInfo.get(messageId);
 
@@ -874,9 +868,19 @@ export abstract class Protocol<SendRequestT extends Request, SendNotificationT e
                 this._responseHandlers.delete(messageId);
                 this._progressHandlers.delete(messageId);
                 this._cleanupTimeout(messageId);
+                const handler = this._progressHandlers.get(messageId);
+                if (handler) {
+                    handler(params);
+                }
                 responseHandler(error as Error);
                 return;
             }
+        }
+
+        const handler = this._progressHandlers.get(messageId);
+        if (!handler) {
+            this._onerror(new Error(`Received a progress notification for an unknown token: ${JSON.stringify(notification)}`));
+            return;
         }
 
         handler(params);


### PR DESCRIPTION
Refs #2076.

There's a setting in the MCP client library that keeps long-running tasks from timing out. By default, requests die after 60 seconds. With this setting turned on, every time the server reports "I'm still working," that 60-second timer resets so the task can continue. But it only works if the client also provides an `onprogress` callback alongside it. If the client passes `resetTimeoutOnProgress: true` without also passing `onprogress`, the progress notifications arrive but are silently dropped and the timer never resets. The option claims to work on its own — it doesn't.

### Why it happens

`_onprogress()` looks up the handler in `_progressHandlers` first, and that map is only populated when `onprogress` is provided (in `request()`). If no handler exists, the method errors and returns before reaching the timeout reset code.

### The fix

Move the timeout reset before the handler lookup. Guard only `handler(params)`.

### After

- `resetTimeoutOnProgress: true` works standalone — no `onprogress` needed
- Existing callers with both options work identically
- Unknown tokens still error after attempted reset
