### PR TITLE
fix(server): allow application/json-only Accept in JSON response mode (closes #1944)

### DIFF
--- a/packages/server/src/server/streamableHttp.ts
+++ b/packages/server/src/server/streamableHttp.ts
@@ -617,10 +617,21 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
      */
     private async handlePostRequest(req: Request, options?: HandleRequestOptions): Promise<Response> {
         try {
-            // Validate the Accept header
+            // Validate the Accept header.
+            //
+            // When the transport is in pure request/response mode (`enableJsonResponse: true`)
+            // we never open an SSE stream, so we only require `application/json`. In streaming
+            // mode the spec requires the client to accept both content types so the server can
+            // upgrade to SSE.
             const acceptHeader = req.headers.get('accept');
-            // The client MUST include an Accept header, listing both application/json and text/event-stream as supported content types.
-            if (!acceptHeader?.includes('application/json') || !acceptHeader.includes('text/event-stream')) {
+            const acceptsJson = acceptHeader?.includes('application/json') ?? false;
+            const acceptsEventStream = acceptHeader?.includes('text/event-stream') ?? false;
+            if (this._enableJsonResponse) {
+                if (!acceptsJson) {
+                    this.onerror?.(new Error('Not Acceptable: Client must accept application/json'));
+                    return this.createJsonErrorResponse(406, -32_000, 'Not Acceptable: Client must accept application/json');
+                }
+            } else if (!acceptsJson || !acceptsEventStream) {
                 this.onerror?.(new Error('Not Acceptable: Client must accept both application/json and text/event-stream'));
                 return this.createJsonErrorResponse(
                     406,

--- a/packages/server/test/server/streamableHttp.test.ts
+++ b/packages/server/test/server/streamableHttp.test.ts
@@ -559,6 +559,30 @@ describe('Zod v4', () => {
                 id: 'call-1'
             });
         });
+
+        it('should accept application/json-only Accept header in JSON response mode (regression for #1944)', async () => {
+            // The strict Accept check used to require text/event-stream even when
+            // enableJsonResponse: true (i.e. the transport will never open an SSE stream).
+            // After the fix, application/json alone is sufficient.
+            sessionId = await initializeServer();
+            const request = createRequest('POST', TEST_MESSAGES.toolsList, {
+                sessionId,
+                accept: 'application/json'
+            });
+            const response = await transport.handleRequest(request);
+            expect(response.status).toBe(200);
+            expect(response.headers.get('content-type')).toBe('application/json');
+        });
+
+        it('should still reject Accept that does not include application/json (JSON response mode)', async () => {
+            sessionId = await initializeServer();
+            const request = createRequest('POST', TEST_MESSAGES.toolsList, {
+                sessionId,
+                accept: 'text/plain'
+            });
+            const response = await transport.handleRequest(request);
+            expect(response.status).toBe(406);
+        });
     });
 
     describe('HTTPServerTransport - Session Callbacks', () => {


### PR DESCRIPTION
Closes #1944.

### The bug

`StreamableHTTPServerTransport`'s POST handler required both `application/json`
and `text/event-stream` in the client's `Accept` unconditionally - even when
the transport was constructed with `enableJsonResponse: true` and would
never open an SSE stream. That breaks reasonable clients that probe an MCP
server with a plain JSON-RPC Accept header.

### The fix

Branch the Accept-header validation on `_enableJsonResponse`:

```diff
-            // The client MUST include an Accept header, listing both application/json and text/event-stream as supported content types.
-            if (!acceptHeader?.includes('application/json') || !acceptHeader.includes('text/event-stream')) {
-                this.onerror?.(new Error('Not Acceptable: Client must accept both application/json and text/event-stream'));
+            const acceptsJson = acceptHeader?.includes('application/json') ?? false;
+            const acceptsEventStream = acceptHeader?.includes('text/event-stream') ?? false;
+            if (this._enableJsonResponse) {
                 ...
             } else if (!acceptsJson || !acceptsEventStream) {
```

- **JSON response mode** (`enableJsonResponse: true`): require only
  `application/json`. No SSE stream will ever be opened here, so requiring
  `text/event-stream` is purely a compatibility cost.
- **Streaming mode** (default): require both - unchanged behavior, so the
  on-wire contract the spec documents for the SSE-capable path does not regress.
- GET (SSE subscription) is unaffected, it goes through a different codepath.

### Tests

Two new tests inside the existing `HTTPServerTransport - JSON Response Mode`
suite:

1. `should accept application/json-only Accept header in JSON response mode (regression for #1944)`
2. `should still reject Accept that does not include application/json (JSON response mode)`

Existing coverage for the streaming-mode Accept check (lines 297-301,
367-371) was left untouched.

### Verification

```
cd packages/server && pnpm exec vitest run test/server/streamableHttp.test.ts
```

-> **42 / 42** tests pass (prior "40 / 40" + the two new).

You can also run the issue author's repro - the curl that previously returned
406 now returns 200 with the expected `initialize` result.

### Credit

Clean pick-up of the issue author's root-cause analysis and proposed
strategy in #1944.
