### PR TITLE
fix(server): emit object schema for wrapped Zod inputs in tools/list

### DIFF
--- a/.changeset/fix-tools-list-wrapped-schemas.md
+++ b/.changeset/fix-tools-list-wrapped-schemas.md
@@ -1,0 +1,6 @@
+---
+'@modelcontextprotocol/sdk': patch
+---
+
+Fix `tools/list` emitting `inputSchema: {}` (and silently dropping `outputSchema`) for tools whose schema is wrapped in `ZodEffects` / `ZodPipeline` (`.refine`, `.superRefine`, `.transform`, `.pipe`). The emission sites now fall back to the original schema when
+`normalizeObjectSchema` can't unwrap, mirroring what `validateToolInput` already does — the converter libraries walk those wrappers natively.

--- a/src/server/mcp.ts
+++ b/src/server/mcp.ts
@@ -146,13 +146,15 @@ export class McpServer {
                             title: tool.title,
                             description: tool.description,
                             inputSchema: (() => {
+                                if (!tool.inputSchema) return EMPTY_OBJECT_JSON_SCHEMA;
+                                // Fallback to the original schema when normalizeObjectSchema can't unwrap
+                                // it (e.g. .refine/.superRefine/.transform/.pipe). The converter walks
+                                // those wrappers natively and emits the underlying object's properties.
                                 const obj = normalizeObjectSchema(tool.inputSchema);
-                                return obj
-                                    ? (toJsonSchemaCompat(obj, {
-                                          strictUnions: true,
-                                          pipeStrategy: 'input'
-                                      }) as Tool['inputSchema'])
-                                    : EMPTY_OBJECT_JSON_SCHEMA;
+                                return toJsonSchemaCompat(obj ?? (tool.inputSchema as AnySchema), {
+                                    strictUnions: true,
+                                    pipeStrategy: 'input'
+                                }) as Tool['inputSchema'];
                             })(),
                             annotations: tool.annotations,
                             execution: tool.execution,
@@ -161,12 +163,10 @@ export class McpServer {
 
                         if (tool.outputSchema) {
                             const obj = normalizeObjectSchema(tool.outputSchema);
-                            if (obj) {
-                                toolDefinition.outputSchema = toJsonSchemaCompat(obj, {
-                                    strictUnions: true,
-                                    pipeStrategy: 'output'
-                                }) as Tool['outputSchema'];
-                            }
+                            toolDefinition.outputSchema = toJsonSchemaCompat(obj ?? (tool.outputSchema as AnySchema), {
+                                strictUnions: true,
+                                pipeStrategy: 'output'
+                            }) as Tool['outputSchema'];
                         }
 
                         return toolDefinition;
@@ -306,8 +306,11 @@ export class McpServer {
         }
 
         // if the tool has an output schema, validate structured content
-        const outputObj = normalizeObjectSchema(tool.outputSchema) as AnyObjectSchema;
-        const parseResult = await safeParseAsync(outputObj, result.structuredContent);
+        // Same fallback as validateToolInput: when normalizeObjectSchema returns undefined
+        // (wrapped schema), parse against the original to avoid passing undefined into safeParseAsync.
+        const outputObj = normalizeObjectSchema(tool.outputSchema);
+        const schemaToParse = outputObj ?? (tool.outputSchema as AnySchema);
+        const parseResult = await safeParseAsync(schemaToParse, result.structuredContent);
         if (!parseResult.success) {
             const error = 'error' in parseResult ? parseResult.error : 'Unknown error';
             const errorMessage = getParseErrorMessage(error);

--- a/src/server/mcp.ts
+++ b/src/server/mcp.ts
@@ -306,11 +306,8 @@ export class McpServer {
         }
 
         // if the tool has an output schema, validate structured content
-        // Same fallback as validateToolInput: when normalizeObjectSchema returns undefined
-        // (wrapped schema), parse against the original to avoid passing undefined into safeParseAsync.
-        const outputObj = normalizeObjectSchema(tool.outputSchema);
-        const schemaToParse = outputObj ?? (tool.outputSchema as AnySchema);
-        const parseResult = await safeParseAsync(schemaToParse, result.structuredContent);
+        const outputObj = normalizeObjectSchema(tool.outputSchema) as AnyObjectSchema;
+        const parseResult = await safeParseAsync(outputObj, result.structuredContent);
         if (!parseResult.success) {
             const error = 'error' in parseResult ? parseResult.error : 'Unknown error';
             const errorMessage = getParseErrorMessage(error);

--- a/src/server/zod-json-schema-compat.ts
+++ b/src/server/zod-json-schema-compat.ts
@@ -28,7 +28,7 @@ function mapMiniTarget(t: CommonOpts['target'] | undefined): 'draft-7' | 'draft-
     return 'draft-7'; // fallback
 }
 
-export function toJsonSchemaCompat(schema: AnyObjectSchema, opts?: CommonOpts): JsonSchema {
+export function toJsonSchemaCompat(schema: AnySchema, opts?: CommonOpts): JsonSchema {
     if (isZ4Schema(schema)) {
         // v4 branch — use Mini's built-in toJSONSchema
         return z4mini.toJSONSchema(schema as z4c.$ZodType, {

--- a/test/server/mcp.test.ts
+++ b/test/server/mcp.test.ts
@@ -5237,10 +5237,9 @@ describe.each(zodTestMatrix)('$zodVersionLabel', (entry: ZodMatrixEntry) => {
             {
                 name: '.refine',
                 build: () =>
-                    (buildBase() as { refine: (...args: unknown[]) => AnySchema }).refine(
-                        (v: { count: number }) => v.count <= 100,
-                        { message: 'count must be <= 100' }
-                    ),
+                    (buildBase() as { refine: (...args: unknown[]) => AnySchema }).refine((v: { count: number }) => v.count <= 100, {
+                        message: 'count must be <= 100'
+                    }),
                 rejectsLargeCount: true
             },
             {
@@ -5257,10 +5256,7 @@ describe.each(zodTestMatrix)('$zodVersionLabel', (entry: ZodMatrixEntry) => {
             },
             {
                 name: '.transform',
-                build: () =>
-                    (buildBase() as { transform: (...args: unknown[]) => AnySchema }).transform(
-                        (v: Record<string, unknown>) => v
-                    ),
+                build: () => (buildBase() as { transform: (...args: unknown[]) => AnySchema }).transform((v: Record<string, unknown>) => v),
                 rejectsLargeCount: false
             },
             {
@@ -5280,11 +5276,7 @@ describe.each(zodTestMatrix)('$zodVersionLabel', (entry: ZodMatrixEntry) => {
             const server = new McpServer({ name: 'test', version: '1.0.0' });
             const client = new Client({ name: 'test', version: '1.0.0' });
 
-            server.registerTool(
-                'wrapped',
-                { inputSchema: build() },
-                async () => ({ content: [{ type: 'text' as const, text: 'ok' }] })
-            );
+            server.registerTool('wrapped', { inputSchema: build() }, async () => ({ content: [{ type: 'text' as const, text: 'ok' }] }));
 
             const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
             await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
@@ -5303,11 +5295,7 @@ describe.each(zodTestMatrix)('$zodVersionLabel', (entry: ZodMatrixEntry) => {
             const server = new McpServer({ name: 'test', version: '1.0.0' });
             const client = new Client({ name: 'test', version: '1.0.0' });
 
-            server.registerTool(
-                'wrapped',
-                { inputSchema: build() },
-                async () => ({ content: [{ type: 'text' as const, text: 'ok' }] })
-            );
+            server.registerTool('wrapped', { inputSchema: build() }, async () => ({ content: [{ type: 'text' as const, text: 'ok' }] }));
 
             const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
             await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
@@ -5341,15 +5329,12 @@ describe.each(zodTestMatrix)('$zodVersionLabel', (entry: ZodMatrixEntry) => {
             const server = new McpServer({ name: 'test', version: '1.0.0' });
             const client = new Client({ name: 'test', version: '1.0.0' });
 
-            const wrappedOutput = (
-                z.object({ result: z.string() }) as { refine: (...args: unknown[]) => AnySchema }
-            ).refine(() => true);
+            const wrappedOutput = (z.object({ result: z.string() }) as { refine: (...args: unknown[]) => AnySchema }).refine(() => true);
 
-            server.registerTool(
-                'with-wrapped-output',
-                { outputSchema: wrappedOutput },
-                async () => ({ content: [{ type: 'text' as const, text: 'ok' }], structuredContent: { result: 'ok' } })
-            );
+            server.registerTool('with-wrapped-output', { outputSchema: wrappedOutput }, async () => ({
+                content: [{ type: 'text' as const, text: 'ok' }],
+                structuredContent: { result: 'ok' }
+            }));
 
             const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
             await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);

--- a/test/server/mcp.test.ts
+++ b/test/server/mcp.test.ts
@@ -21,6 +21,7 @@ import {
 } from '../../src/types.js';
 import { completable } from '../../src/server/completable.js';
 import { McpServer, ResourceTemplate } from '../../src/server/mcp.js';
+import type { AnySchema } from '../../src/server/zod-compat.js';
 import { InMemoryTaskStore } from '../../src/experimental/tasks/stores/in-memory.js';
 import { zodTestMatrix, type ZodMatrixEntry } from '../../src/__fixtures__/zodTestMatrix.js';
 
@@ -5217,6 +5218,150 @@ describe.each(zodTestMatrix)('$zodVersionLabel', (entry: ZodMatrixEntry) => {
                     text: 'items: 5 -> 10'
                 }
             ]);
+        });
+    });
+
+    describe('tools/list with wrapped inputSchema (issue #2145)', () => {
+        // Each entry wraps the same plain object shape:
+        //   z.object({ prompt: z.string().min(1), count: z.number().int().positive().default(1) })
+        // The wrapper (.refine / .superRefine / .transform / .pipe) hides `.shape` from the
+        // top-level schema, but tools/list should still emit the underlying object's
+        // `properties` instead of falling back to {}.
+        const buildBase = () =>
+            z.object({
+                prompt: z.string().min(1),
+                count: z.number().int().positive().default(1)
+            });
+
+        const wrappers: Array<{ name: string; build: () => AnySchema; rejectsLargeCount: boolean }> = [
+            {
+                name: '.refine',
+                build: () =>
+                    (buildBase() as { refine: (...args: unknown[]) => AnySchema }).refine(
+                        (v: { count: number }) => v.count <= 100,
+                        { message: 'count must be <= 100' }
+                    ),
+                rejectsLargeCount: true
+            },
+            {
+                name: '.superRefine',
+                build: () =>
+                    (buildBase() as { superRefine: (...args: unknown[]) => AnySchema }).superRefine(
+                        (v: { count: number }, ctx: { addIssue: (issue: Record<string, unknown>) => void }) => {
+                            if (v.count > 100) {
+                                ctx.addIssue({ code: 'custom', path: ['count'], message: 'count must be <= 100' });
+                            }
+                        }
+                    ),
+                rejectsLargeCount: true
+            },
+            {
+                name: '.transform',
+                build: () =>
+                    (buildBase() as { transform: (...args: unknown[]) => AnySchema }).transform(
+                        (v: Record<string, unknown>) => v
+                    ),
+                rejectsLargeCount: false
+            },
+            {
+                name: '.pipe',
+                build: () =>
+                    (buildBase() as { pipe: (...args: unknown[]) => AnySchema }).pipe(
+                        z.object({
+                            prompt: z.string(),
+                            count: z.number()
+                        })
+                    ),
+                rejectsLargeCount: false
+            }
+        ];
+
+        test.each(wrappers)('$name: tools/list emits properties from the underlying object', async ({ build }) => {
+            const server = new McpServer({ name: 'test', version: '1.0.0' });
+            const client = new Client({ name: 'test', version: '1.0.0' });
+
+            server.registerTool(
+                'wrapped',
+                { inputSchema: build() },
+                async () => ({ content: [{ type: 'text' as const, text: 'ok' }] })
+            );
+
+            const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+            await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
+
+            const result = await client.request({ method: 'tools/list' }, ListToolsResultSchema);
+            const wrapped = result.tools.find(t => t.name === 'wrapped');
+            expect(wrapped).toBeDefined();
+            expect(wrapped!.inputSchema.type).toBe('object');
+            const properties = wrapped!.inputSchema.properties as Record<string, unknown> | undefined;
+            expect(properties).toBeDefined();
+            expect(properties!.prompt).toBeDefined();
+            expect(properties!.count).toBeDefined();
+        });
+
+        test.each(wrappers)('$name: tools/call still validates against the wrapped schema', async ({ build, rejectsLargeCount }) => {
+            const server = new McpServer({ name: 'test', version: '1.0.0' });
+            const client = new Client({ name: 'test', version: '1.0.0' });
+
+            server.registerTool(
+                'wrapped',
+                { inputSchema: build() },
+                async () => ({ content: [{ type: 'text' as const, text: 'ok' }] })
+            );
+
+            const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+            await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
+
+            const okResult = await client.callTool({ name: 'wrapped', arguments: { prompt: 'hi', count: 5 } });
+            expect(okResult.isError).toBeFalsy();
+
+            if (rejectsLargeCount) {
+                const badResult = await client.callTool({ name: 'wrapped', arguments: { prompt: 'hi', count: 200 } });
+                expect(badResult.isError).toBe(true);
+                expect(JSON.stringify(badResult.content)).toContain('count');
+            }
+        });
+
+        test('regression: tool without inputSchema still emits EMPTY_OBJECT_JSON_SCHEMA', async () => {
+            const server = new McpServer({ name: 'test', version: '1.0.0' });
+            const client = new Client({ name: 'test', version: '1.0.0' });
+
+            server.registerTool('no-args', {}, async () => ({ content: [{ type: 'text' as const, text: 'ok' }] }));
+
+            const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+            await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
+
+            const result = await client.request({ method: 'tools/list' }, ListToolsResultSchema);
+            const tool = result.tools.find(t => t.name === 'no-args');
+            expect(tool).toBeDefined();
+            expect(tool!.inputSchema).toEqual({ type: 'object', properties: {} });
+        });
+
+        test('wrapped outputSchema is also emitted in tools/list', async () => {
+            const server = new McpServer({ name: 'test', version: '1.0.0' });
+            const client = new Client({ name: 'test', version: '1.0.0' });
+
+            const wrappedOutput = (
+                z.object({ result: z.string() }) as { refine: (...args: unknown[]) => AnySchema }
+            ).refine(() => true);
+
+            server.registerTool(
+                'with-wrapped-output',
+                { outputSchema: wrappedOutput },
+                async () => ({ content: [{ type: 'text' as const, text: 'ok' }], structuredContent: { result: 'ok' } })
+            );
+
+            const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+            await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
+
+            const result = await client.request({ method: 'tools/list' }, ListToolsResultSchema);
+            const tool = result.tools.find(t => t.name === 'with-wrapped-output');
+            expect(tool).toBeDefined();
+            expect(tool!.outputSchema).toBeDefined();
+            expect(tool!.outputSchema!.type).toBe('object');
+            const properties = tool!.outputSchema!.properties as Record<string, unknown> | undefined;
+            expect(properties).toBeDefined();
+            expect(properties!.result).toBeDefined();
         });
     });
 


### PR DESCRIPTION
Fixes #2145

## Summary
`tools/list` emits `inputSchema: {}` (and silently drops `outputSchema`) for tools whose schema is wrapped in `ZodEffects` / `ZodPipeline` (`.refine`, `.superRefine`, `.transform`, `.pipe`), because `normalizeObjectSchema` only walks unwrapped `ZodObject`s.

Fix: mirror the fallback `validateToolInput` already uses at the two emission sites, and widen `toJsonSchemaCompat`'s first parameter from `AnyObjectSchema` to `AnySchema`. When `normalizeObjectSchema` can't unwrap, hand the original schema to the converter. `zod-to-json-schema` (v3) and `z4mini.toJSONSchema` (v4) walk those wrappers natively and drop the refinement body, so no wrapper-type list is maintained across zod versions. Validation isn't touched.

Scope is limited to `tools/list` emission. `validateToolOutput` has the same broken pattern (`safeParseAsync(undefined, ...)` crashes on a wrapped `outputSchema`) but is already covered by #2106 (#1308), so leaving it alone here to keep ownership clean.

## Test plan
New `tools/list with wrapped inputSchema (issue #2145)` describe block in `test/server/mcp.test.ts`, parametrized over `.refine` / `.superRefine` / `.transform` / `.pipe`, under the existing `zodTestMatrix` (Zod v3 and v4):
- [x] For each wrapper: `tools/list` emits an inputSchema with `type: "object"` and `properties` containing both fields.
- [x] For each wrapper: `tools/call` with valid args passes; for `.refine` / `.superRefine`, args violating the rule still fail validation.
- [x] Regression: tool with no `inputSchema` still emits `EMPTY_OBJECT_JSON_SCHEMA`.
- [x] A tool with a wrapped `outputSchema` now has it emitted in `tools/list` (previously dropped).

20 new tests pass (10 per zod version). Typecheck and eslint clean on changed files.