### PR TITLE
fix(server): replay request-scoped terminal response after closeSSEStream

### DIFF
--- a/packages/middleware/node/test/streamableHttp.test.ts
+++ b/packages/middleware/node/test/streamableHttp.test.ts
@@ -1954,6 +1954,92 @@ describe('Zod v4', () => {
             toolResolve!();
         });
 
+        it('should replay the terminal response after closeSSE and reconnect', async () => {
+            const result = await createTestServer({
+                sessionIdGenerator: () => randomUUID(),
+                eventStore: createEventStore(),
+                retryInterval: 1000
+            });
+            server = result.server;
+            transport = result.transport;
+            baseUrl = result.baseUrl;
+            mcpServer = result.mcpServer;
+
+            // Tool closes its own SSE stream, then produces its final result while the
+            // client is disconnected. The result must be replayable on reconnect.
+            let toolResolve: () => void;
+            const toolCompletePromise = new Promise<void>(resolve => {
+                toolResolve = resolve;
+            });
+
+            mcpServer.registerTool('close-then-finish-tool', { description: 'Closes its stream, then returns a result' }, async ctx => {
+                ctx.http?.closeSSE?.();
+                await toolCompletePromise;
+                return { content: [{ type: 'text', text: 'replayed-result' }] };
+            });
+
+            const initResponse = await sendPostRequest(baseUrl, TEST_MESSAGES.initialize);
+            sessionId = initResponse.headers.get('mcp-session-id') as string;
+            expect(sessionId).toBeDefined();
+
+            const toolCallRequest: JSONRPCMessage = {
+                jsonrpc: '2.0',
+                id: 100,
+                method: 'tools/call',
+                params: { name: 'close-then-finish-tool', arguments: {} }
+            };
+
+            const postResponse = await fetch(baseUrl, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    Accept: 'text/event-stream, application/json',
+                    'mcp-session-id': sessionId,
+                    'mcp-protocol-version': '2025-11-25'
+                },
+                body: JSON.stringify(toolCallRequest)
+            });
+            expect(postResponse.status).toBe(200);
+
+            // Read the priming event and capture its event ID for reconnection.
+            const reader = postResponse.body?.getReader();
+            const primingData = await reader!.read();
+            const primingText = new TextDecoder().decode(primingData.value);
+            const idMatch = primingText.match(/id: ([^\n]+)/);
+            expect(idMatch).toBeTruthy();
+            const primingEventId = idMatch![1]!;
+
+            // The POST SSE stream closes once the tool calls closeSSE.
+            const { done } = await reader!.read();
+            expect(done).toBe(true);
+
+            // Let the tool produce its final result while the client is disconnected.
+            toolResolve!();
+            await new Promise(resolve => setTimeout(resolve, 100));
+
+            // Reconnect with the priming event ID; the terminal response must be replayed.
+            const reconnectResponse = await fetch(baseUrl, {
+                method: 'GET',
+                headers: {
+                    Accept: 'text/event-stream',
+                    'mcp-session-id': sessionId,
+                    'mcp-protocol-version': '2025-11-25',
+                    'last-event-id': primingEventId
+                }
+            });
+            expect(reconnectResponse.status).toBe(200);
+
+            const reconnectReader = reconnectResponse.body?.getReader();
+            const reconnectData = await reconnectReader!.read();
+            const reconnectText = new TextDecoder().decode(reconnectData.value);
+
+            expect(reconnectText).toContain('replayed-result');
+            expect(reconnectText).toContain('"id":100');
+            expect(reconnectText).toContain('id: ');
+
+            await reconnectReader!.cancel();
+        });
+
         it('should provide closeSSEStream callback in ctx when eventStore is configured', async () => {
             const result = await createTestServer({
                 sessionIdGenerator: () => randomUUID(),

--- a/packages/server/src/server/streamableHttp.ts
+++ b/packages/server/src/server/streamableHttp.ts
@@ -985,15 +985,20 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
 
         const stream = this._streamMapping.get(streamId);
 
-        if (!this._enableJsonResponse && stream?.controller && stream?.encoder) {
-            // For SSE responses, generate event ID if event store is provided
+        if (!this._enableJsonResponse) {
+            // For SSE responses, generate event ID if event store is provided.
+            // Store the event even if the stream is currently disconnected (e.g. after
+            // closeSSEStream) so it can be replayed when the client reconnects, mirroring
+            // the standalone SSE stream above.
             let eventId: string | undefined;
 
             if (this._eventStore) {
                 eventId = await this._eventStore.storeEvent(streamId, message);
             }
-            // Write the event to the response stream
-            this.writeSSEEvent(stream.controller, stream.encoder, message, eventId);
+            // Write the event to the response stream only if a controller is attached.
+            if (stream?.controller && stream?.encoder) {
+                this.writeSSEEvent(stream.controller, stream.encoder, message, eventId);
+            }
         }
 
         if (isJSONRPCResultResponse(message) || isJSONRPCErrorResponse(message)) {
@@ -1005,6 +1010,18 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
 
             if (allResponsesReady) {
                 if (!stream) {
+                    // The stream was disconnected (e.g. via closeSSEStream) before the final
+                    // response was produced. When an event store is configured, the response
+                    // has already been persisted above and will be replayed on reconnect, so
+                    // just clean up the request mappings. Without an event store there is no
+                    // way to deliver the response, so surface the error as before.
+                    if (this._eventStore && !this._enableJsonResponse) {
+                        for (const id of relatedIds) {
+                            this._requestResponseMap.delete(id);
+                            this._requestToStreamMapping.delete(id);
+                        }
+                        return;
+                    }
                     throw new Error(`No connection established for request ID: ${String(requestId)}`);
                 }
                 if (this._enableJsonResponse && stream.resolveJson) {


### PR DESCRIPTION
Fixes #2151.

## Problem

`closeSSEStream(requestId)` is meant to support the SEP-1699 flow where the server disconnects a request-scoped POST SSE stream, keeps working, and replays missed events after the client reconnects. On `main` this breaks when the terminal response is produced while the stream is disconnected:

- `closeSSEStream` removes the stream from `_streamMapping` but keeps `_requestToStreamMapping`.
- In `send()`, request-scoped events are only stored inside `if (!this._enableJsonResponse && stream?.controller && stream?.encoder)`, so once the controller is gone the result/error is never written to the event store.
- When all responses for the request are ready and no live stream exists, `send()` throws `No connection established for request ID: ...`.

So the documented "close SSE, reconnect, replay final result" path is not reliable for request-scoped POST SSE streams. The standalone GET SSE path already does the opposite (stores while disconnected, returns without throwing when no controller), so the two paths were asymmetric.

## Fix

Mirror the standalone GET SSE behavior for request-scoped responses:

- store request-scoped events whenever an event store is configured, regardless of whether a controller is currently attached;
- write to the controller only when one is present;
- when all responses are ready but the stream is gone, and an event store can replay the persisted response, clean up the request mappings and return instead of throwing. Without an event store there is no way to deliver the response, so the original error is preserved.

No behavior change when no event store is configured.

## Testing

Added `should replay the terminal response after closeSSE and reconnect` to `packages/middleware/node/test/streamableHttp.test.ts` (the file that previously only asserted the stream closes, not that the result is replayable). It calls `ctx.http?.closeSSE?.()`, completes the tool while disconnected, reconnects with `Last-Event-ID`, and asserts the terminal `tools/call` result is replayed. The test fails on `main` (reconnect never receives the result) and passes with this change.

`pnpm --filter @modelcontextprotocol/server test` (65 passed) and `pnpm --filter @modelcontextprotocol/node test` for the streamableHttp suite (75 passed) are green; typecheck and lint pass.