### PR TITLE
Continue OAuth discovery on non-JSON metadata responses

### DIFF
--- a/.changeset/non-json-oauth-discovery.md
+++ b/.changeset/non-json-oauth-discovery.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/client': patch
+---
+
+Continue authorization server metadata discovery when a candidate well-known endpoint returns HTTP 200 with a non-JSON body, allowing fallback to the next OAuth/OIDC discovery URL.

--- a/packages/client/src/client/auth.ts
+++ b/packages/client/src/client/auth.ts
@@ -1826,11 +1826,16 @@ export async function discoverAuthorizationServerMetadata(
             );
         }
 
+        let metadata: unknown;
+        try {
+            metadata = await response.json();
+        } catch {
+            await response.body?.cancel().catch(() => {});
+            continue;
+        }
+
         // Parse and validate based on type
-        const parsed =
-            type === 'oauth'
-                ? OAuthMetadataSchema.parse(await response.json())
-                : OpenIdProviderDiscoveryMetadataSchema.parse(await response.json());
+        const parsed = type === 'oauth' ? OAuthMetadataSchema.parse(metadata) : OpenIdProviderDiscoveryMetadataSchema.parse(metadata);
 
         if (!skipIssuerValidation) {
             // RFC 8414 §3.3 / OIDC Discovery §4.3: the `issuer` value in the document MUST be

--- a/packages/client/test/client/auth.test.ts
+++ b/packages/client/test/client/auth.test.ts
@@ -1058,6 +1058,19 @@ describe('OAuth Authorization', () => {
             expect(mockFetch).toHaveBeenCalledTimes(2);
         });
 
+        it('continues when an authorization metadata endpoint returns non-JSON', async () => {
+            const tenantOidcMetadata = { ...validOpenIdMetadata, issuer: 'https://auth.example.com/tenant1' };
+            mockFetch.mockResolvedValueOnce(new Response('<html>not metadata</html>', { status: 200 }));
+            mockFetch.mockResolvedValueOnce(Response.json(tenantOidcMetadata, { status: 200 }));
+
+            const metadata = await discoverAuthorizationServerMetadata('https://auth.example.com/tenant1');
+
+            expect(metadata).toEqual(tenantOidcMetadata);
+            expect(mockFetch).toHaveBeenCalledTimes(2);
+            expect(mockFetch.mock.calls[0]![0].toString()).toBe('https://auth.example.com/.well-known/oauth-authorization-server/tenant1');
+            expect(mockFetch.mock.calls[1]![0].toString()).toBe('https://auth.example.com/.well-known/openid-configuration/tenant1');
+        });
+
         it('throws on non-502 5xx errors', async () => {
             mockFetch.mockResolvedValueOnce({
                 ok: false,


### PR DESCRIPTION
## Summary

Fixes #2126.

`discoverAuthorizationServerMetadata()` currently treats any HTTP 200 discovery response as parseable metadata. If the RFC 8414 candidate endpoint returns an HTML/static page, `response.json()` throws and the SDK never tries the later OIDC discovery URLs.

This catches non-JSON bodies for successful discovery responses and continues to the next OAuth/OIDC metadata candidate, preserving existing behavior for 4xx/502 fallback and non-502 5xx errors.

## Tests

- `npx -y pnpm@10.26.1 --filter @modelcontextprotocol/client test -- auth.test.ts`
- `npx -y pnpm@10.26.1 --filter @modelcontextprotocol/client lint`
- `npx -y pnpm@10.26.1 --filter @modelcontextprotocol/client typecheck`
- `npx -y pnpm@10.26.1 --filter @modelcontextprotocol/client build`
- `npx -y pnpm@10.26.1 run sync:snippets --check`