### PR TITLE
feat(server): scope challenges for resources, prompts, completions (stacked on #1624)

### DIFF
--- a/.changeset/scope-challenge-primitives.md
+++ b/.changeset/scope-challenge-primitives.md
@@ -1,0 +1,25 @@
+---
+'@modelcontextprotocol/server': minor
+'@modelcontextprotocol/node': minor
+---
+
+Extend OAuth scope challenge support to non-tool primitives.
+
+Building on the tool-side implementation, `resources/read`, `prompts/get`, and
+`completion/complete` now participate in the same pre-execution scope check.
+
+- `registerResource()` accepts `scopes` in its config, supporting static
+  arrays, `ToolScopeConfig`, or a dynamic resolver `(uri, variables) => scopes`
+  for templated resources where the required scope depends on path parameters.
+- `registerPrompt()` accepts `scopes` in its config.
+- `setResourceScopes()`, `setPromptScopes()`, and `setCompletionScopes()` allow
+  decoupled or centralised scope declaration.
+- Completion scopes are an explicit, separate domain with no inheritance from
+  the referenced prompt or resource; pass `'*'` as `argumentName` to apply the
+  same scopes to every argument of a reference.
+
+Internally, the transport's `ScopeResolver` is now operation-aware. It
+receives the full JSON-RPC request and returns a `ScopeResolution` object
+carrying both the scope config and an `operationName` label
+(`tool:foo`, `resource:foo://bar`, `prompt:foo`, `completion:...`).
+`McpServer.connect()` auto-wires a router that dispatches on JSON-RPC method.

--- a/.changeset/scope-challenge-server.md
+++ b/.changeset/scope-challenge-server.md
@@ -1,0 +1,19 @@
+---
+'@modelcontextprotocol/server': minor
+'@modelcontextprotocol/node': minor
+---
+
+Add server-side OAuth scope challenge support (step-up auth) per MCP spec §10.1.
+
+Servers can now declare required OAuth scopes per tool and the Streamable HTTP transport
+automatically returns HTTP 403 with `WWW-Authenticate` headers when a client's token
+lacks sufficient scopes, triggering the client's existing re-authorization flow.
+
+New APIs:
+- `ToolScopeConfig` type for declaring `required` and `accepted` scopes per tool
+- `ScopeChallengeConfig` transport option with `resourceMetadataUrl`
+- `McpServer.registerTool()` accepts a `scopes` option (`string[]` or `ToolScopeConfig`)
+- `McpServer.setToolScopes()` for decoupled/centralized scope declaration
+- `McpServer.getToolScopes()` to query resolved scope config
+- `setScopeResolver()` on both `WebStandardStreamableHTTPServerTransport` and `NodeStreamableHTTPServerTransport`
+- Auto-wiring of scope resolver in `McpServer.connect()`

--- a/.changeset/scope-challenge-server.md
+++ b/.changeset/scope-challenge-server.md
@@ -3,15 +3,22 @@
 '@modelcontextprotocol/node': minor
 ---
 
-Add server-side OAuth scope challenge support (step-up auth) per MCP spec §10.1.
+Add server-side OAuth scope challenge support (step-up auth) per MCP spec §10.1
+and [SEP-2350](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2350).
 
 Servers can now declare required OAuth scopes per tool and the Streamable HTTP transport
 automatically returns HTTP 403 with `WWW-Authenticate` headers when a client's token
 lacks sufficient scopes, triggering the client's existing re-authorization flow.
 
+Per RFC 6750 §3.1 / SEP-2350, the `WWW-Authenticate` `scope` parameter advertises
+only the scopes required for the current operation — clients are expected to
+accumulate scopes across step-up challenges (see #1657). An opt-in
+`scopeChallenge.includeGrantedScopes: true` restores the additive union behavior
+for servers that need to defend against non-accumulating clients.
+
 New APIs:
-- `ToolScopeConfig` type for declaring `required` and `accepted` scopes per tool
-- `ScopeChallengeConfig` transport option with `resourceMetadataUrl`
+- `ToolScopeConfig` type for declaring `required` (AND) and `accepted` (OR / hierarchy) scopes per tool
+- `ScopeChallengeConfig` transport option with `resourceMetadataUrl` and optional `includeGrantedScopes`
 - `McpServer.registerTool()` accepts a `scopes` option (`string[]` or `ToolScopeConfig`)
 - `McpServer.setToolScopes()` for decoupled/centralized scope declaration
 - `McpServer.getToolScopes()` to query resolved scope config

--- a/docs/proposals/scope-challenge-server-sdk.md
+++ b/docs/proposals/scope-challenge-server-sdk.md
@@ -1,0 +1,447 @@
+# Server SDK Support for Scope Challenges (Step-Up Auth)
+
+**Author:** Sam Morrow  
+**Date:** 2026-03-04  
+**Status:** Spike Proposal — for discussion with SDK devs and Tool Scopes Working Group  
+**Relates to:** [TS SDK #1151](https://github.com/modelcontextprotocol/typescript-sdk/issues/1151), [TS SDK #1294](https://github.com/modelcontextprotocol/typescript-sdk/issues/1294), [MCP Spec §10.1 Scope Challenge Handling](https://modelcontextprotocol.io/specification/draft/basic/authorization#scope-challenge-handling)
+
+---
+
+## 1. Problem Statement
+
+Server SDK authors have **no ergonomic way to trigger OAuth scope challenges** during tool execution. The MCP spec ([SEP-835](https://modelcontextprotocol.io/specification/draft/basic/authorization#scope-challenge-handling)) fully defines how servers should return HTTP 403 with `WWW-Authenticate` headers when a client's token lacks required scopes, and how clients should perform step-up authorization. But today:
+
+- **Client-side handling is implemented** — the TypeScript SDK already handles 403 `insufficient_scope` responses, extracts scopes from `WWW-Authenticate`, performs re-authorization, and retries the request (with infinite-loop prevention).
+- **Server-side SDK support is missing** — there is no way to declare required scopes per tool, no way for tool handlers to trigger scope challenges, and no mechanism to convert a tool handler error into an HTTP 403 response.
+- **github/github-mcp-server works around this** by implementing scope challenges entirely in custom HTTP middleware and a bespoke inventory/scopes system *outside* any SDK, parsing raw JSON-RPC to extract tool names and match them against a scope map.
+
+## 2. Current State of the Art
+
+### 2.1 What the Spec Says (§10.1)
+
+When a client makes a request with an access token with insufficient scope:
+- Server responds with **HTTP 403 Forbidden**
+- `WWW-Authenticate: Bearer error="insufficient_scope", scope="required_scope1 required_scope2", resource_metadata="https://.../.well-known/oauth-protected-resource"`
+- Client parses the challenge, re-authorizes with the new scope set, and retries
+
+### 2.2 Client-Side (TypeScript SDK) — ✅ Already Implemented
+
+`packages/client/src/client/streamableHttp.ts` (lines 525-572):
+```typescript
+if (response.status === 403 && this._authProvider) {
+    const { resourceMetadataUrl, scope, error } = extractWWWAuthenticateParams(response);
+    if (error === 'insufficient_scope') {
+        // Prevent infinite loops
+        if (this._lastUpscopingHeader === wwwAuthHeader) {
+            throw new SdkError(SdkErrorCode.ClientHttpForbidden,
+              'Server returned 403 after trying upscoping', ...);
+        }
+        this._scope = scope;
+        this._resourceMetadataUrl = resourceMetadataUrl;
+        this._lastUpscopingHeader = wwwAuthHeader;
+        const result = await auth(this._authProvider,
+          { serverUrl, resourceMetadataUrl, scope, ... });
+        if (result !== 'AUTHORIZED') throw new UnauthorizedError();
+        return this.send(message); // Retry
+    }
+}
+```
+
+Open issues: [#1582](https://github.com/modelcontextprotocol/typescript-sdk/issues/1582) (scope overwrite during progressive auth), [#1618](https://github.com/modelcontextprotocol/typescript-sdk/pull/1618) (fix: accumulate scopes across challenges).
+
+### 2.3 Server-Side (github/github-mcp-server) — Custom Workaround via HTTP Middleware
+
+The GitHub MCP Server implements scope challenges entirely in custom application-level HTTP middleware and a bespoke inventory/scopes package — none of this is part of the Go SDK (`github.com/modelcontextprotocol/go-sdk`). The Go SDK itself has no scope challenge support. File: `pkg/http/middleware/scope_challenge.go`:
+
+```go
+func WithScopeChallenge(oauthCfg *oauth.Config,
+    scopeFetcher scopes.FetcherInterface) func(http.Handler) http.Handler {
+    return func(next http.Handler) http.Handler {
+        fn := func(w http.ResponseWriter, r *http.Request) {
+            // 1. Parse JSON-RPC body to extract tool name
+            // 2. Look up tool's RequiredScopes/AcceptedScopes from global scope map
+            // 3. Fetch user's active scopes from GitHub API
+            // 4. If user lacks required scopes → return HTTP 403 + WWW-Authenticate
+            // 5. Otherwise → next.ServeHTTP(w, r)
+        }
+        return http.HandlerFunc(fn)
+    }
+}
+```
+
+Tools declare scopes at registration time via `RequiredScopes` / `AcceptedScopes` on the github-mcp-server's custom `ServerTool` struct (not part of the Go SDK):
+
+```go
+func NewTool[In, Out any](toolset ToolsetMetadata, tool mcp.Tool,
+    requiredScopes []scopes.Scope, handler ...) ServerTool {
+    st := inventory.NewServerToolWithContextHandler(tool, toolset, handler)
+    st.RequiredScopes = scopes.ToStringSlice(requiredScopes...)
+    st.AcceptedScopes = scopes.ExpandScopes(requiredScopes...)
+    return st
+}
+```
+
+Key design pattern: **scope checking happens at the HTTP layer, BEFORE the JSON-RPC/SSE stream begins**. This is critical because once an HTTP 200 response with an SSE stream is opened, the HTTP status code cannot be changed. Note: all of this machinery is custom to the github-mcp-server application — the Go SDK provides none of it.
+
+### 2.4 Related Spec Proposals
+
+| SEP | Title | Status | Relevance |
+|-----|-------|--------|-----------|
+| [SEP-1488](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1488) | `securitySchemes` in Tool Metadata | Draft | Per-tool `oauth2` scheme with scopes array |
+| [SEP-1489](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1489) | Tool Error Responses for Triggering OAuth Flows | Draft | `_meta.mcp/www_authenticate` in tool results — transport-agnostic alternative (rejected by consensus in favor of HTTP-bound approach) |
+| [SEP-1880](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1880) | Tool-level scope requirements (`authorization.scopes`) | Closed (not planned) | `Tool.authorization.scopes` advisory metadata |
+| [SEP-1881](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1881) | Scope-Filtered Tool Discovery | Draft | Filter `tools/list` by token scopes |
+
+## 3. The Architectural Constraint
+
+The fundamental constraint that shapes this entire design:
+
+> **HTTP status codes are committed BEFORE tool handlers execute.**
+
+In the Streamable HTTP transport, `handlePostRequest()` returns `new Response(readable, { status: 200, headers })` immediately, then fires `onmessage()` callbacks that route through the Protocol layer to tool handlers. By the time a tool handler runs, HTTP 200 is already sent. Any error from the handler becomes a JSON-RPC error response delivered as an SSE event — **not an HTTP 403**.
+
+This means **scope challenges must be evaluated before the SSE stream opens**, at the HTTP middleware/transport layer. This is exactly how github/github-mcp-server does it.
+
+## 4. Proposed Design
+
+### 4.1 Declare scopes at tool registration (co-located)
+
+Add optional scope metadata to `McpServer.registerTool()`:
+
+```typescript
+mcpServer.registerTool(
+  'get_private_repo',
+  {
+    description: 'Get private repository details',
+    inputSchema: { repo: z.string() },
+    scopes: ['repo:read'],  // Simple: just an array of required scopes
+  },
+  async ({ repo }, ctx) => { /* ... */ }
+);
+
+// Or with scope hierarchy support:
+mcpServer.registerTool(
+  'get_repo',
+  {
+    scopes: {
+      required: ['public_repo'],
+      accepted: ['public_repo', 'repo'], // 'repo' implies 'public_repo'
+    },
+  },
+  handler
+);
+```
+
+### 4.2 Declare scopes separately (decoupled)
+
+Scopes don't have to live with tool definitions. `setToolScopes()` lets implementers
+define scopes in one central place — from a config file, a mapping, or dynamically:
+
+```typescript
+// Define all scopes in one place
+const TOOL_SCOPES: Record<string, string[]> = {
+    'get_repo': ['repo:read'],
+    'create_issue': ['repo:write'],
+    'list_orgs': ['read:org'],
+};
+
+for (const [tool, scopes] of Object.entries(TOOL_SCOPES)) {
+    mcpServer.setToolScopes(tool, scopes);
+}
+```
+
+Scopes set via `setToolScopes()` take precedence over any `scopes` provided during
+tool registration. Both approaches can be mixed freely.
+
+### 4.3 Transport configuration
+
+Add a `scopeChallenge` option to `StreamableHTTPServerTransport`. Only one field
+is required — the `resourceMetadataUrl` for the `WWW-Authenticate` header:
+
+```typescript
+const transport = new WebStandardStreamableHTTPServerTransport({
+  sessionIdGenerator: () => randomUUID(),
+  scopeChallenge: {
+    resourceMetadataUrl:
+      'https://mcp.example.com/.well-known/oauth-protected-resource',
+  }
+});
+```
+
+The transport reads the token's active scopes from `AuthInfo.scopes`, which is
+populated by the implementer's own auth middleware. The SDK does not determine what
+scopes are active — that is entirely the implementer's responsibility, just as it is
+the implementer's choice what scopes to require per tool.
+
+### 4.4 Automatic wiring via `connect()`
+
+`McpServer.connect()` automatically wires the scope resolver to the transport:
+
+```typescript
+await mcpServer.connect(transport);
+// That's it — scope challenges are now active.
+```
+
+Under the hood, `connect()` detects if the transport supports `setScopeResolver()`
+and wires `McpServer.getToolScopes()` into it. No manual plumbing needed.
+
+When `scopeChallenge` is configured, the transport:
+1. Before opening the SSE stream, parses the JSON-RPC message to identify `tools/call` requests
+2. Looks up the tool's registered scopes via the auto-wired resolver
+3. Compares against the token's active scopes from `authInfo.scopes`
+4. If insufficient: returns HTTP 403 + `WWW-Authenticate` header **without opening the SSE stream**
+5. If sufficient: proceeds normally
+
+### 4.5 Transport-scoping: stdio and other transports ignore this entirely
+
+The `scopeChallenge` configuration is only available on `StreamableHTTPServerTransport`. The `StdioServerTransport` and any non-HTTP transports have no concept of HTTP status codes and no OAuth flow — scope challenges are meaningless there. This aligns with the MCP spec: "Implementations using an STDIO transport SHOULD NOT follow this specification."
+
+### 4.6 Error response format
+
+The 403 response body matches the protected resource metadata error format:
+
+```
+HTTP/1.1 403 Forbidden
+WWW-Authenticate: Bearer error="insufficient_scope",
+                         scope="repo:read user:profile",
+                         resource_metadata="https://mcp.example.com/...",
+                         error_description="Additional repository read permission required"
+Content-Type: application/json
+
+{
+  "jsonrpc": "2.0",
+  "error": {
+    "code": -32403,
+    "message": "Insufficient scope: required repo:read"
+  },
+  "id": 1
+}
+```
+
+This reuses the existing `createJsonErrorResponse` helper in the transport, which already handles headers and status codes.
+
+## 5. Worked Example: End-to-End Flow
+
+```
+┌─────────┐                        ┌─────────────────┐            ┌──────────┐
+│  Client  │                        │  MCP Server      │            │ Auth Srv │
+└────┬─────┘                        └────────┬─────────┘            └────┬─────┘
+     │                                       │                           │
+     │ POST /mcp  (tools/call: get_repo)     │                           │
+     │ Authorization: Bearer <token_v1>      │                           │
+     ├──────────────────────────────────────►│                           │
+     │                                       │                           │
+     │                     [Transport layer: │                           │
+     │                      parse JSON-RPC,  │                           │
+     │                      find tool scope  │                           │
+     │                      metadata,        │                           │
+     │                      check token      │                           │
+     │                      scopes vs        │                           │
+     │                      required scopes] │                           │
+     │                                       │                           │
+     │ 403 Forbidden                         │                           │
+     │ WWW-Authenticate: Bearer              │                           │
+     │   error="insufficient_scope"          │                           │
+     │   scope="repo:read"                   │                           │
+     │   resource_metadata="https://..."     │                           │
+     │◄──────────────────────────────────────┤                           │
+     │                                       │                           │
+     │ [Client SDK: extract scope,           │                           │
+     │  re-authorize with new scope]         │                           │
+     │                                       │                           │
+     │ Authorization request (scope=repo:read)                           │
+     ├──────────────────────────────────────────────────────────────────►│
+     │                                                                   │
+     │ Access token (scope=repo:read)                                    │
+     │◄──────────────────────────────────────────────────────────────────┤
+     │                                       │                           │
+     │ POST /mcp  (tools/call: get_repo)     │                           │
+     │ Authorization: Bearer <token_v2>      │                           │
+     ├──────────────────────────────────────►│                           │
+     │                                       │                           │
+     │                     [Scope check OK]  │                           │
+     │                                       │                           │
+     │ 200 OK (SSE stream)                   │                           │
+     │ data: {"result": {...}}               │                           │
+     │◄──────────────────────────────────────┤                           │
+```
+
+## 6. Mid-Tool-Call Scope Challenges: The Unsolved Problem
+
+This proposal **explicitly does not attempt** mid-tool-call scope challenges. Here's why, and what the future might look like.
+
+### 6.1 The Problem
+
+Some scope requirements are **dynamic** — they depend on runtime data. Example: calling `get_repo` for a public repo needs no extra scopes, but for a private repo needs `repo:read`. The server only discovers this after making an upstream API call, by which point the HTTP 200 SSE stream is already open.
+
+### 6.2 Why It's Hard
+
+Mid-handler scope challenges would require fundamentally changing how JSON-RPC over HTTP works:
+
+1. **HTTP status is already committed**: The 200+SSE model means we can't retroactively return 403
+2. **JSON-RPC has no concept of "retry with different auth"**: The protocol has no standardized error code for "re-authenticate and retry"
+3. **Multiplexed requests**: A single HTTP POST can contain multiple JSON-RPC requests — one needing a scope challenge doesn't mean all do
+
+### 6.3 Potential Future Approaches
+
+**Option A: Sentinel error in JSON-RPC result (`_meta` approach — SEP-1489)**
+
+```typescript
+// Server returns this as a tool result:
+{
+  "content": [{ "type": "text", "text": "Additional permissions required" }],
+  "isError": true,
+  "_meta": {
+    "mcp/www_authenticate": [
+      "Bearer error=\"insufficient_scope\", scope=\"repo:read\", ..."
+    ]
+  }
+}
+```
+
+Client detects `_meta.mcp/www_authenticate`, triggers OAuth flow, retries. This is **transport-agnostic** but was rejected by consensus in favor of the HTTP-bound approach. It also requires client SDK changes to recognize and act on this `_meta` field.
+
+**Option B: Sentinel error thrown by handler (`ScopeChallengeError`)**
+
+```typescript
+throw new ScopeChallengeError(['repo:read']);
+```
+
+The Protocol layer catches this, and... what? Within an SSE stream, it can only send a JSON-RPC error response. The client SDK would need to recognize this specific error shape and trigger re-auth. This is essentially Option A with extra SDK machinery to translate the thrown error into the right JSON-RPC shape.
+
+**Option C: Breaking change — defer HTTP response**
+
+The transport could buffer requests and not open the SSE stream until the tool handler completes (or explicitly signals success). This would allow the transport to still return 403 for scope challenges. However, this **fundamentally breaks streaming** — the entire point of SSE is to start sending data immediately. This is a major architectural change.
+
+**Option D: Protocol-level step-up negotiation**
+
+A new MCP method like `auth/stepUp` that the server sends as a request to the client (using the bidirectional protocol), carrying the scope challenge information. The client handles it, re-authorizes, and the server retries the upstream call. This is the cleanest approach but requires spec changes and is a significant addition to the protocol.
+
+### 6.4 Recommendation for Mid-Handler Challenges
+
+For now, servers with dynamic scope requirements should:
+1. Use the pre-execution static scope check where possible (covering the common case)
+2. For truly dynamic cases, return a tool error result with a descriptive message that explains what permissions are needed — the LLM/user can then retry after re-authorizing
+3. Future spec work (potentially via the working group) should evaluate Option D (protocol-level step-up) as the cleanest long-term solution
+
+## 7. Implementation (Shipped with This Proposal)
+
+This is not a sketch — working code is included in this PR. Here's what was added:
+
+### 7.1 `ToolScopeConfig` type (`packages/server/src/server/mcp.ts`)
+
+```typescript
+export interface ToolScopeConfig {
+  required: string[];
+  accepted?: string[]; // Defaults to required if not provided
+}
+```
+
+### 7.2 `ScopeChallengeConfig` type (`packages/server/src/server/streamableHttp.ts`)
+
+```typescript
+export interface ScopeChallengeConfig {
+  resourceMetadataUrl: string;
+  buildErrorDescription?: (toolName: string, requiredScopes: string[]) => string;
+}
+```
+
+No `getTokenScopes` callback — the transport reads `authInfo.scopes` directly.
+The implementer populates `authInfo` in their auth middleware; the SDK does not
+determine what scopes are active.
+
+### 7.3 Tool scope registration — two paths
+
+**Co-located** (via `registerTool` config):
+```typescript
+server.registerTool('get_repo', { scopes: ['repo:read'] }, handler);
+```
+
+**Decoupled** (via `setToolScopes`):
+```typescript
+server.setToolScopes('get_repo', ['repo:read']);
+```
+
+`setToolScopes` takes precedence when both are used. Both accept `string[]` (sugar)
+or `{ required, accepted }` (for scope hierarchy).
+
+### 7.4 Auto-wiring in `McpServer.connect()`
+
+```typescript
+async connect(transport: Transport): Promise<void> {
+    if ('setScopeResolver' in transport && typeof transport.setScopeResolver === 'function') {
+        transport.setScopeResolver((toolName: string) => this.getToolScopes(toolName));
+    }
+    return await this.server.connect(transport);
+}
+```
+
+### 7.5 Pre-execution check in transport
+
+The `_checkScopeChallenge()` method runs after message parsing but before the SSE
+stream opens. It only fires for `tools/call` requests where scope metadata exists.
+
+**Additive scoping:** The `scope` value in the `WWW-Authenticate` challenge header
+is always the **union** of the token's existing scopes plus the tool's `required`
+scopes. This ensures the client never loses scopes it already has when
+re-authorizing — a pattern established by github/github-mcp-server and consistent
+with how OAuth scope accumulation should work. For example, if a token has
+`['user:read', 'user:write']` and the tool requires `['repo:read']`, the challenge
+recommends `scope="user:read user:write repo:read"`.
+
+### 7.6 What this does NOT change
+
+- **No changes to the Protocol layer** — scope challenges are purely at the transport level
+- **No changes to JSON-RPC message handling** — errors stay as JSON-RPC errors
+- **No changes to stdio transport** — scope challenges are HTTP-only
+- **No changes to client SDK** — the existing 403 handling already works
+- **No changes to the MCP specification** — this implements existing spec behavior
+
+## 8. Comparison with github/github-mcp-server Approach
+
+| Aspect | github-mcp-server (custom, not Go SDK) | This Proposal (TS SDK) |
+|--------|----------------------|-------------------------------|
+| **Scope declaration** | `ServerTool.RequiredScopes` + `AcceptedScopes` set at tool creation via `NewTool()` | `scopes: { required, accepted }` in `McpServer.tool()` config |
+| **Scope checking** | HTTP middleware (`WithScopeChallenge`) parses JSON-RPC body to find tool name | Transport-level pre-execution hook, tool registry lookup |
+| **Scope hierarchy** | `ExpandScopes()` with explicit `ScopeHierarchy` map | Server author provides `accepted` explicitly (utilities can be offered separately) |
+| **Scope fetching** | `scopeFetcher.FetchTokenScopes()` — can call GitHub API | Reads `authInfo.scopes` directly — populated by the implementer's auth middleware |
+| **Where it runs** | Completely outside any SDK, in custom application middleware | Inside the SDK transport layer, configured via options |
+| **Dynamic challenges** | Not supported (only static pre-check) | Not supported (same constraint) |
+
+The key difference: this proposal brings scope challenge support **into the SDK** rather than requiring every server author to implement it in custom application middleware (as github-mcp-server had to). All MCP SDKs (Go, Python, etc.) could adopt a similar SDK-level approach.
+
+## 9. Open Questions for Working Group
+
+1. **Should `ToolScopeConfig` be part of the `Tool` schema?** SEP-1880 proposed `Tool.authorization.scopes` at the spec level. This was closed, but there's clear demand. Should the working group champion this?
+
+2. **Scope hierarchy utilities:** Should the SDK provide `expandScopes()` with a configurable hierarchy, or is this the server author's responsibility?
+
+3. **Scope-filtered discovery (SEP-1881):** If tools declare scopes, should `tools/list` automatically filter tools the client can't use? This is a related but separable concern.
+
+4. **Protocol-level step-up (Option D):** Is there appetite for a new MCP method like `auth/stepUp` that enables mid-handler scope challenges without breaking the HTTP model?
+
+5. **Multi-request batches:** When a single HTTP POST contains multiple JSON-RPC requests, and one needs a scope challenge, should the entire batch be rejected with 403, or should only the failing tool call get an error?
+
+6. **Accumulative scoping:** The current client overwrite behavior ([#1582](https://github.com/modelcontextprotocol/typescript-sdk/issues/1582)) means progressive authorization drops previous scopes. [PR #1618](https://github.com/modelcontextprotocol/typescript-sdk/pull/1618) proposes union-based accumulation. This proposal takes the position that **additive scoping is correct**: the server always includes the token's existing scopes in the challenge `scope` parameter, so the client re-authorizes with the full union. The spec should mandate this behavior — dropping scopes on step-up creates a broken loop where gaining one scope loses another.
+
+## 10. What's NOT in Scope (Pun Intended)
+
+- **Transport-agnostic scope challenges** (SEP-1489's `_meta` approach) — consensus rejected this
+- **Mid-handler scope challenges** — acknowledged as desirable but architecturally constrained; deferred to future work
+- **Changes to the MCP specification** — this implements existing spec behavior
+- **Token expiry signaling** ([#1294](https://github.com/modelcontextprotocol/typescript-sdk/issues/1294)) — related pattern (401 from tool handler) but separate concern
+
+## Appendix A: Reference Links
+
+- [MCP Spec — Scope Challenge Handling](https://modelcontextprotocol.io/specification/draft/basic/authorization#scope-challenge-handling)
+- [TS SDK Issue #1151 — Server SDK support for scope challenges](https://github.com/modelcontextprotocol/typescript-sdk/issues/1151)
+- [TS SDK Issue #1294 — Server SDK support for signaling token expiry](https://github.com/modelcontextprotocol/typescript-sdk/issues/1294)
+- [TS SDK Issue #1582 — Scope overwrite during progressive auth](https://github.com/modelcontextprotocol/typescript-sdk/issues/1582)
+- [TS SDK PR #1618 — Fix: accumulate scopes across challenges](https://github.com/modelcontextprotocol/typescript-sdk/pull/1618)
+- [github/github-mcp-server — scope_challenge.go](https://github.com/github/github-mcp-server/blob/main/pkg/http/middleware/scope_challenge.go)
+- [github/github-mcp-server — scopes package](https://github.com/github/github-mcp-server/tree/main/pkg/scopes)
+- [SEP-1488 — securitySchemes in Tool Metadata](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1488)
+- [SEP-1489 — Tool Error Responses for OAuth Flows](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1489)
+- [SEP-1880 — Tool-level scope requirements](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1880)
+- [SEP-1881 — Scope-Filtered Tool Discovery](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1881)
+- [Conformance test — scope step-up](https://github.com/modelcontextprotocol/conformance/blob/main/src/scenarios/client/auth/scope-handling.ts#L237)

--- a/docs/proposals/scope-challenge-server-sdk.md
+++ b/docs/proposals/scope-challenge-server-sdk.md
@@ -381,21 +381,40 @@ async connect(transport: Transport): Promise<void> {
 The `_checkScopeChallenge()` method runs after message parsing but before the SSE
 stream opens. It only fires for `tools/call` requests where scope metadata exists.
 
-**Additive scoping:** The `scope` value in the `WWW-Authenticate` challenge header
-is always the **union** of the token's existing scopes plus the tool's `required`
-scopes. This ensures the client never loses scopes it already has when
-re-authorizing — a pattern established by github/github-mcp-server and consistent
-with how OAuth scope accumulation should work. For example, if a token has
-`['user:read', 'user:write']` and the tool requires `['repo:read']`, the challenge
-recommends `scope="user:read user:write repo:read"`.
+**Per-operation scoping (default, post-SEP-2350):** The `scope` value in the
+`WWW-Authenticate` challenge header advertises only the scopes required for the
+current operation, per [RFC 6750 §3.1](https://datatracker.ietf.org/doc/html/rfc6750#section-3.1)
+and [SEP-2350](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2350).
+Clients are responsible for accumulating scopes across step-up challenges (see
+[TS SDK #1657](https://github.com/modelcontextprotocol/typescript-sdk/pull/1657)).
+
+**Opt-in additive scoping:** Servers that need to defend against older / non-accumulating
+clients can set `scopeChallenge.includeGrantedScopes: true`, which restores the
+union behavior (`activeScopes ∪ required`). This is the pattern previously used
+by `github/github-mcp-server`, kept available for compatibility but no longer
+the default.
+
+**Required vs accepted semantics:**
+- `required` uses **AND** — every entry must be present in the token (or `accepted`
+  must satisfy the OR escape hatch).
+- `accepted` (optional) uses **OR** — if any entry is present in the token, the
+  call proceeds. Use for scope hierarchies (e.g. `repo` subsumes `repo:read`).
+
+**Header quoting:** All `WWW-Authenticate` `quoted-string` auth-param values
+(`scope`, `resource_metadata`, `error_description`) are escaped per RFC 7235 so
+that developer-supplied descriptions or scopes containing `"` or `\` do not break
+the header.
 
 ### 7.6 What this does NOT change
 
 - **No changes to the Protocol layer** — scope challenges are purely at the transport level
 - **No changes to JSON-RPC message handling** — errors stay as JSON-RPC errors
 - **No changes to stdio transport** — scope challenges are HTTP-only
-- **No changes to client SDK** — the existing 403 handling already works
-- **No changes to the MCP specification** — this implements existing spec behavior
+- **No changes to client SDK** — the existing 403 handling already works (client-side accumulation lands separately in [#1657](https://github.com/modelcontextprotocol/typescript-sdk/pull/1657))
+- **No changes to the MCP specification** — this implements existing spec behavior (post-SEP-2350)
+- **Tools/call only** — scope challenges for `resources/read`, `prompts/get`, etc. are
+  follow-up work; the SEP language talks about generic "operations" but this
+  initial implementation covers tools only.
 
 ## 8. Comparison with github/github-mcp-server Approach
 
@@ -422,7 +441,21 @@ The key difference: this proposal brings scope challenge support **into the SDK*
 
 5. **Multi-request batches:** When a single HTTP POST contains multiple JSON-RPC requests, and one needs a scope challenge, should the entire batch be rejected with 403, or should only the failing tool call get an error?
 
-6. **Accumulative scoping:** The current client overwrite behavior ([#1582](https://github.com/modelcontextprotocol/typescript-sdk/issues/1582)) means progressive authorization drops previous scopes. [PR #1618](https://github.com/modelcontextprotocol/typescript-sdk/pull/1618) proposes union-based accumulation. This proposal takes the position that **additive scoping is correct**: the server always includes the token's existing scopes in the challenge `scope` parameter, so the client re-authorizes with the full union. The spec should mandate this behavior — dropping scopes on step-up creates a broken loop where gaining one scope loses another.
+6. **Accumulative scoping (resolved by SEP-2350):** The earlier draft of this
+   proposal took the position that the **server** should always include the token's
+   existing scopes in the challenge `scope` parameter (additive scoping). This
+   has since been resolved by [SEP-2350](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2350)
+   (merged), which aligns MCP with [RFC 6750 §3.1](https://datatracker.ietf.org/doc/html/rfc6750#section-3.1):
+   **servers emit per-operation scopes only; clients accumulate scopes across
+   step-up challenges.** Client-side accumulation in the TS SDK lands in
+   [#1657](https://github.com/modelcontextprotocol/typescript-sdk/pull/1657).
+   This implementation defaults to per-operation, with `includeGrantedScopes`
+   as an opt-in for servers that need to defend against non-accumulating clients.
+
+7. **Resources/prompts step-up:** The SEP talks about generic "operations" but this
+   implementation covers `tools/call` only. Extending to `resources/read`,
+   `prompts/get`, and other operations is straightforward (same pre-execution
+   pattern, keyed on method + params) and is deferred to follow-up.
 
 ## 10. What's NOT in Scope (Pun Intended)
 
@@ -437,7 +470,12 @@ The key difference: this proposal brings scope challenge support **into the SDK*
 - [TS SDK Issue #1151 — Server SDK support for scope challenges](https://github.com/modelcontextprotocol/typescript-sdk/issues/1151)
 - [TS SDK Issue #1294 — Server SDK support for signaling token expiry](https://github.com/modelcontextprotocol/typescript-sdk/issues/1294)
 - [TS SDK Issue #1582 — Scope overwrite during progressive auth](https://github.com/modelcontextprotocol/typescript-sdk/issues/1582)
-- [TS SDK PR #1618 — Fix: accumulate scopes across challenges](https://github.com/modelcontextprotocol/typescript-sdk/pull/1618)
+- [TS SDK PR #1618 — Fix: accumulate scopes across challenges (superseded)](https://github.com/modelcontextprotocol/typescript-sdk/pull/1618)
+- [TS SDK PR #1657 — Client-side scope accumulation on 401/403](https://github.com/modelcontextprotocol/typescript-sdk/pull/1657)
+- [SEP-2350 — Clarify client-side scope accumulation in step-up authorization (merged)](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2350)
+- [Python SDK PR #2676 — SEP-2350 implementation](https://github.com/modelcontextprotocol/python-sdk/pull/2676)
+- [RFC 6750 §3.1 — Bearer error responses](https://datatracker.ietf.org/doc/html/rfc6750#section-3.1)
+- [RFC 7235 — HTTP Authentication](https://datatracker.ietf.org/doc/html/rfc7235)
 - [github/github-mcp-server — scope_challenge.go](https://github.com/github/github-mcp-server/blob/main/pkg/http/middleware/scope_challenge.go)
 - [github/github-mcp-server — scopes package](https://github.com/github/github-mcp-server/tree/main/pkg/scopes)
 - [SEP-1488 — securitySchemes in Tool Metadata](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1488)

--- a/docs/proposals/scope-challenge-server-sdk.md
+++ b/docs/proposals/scope-challenge-server-sdk.md
@@ -412,9 +412,42 @@ the header.
 - **No changes to stdio transport** — scope challenges are HTTP-only
 - **No changes to client SDK** — the existing 403 handling already works (client-side accumulation lands separately in [#1657](https://github.com/modelcontextprotocol/typescript-sdk/pull/1657))
 - **No changes to the MCP specification** — this implements existing spec behavior (post-SEP-2350)
-- **Tools/call only** — scope challenges for `resources/read`, `prompts/get`, etc. are
-  follow-up work; the SEP language talks about generic "operations" but this
-  initial implementation covers tools only.
+
+### 7.7 Extension to non-tool primitives (stacked follow-up PR)
+
+The same pre-execution check is extended to the remaining MCP operations in a
+stacked follow-up PR. The architecture stays the same; only the resolver
+becomes operation-aware.
+
+The transport's `ScopeResolver` widens from `(toolName) => ToolScopeConfig`
+to `(request: JSONRPCRequest) => ScopeResolution | Promise<ScopeResolution>`,
+where `ScopeResolution` carries both the resolved `ToolScopeConfig` and an
+`operationName` label used in the 403 error description (for example
+`tool:get_repo`, `resource:github://octo/hello`, `prompt:summarise`,
+`completion:prompt:summarise/repository`).
+
+`McpServer.connect()` auto-wires a router that dispatches on JSON-RPC method:
+
+| Method | Lookup |
+|---|---|
+| `tools/call` | tool scopes by `params.name` |
+| `resources/read` | resource scopes by exact `params.uri`, then by template match |
+| `prompts/get` | prompt scopes by `params.name` |
+| `completion/complete` | completion scopes by `(ref, argumentName)` |
+
+**Resources** accept either static scopes or a dynamic resolver function on the
+template, which receives the concrete URI and the matched template variables
+and returns the required scopes at request time. This handles cases like
+"public repos require `public_repo`, private repos require `repo`" without
+forcing the implementer into custom transport-level middleware.
+
+**Completions** have an explicit, separate scope domain with no inheritance
+from the referenced prompt or resource. Listing or searching argument values
+is typically a distinct capability from reading the resource itself (for
+example, `repo:list` is not implied by `repo:read`). Implementers who do want
+the same scopes on both can pass the same scopes array to `registerPrompt` and
+`setCompletionScopes`. A `'*'` argument name applies the same scopes to every
+argument of a given reference.
 
 ## 8. Comparison with github/github-mcp-server Approach
 

--- a/packages/middleware/node/src/streamableHttp.ts
+++ b/packages/middleware/node/src/streamableHttp.ts
@@ -11,7 +11,7 @@ import type { IncomingMessage, ServerResponse } from 'node:http';
 
 import { getRequestListener } from '@hono/node-server';
 import type { AuthInfo, JSONRPCMessage, MessageExtraInfo, RequestId, Transport } from '@modelcontextprotocol/core';
-import type { WebStandardStreamableHTTPServerTransportOptions } from '@modelcontextprotocol/server';
+import type { ToolScopeConfig, WebStandardStreamableHTTPServerTransportOptions } from '@modelcontextprotocol/server';
 import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/server';
 
 /**
@@ -150,6 +150,17 @@ export class NodeStreamableHTTPServerTransport implements Transport {
      */
     async send(message: JSONRPCMessage, options?: { relatedRequestId?: RequestId }): Promise<void> {
         return this._webStandardTransport.send(message, options);
+    }
+
+    /**
+     * Sets the scope resolver for pre-execution scope challenge checks.
+     * Delegates to the underlying {@linkcode WebStandardStreamableHTTPServerTransport}.
+     *
+     * This is auto-wired by `McpServer.connect()` when `scopeChallenge`
+     * is configured on the transport.
+     */
+    setScopeResolver(resolver: (toolName: string) => ToolScopeConfig | undefined): void {
+        this._webStandardTransport.setScopeResolver(resolver);
     }
 
     /**

--- a/packages/middleware/node/src/streamableHttp.ts
+++ b/packages/middleware/node/src/streamableHttp.ts
@@ -11,7 +11,7 @@ import type { IncomingMessage, ServerResponse } from 'node:http';
 
 import { getRequestListener } from '@hono/node-server';
 import type { AuthInfo, JSONRPCMessage, MessageExtraInfo, RequestId, Transport } from '@modelcontextprotocol/core';
-import type { ToolScopeConfig, WebStandardStreamableHTTPServerTransportOptions } from '@modelcontextprotocol/server';
+import type { ScopeResolver, WebStandardStreamableHTTPServerTransportOptions } from '@modelcontextprotocol/server';
 import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/server';
 
 /**
@@ -159,7 +159,7 @@ export class NodeStreamableHTTPServerTransport implements Transport {
      * This is auto-wired by `McpServer.connect()` when `scopeChallenge`
      * is configured on the transport.
      */
-    setScopeResolver(resolver: (toolName: string) => ToolScopeConfig | undefined): void {
+    setScopeResolver(resolver: ScopeResolver): void {
         this._webStandardTransport.setScopeResolver(resolver);
     }
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -21,6 +21,8 @@ export type {
     RegisteredResourceTemplate,
     RegisteredTool,
     ResourceMetadata,
+    ResourceScopeConfig,
+    ResourceScopeFn,
     ToolCallback,
     ToolScopeConfig
 } from './server/mcp.js';
@@ -38,6 +40,7 @@ export type {
     HandleRequestOptions,
     ScopeAware,
     ScopeChallengeConfig,
+    ScopeResolution,
     ScopeResolver,
     StreamId,
     WebStandardStreamableHTTPServerTransportOptions

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -21,7 +21,8 @@ export type {
     RegisteredResourceTemplate,
     RegisteredTool,
     ResourceMetadata,
-    ToolCallback
+    ToolCallback,
+    ToolScopeConfig
 } from './server/mcp.js';
 export { McpServer, ResourceTemplate } from './server/mcp.js';
 export type { HostHeaderValidationResult } from './server/middleware/hostHeaderValidation.js';
@@ -35,10 +36,13 @@ export type {
     EventId,
     EventStore,
     HandleRequestOptions,
+    ScopeAware,
+    ScopeChallengeConfig,
+    ScopeResolver,
     StreamId,
     WebStandardStreamableHTTPServerTransportOptions
 } from './server/streamableHttp.js';
-export { WebStandardStreamableHTTPServerTransport } from './server/streamableHttp.js';
+export { isScopeAware, WebStandardStreamableHTTPServerTransport } from './server/streamableHttp.js';
 
 // experimental exports
 export type { CreateTaskRequestHandler, TaskRequestHandler, ToolTaskHandler } from './experimental/tasks/interfaces.js';

--- a/packages/server/src/server/mcp.ts
+++ b/packages/server/src/server/mcp.ts
@@ -107,6 +107,10 @@ export class McpServer {
      * ```
      */
     async connect(transport: Transport): Promise<void> {
+        // Auto-wire scope resolver if the transport supports scope challenges
+        if ('setScopeResolver' in transport && typeof transport.setScopeResolver === 'function') {
+            transport.setScopeResolver((toolName: string) => this.getToolScopes(toolName));
+        }
         return await this.server.connect(transport);
     }
 
@@ -115,6 +119,51 @@ export class McpServer {
      */
     async close(): Promise<void> {
         await this.server.close();
+    }
+
+    /**
+     * Returns the scope configuration for a registered tool, if any.
+     * Checks tool-level scopes first, then falls back to server-level scope overrides.
+     * Used by the transport layer for pre-execution scope challenge checks.
+     */
+    getToolScopes(toolName: string): ToolScopeConfig | undefined {
+        return this._toolScopeOverrides[toolName] ?? this._registeredTools[toolName]?.scopes;
+    }
+
+    private _toolScopeOverrides: { [name: string]: ToolScopeConfig } = {};
+
+    /**
+     * Sets scope requirements for a tool independently of tool registration.
+     *
+     * This allows defining scopes separately — from a config file, a central
+     * mapping, or dynamically at runtime — rather than co-locating them with
+     * the tool definition. Scopes set here take precedence over any `scopes`
+     * provided during tool registration.
+     *
+     * @example Central scope mapping
+     * ```typescript
+     * // Define all scopes in one place
+     * const TOOL_SCOPES: Record<string, string[]> = {
+     *     'get_repo': ['repo:read'],
+     *     'create_issue': ['repo:write'],
+     *     'list_orgs': ['read:org'],
+     * };
+     *
+     * for (const [tool, scopes] of Object.entries(TOOL_SCOPES)) {
+     *     server.setToolScopes(tool, scopes);
+     * }
+     * ```
+     *
+     * @example With scope hierarchy
+     * ```typescript
+     * server.setToolScopes('get_repo', {
+     *     required: ['public_repo'],
+     *     accepted: ['public_repo', 'repo'],
+     * });
+     * ```
+     */
+    setToolScopes(toolName: string, scopes: string[] | ToolScopeConfig): void {
+        this._toolScopeOverrides[toolName] = Array.isArray(scopes) ? { required: scopes } : scopes;
     }
 
     private _toolHandlersInitialized = false;
@@ -872,6 +921,34 @@ export class McpServer {
             inputSchema?: InputArgs;
             outputSchema?: OutputArgs;
             annotations?: ToolAnnotations;
+            /**
+             * OAuth scopes required for this tool.
+             *
+             * When provided alongside a `ScopeChallengeConfig` on the transport,
+             * the transport checks the client's token scopes before executing the tool.
+             * If the token lacks required scopes, the transport returns HTTP 403 with a
+             * `WWW-Authenticate` header, triggering the client's step-up authorization flow.
+             *
+             * Can be a simple array of required scope strings, or an object with `required`
+             * and optional `accepted` arrays (for scope hierarchy support).
+             *
+             * @example Simple scopes
+             * ```typescript
+             * server.registerTool('get_repo', {
+             *     description: 'Get repository details',
+             *     scopes: ['repo:read'],
+             * }, handler);
+             * ```
+             *
+             * @example With scope hierarchy
+             * ```typescript
+             * server.registerTool('get_repo', {
+             *     description: 'Get repository details',
+             *     scopes: { required: ['public_repo'], accepted: ['public_repo', 'repo'] },
+             * }, handler);
+             * ```
+             */
+            scopes?: string[] | ToolScopeConfig;
             _meta?: Record<string, unknown>;
         },
         cb: ToolCallback<InputArgs>
@@ -905,9 +982,9 @@ export class McpServer {
             throw new Error(`Tool ${name} is already registered`);
         }
 
-        const { title, description, inputSchema, outputSchema, annotations, _meta } = config;
+        const { title, description, inputSchema, outputSchema, annotations, scopes, _meta } = config;
 
-        return this._createRegisteredTool(
+        const tool = this._createRegisteredTool(
             name,
             title,
             description,
@@ -918,6 +995,13 @@ export class McpServer {
             _meta,
             cb as ToolCallback<StandardSchemaWithJSON | undefined>
         );
+
+        // Normalize and attach scope metadata
+        if (scopes) {
+            tool.scopes = Array.isArray(scopes) ? { required: scopes } : scopes;
+        }
+
+        return tool;
     }
 
     /**
@@ -1164,6 +1248,7 @@ export type RegisteredTool = {
     outputSchema?: StandardSchemaWithJSON;
     annotations?: ToolAnnotations;
     execution?: ToolExecution;
+    scopes?: ToolScopeConfig;
     _meta?: Record<string, unknown>;
     handler: AnyToolHandler<StandardSchemaWithJSON | undefined>;
     /** @hidden */
@@ -1184,6 +1269,42 @@ export type RegisteredTool = {
     }): void;
     remove(): void;
 };
+
+/**
+ * Scope metadata for a tool, used for pre-execution scope challenge checks.
+ *
+ * When configured alongside a `ScopeChallengeConfig` on the transport,
+ * the transport will check the client's token scopes against these requirements
+ * before executing the tool. If the token lacks the required scopes, the transport
+ * returns HTTP 403 with a `WWW-Authenticate` header per RFC 6750 §3.1.
+ */
+export interface ToolScopeConfig {
+    /**
+     * The scopes recommended in the 403 scope challenge response.
+     *
+     * When the token lacks sufficient scopes, these are included in the
+     * `WWW-Authenticate` header's `scope` parameter (unioned with the
+     * token's existing scopes) so the client knows what to request
+     * during re-authorization.
+     */
+    required: string[];
+    /**
+     * All scopes that satisfy the requirement — if the token has ANY of
+     * these, the tool call proceeds without challenge.
+     *
+     * Use this for scope hierarchies where a broader scope implies a
+     * narrower one. For example, a tool that requires `repo:read` might
+     * also accept `repo` (which implies read access).
+     *
+     * Defaults to `required` if not provided.
+     *
+     * @example
+     * ```typescript
+     * { required: ['repo:read'], accepted: ['repo:read', 'repo'] }
+     * ```
+     */
+    accepted?: string[];
+}
 
 /**
  * Creates an executor that invokes the handler with the appropriate arguments.

--- a/packages/server/src/server/mcp.ts
+++ b/packages/server/src/server/mcp.ts
@@ -9,6 +9,7 @@ import type {
     CreateTaskServerContext,
     GetPromptResult,
     Implementation,
+    JSONRPCRequest,
     ListPromptsResult,
     ListResourcesResult,
     ListToolsResult,
@@ -46,6 +47,7 @@ import { ExperimentalMcpServerTasks } from '../experimental/tasks/mcpServer.js';
 import { getCompleter, isCompletable } from './completable.js';
 import type { ServerOptions } from './server.js';
 import { Server } from './server.js';
+import type { ScopeResolution } from './streamableHttp.js';
 import { isScopeAware } from './streamableHttp.js';
 
 /**
@@ -110,7 +112,7 @@ export class McpServer {
     async connect(transport: Transport): Promise<void> {
         // Auto-wire scope resolver if the transport supports scope challenges.
         if (isScopeAware(transport)) {
-            transport.setScopeResolver(toolName => this.getToolScopes(toolName));
+            transport.setScopeResolver(request => this._resolveOperationScopes(request));
         }
         return await this.server.connect(transport);
     }
@@ -120,6 +122,48 @@ export class McpServer {
      */
     async close(): Promise<void> {
         await this.server.close();
+    }
+
+    /**
+     * Routes an incoming JSON-RPC request to the correct scope resolver based
+     * on its method. Returns a {@linkcode ScopeResolution} when the operation
+     * has scope requirements, or `undefined` otherwise (the transport then
+     * allows the request through).
+     */
+    private async _resolveOperationScopes(request: JSONRPCRequest): Promise<ScopeResolution | undefined> {
+        const params = request.params as Record<string, unknown> | undefined;
+        switch (request.method) {
+            case 'tools/call': {
+                const name = typeof params?.name === 'string' ? params.name : undefined;
+                if (!name) return undefined;
+                const scopes = this.getToolScopes(name);
+                return scopes ? { operationName: `tool:${name}`, scopes } : undefined;
+            }
+            case 'resources/read': {
+                const uri = typeof params?.uri === 'string' ? params.uri : undefined;
+                if (!uri) return undefined;
+                const scopes = await this.getResourceScopes(uri);
+                return scopes ? { operationName: `resource:${uri}`, scopes } : undefined;
+            }
+            case 'prompts/get': {
+                const name = typeof params?.name === 'string' ? params.name : undefined;
+                if (!name) return undefined;
+                const scopes = this.getPromptScopes(name);
+                return scopes ? { operationName: `prompt:${name}`, scopes } : undefined;
+            }
+            case 'completion/complete': {
+                const ref = params?.ref as { type?: string; name?: string; uri?: string } | undefined;
+                const argument = params?.argument as { name?: string } | undefined;
+                if (!ref || !argument?.name) return undefined;
+                const refKey = completionRefKey(ref);
+                if (!refKey) return undefined;
+                const scopes = this.getCompletionScopes(ref, argument.name);
+                return scopes ? { operationName: `completion:${refKey}/${argument.name}`, scopes } : undefined;
+            }
+            default: {
+                return undefined;
+            }
+        }
     }
 
     /**
@@ -165,6 +209,111 @@ export class McpServer {
      */
     setToolScopes(toolName: string, scopes: string[] | ToolScopeConfig): void {
         this._toolScopeOverrides[toolName] = Array.isArray(scopes) ? { required: scopes } : scopes;
+    }
+
+    private _promptScopeOverrides: { [name: string]: ToolScopeConfig } = {};
+    private _resourceScopeOverrides: { [uri: string]: ResourceScopeConfig } = {};
+    private _completionScopeOverrides: { [refKey: string]: { [argumentName: string]: ToolScopeConfig } } = {};
+
+    /**
+     * Returns the scope configuration for a registered prompt, if any.
+     * Checks server-level overrides first, then prompt-level scopes set at
+     * registration time. Used by the transport for pre-execution scope checks
+     * on `prompts/get` requests.
+     */
+    getPromptScopes(promptName: string): ToolScopeConfig | undefined {
+        return this._promptScopeOverrides[promptName] ?? this._registeredPrompts[promptName]?.scopes;
+    }
+
+    /**
+     * Sets scope requirements for a prompt independently of registration.
+     * Mirrors {@linkcode setToolScopes} for `prompts/get`.
+     */
+    setPromptScopes(promptName: string, scopes: string[] | ToolScopeConfig): void {
+        this._promptScopeOverrides[promptName] = Array.isArray(scopes) ? { required: scopes } : scopes;
+    }
+
+    /**
+     * Returns the scope configuration for a resource URI, if any. Checks (in
+     * order): server-level exact-URI override; the static resource registered
+     * at exactly this URI; each registered resource template whose URI
+     * template matches the URI, calling its dynamic scope function if
+     * configured.
+     *
+     * For dynamic template-scope functions the call is `await`ed, so this
+     * method returns a Promise.
+     */
+    async getResourceScopes(uri: string): Promise<ToolScopeConfig | undefined> {
+        const override = this._resourceScopeOverrides[uri];
+        if (override !== undefined) {
+            return resolveResourceScopeConfig(override, uri, {});
+        }
+
+        const exact = this._registeredResources[uri];
+        if (exact?.scopes !== undefined) {
+            return resolveResourceScopeConfig(exact.scopes, uri, {});
+        }
+
+        for (const [name, registered] of Object.entries(this._registeredResourceTemplates)) {
+            if (!registered.scopes) continue;
+            const variables = registered.resourceTemplate.uriTemplate.match(uri);
+            if (variables === null) continue;
+            const templateOverride = this._resourceScopeOverrides[name];
+            const config = templateOverride ?? registered.scopes;
+            return resolveResourceScopeConfig(config, uri, variables);
+        }
+
+        return undefined;
+    }
+
+    /**
+     * Sets scope requirements for a resource. Pass an exact URI for static
+     * resources or the template `name` for templated resources; overrides take
+     * precedence over scopes set at registration time.
+     *
+     * The scopes value can be a plain array, a {@linkcode ToolScopeConfig},
+     * or a function that receives the concrete URI and matched template
+     * variables and returns scopes at request time (useful when the required
+     * scope depends on path parameters, e.g. public vs private repositories).
+     */
+    setResourceScopes(uriOrTemplateName: string, scopes: ResourceScopeConfig): void {
+        this._resourceScopeOverrides[uriOrTemplateName] = scopes;
+    }
+
+    /**
+     * Returns the scope configuration for a completion request, if any.
+     * Looks up by reference (prompt name or resource URI template) and
+     * argument name, falling back to a `'*'` wildcard entry that applies to
+     * any argument of that reference.
+     */
+    getCompletionScopes(
+        ref: PromptReference | ResourceTemplateReference | { type?: string; name?: string; uri?: string },
+        argumentName: string
+    ): ToolScopeConfig | undefined {
+        const refKey = completionRefKey(ref);
+        if (!refKey) return undefined;
+        const argMap = this._completionScopeOverrides[refKey];
+        return argMap?.[argumentName] ?? argMap?.['*'];
+    }
+
+    /**
+     * Sets scope requirements for completion argument suggestions. Completion
+     * scopes are explicit and never inherited from the referenced prompt or
+     * resource; if your search scope happens to equal the read scope, pass
+     * the same scopes array to both calls.
+     *
+     * Pass `'*'` as `argumentName` to apply the same scopes to every argument
+     * of the reference.
+     */
+    setCompletionScopes(ref: PromptReference | ResourceTemplateReference, argumentName: string, scopes: string[] | ToolScopeConfig): void {
+        const refKey = completionRefKey(ref);
+        if (!refKey) {
+            throw new Error('Invalid completion reference; expected ref/prompt or ref/resource');
+        }
+        const normalized = Array.isArray(scopes) ? { required: scopes } : scopes;
+        const argMap = this._completionScopeOverrides[refKey] ?? {};
+        argMap[argumentName] = normalized;
+        this._completionScopeOverrides[refKey] = argMap;
     }
 
     private _toolHandlersInitialized = false;
@@ -625,19 +774,25 @@ export class McpServer {
      * );
      * ```
      */
-    registerResource(name: string, uriOrTemplate: string, config: ResourceMetadata, readCallback: ReadResourceCallback): RegisteredResource;
+    registerResource(
+        name: string,
+        uriOrTemplate: string,
+        config: ResourceMetadata & { scopes?: ResourceScopeConfig },
+        readCallback: ReadResourceCallback
+    ): RegisteredResource;
     registerResource(
         name: string,
         uriOrTemplate: ResourceTemplate,
-        config: ResourceMetadata,
+        config: ResourceMetadata & { scopes?: ResourceScopeConfig },
         readCallback: ReadResourceTemplateCallback
     ): RegisteredResourceTemplate;
     registerResource(
         name: string,
         uriOrTemplate: string | ResourceTemplate,
-        config: ResourceMetadata,
+        config: ResourceMetadata & { scopes?: ResourceScopeConfig },
         readCallback: ReadResourceCallback | ReadResourceTemplateCallback
     ): RegisteredResource | RegisteredResourceTemplate {
+        const { scopes, ...metadata } = config;
         if (typeof uriOrTemplate === 'string') {
             if (this._registeredResources[uriOrTemplate]) {
                 throw new Error(`Resource ${uriOrTemplate} is already registered`);
@@ -645,10 +800,11 @@ export class McpServer {
 
             const registeredResource = this._createRegisteredResource(
                 name,
-                (config as BaseMetadata).title,
+                (metadata as BaseMetadata).title,
                 uriOrTemplate,
-                config,
-                readCallback as ReadResourceCallback
+                metadata,
+                readCallback as ReadResourceCallback,
+                scopes
             );
 
             this.setResourceRequestHandlers();
@@ -661,10 +817,11 @@ export class McpServer {
 
             const registeredResourceTemplate = this._createRegisteredResourceTemplate(
                 name,
-                (config as BaseMetadata).title,
+                (metadata as BaseMetadata).title,
                 uriOrTemplate,
-                config,
-                readCallback as ReadResourceTemplateCallback
+                metadata,
+                readCallback as ReadResourceTemplateCallback,
+                scopes
             );
 
             this.setResourceRequestHandlers();
@@ -678,13 +835,15 @@ export class McpServer {
         title: string | undefined,
         uri: string,
         metadata: ResourceMetadata | undefined,
-        readCallback: ReadResourceCallback
+        readCallback: ReadResourceCallback,
+        scopes?: ResourceScopeConfig
     ): RegisteredResource {
         const registeredResource: RegisteredResource = {
             name,
             title,
             metadata,
             readCallback,
+            scopes,
             enabled: true,
             disable: () => registeredResource.update({ enabled: false }),
             enable: () => registeredResource.update({ enabled: true }),
@@ -711,13 +870,15 @@ export class McpServer {
         title: string | undefined,
         template: ResourceTemplate,
         metadata: ResourceMetadata | undefined,
-        readCallback: ReadResourceTemplateCallback
+        readCallback: ReadResourceTemplateCallback,
+        scopes?: ResourceScopeConfig
     ): RegisteredResourceTemplate {
         const registeredResourceTemplate: RegisteredResourceTemplate = {
             resourceTemplate: template,
             title,
             metadata,
             readCallback,
+            scopes,
             enabled: true,
             disable: () => registeredResourceTemplate.update({ enabled: false }),
             enable: () => registeredResourceTemplate.update({ enabled: true }),
@@ -1038,6 +1199,7 @@ export class McpServer {
             title?: string;
             description?: string;
             argsSchema?: Args;
+            scopes?: string[] | ToolScopeConfig;
             _meta?: Record<string, unknown>;
         },
         cb: PromptCallback<Args>
@@ -1049,6 +1211,7 @@ export class McpServer {
             title?: string;
             description?: string;
             argsSchema?: Args;
+            scopes?: string[] | ToolScopeConfig;
             _meta?: Record<string, unknown>;
         },
         cb: LegacyPromptCallback<Args>
@@ -1059,6 +1222,7 @@ export class McpServer {
             title?: string;
             description?: string;
             argsSchema?: StandardSchemaWithJSON | ZodRawShape;
+            scopes?: string[] | ToolScopeConfig;
             _meta?: Record<string, unknown>;
         },
         cb: PromptCallback<StandardSchemaWithJSON> | LegacyPromptCallback<ZodRawShape>
@@ -1067,7 +1231,7 @@ export class McpServer {
             throw new Error(`Prompt ${name} is already registered`);
         }
 
-        const { title, description, argsSchema, _meta } = config;
+        const { title, description, argsSchema, scopes, _meta } = config;
 
         const registeredPrompt = this._createRegisteredPrompt(
             name,
@@ -1077,6 +1241,10 @@ export class McpServer {
             cb as PromptCallback<StandardSchemaWithJSON | undefined>,
             _meta
         );
+
+        if (scopes) {
+            registeredPrompt.scopes = Array.isArray(scopes) ? { required: scopes } : scopes;
+        }
 
         this.setPromptRequestHandlers();
         this.sendPromptListChanged();
@@ -1282,8 +1450,8 @@ export type RegisteredTool = {
  */
 export interface ToolScopeConfig {
     /**
-     * Scopes required for this tool, with **AND** semantics — the token must
-     * contain every scope in this array for the call to proceed (unless
+     * Scopes required for this operation, with **AND** semantics: the token
+     * must contain every scope in this array for the call to proceed (unless
      * `accepted` is provided, see below). These are the scopes advertised in
      * the 403 `WWW-Authenticate` challenge's `scope` parameter when the token
      * is insufficient.
@@ -1305,8 +1473,8 @@ export interface ToolScopeConfig {
      * "token has ANY of `accepted`". Use this for scope hierarchies where a
      * broader scope subsumes a narrower one.
      *
-     * Note: `accepted` only affects whether the request is allowed through —
-     * the scope challenge advertised on a 403 is still based on `required`.
+     * Note: `accepted` only affects whether the request is allowed through.
+     * The scope challenge advertised on a 403 is still based on `required`.
      *
      * @example Hierarchy: `repo` (broad) satisfies `repo:read` (narrow)
      * ```typescript
@@ -1314,6 +1482,55 @@ export interface ToolScopeConfig {
      * ```
      */
     accepted?: string[];
+}
+
+/**
+ * Dynamic resolver for resource scopes. Receives the concrete URI being read
+ * and any variables matched against the template, and returns the scope
+ * requirements at request time. Returning `undefined` means the request has
+ * no scope requirement and is allowed through.
+ *
+ * Useful when the required scope depends on path parameters (for example,
+ * `public_repo` for public repositories and `repo` for private ones).
+ */
+export type ResourceScopeFn = (
+    uri: string,
+    variables: Variables
+) => string[] | ToolScopeConfig | Promise<string[] | ToolScopeConfig | undefined> | undefined;
+
+/**
+ * Scope configuration accepted by `registerResource` and `setResourceScopes`.
+ * Either static scopes or a {@linkcode ResourceScopeFn} for per-request
+ * dynamic resolution.
+ */
+export type ResourceScopeConfig = string[] | ToolScopeConfig | ResourceScopeFn;
+
+/**
+ * Computes a stable key for a {@linkcode PromptReference} or
+ * {@linkcode ResourceTemplateReference} for use in scope override maps.
+ */
+function completionRefKey(ref: { type?: string; name?: string; uri?: string }): string | undefined {
+    if (ref.type === 'ref/prompt' && typeof ref.name === 'string') {
+        return `prompt:${ref.name}`;
+    }
+    if (ref.type === 'ref/resource' && typeof ref.uri === 'string') {
+        return `resource:${ref.uri}`;
+    }
+    return undefined;
+}
+
+/**
+ * Normalises a {@linkcode ResourceScopeConfig} into a {@linkcode ToolScopeConfig},
+ * resolving dynamic functions and `string[]` shorthand.
+ */
+async function resolveResourceScopeConfig(
+    config: ResourceScopeConfig,
+    uri: string,
+    variables: Variables
+): Promise<ToolScopeConfig | undefined> {
+    const resolved: string[] | ToolScopeConfig | undefined = typeof config === 'function' ? await config(uri, variables) : config;
+    if (!resolved) return undefined;
+    return Array.isArray(resolved) ? { required: resolved } : resolved;
 }
 
 /**
@@ -1377,6 +1594,11 @@ export type RegisteredResource = {
     title?: string;
     metadata?: ResourceMetadata;
     readCallback: ReadResourceCallback;
+    /**
+     * OAuth scopes required to read this resource, used for pre-execution
+     * scope challenge checks. See {@linkcode ResourceScopeConfig}.
+     */
+    scopes?: ResourceScopeConfig;
     enabled: boolean;
     enable(): void;
     disable(): void;
@@ -1405,6 +1627,12 @@ export type RegisteredResourceTemplate = {
     title?: string;
     metadata?: ResourceMetadata;
     readCallback: ReadResourceTemplateCallback;
+    /**
+     * OAuth scopes required to read resources matching this template, used
+     * for pre-execution scope challenge checks. See
+     * {@linkcode ResourceScopeConfig}.
+     */
+    scopes?: ResourceScopeConfig;
     enabled: boolean;
     enable(): void;
     disable(): void;
@@ -1440,6 +1668,11 @@ export type RegisteredPrompt = {
     description?: string;
     argsSchema?: StandardSchemaWithJSON;
     _meta?: Record<string, unknown>;
+    /**
+     * OAuth scopes required to get this prompt, used for pre-execution scope
+     * challenge checks on `prompts/get`.
+     */
+    scopes?: ToolScopeConfig;
     /** @hidden */
     handler: PromptHandler;
     enabled: boolean;

--- a/packages/server/src/server/mcp.ts
+++ b/packages/server/src/server/mcp.ts
@@ -46,6 +46,7 @@ import { ExperimentalMcpServerTasks } from '../experimental/tasks/mcpServer.js';
 import { getCompleter, isCompletable } from './completable.js';
 import type { ServerOptions } from './server.js';
 import { Server } from './server.js';
+import { isScopeAware } from './streamableHttp.js';
 
 /**
  * High-level MCP server that provides a simpler API for working with resources, tools, and prompts.
@@ -107,9 +108,9 @@ export class McpServer {
      * ```
      */
     async connect(transport: Transport): Promise<void> {
-        // Auto-wire scope resolver if the transport supports scope challenges
-        if ('setScopeResolver' in transport && typeof transport.setScopeResolver === 'function') {
-            transport.setScopeResolver((toolName: string) => this.getToolScopes(toolName));
+        // Auto-wire scope resolver if the transport supports scope challenges.
+        if (isScopeAware(transport)) {
+            transport.setScopeResolver(toolName => this.getToolScopes(toolName));
         }
         return await this.server.connect(transport);
     }
@@ -974,6 +975,7 @@ export class McpServer {
             inputSchema?: StandardSchemaWithJSON | ZodRawShape;
             outputSchema?: StandardSchemaWithJSON | ZodRawShape;
             annotations?: ToolAnnotations;
+            scopes?: string[] | ToolScopeConfig;
             _meta?: Record<string, unknown>;
         },
         cb: ToolCallback<StandardSchemaWithJSON | undefined> | LegacyToolCallback<ZodRawShape>
@@ -1280,25 +1282,33 @@ export type RegisteredTool = {
  */
 export interface ToolScopeConfig {
     /**
-     * The scopes recommended in the 403 scope challenge response.
+     * Scopes required for this tool, with **AND** semantics — the token must
+     * contain every scope in this array for the call to proceed (unless
+     * `accepted` is provided, see below). These are the scopes advertised in
+     * the 403 `WWW-Authenticate` challenge's `scope` parameter when the token
+     * is insufficient.
      *
-     * When the token lacks sufficient scopes, these are included in the
-     * `WWW-Authenticate` header's `scope` parameter (unioned with the
-     * token's existing scopes) so the client knows what to request
-     * during re-authorization.
+     * @example Single scope
+     * ```typescript
+     * { required: ['repo:read'] }
+     * ```
+     *
+     * @example Multiple scopes (all must be present)
+     * ```typescript
+     * { required: ['repo:read', 'user:read'] }
+     * ```
      */
     required: string[];
     /**
-     * All scopes that satisfy the requirement — if the token has ANY of
-     * these, the tool call proceeds without challenge.
+     * Optional **OR** escape hatch for the satisfaction check. When provided,
+     * the satisfaction check switches from "token has all `required`" to
+     * "token has ANY of `accepted`". Use this for scope hierarchies where a
+     * broader scope subsumes a narrower one.
      *
-     * Use this for scope hierarchies where a broader scope implies a
-     * narrower one. For example, a tool that requires `repo:read` might
-     * also accept `repo` (which implies read access).
+     * Note: `accepted` only affects whether the request is allowed through —
+     * the scope challenge advertised on a 403 is still based on `required`.
      *
-     * Defaults to `required` if not provided.
-     *
-     * @example
+     * @example Hierarchy: `repo` (broad) satisfies `repo:read` (narrow)
      * ```typescript
      * { required: ['repo:read'], accepted: ['repo:read', 'repo'] }
      * ```

--- a/packages/server/src/server/streamableHttp.ts
+++ b/packages/server/src/server/streamableHttp.ts
@@ -18,6 +18,8 @@ import {
     SUPPORTED_PROTOCOL_VERSIONS
 } from '@modelcontextprotocol/core';
 
+import type { ToolScopeConfig } from './mcp.js';
+
 export type StreamId = string;
 export type EventId = string;
 
@@ -65,6 +67,48 @@ interface StreamMapping {
     resolveJson?: (response: Response) => void;
     /** Cleanup function to close stream and remove mapping */
     cleanup: () => void;
+}
+
+/**
+ * Configuration for automatic scope challenge handling on tool calls.
+ *
+ * When provided to the transport, the transport checks the client's token scopes
+ * (from {@linkcode AuthInfo.scopes}) against tool-level scope requirements before
+ * executing the tool. If the token lacks required scopes, the transport returns
+ * HTTP 403 with a `WWW-Authenticate` header per RFC 6750 §3.1, triggering the
+ * client's step-up authorization flow.
+ *
+ * The server implementer is responsible for populating {@linkcode AuthInfo.scopes}
+ * with the token's active scopes in their auth middleware, and for declaring the
+ * required/accepted scopes on each tool at registration time. The SDK only provides
+ * the plumbing to compare them and emit the correct HTTP response.
+ *
+ * This is only meaningful for HTTP-based transports — stdio transports have no
+ * concept of HTTP status codes or OAuth flows.
+ *
+ * @example
+ * ```typescript
+ * const transport = new WebStandardStreamableHTTPServerTransport({
+ *     sessionIdGenerator: () => crypto.randomUUID(),
+ *     scopeChallenge: {
+ *         resourceMetadataUrl: 'https://api.example.com/.well-known/oauth-protected-resource',
+ *     }
+ * });
+ * ```
+ */
+export interface ScopeChallengeConfig {
+    /**
+     * The `resource_metadata` URL to include in `WWW-Authenticate` headers.
+     * Should point to the server's OAuth Protected Resource Metadata document
+     * per RFC 9728.
+     */
+    resourceMetadataUrl: string;
+
+    /**
+     * Optional custom error description generator.
+     * If not provided, a default description listing the required scopes is used.
+     */
+    buildErrorDescription?: (toolName: string, requiredScopes: string[]) => string;
 }
 
 /**
@@ -152,6 +196,19 @@ export interface WebStandardStreamableHTTPServerTransportOptions {
      * @default {@linkcode SUPPORTED_PROTOCOL_VERSIONS}
      */
     supportedProtocolVersions?: string[];
+
+    /**
+     * Configuration for automatic scope challenge handling.
+     *
+     * When provided alongside tools registered with `scopes` metadata, the transport
+     * will check the client's token scopes before executing `tools/call` requests.
+     * If the token lacks required scopes, HTTP 403 is returned with a `WWW-Authenticate`
+     * header, triggering the client's step-up authorization (upscoping) flow.
+     *
+     * Also requires a `scopeResolver` to be set — a function that looks up scope
+     * metadata for a given tool name. This is typically wired to `McpServer.getToolScopes()`.
+     */
+    scopeChallenge?: ScopeChallengeConfig;
 }
 
 /**
@@ -240,6 +297,8 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
     private _enableDnsRebindingProtection: boolean;
     private _retryInterval?: number;
     private _supportedProtocolVersions: string[];
+    private _scopeChallenge?: ScopeChallengeConfig;
+    private _scopeResolver?: (toolName: string) => ToolScopeConfig | undefined;
 
     sessionId?: string;
     onclose?: () => void;
@@ -257,6 +316,20 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
         this._enableDnsRebindingProtection = options.enableDnsRebindingProtection ?? false;
         this._retryInterval = options.retryInterval;
         this._supportedProtocolVersions = options.supportedProtocolVersions ?? SUPPORTED_PROTOCOL_VERSIONS;
+        this._scopeChallenge = options.scopeChallenge;
+    }
+
+    /**
+     * Sets the scope resolver function, which looks up scope metadata for a given tool name.
+     * This is typically wired to `McpServer.getToolScopes()`.
+     *
+     * @example
+     * ```typescript
+     * transport.setScopeResolver((toolName) => mcpServer.getToolScopes(toolName));
+     * ```
+     */
+    setScopeResolver(resolver: (toolName: string) => ToolScopeConfig | undefined): void {
+        this._scopeResolver = resolver;
     }
 
     /**
@@ -305,6 +378,64 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
                 }
             }
         );
+    }
+
+    /**
+     * Checks if a tools/call request has sufficient scopes.
+     * Returns an HTTP 403 response with WWW-Authenticate header if scopes are insufficient,
+     * or undefined if the request should proceed normally.
+     *
+     * This implements the MCP Scope Challenge Handling spec (§10.1):
+     * https://modelcontextprotocol.io/specification/draft/basic/authorization#scope-challenge-handling
+     */
+    private _checkScopeChallenge(messages: JSONRPCMessage[], authInfo?: AuthInfo): Response | undefined {
+        if (!this._scopeChallenge || !this._scopeResolver || !authInfo) {
+            return undefined;
+        }
+
+        const activeScopes = authInfo.scopes;
+
+        for (const message of messages) {
+            if (!isJSONRPCRequest(message) || message.method !== 'tools/call') {
+                continue;
+            }
+
+            const toolName = (message.params as { name?: string })?.name;
+            if (!toolName) {
+                continue;
+            }
+
+            const toolScopes = this._scopeResolver(toolName);
+            if (!toolScopes) {
+                continue;
+            }
+
+            const acceptedScopes = toolScopes.accepted ?? toolScopes.required;
+
+            // Check if the token has any of the accepted scopes
+            if (acceptedScopes.some(s => activeScopes.includes(s))) {
+                continue;
+            }
+
+            // Additive scoping: recommend the union of existing + required scopes.
+            // This ensures the client never loses scopes it already has when
+            // re-authorizing, matching the pattern from github/github-mcp-server.
+            const recommendedScopes = [...new Set([...activeScopes, ...toolScopes.required])];
+
+            const errorDescription = this._scopeChallenge.buildErrorDescription
+                ? this._scopeChallenge.buildErrorDescription(toolName, toolScopes.required)
+                : `Additional scopes required: ${toolScopes.required.join(', ')}`;
+
+            const wwwAuthenticate = `Bearer error="insufficient_scope", scope="${recommendedScopes.join(' ')}", resource_metadata="${this._scopeChallenge.resourceMetadataUrl}", error_description="${errorDescription}"`;
+
+            return this.createJsonErrorResponse(403, -32_600, `Insufficient scope for tool: ${toolName}`, {
+                headers: {
+                    'WWW-Authenticate': wwwAuthenticate
+                }
+            });
+        }
+
+        return undefined;
     }
 
     /**
@@ -697,6 +828,13 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
                 if (protocolError) {
                     return protocolError;
                 }
+            }
+
+            // Pre-execution scope challenge check for tools/call requests.
+            // This runs BEFORE the SSE stream opens so we can still return HTTP 403.
+            const scopeChallengeResponse = this._checkScopeChallenge(messages, options?.authInfo);
+            if (scopeChallengeResponse) {
+                return scopeChallengeResponse;
             }
 
             // check if it contains requests

--- a/packages/server/src/server/streamableHttp.ts
+++ b/packages/server/src/server/streamableHttp.ts
@@ -96,6 +96,34 @@ interface StreamMapping {
  * });
  * ```
  */
+/**
+ * Function that resolves scope requirements for a given tool name.
+ * Returns the tool's {@linkcode ToolScopeConfig} or `undefined` if the tool has
+ * no scope requirements (in which case the request is allowed through).
+ */
+export type ScopeResolver = (toolName: string) => ToolScopeConfig | undefined;
+
+/**
+ * Transports that support scope challenge handling implement this interface,
+ * allowing {@linkcode McpServer.connect} to auto-wire a {@linkcode ScopeResolver}
+ * sourced from the registered tools.
+ */
+export interface ScopeAware {
+    setScopeResolver(resolver: ScopeResolver): void;
+}
+
+/**
+ * Type guard for transports that implement {@linkcode ScopeAware}.
+ */
+export function isScopeAware(transport: unknown): transport is ScopeAware {
+    return (
+        typeof transport === 'object' &&
+        transport !== null &&
+        'setScopeResolver' in transport &&
+        typeof (transport as { setScopeResolver: unknown }).setScopeResolver === 'function'
+    );
+}
+
 export interface ScopeChallengeConfig {
     /**
      * The `resource_metadata` URL to include in `WWW-Authenticate` headers.
@@ -105,10 +133,36 @@ export interface ScopeChallengeConfig {
     resourceMetadataUrl: string;
 
     /**
+     * When `true`, the `WWW-Authenticate` `scope` parameter is the union of the
+     * token's currently active scopes and the tool's `required` scopes, rather
+     * than just the per-operation `required` scopes.
+     *
+     * Per RFC 6750 §3.1 and MCP SEP-2350, the recommended posture is to emit
+     * only the scopes required for the current operation and rely on the client
+     * to accumulate scopes across step-up challenges. Enable this option only
+     * if you need to defend against older clients that do not accumulate scopes
+     * client-side (i.e. they replace their requested scope set on each 403).
+     *
+     * @default false
+     */
+    includeGrantedScopes?: boolean;
+
+    /**
      * Optional custom error description generator.
      * If not provided, a default description listing the required scopes is used.
      */
     buildErrorDescription?: (toolName: string, requiredScopes: string[]) => string;
+}
+
+/**
+ * Quotes a value for use inside a `WWW-Authenticate` auth-param `quoted-string`
+ * per RFC 7235. Escapes `\` and `"` so the header parses unambiguously even when
+ * developer-supplied descriptions or scope strings contain quotes or commas.
+ *
+ * Does NOT add the surrounding quotes — call sites embed the result inside `"..."`.
+ */
+function quoteAuthParam(value: string): string {
+    return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
 }
 
 /**
@@ -298,7 +352,7 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
     private _retryInterval?: number;
     private _supportedProtocolVersions: string[];
     private _scopeChallenge?: ScopeChallengeConfig;
-    private _scopeResolver?: (toolName: string) => ToolScopeConfig | undefined;
+    private _scopeResolver?: ScopeResolver;
 
     sessionId?: string;
     onclose?: () => void;
@@ -328,7 +382,7 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
      * transport.setScopeResolver((toolName) => mcpServer.getToolScopes(toolName));
      * ```
      */
-    setScopeResolver(resolver: (toolName: string) => ToolScopeConfig | undefined): void {
+    setScopeResolver(resolver: ScopeResolver): void {
         this._scopeResolver = resolver;
     }
 
@@ -410,23 +464,36 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
                 continue;
             }
 
-            const acceptedScopes = toolScopes.accepted ?? toolScopes.required;
+            // Satisfaction check:
+            //   - If `accepted` is provided, ANY of those scopes in the token satisfies
+            //     the requirement (OR / hierarchy escape hatch).
+            //   - Otherwise, ALL `required` scopes must be present in the token (AND).
+            const satisfied = toolScopes.accepted
+                ? toolScopes.accepted.some(s => activeScopes.includes(s))
+                : toolScopes.required.every(s => activeScopes.includes(s));
 
-            // Check if the token has any of the accepted scopes
-            if (acceptedScopes.some(s => activeScopes.includes(s))) {
+            if (satisfied) {
                 continue;
             }
 
-            // Additive scoping: recommend the union of existing + required scopes.
-            // This ensures the client never loses scopes it already has when
-            // re-authorizing, matching the pattern from github/github-mcp-server.
-            const recommendedScopes = [...new Set([...activeScopes, ...toolScopes.required])];
+            // Per RFC 6750 §3.1 and MCP SEP-2350, the `scope` parameter advertises
+            // the scopes needed for the *current operation* — clients are expected
+            // to accumulate scopes across step-up challenges. Opt in via
+            // `includeGrantedScopes` to additionally union the token's active
+            // scopes (defensive against clients that don't accumulate).
+            const recommendedScopes = this._scopeChallenge.includeGrantedScopes
+                ? [...new Set([...activeScopes, ...toolScopes.required])]
+                : toolScopes.required;
 
             const errorDescription = this._scopeChallenge.buildErrorDescription
                 ? this._scopeChallenge.buildErrorDescription(toolName, toolScopes.required)
                 : `Additional scopes required: ${toolScopes.required.join(', ')}`;
 
-            const wwwAuthenticate = `Bearer error="insufficient_scope", scope="${recommendedScopes.join(' ')}", resource_metadata="${this._scopeChallenge.resourceMetadataUrl}", error_description="${errorDescription}"`;
+            const wwwAuthenticate =
+                `Bearer error="insufficient_scope"` +
+                `, scope="${quoteAuthParam(recommendedScopes.join(' '))}"` +
+                `, resource_metadata="${quoteAuthParam(this._scopeChallenge.resourceMetadataUrl)}"` +
+                `, error_description="${quoteAuthParam(errorDescription)}"`;
 
             return this.createJsonErrorResponse(403, -32_600, `Insufficient scope for tool: ${toolName}`, {
                 headers: {

--- a/packages/server/src/server/streamableHttp.ts
+++ b/packages/server/src/server/streamableHttp.ts
@@ -7,7 +7,7 @@
  * For Node.js Express/HTTP compatibility, use {@linkcode @modelcontextprotocol/node!NodeStreamableHTTPServerTransport | NodeStreamableHTTPServerTransport} which wraps this transport.
  */
 
-import type { AuthInfo, JSONRPCMessage, MessageExtraInfo, RequestId, Transport } from '@modelcontextprotocol/core';
+import type { AuthInfo, JSONRPCMessage, JSONRPCRequest, MessageExtraInfo, RequestId, Transport } from '@modelcontextprotocol/core';
 import {
     DEFAULT_NEGOTIATED_PROTOCOL_VERSION,
     isInitializeRequest,
@@ -97,16 +97,42 @@ interface StreamMapping {
  * ```
  */
 /**
- * Function that resolves scope requirements for a given tool name.
- * Returns the tool's {@linkcode ToolScopeConfig} or `undefined` if the tool has
- * no scope requirements (in which case the request is allowed through).
+ * Result returned by a {@linkcode ScopeResolver}. Identifies the operation
+ * being checked (for inclusion in the `WWW-Authenticate` error description)
+ * and the scopes that must be satisfied.
  */
-export type ScopeResolver = (toolName: string) => ToolScopeConfig | undefined;
+export interface ScopeResolution {
+    /**
+     * A human-readable label for the operation being checked, used in default
+     * error messages and as the `operationName` passed to
+     * {@linkcode ScopeChallengeConfig.buildErrorDescription}.
+     *
+     * Examples: `'tool:get_repo'`, `'resource:github://octo/hello'`,
+     * `'prompt:summarise'`, `'completion:summarise/repository'`.
+     */
+    operationName: string;
+
+    /**
+     * The scope requirements for this operation.
+     */
+    scopes: ToolScopeConfig;
+}
+
+/**
+ * Function that resolves scope requirements for an incoming JSON-RPC request.
+ * Receives the full request so it can dispatch on method and params.
+ *
+ * Returns `undefined` if the request has no scope requirements (the request is
+ * then allowed through). May return synchronously or as a Promise so that
+ * implementations can perform asynchronous lookups (for example, matching a
+ * resource URI against a list of dynamic resource templates).
+ */
+export type ScopeResolver = (request: JSONRPCRequest) => ScopeResolution | Promise<ScopeResolution | undefined> | undefined;
 
 /**
  * Transports that support scope challenge handling implement this interface,
  * allowing {@linkcode McpServer.connect} to auto-wire a {@linkcode ScopeResolver}
- * sourced from the registered tools.
+ * sourced from the registered primitives.
  */
 export interface ScopeAware {
     setScopeResolver(resolver: ScopeResolver): void;
@@ -134,8 +160,8 @@ export interface ScopeChallengeConfig {
 
     /**
      * When `true`, the `WWW-Authenticate` `scope` parameter is the union of the
-     * token's currently active scopes and the tool's `required` scopes, rather
-     * than just the per-operation `required` scopes.
+     * token's currently active scopes and the operation's `required` scopes,
+     * rather than just the per-operation `required` scopes.
      *
      * Per RFC 6750 §3.1 and MCP SEP-2350, the recommended posture is to emit
      * only the scopes required for the current operation and rely on the client
@@ -148,10 +174,11 @@ export interface ScopeChallengeConfig {
     includeGrantedScopes?: boolean;
 
     /**
-     * Optional custom error description generator.
-     * If not provided, a default description listing the required scopes is used.
+     * Optional custom error description generator. Receives the operation name
+     * (e.g. `'tool:get_repo'`) and the required scopes. If not provided, a
+     * default description listing the required scopes is used.
      */
-    buildErrorDescription?: (toolName: string, requiredScopes: string[]) => string;
+    buildErrorDescription?: (operationName: string, requiredScopes: string[]) => string;
 }
 
 /**
@@ -162,7 +189,7 @@ export interface ScopeChallengeConfig {
  * Does NOT add the surrounding quotes — call sites embed the result inside `"..."`.
  */
 function quoteAuthParam(value: string): string {
-    return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+    return value.replaceAll('\\', '\\\\').replaceAll('"', String.raw`\"`);
 }
 
 /**
@@ -435,14 +462,16 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
     }
 
     /**
-     * Checks if a tools/call request has sufficient scopes.
-     * Returns an HTTP 403 response with WWW-Authenticate header if scopes are insufficient,
-     * or undefined if the request should proceed normally.
+     * Checks each request in the incoming JSON-RPC payload against the
+     * configured {@linkcode ScopeResolver}. Returns an HTTP 403 response with
+     * a `WWW-Authenticate` header for the first request that fails its scope
+     * check, or `undefined` if all requests pass (or no scope challenge is
+     * configured).
      *
-     * This implements the MCP Scope Challenge Handling spec (§10.1):
+     * Implements the MCP Scope Challenge Handling spec (§10.1):
      * https://modelcontextprotocol.io/specification/draft/basic/authorization#scope-challenge-handling
      */
-    private _checkScopeChallenge(messages: JSONRPCMessage[], authInfo?: AuthInfo): Response | undefined {
+    private async _checkScopeChallenge(messages: JSONRPCMessage[], authInfo?: AuthInfo): Promise<Response | undefined> {
         if (!this._scopeChallenge || !this._scopeResolver || !authInfo) {
             return undefined;
         }
@@ -450,44 +479,41 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
         const activeScopes = authInfo.scopes;
 
         for (const message of messages) {
-            if (!isJSONRPCRequest(message) || message.method !== 'tools/call') {
+            if (!isJSONRPCRequest(message)) {
                 continue;
             }
 
-            const toolName = (message.params as { name?: string })?.name;
-            if (!toolName) {
+            const resolved = await this._scopeResolver(message);
+            if (!resolved) {
                 continue;
             }
 
-            const toolScopes = this._scopeResolver(toolName);
-            if (!toolScopes) {
-                continue;
-            }
+            const { operationName, scopes } = resolved;
 
             // Satisfaction check:
             //   - If `accepted` is provided, ANY of those scopes in the token satisfies
             //     the requirement (OR / hierarchy escape hatch).
             //   - Otherwise, ALL `required` scopes must be present in the token (AND).
-            const satisfied = toolScopes.accepted
-                ? toolScopes.accepted.some(s => activeScopes.includes(s))
-                : toolScopes.required.every(s => activeScopes.includes(s));
+            const satisfied = scopes.accepted
+                ? scopes.accepted.some(s => activeScopes.includes(s))
+                : scopes.required.every(s => activeScopes.includes(s));
 
             if (satisfied) {
                 continue;
             }
 
             // Per RFC 6750 §3.1 and MCP SEP-2350, the `scope` parameter advertises
-            // the scopes needed for the *current operation* — clients are expected
-            // to accumulate scopes across step-up challenges. Opt in via
-            // `includeGrantedScopes` to additionally union the token's active
-            // scopes (defensive against clients that don't accumulate).
+            // the scopes needed for the current operation; clients accumulate
+            // across step-up challenges. Opt in via `includeGrantedScopes` to
+            // additionally union the token's active scopes (defensive against
+            // clients that don't accumulate).
             const recommendedScopes = this._scopeChallenge.includeGrantedScopes
-                ? [...new Set([...activeScopes, ...toolScopes.required])]
-                : toolScopes.required;
+                ? [...new Set([...activeScopes, ...scopes.required])]
+                : scopes.required;
 
             const errorDescription = this._scopeChallenge.buildErrorDescription
-                ? this._scopeChallenge.buildErrorDescription(toolName, toolScopes.required)
-                : `Additional scopes required: ${toolScopes.required.join(', ')}`;
+                ? this._scopeChallenge.buildErrorDescription(operationName, scopes.required)
+                : `Additional scopes required: ${scopes.required.join(', ')}`;
 
             const wwwAuthenticate =
                 `Bearer error="insufficient_scope"` +
@@ -495,7 +521,7 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
                 `, resource_metadata="${quoteAuthParam(this._scopeChallenge.resourceMetadataUrl)}"` +
                 `, error_description="${quoteAuthParam(errorDescription)}"`;
 
-            return this.createJsonErrorResponse(403, -32_600, `Insufficient scope for tool: ${toolName}`, {
+            return this.createJsonErrorResponse(403, -32_600, `Insufficient scope for ${operationName}`, {
                 headers: {
                     'WWW-Authenticate': wwwAuthenticate
                 }
@@ -897,9 +923,9 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
                 }
             }
 
-            // Pre-execution scope challenge check for tools/call requests.
-            // This runs BEFORE the SSE stream opens so we can still return HTTP 403.
-            const scopeChallengeResponse = this._checkScopeChallenge(messages, options?.authInfo);
+            // Pre-execution scope challenge check.
+            // Runs BEFORE the SSE stream opens so we can still return HTTP 403.
+            const scopeChallengeResponse = await this._checkScopeChallenge(messages, options?.authInfo);
             if (scopeChallengeResponse) {
                 return scopeChallengeResponse;
             }

--- a/packages/server/test/server/scopeChallenge.test.ts
+++ b/packages/server/test/server/scopeChallenge.test.ts
@@ -1,0 +1,504 @@
+import { randomUUID } from 'node:crypto';
+
+import type { AuthInfo, CallToolResult, JSONRPCMessage } from '@modelcontextprotocol/core';
+import * as z from 'zod/v4';
+
+import { McpServer } from '../../src/server/mcp.js';
+import { WebStandardStreamableHTTPServerTransport } from '../../src/server/streamableHttp.js';
+
+/**
+ * Helper to create a Web Standard Request
+ */
+function createRequest(
+    method: string,
+    body?: JSONRPCMessage | JSONRPCMessage[],
+    options?: {
+        sessionId?: string;
+        accept?: string;
+        contentType?: string;
+        extraHeaders?: Record<string, string>;
+    }
+): Request {
+    const headers: Record<string, string> = {};
+
+    if (options?.accept) {
+        headers['Accept'] = options.accept;
+    } else if (method === 'POST') {
+        headers['Accept'] = 'application/json, text/event-stream';
+    } else if (method === 'GET') {
+        headers['Accept'] = 'text/event-stream';
+    }
+
+    if (options?.contentType) {
+        headers['Content-Type'] = options.contentType;
+    } else if (body) {
+        headers['Content-Type'] = 'application/json';
+    }
+
+    if (options?.sessionId) {
+        headers['mcp-session-id'] = options.sessionId;
+        headers['mcp-protocol-version'] = '2025-11-25';
+    }
+
+    if (options?.extraHeaders) {
+        Object.assign(headers, options.extraHeaders);
+    }
+
+    return new Request('http://localhost/mcp', {
+        method,
+        headers,
+        body: body ? JSON.stringify(body) : undefined
+    });
+}
+
+const RESOURCE_METADATA_URL = 'https://auth.example.com/.well-known/oauth-protected-resource';
+
+function createToolCallMessage(toolName: string, args: Record<string, unknown> = {}, id: string | number = 'call-1'): JSONRPCMessage {
+    return {
+        jsonrpc: '2.0',
+        method: 'tools/call',
+        params: { name: toolName, arguments: args },
+        id
+    } as JSONRPCMessage;
+}
+
+const INITIALIZE_MESSAGE: JSONRPCMessage = {
+    jsonrpc: '2.0',
+    method: 'initialize',
+    params: {
+        clientInfo: { name: 'test-client', version: '1.0' },
+        protocolVersion: '2025-11-25',
+        capabilities: {}
+    },
+    id: 'init-1'
+} as JSONRPCMessage;
+
+describe('Scope Challenge / Step-Up Auth', () => {
+    let transport: WebStandardStreamableHTTPServerTransport;
+    let mcpServer: McpServer;
+
+    afterEach(async () => {
+        await transport.close();
+    });
+
+    async function initializeServer(): Promise<string> {
+        const request = createRequest('POST', INITIALIZE_MESSAGE);
+        const response = await transport.handleRequest(request);
+        expect(response.status).toBe(200);
+        const sessionId = response.headers.get('mcp-session-id');
+        expect(sessionId).toBeDefined();
+        return sessionId as string;
+    }
+
+    function setupServer(options: {
+        scopeChallenge?: {
+            resourceMetadataUrl: string;
+            buildErrorDescription?: (toolName: string, requiredScopes: string[]) => string;
+        };
+        tools?: Array<{
+            name: string;
+            scopes?: string[] | { required: string[]; accepted?: string[] };
+            schema?: z.ZodObject<{ name: z.ZodString }>;
+        }>;
+        toolScopeOverrides?: Record<string, string[] | { required: string[]; accepted?: string[] }>;
+    }): void {
+        mcpServer = new McpServer({ name: 'scope-test-server', version: '1.0.0' }, { capabilities: { logging: {} } });
+
+        const tools = options.tools ?? [
+            { name: 'public_tool' },
+            { name: 'read_repo', scopes: ['repo:read'] },
+            { name: 'write_repo', scopes: { required: ['repo:write'], accepted: ['repo:write', 'repo'] } }
+        ];
+
+        for (const tool of tools) {
+            mcpServer.registerTool(
+                tool.name,
+                {
+                    description: `Test tool: ${tool.name}`,
+                    inputSchema: tool.schema ?? z.object({ name: z.string() }),
+                    scopes: tool.scopes
+                },
+                async ({ name }): Promise<CallToolResult> => {
+                    return { content: [{ type: 'text', text: `Result from ${tool.name}: ${name}` }] };
+                }
+            );
+        }
+
+        if (options.toolScopeOverrides) {
+            for (const [toolName, scopes] of Object.entries(options.toolScopeOverrides)) {
+                mcpServer.setToolScopes(toolName, scopes);
+            }
+        }
+
+        transport = new WebStandardStreamableHTTPServerTransport({
+            sessionIdGenerator: () => randomUUID(),
+            scopeChallenge: options.scopeChallenge
+        });
+    }
+
+    describe('HTTP 403 scope challenge responses', () => {
+        beforeEach(async () => {
+            setupServer({
+                scopeChallenge: { resourceMetadataUrl: RESOURCE_METADATA_URL }
+            });
+            await mcpServer.connect(transport);
+        });
+
+        it('should return 403 when token lacks required scopes', async () => {
+            const sessionId = await initializeServer();
+
+            const authInfo: AuthInfo = {
+                token: 'test-token',
+                clientId: 'test-client',
+                scopes: ['user:read']
+            };
+
+            const request = createRequest('POST', createToolCallMessage('read_repo', { name: 'test' }), { sessionId });
+
+            const response = await transport.handleRequest(request, { authInfo });
+
+            expect(response.status).toBe(403);
+
+            const wwwAuth = response.headers.get('WWW-Authenticate');
+            expect(wwwAuth).toBeDefined();
+            expect(wwwAuth).toContain('error="insufficient_scope"');
+            expect(wwwAuth).toContain('scope="user:read repo:read"');
+            expect(wwwAuth).toContain(`resource_metadata="${RESOURCE_METADATA_URL}"`);
+
+            const body = (await response.json()) as { jsonrpc: string; error: { code: number; message: string } };
+            expect(body.jsonrpc).toBe('2.0');
+            expect(body.error.code).toBe(-32600);
+            expect(body.error.message).toContain('Insufficient scope');
+            expect(body.error.message).toContain('read_repo');
+        });
+
+        it('should pass when token has a required scope', async () => {
+            const sessionId = await initializeServer();
+
+            const authInfo: AuthInfo = {
+                token: 'test-token',
+                clientId: 'test-client',
+                scopes: ['repo:read']
+            };
+
+            const request = createRequest('POST', createToolCallMessage('read_repo', { name: 'test' }), { sessionId });
+
+            const response = await transport.handleRequest(request, { authInfo });
+
+            // Should NOT be 403 — tool should execute
+            expect(response.status).toBe(200);
+        });
+
+        it('should pass when token has an accepted (parent) scope', async () => {
+            const sessionId = await initializeServer();
+
+            const authInfo: AuthInfo = {
+                token: 'test-token',
+                clientId: 'test-client',
+                scopes: ['repo'] // parent scope — accepted by write_repo
+            };
+
+            const request = createRequest('POST', createToolCallMessage('write_repo', { name: 'test' }), { sessionId });
+
+            const response = await transport.handleRequest(request, { authInfo });
+
+            expect(response.status).toBe(200);
+        });
+
+        it('should pass through tools with no scope configuration', async () => {
+            const sessionId = await initializeServer();
+
+            const authInfo: AuthInfo = {
+                token: 'test-token',
+                clientId: 'test-client',
+                scopes: [] // no scopes at all
+            };
+
+            const request = createRequest('POST', createToolCallMessage('public_tool', { name: 'test' }), { sessionId });
+
+            const response = await transport.handleRequest(request, { authInfo });
+
+            expect(response.status).toBe(200);
+        });
+
+        it('should pass through non-tools/call requests', async () => {
+            const sessionId = await initializeServer();
+
+            const authInfo: AuthInfo = {
+                token: 'test-token',
+                clientId: 'test-client',
+                scopes: []
+            };
+
+            const listToolsMsg: JSONRPCMessage = {
+                jsonrpc: '2.0',
+                method: 'tools/list',
+                params: {},
+                id: 'list-1'
+            } as JSONRPCMessage;
+
+            const request = createRequest('POST', listToolsMsg, { sessionId });
+            const response = await transport.handleRequest(request, { authInfo });
+
+            expect(response.status).toBe(200);
+        });
+
+        it('should include recommended scopes as union of existing + required', async () => {
+            const sessionId = await initializeServer();
+
+            const authInfo: AuthInfo = {
+                token: 'test-token',
+                clientId: 'test-client',
+                scopes: ['user:read', 'user:write']
+            };
+
+            const request = createRequest('POST', createToolCallMessage('read_repo', { name: 'test' }), { sessionId });
+
+            const response = await transport.handleRequest(request, { authInfo });
+
+            expect(response.status).toBe(403);
+            const wwwAuth = response.headers.get('WWW-Authenticate')!;
+            // Should contain all existing scopes + the required one
+            expect(wwwAuth).toContain('user:read');
+            expect(wwwAuth).toContain('user:write');
+            expect(wwwAuth).toContain('repo:read');
+        });
+    });
+
+    describe('without scope challenge configured', () => {
+        beforeEach(async () => {
+            setupServer({}); // no scopeChallenge
+            await mcpServer.connect(transport);
+        });
+
+        it('should pass through all tools/call requests when scope challenge is not configured', async () => {
+            const sessionId = await initializeServer();
+
+            const authInfo: AuthInfo = {
+                token: 'test-token',
+                clientId: 'test-client',
+                scopes: []
+            };
+
+            const request = createRequest('POST', createToolCallMessage('read_repo', { name: 'test' }), { sessionId });
+
+            const response = await transport.handleRequest(request, { authInfo });
+
+            // Without scopeChallenge configured, scope check is skipped
+            expect(response.status).toBe(200);
+        });
+    });
+
+    describe('setToolScopes override', () => {
+        it('should use overridden scopes from setToolScopes instead of registration scopes', async () => {
+            setupServer({
+                scopeChallenge: { resourceMetadataUrl: RESOURCE_METADATA_URL },
+                tools: [{ name: 'read_repo', scopes: ['repo:read'] }],
+                toolScopeOverrides: {
+                    read_repo: ['admin:repo'] // Override: now requires admin:repo instead
+                }
+            });
+            await mcpServer.connect(transport);
+            const sessionId = await initializeServer();
+
+            // Token has repo:read (the original scope), but not admin:repo (the override)
+            const authInfo: AuthInfo = {
+                token: 'test-token',
+                clientId: 'test-client',
+                scopes: ['repo:read']
+            };
+
+            const request = createRequest('POST', createToolCallMessage('read_repo', { name: 'test' }), { sessionId });
+
+            const response = await transport.handleRequest(request, { authInfo });
+
+            // Should be 403 because the override requires admin:repo
+            expect(response.status).toBe(403);
+            const wwwAuth = response.headers.get('WWW-Authenticate')!;
+            expect(wwwAuth).toContain('admin:repo');
+        });
+
+        it('should allow setting scopes on tools that had no scopes at registration', async () => {
+            setupServer({
+                scopeChallenge: { resourceMetadataUrl: RESOURCE_METADATA_URL },
+                tools: [
+                    { name: 'public_tool' } // No scopes at registration
+                ],
+                toolScopeOverrides: {
+                    public_tool: ['admin:read'] // Now requires scopes
+                }
+            });
+            await mcpServer.connect(transport);
+            const sessionId = await initializeServer();
+
+            const authInfo: AuthInfo = {
+                token: 'test-token',
+                clientId: 'test-client',
+                scopes: []
+            };
+
+            const request = createRequest('POST', createToolCallMessage('public_tool', { name: 'test' }), { sessionId });
+
+            const response = await transport.handleRequest(request, { authInfo });
+
+            expect(response.status).toBe(403);
+        });
+    });
+
+    describe('custom error description', () => {
+        it('should use buildErrorDescription when provided', async () => {
+            setupServer({
+                scopeChallenge: {
+                    resourceMetadataUrl: RESOURCE_METADATA_URL,
+                    buildErrorDescription: (toolName, requiredScopes) => `Tool "${toolName}" needs: ${requiredScopes.join(', ')}`
+                }
+            });
+            await mcpServer.connect(transport);
+            const sessionId = await initializeServer();
+
+            const authInfo: AuthInfo = {
+                token: 'test-token',
+                clientId: 'test-client',
+                scopes: []
+            };
+
+            const request = createRequest('POST', createToolCallMessage('read_repo', { name: 'test' }), { sessionId });
+
+            const response = await transport.handleRequest(request, { authInfo });
+
+            expect(response.status).toBe(403);
+            const wwwAuth = response.headers.get('WWW-Authenticate')!;
+            expect(wwwAuth).toContain('Tool "read_repo" needs: repo:read');
+        });
+    });
+
+    describe('batch requests', () => {
+        beforeEach(async () => {
+            setupServer({
+                scopeChallenge: { resourceMetadataUrl: RESOURCE_METADATA_URL }
+            });
+            await mcpServer.connect(transport);
+        });
+
+        it('should reject the entire batch if any tools/call lacks scopes', async () => {
+            const sessionId = await initializeServer();
+
+            const authInfo: AuthInfo = {
+                token: 'test-token',
+                clientId: 'test-client',
+                scopes: []
+            };
+
+            const batch: JSONRPCMessage[] = [
+                createToolCallMessage('public_tool', { name: 'ok' }, 'call-1'),
+                createToolCallMessage('read_repo', { name: 'fail' }, 'call-2')
+            ];
+
+            const request = createRequest('POST', batch, { sessionId });
+            const response = await transport.handleRequest(request, { authInfo });
+
+            expect(response.status).toBe(403);
+        });
+    });
+
+    describe('McpServer scope API', () => {
+        it('getToolScopes returns undefined for tools without scopes', () => {
+            mcpServer = new McpServer({ name: 'test', version: '1.0.0' });
+            mcpServer.registerTool(
+                'no_scopes',
+                {
+                    description: 'No scopes',
+                    inputSchema: z.object({ x: z.string() })
+                },
+                async () => ({ content: [] })
+            );
+
+            expect(mcpServer.getToolScopes('no_scopes')).toBeUndefined();
+        });
+
+        it('getToolScopes returns normalized scopes from string[] registration', () => {
+            mcpServer = new McpServer({ name: 'test', version: '1.0.0' });
+            mcpServer.registerTool(
+                'scoped',
+                {
+                    description: 'Scoped',
+                    inputSchema: z.object({ x: z.string() }),
+                    scopes: ['repo:read', 'repo:write']
+                },
+                async () => ({ content: [] })
+            );
+
+            const scopes = mcpServer.getToolScopes('scoped');
+            expect(scopes).toEqual({ required: ['repo:read', 'repo:write'] });
+        });
+
+        it('getToolScopes returns full config from object registration', () => {
+            mcpServer = new McpServer({ name: 'test', version: '1.0.0' });
+            mcpServer.registerTool(
+                'scoped',
+                {
+                    description: 'Scoped',
+                    inputSchema: z.object({ x: z.string() }),
+                    scopes: { required: ['public_repo'], accepted: ['public_repo', 'repo'] }
+                },
+                async () => ({ content: [] })
+            );
+
+            const scopes = mcpServer.getToolScopes('scoped');
+            expect(scopes).toEqual({ required: ['public_repo'], accepted: ['public_repo', 'repo'] });
+        });
+
+        it('setToolScopes overrides registration scopes', () => {
+            mcpServer = new McpServer({ name: 'test', version: '1.0.0' });
+            mcpServer.registerTool(
+                'scoped',
+                {
+                    description: 'Scoped',
+                    inputSchema: z.object({ x: z.string() }),
+                    scopes: ['repo:read']
+                },
+                async () => ({ content: [] })
+            );
+
+            mcpServer.setToolScopes('scoped', ['admin:repo']);
+
+            const scopes = mcpServer.getToolScopes('scoped');
+            expect(scopes).toEqual({ required: ['admin:repo'] });
+        });
+
+        it('setToolScopes can set scopes on unregistered tool names', () => {
+            mcpServer = new McpServer({ name: 'test', version: '1.0.0' });
+            mcpServer.setToolScopes('future_tool', ['admin:read']);
+
+            // Returns the override even if tool isn't registered yet
+            const scopes = mcpServer.getToolScopes('future_tool');
+            expect(scopes).toEqual({ required: ['admin:read'] });
+        });
+    });
+
+    describe('auto-wiring', () => {
+        it('should auto-wire scope resolver on connect when transport supports it', async () => {
+            setupServer({
+                scopeChallenge: { resourceMetadataUrl: RESOURCE_METADATA_URL }
+            });
+
+            // Before connect, the transport has no resolver — scope checks should pass
+            // We verify this indirectly: after connect, scope checks work
+            await mcpServer.connect(transport);
+            const sessionId = await initializeServer();
+
+            const authInfo: AuthInfo = {
+                token: 'test-token',
+                clientId: 'test-client',
+                scopes: []
+            };
+
+            const request = createRequest('POST', createToolCallMessage('read_repo', { name: 'test' }), { sessionId });
+
+            const response = await transport.handleRequest(request, { authInfo });
+
+            // If auto-wiring didn't work, this would pass through
+            expect(response.status).toBe(403);
+        });
+    });
+});

--- a/packages/server/test/server/scopeChallenge.test.ts
+++ b/packages/server/test/server/scopeChallenge.test.ts
@@ -471,7 +471,8 @@ describe('Scope Challenge / Step-Up Auth', () => {
             setupServer({
                 scopeChallenge: {
                     resourceMetadataUrl: RESOURCE_METADATA_URL,
-                    buildErrorDescription: (toolName, requiredScopes) => `Tool "${toolName}" needs: ${requiredScopes.join(', ')}`
+                    buildErrorDescription: (operationName, requiredScopes) =>
+                        `Operation "${operationName}" needs: ${requiredScopes.join(', ')}`
                 }
             });
             await mcpServer.connect(transport);
@@ -489,8 +490,8 @@ describe('Scope Challenge / Step-Up Auth', () => {
 
             expect(response.status).toBe(403);
             const wwwAuth = response.headers.get('WWW-Authenticate')!;
-            // The quotes in `"read_repo"` are escaped per RFC 7235 quoted-string rules.
-            expect(wwwAuth).toContain('Tool \\"read_repo\\" needs: repo:read');
+            // operationName is `tool:read_repo`; quotes are RFC 7235 escaped.
+            expect(wwwAuth).toContain('Operation \\"tool:read_repo\\" needs: repo:read');
         });
     });
 

--- a/packages/server/test/server/scopeChallenge.test.ts
+++ b/packages/server/test/server/scopeChallenge.test.ts
@@ -93,6 +93,7 @@ describe('Scope Challenge / Step-Up Auth', () => {
     function setupServer(options: {
         scopeChallenge?: {
             resourceMetadataUrl: string;
+            includeGrantedScopes?: boolean;
             buildErrorDescription?: (toolName: string, requiredScopes: string[]) => string;
         };
         tools?: Array<{
@@ -162,7 +163,10 @@ describe('Scope Challenge / Step-Up Auth', () => {
             const wwwAuth = response.headers.get('WWW-Authenticate');
             expect(wwwAuth).toBeDefined();
             expect(wwwAuth).toContain('error="insufficient_scope"');
-            expect(wwwAuth).toContain('scope="user:read repo:read"');
+            // Per RFC 6750 §3.1 and SEP-2350, advertise only the per-operation
+            // required scope by default — clients accumulate across step-ups.
+            expect(wwwAuth).toContain('scope="repo:read"');
+            expect(wwwAuth).not.toContain('user:read');
             expect(wwwAuth).toContain(`resource_metadata="${RESOURCE_METADATA_URL}"`);
 
             const body = (await response.json()) as { jsonrpc: string; error: { code: number; message: string } };
@@ -243,7 +247,7 @@ describe('Scope Challenge / Step-Up Auth', () => {
             expect(response.status).toBe(200);
         });
 
-        it('should include recommended scopes as union of existing + required', async () => {
+        it('should advertise only per-operation required scopes by default (RFC 6750 §3.1, SEP-2350)', async () => {
             const sessionId = await initializeServer();
 
             const authInfo: AuthInfo = {
@@ -258,10 +262,127 @@ describe('Scope Challenge / Step-Up Auth', () => {
 
             expect(response.status).toBe(403);
             const wwwAuth = response.headers.get('WWW-Authenticate')!;
-            // Should contain all existing scopes + the required one
+            // Only the operation's required scope is advertised; client accumulates.
+            expect(wwwAuth).toContain('scope="repo:read"');
+            expect(wwwAuth).not.toContain('user:read');
+            expect(wwwAuth).not.toContain('user:write');
+        });
+    });
+
+    describe('required scopes (AND semantics)', () => {
+        beforeEach(async () => {
+            setupServer({
+                scopeChallenge: { resourceMetadataUrl: RESOURCE_METADATA_URL },
+                tools: [{ name: 'multi_scope_tool', scopes: ['repo:read', 'user:read'] }]
+            });
+            await mcpServer.connect(transport);
+        });
+
+        it('should require ALL scopes in required[] to be present', async () => {
+            const sessionId = await initializeServer();
+
+            const authInfo: AuthInfo = {
+                token: 'test-token',
+                clientId: 'test-client',
+                scopes: ['repo:read'] // missing user:read
+            };
+
+            const request = createRequest('POST', createToolCallMessage('multi_scope_tool', { name: 'test' }), { sessionId });
+            const response = await transport.handleRequest(request, { authInfo });
+
+            expect(response.status).toBe(403);
+        });
+
+        it('should pass when ALL required scopes are present', async () => {
+            const sessionId = await initializeServer();
+
+            const authInfo: AuthInfo = {
+                token: 'test-token',
+                clientId: 'test-client',
+                scopes: ['repo:read', 'user:read', 'extra:scope']
+            };
+
+            const request = createRequest('POST', createToolCallMessage('multi_scope_tool', { name: 'test' }), { sessionId });
+            const response = await transport.handleRequest(request, { authInfo });
+
+            expect(response.status).toBe(200);
+        });
+    });
+
+    describe('includeGrantedScopes opt-in', () => {
+        beforeEach(async () => {
+            setupServer({
+                scopeChallenge: {
+                    resourceMetadataUrl: RESOURCE_METADATA_URL,
+                    includeGrantedScopes: true
+                }
+            });
+            await mcpServer.connect(transport);
+        });
+
+        it('should union active token scopes with required when includeGrantedScopes=true', async () => {
+            const sessionId = await initializeServer();
+
+            const authInfo: AuthInfo = {
+                token: 'test-token',
+                clientId: 'test-client',
+                scopes: ['user:read', 'user:write']
+            };
+
+            const request = createRequest('POST', createToolCallMessage('read_repo', { name: 'test' }), { sessionId });
+            const response = await transport.handleRequest(request, { authInfo });
+
+            expect(response.status).toBe(403);
+            const wwwAuth = response.headers.get('WWW-Authenticate')!;
             expect(wwwAuth).toContain('user:read');
             expect(wwwAuth).toContain('user:write');
             expect(wwwAuth).toContain('repo:read');
+        });
+
+        it('should deduplicate scopes in the union', async () => {
+            const sessionId = await initializeServer();
+
+            // Token already has repo:read; tool will also require repo:read (plus a missing scope)
+            // so the union has a natural duplicate to deduplicate.
+            mcpServer.setToolScopes('read_repo', ['repo:read', 'repo:write']);
+
+            const authInfo: AuthInfo = {
+                token: 'test-token',
+                clientId: 'test-client',
+                scopes: ['repo:read', 'user:read']
+            };
+
+            const request = createRequest('POST', createToolCallMessage('read_repo', { name: 'test' }), { sessionId });
+            const response = await transport.handleRequest(request, { authInfo });
+
+            expect(response.status).toBe(403);
+            const wwwAuth = response.headers.get('WWW-Authenticate')!;
+            const scopeMatch = wwwAuth.match(/scope="([^"]*)"/);
+            const scopes = (scopeMatch?.[1] ?? '').split(' ');
+            // No duplicates in the advertised scope value (RFC 6750 §3 — scope is a set).
+            expect(new Set(scopes).size).toBe(scopes.length);
+        });
+    });
+
+    describe('WWW-Authenticate header quoting', () => {
+        it('should escape embedded quotes and backslashes per RFC 7235', async () => {
+            setupServer({
+                scopeChallenge: {
+                    resourceMetadataUrl: RESOURCE_METADATA_URL,
+                    buildErrorDescription: () => 'Needs "repo:read", path\\to\\thing'
+                }
+            });
+            await mcpServer.connect(transport);
+
+            const sessionId = await initializeServer();
+            const authInfo: AuthInfo = { token: 't', clientId: 'c', scopes: [] };
+            const request = createRequest('POST', createToolCallMessage('read_repo'), { sessionId });
+            const response = await transport.handleRequest(request, { authInfo });
+
+            expect(response.status).toBe(403);
+            const wwwAuth = response.headers.get('WWW-Authenticate')!;
+            // Both `"` and `\` must be backslash-escaped to keep the header parseable.
+            expect(wwwAuth).toContain('error_description="Needs \\"repo:read\\", path\\\\to\\\\thing"');
         });
     });
 
@@ -368,7 +489,8 @@ describe('Scope Challenge / Step-Up Auth', () => {
 
             expect(response.status).toBe(403);
             const wwwAuth = response.headers.get('WWW-Authenticate')!;
-            expect(wwwAuth).toContain('Tool "read_repo" needs: repo:read');
+            // The quotes in `"read_repo"` are escaped per RFC 7235 quoted-string rules.
+            expect(wwwAuth).toContain('Tool \\"read_repo\\" needs: repo:read');
         });
     });
 
@@ -398,81 +520,6 @@ describe('Scope Challenge / Step-Up Auth', () => {
             const response = await transport.handleRequest(request, { authInfo });
 
             expect(response.status).toBe(403);
-        });
-    });
-
-    describe('McpServer scope API', () => {
-        it('getToolScopes returns undefined for tools without scopes', () => {
-            mcpServer = new McpServer({ name: 'test', version: '1.0.0' });
-            mcpServer.registerTool(
-                'no_scopes',
-                {
-                    description: 'No scopes',
-                    inputSchema: z.object({ x: z.string() })
-                },
-                async () => ({ content: [] })
-            );
-
-            expect(mcpServer.getToolScopes('no_scopes')).toBeUndefined();
-        });
-
-        it('getToolScopes returns normalized scopes from string[] registration', () => {
-            mcpServer = new McpServer({ name: 'test', version: '1.0.0' });
-            mcpServer.registerTool(
-                'scoped',
-                {
-                    description: 'Scoped',
-                    inputSchema: z.object({ x: z.string() }),
-                    scopes: ['repo:read', 'repo:write']
-                },
-                async () => ({ content: [] })
-            );
-
-            const scopes = mcpServer.getToolScopes('scoped');
-            expect(scopes).toEqual({ required: ['repo:read', 'repo:write'] });
-        });
-
-        it('getToolScopes returns full config from object registration', () => {
-            mcpServer = new McpServer({ name: 'test', version: '1.0.0' });
-            mcpServer.registerTool(
-                'scoped',
-                {
-                    description: 'Scoped',
-                    inputSchema: z.object({ x: z.string() }),
-                    scopes: { required: ['public_repo'], accepted: ['public_repo', 'repo'] }
-                },
-                async () => ({ content: [] })
-            );
-
-            const scopes = mcpServer.getToolScopes('scoped');
-            expect(scopes).toEqual({ required: ['public_repo'], accepted: ['public_repo', 'repo'] });
-        });
-
-        it('setToolScopes overrides registration scopes', () => {
-            mcpServer = new McpServer({ name: 'test', version: '1.0.0' });
-            mcpServer.registerTool(
-                'scoped',
-                {
-                    description: 'Scoped',
-                    inputSchema: z.object({ x: z.string() }),
-                    scopes: ['repo:read']
-                },
-                async () => ({ content: [] })
-            );
-
-            mcpServer.setToolScopes('scoped', ['admin:repo']);
-
-            const scopes = mcpServer.getToolScopes('scoped');
-            expect(scopes).toEqual({ required: ['admin:repo'] });
-        });
-
-        it('setToolScopes can set scopes on unregistered tool names', () => {
-            mcpServer = new McpServer({ name: 'test', version: '1.0.0' });
-            mcpServer.setToolScopes('future_tool', ['admin:read']);
-
-            // Returns the override even if tool isn't registered yet
-            const scopes = mcpServer.getToolScopes('future_tool');
-            expect(scopes).toEqual({ required: ['admin:read'] });
         });
     });
 

--- a/packages/server/test/server/scopeChallengePrimitives.test.ts
+++ b/packages/server/test/server/scopeChallengePrimitives.test.ts
@@ -1,0 +1,355 @@
+import { randomUUID } from 'node:crypto';
+
+import type { AuthInfo, JSONRPCMessage } from '@modelcontextprotocol/core';
+import * as z from 'zod/v4';
+
+import { McpServer, ResourceTemplate } from '../../src/server/mcp.js';
+import { WebStandardStreamableHTTPServerTransport } from '../../src/server/streamableHttp.js';
+
+const RESOURCE_METADATA_URL = 'https://auth.example.com/.well-known/oauth-protected-resource';
+
+function createRequest(body: JSONRPCMessage | JSONRPCMessage[], sessionId?: string): Request {
+    const headers: Record<string, string> = {
+        Accept: 'application/json, text/event-stream',
+        'Content-Type': 'application/json'
+    };
+    if (sessionId) {
+        headers['mcp-session-id'] = sessionId;
+        headers['mcp-protocol-version'] = '2025-11-25';
+    }
+    return new Request('http://localhost/mcp', { method: 'POST', headers, body: JSON.stringify(body) });
+}
+
+const INITIALIZE_MESSAGE: JSONRPCMessage = {
+    jsonrpc: '2.0',
+    method: 'initialize',
+    params: {
+        clientInfo: { name: 'test-client', version: '1.0' },
+        protocolVersion: '2025-11-25',
+        capabilities: {}
+    },
+    id: 'init-1'
+} as JSONRPCMessage;
+
+function readResourceMessage(uri: string, id: string | number = 'read-1'): JSONRPCMessage {
+    return {
+        jsonrpc: '2.0',
+        method: 'resources/read',
+        params: { uri },
+        id
+    } as JSONRPCMessage;
+}
+
+function getPromptMessage(name: string, id: string | number = 'prompt-1'): JSONRPCMessage {
+    return {
+        jsonrpc: '2.0',
+        method: 'prompts/get',
+        params: { name, arguments: {} },
+        id
+    } as JSONRPCMessage;
+}
+
+function completionMessage(
+    ref: { type: 'ref/prompt'; name: string } | { type: 'ref/resource'; uri: string },
+    argumentName: string,
+    value: string,
+    id: string | number = 'comp-1'
+): JSONRPCMessage {
+    return {
+        jsonrpc: '2.0',
+        method: 'completion/complete',
+        params: { ref, argument: { name: argumentName, value } },
+        id
+    } as JSONRPCMessage;
+}
+
+describe('Scope Challenge / non-tool primitives', () => {
+    let transport: WebStandardStreamableHTTPServerTransport;
+    let mcpServer: McpServer;
+
+    afterEach(async () => {
+        await transport.close();
+    });
+
+    async function initialize(): Promise<string> {
+        const response = await transport.handleRequest(createRequest(INITIALIZE_MESSAGE));
+        expect(response.status).toBe(200);
+        return response.headers.get('mcp-session-id') as string;
+    }
+
+    function newServer(): void {
+        mcpServer = new McpServer({ name: 'scope-primitives-test', version: '1.0.0' }, { capabilities: { logging: {} } });
+        transport = new WebStandardStreamableHTTPServerTransport({
+            sessionIdGenerator: () => randomUUID(),
+            scopeChallenge: { resourceMetadataUrl: RESOURCE_METADATA_URL }
+        });
+    }
+
+    describe('resources/read', () => {
+        it('returns 403 when token lacks scopes for a static resource', async () => {
+            newServer();
+            mcpServer.registerResource('config', 'config://settings', { scopes: ['config:read'], mimeType: 'text/plain' }, async uri => ({
+                contents: [{ uri: uri.href, text: 'data' }]
+            }));
+            await mcpServer.connect(transport);
+            const sessionId = await initialize();
+            const authInfo: AuthInfo = { token: 't', clientId: 'c', scopes: [] };
+
+            const response = await transport.handleRequest(createRequest(readResourceMessage('config://settings'), sessionId), {
+                authInfo
+            });
+
+            expect(response.status).toBe(403);
+            const wwwAuth = response.headers.get('WWW-Authenticate')!;
+            expect(wwwAuth).toContain('error="insufficient_scope"');
+            expect(wwwAuth).toContain('scope="config:read"');
+        });
+
+        it('passes when token has required scope for a static resource', async () => {
+            newServer();
+            mcpServer.registerResource('config', 'config://settings', { scopes: ['config:read'], mimeType: 'text/plain' }, async uri => ({
+                contents: [{ uri: uri.href, text: 'data' }]
+            }));
+            await mcpServer.connect(transport);
+            const sessionId = await initialize();
+            const authInfo: AuthInfo = { token: 't', clientId: 'c', scopes: ['config:read'] };
+
+            const response = await transport.handleRequest(createRequest(readResourceMessage('config://settings'), sessionId), {
+                authInfo
+            });
+            expect(response.status).toBe(200);
+        });
+
+        it('passes through static resources with no scope configuration', async () => {
+            newServer();
+            mcpServer.registerResource('public', 'public://thing', { mimeType: 'text/plain' }, async uri => ({
+                contents: [{ uri: uri.href, text: 'data' }]
+            }));
+            await mcpServer.connect(transport);
+            const sessionId = await initialize();
+            const authInfo: AuthInfo = { token: 't', clientId: 'c', scopes: [] };
+
+            const response = await transport.handleRequest(createRequest(readResourceMessage('public://thing'), sessionId), {
+                authInfo
+            });
+            expect(response.status).toBe(200);
+        });
+
+        it('matches a templated URI and returns 403 when scopes are missing', async () => {
+            newServer();
+            mcpServer.registerResource(
+                'repo',
+                new ResourceTemplate('github://{owner}/{repo}', { list: undefined }),
+                { scopes: ['repo:read'] },
+                async (uri, variables) => ({ contents: [{ uri: uri.href, text: JSON.stringify(variables) }] })
+            );
+            await mcpServer.connect(transport);
+            const sessionId = await initialize();
+            const authInfo: AuthInfo = { token: 't', clientId: 'c', scopes: [] };
+
+            const response = await transport.handleRequest(createRequest(readResourceMessage('github://octo/hello'), sessionId), {
+                authInfo
+            });
+            expect(response.status).toBe(403);
+            expect(response.headers.get('WWW-Authenticate')).toContain('scope="repo:read"');
+        });
+
+        it('resolves dynamic per-request scopes from template variables', async () => {
+            newServer();
+            mcpServer.registerResource(
+                'repo',
+                new ResourceTemplate('github://{owner}/{repo}', { list: undefined }),
+                {
+                    scopes: (_uri, variables) => (variables.owner === 'private-org' ? ['repo'] : ['public_repo'])
+                },
+                async (uri, variables) => ({ contents: [{ uri: uri.href, text: JSON.stringify(variables) }] })
+            );
+            await mcpServer.connect(transport);
+            const sessionId = await initialize();
+
+            // private-org token only has public_repo -> 403 with `repo` advertised
+            const privateResponse = await transport.handleRequest(
+                createRequest(readResourceMessage('github://private-org/secret'), sessionId),
+                { authInfo: { token: 't', clientId: 'c', scopes: ['public_repo'] } }
+            );
+            expect(privateResponse.status).toBe(403);
+            expect(privateResponse.headers.get('WWW-Authenticate')).toContain('scope="repo"');
+
+            // public org with public_repo token -> 200
+            const publicResponse = await transport.handleRequest(createRequest(readResourceMessage('github://octo/hello'), sessionId), {
+                authInfo: { token: 't', clientId: 'c', scopes: ['public_repo'] }
+            });
+            expect(publicResponse.status).toBe(200);
+        });
+    });
+
+    describe('prompts/get', () => {
+        it('returns 403 when token lacks the prompt scope', async () => {
+            newServer();
+            mcpServer.registerPrompt('summarise_repo', { description: 'Summarise a repo', scopes: ['repo:read'] }, () => ({
+                messages: [{ role: 'user', content: { type: 'text', text: 'go' } }]
+            }));
+            await mcpServer.connect(transport);
+            const sessionId = await initialize();
+            const authInfo: AuthInfo = { token: 't', clientId: 'c', scopes: [] };
+
+            const response = await transport.handleRequest(createRequest(getPromptMessage('summarise_repo'), sessionId), {
+                authInfo
+            });
+            expect(response.status).toBe(403);
+            expect(response.headers.get('WWW-Authenticate')).toContain('scope="repo:read"');
+        });
+
+        it('passes when token has the prompt scope', async () => {
+            newServer();
+            mcpServer.registerPrompt('summarise_repo', { description: 'Summarise a repo', scopes: ['repo:read'] }, () => ({
+                messages: [{ role: 'user', content: { type: 'text', text: 'go' } }]
+            }));
+            await mcpServer.connect(transport);
+            const sessionId = await initialize();
+            const authInfo: AuthInfo = { token: 't', clientId: 'c', scopes: ['repo:read'] };
+
+            const response = await transport.handleRequest(createRequest(getPromptMessage('summarise_repo'), sessionId), {
+                authInfo
+            });
+            expect(response.status).toBe(200);
+        });
+
+        it('passes through prompts with no scope configuration', async () => {
+            newServer();
+            mcpServer.registerPrompt('hello', { description: 'Hello' }, () => ({
+                messages: [{ role: 'user', content: { type: 'text', text: 'hi' } }]
+            }));
+            await mcpServer.connect(transport);
+            const sessionId = await initialize();
+            const authInfo: AuthInfo = { token: 't', clientId: 'c', scopes: [] };
+
+            const response = await transport.handleRequest(createRequest(getPromptMessage('hello'), sessionId), { authInfo });
+            expect(response.status).toBe(200);
+        });
+    });
+
+    describe('completion/complete (explicit, no inheritance)', () => {
+        it('returns 403 when completion scope is missing for the specific argument', async () => {
+            newServer();
+            mcpServer.registerPrompt(
+                'summarise_repo',
+                { description: 'Summarise a repo', argsSchema: z.object({ repository: z.string() }) },
+                () => ({ messages: [{ role: 'user', content: { type: 'text', text: 'x' } }] })
+            );
+            mcpServer.setCompletionScopes({ type: 'ref/prompt', name: 'summarise_repo' }, 'repository', ['repo:list']);
+            await mcpServer.connect(transport);
+            const sessionId = await initialize();
+            const authInfo: AuthInfo = { token: 't', clientId: 'c', scopes: ['repo:read'] };
+
+            const response = await transport.handleRequest(
+                createRequest(completionMessage({ type: 'ref/prompt', name: 'summarise_repo' }, 'repository', 'oc'), sessionId),
+                { authInfo }
+            );
+            expect(response.status).toBe(403);
+            expect(response.headers.get('WWW-Authenticate')).toContain('scope="repo:list"');
+        });
+
+        it('does not inherit scopes from the referenced prompt', async () => {
+            // A prompt requires repo:read; completion has no scopes configured.
+            // Token has nothing. The completion should still pass through because
+            // completion scopes are explicit-only (no inheritance).
+            newServer();
+            mcpServer.registerPrompt(
+                'summarise_repo',
+                {
+                    description: 'Summarise a repo',
+                    scopes: ['repo:read'],
+                    argsSchema: z.object({ repository: z.string() })
+                },
+                () => ({ messages: [{ role: 'user', content: { type: 'text', text: 'x' } }] })
+            );
+            await mcpServer.connect(transport);
+            const sessionId = await initialize();
+            const authInfo: AuthInfo = { token: 't', clientId: 'c', scopes: [] };
+
+            const response = await transport.handleRequest(
+                createRequest(completionMessage({ type: 'ref/prompt', name: 'summarise_repo' }, 'repository', 'oc'), sessionId),
+                { authInfo }
+            );
+            expect(response.status).toBe(200);
+        });
+
+        it('applies the * wildcard to any argument of the same ref', async () => {
+            newServer();
+            mcpServer.registerPrompt(
+                'summarise_repo',
+                { description: 'x', argsSchema: z.object({ a: z.string(), b: z.string() }) },
+                () => ({ messages: [{ role: 'user', content: { type: 'text', text: 'x' } }] })
+            );
+            mcpServer.setCompletionScopes({ type: 'ref/prompt', name: 'summarise_repo' }, '*', ['repo:list']);
+            await mcpServer.connect(transport);
+            const sessionId = await initialize();
+            const authInfo: AuthInfo = { token: 't', clientId: 'c', scopes: [] };
+
+            for (const argName of ['a', 'b']) {
+                const response = await transport.handleRequest(
+                    createRequest(completionMessage({ type: 'ref/prompt', name: 'summarise_repo' }, argName, 'x'), sessionId),
+                    { authInfo }
+                );
+                expect(response.status).toBe(403);
+            }
+        });
+    });
+
+    describe('setResourceScopes / setPromptScopes overrides', () => {
+        it('setResourceScopes for a static URI overrides registration-time scopes', async () => {
+            newServer();
+            mcpServer.registerResource('config', 'config://settings', { scopes: ['config:read'] }, async uri => ({
+                contents: [{ uri: uri.href, text: 'data' }]
+            }));
+            mcpServer.setResourceScopes('config://settings', ['admin:config']);
+            await mcpServer.connect(transport);
+            const sessionId = await initialize();
+
+            const response = await transport.handleRequest(createRequest(readResourceMessage('config://settings'), sessionId), {
+                authInfo: { token: 't', clientId: 'c', scopes: ['config:read'] }
+            });
+            expect(response.status).toBe(403);
+            expect(response.headers.get('WWW-Authenticate')).toContain('scope="admin:config"');
+        });
+
+        it('setPromptScopes overrides registration-time scopes', async () => {
+            newServer();
+            mcpServer.registerPrompt('summarise_repo', { description: 'x', scopes: ['repo:read'] }, () => ({
+                messages: [{ role: 'user', content: { type: 'text', text: 'x' } }]
+            }));
+            mcpServer.setPromptScopes('summarise_repo', ['admin:repo']);
+            await mcpServer.connect(transport);
+            const sessionId = await initialize();
+
+            const response = await transport.handleRequest(createRequest(getPromptMessage('summarise_repo'), sessionId), {
+                authInfo: { token: 't', clientId: 'c', scopes: ['repo:read'] }
+            });
+            expect(response.status).toBe(403);
+            expect(response.headers.get('WWW-Authenticate')).toContain('scope="admin:repo"');
+        });
+    });
+
+    describe('mixed batch', () => {
+        it('returns 403 when any request in a mixed batch lacks scopes', async () => {
+            newServer();
+            mcpServer.registerPrompt('p', { description: 'x', scopes: ['p:read'] }, () => ({
+                messages: [{ role: 'user', content: { type: 'text', text: 'x' } }]
+            }));
+            mcpServer.registerResource('config', 'config://settings', { scopes: ['config:read'] }, async uri => ({
+                contents: [{ uri: uri.href, text: 'data' }]
+            }));
+            await mcpServer.connect(transport);
+            const sessionId = await initialize();
+
+            const batch: JSONRPCMessage[] = [getPromptMessage('p', 'b1'), readResourceMessage('config://settings', 'b2')];
+            // Token has p:read but missing config:read - resource read should fail.
+            const response = await transport.handleRequest(createRequest(batch, sessionId), {
+                authInfo: { token: 't', clientId: 'c', scopes: ['p:read'] }
+            });
+            expect(response.status).toBe(403);
+            expect(response.headers.get('WWW-Authenticate')).toContain('scope="config:read"');
+        });
+    });
+});


### PR DESCRIPTION
**Stacked on top of #1624.** Until that merges, the diff in this PR will include those commits; once #1624 merges this PR will rebase cleanly against `main`.

## Summary

Extends the pre-execution scope challenge check from `tools/call` to the rest of the MCP operation surface: `resources/read`, `prompts/get`, and `completion/complete`.

Same architecture, same opinions on per-operation scopes, AND/OR semantics, and SEP-2350 alignment, just generalised across primitives.

## What's new

### Resources

`registerResource()` now accepts `scopes` in its config. For templated resources, `scopes` can also be a function that receives the concrete URI and matched template variables, so the required scope can depend on path parameters (for example, public vs private repositories).

```typescript
// Static URI, static scope
server.registerResource(
  'config',
  'config://settings',
  { scopes: ['config:read'], mimeType: 'text/plain' },
  readCallback,
);

// Templated URI, dynamic per-request scope resolution
server.registerResource(
  'repo',
  new ResourceTemplate('github://{owner}/{repo}', { list: undefined }),
  { scopes: (_uri, vars) => vars.owner === 'private-org' ? ['repo'] : ['public_repo'] },
  readCallback,
);
```

### Prompts

`registerPrompt()` accepts `scopes` in its config. Exact-name lookup like tools.

```typescript
server.registerPrompt(
  'summarise_repo',
  { description: 'Summarise a repo', scopes: ['repo:read'], argsSchema: ... },
  handler,
);
```

### Completions

Completions get an explicit, separate scope domain. **No inheritance from the referenced prompt or resource** by design: search and read are typically distinct capabilities (`repo:list` is not implied by `repo:read`). If you genuinely want them identical, pass the same scopes array to both `registerPrompt` and `setCompletionScopes`.

```typescript
server.setCompletionScopes(
  { type: 'ref/prompt', name: 'summarise_repo' },
  'repository',   // or '*' for any argument of this ref
  ['repo:list'],
);
```

### Central overrides

For decoupled or centralised scope configuration: `setPromptScopes(name, scopes)`, `setResourceScopes(uriOrTemplateName, scopes)`, `setCompletionScopes(ref, arg, scopes)`. All take precedence over registration-time scopes.

## Architecture

- `ScopeResolver` widens from `(toolName) => ToolScopeConfig` to `(request: JSONRPCRequest) => ScopeResolution | Promise<...>`. Breaking for any alpha consumer of `setScopeResolver`; no external consumers yet.
- New `ScopeResolution = { operationName: string; scopes: ToolScopeConfig }`. The `operationName` (e.g. `tool:get_repo`, `resource:github://octo/hello`, `prompt:summarise`, `completion:prompt:summarise/repository`) is used in the default 403 error description and is passed to `buildErrorDescription`.
- `_checkScopeChallenge` becomes async to support async resource resolvers.
- `McpServer.connect()` auto-wires an operation-aware router that dispatches on JSON-RPC method.

## What's NOT in scope

- **`*/list` scope filtering (SEP-1881).** When tools, resources, or prompts declare scopes, `tools/list`, `resources/list`, `prompts/list`, and `resources/templates/list` could automatically filter their results to items the current token can satisfy. Intentionally out of scope for this PR but worth a follow-up.
- **Mid-handler scope challenges.** Same constraint as #1624: HTTP status codes are committed before handlers run.

## Testing

14 new behaviour tests in `scopeChallengePrimitives.test.ts` covering:

- Static and templated resources: 403, pass, no-scopes passthrough, template URI matching, dynamic per-request resolution.
- Prompts: 403, pass, no-scopes passthrough.
- Completions: 403, no-inheritance contract, `'*'` argument wildcard.
- Override registries: `setResourceScopes`, `setPromptScopes`.
- Mixed JSON-RPC batch with a prompt and a resource read; the first failing operation surfaces a 403.

The 17 tool tests in `scopeChallenge.test.ts` continue to pass unchanged. All 96 tests in `@modelcontextprotocol/server` pass; typecheck and lint clean.

## Notes for review

- Completion's "no inheritance" was the considered choice; it matches typical OAuth scope shapes where listing capabilities are distinct from reading. Inheritance can be added later as an opt-in (`{ inherit: true }` flag) if real-world usage shows it's wanted.
- `accepted` (OR escape hatch) extends to all primitives because it lives on `ToolScopeConfig`. Dynamic resource resolvers can return `ToolScopeConfig` directly to use `accepted` per-URI.
