### PR TITLE
Align Streamable HTTP onclose type with Transport contract

### DIFF
--- a/.changeset/streamable-http-onclose-types.md
+++ b/.changeset/streamable-http-onclose-types.md
@@ -1,0 +1,6 @@
+---
+'@modelcontextprotocol/node': patch
+'@modelcontextprotocol/server': patch
+---
+
+Align Streamable HTTP onclose types with the shared Transport contract.

--- a/packages/middleware/node/src/streamableHttp.ts
+++ b/packages/middleware/node/src/streamableHttp.ts
@@ -100,11 +100,11 @@ export class NodeStreamableHTTPServerTransport implements Transport {
     /**
      * Sets callback for when the transport is closed.
      */
-    set onclose(handler: (() => void) | undefined) {
+    set onclose(handler: Transport['onclose']) {
         this._webStandardTransport.onclose = handler;
     }
 
-    get onclose(): (() => void) | undefined {
+    get onclose(): Transport['onclose'] {
         return this._webStandardTransport.onclose;
     }
 

--- a/packages/middleware/node/test/streamableHttp.typecheck.ts
+++ b/packages/middleware/node/test/streamableHttp.typecheck.ts
@@ -1,0 +1,5 @@
+import type { Transport } from '@modelcontextprotocol/core';
+import { NodeStreamableHTTPServerTransport } from '../src/streamableHttp.js';
+
+const transport: Transport = new NodeStreamableHTTPServerTransport({});
+transport.onclose = undefined;

--- a/packages/server/src/server/streamableHttp.ts
+++ b/packages/server/src/server/streamableHttp.ts
@@ -242,7 +242,7 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
     private _supportedProtocolVersions: string[];
 
     sessionId?: string;
-    onclose?: () => void;
+    onclose?: Transport['onclose'];
     onerror?: (error: Error) => void;
     onmessage?: (message: JSONRPCMessage, extra?: MessageExtraInfo) => void;
 


### PR DESCRIPTION
Summary:\n- Align Streamable HTTP `onclose` declarations with `Transport['onclose']`.\n- Remove redundant `onclose` casts in the Node wrapper transport.\n- Add a typecheck-only fixture covering `NodeStreamableHTTPServerTransport` assignability to `Transport` and `onclose = undefined`.\n\nFixes #2083