### PR TITLE
fix(server): guard no-schema tool handler signatures

### DIFF
--- a/packages/server/src/server/mcp.ts
+++ b/packages/server/src/server/mcp.ts
@@ -1216,6 +1216,14 @@ function createToolExecutor(
         return async (args, ctx) => callback(args, ctx);
     }
 
+    if (handler.length > 1) {
+        throw new Error(
+            `Tool handler accepts ${handler.length} parameters but no inputSchema was provided. ` +
+                'Add inputSchema to the tool definition to enable the (args, ctx) two-parameter signature, ' +
+                'or change the handler to accept only one parameter (ctx).'
+        );
+    }
+
     // When no inputSchema, call with just ctx (the handler expects (ctx) signature)
     const callback = handler as (ctx: ServerContext) => CallToolResult | Promise<CallToolResult>;
     return async (_args, ctx) => callback(ctx);

--- a/packages/server/test/server/mcp.compat.test.ts
+++ b/packages/server/test/server/mcp.compat.test.ts
@@ -119,6 +119,17 @@ describe('registerTool/registerPrompt accept raw Zod shape (auto-wrapped)', () =
 
         await server.close();
     });
+
+    it('rejects a two-argument handler when inputSchema is omitted', () => {
+        const server = new McpServer({ name: 't', version: '1.0.0' });
+        const handler = ((_args: unknown, _ctx: unknown) => ({
+            content: [{ type: 'text' as const, text: 'ok' }]
+        })) as never;
+
+        expect(() => server.registerTool('no-schema', {}, handler)).toThrow(
+            /no inputSchema.*two-parameter signature|inputSchema.*two-parameter signature/
+        );
+    });
 });
 
 describe('InferRawShape', () => {


### PR DESCRIPTION
## Summary

Fixes #811.

When a tool is registered without `inputSchema`, the SDK calls its handler with the one-parameter `(ctx)` signature. JavaScript callers can still accidentally provide a two-parameter `(args, ctx)` handler, which leaves `ctx` undefined at call time and produces a less actionable destructuring crash.

This adds a registration-time guard for the no-`inputSchema` path so the mismatch fails early with an error that explains both supported options:

- add `inputSchema` to use the `(args, ctx)` signature
- keep no `inputSchema` and use the one-parameter `(ctx)` signature

## Changes

- Reject no-`inputSchema` tool handlers that declare more than one parameter.
- Add a regression test covering the JavaScript/runtime escape hatch where TypeScript's overloads are bypassed.

## Risk

Low. The check only affects no-`inputSchema` tool registrations whose handler declares multiple parameters. Existing valid no-schema one-parameter handlers and schema-backed two-parameter handlers keep the same behavior.

## Verification

```bash
pnpm --filter @modelcontextprotocol/server test -- mcp.compat.test.ts
pnpm --filter @modelcontextprotocol/server test
pnpm --filter @modelcontextprotocol/server check
```
