### PR TITLE
Return protocol errors for invalid tool arguments

### DIFF
--- a/.changeset/tool-input-protocol-error.md
+++ b/.changeset/tool-input-protocol-error.md
@@ -1,0 +1,5 @@
+---
+"@modelcontextprotocol/server": patch
+---
+
+Return protocol errors for invalid tool arguments instead of tool execution errors.

--- a/packages/server/src/server/mcp.ts
+++ b/packages/server/src/server/mcp.ts
@@ -208,8 +208,13 @@ export class McpServer {
                 await this.validateToolOutput(tool, result, request.params.name);
                 return result;
             } catch (error) {
-                if (error instanceof ProtocolError && error.code === ProtocolErrorCode.UrlElicitationRequired) {
-                    throw error; // Return the error to the caller without wrapping in CallToolResult
+                if (
+                    error instanceof ProtocolError &&
+                    (error.code === ProtocolErrorCode.UrlElicitationRequired ||
+                        (error.code === ProtocolErrorCode.InvalidParams &&
+                            error.message.startsWith('Input validation error: Invalid arguments for tool ')))
+                ) {
+                    throw error;
                 }
                 return this.createToolError(error instanceof Error ? error.message : String(error));
             }

--- a/test/integration/test/server/mcp.test.ts
+++ b/test/integration/test/server/mcp.test.ts
@@ -28,6 +28,25 @@ function createLatch() {
     };
 }
 
