### PR TITLE
fix: add @cfworker/json-schema as runtime dependency in client package

### DIFF
--- a/.changeset/sixty-cooks-bathe.md
+++ b/.changeset/sixty-cooks-bathe.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/client': patch
+---
+
+Add @cfworker/json-schema as a runtime dependency to fix ERR_MODULE_NOT_FOUND

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -79,6 +79,7 @@
         "client": "tsx scripts/cli.ts client"
     },
     "dependencies": {
+        "@cfworker/json-schema": "^4.0.3",
         "cross-spawn": "catalog:runtimeClientOnly",
         "eventsource": "catalog:runtimeClientOnly",
         "eventsource-parser": "catalog:runtimeClientOnly",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -492,6 +492,9 @@ importers:
 
   packages/client:
     dependencies:
+      '@cfworker/json-schema':
+        specifier: ^4.0.3
+        version: 4.1.1
       cross-spawn:
         specifier: catalog:runtimeClientOnly
         version: 7.0.6
@@ -511,9 +514,6 @@ importers:
         specifier: catalog:runtimeShared
         version: 4.3.6
     devDependencies:
-      '@cfworker/json-schema':
-        specifier: catalog:runtimeShared
-        version: 4.1.1
       '@eslint/js':
         specifier: catalog:devTools
         version: 9.39.4


### PR DESCRIPTION
Fixes #2143

## Problem
`@modelcontextprotocol/client` imports `@cfworker/json-schema` at runtime 
(via `src/validators/cfWorker.ts`) but does not declare it as a dependency. 
This causes `ERR_MODULE_NOT_FOUND` for users who install the package, since 
npm/pnpm does not automatically install undeclared dependencies.

Manually installing `@cfworker/json-schema` works around the issue, but 
users should not need to do this.

## Fix
Added `@cfworker/json-schema` to the `dependencies` field in 
`packages/client/package.json`.