### PR TITLE
fix(core): match multi-variable URI templates like `{a,b}` (#2166)

### DIFF
--- a/.changeset/uri-template-multi-variable-match.md
+++ b/.changeset/uri-template-multi-variable-match.md
@@ -1,0 +1,21 @@
+---
+'@modelcontextprotocol/core-internal': patch
+'@modelcontextprotocol/server': patch
+---
+
+Match multi-variable URI template expressions like `{userId,format}`.
+
+`UriTemplate.expand` joins a multi-name expansion with commas, as RFC 6570 §3.2.2
+requires, but `match` emitted a single regex capture per part and assigned the whole
+captured run to `part.name` — the first name only. The pattern for the bare operator,
+`([^/,]+)`, also excludes the comma that `expand` had just written, so the URI failed to
+match at all and `match` returned `null`.
+
+`partToRegExp` now emits one capture per name for a multi-name part, with a literal comma
+between them, mirroring `expandPart`. The `/`, `.` and `#` operators keep their literal
+prefix on the first capture; the bare and reserved forms sit at the current position.
+Single-name parts and the `?` / `&` query forms are untouched.
+
+The visible effect is in `McpServer`: a resource registered against a template such as
+`data://users/{userId,format}` never matched, so its handler was unreachable and the
+`resources/read` was answered as unknown.

--- a/packages/core-internal/src/shared/uriTemplate.ts
+++ b/packages/core-internal/src/shared/uriTemplate.ts
@@ -222,6 +222,41 @@ export class UriTemplate {
             return patterns;
         }
 
+        // Multi-variable expressions like `{a,b}` or `{/a,b}` expand each value
+        // and join them with commas (see `expandPart`). Mirror that on the way
+        // back by emitting one capture per name with literal commas between
+        // them. Without this, only the first name was assigned and the rest of
+        // the path silently never matched (#2166).
+        if (part.names.length > 1) {
+            let firstPrefix: string;
+            switch (part.operator) {
+                case '/': {
+                    firstPrefix = '/';
+                    break;
+                }
+                case '.': {
+                    firstPrefix = String.raw`\.`;
+                    break;
+                }
+                case '#': {
+                    firstPrefix = '#';
+                    break;
+                }
+                default: {
+                    firstPrefix = '';
+                }
+            }
+            for (let i = 0; i < part.names.length; i++) {
+                const name = part.names[i]!;
+                const prefix = i === 0 ? firstPrefix : ',';
+                patterns.push({
+                    pattern: prefix + '([^/,]+)',
+                    name
+                });
+            }
+            return patterns;
+        }
+
         let pattern: string;
         const name = part.name;
 

--- a/packages/core-internal/test/shared/uriTemplate.test.ts
+++ b/packages/core-internal/test/shared/uriTemplate.test.ts
@@ -98,6 +98,25 @@ describe('UriTemplate', () => {
             expect(match).toEqual({ username: 'fred', postId: '123' });
         });
 
+        it('should match a comma-separated multi-variable expression (#2166)', () => {
+            const template = new UriTemplate('/users/{userId,format}');
+            const match = template.match('/users/42,json');
+            expect(match).toEqual({ userId: '42', format: 'json' });
+        });
+
+        it('should round-trip expand and match for a multi-variable expression (#2166)', () => {
+            const template = new UriTemplate('data://users/{userId,format}');
+            const expanded = template.expand({ userId: '42', format: 'json' });
+            expect(expanded).toBe('data://users/42,json');
+            expect(template.match(expanded)).toEqual({ userId: '42', format: 'json' });
+        });
+
+        it('should match a multi-variable expression with the path operator (#2166)', () => {
+            const template = new UriTemplate('{/userId,format}');
+            const match = template.match('/42,json');
+            expect(match).toEqual({ userId: '42', format: 'json' });
+        });
+
         it('should return null for non-matching URIs', () => {
             const template = new UriTemplate('/users/{username}');
             const match = template.match('/posts/123');


### PR DESCRIPTION
Closes #2166.

## What's wrong

`UriTemplate.expand` already supports multi-variable expansions like `{userId,format}` and produces values joined by commas. `UriTemplate.match` only emitted a single regex capture per part and assigned the entire captured run to `part.name`, so everything past the first variable was silently dropped. Any resource registered with a template such as `data://users/{userId,format}` never routed because `match()` returned `null`.

Minimal repro:

```ts
const tpl = new UriTemplate('/users/{userId,format}');
tpl.match('/users/42,json');
// before: null
// after:  { userId: '42', format: 'json' }
```

## The fix

`packages/core/src/shared/uriTemplate.ts`:

- In `partToRegExp`, when `part.names.length > 1` and the operator is not `?` / `&`, emit one capture per name with a literal comma between captures, mirroring the comma join `expandPart` already does.
- The first capture still gets the operator's literal prefix where it has one (`/`, `\\.`, `#`), so path / label / fragment operators keep matching like they did for the single-variable case.

`?` and `&` (form-style query strings) were already handled by the earlier branch and are untouched.

## Tests

`packages/core/test/shared/uriTemplate.test.ts`:

- match a `{userId,format}` template against `42,json`
- round-trip expand and match through `data://users/{userId,format}`
- multi-variable expression behind the path operator (`{/userId,format}`)

```
Test Files  1 passed
Tests       3 passed | 552 skipped (555 total in the package)
```

`pnpm --filter @modelcontextprotocol/core lint` and `typecheck` clean. Lefthook pre-push (typecheck, build, lint) all green.