### PR TITLE
fix(server): preserve prompt icons in list responses

### DIFF
--- a/.changeset/prompt-icons-list.md
+++ b/.changeset/prompt-icons-list.md
@@ -1,0 +1,5 @@
+---
+"@modelcontextprotocol/server": patch
+---
+
+Preserve prompt icons registered through `registerPrompt()` in `prompts/list`.

--- a/packages/server/src/server/mcp.ts
+++ b/packages/server/src/server/mcp.ts
@@ -5,6 +5,7 @@ import type {
     CompleteRequestResourceTemplate,
     CompleteResult,
     GetPromptResult,
+    Icon,
     Implementation,
     ListPromptsResult,
     ListResourcesResult,
@@ -438,6 +439,7 @@ export class McpServer {
                             name,
                             title: prompt.title,
                             description: prompt.description,
+                            icons: prompt.icons,
                             arguments: prompt.argsSchema ? promptArgumentsFromStandardSchema(prompt.argsSchema) : undefined,
                             _meta: prompt._meta
                         };
@@ -607,6 +609,7 @@ export class McpServer {
         name: string,
         title: string | undefined,
         description: string | undefined,
+        icons: Icon[] | undefined,
         argsSchema: StandardSchemaWithJSON | undefined,
         callback: PromptCallback<StandardSchemaWithJSON | undefined>,
         _meta: Record<string, unknown> | undefined
@@ -618,6 +621,7 @@ export class McpServer {
         const registeredPrompt: RegisteredPrompt = {
             title,
             description,
+            icons,
             argsSchema,
             _meta,
             handler: createPromptHandler(name, argsSchema, callback),
@@ -632,6 +636,7 @@ export class McpServer {
                 }
                 if (updates.title !== undefined) registeredPrompt.title = updates.title;
                 if (updates.description !== undefined) registeredPrompt.description = updates.description;
+                if (updates.icons !== undefined) registeredPrompt.icons = updates.icons;
                 if (updates._meta !== undefined) registeredPrompt._meta = updates._meta;
 
                 // Track if we need to regenerate the handler
@@ -857,6 +862,7 @@ export class McpServer {
         config: {
             title?: string;
             description?: string;
+            icons?: Icon[];
             argsSchema?: Args;
             _meta?: Record<string, unknown>;
         },
@@ -868,6 +874,7 @@ export class McpServer {
         config: {
             title?: string;
             description?: string;
+            icons?: Icon[];
             argsSchema?: Args;
             _meta?: Record<string, unknown>;
         },
@@ -878,6 +885,7 @@ export class McpServer {
         config: {
             title?: string;
             description?: string;
+            icons?: Icon[];
             argsSchema?: StandardSchemaWithJSON | ZodRawShape;
             _meta?: Record<string, unknown>;
         },
@@ -887,12 +895,13 @@ export class McpServer {
             throw new Error(`Prompt ${name} is already registered`);
         }
 
-        const { title, description, argsSchema, _meta } = config;
+        const { title, description, icons, argsSchema, _meta } = config;
 
         const registeredPrompt = this._createRegisteredPrompt(
             name,
             title,
             description,
+            icons,
             normalizeRawShapeSchema(argsSchema),
             cb as PromptCallback<StandardSchemaWithJSON | undefined>,
             _meta
@@ -1192,6 +1201,7 @@ type ToolCallbackInternal = (args: unknown, ctx: ServerContext) => CallToolResul
 export type RegisteredPrompt = {
     title?: string;
     description?: string;
+    icons?: Icon[];
     argsSchema?: StandardSchemaWithJSON;
     _meta?: Record<string, unknown>;
     /** @hidden */
@@ -1203,6 +1213,7 @@ export type RegisteredPrompt = {
         name?: string | null;
         title?: string;
         description?: string;
+        icons?: Icon[];
         argsSchema?: Args;
         _meta?: Record<string, unknown>;
         callback?: PromptCallback<Args>;

--- a/packages/server/test/server/mcp.compat.test.ts
+++ b/packages/server/test/server/mcp.compat.test.ts
@@ -77,6 +77,44 @@ describe('registerTool/registerPrompt accept raw Zod shape (auto-wrapped)', () =
         expect(isStandardSchema(prompts['p']?.argsSchema)).toBe(true);
     });
 
+    it('registerPrompt includes icons in prompts/list', async () => {
+        const server = new McpServer({ name: 't', version: '1.0.0' });
+
+        const icons = [{ src: 'data:image/svg+xml;base64,PHN2Zy8+', mimeType: 'image/svg+xml', sizes: ['24x24'] }];
+        server.registerPrompt('with-icon', { description: 'Prompt with an icon', icons }, async () => ({
+            messages: [{ role: 'user' as const, content: { type: 'text' as const, text: 'hello' } }]
+        }));
+
+        const [client, srv] = InMemoryTransport.createLinkedPair();
+        await server.connect(srv);
+        await client.start();
+
+        const responses: JSONRPCMessage[] = [];
+        client.onmessage = m => responses.push(m);
+
+        await client.send({
+            jsonrpc: '2.0',
+            id: 1,
+            method: 'initialize',
+            params: {
+                protocolVersion: LATEST_PROTOCOL_VERSION,
+                capabilities: {},
+                clientInfo: { name: 'c', version: '1.0.0' }
+            }
+        } as JSONRPCMessage);
+        await client.send({ jsonrpc: '2.0', method: 'notifications/initialized' } as JSONRPCMessage);
+        await client.send({ jsonrpc: '2.0', id: 2, method: 'prompts/list', params: {} } as JSONRPCMessage);
+
+        await vi.waitFor(() => expect(responses.some(r => 'id' in r && r.id === 2)).toBe(true));
+
+        const response = responses.find(r => 'id' in r && r.id === 2) as {
+            result?: { prompts: Array<{ name: string; icons?: typeof icons }> };
+        };
+        expect(response.result?.prompts).toContainEqual(expect.objectContaining({ name: 'with-icon', icons }));
+
+        await server.close();
+    });
+
     it('callback receives validated, typed args end-to-end via tools/call', async () => {
         const server = new McpServer({ name: 't', version: '1.0.0' });
 


### PR DESCRIPTION
﻿## Summary

Fixes #2054.

`registerPrompt()` accepted prompt metadata that includes `icons`, but the high-level server dropped that field before `prompts/list` serialized registered prompts. This keeps the icons on the registered prompt and includes them in list responses.

## Test plan

- `pnpm --filter @modelcontextprotocol/server test -- mcp.compat.test.ts`
- `pnpm --filter @modelcontextprotocol/server typecheck`
- `pnpm --filter @modelcontextprotocol/server lint`
- `pnpm --filter @modelcontextprotocol/server build`
- pre-push hook: `pnpm -r typecheck`, `pnpm -r build`, `pnpm sync:snippets --check`, `pnpm -r lint`
