### PR TITLE
fix(server): accept omitted prompt arguments

### DIFF
--- a/.changeset/fix-prompt-optional-arguments.md
+++ b/.changeset/fix-prompt-optional-arguments.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/server': patch
+---
+
+fix(server): accept omitted prompt arguments when the schema only has optional fields

--- a/packages/server/src/server/mcp.ts
+++ b/packages/server/src/server/mcp.ts
@@ -1224,7 +1224,7 @@ function createPromptHandler(
         const typedCallback = callback as (args: unknown, ctx: ServerContext) => GetPromptResult | Promise<GetPromptResult>;
 
         return async (args, ctx) => {
-            const parseResult = await validateStandardSchema(argsSchema, args);
+            const parseResult = await validateStandardSchema(argsSchema, args ?? {});
             if (!parseResult.success) {
                 throw new ProtocolError(ProtocolErrorCode.InvalidParams, `Invalid arguments for prompt ${name}: ${parseResult.error}`);
             }

--- a/packages/server/test/server/mcp.compat.test.ts
+++ b/packages/server/test/server/mcp.compat.test.ts
@@ -119,6 +119,56 @@ describe('registerTool/registerPrompt accept raw Zod shape (auto-wrapped)', () =
 
         await server.close();
     });
+
+    it('omitted prompt arguments validate as an empty object', async () => {
+        const server = new McpServer({ name: 't', version: '1.0.0' });
+
+        let received: { topic?: string } | undefined;
+        server.registerPrompt('draft', { argsSchema: z.object({ topic: z.string().optional() }) }, async args => {
+            received = args;
+            return {
+                messages: [
+                    {
+                        role: 'user' as const,
+                        content: { type: 'text' as const, text: args.topic ?? 'default' }
+                    }
+                ]
+            };
+        });
+
+        const [client, srv] = InMemoryTransport.createLinkedPair();
+        await server.connect(srv);
+        await client.start();
+
+        const responses: JSONRPCMessage[] = [];
+        client.onmessage = m => responses.push(m);
+
+        await client.send({
+            jsonrpc: '2.0',
+            id: 1,
+            method: 'initialize',
+            params: {
+                protocolVersion: LATEST_PROTOCOL_VERSION,
+                capabilities: {},
+                clientInfo: { name: 'c', version: '1.0.0' }
+            }
+        } as JSONRPCMessage);
+        await client.send({ jsonrpc: '2.0', method: 'notifications/initialized' } as JSONRPCMessage);
+        await client.send({
+            jsonrpc: '2.0',
+            id: 2,
+            method: 'prompts/get',
+            params: { name: 'draft' }
+        } as JSONRPCMessage);
+
+        await vi.waitFor(() => expect(responses.some(r => 'id' in r && r.id === 2)).toBe(true));
+
+        expect(received).toEqual({});
+        const result = responses.find(r => 'id' in r && r.id === 2) as { result?: { messages: Array<{ content: { text: string } }> } };
+        expect(result.result?.messages[0]?.content.text).toBe('default');
+
+        await server.close();
+    });
 });
 
 describe('InferRawShape', () => {


### PR DESCRIPTION
﻿## Summary
- default omitted prompt arguments to an empty object before schema validation
- add an end-to-end `prompts/get` regression test for an all-optional args schema
- add a patch changeset for `@modelcontextprotocol/server`

Closes #1869.

## To verify
- `pnpm --filter @modelcontextprotocol/server test -- test/server/mcp.compat.test.ts`
- `pnpm --filter @modelcontextprotocol/server typecheck`
- `pnpm --filter @modelcontextprotocol/server lint`
- `pnpm --filter @modelcontextprotocol/server build`
- `pnpm exec prettier --check .changeset/fix-prompt-optional-arguments.md`
- `git diff --check`
- pre-push: `pnpm -r build`, `pnpm run lint:all`, `pnpm -r typecheck`
