### PR TITLE
fix(core): treat relatedRequestId 0 as present in debounce guard (closes #2117)

### DIFF
--- a/packages/core/src/shared/protocol.ts
+++ b/packages/core/src/shared/protocol.ts
@@ -1010,7 +1010,10 @@ export abstract class Protocol<ContextT extends BaseContext> {
         // A notification can only be debounced if it's in the list AND it's "simple"
         // (i.e., has no parameters and no related request ID or related task that could be lost).
         const canDebounce =
-            debouncedMethods.includes(notification.method) && !notification.params && !options?.relatedRequestId && !options?.relatedTask;
+            debouncedMethods.includes(notification.method) &&
+            !notification.params &&
+            options?.relatedRequestId == null &&
+            !options?.relatedTask;
 
         if (canDebounce) {
             // If a notification of this type is already scheduled, do nothing.

--- a/packages/core/test/shared/protocol.test.ts
+++ b/packages/core/test/shared/protocol.test.ts
@@ -768,6 +768,22 @@ describe('protocol tests', () => {
             expect(sendSpy).toHaveBeenCalledWith(expect.any(Object), { relatedRequestId: 'req-2' });
         });
 
+        it('should NOT debounce a notification that has relatedRequestId 0 (regression for #2117)', async () => {
+            // ARRANGE: id=0 is a valid JSON-RPC RequestId (and the first id a Protocol uses).
+            // The truthy guard `!options?.relatedRequestId` treated 0 as absent and
+            // incorrectly debounced these related notifications. Pin the fixed behaviour.
+            protocol = new TestProtocolImpl({ debouncedNotificationMethods: ['test/debounced_with_options'] });
+            await protocol.connect(transport);
+
+            // ACT
+            await protocol.notification({ method: 'test/debounced_with_options' }, { relatedRequestId: 0 });
+            await protocol.notification({ method: 'test/debounced_with_options' }, { relatedRequestId: 0 });
+
+            // ASSERT: both calls must reach the transport (no coalescing).
+            expect(sendSpy).toHaveBeenCalledTimes(2);
+            expect(sendSpy).toHaveBeenCalledWith(expect.any(Object), { relatedRequestId: 0 });
+        });
+
         it('should clear pending debounced notifications on connection close', async () => {
             // ARRANGE
             protocol = new TestProtocolImpl({ debouncedNotificationMethods: ['test/debounced'] });


### PR DESCRIPTION
Closes #2117.

The debounce guard in `Protocol.notification()` treated `relatedRequestId: 0`
as absent:

```ts
// packages/core/src/shared/protocol.ts
const canDebounce =
    debouncedMethods.includes(notification.method) &&
    !notification.params &&
    !options?.relatedRequestId &&    // ✇ falsy-check eats 0
    !options?.relatedTask;
```

`0` is a valid JSON-RPC RequestId (and is also the **first** id a `Protocol`
instance uses for requests). The issue author included a standalone repro that
drives `notification()` directly and shows the asymmetry:

| relatedRequestId | debounced? (pre-fix) |
| ---              | ---                  |
| `0`              | **YES (bug)**        |
| `1`              | no                   |
| `"0"`            | no                   |

So two related notifications for request id 0 in the same tick got coalesced
even though related notifications are explicitly supposed to bypass debouncing.

### The fix

One-line change: swap the truthy check for a null check (the same fix pattern
the issue author proposed):

```diff
         const canDebounce =
-            debouncedMethods.includes(notification.method) && !notification.params && !options?.relatedRequestId && !options?.relatedTask;
+            debouncedMethods.includes(notification.method) && !notification.params && options?.relatedRequestId == null && !options?.relatedTask;
```

`== null` catches both `null` and `undefined`, and is the idiom the codebase
already uses when preserving 0 as a valid id (e.g. in parallel patches for
`#2115` / `#2116`).

`relatedTask` is a `RelatedTaskMetadata` object, so a falsy check is still
correct for it.

### Test

Added a regression test `should NOT debounce a notification that has
relatedRequestId 0` immediately after the existing `'req-1' / 'req-2'` test.
It pins that two synchronous calls with `0` each reach the transport (no
coalescing). Without the fix, the test fails (only 1 call reaches the spy).

### Verification

```
cd packages/core && pnpm exec vitest run test/shared/protocol.test.ts
```

-> **151 / 151** tests passing (the new test is in the 151).

### No behavioral regression

The only change is that `relatedRequestId: 0` now correctly bypasses debouncing.
All other values (`1`, `"req-1"`, `undefined`) hit the same code path as before.

---

(This is a clean pick-up of the issue author's root-cause analysis and
proposed fix - all credit to @tylerklose for the diagnosis.)
