### PR TITLE
fix: accept null tool call arguments

### DIFF
--- a/.changeset/null-tool-call-arguments.md
+++ b/.changeset/null-tool-call-arguments.md
@@ -1,0 +1,6 @@
+---
+"@modelcontextprotocol/core": patch
+"@modelcontextprotocol/server": patch
+---
+
+Accept `null` tool call arguments as omitted.

--- a/packages/core/src/types/schemas.ts
+++ b/packages/core/src/types/schemas.ts
@@ -1417,7 +1417,11 @@ export const CallToolRequestParamsSchema = TaskAugmentedRequestParamsSchema.exte
     /**
      * Arguments to pass to the tool.
      */
-    arguments: z.record(z.string(), z.unknown()).optional()
+    arguments: z
+        .record(z.string(), z.unknown())
+        .nullable()
+        .transform(args => args ?? undefined)
+        .optional()
 });
 
 /**

--- a/packages/core/test/types.test.ts
+++ b/packages/core/test/types.test.ts
@@ -1,4 +1,5 @@
 import {
+    CallToolRequestSchema,
     CallToolResultSchema,
     ClientCapabilitiesSchema,
     CompleteRequestSchema,
@@ -31,6 +32,25 @@ describe('Types', () => {
         expect(SUPPORTED_PROTOCOL_VERSIONS).toContain('2025-03-26');
         expect(SUPPORTED_PROTOCOL_VERSIONS).toContain('2024-11-05');
         expect(SUPPORTED_PROTOCOL_VERSIONS).toContain('2024-10-07');
+    });
+
+    describe('CallToolRequest', () => {
+        test('should treat null arguments as omitted', () => {
+            const request = {
+                method: 'tools/call',
+                params: {
+                    name: 'echo',
+                    arguments: null
+                }
+            };
+
+            const result = CallToolRequestSchema.safeParse(request);
+
+            expect(result.success).toBe(true);
+            if (result.success) {
+                expect(result.data.params.arguments).toBeUndefined();
+            }
+        });
     });
 
     describe('ResourceLink', () => {

--- a/packages/server/test/server/mcp.compat.test.ts
+++ b/packages/server/test/server/mcp.compat.test.ts
@@ -119,6 +119,49 @@ describe('registerTool/registerPrompt accept raw Zod shape (auto-wrapped)', () =
 
         await server.close();
     });
+
+    it('treats null tools/call arguments as omitted', async () => {
+        const server = new McpServer({ name: 't', version: '1.0.0' });
+
+        let received: unknown;
+        server.registerTool('empty', { inputSchema: {} }, async args => {
+            received = args;
+            return { content: [{ type: 'text' as const, text: 'ok' }] };
+        });
+
+        const [client, srv] = InMemoryTransport.createLinkedPair();
+        await server.connect(srv);
+        await client.start();
+
+        const responses: JSONRPCMessage[] = [];
+        client.onmessage = m => responses.push(m);
+
+        await client.send({
+            jsonrpc: '2.0',
+            id: 1,
+            method: 'initialize',
+            params: {
+                protocolVersion: LATEST_PROTOCOL_VERSION,
+                capabilities: {},
+                clientInfo: { name: 'c', version: '1.0.0' }
+            }
+        } as JSONRPCMessage);
+        await client.send({ jsonrpc: '2.0', method: 'notifications/initialized' } as JSONRPCMessage);
+        await client.send({
+            jsonrpc: '2.0',
+            id: 2,
+            method: 'tools/call',
+            params: { name: 'empty', arguments: null }
+        } as JSONRPCMessage);
+
+        await vi.waitFor(() => expect(responses.some(r => 'id' in r && r.id === 2)).toBe(true));
+
+        expect(received).toEqual({});
+        const result = responses.find(r => 'id' in r && r.id === 2) as { result?: { content: Array<{ text: string }> } };
+        expect(result.result?.content[0]?.text).toBe('ok');
+
+        await server.close();
+    });
 });
 
 describe('InferRawShape', () => {


### PR DESCRIPTION
Fixes #2012.

## Summary
- Accept `null` for `tools/call` `arguments` in the core request schema and normalize it to the same output as omitted arguments.
- Add regression coverage for direct schema parsing and the high-level `McpServer` `tools/call` path.

## Validation
- Ran a targeted Zod runtime check for the updated schema expression: `{ arguments: null }` parses successfully and normalizes to omitted, while non-record values still fail.
- Attempted `corepack pnpm install --frozen-lockfile` and `corepack pnpm install --frozen-lockfile --ignore-scripts`; dependency linking did not complete in this Windows environment, so Vitest could not be run locally.