### PR TITLE
fix: handle cancellation for request id zero

### DIFF
--- a/.changeset/request-id-zero-cancel.md
+++ b/.changeset/request-id-zero-cancel.md
@@ -1,0 +1,5 @@
+---
+"@modelcontextprotocol/core": patch
+---
+
+fix: handle cancellation for request id zero

--- a/packages/core/src/shared/protocol.ts
+++ b/packages/core/src/shared/protocol.ts
@@ -334,11 +334,12 @@ export abstract class Protocol<ContextT extends BaseContext> {
     protected abstract buildContext(ctx: BaseContext, transportInfo?: MessageExtraInfo): ContextT;
 
     private async _oncancel(notification: CancelledNotification): Promise<void> {
-        if (!notification.params.requestId) {
+        const requestId = notification.params.requestId;
+        if (requestId === undefined) {
             return;
         }
         // Handle request cancellation
-        const controller = this._requestHandlerAbortControllers.get(notification.params.requestId);
+        const controller = this._requestHandlerAbortControllers.get(requestId);
         controller?.abort(notification.params.reason);
     }
 

--- a/packages/core/test/shared/protocol.test.ts
+++ b/packages/core/test/shared/protocol.test.ts
@@ -817,6 +817,39 @@ describe('protocol tests', () => {
             // Verify the request was aborted
             expect(wasAborted).toBe(true);
         });
+
+        test('should abort request handler for requestId 0', async () => {
+            await protocol.connect(transport);
+
+            let wasAborted = false;
+            protocol.setRequestHandler('ping', async (_request, ctx) => {
+                await new Promise(resolve => setTimeout(resolve, 100));
+                wasAborted = ctx.mcpReq.signal.aborted;
+                return {};
+            });
+
+            transport.onmessage?.({
+                jsonrpc: '2.0',
+                id: 0,
+                method: 'ping',
+                params: {}
+            });
+
+            await new Promise(resolve => setTimeout(resolve, 10));
+
+            transport.onmessage?.({
+                jsonrpc: '2.0',
+                method: 'notifications/cancelled',
+                params: {
+                    requestId: 0,
+                    reason: 'User cancelled'
+                }
+            });
+
+            await new Promise(resolve => setTimeout(resolve, 150));
+
+            expect(wasAborted).toBe(true);
+        });
     });
 });
 


### PR DESCRIPTION
## Summary

- preserve `requestId: 0` when handling `notifications/cancelled`
- add a regression test that cancels an inbound request whose JSON-RPC id is `0`

Fixes #2115.

## Validation

- `pnpm --filter @modelcontextprotocol/core exec vitest run test/shared/protocol.test.ts -t "notifications/cancelled behavior"`
- `pnpm --filter @modelcontextprotocol/core exec vitest run test/shared/protocol.test.ts`
- `pnpm --filter @modelcontextprotocol/core run typecheck`
- `pnpm --filter @modelcontextprotocol/core run lint`
- pre-push hook: `pnpm -r typecheck`, `pnpm -r build`, `pnpm sync:snippets --check`, `pnpm -r lint`
- `git diff --check`