+async function expectInvalidParams(promise: Promise<unknown>, expectedMessages: Array<string | RegExp> = []) {
+    let caught: unknown;
+    try {
+        await promise;
+    } catch (error) {
+        caught = error;
+    }
+
+    expect(caught).toMatchObject({ code: ProtocolErrorCode.InvalidParams });
+    const message = caught instanceof Error ? caught.message : String(caught);
+    for (const expected of expectedMessages) {
+        if (expected instanceof RegExp) {
+            expect(message).toMatch(expected);
+        } else {
+            expect(message).toContain(expected);
+        }
+    }
+}
+
 describe('Zod v4', () => {
     describe('McpServer', () => {
         /***
@@ -1212,25 +1231,18 @@ describe('Zod v4', () => {
 
             await Promise.all([client.connect(clientTransport), mcpServer.server.connect(serverTransport)]);
 
-            const result = await client.request({
-                method: 'tools/call',
-                params: {
-                    name: 'test',
-                    arguments: {
+            await expectInvalidParams(
+                client.request({
+                    method: 'tools/call',
+                    params: {
                         name: 'test',
-                        value: 'not a number'
+                        arguments: {
+                            name: 'test',
+                            value: 'not a number'
+                        }
                     }
-                }
-            });
-
-            expect(result.isError).toBe(true);
-            expect(result.content).toEqual(
-                expect.arrayContaining([
-                    {
-                        type: 'text',
-                        text: expect.stringContaining('Input validation error: Invalid arguments for tool test')
-                    }
-                ])
+                }),
+                ['Input validation error: Invalid arguments for tool test']
             );
         });
 
@@ -5149,22 +5161,15 @@ describe('Zod v4', () => {
             await server.connect(serverTransport);
             await client.connect(clientTransport);
 
-            const invalidTypeResult = await client.callTool({
-                name: 'union-test',
-                arguments: {
-                    type: 'a',
-                    value: 123
-                }
-            });
-
-            expect(invalidTypeResult.isError).toBe(true);
-            expect(invalidTypeResult.content).toEqual(
-                expect.arrayContaining([
-                    expect.objectContaining({
-                        type: 'text',
-                        text: expect.stringContaining('Input validation error')
-                    })
-                ])
+            await expectInvalidParams(
+                client.callTool({
+                    name: 'union-test',
+                    arguments: {
+                        type: 'a',
+                        value: 123
+                    }
+                }),
+                ['Input validation error']
             );
         });
     });
@@ -6407,40 +6412,26 @@ describe('Zod v4', () => {
             await server.connect(serverTransport);
             await client.connect(clientTransport);
 
-            const invalidTypeResult = await client.callTool({
-                name: 'union-test',
-                arguments: {
-                    type: 'a',
-                    value: 123
-                }
-            });
-
-            expect(invalidTypeResult.isError).toBe(true);
-            expect(invalidTypeResult.content).toEqual(
-                expect.arrayContaining([
-                    expect.objectContaining({
-                        type: 'text',
-                        text: expect.stringContaining('Input validation error')
-                    })
-                ])
+            await expectInvalidParams(
+                client.callTool({
+                    name: 'union-test',
+                    arguments: {
+                        type: 'a',
+                        value: 123
+                    }
+                }),
+                ['Input validation error']
             );
 
-            const invalidDiscriminatorResult = await client.callTool({
-                name: 'union-test',
-                arguments: {
-                    type: 'c',
-                    value: 'test'
-                }
-            });
-
-            expect(invalidDiscriminatorResult.isError).toBe(true);
-            expect(invalidDiscriminatorResult.content).toEqual(
-                expect.arrayContaining([
-                    expect.objectContaining({
-                        type: 'text',
-                        text: expect.stringContaining('Input validation error')
-                    })
-                ])
+            await expectInvalidParams(
+                client.callTool({
+                    name: 'union-test',
+                    arguments: {
+                        type: 'c',
+                        value: 'test'
+                    }
+                }),
+                ['Input validation error']
             );
         });
     });

--- a/test/integration/test/standardSchema.test.ts
+++ b/test/integration/test/standardSchema.test.ts
@@ -5,7 +5,7 @@
 
 import { Client } from '@modelcontextprotocol/client';
 import type { TextContent } from '@modelcontextprotocol/core';
-import { AjvJsonSchemaValidator, fromJsonSchema, InMemoryTransport } from '@modelcontextprotocol/core';
+import { AjvJsonSchemaValidator, fromJsonSchema, InMemoryTransport, ProtocolErrorCode } from '@modelcontextprotocol/core';
 import { completable, fromJsonSchema as serverFromJsonSchema, McpServer } from '@modelcontextprotocol/server';
 import { toStandardJsonSchema } from '@valibot/to-json-schema';
 import { type } from 'arktype';
@@ -31,6 +31,29 @@ describe('Standard Schema Support', () => {
     async function connectClientAndServer() {
         const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
         await Promise.all([client.connect(clientTransport), mcpServer.connect(serverTransport)]);
+    }
+
+    async function expectInvalidToolArguments(
+        params: { name: string; arguments?: Record<string, unknown> },
+        expectedMessages: Array<string | RegExp> = []
+    ) {
+        let caught: unknown;
+        try {
+            await client.request({ method: 'tools/call', params });
+        } catch (error) {
+            caught = error;
+        }
+
+        expect(caught).toMatchObject({ code: ProtocolErrorCode.InvalidParams });
+        const message = caught instanceof Error ? caught.message : String(caught);
+        expect(message).toContain('Input validation error');
+        for (const expected of expectedMessages) {
+            if (expected instanceof RegExp) {
+                expect(message).toMatch(expected);
+            } else {
+                expect(message).toContain(expected);
+            }
+        }
     }
 
     describe('ArkType schemas', () => {
@@ -130,16 +153,7 @@ describe('Standard Schema Support', () => {
 
                 await connectClientAndServer();
 
-                const result = await client.request({
-                    method: 'tools/call',
-                    params: { name: 'double', arguments: { value: 'not a number' } }
-                });
-
-                expect(result.isError).toBe(true);
-                const errorText = (result.content[0] as TextContent).text;
-                expect(errorText).toContain('Input validation error');
-                expect(errorText).toContain('value');
-                expect(errorText).toContain('number');
+                await expectInvalidToolArguments({ name: 'double', arguments: { value: 'not a number' } }, ['value', 'number']);
             });
 
             test('should return validation error for invalid enum value', async () => {
@@ -153,15 +167,7 @@ describe('Standard Schema Support', () => {
 
                 await connectClientAndServer();
 
-                const result = await client.request({
-                    method: 'tools/call',
-                    params: { name: 'calculate', arguments: { operation: 'divide' } }
-                });
-
-                expect(result.isError).toBe(true);
-                const errorText = (result.content[0] as TextContent).text;
-                expect(errorText).toContain('Input validation error');
-                expect(errorText).toMatch(/add|subtract|multiply/);
+                await expectInvalidToolArguments({ name: 'calculate', arguments: { operation: 'divide' } }, [/add|subtract|multiply/]);
             });
 
             test('should return validation error for missing required field', async () => {
@@ -173,15 +179,7 @@ describe('Standard Schema Support', () => {
 
                 await connectClientAndServer();
 
-                const result = await client.request({
-                    method: 'tools/call',
-                    params: { name: 'greet', arguments: { name: 'Alice' } }
-                });
-
-                expect(result.isError).toBe(true);
-                const errorText = (result.content[0] as TextContent).text;
-                expect(errorText).toContain('Input validation error');
-                expect(errorText).toContain('age');
+                await expectInvalidToolArguments({ name: 'greet', arguments: { name: 'Alice' } }, ['age']);
             });
         });
     });
@@ -273,15 +271,7 @@ describe('Standard Schema Support', () => {
 
                 await connectClientAndServer();
 
-                const result = await client.request({
-                    method: 'tools/call',
-                    params: { name: 'double', arguments: { value: 'not a number' } }
-                });
-
-                expect(result.isError).toBe(true);
-                const errorText = (result.content[0] as TextContent).text;
-                expect(errorText).toContain('Input validation error');
-                expect(errorText).toContain('number');
+                await expectInvalidToolArguments({ name: 'double', arguments: { value: 'not a number' } }, ['number']);
             });
 
             test('should return validation error for invalid picklist value', async () => {
@@ -297,14 +287,7 @@ describe('Standard Schema Support', () => {
 
                 await connectClientAndServer();
 
-                const result = await client.request({
-                    method: 'tools/call',
-                    params: { name: 'calculate', arguments: { operation: 'divide' } }
-                });
-
-                expect(result.isError).toBe(true);
-                const errorText = (result.content[0] as TextContent).text;
-                expect(errorText).toContain('Input validation error');
+                await expectInvalidToolArguments({ name: 'calculate', arguments: { operation: 'divide' } });
             });
 
             test('should validate min/max constraints', async () => {
@@ -328,13 +311,7 @@ describe('Standard Schema Support', () => {
                 expect(validResult.isError).toBeFalsy();
 
                 // Invalid value (too high)
-                const invalidResult = await client.request({
-                    method: 'tools/call',
-                    params: { name: 'setPercentage', arguments: { percentage: 150 } }
-                });
-                expect(invalidResult.isError).toBe(true);
-                const errorText = (invalidResult.content[0] as TextContent).text;
-                expect(errorText).toContain('Input validation error');
+                await expectInvalidToolArguments({ name: 'setPercentage', arguments: { percentage: 150 } });
             });
         });
     });
@@ -420,11 +397,7 @@ describe('Standard Schema Support', () => {
 
             await connectClientAndServer();
 
-            const result = await client.request({ method: 'tools/call', params: { name: 'double', arguments: { count: 'not a number' } } });
-
-            expect(result.isError).toBe(true);
-            const errorText = (result.content[0] as TextContent).text;
-            expect(errorText).toContain('Input validation error');
+            await expectInvalidToolArguments({ name: 'double', arguments: { count: 'not a number' } });
         });
     });
 
@@ -456,13 +429,7 @@ describe('Standard Schema Support', () => {
 
             await connectClientAndServer();
 
-            const result = await client.request({
-                method: 'tools/call',
-                params: { name: 'double-default', arguments: { count: 'not a number' } }
-            });
-            expect(result.isError).toBe(true);
-            const errorText = (result.content[0] as TextContent).text;
-            expect(errorText).toContain('Input validation error');
+            await expectInvalidToolArguments({ name: 'double-default', arguments: { count: 'not a number' } });
         });
     });
 
@@ -595,25 +562,17 @@ describe('Standard Schema Support', () => {
 
             await connectClientAndServer();
 
-            const result = await client.request({
-                method: 'tools/call',
-                params: {
+            await expectInvalidToolArguments(
+                {
                     name: 'test',
                     arguments: {
                         email: 123,
                         age: 'not a number',
                         status: 'unknown'
                     }
-                }
-            });
-
-            expect(result.isError).toBe(true);
-            const errorText = (result.content[0] as TextContent).text;
-
-            // Check that error mentions the specific issues
-            expect(errorText).toContain('Input validation error');
-            // ArkType should mention type mismatches
-            expect(errorText).toMatch(/email|age|status/i);
+                },
+                [/email|age|status/i]
+            );
         });
 
         test('Valibot should provide descriptive error messages', async () => {
@@ -631,25 +590,17 @@ describe('Standard Schema Support', () => {
 
             await connectClientAndServer();
 
-            const result = await client.request({
-                method: 'tools/call',
-                params: {
+            await expectInvalidToolArguments(
+                {
                     name: 'test',
                     arguments: {
                         email: 123,
                         age: 'not a number',
                         status: 'unknown'
                     }
-                }
-            });
-
-            expect(result.isError).toBe(true);
-            const errorText = (result.content[0] as TextContent).text;
-
-            // Check that error mentions the specific issues
-            expect(errorText).toContain('Input validation error');
-            // Valibot should provide "Invalid type" messages
-            expect(errorText).toContain('Invalid type');
+                },
+                ['Invalid type']
+            );
         });
 
         test('Zod should provide descriptive error messages', async () => {
@@ -665,23 +616,14 @@ describe('Standard Schema Support', () => {
 
             await connectClientAndServer();
 
-            const result = await client.request({
-                method: 'tools/call',
-                params: {
-                    name: 'test',
-                    arguments: {
-                        email: 123,
-                        age: 'not a number',
-                        status: 'unknown'
-                    }
+            await expectInvalidToolArguments({
+                name: 'test',
+                arguments: {
+                    email: 123,
+                    age: 'not a number',
+                    status: 'unknown'
                 }
             });
-
-            expect(result.isError).toBe(true);
-            const errorText = (result.content[0] as TextContent).text;
-
-            // Check that error mentions the specific issues
-            expect(errorText).toContain('Input validation error');
         });
     });
 


### PR DESCRIPTION
## Summary

Fixes #2162.

Invalid tool arguments are request-level validation failures, but `McpServer` was wrapping input schema validation failures in a `CallToolResult` with `isError: true`. This rethrows input validation `ProtocolErrorCode.InvalidParams` errors so clients receive a protocol error for malformed tool calls, while preserving tool execution errors as `CallToolResult` failures.

The tests update the existing Zod, union, ArkType, Valibot, and JSON Schema invalid-input cases to assert `InvalidParams` instead of tool error content.

## Tests

- `npx -y pnpm@10.26.1 --filter @modelcontextprotocol/server test -- mcp.test.ts standardSchema.test.ts`
- `npx -y pnpm@10.26.1 --filter @modelcontextprotocol/server lint`
- `npx -y pnpm@10.26.1 --filter @modelcontextprotocol/server typecheck`
- `npx -y pnpm@10.26.1 --filter @modelcontextprotocol/server build`
- `git diff --check HEAD~1..HEAD`

Note: `git push` hit repeated network timeouts to github.com:443 from this environment, so I created the fork branch via the GitHub Git Data API after the local checks passed.
