### PR TITLE
fix: propagate refresh token persistence errors

### DIFF
--- a/.changeset/quiet-hounds-refresh.md
+++ b/.changeset/quiet-hounds-refresh.md
@@ -1,0 +1,5 @@
+---
+"@modelcontextprotocol/client": patch
+---
+
+fix: propagate refresh token persistence errors

--- a/packages/client/src/client/auth.ts
+++ b/packages/client/src/client/auth.ts
@@ -763,9 +763,11 @@ async function authInternal(
 
     // Handle token refresh or new authorization
     if (tokens?.refresh_token) {
+        let newTokens: OAuthTokens | undefined;
+
         try {
             // Attempt to refresh the token
-            const newTokens = await refreshAuthorization(authorizationServerUrl, {
+            newTokens = await refreshAuthorization(authorizationServerUrl, {
                 metadata,
                 clientInformation,
                 refreshToken: tokens.refresh_token,
@@ -773,9 +775,6 @@ async function authInternal(
                 addClientAuthentication: provider.addClientAuthentication,
                 fetchFn
             });
-
-            await provider.saveTokens(newTokens);
-            return 'AUTHORIZED';
         } catch (error) {
             // If this is a ServerError, or an unknown type, log it out and try to continue. Otherwise, escalate so we can fix things and retry.
             if (!(error instanceof OAuthError) || error.code === OAuthErrorCode.ServerError) {
@@ -784,6 +783,11 @@ async function authInternal(
                 // Refresh failed for another reason, re-throw
                 throw error;
             }
+        }
+
+        if (newTokens) {
+            await provider.saveTokens(newTokens);
+            return 'AUTHORIZED';
         }
     }
 

--- a/packages/client/test/client/auth.test.ts
+++ b/packages/client/test/client/auth.test.ts
@@ -2591,6 +2591,74 @@ describe('OAuth Authorization', () => {
             expect(body.get('refresh_token')).toBe('refresh123');
         });
 
+        it('propagates token persistence errors after a successful refresh', async () => {
+            mockFetch.mockImplementation(url => {
+                const urlString = url.toString();
+
+                if (urlString.includes('/.well-known/oauth-protected-resource')) {
+                    return Promise.resolve({
+                        ok: true,
+                        status: 200,
+                        json: async () => ({
+                            resource: 'https://api.example.com/mcp-server',
+                            authorization_servers: ['https://auth.example.com']
+                        })
+                    });
+                } else if (urlString.includes('/.well-known/oauth-authorization-server')) {
+                    return Promise.resolve({
+                        ok: true,
+                        status: 200,
+                        json: async () => ({
+                            issuer: 'https://auth.example.com',
+                            authorization_endpoint: 'https://auth.example.com/authorize',
+                            token_endpoint: 'https://auth.example.com/token',
+                            response_types_supported: ['code'],
+                            code_challenge_methods_supported: ['S256']
+                        })
+                    });
+                } else if (urlString.includes('/token')) {
+                    return Promise.resolve({
+                        ok: true,
+                        status: 200,
+                        json: async () => ({
+                            access_token: 'new-access123',
+                            token_type: 'Bearer',
+                            expires_in: 3600,
+                            refresh_token: 'new-refresh123'
+                        })
+                    });
+                }
+
+                return Promise.resolve({ ok: false, status: 404 });
+            });
+
+            const saveError = new Error('could not persist refreshed tokens');
+            (mockProvider.clientInformation as Mock).mockResolvedValue({
+                client_id: 'test-client',
+                client_secret: 'test-secret'
+            });
+            (mockProvider.tokens as Mock).mockResolvedValue({
+                access_token: 'old-access',
+                refresh_token: 'refresh123'
+            });
+            (mockProvider.saveTokens as Mock).mockRejectedValueOnce(saveError);
+            (mockProvider.redirectToAuthorization as Mock).mockResolvedValue(undefined);
+
+            await expect(
+                auth(mockProvider, {
+                    serverUrl: 'https://api.example.com/mcp-server'
+                })
+            ).rejects.toThrow('could not persist refreshed tokens');
+
+            expect(mockProvider.saveTokens).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    access_token: 'new-access123',
+                    refresh_token: 'new-refresh123'
+                })
+            );
+            expect(mockProvider.redirectToAuthorization).not.toHaveBeenCalled();
+        });
+
         it('skips default PRM resource validation when custom validateResourceURL is provided', async () => {
             const mockValidateResourceURL = vi.fn().mockResolvedValue(undefined);
             const providerWithCustomValidation = {


### PR DESCRIPTION
﻿## Summary

Fixes #2034.

When refresh-token flow succeeds but `provider.saveTokens()` fails, the current `auth()` path catches that persistence error in the same `try` block as `refreshAuthorization()`. That makes the SDK fall through to a fresh authorization redirect even though the authorization server may already have rotated the refresh token.

This separates the refresh request from token persistence. Refresh failures keep the existing fallback behavior, while persistence failures now propagate to the caller so filesystem or storage problems are visible and the client does not silently lose the newly issued tokens.

## To verify

- `pnpm --filter @modelcontextprotocol/client exec vitest run test/client/auth.test.ts -t "propagates token persistence errors"`
- `pnpm --filter @modelcontextprotocol/client exec vitest run test/client/auth.test.ts`
- `pnpm --filter @modelcontextprotocol/client typecheck`
- `pnpm --filter @modelcontextprotocol/client lint`
- `git diff --check`
- pre-push hook: full workspace `typecheck`, `build`, and `lint`
