### PR TITLE
[DRAFT] test(e2e): 2026-06 spec backlog — SEP-2260 + SEP-2575/2567 as expected-fail stubs

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1034,6 +1034,9 @@ importers:
 
   test/e2e:
     devDependencies:
+      '@hono/node-server':
+        specifier: catalog:runtimeServerOnly
+        version: 1.19.11(hono@4.12.9)
       '@modelcontextprotocol/client':
         specifier: workspace:^
         version: link:../../packages/client
@@ -1046,6 +1049,12 @@ importers:
       '@modelcontextprotocol/express':
         specifier: workspace:^
         version: link:../../packages/middleware/express
+      '@modelcontextprotocol/fastify':
+        specifier: workspace:^
+        version: link:../../packages/middleware/fastify
+      '@modelcontextprotocol/hono':
+        specifier: workspace:^
+        version: link:../../packages/middleware/hono
       '@modelcontextprotocol/node':
         specifier: workspace:^
         version: link:../../packages/middleware/node
@@ -1067,12 +1076,24 @@ importers:
       '@types/express':
         specifier: catalog:devTools
         version: 5.0.6
+      '@valibot/to-json-schema':
+        specifier: catalog:devTools
+        version: 1.6.0(valibot@1.3.1(typescript@5.9.3))
+      arktype:
+        specifier: catalog:devTools
+        version: 2.2.0
       cors:
         specifier: catalog:runtimeServerOnly
         version: 2.8.6
       express:
         specifier: catalog:runtimeServerOnly
         version: 5.2.1
+      fastify:
+        specifier: catalog:runtimeServerOnly
+        version: 5.8.4
+      hono:
+        specifier: catalog:runtimeServerOnly
+        version: 4.12.9
       jose:
         specifier: catalog:runtimeClientOnly
         version: 6.2.2
@@ -1082,6 +1103,9 @@ importers:
       typescript:
         specifier: catalog:devTools
         version: 5.9.3
+      valibot:
+        specifier: catalog:devTools
+        version: 1.3.1(typescript@5.9.3)
       vitest:
         specifier: catalog:devTools
         version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(vite@7.3.0(@types/node@25.5.0)(tsx@4.21.0)(yaml@2.8.3))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1032,6 +1032,63 @@ importers:
         specifier: catalog:runtimeShared
         version: 4.3.6
 
+  test/e2e:
+    devDependencies:
+      '@modelcontextprotocol/client':
+        specifier: workspace:^
+        version: link:../../packages/client
+      '@modelcontextprotocol/core':
+        specifier: workspace:^
+        version: link:../../packages/core
+      '@modelcontextprotocol/eslint-config':
+        specifier: workspace:^
+        version: link:../../common/eslint-config
+      '@modelcontextprotocol/express':
+        specifier: workspace:^
+        version: link:../../packages/middleware/express
+      '@modelcontextprotocol/node':
+        specifier: workspace:^
+        version: link:../../packages/middleware/node
+      '@modelcontextprotocol/server':
+        specifier: workspace:^
+        version: link:../../packages/server
+      '@modelcontextprotocol/test-helpers':
+        specifier: workspace:^
+        version: link:../helpers
+      '@modelcontextprotocol/tsconfig':
+        specifier: workspace:^
+        version: link:../../common/tsconfig
+      '@modelcontextprotocol/vitest-config':
+        specifier: workspace:^
+        version: link:../../common/vitest-config
+      '@types/cors':
+        specifier: catalog:devTools
+        version: 2.8.19
+      '@types/express':
+        specifier: catalog:devTools
+        version: 5.0.6
+      cors:
+        specifier: catalog:runtimeServerOnly
+        version: 2.8.6
+      express:
+        specifier: catalog:runtimeServerOnly
+        version: 5.2.1
+      jose:
+        specifier: catalog:runtimeClientOnly
+        version: 6.2.2
+      tsx:
+        specifier: catalog:devTools
+        version: 4.21.0
+      typescript:
+        specifier: catalog:devTools
+        version: 5.9.3
+      vitest:
+        specifier: catalog:devTools
+        version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(vite@7.3.0(@types/node@25.5.0)(tsx@4.21.0)(yaml@2.8.3))
+      zod:
+        specifier: catalog:runtimeShared
+        version: 4.3.6
+
   test/helpers:
     devDependencies:
       '@modelcontextprotocol/core':

--- a/test/e2e/CLAUDE.md
+++ b/test/e2e/CLAUDE.md
@@ -1,16 +1,19 @@
 # E2E test suite
 
-Conformance-style tests for the SDK's public surface. `requirements.ts` is the manifest: every behavior the SDK must satisfy, linked to the test cases that prove it. `matrix.test.ts` runs each over `ALL_TRANSPORTS`.
+Conformance-style tests for the SDK's public surface. `requirements.ts` is a pure-data manifest: every behavior the SDK must satisfy, with its spec/source link. Test files in `scenarios/` cite the requirement id(s) they prove via `verifies()` (`helpers/verifies.ts`), which
+registers one cell per applicable (transport, spec version). `coverage.test.ts` statically checks that every non-deferred requirement is cited and that the manifest is internally consistent.
 
 ## Writing a test
 
-A test is an exported async function in `scenarios/<area>.ts`:
+Add a `verifies()` call with an anonymous async body to `scenarios/<area>.test.ts`:
 
 ```ts
-export async function toolsCallContentText(transport: Transport) {
+verifies('tools:call:content:text', async ({ transport }) => {
     const makeServer = () => {
         const s = new McpServer({ name: 't', version: '0' });
-        s.registerTool('echo', { inputSchema: z.object({ text: z.string() }) }, ({ text }) => ({ content: [{ type: 'text', text }] }));
+        s.registerTool('echo', { inputSchema: z.object({ text: z.string() }) }, ({ text }) => ({
+            content: [{ type: 'text', text }]
+        }));
         return s;
     };
     const client = new Client({ name: 'c', version: '0' });
@@ -19,45 +22,52 @@ export async function toolsCallContentText(transport: Transport) {
 
     const r = await client.callTool({ name: 'echo', arguments: { text: 'hi' } });
     expect(r.content).toEqual([{ type: 'text', text: 'hi' }]);
-}
+});
 ```
 
-Self-contained: build server inline (factory), build client inline, `wire()`, assert. No shared fixture files.
+Self-contained: build server inline (factory), build client inline, `wire()`, assert. No shared fixture files. Pass an array of ids when one body genuinely proves several requirements; pass `{ title: '...' }` as the third argument only when a requirement needs more than one body
+(the title is how knownFailures target a specific body).
 
-Then link it in `requirements.ts`:
+The corresponding manifest entry is pure data:
 
 ```ts
 'tools:call:content:text': {
     source: 'https://modelcontextprotocol.io/...',
-    behavior: 'tools/call returns content[] with type:text...',
-    tests: [tools.toolsCallContentText]
+    behavior: 'tools/call returns content[] with type:text...'
 },
 ```
 
-## knownFailures and transport restrictions
+## knownFailures, deferred, and transport restrictions
 
-When a test asserts spec-correct behavior the SDK doesn't yet implement:
+When a test asserts required behavior the SDK does not satisfy, keep the test exact and record it in the manifest:
 
 ```ts
-knownFailures: [{ test: tools.toolsCallUnknownName, note: 'McpServer wraps as isError; spec says JSON-RPC error' }];
+knownFailures: [{ note: 'changed in v2: ...' /* optional: test: '<verifies title>', transport, specVersion */ }];
 ```
 
-`matrix.test.ts` runs it as `test.fails()` — passes when it fails as expected, fails when the SDK is fixed (then remove the entry).
+`verifies()` runs matching cells as `test.fails()` — they pass while the SDK misbehaves and fail once it is fixed (then remove the entry). When the behavior cannot be expressed against the public surface at all (e.g. an API removed in v2), mark the requirement
+`deferred: '<reason>'` instead — deferred ids must not be cited by any `verifies()` call.
 
-When a transport structurally cannot express the behavior (e.g., server→client roundtrip on stateless hosting), restrict the requirement itself rather than skipping tests:
+When a transport structurally cannot express the behavior (e.g. server→client roundtrip on stateless hosting), restrict the requirement itself rather than skipping tests:
 
 ```ts
 transports: STATEFUL_TRANSPORTS, // or an explicit list
 note: 'stateless hosting has no server→client back-channel'
 ```
 
+`addedInSpecVersion` / `removedInSpecVersion` bound the spec versions a requirement applies to; a behavior changed by a spec release gets a sibling entry linked via `supersedes`.
+
 ## Running
 
+From the repo root (the suite is the `@modelcontextprotocol/test-e2e` workspace package):
+
 ```bash
-npx vitest run test/e2e                       # all
-npx vitest run test/e2e/tools.test.ts         # one area
-npx vitest run test/e2e -t 'tools:'           # one requirement-id prefix
-npx vitest run test/e2e/coverage.test.ts      # gate: every req id is cited by a verifies() test
+pnpm --filter @modelcontextprotocol/test-e2e test                                    # all
+pnpm --filter @modelcontextprotocol/test-e2e exec vitest run scenarios/tools.test.ts # one area
+pnpm --filter @modelcontextprotocol/test-e2e exec vitest run -t 'tools:'             # one requirement-id prefix
+pnpm --filter @modelcontextprotocol/test-e2e exec vitest run coverage.test.ts        # manifest gates
+pnpm --filter @modelcontextprotocol/test-e2e typecheck
+pnpm --filter @modelcontextprotocol/test-e2e lint
 ```
 
 Slugs prefixed `typescript:` are TypeScript-SDK-specific requirements (they describe this SDK's own API surface and intentionally have no shared cross-SDK meaning); unprefixed slugs share their id and behavior wording with the Python interaction suite where both cover the

--- a/test/e2e/CLAUDE.md
+++ b/test/e2e/CLAUDE.md
@@ -1,0 +1,64 @@
+# E2E test suite
+
+Conformance-style tests for the SDK's public surface. `requirements.ts` is the manifest: every behavior the SDK must satisfy, linked to the test cases that prove it. `matrix.test.ts` runs each over `ALL_TRANSPORTS`.
+
+## Writing a test
+
+A test is an exported async function in `scenarios/<area>.ts`:
+
+```ts
+export async function toolsCallContentText(transport: Transport) {
+    const makeServer = () => {
+        const s = new McpServer({ name: 't', version: '0' });
+        s.registerTool('echo', { inputSchema: z.object({ text: z.string() }) }, ({ text }) => ({ content: [{ type: 'text', text }] }));
+        return s;
+    };
+    const client = new Client({ name: 'c', version: '0' });
+
+    await using _ = await wire(transport, makeServer, client);
+
+    const r = await client.callTool({ name: 'echo', arguments: { text: 'hi' } });
+    expect(r.content).toEqual([{ type: 'text', text: 'hi' }]);
+}
+```
+
+Self-contained: build server inline (factory), build client inline, `wire()`, assert. No shared fixture files.
+
+Then link it in `requirements.ts`:
+
+```ts
+'tools:call:content:text': {
+    source: 'https://modelcontextprotocol.io/...',
+    behavior: 'tools/call returns content[] with type:text...',
+    tests: [tools.toolsCallContentText]
+},
+```
+
+## knownFailures and transport restrictions
+
+When a test asserts spec-correct behavior the SDK doesn't yet implement:
+
+```ts
+knownFailures: [{ test: tools.toolsCallUnknownName, note: 'McpServer wraps as isError; spec says JSON-RPC error' }];
+```
+
+`matrix.test.ts` runs it as `test.fails()` — passes when it fails as expected, fails when the SDK is fixed (then remove the entry).
+
+When a transport structurally cannot express the behavior (e.g., server→client roundtrip on stateless hosting), restrict the requirement itself rather than skipping tests:
+
+```ts
+transports: STATEFUL_TRANSPORTS, // or an explicit list
+note: 'stateless hosting has no server→client back-channel'
+```
+
+## Running
+
+```bash
+npx vitest run test/e2e                       # all
+npx vitest run test/e2e/tools.test.ts         # one area
+npx vitest run test/e2e -t 'tools:'           # one requirement-id prefix
+npx vitest run test/e2e/coverage.test.ts      # gate: every req id is cited by a verifies() test
+```
+
+Slugs prefixed `typescript:` are TypeScript-SDK-specific requirements (they describe this SDK's own API surface and intentionally have no shared cross-SDK meaning); unprefixed slugs share their id and behavior wording with the Python interaction suite where both cover the
+behavior.

--- a/test/e2e/coverage.test.ts
+++ b/test/e2e/coverage.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Manifest gates for the e2e suite.
+ *
+ * The linkage is inverted: test files cite the requirement id(s) they prove via
+ * `verifies(...)` (helpers/verifies.ts) and requirements.ts is pure data. These
+ * tests statically scan test/e2e/scenarios/*.test.ts for the cited ids and check them
+ * against the manifest, plus the manifest's own internal consistency rules.
+ */
+
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { expect, test } from 'vitest';
+
+import { REQUIREMENTS } from './requirements.js';
+
+const E2E_DIR = dirname(fileURLToPath(import.meta.url));
+
+interface VerifiesCall {
+    file: string;
+    /** Explicit `{ title: '...' }` passed to verifies(), if any (undefined for an untitled body). */
+    title: string | undefined;
+    ids: string[];
+}
+
+/** Statically scan test/e2e/scenarios/*.test.ts for `verifies(<ids>, ...)` calls. */
+function scanVerifiesCalls(): VerifiesCall[] {
+    const calls: VerifiesCall[] = [];
+    const scenariosDir = join(E2E_DIR, 'scenarios');
+    const files = readdirSync(scenariosDir)
+        .filter(f => f.endsWith('.test.ts'))
+        .sort();
+    for (const file of files) {
+        const text = readFileSync(join(scenariosDir, file), 'utf8');
+        // Each call spans from its header to the first column-0 close (`});` for an
+        // untitled hugged call, `);` for a call expanded by an opts third argument).
+        for (const m of text.matchAll(/verifies\(\s*('[^']*'|\[[^\]]*\])\s*,\s*async\s*\([\s\S]*?\n(?:\}\);|\);)/g)) {
+            const ids = [...m[1].matchAll(/'([^']*)'/g)].map(x => x[1]);
+            const title = m[0].match(/\{\s*title:\s*'([^']*)'\s*\}\s*\n?\);$/)?.[1];
+            calls.push({ file, title, ids });
+        }
+    }
+    return calls;
+}
+
+const CALLS = scanVerifiesCalls();
+const CITED = new Set(CALLS.flatMap(c => c.ids));
+
+test('every non-deferred requirement id is cited by at least one verifies() call', () => {
+    const missing = Object.entries(REQUIREMENTS)
+        .filter(([id, r]) => !r.deferred && !CITED.has(id))
+        .map(([id]) => id);
+    expect(missing).toEqual([]);
+});
+
+test('every cited requirement id exists in the manifest and is not deferred', () => {
+    const bad: string[] = [];
+    for (const c of CALLS) {
+        for (const id of c.ids) {
+            const req = REQUIREMENTS[id];
+            if (!req) bad.push(`${c.file}: a verifies() call cites unknown requirement '${id}'`);
+            else if (req.deferred) bad.push(`${c.file}: a verifies() call cites deferred requirement '${id}'`);
+        }
+    }
+    expect(bad).toEqual([]);
+});
+
+test('every knownFailure with a test string names an explicit verifies() title that cites the requirement', () => {
+    const bad: string[] = [];
+    for (const [id, r] of Object.entries(REQUIREMENTS)) {
+        for (const kf of r.knownFailures ?? []) {
+            if (kf.test === undefined) continue;
+            const cited = CALLS.some(c => c.title === kf.test && c.ids.includes(id));
+            if (!cited)
+                bad.push(
+                    `${id}: knownFailure references title '${kf.test}', which is not an explicit verifies() title citing this requirement`
+                );
+        }
+    }
+    expect(bad).toEqual([]);
+});
+
+test('every transport-restricted requirement explains why in note', () => {
+    const missing = Object.entries(REQUIREMENTS)
+        .filter(([, r]) => r.transports !== undefined && !r.note)
+        .map(([id]) => id);
+    expect(missing).toEqual([]);
+});
+
+test('every supersedes reference points at an existing requirement id', () => {
+    for (const [id, req] of Object.entries(REQUIREMENTS)) {
+        if (req.supersedes !== undefined) {
+            expect(REQUIREMENTS[req.supersedes], `${id} supersedes unknown id '${req.supersedes}'`).toBeDefined();
+        }
+    }
+});

--- a/test/e2e/coverage.test.ts
+++ b/test/e2e/coverage.test.ts
@@ -8,14 +8,14 @@
  */
 
 import { readdirSync, readFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { expect, test } from 'vitest';
 
 import { REQUIREMENTS } from './requirements.js';
 
-const E2E_DIR = dirname(fileURLToPath(import.meta.url));
+const E2E_DIR = path.dirname(fileURLToPath(import.meta.url));
 
 interface VerifiesCall {
     file: string;
@@ -27,16 +27,16 @@ interface VerifiesCall {
 /** Statically scan test/e2e/scenarios/*.test.ts for `verifies(<ids>, ...)` calls. */
 function scanVerifiesCalls(): VerifiesCall[] {
     const calls: VerifiesCall[] = [];
-    const scenariosDir = join(E2E_DIR, 'scenarios');
+    const scenariosDir = path.join(E2E_DIR, 'scenarios');
     const files = readdirSync(scenariosDir)
         .filter(f => f.endsWith('.test.ts'))
-        .sort();
+        .toSorted();
     for (const file of files) {
-        const text = readFileSync(join(scenariosDir, file), 'utf8');
+        const text = readFileSync(path.join(scenariosDir, file), 'utf8');
         // Each call spans from its header to the first column-0 close (`});` for an
         // untitled hugged call, `);` for a call expanded by an opts third argument).
         for (const m of text.matchAll(/verifies\(\s*('[^']*'|\[[^\]]*\])\s*,\s*async\s*\([\s\S]*?\n(?:\}\);|\);)/g)) {
-            const ids = [...m[1].matchAll(/'([^']*)'/g)].map(x => x[1]);
+            const ids = [...(m[1] ?? '').matchAll(/'([^']*)'/g)].map(x => x[1]).filter(id => id !== undefined);
             const title = m[0].match(/\{\s*title:\s*'([^']*)'\s*\}\s*\n?\);$/)?.[1];
             calls.push({ file, title, ids });
         }

--- a/test/e2e/eslint.config.mjs
+++ b/test/e2e/eslint.config.mjs
@@ -1,0 +1,15 @@
+// @ts-check
+
+import baseConfig from '@modelcontextprotocol/eslint-config';
+
+export default [
+    ...baseConfig,
+    {
+        rules: {
+            // `await using _ = await wire(...)` holds the connection open for the test body; the binding is intentionally unused
+            '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_', varsIgnorePattern: '^_$' }],
+            // scenario files keep the kebab-case names they share with the v1.x suite
+            'unicorn/filename-case': ['error', { cases: { camelCase: true, kebabCase: true } }]
+        }
+    }
+];

--- a/test/e2e/fixtures/stdio-server.ts
+++ b/test/e2e/fixtures/stdio-server.ts
@@ -9,9 +9,8 @@
  */
 
 import { z } from 'zod/v4';
-
-import { McpServer } from '../../../src/server/mcp.js';
-import { StdioServerTransport } from '../../../src/server/stdio.js';
+import { StdioServerTransport } from '@modelcontextprotocol/server/stdio';
+import { McpServer } from '@modelcontextprotocol/server';
 
 const server = new McpServer({ name: 'stdio-echo-server', version: '1.0.0' });
 

--- a/test/e2e/fixtures/stdio-server.ts
+++ b/test/e2e/fixtures/stdio-server.ts
@@ -1,0 +1,61 @@
+/**
+ * Runnable stdio MCP server fixture for the transport:stdio:* e2e tests.
+ *
+ * Spawned as a real child process by test/e2e/scenarios/stdio.ts. Registers a
+ * single `echo` tool, writes a readiness marker line to stderr once it is
+ * serving, and — when E2E_IGNORE_SIGTERM=1 — keeps running after stdin EOF and
+ * swallows SIGTERM so the client transport's shutdown escalation
+ * (stdin EOF → SIGTERM → SIGKILL) is observable.
+ */
+
+import { z } from 'zod/v4';
+
+import { McpServer } from '../../../src/server/mcp.js';
+import { StdioServerTransport } from '../../../src/server/stdio.js';
+
+const server = new McpServer({ name: 'stdio-echo-server', version: '1.0.0' });
+
+server.registerTool(
+    'echo',
+    {
+        description: 'Echoes the input text back as a text content block, including multi-line text.',
+        inputSchema: z.object({ text: z.string() })
+    },
+    ({ text }) => ({ content: [{ type: 'text', text }] })
+);
+
+// env-report tool: returns JSON array of environment variable names (sorted) that
+// reached the child process. This allows tests to verify the env safelist behavior.
+server.registerTool(
+    'env-report',
+    {
+        description: 'Returns sorted array of environment variable names present in this process.',
+        inputSchema: z.object({})
+    },
+    () => {
+        const envKeys = Object.keys(process.env).sort();
+        return { content: [{ type: 'text', text: JSON.stringify(envKeys) }] };
+    }
+);
+
+if (process.env.E2E_IGNORE_SIGTERM === '1') {
+    // Misbehaving-server mode: keep alive after stdin EOF via interval (load-bearing — without it the child exits on stdin EOF and SIGTERM never arrives) and ignore SIGTERM, so only SIGKILL can end the process.
+    setInterval(() => {}, 1_000);
+    setTimeout(() => process.exit(1), 30_000);
+    process.on('SIGTERM', () => {
+        process.stderr.write('[stdio-server] sigterm ignored\n');
+    });
+}
+
+if (process.env.E2E_GARBAGE_STDOUT === '1') {
+    // Broken-server mode: write non-JSON garbage to stdout before the server connects, simulating a broken or misconfigured server that pollutes the JSON-RPC channel.
+    process.stdout.write('GARBAGE LINE 1: not json\n');
+    process.stdout.write('GARBAGE LINE 2: {malformed json\n');
+    process.stdout.write('GARBAGE LINE 3: also not valid jsonrpc\n');
+    process.stdin.resume();
+    process.stdin.on('end', () => process.exit(0));
+    setTimeout(() => process.exit(1), 30_000);
+} else {
+    await server.connect(new StdioServerTransport());
+    process.stderr.write('[stdio-server] ready\n');
+}

--- a/test/e2e/fixtures/stdio-server.ts
+++ b/test/e2e/fixtures/stdio-server.ts
@@ -8,9 +8,11 @@
  * (stdin EOF → SIGTERM → SIGKILL) is observable.
  */
 
-import { z } from 'zod/v4';
-import { StdioServerTransport } from '@modelcontextprotocol/server/stdio';
+/* eslint-disable unicorn/no-process-exit -- standalone spawned executable; exit codes are the behavior under test */
+
 import { McpServer } from '@modelcontextprotocol/server';
+import { StdioServerTransport } from '@modelcontextprotocol/server/stdio';
+import { z } from 'zod/v4';
 
 const server = new McpServer({ name: 'stdio-echo-server', version: '1.0.0' });
 
@@ -32,14 +34,14 @@ server.registerTool(
         inputSchema: z.object({})
     },
     () => {
-        const envKeys = Object.keys(process.env).sort();
+        const envKeys = Object.keys(process.env).toSorted();
         return { content: [{ type: 'text', text: JSON.stringify(envKeys) }] };
     }
 );
 
 if (process.env.E2E_IGNORE_SIGTERM === '1') {
     // Misbehaving-server mode: keep alive after stdin EOF via interval (load-bearing — without it the child exits on stdin EOF and SIGTERM never arrives) and ignore SIGTERM, so only SIGKILL can end the process.
-    setInterval(() => {}, 1_000);
+    setInterval(() => {}, 1000);
     setTimeout(() => process.exit(1), 30_000);
     process.on('SIGTERM', () => {
         process.stderr.write('[stdio-server] sigterm ignored\n');
@@ -51,6 +53,8 @@ if (process.env.E2E_GARBAGE_STDOUT === '1') {
     process.stdout.write('GARBAGE LINE 1: not json\n');
     process.stdout.write('GARBAGE LINE 2: {malformed json\n');
     process.stdout.write('GARBAGE LINE 3: also not valid jsonrpc\n');
+    // Valid JSON but not a valid JSON-RPC message: v2 silently skips non-JSON noise, but schema-invalid messages must still surface via onerror.
+    process.stdout.write('{"jsonrpc":"1.0","bogus":true}\n');
     process.stdin.resume();
     process.stdin.on('end', () => process.exit(0));
     setTimeout(() => process.exit(1), 30_000);

--- a/test/e2e/helpers/express.ts
+++ b/test/e2e/helpers/express.ts
@@ -5,10 +5,11 @@
  * closes cleanly. Used by hosting-express.ts scenarios.
  */
 
-import express, { Express, RequestHandler } from 'express';
 import type { Server as HttpServer } from 'node:http';
 
 import { hostHeaderValidation } from '@modelcontextprotocol/express';
+import type { Express, RequestHandler } from 'express';
+import express from 'express';
 
 export interface ExpressHost extends AsyncDisposable {
     readonly baseUrl: URL;

--- a/test/e2e/helpers/express.ts
+++ b/test/e2e/helpers/express.ts
@@ -8,7 +8,7 @@
 import express, { Express, RequestHandler } from 'express';
 import type { Server as HttpServer } from 'node:http';
 
-import { hostHeaderValidation } from '../../../src/server/middleware/hostHeaderValidation.js';
+import { hostHeaderValidation } from '@modelcontextprotocol/express';
 
 export interface ExpressHost extends AsyncDisposable {
     readonly baseUrl: URL;

--- a/test/e2e/helpers/express.ts
+++ b/test/e2e/helpers/express.ts
@@ -1,0 +1,63 @@
+/**
+ * Express helper for hosting-related e2e tests.
+ *
+ * Builds real Express apps with SDK middleware, listens on ephemeral ports,
+ * closes cleanly. Used by hosting-express.ts scenarios.
+ */
+
+import express, { Express, RequestHandler } from 'express';
+import type { Server as HttpServer } from 'node:http';
+
+import { hostHeaderValidation } from '../../../src/server/middleware/hostHeaderValidation.js';
+
+export interface ExpressHost extends AsyncDisposable {
+    readonly baseUrl: URL;
+    close(): Promise<void>;
+}
+
+async function listen(app: Express, host = '127.0.0.1'): Promise<{ baseUrl: URL; close: () => Promise<void> }> {
+    return new Promise((resolve, reject) => {
+        const server: HttpServer = app.listen(0, host, () => {
+            const addr = server.address();
+            if (!addr || typeof addr === 'string') {
+                reject(new Error(`listen failed: ${addr}`));
+                return;
+            }
+            resolve({
+                baseUrl: new URL(`http://${host}:${addr.port}`),
+                close: () =>
+                    new Promise((res, rej) => {
+                        server.close(err => (err ? rej(err) : res()));
+                    })
+            });
+        });
+        server.on('error', reject);
+    });
+}
+
+export async function startExpressMinimal(handler: RequestHandler): Promise<ExpressHost> {
+    const app = express();
+    app.use(express.json());
+    app.use(handler);
+
+    const { baseUrl, close } = await listen(app);
+    return {
+        baseUrl,
+        close,
+        [Symbol.asyncDispose]: close
+    };
+}
+
+export async function startExpressWithHostValidation(allowedHosts: string[], handler: RequestHandler): Promise<ExpressHost> {
+    const app = express();
+    app.use(express.json());
+    app.use(hostHeaderValidation(allowedHosts));
+    app.use(handler);
+
+    const { baseUrl, close } = await listen(app);
+    return {
+        baseUrl,
+        close,
+        [Symbol.asyncDispose]: close
+    };
+}

--- a/test/e2e/helpers/index.ts
+++ b/test/e2e/helpers/index.ts
@@ -9,17 +9,11 @@
 
 import { randomUUID } from 'node:crypto';
 import { PassThrough } from 'node:stream';
-
-import type { Client } from '../../../src/client/index.js';
-import { StreamableHTTPClientTransport } from '../../../src/client/streamableHttp.js';
-import { InMemoryTransport } from '../../../src/inMemory.js';
-import type { Server } from '../../../src/server/index.js';
-import type { McpServer } from '../../../src/server/mcp.js';
-import { StdioServerTransport } from '../../../src/server/stdio.js';
-import { WebStandardStreamableHTTPServerTransport, type EventStore } from '../../../src/server/webStandardStreamableHttp.js';
-import { ReadBuffer, serializeMessage } from '../../../src/shared/stdio.js';
-import type { JSONRPCMessage } from '../../../src/types.js';
-
+import { StdioServerTransport } from '@modelcontextprotocol/server/stdio';
+import { InMemoryTransport, WebStandardStreamableHTTPServerTransport, ReadBuffer, serializeMessage } from '@modelcontextprotocol/server';
+import type { Server, McpServer, EventStore, JSONRPCMessage } from '@modelcontextprotocol/server';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/client';
+import type { Client } from '@modelcontextprotocol/client';
 import type { Transport } from '../types.js';
 
 import { sniffTransport, type SnifferOptions } from './wire-sniffer.js';

--- a/test/e2e/helpers/index.ts
+++ b/test/e2e/helpers/index.ts
@@ -9,14 +9,16 @@
 
 import { randomUUID } from 'node:crypto';
 import { PassThrough } from 'node:stream';
-import { StdioServerTransport } from '@modelcontextprotocol/server/stdio';
-import { InMemoryTransport, WebStandardStreamableHTTPServerTransport, ReadBuffer, serializeMessage } from '@modelcontextprotocol/server';
-import type { Server, McpServer, EventStore, JSONRPCMessage } from '@modelcontextprotocol/server';
-import { StreamableHTTPClientTransport } from '@modelcontextprotocol/client';
-import type { Client } from '@modelcontextprotocol/client';
-import type { Transport } from '../types.js';
 
-import { sniffTransport, type SnifferOptions } from './wire-sniffer.js';
+import type { Client } from '@modelcontextprotocol/client';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/client';
+import type { EventStore, JSONRPCMessage, McpServer, Server } from '@modelcontextprotocol/server';
+import { InMemoryTransport, ReadBuffer, serializeMessage, WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/server';
+import { StdioServerTransport } from '@modelcontextprotocol/server/stdio';
+
+import type { Transport } from '../types.js';
+import type { SnifferOptions } from './wire-sniffer.js';
+import { sniffTransport } from './wire-sniffer.js';
 
 export type ServerFactory = () => McpServer | Server;
 
@@ -104,12 +106,12 @@ export function hostPerSession(makeServer: ServerFactory): { handleRequest: Http
             if (sid !== undefined) {
                 // Mirror the SDK's documented hosting pattern: an unrecognized session id is
                 // rejected at the app level, so the transport's own 404 is never reached.
-                return new Response(
-                    JSON.stringify({
+                return Response.json(
+                    {
                         jsonrpc: '2.0',
-                        error: { code: -32000, message: 'Bad Request: No valid session ID provided' },
+                        error: { code: -32_000, message: 'Bad Request: No valid session ID provided' },
                         id: null
-                    }),
+                    },
                     { status: 400, headers: { 'Content-Type': 'application/json' } }
                 );
             }
@@ -169,10 +171,13 @@ export function hostStateless(makeServer: ServerFactory): { handleRequest: HttpH
     return {
         handleRequest: async req => {
             if (req.method !== 'POST') {
-                return new Response(JSON.stringify({ jsonrpc: '2.0', error: { code: -32000, message: 'Method not allowed.' }, id: null }), {
-                    status: 405,
-                    headers: { 'Content-Type': 'application/json' }
-                });
+                return Response.json(
+                    { jsonrpc: '2.0', error: { code: -32_000, message: 'Method not allowed.' }, id: null },
+                    {
+                        status: 405,
+                        headers: { 'Content-Type': 'application/json' }
+                    }
+                );
             }
             const server = makeServer();
             const tx = new WebStandardStreamableHTTPServerTransport({ sessionIdGenerator: undefined });

--- a/test/e2e/helpers/index.ts
+++ b/test/e2e/helpers/index.ts
@@ -1,0 +1,230 @@
+/**
+ * Test wiring helpers.
+ *
+ * `wire(transport, makeServer, client)` connects a server (built per call by
+ * `makeServer`) and a client over the named transport, returning an
+ * `AsyncDisposable` for `await using` teardown. All wiring is in-process —
+ * no real sockets, no child processes.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { PassThrough } from 'node:stream';
+
+import type { Client } from '../../../src/client/index.js';
+import { StreamableHTTPClientTransport } from '../../../src/client/streamableHttp.js';
+import { InMemoryTransport } from '../../../src/inMemory.js';
+import type { Server } from '../../../src/server/index.js';
+import type { McpServer } from '../../../src/server/mcp.js';
+import { StdioServerTransport } from '../../../src/server/stdio.js';
+import { WebStandardStreamableHTTPServerTransport, type EventStore } from '../../../src/server/webStandardStreamableHttp.js';
+import { ReadBuffer, serializeMessage } from '../../../src/shared/stdio.js';
+import type { JSONRPCMessage } from '../../../src/types.js';
+
+import type { Transport } from '../types.js';
+
+import { sniffTransport, type SnifferOptions } from './wire-sniffer.js';
+
+export type ServerFactory = () => McpServer | Server;
+
+export interface Wired extends AsyncDisposable {
+    readonly fetch?: (url: URL | string, init?: RequestInit) => Promise<Response>;
+    readonly url?: URL;
+}
+
+/**
+ * The fourth argument controls the wire-format sniffer (see wire-sniffer.ts):
+ * every message the client sends or receives is validated against the SDK's
+ * spec-anchored Zod schemas. Tests that intentionally use vendor-extension
+ * methods pass `{ allowCustomMethods: true }`; tests that deliberately put
+ * malformed MCP on the wire pass `{ strictValidation: false }`.
+ */
+export async function wire(transport: Transport, makeServer: ServerFactory, client: Client, sniff: SnifferOptions = {}): Promise<Wired> {
+    switch (transport) {
+        case 'inMemory': {
+            const server = makeServer();
+            const [clientTx, serverTx] = InMemoryTransport.createLinkedPair();
+            await server.connect(serverTx);
+            await client.connect(sniffTransport(clientTx, 'client', sniff));
+            return { [Symbol.asyncDispose]: () => Promise.all([client.close(), server.close()]).then(() => {}) };
+        }
+        case 'stdio': {
+            const server = makeServer();
+            const c2s = new PassThrough();
+            const s2c = new PassThrough();
+            await server.connect(new StdioServerTransport(c2s, s2c));
+            await client.connect(sniffTransport(stdioClientOverPipes(s2c, c2s), 'client', sniff));
+            return { [Symbol.asyncDispose]: () => Promise.all([client.close(), server.close()]).then(() => {}) };
+        }
+        case 'streamableHttp':
+        case 'streamableHttpStateless': {
+            const handle = transport === 'streamableHttpStateless' ? hostStateless(makeServer) : hostPerSession(makeServer);
+            const url = new URL('http://in-process/mcp');
+            const fetch = (u: URL | string, init?: RequestInit) => handle.handleRequest(new Request(u, init));
+            await client.connect(sniffTransport(new StreamableHTTPClientTransport(url, { fetch }), 'client', sniff));
+            return {
+                fetch,
+                url,
+                [Symbol.asyncDispose]: () => Promise.all([client.close(), handle.close()]).then(() => {})
+            };
+        }
+    }
+}
+
+/**
+ * Tap a connected client's transport so every JSON-RPC message crossing the
+ * wire is recorded. `sent` = client→server, `received` = server→client.
+ * Call after `wire()` so `client.transport` is set. The transport is
+ * monkey-patched in place; teardown via `await using` on `wire()` discards it.
+ */
+export function tapWire(client: Client): { sent: JSONRPCMessage[]; received: JSONRPCMessage[] } {
+    const tx = client.transport;
+    if (!tx) throw new Error('tapWire: client not connected');
+    const sent: JSONRPCMessage[] = [];
+    const received: JSONRPCMessage[] = [];
+    const origSend = tx.send.bind(tx);
+    const origOnMessage = tx.onmessage;
+    tx.send = async (m, opts) => {
+        sent.push(m);
+        return origSend(m, opts);
+    };
+    tx.onmessage = (m, extra) => {
+        received.push(m);
+        origOnMessage?.(m, extra);
+    };
+    return { sent, received };
+}
+
+// ───────────────────────────────────────────────────────────────────────────────
+// HTTP hosting (the two production patterns)
+// ───────────────────────────────────────────────────────────────────────────────
+
+export type HttpHandler = (req: Request) => Promise<Response>;
+
+export function hostPerSession(makeServer: ServerFactory): { handleRequest: HttpHandler; close(): Promise<void> } {
+    const sessions = new Map<string, WebStandardStreamableHTTPServerTransport>();
+    return {
+        handleRequest: async req => {
+            const sid = req.headers.get('mcp-session-id') ?? undefined;
+            const existing = sid ? sessions.get(sid) : undefined;
+            if (existing) return existing.handleRequest(req);
+            if (sid !== undefined) {
+                // Mirror the SDK's documented hosting pattern: an unrecognized session id is
+                // rejected at the app level, so the transport's own 404 is never reached.
+                return new Response(
+                    JSON.stringify({
+                        jsonrpc: '2.0',
+                        error: { code: -32000, message: 'Bad Request: No valid session ID provided' },
+                        id: null
+                    }),
+                    { status: 400, headers: { 'Content-Type': 'application/json' } }
+                );
+            }
+
+            const tx = new WebStandardStreamableHTTPServerTransport({
+                sessionIdGenerator: randomUUID,
+                onsessioninitialized: id => void sessions.set(id, tx),
+                onsessionclosed: id => void sessions.delete(id)
+            });
+            await makeServer().connect(tx);
+            return tx.handleRequest(req);
+        },
+        close: async () => {
+            for (const t of sessions.values()) await t.close();
+            sessions.clear();
+        }
+    };
+}
+
+export interface ResumeHostOptions {
+    eventStore: EventStore;
+    retryInterval?: number;
+}
+
+export function hostResumable(makeServer: ServerFactory, opts: ResumeHostOptions): { handleRequest: HttpHandler; close(): Promise<void> } {
+    const sessions = new Map<string, { tx: WebStandardStreamableHTTPServerTransport; server: McpServer | Server }>();
+
+    return {
+        handleRequest: async req => {
+            const sid = req.headers.get('mcp-session-id') ?? undefined;
+            const existing = sid ? sessions.get(sid) : undefined;
+            if (existing) return existing.tx.handleRequest(req);
+
+            const tx = new WebStandardStreamableHTTPServerTransport({
+                sessionIdGenerator: randomUUID,
+                eventStore: opts.eventStore,
+                retryInterval: opts.retryInterval,
+                onsessioninitialized: id => void sessions.set(id, { tx, server }),
+                onsessionclosed: id => void sessions.delete(id)
+            });
+            const server = makeServer();
+            await server.connect(tx);
+            return tx.handleRequest(req);
+        },
+        close: async () => {
+            for (const { tx, server } of sessions.values()) {
+                await server.close();
+                await tx.close();
+            }
+            sessions.clear();
+        }
+    };
+}
+
+export function hostStateless(makeServer: ServerFactory): { handleRequest: HttpHandler; close(): Promise<void> } {
+    const cleanups: Array<() => Promise<void>> = [];
+    return {
+        handleRequest: async req => {
+            if (req.method !== 'POST') {
+                return new Response(JSON.stringify({ jsonrpc: '2.0', error: { code: -32000, message: 'Method not allowed.' }, id: null }), {
+                    status: 405,
+                    headers: { 'Content-Type': 'application/json' }
+                });
+            }
+            const server = makeServer();
+            const tx = new WebStandardStreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+            await server.connect(tx);
+            cleanups.push(async () => {
+                await server.close();
+                await tx.close();
+            });
+            return tx.handleRequest(req);
+        },
+        close: async () => {
+            for (const c of cleanups) await c();
+        }
+    };
+}
+
+// ───────────────────────────────────────────────────────────────────────────────
+// In-process stdio client — TEST-ONLY
+//
+// Production stdio uses `StdioClientTransport`, which spawns a child process.
+// This is the in-process equivalent for tests: same newline-framed JSON wire
+// format (uses the SDK's `serializeMessage`/`ReadBuffer`), but over PassThrough
+// streams instead of a spawned process. Tests that specifically exercise spawn,
+// env, signals, or stderr must use the real `StdioClientTransport`.
+// ───────────────────────────────────────────────────────────────────────────────
+
+function stdioClientOverPipes(serverStdout: NodeJS.ReadableStream, serverStdin: NodeJS.WritableStream) {
+    const buf = new ReadBuffer();
+    return {
+        onmessage: undefined as ((m: JSONRPCMessage) => void) | undefined,
+        onerror: undefined as ((e: Error) => void) | undefined,
+        onclose: undefined as (() => void) | undefined,
+        async start() {
+            serverStdout.on('data', chunk => {
+                buf.append(chunk);
+                let m: JSONRPCMessage | null;
+                while ((m = buf.readMessage())) this.onmessage?.(m);
+            });
+            serverStdout.on('error', e => this.onerror?.(e));
+            serverStdout.on('close', () => this.onclose?.());
+        },
+        async send(m: JSONRPCMessage) {
+            serverStdin.write(serializeMessage(m));
+        },
+        async close() {
+            serverStdin.end();
+        }
+    };
+}

--- a/test/e2e/helpers/verifies.ts
+++ b/test/e2e/helpers/verifies.ts
@@ -18,7 +18,8 @@
 import { describe, test } from 'vitest';
 
 import { REQUIREMENTS } from '../requirements.js';
-import { ALL_SPEC_VERSIONS, ALL_TRANSPORTS, type TestArgs } from '../types.js';
+import type { TestArgs } from '../types.js';
+import { ALL_SPEC_VERSIONS, ALL_TRANSPORTS } from '../types.js';
 
 type TestBody = (args: TestArgs) => Promise<void>;
 

--- a/test/e2e/helpers/verifies.ts
+++ b/test/e2e/helpers/verifies.ts
@@ -1,0 +1,53 @@
+/**
+ * Inverted manifest linkage: tests declare which requirement(s) they satisfy.
+ * (Staged here in the harness; the restructure codemod copies this file to
+ * sdk/test/e2e/helpers/verifies.ts when the inversion is executed.)
+ *
+ * `verifies(id, fn, opts?)` looks the requirement up in the pure-data manifest
+ * and registers one cell per applicable (transport, spec version) — the same
+ * names and semantics the old matrix runner produced — applying `test.fails`
+ * for knownFailures and the global 15s timeout. Unknown or deferred ids throw
+ * at registration time, so a typo can never silently drop coverage.
+ *
+ * Bodies are anonymous; the registered test title is `opts?.title ?? 'verifies'`.
+ * An explicit `opts.title` is only needed when a requirement is cited by more
+ * than one body (to tell them apart) — a knownFailure with a `test` string only
+ * applies to the body registered with that exact title.
+ */
+
+import { describe, test } from 'vitest';
+
+import { REQUIREMENTS } from '../requirements.js';
+import { ALL_SPEC_VERSIONS, ALL_TRANSPORTS, type TestArgs } from '../types.js';
+
+type TestBody = (args: TestArgs) => Promise<void>;
+
+export function verifies(id: string | readonly string[], fn: TestBody, opts?: { title?: string }): void {
+    const ids = Array.isArray(id) ? id : [id];
+    for (const rid of ids) registerOne(rid, fn, opts);
+}
+
+function registerOne(id: string, fn: TestBody, opts?: { title?: string }): void {
+    const req = REQUIREMENTS[id];
+    if (!req) throw new Error(`verifies('${id}'): unknown requirement id`);
+    if (req.deferred) throw new Error(`verifies('${id}'): requirement is deferred — drop the deferral or the test`);
+
+    const transports = req.transports ?? ALL_TRANSPORTS;
+    const versions = ALL_SPEC_VERSIONS.filter(
+        v =>
+            (req.addedInSpecVersion === undefined || v >= req.addedInSpecVersion) &&
+            (req.removedInSpecVersion === undefined || v < req.removedInSpecVersion)
+    );
+    const cells = versions.flatMap(v => transports.map(t => [t, v] as const));
+
+    describe.each(cells)(`${id} [%s %s]`, (transport, protocolVersion) => {
+        const kf = req.knownFailures?.find(
+            k =>
+                (k.test === undefined || k.test === opts?.title) &&
+                (k.transport === undefined || k.transport === transport) &&
+                (k.specVersion === undefined || k.specVersion === protocolVersion)
+        );
+        const run = kf ? test.fails : test;
+        run(opts?.title ?? 'verifies', () => fn({ transport, protocolVersion }), 15_000);
+    });
+}

--- a/test/e2e/helpers/wire-sniffer.test.ts
+++ b/test/e2e/helpers/wire-sniffer.test.ts
@@ -1,14 +1,15 @@
-import { describe, expect, it } from 'vitest';
 import { LATEST_PROTOCOL_VERSION } from '@modelcontextprotocol/server';
+import { describe, expect, it } from 'vitest';
+
 import { assertWireMessage } from './wire-sniffer.js';
 
 const req = (method: string, params?: unknown, id = 1) => ({
     jsonrpc: '2.0' as const,
     id,
     method,
-    ...(params !== undefined ? { params } : {})
+    ...(params === undefined ? {} : { params })
 });
-const notif = (method: string, params?: unknown) => ({ jsonrpc: '2.0' as const, method, ...(params !== undefined ? { params } : {}) });
+const notif = (method: string, params?: unknown) => ({ jsonrpc: '2.0' as const, method, ...(params === undefined ? {} : { params }) });
 const resp = (result: unknown, id = 1) => ({ jsonrpc: '2.0' as const, id, result });
 
 describe('assertWireMessage', () => {
@@ -61,7 +62,7 @@ describe('assertWireMessage', () => {
     });
 
     it('accepts a JSON-RPC error response for either party', () => {
-        const err = { jsonrpc: '2.0' as const, id: 1, error: { code: -32601, message: 'Method not found' } };
+        const err = { jsonrpc: '2.0' as const, id: 1, error: { code: -32_601, message: 'Method not found' } };
         expect(() => assertWireMessage(err, 'server')).not.toThrow();
         expect(() => assertWireMessage(err, 'client')).not.toThrow();
     });

--- a/test/e2e/helpers/wire-sniffer.test.ts
+++ b/test/e2e/helpers/wire-sniffer.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { LATEST_PROTOCOL_VERSION } from '../../../src/types.js';
-
+import { LATEST_PROTOCOL_VERSION } from '@modelcontextprotocol/server';
 import { assertWireMessage } from './wire-sniffer.js';
 
 const req = (method: string, params?: unknown, id = 1) => ({

--- a/test/e2e/helpers/wire-sniffer.test.ts
+++ b/test/e2e/helpers/wire-sniffer.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import { LATEST_PROTOCOL_VERSION } from '../../../src/types.js';
+
+import { assertWireMessage } from './wire-sniffer.js';
+
+const req = (method: string, params?: unknown, id = 1) => ({
+    jsonrpc: '2.0' as const,
+    id,
+    method,
+    ...(params !== undefined ? { params } : {})
+});
+const notif = (method: string, params?: unknown) => ({ jsonrpc: '2.0' as const, method, ...(params !== undefined ? { params } : {}) });
+const resp = (result: unknown, id = 1) => ({ jsonrpc: '2.0' as const, id, result });
+
+describe('assertWireMessage', () => {
+    it('accepts a valid client initialize request', () => {
+        expect(() =>
+            assertWireMessage(
+                req('initialize', { protocolVersion: LATEST_PROTOCOL_VERSION, capabilities: {}, clientInfo: { name: 'c', version: '0' } }),
+                'client'
+            )
+        ).not.toThrow();
+    });
+
+    it('accepts a valid client tools/list result on the server→client return', () => {
+        // server sends the ListToolsResult back
+        expect(() => assertWireMessage(resp({ tools: [] }), 'server')).not.toThrow();
+    });
+
+    it('accepts a valid client ping and the empty result', () => {
+        expect(() => assertWireMessage(req('ping'), 'client')).not.toThrow();
+        expect(() => assertWireMessage(resp({}), 'server')).not.toThrow();
+    });
+
+    it('rejects a non-JSON-RPC envelope', () => {
+        expect(() => assertWireMessage({ jsonrpc: '1.0', id: 1, method: 'ping' }, 'client')).toThrow(/not a JSON-RPC message/);
+    });
+
+    it('rejects an unknown method without allowCustomMethods', () => {
+        expect(() => assertWireMessage(req('x/custom', { a: 1 }), 'client')).toThrow(/non-spec request method 'x\/custom'/);
+    });
+
+    it('accepts an unknown method with allowCustomMethods', () => {
+        expect(() => assertWireMessage(req('x/custom', { a: 1 }), 'client', { allowCustomMethods: true })).not.toThrow();
+    });
+
+    it('rejects a spec method with malformed params under strict, accepts with strictValidation:false', () => {
+        const bad = notif('notifications/progress', { progressToken: 1, progress: 'not-a-number' });
+        expect(() => assertWireMessage(bad, 'client')).toThrow(/params do not conform/);
+        expect(() => assertWireMessage(bad, 'client', { strictValidation: false })).not.toThrow();
+    });
+
+    it('rejects a server-only request sent by the client (direction check)', () => {
+        // sampling/createMessage is a Server→Client request; the client must not originate it
+        expect(() => assertWireMessage(req('sampling/createMessage', { messages: [], maxTokens: 1 }), 'client')).toThrow(
+            /non-spec request method 'sampling\/createMessage'/
+        );
+    });
+
+    it('accepts that same request when the server sends it', () => {
+        expect(() => assertWireMessage(req('sampling/createMessage', { messages: [], maxTokens: 1 }), 'server')).not.toThrow();
+    });
+
+    it('accepts a JSON-RPC error response for either party', () => {
+        const err = { jsonrpc: '2.0' as const, id: 1, error: { code: -32601, message: 'Method not found' } };
+        expect(() => assertWireMessage(err, 'server')).not.toThrow();
+        expect(() => assertWireMessage(err, 'client')).not.toThrow();
+    });
+});

--- a/test/e2e/helpers/wire-sniffer.ts
+++ b/test/e2e/helpers/wire-sniffer.ts
@@ -1,12 +1,19 @@
 import {
+    ClientNotificationSchema,
+    ClientRequestSchema,
+    ClientResultSchema,
+    ServerNotificationSchema,
+    ServerRequestSchema,
+    ServerResultSchema
+} from '@modelcontextprotocol/core';
+import type { Transport } from '@modelcontextprotocol/server';
+import {
     isJSONRPCErrorResponse,
     isJSONRPCNotification,
     isJSONRPCRequest,
     isJSONRPCResultResponse,
-    specTypeSchemas,
     isSpecType
 } from '@modelcontextprotocol/server';
-import type { Transport } from '@modelcontextprotocol/server';
 
 export type WireParty = 'client' | 'server';
 
@@ -19,28 +26,29 @@ export interface SnifferOptions {
 
 const OUTBOUND = {
     client: {
-        request: specTypeSchemas.ClientRequest,
-        notification: specTypeSchemas.ClientNotification,
-        result: specTypeSchemas.ClientResult
+        request: ClientRequestSchema,
+        notification: ClientNotificationSchema,
+        result: ClientResultSchema
     },
     server: {
-        request: specTypeSchemas.ServerRequest,
-        notification: specTypeSchemas.ServerNotification,
-        result: specTypeSchemas.ServerResult
+        request: ServerRequestSchema,
+        notification: ServerNotificationSchema,
+        result: ServerResultSchema
     }
 } as const;
 
 /** Method names valid as an outbound request/notification for each party. */
 const SPEC_METHODS: Record<WireParty, { request: Set<string>; notification: Set<string> }> = {
-    client: { request: methodSet(specTypeSchemas.ClientRequest), notification: methodSet(specTypeSchemas.ClientNotification) },
-    server: { request: methodSet(specTypeSchemas.ServerRequest), notification: methodSet(specTypeSchemas.ServerNotification) }
+    client: { request: methodSet(ClientRequestSchema), notification: methodSet(ClientNotificationSchema) },
+    server: { request: methodSet(ServerRequestSchema), notification: methodSet(ServerNotificationSchema) }
 };
 
-function methodSet(union: { options?: ReadonlyArray<{ shape?: { method?: { value?: string } } }> }): Set<string> {
+function methodSet(union: { options?: ReadonlyArray<{ shape?: { method?: { values?: ReadonlySet<unknown> } } }> }): Set<string> {
     const out = new Set<string>();
     for (const member of union.options ?? []) {
-        const v = member.shape?.method?.value;
-        if (typeof v === 'string') out.add(v);
+        for (const v of member.shape?.method?.values ?? []) {
+            if (typeof v === 'string') out.add(v);
+        }
     }
     return out;
 }

--- a/test/e2e/helpers/wire-sniffer.ts
+++ b/test/e2e/helpers/wire-sniffer.ts
@@ -1,35 +1,12 @@
-/**
- * Wire-format sniffer: asserts every JSON-RPC message crossing a transport is a
- * well-formed MCP message for its direction.
- *
- * Validation runs against the SDK's runtime Zod schemas in `src/types.ts`
- * (`ClientRequestSchema`, `ServerResultSchema`, …). Those schemas are proven
- * equivalent to the spec-synced `src/spec.types.ts` by `test/spec.types.test.ts`
- * (mutual assignability + per-type completeness). So conformance here is
- * transitively conformance to the spec, with `spec.types.ts` as the anchor: if
- * the SDK schemas ever drift off-spec, that equivalence test goes red first.
- *
- * Two layers:
- *   1. JSON-RPC envelope (always) — request / notification / response / error.
- *   2. MCP shape (unless `strictValidation: false`) — the method is a spec
- *      method for the sender's direction and its params/result match the schema.
- *      Vendor-extension method names are rejected unless `allowCustomMethods`.
- */
-
 import {
-    ClientNotificationSchema,
-    ClientRequestSchema,
-    ClientResultSchema,
     isJSONRPCErrorResponse,
     isJSONRPCNotification,
     isJSONRPCRequest,
     isJSONRPCResultResponse,
-    JSONRPCMessageSchema,
-    ServerNotificationSchema,
-    ServerRequestSchema,
-    ServerResultSchema
-} from '../../../src/types.js';
-import type { Transport } from '../../../src/shared/transport.js';
+    specTypeSchemas,
+    isSpecType
+} from '@modelcontextprotocol/server';
+import type { Transport } from '@modelcontextprotocol/server';
 
 export type WireParty = 'client' | 'server';
 
@@ -41,14 +18,22 @@ export interface SnifferOptions {
 }
 
 const OUTBOUND = {
-    client: { request: ClientRequestSchema, notification: ClientNotificationSchema, result: ClientResultSchema },
-    server: { request: ServerRequestSchema, notification: ServerNotificationSchema, result: ServerResultSchema }
+    client: {
+        request: specTypeSchemas.ClientRequest,
+        notification: specTypeSchemas.ClientNotification,
+        result: specTypeSchemas.ClientResult
+    },
+    server: {
+        request: specTypeSchemas.ServerRequest,
+        notification: specTypeSchemas.ServerNotification,
+        result: specTypeSchemas.ServerResult
+    }
 } as const;
 
 /** Method names valid as an outbound request/notification for each party. */
 const SPEC_METHODS: Record<WireParty, { request: Set<string>; notification: Set<string> }> = {
-    client: { request: methodSet(ClientRequestSchema), notification: methodSet(ClientNotificationSchema) },
-    server: { request: methodSet(ServerRequestSchema), notification: methodSet(ServerNotificationSchema) }
+    client: { request: methodSet(specTypeSchemas.ClientRequest), notification: methodSet(specTypeSchemas.ClientNotification) },
+    server: { request: methodSet(specTypeSchemas.ServerRequest), notification: methodSet(specTypeSchemas.ServerNotification) }
 };
 
 function methodSet(union: { options?: ReadonlyArray<{ shape?: { method?: { value?: string } } }> }): Set<string> {
@@ -70,7 +55,7 @@ function fail(party: WireParty, reason: string, msg: unknown): never {
  * @param party who put it on the wire (`client` outbound = ClientRequest/Notification/Result)
  */
 export function assertWireMessage(msg: unknown, party: WireParty, opts: SnifferOptions = {}): void {
-    if (!JSONRPCMessageSchema.safeParse(msg).success) {
+    if (!isSpecType.JSONRPCMessage(msg)) {
         fail(party, 'not a JSON-RPC message', msg);
     }
     if (opts.strictValidation === false) return;

--- a/test/e2e/helpers/wire-sniffer.ts
+++ b/test/e2e/helpers/wire-sniffer.ts
@@ -1,0 +1,142 @@
+/**
+ * Wire-format sniffer: asserts every JSON-RPC message crossing a transport is a
+ * well-formed MCP message for its direction.
+ *
+ * Validation runs against the SDK's runtime Zod schemas in `src/types.ts`
+ * (`ClientRequestSchema`, `ServerResultSchema`, …). Those schemas are proven
+ * equivalent to the spec-synced `src/spec.types.ts` by `test/spec.types.test.ts`
+ * (mutual assignability + per-type completeness). So conformance here is
+ * transitively conformance to the spec, with `spec.types.ts` as the anchor: if
+ * the SDK schemas ever drift off-spec, that equivalence test goes red first.
+ *
+ * Two layers:
+ *   1. JSON-RPC envelope (always) — request / notification / response / error.
+ *   2. MCP shape (unless `strictValidation: false`) — the method is a spec
+ *      method for the sender's direction and its params/result match the schema.
+ *      Vendor-extension method names are rejected unless `allowCustomMethods`.
+ */
+
+import {
+    ClientNotificationSchema,
+    ClientRequestSchema,
+    ClientResultSchema,
+    isJSONRPCErrorResponse,
+    isJSONRPCNotification,
+    isJSONRPCRequest,
+    isJSONRPCResultResponse,
+    JSONRPCMessageSchema,
+    ServerNotificationSchema,
+    ServerRequestSchema,
+    ServerResultSchema
+} from '../../../src/types.js';
+import type { Transport } from '../../../src/shared/transport.js';
+
+export type WireParty = 'client' | 'server';
+
+export interface SnifferOptions {
+    /** Permit non-spec (vendor-extension) method names. Spec methods stay strict. */
+    allowCustomMethods?: boolean;
+    /** `false` → envelope check only (for tests that deliberately send malformed messages). */
+    strictValidation?: boolean;
+}
+
+const OUTBOUND = {
+    client: { request: ClientRequestSchema, notification: ClientNotificationSchema, result: ClientResultSchema },
+    server: { request: ServerRequestSchema, notification: ServerNotificationSchema, result: ServerResultSchema }
+} as const;
+
+/** Method names valid as an outbound request/notification for each party. */
+const SPEC_METHODS: Record<WireParty, { request: Set<string>; notification: Set<string> }> = {
+    client: { request: methodSet(ClientRequestSchema), notification: methodSet(ClientNotificationSchema) },
+    server: { request: methodSet(ServerRequestSchema), notification: methodSet(ServerNotificationSchema) }
+};
+
+function methodSet(union: { options?: ReadonlyArray<{ shape?: { method?: { value?: string } } }> }): Set<string> {
+    const out = new Set<string>();
+    for (const member of union.options ?? []) {
+        const v = member.shape?.method?.value;
+        if (typeof v === 'string') out.add(v);
+    }
+    return out;
+}
+
+function fail(party: WireParty, reason: string, msg: unknown): never {
+    throw new Error(`[wire] ${party} sent an invalid message: ${reason}\n${JSON.stringify(msg, null, 2)}`);
+}
+
+/**
+ * Assert a single message is valid for the given sending party.
+ * @param msg the raw JSON-RPC message
+ * @param party who put it on the wire (`client` outbound = ClientRequest/Notification/Result)
+ */
+export function assertWireMessage(msg: unknown, party: WireParty, opts: SnifferOptions = {}): void {
+    if (!JSONRPCMessageSchema.safeParse(msg).success) {
+        fail(party, 'not a JSON-RPC message', msg);
+    }
+    if (opts.strictValidation === false) return;
+
+    const schemas = OUTBOUND[party];
+
+    if (isJSONRPCRequest(msg) || isJSONRPCNotification(msg)) {
+        const kind = isJSONRPCRequest(msg) ? 'request' : 'notification';
+        const method = (msg as { method: string }).method;
+        if (!SPEC_METHODS[party][kind].has(method)) {
+            if (opts.allowCustomMethods) return;
+            fail(party, `non-spec ${kind} method '${method}' (pass { allowCustomMethods: true } if intentional)`, msg);
+        }
+        const params = (msg as { params?: unknown }).params;
+        const r = schemas[kind].safeParse({ method, params });
+        if (!r.success) {
+            fail(party, `spec method '${method}' params do not conform: ${r.error.message}`, msg);
+        }
+        return;
+    }
+
+    if (isJSONRPCResultResponse(msg)) {
+        const result = (msg as { result: unknown }).result;
+        const r = schemas.result.safeParse(result);
+        if (!r.success) {
+            // A result for a vendor-extension request legitimately won't match the spec union.
+            if (opts.allowCustomMethods) return;
+            fail(party, `result does not conform to any spec result: ${r.error.message}`, msg);
+        }
+        return;
+    }
+
+    if (isJSONRPCErrorResponse(msg)) return; // envelope already validated; error bodies are not method-specific
+}
+
+/**
+ * Wrap a transport so every outbound `send` (validated as `party`) and inbound
+ * `onmessage` (validated as the counterpart) is asserted. Returns the same
+ * transport instance (monkey-patched in place).
+ */
+export function sniffTransport<T extends Transport>(transport: T, party: WireParty, opts: SnifferOptions = {}): T {
+    const counterpart: WireParty = party === 'client' ? 'server' : 'client';
+
+    const origSend = transport.send.bind(transport);
+    transport.send = (message, sendOpts) => {
+        assertWireMessage(message, party, opts);
+        return origSend(message, sendOpts);
+    };
+
+    // `onmessage` is assigned by Protocol.connect() after we wrap. Intercept via
+    // an accessor so we wrap whatever handler it installs, validating each
+    // inbound message (sent by the counterpart) before passing it through.
+    let handler: Transport['onmessage'];
+    Object.defineProperty(transport, 'onmessage', {
+        configurable: true,
+        enumerable: true,
+        get: () => handler,
+        set: next => {
+            handler = next
+                ? (message, extra) => {
+                      assertWireMessage(message, counterpart, opts);
+                      return next(message, extra);
+                  }
+                : next;
+        }
+    });
+
+    return transport;
+}

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -1,0 +1,52 @@
+{
+    "name": "@modelcontextprotocol/test-e2e",
+    "private": true,
+    "version": "2.0.0-alpha.0",
+    "description": "Model Context Protocol implementation for TypeScript",
+    "license": "MIT",
+    "author": "Anthropic, PBC (https://anthropic.com)",
+    "homepage": "https://modelcontextprotocol.io",
+    "bugs": "https://github.com/modelcontextprotocol/typescript-sdk/issues",
+    "type": "module",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/modelcontextprotocol/typescript-sdk.git"
+    },
+    "engines": {
+        "node": ">=20",
+        "pnpm": ">=10.24.0"
+    },
+    "packageManager": "pnpm@10.24.0",
+    "keywords": [
+        "modelcontextprotocol",
+        "mcp"
+    ],
+    "scripts": {
+        "typecheck": "tsc -p tsconfig.json --noEmit",
+        "lint": "eslint . && prettier --ignore-path ../../.prettierignore --check .",
+        "lint:fix": "eslint . --fix && prettier --ignore-path ../../.prettierignore --write .",
+        "check": "npm run typecheck && npm run lint",
+        "test": "vitest run",
+        "test:watch": "vitest"
+    },
+    "devDependencies": {
+        "@modelcontextprotocol/client": "workspace:^",
+        "@modelcontextprotocol/core": "workspace:^",
+        "@modelcontextprotocol/server": "workspace:^",
+        "@modelcontextprotocol/express": "workspace:^",
+        "@modelcontextprotocol/node": "workspace:^",
+        "@modelcontextprotocol/eslint-config": "workspace:^",
+        "@modelcontextprotocol/test-helpers": "workspace:^",
+        "@modelcontextprotocol/tsconfig": "workspace:^",
+        "@modelcontextprotocol/vitest-config": "workspace:^",
+        "@types/cors": "catalog:devTools",
+        "@types/express": "catalog:devTools",
+        "cors": "catalog:runtimeServerOnly",
+        "express": "catalog:runtimeServerOnly",
+        "jose": "catalog:runtimeClientOnly",
+        "tsx": "catalog:devTools",
+        "typescript": "catalog:devTools",
+        "vitest": "catalog:devTools",
+        "zod": "catalog:runtimeShared"
+    }
+}

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -30,10 +30,13 @@
         "test:watch": "vitest"
     },
     "devDependencies": {
+        "@hono/node-server": "catalog:runtimeServerOnly",
         "@modelcontextprotocol/client": "workspace:^",
         "@modelcontextprotocol/core": "workspace:^",
         "@modelcontextprotocol/server": "workspace:^",
         "@modelcontextprotocol/express": "workspace:^",
+        "@modelcontextprotocol/fastify": "workspace:^",
+        "@modelcontextprotocol/hono": "workspace:^",
         "@modelcontextprotocol/node": "workspace:^",
         "@modelcontextprotocol/eslint-config": "workspace:^",
         "@modelcontextprotocol/test-helpers": "workspace:^",
@@ -41,11 +44,16 @@
         "@modelcontextprotocol/vitest-config": "workspace:^",
         "@types/cors": "catalog:devTools",
         "@types/express": "catalog:devTools",
+        "@valibot/to-json-schema": "catalog:devTools",
+        "arktype": "catalog:devTools",
         "cors": "catalog:runtimeServerOnly",
         "express": "catalog:runtimeServerOnly",
+        "fastify": "catalog:runtimeServerOnly",
+        "hono": "catalog:runtimeServerOnly",
         "jose": "catalog:runtimeClientOnly",
         "tsx": "catalog:devTools",
         "typescript": "catalog:devTools",
+        "valibot": "catalog:devTools",
         "vitest": "catalog:devTools",
         "zod": "catalog:runtimeShared"
     }

--- a/test/e2e/requirements.ts
+++ b/test/e2e/requirements.ts
@@ -1,0 +1,2321 @@
+/**
+ * Requirements manifest for the e2e suite.
+ *
+ * Each entry documents one behavior the SDK must satisfy, links to the test
+ * cases that prove it, and records known failures (where the SDK does not yet
+ * meet the requirement) and structural skips (where a transport cannot express
+ * the behavior).
+ */
+
+import type { Requirement } from './types.js';
+
+/** Transports with a persistent server instance / standalone notification stream. */
+const STATEFUL_TRANSPORTS = ['inMemory', 'stdio', 'streamableHttp'] as const;
+
+export const REQUIREMENTS: Record<string, Requirement> = {
+    // Lifecycle & version negotiation
+
+    'lifecycle:capability:client-not-declared': {
+        transports: STATEFUL_TRANSPORTS,
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle#operation',
+        behavior: 'The client rejects sending notifications or registering handlers for capabilities it did not declare.',
+        note: 'Under stateless hosting each request is served by a new server instance, so state set up earlier in the session cannot be observed.'
+    },
+    'lifecycle:capability:server-not-advertised': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle#operation',
+        behavior: 'The client rejects calls to methods (e.g. resources/list) for capabilities the server did not advertise.'
+    },
+    'lifecycle:initialize:basic': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle#initialization',
+        behavior:
+            'Connecting sends initialize with the protocol version, client capabilities, and client info; the server responds with its own and the connection is established.'
+    },
+    'lifecycle:initialize:instructions': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle#initialization',
+        behavior: 'A server may include an instructions string in the initialize result; the client exposes it.'
+    },
+    'lifecycle:initialized-notification': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle#initialization',
+        behavior: 'After successful initialization, the client sends exactly one initialized notification, before any non-ping request.'
+    },
+    'lifecycle:ping': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/ping#behavior-requirements',
+        behavior: 'ping in either direction returns an empty result.'
+    },
+    'lifecycle:version:downgrade': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle#version-negotiation',
+        behavior:
+            'When the server returns an older supported protocol version, the client downgrades to it and the connection succeeds at that version.'
+    },
+    'lifecycle:version:match': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle#version-negotiation',
+        behavior:
+            'When the server supports the requested protocol version it echoes that version in the initialize result, and the connection proceeds at that version.'
+    },
+    'lifecycle:version:reject-unsupported': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle#version-negotiation',
+        behavior: 'When server returns a protocolVersion the client does not support, connect rejects and the transport is closed.',
+        knownFailures: [
+            {
+                transport: 'stdio',
+                note: 'connect rejects but client.transport is not cleared on stdio (other transports clear it)'
+            }
+        ]
+    },
+    'lifecycle:capability:experimental-passthrough': {
+        transports: STATEFUL_TRANSPORTS,
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle#capability-negotiation',
+        behavior:
+            'Server-declared capabilities.experimental entries (vendor-namespaced keys, arbitrary object values) survive the initialize handshake and are exposed verbatim via client.getServerCapabilities().experimental; an undeclared key reads as undefined. Symmetric for client→server via getClientCapabilities().',
+        note: 'Under stateless hosting each request is served by a new server instance, so state set up earlier in the session cannot be observed.'
+    },
+    'lifecycle:connect:onerror-pre-handshake': {
+        source: 'sdk',
+        behavior:
+            'Transport errors emitted after transport.start() but before client.connect() resolves are delivered to a client.onerror handler set prior to connect (Protocol wires transport.onerror before start() and before the initialize handshake).',
+        transports: ['stdio'],
+        note: 'The behavior itself is transport-agnostic but the garbage injection needs a real child process.'
+    },
+    'lifecycle:initialize:server-info': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle#initialization',
+        behavior: 'The initialize result identifies the server: name and version, plus title when declared.'
+    },
+    'lifecycle:initialize:client-info': {
+        source: 'sdk',
+        behavior: "The client's name, version, and title are visible to server handlers after initialization.",
+        transports: STATEFUL_TRANSPORTS,
+        note: 'Under stateless hosting each request is served by a new server instance, so state set up earlier in the session cannot be observed.'
+    },
+    'lifecycle:version:server-fallback-latest': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle#version-negotiation',
+        behavior:
+            'An initialize request carrying a protocol version the server does not support is answered with another version the server supports — the latest one — rather than an error.'
+    },
+    'lifecycle:pre-initialization-ordering': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle#initialization',
+        behavior:
+            'Before initialization completes, the client sends no requests other than pings, and the server sends no requests other than pings and logging.'
+    },
+    'lifecycle:initialize:capabilities:minimal': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle#capability-negotiation',
+        behavior: 'A server with no feature handlers advertises no feature capabilities.'
+    },
+    'typescript:server:get-client-capabilities': {
+        source: 'sdk',
+        behavior:
+            'After initialize, Server.getClientCapabilities() returns the capabilities object the client sent in InitializeRequest.params.capabilities; before initialize it returns undefined. Servers use this to gate optional features (e.g. dynamic registration) on what the connected client declared.',
+        transports: STATEFUL_TRANSPORTS,
+        note: 'Under stateless hosting each request is served by a new server instance, so state set up earlier in the session cannot be observed.'
+    },
+
+    // Protocol primitives: cancellation, timeout, progress, errors, _meta
+
+    'protocol:cancel:abort-signal': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/cancellation#cancellation-flow',
+        behavior:
+            'Cancelling an in-flight request through the client API sends notifications/cancelled with the request id and fails the local call.'
+    },
+    'protocol:cancel:handler-abort-propagates': {
+        transports: STATEFUL_TRANSPORTS,
+        source: 'sdk',
+        behavior: 'On the receiving side, a cancellation notification stops the running request handler.',
+        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
+    },
+    'protocol:cancel:initialize-not-cancellable': {
+        transports: STATEFUL_TRANSPORTS,
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/cancellation#behavior-requirements',
+        behavior: 'The client never sends notifications/cancelled for the initialize request.',
+        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.',
+        knownFailures: [
+            {
+                note: 'SDK sends notifications/cancelled for initialize when connect() is aborted; spec says initialize MUST NOT be cancelled.'
+            }
+        ]
+    },
+    'protocol:cancel:late-response-ignored': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/cancellation#timing-considerations',
+        behavior:
+            'A response that arrives after the sender issued notifications/cancelled is ignored; the request stays failed and no error is raised.',
+        knownFailures: [
+            {
+                note: 'late response after cancellation fires client.onerror; spec says silently ignore'
+            }
+        ]
+    },
+    'protocol:cancel:unknown-id-ignored': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/cancellation#error-handling',
+        behavior:
+            'The receiver silently ignores a cancellation notification referencing an unknown or already-completed request id; no error response is sent and no exception is raised.'
+    },
+    'typescript:protocol:error:connection-closed': {
+        source: 'sdk',
+        behavior: 'Closing the transport invokes onclose and rejects all in-flight requests with ErrorCode.ConnectionClosed.',
+        knownFailures: [
+            {
+                transport: 'stdio',
+                note: 'in-process stdio does not fire client.onclose after close()'
+            }
+        ]
+    },
+    'protocol:error:internal-error': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic#responses',
+        behavior: 'An unhandled exception in a request handler is returned to the caller as JSON-RPC error -32603 Internal error.'
+    },
+    'protocol:error:invalid-params': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic#responses',
+        behavior: 'A request with malformed params is answered with JSON-RPC error -32602 Invalid params.',
+        knownFailures: [
+            {
+                note: 'Protocol wraps schema-parse failures as -32603 (InternalError), not -32602 (InvalidParams) as required by JSON-RPC 2.0.'
+            }
+        ]
+    },
+    'protocol:error:method-not-found': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic#responses',
+        behavior: 'A request whose method has no registered handler is answered with a METHOD_NOT_FOUND error.'
+    },
+    'protocol:error:reconnect-no-stale-timers': {
+        transports: STATEFUL_TRANSPORTS,
+        source: 'sdk',
+        behavior: 'Reconnecting on the same Protocol instance after close does not leave stale timers that fire spurious cancellations.',
+        note: 'Under stateless hosting each request is served by a new server instance, so state set up earlier in the session cannot be observed.'
+    },
+    'protocol:progress:callback': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/progress#progress-flow',
+        behavior:
+            "Progress notifications emitted by a handler during a request are delivered to the caller's progress callback, in order, with their progress, total, and message."
+    },
+    'typescript:protocol:progress:token-injected': {
+        source: 'sdk',
+        behavior: 'Passing onprogress causes a progressToken to be injected into request _meta, preserving existing _meta fields.'
+    },
+    'protocol:progress:token-unique': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/progress#progress-flow',
+        behavior: 'Concurrent in-flight requests that each supply a progress callback carry distinct progress tokens.'
+    },
+    'protocol:timeout:basic': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle#timeouts',
+        behavior: 'A request that exceeds its read timeout fails with a request-timeout error instead of waiting forever for the response.'
+    },
+    'protocol:timeout:max-total': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle#timeouts',
+        behavior: 'A maximum total timeout is enforced even when progress notifications keep arriving.'
+    },
+    'protocol:timeout:reset-on-progress': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle#timeouts',
+        behavior: "When configured to do so, each progress notification resets the request's read timeout."
+    },
+    'protocol:timeout:sends-cancellation': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle#timeouts',
+        behavior: 'When a request times out, the sender issues notifications/cancelled for that request before failing the local call.'
+    },
+    'mcpserver:onerror:reach-through': {
+        source: 'sdk',
+        behavior:
+            'Setting mcpServer.server.onerror (or server.onerror on raw Server) receives both transport-level errors and protocol/handler errors (uncaught notification handler, failed-to-send-response, unknown-message-id). The reach-through via McpServer.server is the supported access path until McpServer exposes onerror directly.'
+    },
+    'protocol:custom-method:notification': {
+        transports: STATEFUL_TRANSPORTS,
+        source: 'sdk',
+        behavior:
+            "server.notification({method:'x/custom', params}) reaches a client.setNotificationHandler(CustomSchema, ...) registered for that non-spec method; the handler fires with Zod-parsed params and no capability error is raised on either side.",
+        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
+    },
+    'protocol:custom-method:request': {
+        source: 'sdk',
+        behavior:
+            "A user-defined request schema registered via server.setRequestHandler(CustomSchema, h) is dispatched when client.request({method:'x/custom', params}, CustomResultSchema) is called; the handler's return value is parsed by the result schema and resolved to the caller. Capability checks do not reject non-spec method names."
+    },
+    'protocol:custom-method:roundtrip': {
+        source: 'sdk',
+        behavior:
+            "server.setRequestHandler with a schema whose method literal is NOT in the MCP spec registers a handler; client.request({method:'<custom>'}, ResultSchema) returns the handler's result, not -32601 MethodNotFound. Capability assertions on both sides pass through unknown methods."
+    },
+    'protocol:custom-notification:roundtrip': {
+        source: 'sdk',
+        behavior:
+            "server.setNotificationHandler(CustomNotifSchema, h) registers a handler for a non-spec method; client.notification({method:'myorg/event', params}) delivers to it and h receives the schema-parsed notification."
+    },
+    'protocol:error:data-roundtrip': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic#responses',
+        behavior:
+            'A request handler that throws McpError(code, message, data) produces a JSON-RPC error whose error.data equals the thrown data; the client-side rejection is an McpError with .data deep-equal to the original object.'
+    },
+    'protocol:fallback-notification-handler': {
+        source: 'sdk',
+        behavior:
+            'Setting fallbackNotificationHandler on a Client/Server receives any inbound notification whose method has no registered handler; notifications with a method-specific handler do not reach it.'
+    },
+    'protocol:handler:re-register-replaces': {
+        transports: STATEFUL_TRANSPORTS,
+        source: 'sdk',
+        behavior:
+            'Calling setRequestHandler() twice for the same method replaces the prior handler (no throw, no chaining); subsequent inbound requests dispatch only to the latest handler.',
+        note: 'Under stateless hosting each request is served by a new server instance, so state set up earlier in the session cannot be observed.'
+    },
+    'protocol:request-handler:override-builtin': {
+        source: 'sdk',
+        behavior:
+            'server.setRequestHandler() for a spec method that has a built-in handler (initialize, ping, logging/setLevel) replaces that handler; the user-supplied result is what the client receives. No throw on re-registration.'
+    },
+
+    // Tools
+
+    'tools:call:content:audio': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/server/tools#audio-content',
+        behavior: 'A tool result can carry audio content: base64 data with a mimeType.'
+    },
+    'tools:call:content:embedded-resource': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/server/tools#embedded-resources',
+        behavior: 'A tool result can carry an embedded resource with full text or blob contents.'
+    },
+    'tools:call:content:image': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/server/tools#image-content',
+        behavior: 'A tool result can carry image content: base64 data with a mimeType.'
+    },
+    'tools:call:content:mixed': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/server/tools#tool-result',
+        behavior: 'A tool result can carry multiple content blocks of different types; order is preserved.'
+    },
+    'tools:call:content:resource-link': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/server/tools#resource-links',
+        behavior: 'A tool result can carry a resource_link content block referencing a resource by URI.'
+    },
+    'tools:call:content:text': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/server/tools#text-content',
+        behavior: 'tools/call delivers arguments to the tool handler and returns its text content to the caller.'
+    },
+    'tools:call:elicitation-roundtrip': {
+        transports: STATEFUL_TRANSPORTS,
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation#user-interaction-model',
+        behavior: "A tool handler that issues an elicitation receives the client's result and can embed it in the tool call result.",
+        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
+    },
+    'tools:call:is-error': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/server/tools#error-handling',
+        behavior:
+            'A tool execution failure is returned as a result with isError true and the failure described in content, not as a JSON-RPC error.'
+    },
+    'tools:call:logging-mid-execution': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/server/utilities/logging#log-message-notifications',
+        behavior:
+            "Log notifications emitted by a tool handler during execution reach the client's logging callback before the tool result returns."
+    },
+    'tools:call:progress': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/progress#progress-flow',
+        behavior: "Progress notifications emitted by a tool handler reach the caller's progress callback before the tool result returns."
+    },
+    'tools:call:sampling-roundtrip': {
+        transports: STATEFUL_TRANSPORTS,
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/client/sampling',
+        behavior:
+            "A tool handler that issues a sampling request receives the client's completion and can embed it in the tool call result.",
+        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
+    },
+    'tools:call:structured-content': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/server/tools#structured-content',
+        behavior: 'A tool result can carry structuredContent alongside content; the client receives both.'
+    },
+    'tools:call:structured-content:text-mirror': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/server/tools#structured-content',
+        behavior: 'A tool returning structured content also returns the serialized JSON as a text content block.'
+    },
+    'tools:call:unknown-name': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/server/tools#error-handling',
+        behavior: 'tools/call for a name the server does not recognise returns a JSON-RPC error.',
+        knownFailures: [
+            {
+                test: 'mcpserver',
+                note: "RULED 2026-05-26: spec violation (spec error-handling section shows -32602 protocol error for unknown tools). McpServer's blanket try/catch around the tools/call handler converts the McpError(InvalidParams, 'Tool {name} not found') into {isError:true} via createToolError(), so callTool() resolves instead of rejecting. Spec says unknown tool is a protocol error and MUST surface as a JSON-RPC error envelope."
+            }
+        ]
+    },
+    'tools:capability:declared': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/server/tools#capabilities',
+        behavior: 'A server that exposes tools declares the tools capability (optionally with listChanged) in its InitializeResult.'
+    },
+    'tools:input-schema:json-schema-2020-12': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/server/tools#tool',
+        behavior:
+            'A tool registered with a JSON Schema 2020-12 inputSchema (nested objects, $defs references) is discoverable and callable.'
+    },
+    'tools:input-schema:preserve-additional-properties': {
+        source: 'sdk',
+        behavior: 'tools/list preserves inputSchema additionalProperties as registered.'
+    },
+    'tools:input-schema:preserve-defs': {
+        source: 'sdk',
+        behavior: 'tools/list preserves inputSchema $defs as registered.'
+    },
+    'tools:input-schema:preserve-schema-dialect': {
+        source: 'sdk',
+        behavior: 'tools/list preserves the inputSchema $schema dialect URI as registered.'
+    },
+    'tools:list-changed': {
+        transports: STATEFUL_TRANSPORTS,
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/server/tools#list-changed-notification',
+        behavior: "When the tool set changes, the server sends notifications/tools/list_changed and it reaches the client's handler.",
+        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
+    },
+    'tools:list:basic': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/server/tools#listing-tools',
+        behavior: 'tools/list returns the registered tools with name, description, and inputSchema.'
+    },
+    'tools:list:metadata': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/server/tools#tool',
+        behavior:
+            'tools/list includes title, annotations (readOnlyHint, destructiveHint, idempotentHint, openWorldHint), _meta, icons, and execution.taskSupport when set.'
+    },
+    'tools:list:pagination': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/server/tools#listing-tools',
+        behavior:
+            'tools/list supports cursor pagination: the nextCursor returned by a list handler round-trips back to the handler as an opaque cursor until the listing is exhausted.',
+        knownFailures: [
+            {
+                test: 'mcpserver',
+                note: 'McpServer does not implement automatic pagination — handlers receive the cursor but the high-level API returns the full list with no nextCursor unless the user implements cursor handling in their own handler.'
+            }
+        ]
+    },
+    'tools:call:concurrent': {
+        source: 'sdk',
+        behavior:
+            'Multiple tool calls in flight on one session are dispatched concurrently, and each caller receives the response to its own request.'
+    },
+
+    // Tools: SDK guarantees
+
+    'client:output-schema:skip-on-error': {
+        source: 'sdk',
+        behavior: 'The client skips structured-content validation when the tool result has isError true.'
+    },
+    'client:output-schema:validate': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/server/tools#output-schema',
+        behavior:
+            "A tool result whose structuredContent does not conform to the tool's declared outputSchema is rejected by the client: the call raises instead of returning the invalid result."
+    },
+    'client:output-schema:missing-structured': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/server/tools#output-schema',
+        behavior: 'A tool that declares an output schema but returns no structuredContent fails client-side validation.'
+    },
+    'mcpserver:output-schema:missing-structured': {
+        source: 'sdk',
+        behavior: 'A tool with an output schema whose function returns no structured content produces a server error.'
+    },
+    'typescript:mcpserver:output-schema:server-validate': {
+        source: 'sdk',
+        behavior: 'McpServer validates structuredContent against outputSchema before returning; mismatch produces a server error.'
+    },
+    'mcpserver:output-schema:skip-on-error': {
+        source: 'sdk',
+        behavior: 'Server-side output schema validation is skipped when the tool returns an isError result.'
+    },
+    'mcpserver:tool:duplicate-name': {
+        source: 'sdk',
+        behavior: 'Registering a tool with a name already in use is rejected at registration time.'
+    },
+    'typescript:mcpserver:tool:extra': {
+        source: 'sdk',
+        behavior:
+            'Tool handlers receive RequestHandlerExtra with sessionId, requestId, signal, sendNotification, and (when applicable) authInfo and requestInfo.'
+    },
+    'mcpserver:tool:handle-update': {
+        transports: STATEFUL_TRANSPORTS,
+        source: 'sdk',
+        behavior:
+            'The handle returned by registerTool can .update() description/schema/handler; changes reflect in subsequent tools/list and tools/call and trigger list_changed.',
+        note: 'Under stateless hosting each request is served by a new server instance, so state set up earlier in the session cannot be observed.'
+    },
+    'typescript:mcpserver:tool:handler-throws': {
+        source: 'sdk',
+        behavior: "A tool handler that throws is converted to {isError:true, content:[{type:'text', text:<message>}]}."
+    },
+    'mcpserver:tool:input-validation': {
+        source: 'sdk',
+        behavior:
+            "Arguments that fail the tool's input validation produce a tool execution error (isError true with the validation failure described in content) without invoking the function."
+    },
+    'mcpserver:tool:naming-validation': {
+        source: 'sdk',
+        behavior: "Registering a tool whose name violates the spec's tool-naming conventions emits a warning; registration still succeeds."
+    },
+    'mcpserver:tool:url-elicitation-error': {
+        source: 'sdk',
+        behavior:
+            'A tool function that raises the URL-elicitation-required error surfaces to the caller as error -32042 with the elicitation parameters intact.'
+    },
+    'typescript:mcpserver:tool:schema-variants': {
+        source: 'sdk',
+        behavior:
+            'inputSchema accepts Zod union, intersection, nested-object, preprocess, transform, and pipe schemas; validation/coercion runs before the handler.'
+    },
+    'client:call-tool:compat-result-schema': {
+        source: 'sdk',
+        behavior:
+            'Client.callTool(params, CompatibilityCallToolResultSchema) accepts a legacy protocol-2024-10-07 result ({toolResult: ...}, no content[]) without throwing and returns the parsed toolResult field.'
+    },
+    'mcpserver:tool:variadic-forms': {
+        source: 'sdk',
+        behavior:
+            'Deprecated McpServer.tool() positional overloads — (name,cb), (name,desc,cb), (name,paramsSchema,cb), (name,desc,paramsSchema,cb), (name,desc,paramsSchema,annotations,cb), and the annotations-without-schema forms — register tools whose tools/list entry and tools/call result match an equivalent registerTool() registration.'
+    },
+
+    // Resources
+
+    'resources:annotations': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/server/resources#annotations',
+        behavior:
+            'Resources, resource templates, and resource contents may carry annotations {audience, priority, lastModified}; these round-trip from server registration to the client list/read result.'
+    },
+    'resources:capability:declared': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/server/resources#capabilities',
+        behavior:
+            'A server with resource handlers advertises the resources capability, including the subscribe  sub-flag when a subscribe handler is registered.'
+    },
+    'resources:list-changed': {
+        transports: STATEFUL_TRANSPORTS,
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/server/resources#list-changed-notification',
+        behavior:
+            "When the resource set changes, the server sends notifications/resources/list_changed and it reaches the client's handler.",
+        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
+    },
+    'resources:list:basic': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/server/resources#listing-resources',
+        behavior:
+            'resources/list returns the registered resources with uri, name, and the optional descriptive fields supplied by the server.'
+    },
+    'resources:list:pagination': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/server/resources#listing-resources',
+        behavior: 'resources/list supports cursor pagination.',
+        knownFailures: [
+            {
+                test: 'mcpserver',
+                note: 'McpServer does not implement automatic pagination — handlers receive the cursor but the high-level API returns the full list with no nextCursor unless the user implements cursor handling in their own handler.'
+            }
+        ]
+    },
+    'resources:read:blob': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/server/resources#reading-resources',
+        behavior: 'resources/read returns binary contents base64-encoded in blob.'
+    },
+    'resources:read:template-vars': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/server/resources#resource-templates',
+        behavior: 'Variables extracted from a templated resource URI reach the resource function as typed arguments.'
+    },
+    'resources:read:text': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/server/resources#reading-resources',
+        behavior: 'resources/read returns text contents carrying uri, mimeType, and the text.'
+    },
+    'resources:read:unknown-uri': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/server/resources#error-handling',
+        behavior: 'resources/read for an unknown URI returns JSON-RPC error -32002 (resource not found).',
+        knownFailures: [
+            {
+                note: 'SDK emits -32602 (InvalidParams) instead of spec-mandated -32002 (ResourceNotFound). ErrorCode enum lacks ResourceNotFound member.'
+            }
+        ]
+    },
+    'resources:subscribe:capability-required': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/server/resources#capabilities',
+        behavior: 'resources/subscribe to a server that did not advertise the subscribe capability is rejected with an error.'
+    },
+    'resources:subscribe:updated': {
+        transports: STATEFUL_TRANSPORTS,
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/server/resources#subscriptions',
+        behavior: 'After resources/subscribe, server changes to that URI send notifications/resources/updated.',
+        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
+    },
+    'resources:templates:list': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/server/resources#resource-templates',
+        behavior: 'resources/templates/list returns the registered templates with their uriTemplate and descriptive fields.'
+    },
+    'resources:templates:pagination': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/server/utilities/pagination#operations-supporting-pagination',
+        behavior: 'resources/templates/list supports cursor pagination.',
+        knownFailures: [
+            {
+                test: 'mcpserver',
+                note: 'McpServer does not implement automatic pagination — handlers receive the cursor but the high-level API returns the full list with no nextCursor unless the user implements cursor handling in their own handler.'
+            }
+        ]
+    },
+    'resources:unsubscribe:stops-updates': {
+        transports: STATEFUL_TRANSPORTS,
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/server/resources#subscriptions',
+        behavior: 'After resources/unsubscribe the server stops sending updated notifications for that URI.',
+        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
+    },
+
+    // Resources: SDK guarantees
+
+    'mcpserver:resource:duplicate-name': {
+        source: 'sdk',
+        behavior: 'Registering a resource or template with a duplicate identifier is rejected at registration time.'
+    },
+    'mcpserver:resource:handle-update-remove': {
+        transports: STATEFUL_TRANSPORTS,
+        source: 'sdk',
+        behavior: 'The handle from resource()/registerResource() can .update() and .remove(), triggering list_changed.',
+        note: 'Under stateless hosting each request is served by a new server instance, so state set up earlier in the session cannot be observed.'
+    },
+    'mcpserver:resource:metadata-override': {
+        source: 'sdk',
+        behavior: 'Per-resource metadata from a template list callback overrides template-level metadata field-by-field.'
+    },
+    'mcpserver:resource:read-throws-surfaced': {
+        source: 'sdk',
+        behavior: 'A resource function that raises is surfaced to the caller as a JSON-RPC error response.'
+    },
+    'mcpserver:resource:template-list-callback': {
+        source: 'sdk',
+        behavior: 'A ResourceTemplate with a list callback contributes its expanded items to resources/list.'
+    },
+    'mcpserver:resource:legacy-overload': {
+        source: 'sdk',
+        behavior:
+            'The deprecated McpServer.resource() overloads (fixed-URI and ResourceTemplate, with and without the optional metadata arg) register a resource that surfaces in resources/list and reads via resources/read identically to registerResource().'
+    },
+
+    // Prompts
+
+    'prompts:capability:declared': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/server/prompts#capabilities',
+        behavior: 'A server with a list_prompts handler advertises the prompts capability in its initialize result.'
+    },
+    'prompts:get:content:audio': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/server/prompts#audio-content',
+        behavior: 'Prompt messages may contain audio content with base64 data and a mimeType.'
+    },
+    'prompts:get:content:embedded-resource': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/server/prompts#embedded-resources',
+        behavior: 'Prompt messages may contain embedded resource content.'
+    },
+    'prompts:get:content:image': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/server/prompts#image-content',
+        behavior: 'Prompt messages may contain image content.'
+    },
+    'prompts:get:missing-required-args': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/server/prompts#error-handling',
+        behavior: 'prompts/get omitting a required argument returns JSON-RPC error -32602 (Invalid params).'
+    },
+    'prompts:get:no-args': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/server/prompts#getting-a-prompt',
+        behavior: "prompts/get with no arguments returns the prompt's messages."
+    },
+    'prompts:get:unknown-name': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/server/prompts#error-handling',
+        behavior: 'prompts/get for an unknown prompt name returns JSON-RPC error -32602 (Invalid params).'
+    },
+    'prompts:get:with-args': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/server/prompts#getting-a-prompt',
+        behavior: 'prompts/get delivers the supplied arguments to the prompt handler and returns its messages.'
+    },
+    'prompts:list-changed': {
+        transports: STATEFUL_TRANSPORTS,
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/server/prompts#list-changed-notification',
+        behavior: "When the prompt set changes, the server sends notifications/prompts/list_changed and it reaches the client's handler.",
+        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
+    },
+    'prompts:list:basic': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/server/prompts#listing-prompts',
+        behavior: 'prompts/list returns the registered prompts with name, description, and argument declarations.'
+    },
+    'prompts:list:pagination': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/server/prompts#listing-prompts',
+        behavior: 'prompts/list supports cursor pagination.',
+        knownFailures: [
+            {
+                test: 'mcpserver',
+                note: 'McpServer does not implement automatic pagination — handlers receive the cursor but the high-level API returns the full list with no nextCursor unless the user implements cursor handling in their own handler.'
+            }
+        ]
+    },
+    'prompts:get:multi-message': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/server/prompts#getting-a-prompt',
+        behavior: 'A prompt can return multiple messages mixing user and assistant roles; order is preserved.'
+    },
+
+    // Prompts: SDK guarantees
+
+    'mcpserver:prompt:args-validation': {
+        source: 'sdk',
+        behavior: "prompts/get arguments that fail the prompt's argument schema are rejected before the function runs."
+    },
+    'mcpserver:prompt:duplicate-name': {
+        source: 'sdk',
+        behavior: 'Registering a duplicate prompt name is rejected at registration time.'
+    },
+    'mcpserver:prompt:handle-update-remove': {
+        transports: STATEFUL_TRANSPORTS,
+        source: 'sdk',
+        behavior: 'The handle from prompt()/registerPrompt() can .update() and .remove(), triggering list_changed.',
+        note: 'Under stateless hosting each request is served by a new server instance, so state set up earlier in the session cannot be observed.'
+    },
+    'mcpserver:prompt:optional-args': {
+        source: 'sdk',
+        behavior: 'A prompt with optional arguments can be fetched without supplying them.'
+    },
+    'mcpserver:prompt:legacy-overload': {
+        source: 'sdk',
+        behavior:
+            'McpServer.prompt() (deprecated positional overloads: name+cb, name+desc+cb, name+args+cb, name+desc+args+cb) registers a prompt that appears in prompts/list with the given description/arguments and is callable via prompts/get.'
+    },
+
+    // Completion
+
+    'completion:capability:declared': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/server/utilities/completion#capabilities',
+        behavior: 'A server with a completion handler advertises the completions capability in its initialize result.'
+    },
+    'completion:context-arguments': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/server/utilities/completion#requesting-completions',
+        behavior: 'Previously-resolved argument values supplied in context.arguments reach the completion handler.'
+    },
+    'completion:error:invalid-ref': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/server/utilities/completion#error-handling',
+        behavior:
+            'completion/complete with a ref naming an unknown prompt or non-matching resource URI returns JSON-RPC error -32602 (Invalid params).'
+    },
+    'completion:prompt-arg': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/server/utilities/completion#reference-types',
+        behavior: 'completion/complete with a ref/prompt returns suggested values for the named prompt argument.'
+    },
+    'completion:resource-template-arg': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/server/utilities/completion#reference-types',
+        behavior: 'completion/complete with a ref/resource returns suggested values for a URI template variable.'
+    },
+    'completion:result-shape': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/server/utilities/completion#completion-results',
+        behavior: 'The completion result carries values (at most 100), an optional total, and an optional hasMore flag.'
+    },
+    'completion:complete:not-supported': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/server/utilities/completion#capabilities',
+        behavior:
+            'A server with no completion handler does not advertise the completions capability and rejects completion/complete with METHOD_NOT_FOUND.'
+    },
+    'mcpserver:completion:capability-auto': {
+        source: 'sdk',
+        behavior:
+            'MCPServer advertises the completions capability when at least one completion source is registered, and omits it otherwise.'
+    },
+
+    // Logging
+
+    'logging:capability:declared': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/server/utilities/logging#capabilities',
+        behavior: 'A server that emits log message notifications declares the logging capability in its initialize result.'
+    },
+    'logging:message:fields': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/server/utilities/logging#log-message-notifications',
+        behavior:
+            "A log message sent by a server handler is delivered to the client's logging callback with its severity level, logger name, and data."
+    },
+    'logging:message:filtered': {
+        transports: STATEFUL_TRANSPORTS,
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/server/utilities/logging#setting-log-level',
+        behavior: 'After logging/setLevel, log messages below the configured level are not sent.',
+        note: 'Under stateless hosting each request is served by a new server instance, so state set up earlier in the session cannot be observed.'
+    },
+    'logging:set-level': {
+        transports: STATEFUL_TRANSPORTS,
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/server/utilities/logging#setting-log-level',
+        behavior: 'logging/setLevel sets the minimum level for notifications/message.',
+        note: 'Under stateless hosting each request is served by a new server instance, so state set up earlier in the session cannot be observed.'
+    },
+    'logging:set-level:invalid-level': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/server/utilities/logging#error-handling',
+        behavior: 'logging/setLevel with an invalid level value returns JSON-RPC error -32602 (Invalid params).',
+        knownFailures: [
+            {
+                test: 'mcpserver',
+                note: 'Protocol wraps schema-parse failures as -32603 (InternalError), not -32602 (InvalidParams) as required by JSON-RPC 2.0.'
+            }
+        ]
+    },
+    'logging:out-of-band:basic': {
+        transports: STATEFUL_TRANSPORTS,
+        source: 'sdk',
+        behavior:
+            'McpServer.sendLoggingMessage() called outside any request handler delivers the notifications/message to a connected client over the standalone notification stream.',
+        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
+    },
+    'logging:message:all-levels': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/server/utilities/logging#log-levels',
+        behavior: 'All eight RFC 5424 severity levels are deliverable as log message notifications.',
+        transports: ['inMemory', 'stdio', 'streamableHttp'],
+        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
+    },
+
+    // Sampling
+
+    'sampling:capability:declare': {
+        transports: STATEFUL_TRANSPORTS,
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/client/sampling#capabilities',
+        behavior: 'A client that handles sampling requests advertises the sampling capability in its initialize request.',
+        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
+    },
+    'sampling:create:basic': {
+        transports: STATEFUL_TRANSPORTS,
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/client/sampling#creating-messages',
+        behavior:
+            "A sampling/createMessage request from a server handler is answered by the client's sampling callback, and the callback's result (role, content, model, stopReason) is returned to the handler.",
+        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
+    },
+    'sampling:create:include-context': {
+        transports: STATEFUL_TRANSPORTS,
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/client/sampling#capabilities',
+        behavior: 'The includeContext value supplied by the server reaches the client callback intact.',
+        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
+    },
+    'sampling:create:model-preferences': {
+        transports: STATEFUL_TRANSPORTS,
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/client/sampling#model-preferences',
+        behavior:
+            'The model preferences supplied by the server (hints and the cost, speed, and intelligence priorities) reach the client callback intact.',
+        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
+    },
+    'sampling:create:system-prompt': {
+        transports: STATEFUL_TRANSPORTS,
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/client/sampling#creating-messages',
+        behavior: 'The system prompt supplied by the server reaches the client callback intact.',
+        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
+    },
+    'sampling:create:tools': {
+        transports: STATEFUL_TRANSPORTS,
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/client/sampling#tools-in-sampling',
+        behavior:
+            'A sampling request carrying tools and toolChoice reaches the client, and a tool_use response with a toolUse stop reason returns to the requesting handler.',
+        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
+    },
+    'sampling:error:user-rejected': {
+        transports: STATEFUL_TRANSPORTS,
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/client/sampling#error-handling',
+        behavior:
+            "A sampling request the user rejects is answered with a JSON-RPC error (the spec's code for this case is -1, 'User rejected sampling request'), surfaced to the requesting handler as an MCPError.",
+        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
+    },
+    'sampling:message:content-cardinality': {
+        transports: STATEFUL_TRANSPORTS,
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/client/sampling',
+        behavior: "A sampling message's content may be a single block or an array of blocks.",
+        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
+    },
+    'sampling:result:no-tools-single-content': {
+        transports: STATEFUL_TRANSPORTS,
+        source: 'sdk',
+        behavior: 'When the request carries no tools, a sampling callback result whose content is an array is rejected by the client.',
+        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
+    },
+    'sampling:result:with-tools-array-content': {
+        transports: STATEFUL_TRANSPORTS,
+        source: 'sdk',
+        behavior:
+            'When the request includes tools, the client accepts a callback result whose content is an array including tool_use blocks.',
+        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
+    },
+    'sampling:tool-result:no-mixed-content': {
+        transports: STATEFUL_TRANSPORTS,
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/client/sampling#tool-result-messages',
+        behavior:
+            'A user SamplingMessage containing tool_result content MUST contain only tool_result blocks; mixing with text/image/audio is rejected by the client with -32602 Invalid params.',
+        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.',
+        knownFailures: [{ note: 'client does not validate tool_result-only constraint' }]
+    },
+    'sampling:tool-use:result-balance': {
+        transports: STATEFUL_TRANSPORTS,
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/client/sampling#tool-use-and-result-balance',
+        behavior:
+            'In a sampling/createMessage request, every assistant tool_use block in messages MUST be matched by a tool_result with the same toolUseId in the immediately-following user message; an unmatched tool_use is rejected with -32602 Invalid params.',
+        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.',
+        knownFailures: [{ note: 'client does not validate tool_use/tool_result balance' }]
+    },
+    'sampling:tools:server-gated-by-capability': {
+        transports: STATEFUL_TRANSPORTS,
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/client/sampling#tools-in-sampling',
+        behavior:
+            'A tool-enabled sampling request to a client that did not declare sampling.tools is rejected by the server before anything reaches the wire (the SDK surfaces this as an Invalid params error).',
+        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
+    },
+    'sampling:create:image-content': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/client/sampling#image-content',
+        behavior:
+            'sampling/createMessage round-trips image content: base64 data and mimeType survive from the server request to the client callback and back in the result.',
+        transports: ['inMemory', 'stdio', 'streamableHttp'],
+        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
+    },
+    'sampling:create:audio-content': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/client/sampling#audio-content',
+        behavior:
+            'sampling/createMessage round-trips audio content: base64 data and mimeType survive from the server request to the client callback and back in the result.',
+        transports: ['inMemory', 'stdio', 'streamableHttp'],
+        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
+    },
+    'sampling:context:server-gated-by-capability': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/client/sampling#capabilities',
+        behavior:
+            'The server does not use includeContext values thisServer or allServers unless the client declared the sampling.context capability.',
+        transports: ['inMemory', 'stdio', 'streamableHttp'],
+        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.',
+        knownFailures: [
+            {
+                note: "Server.createMessage (src/server/index.ts ~line 497) only gates tools/toolChoice on clientCapabilities.sampling.tools; there is no check of clientCapabilities.sampling.context for includeContext 'thisServer'/'allServers', so the request reaches the client callback instead of being refused."
+            }
+        ]
+    },
+    'sampling:create:not-supported': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/client/sampling#capabilities',
+        behavior: 'The server refuses to send sampling/createMessage to a client that did not declare the sampling capability.',
+        transports: ['inMemory', 'stdio', 'streamableHttp'],
+        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
+    },
+
+    // Elicitation
+
+    'elicitation:capability:empty-is-form': {
+        transports: STATEFUL_TRANSPORTS,
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation#capabilities',
+        behavior: 'A client advertising an empty elicitation capability accepts form-mode elicitation requests.',
+        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
+    },
+    'elicitation:capability:mode-mismatch': {
+        transports: STATEFUL_TRANSPORTS,
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation#error-handling',
+        behavior: 'The client answers elicitation requests for a mode it did not advertise with JSON-RPC error -32602 (Invalid params).',
+        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
+    },
+    'elicitation:capability:server-respects-mode': {
+        transports: STATEFUL_TRANSPORTS,
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation#capabilities',
+        behavior: 'The server refuses to send an elicitation request with a mode the connected client did not declare in its capabilities.',
+        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
+    },
+    'elicitation:form:action:accept': {
+        transports: STATEFUL_TRANSPORTS,
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation#response-actions',
+        behavior: "A form-mode elicitation answered with action 'accept' returns the user's content to the requesting handler.",
+        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
+    },
+    'elicitation:form:action:cancel': {
+        transports: STATEFUL_TRANSPORTS,
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation#response-actions',
+        behavior: "A form-mode elicitation answered with action 'cancel' returns no content to the handler.",
+        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
+    },
+    'elicitation:form:action:decline': {
+        transports: STATEFUL_TRANSPORTS,
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation#response-actions',
+        behavior: "A form-mode elicitation answered with action 'decline' returns no content to the handler.",
+        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
+    },
+    'elicitation:form:basic': {
+        transports: STATEFUL_TRANSPORTS,
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation#form-mode-elicitation-requests',
+        behavior:
+            'A form-mode elicitation delivers the message and requested schema to the client callback exactly as the server sent them.',
+        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
+    },
+    'elicitation:form:defaults': {
+        transports: STATEFUL_TRANSPORTS,
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation#requested-schema',
+        behavior: 'When client advertises elicitation.form.applyDefaults, schema default values are filled into the result content.',
+        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
+    },
+    'elicitation:form:mode-omitted-default': {
+        transports: STATEFUL_TRANSPORTS,
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation#elicitation-requests',
+        behavior: 'An elicitation request with no mode field is treated as form mode by the client.',
+        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
+    },
+    'elicitation:form:schema:enum-variants': {
+        transports: STATEFUL_TRANSPORTS,
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation#requested-schema',
+        behavior: 'Requested-schema enum fields (including titled and multi-select variants) reach the client callback as sent.',
+        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
+    },
+    'elicitation:form:schema:primitives': {
+        transports: STATEFUL_TRANSPORTS,
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation#requested-schema',
+        behavior: 'Requested-schema fields may be string (with format), number or integer, or boolean.',
+        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
+    },
+    'elicitation:url:action:accept-no-content': {
+        transports: STATEFUL_TRANSPORTS,
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation#response-actions',
+        behavior:
+            'A URL-mode elicitation delivers the message, URL, and elicitationId to the client; an accept response carries no content (accept means the user agreed to visit the URL, not that the interaction completed).',
+        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
+    },
+    'elicitation:url:basic': {
+        transports: STATEFUL_TRANSPORTS,
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation#url-mode-elicitation-requests',
+        behavior: 'A url-mode elicitation delivers the elicitation id and URL to the client callback exactly as the server sent them.',
+        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
+    },
+    'elicitation:url:complete-notification': {
+        transports: STATEFUL_TRANSPORTS,
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation#completion-notifications-for-url-mode-elicitation',
+        behavior:
+            'An elicitation/complete notification sent by the server after an out-of-band elicitation finishes reaches the client carrying the elicitationId.',
+        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
+    },
+    'elicitation:url:complete-unknown-ignored': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation#completion-notifications-for-url-mode-elicitation',
+        behavior:
+            'The client ignores an elicitation/complete notification referencing an unknown or already-completed elicitationId without error.'
+    },
+    'elicitation:url:required-error': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation#url-elicitation-required-error',
+        behavior:
+            'A handler that cannot proceed without a URL elicitation rejects the request with error -32042, carrying the pending elicitations in the error data.'
+    },
+    'elicitation:form:response-validation': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation#form-mode-security',
+        behavior:
+            'Accepted form-mode content is validated against the requested schema: the client validates the response before sending and the server validates the content it receives.',
+        transports: ['inMemory', 'stdio', 'streamableHttp'],
+        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
+    },
+    'elicitation:capability:not-declared': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation#error-handling',
+        behavior:
+            'The server refuses to send elicitation/create (form or URL mode) to a client that did not declare the elicitation capability.',
+        transports: ['inMemory', 'stdio', 'streamableHttp'],
+        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
+    },
+    'elicitation:url:action:cancel': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation#response-actions',
+        behavior: "A URL-mode elicitation answered with action 'cancel' returns no content to the handler.",
+        transports: ['inMemory', 'stdio', 'streamableHttp'],
+        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
+    },
+    'elicitation:url:action:decline': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation#response-actions',
+        behavior: "A URL-mode elicitation answered with action 'decline' returns no content to the handler.",
+        transports: ['inMemory', 'stdio', 'streamableHttp'],
+        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
+    },
+    'elicitation:form:schema:restricted-subset': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation#requested-schema',
+        behavior:
+            'Form-mode requested schemas are flat objects with primitive-typed properties only; nested structures and arrays of objects are not used.',
+        transports: ['inMemory', 'stdio', 'streamableHttp'],
+        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.',
+        knownFailures: [
+            {
+                note: 'The client rejects a nested requestedSchema before the user handler, but via the raw ZodError from parseWithCompat in Protocol.setRequestHandler (src/shared/protocol.ts:1428-1431), which _onrequest maps to -32603 InternalError (~line 823) instead of -32602 InvalidParams; the InvalidParams guard in src/client/index.ts (~363-368) is unreachable.'
+            }
+        ]
+    },
+
+    // Roots
+
+    'roots:list-changed': {
+        transports: STATEFUL_TRANSPORTS,
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/client/roots#root-list-changes',
+        behavior: "A roots/list_changed notification sent by the client is delivered to the server's handler.",
+        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
+    },
+    'roots:list:basic': {
+        transports: STATEFUL_TRANSPORTS,
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/client/roots#listing-roots',
+        behavior:
+            "A roots/list request from a server handler is answered by the client's roots callback, and the returned roots (uri, name) reach the handler.",
+        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
+    },
+    'roots:list:client-error': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/client/roots#error-handling',
+        behavior: 'A roots callback that answers with an error surfaces to the requesting handler as an MCPError.',
+        transports: ['inMemory', 'stdio', 'streamableHttp'],
+        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
+    },
+    'roots:list:not-supported': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/client/roots#error-handling',
+        behavior: 'A roots/list request to a client that did not declare the roots capability is answered with -32601 Method not found.',
+        transports: ['inMemory', 'stdio', 'streamableHttp'],
+        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
+    },
+    'roots:list:empty': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/client/roots#listing-roots',
+        behavior: 'An empty roots list is a valid response and reaches the handler as such.',
+        transports: ['inMemory', 'stdio', 'streamableHttp'],
+        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
+    },
+
+    // list_changed & dynamic registration
+
+    'client:list-changed:auto-refresh': {
+        transports: STATEFUL_TRANSPORTS,
+        source: 'sdk',
+        behavior:
+            'A client configured to react to list_changed notifications automatically re-fetches the corresponding list and delivers the fresh result to its callback.',
+        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
+    },
+    'client:list-changed:capability-gated': {
+        transports: STATEFUL_TRANSPORTS,
+        source: 'sdk',
+        behavior: 'The client does not activate list-changed handling for a kind the server did not advertise with listChanged true.',
+        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
+    },
+    'client:list-changed:signal-only': {
+        transports: STATEFUL_TRANSPORTS,
+        source: 'sdk',
+        behavior: 'A client configured for signal-only list-changed handling is notified without auto-refreshing.',
+        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
+    },
+    'mcpserver:handle:enable-disable': {
+        transports: STATEFUL_TRANSPORTS,
+        source: 'sdk',
+        behavior:
+            'handle.disable() removes the item from list results and calling/reading it errors; handle.enable() restores it; each transition emits list_changed.',
+        note: 'Under stateless hosting each request is served by a new server instance, so state set up earlier in the session cannot be observed.'
+    },
+    'mcpserver:list-changed:debounce': {
+        transports: STATEFUL_TRANSPORTS,
+        source: 'sdk',
+        behavior: 'Bursts of registration changes on MCPServer are debounced into one list_changed notification per kind.',
+        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
+    },
+    'mcpserver:register:post-connect': {
+        transports: STATEFUL_TRANSPORTS,
+        source: 'sdk',
+        behavior:
+            'A tool, resource, or prompt registered or removed after the client connected appears in (or disappears from) the corresponding list results, and the change is announced with a list_changed notification.',
+        note: 'Under stateless hosting each request is served by a new server instance, so state set up earlier in the session cannot be observed.'
+    },
+
+    // Pagination
+
+    'pagination:invalid-cursor': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/server/utilities/pagination#error-handling',
+        behavior: 'A list request with an invalid cursor returns JSON-RPC error -32602 (Invalid params).',
+        knownFailures: [
+            {
+                note: 'McpServer does not implement automatic pagination — handlers receive the cursor but the high-level API ignores invalid cursors instead of returning -32602.'
+            }
+        ]
+    },
+    'pagination:client:cursor-handling': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/server/utilities/pagination#implementation-guidelines',
+        behavior:
+            'The client treats cursors as opaque tokens — it does not parse, modify, or persist them — and does not assume a fixed page size.'
+    },
+
+    // Tasks
+    'protocol:meta:related-task': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/tasks#related-task-metadata',
+        behavior: 'Messages may carry related-task _meta associating them with a task.',
+        deferred:
+            'Tasks are experimental and the spec is being substantially revised. Scenarios deferred until the next spec revision settles.'
+    },
+    'protocol:meta:request-to-handler': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic#_meta',
+        behavior: "_meta sent in a request's params by the client is delivered intact to the server-side request handler."
+    },
+    'protocol:meta:result-to-client': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic#_meta',
+        behavior: "_meta returned in a handler's result is delivered intact to the requesting client."
+    },
+    'protocol:request-id:unique': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic#requests',
+        behavior:
+            'Every request sent on a session carries a unique, non-null string or integer id; ids are never reused within the session.'
+    },
+    'protocol:notifications:no-response': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic#notifications',
+        behavior:
+            'Notifications are never answered: every message the server delivers is either the response to a request the client sent or a notification carrying no id.'
+    },
+    'protocol:progress:monotonic': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/progress#behavior-requirements',
+        behavior: 'The progress value increases with each notification for a given token, even when the total is unknown.',
+        knownFailures: [
+            {
+                note: 'Neither the sender path (Protocol.notification via extra.sendNotification) nor the receiver (_onprogress, src/shared/protocol.ts:856-883, which just calls handler(params)) enforces the spec MUST that progress increases per token, so a non-increasing value emitted by the handler is forwarded to the client callback unchanged.'
+            }
+        ]
+    },
+    'protocol:progress:stops-after-completion': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/progress#behavior-requirements',
+        behavior: 'Progress notifications for a token stop once the associated request completes.',
+        transports: ['inMemory', 'stdio', 'streamableHttp'],
+        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.',
+        knownFailures: [
+            {
+                note: 'The server-side send path (server.notification / Protocol.notification) does not check whether the request associated with a progressToken has already completed, so a post-completion progress notification is still sent and reaches the client wire (the client merely drops it via the unknown-token onerror path in _onprogress, src/shared/protocol.ts:860-863).'
+            }
+        ]
+    },
+    'protocol:cancel:in-flight': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/cancellation#behavior-requirements',
+        behavior:
+            'A cancellation notification for an in-flight request stops the server-side handler, and the receiver does not send a response for the cancelled request.',
+        transports: ['inMemory', 'stdio', 'streamableHttp'],
+        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
+    },
+    'protocol:progress:client-to-server': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/progress#progress-flow',
+        behavior: "A progress notification sent by the client is delivered to the server's progress handler.",
+        transports: ['inMemory', 'stdio', 'streamableHttp'],
+        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
+    },
+
+    'tasks:auth:context-isolation': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/tasks#task-isolation-and-access-control',
+        behavior:
+            'When an authorization context is available, task operations are scoped to the context that created the task: other contexts cannot get it, retrieve its result, cancel it, or see it in tasks/list.',
+        transports: ['streamableHttp'],
+        note: 'This exercises the HTTP hosting/auth layer; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.',
+        deferred:
+            'Tasks are experimental and the spec is being substantially revised. Scenarios deferred until the next spec revision settles.'
+    },
+    'tasks:bidirectional': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/tasks#definitions',
+        behavior: 'Task APIs are bidirectional: the server may create, get, list, and cancel tasks on the client.',
+        deferred:
+            'Tasks are experimental and the spec is being substantially revised. Scenarios deferred until the next spec revision settles.'
+    },
+    'tasks:cancel:no-handler-abort': {
+        source: 'sdk',
+        behavior:
+            'tasks/cancel marks the task cancelled without aborting the originating request handler (the spec says receivers SHOULD attempt to stop execution).',
+        deferred:
+            'Tasks are experimental and the spec is being substantially revised. Scenarios deferred until the next spec revision settles.'
+    },
+    'tasks:cancel:remains-cancelled': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/tasks#task-cancellation',
+        behavior: 'After tasks/cancel, the task remains cancelled even if the underlying handler subsequently completes or fails.',
+        deferred:
+            'Tasks are experimental and the spec is being substantially revised. Scenarios deferred until the next spec revision settles.'
+    },
+    'tasks:cancel:terminal-rejected': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/tasks#task-cancellation',
+        behavior: 'tasks/cancel on a task already in a terminal state returns Invalid params (-32602).',
+        deferred:
+            'Tasks are experimental and the spec is being substantially revised. Scenarios deferred until the next spec revision settles.'
+    },
+    'tasks:cancel:working': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/tasks#task-cancellation',
+        behavior: 'tasks/cancel on a working task transitions it to cancelled and returns the updated task.',
+        deferred:
+            'Tasks are experimental and the spec is being substantially revised. Scenarios deferred until the next spec revision settles.'
+    },
+    'tasks:create:ttl-honored': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/tasks#ttl-and-resource-management',
+        behavior:
+            'tasks/get responses include the actual ttl applied by the receiver (or null for unlimited); the create-task result carries the same value.',
+        deferred:
+            'Tasks are experimental and the spec is being substantially revised. Scenarios deferred until the next spec revision settles.'
+    },
+    'tasks:create:via-tool-call': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/tasks#creating-tasks',
+        behavior: 'A task-augmented tools/call returns a create-task result instead of the tool result.',
+        deferred:
+            'Tasks are experimental and the spec is being substantially revised. Scenarios deferred until the next spec revision settles.'
+    },
+    'tasks:get': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/tasks#getting-tasks',
+        behavior: "tasks/get returns the task's current status, ttl, timestamps, and status message.",
+        deferred:
+            'Tasks are experimental and the spec is being substantially revised. Scenarios deferred until the next spec revision settles.'
+    },
+    'tasks:lifecycle:initial-working': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/tasks#task-status-lifecycle',
+        behavior: "A newly created task has status 'working'.",
+        deferred:
+            'Tasks are experimental and the spec is being substantially revised. Scenarios deferred until the next spec revision settles.'
+    },
+    'tasks:lifecycle:input-required': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/tasks#input-required-status',
+        behavior:
+            'While a task awaits a side-channel client response its status is input_required; once the response arrives the task leaves input_required (typically returning to working).',
+        deferred:
+            'Tasks are experimental and the spec is being substantially revised. Scenarios deferred until the next spec revision settles.'
+    },
+    'tasks:list:invalid-cursor': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/tasks#protocol-errors',
+        behavior: 'tasks/list with an invalid cursor returns Invalid params (-32602).',
+        deferred:
+            'Tasks are experimental and the spec is being substantially revised. Scenarios deferred until the next spec revision settles.'
+    },
+    'tasks:list:pagination': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/tasks#listing-tasks',
+        behavior: 'tasks/list returns created tasks and supports cursor pagination.',
+        deferred:
+            'Tasks are experimental and the spec is being substantially revised. Scenarios deferred until the next spec revision settles.'
+    },
+    'tasks:no-capability:ignore-task-param': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/tasks#task-support-and-handling',
+        behavior:
+            'A receiver that did not declare task capability for a request type processes the request normally and returns the ordinary result, ignoring the task augmentation.',
+        deferred:
+            'Tasks are experimental and the spec is being substantially revised. Scenarios deferred until the next spec revision settles.'
+    },
+    'tasks:progress:after-create': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/tasks#task-progress-notifications',
+        behavior:
+            'After the create-task result, progress notifications keyed to the original progress token continue to reach the caller until the task is terminal.',
+        deferred:
+            'Tasks are experimental and the spec is being substantially revised. Scenarios deferred until the next spec revision settles.'
+    },
+    'tasks:request-cancel:no-task-cancel': {
+        source: 'sdk',
+        behavior: 'A cancellation notification for the originating request does not auto-cancel the created task.',
+        deferred:
+            'Tasks are experimental and the spec is being substantially revised. Scenarios deferred until the next spec revision settles.'
+    },
+    'tasks:result:failed': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/tasks#task-execution-errors',
+        behavior: 'tasks/result for a failed task returns the failure result (isError true).',
+        deferred:
+            'Tasks are experimental and the spec is being substantially revised. Scenarios deferred until the next spec revision settles.'
+    },
+    'tasks:result:related-task-meta': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/tasks#related-task-metadata',
+        behavior: 'The tasks/result response carries related-task _meta naming the requested task.',
+        deferred:
+            'Tasks are experimental and the spec is being substantially revised. Scenarios deferred until the next spec revision settles.'
+    },
+    'tasks:result:terminal': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/tasks#result-retrieval',
+        behavior: 'tasks/result for a completed task returns the stored result of the original request type.',
+        deferred:
+            'Tasks are experimental and the spec is being substantially revised. Scenarios deferred until the next spec revision settles.'
+    },
+    'tasks:side-channel:drain-fifo': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/tasks#input-required-status',
+        behavior: 'tasks/result drains queued related-task messages in FIFO order before returning the final result.',
+        deferred:
+            'Tasks are experimental and the spec is being substantially revised. Scenarios deferred until the next spec revision settles.'
+    },
+    'tasks:side-channel:drop-on-cancel': {
+        source: 'sdk',
+        behavior: 'When a task is cancelled before tasks/result, queued related-task messages are dropped.',
+        deferred:
+            'Tasks are experimental and the spec is being substantially revised. Scenarios deferred until the next spec revision settles.'
+    },
+    'tasks:side-channel:elicitation': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/tasks#input-required-status',
+        behavior:
+            "An elicitation issued mid-task is delivered through the tasks/result side-channel, and the client's response routes back to the handler.",
+        deferred:
+            'Tasks are experimental and the spec is being substantially revised. Scenarios deferred until the next spec revision settles.'
+    },
+    'tasks:side-channel:queue': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/tasks#input-required-status',
+        behavior: 'Server-to-client requests with related-task metadata sent while no tasks/result is open are queued.',
+        deferred:
+            'Tasks are experimental and the spec is being substantially revised. Scenarios deferred until the next spec revision settles.'
+    },
+    'tasks:side-channel:sampling': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/tasks#input-required-status',
+        behavior:
+            "A sampling request issued mid-task is delivered through the tasks/result side-channel, and the client's response routes back to the task.",
+        deferred:
+            'Tasks are experimental and the spec is being substantially revised. Scenarios deferred until the next spec revision settles.'
+    },
+    'tasks:side-channel:stream': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/tasks#result-retrieval',
+        behavior:
+            'Calling tasks/result while the task is working streams related-task messages as they are produced, then returns the result.',
+        deferred:
+            'Tasks are experimental and the spec is being substantially revised. Scenarios deferred until the next spec revision settles.'
+    },
+    'tasks:status-notification': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/tasks#task-status-notification',
+        behavior: 'Task status notifications deliver status updates carrying the full task fields.',
+        deferred:
+            'Tasks are experimental and the spec is being substantially revised. Scenarios deferred until the next spec revision settles.'
+    },
+    'tasks:tool-level:forbidden-with-task-32601': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/tasks#tool-level-negotiation',
+        behavior: 'A task-augmented tools/call on a tool that does not support tasks returns Method not found (-32601).',
+        deferred:
+            'Tasks are experimental and the spec is being substantially revised. Scenarios deferred until the next spec revision settles.'
+    },
+    'tasks:tool-level:required-no-task-32601': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/tasks#tool-level-negotiation',
+        behavior: 'A plain tools/call on a tool that requires task augmentation returns Method not found (-32601).',
+        deferred:
+            'Tasks are experimental and the spec is being substantially revised. Scenarios deferred until the next spec revision settles.'
+    },
+    'tasks:unknown-id': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/tasks#protocol-errors',
+        behavior: 'tasks/get, tasks/result, and tasks/cancel for an unknown task id return Invalid params (-32602).',
+        deferred:
+            'Tasks are experimental and the spec is being substantially revised. Scenarios deferred until the next spec revision settles.'
+    },
+
+    // Tasks: registerToolTask (SDK)
+
+    'mcpserver:tooltask:advertise': {
+        source: 'sdk',
+        behavior: 'registerToolTask tools advertise their execution.taskSupport in tools/list.',
+        deferred:
+            'Tasks are experimental and the spec is being substantially revised. Scenarios deferred until the next spec revision settles.'
+    },
+    'mcpserver:tooltask:autopoll-cancelled': {
+        source: 'sdk',
+        behavior: 'Auto-polling surfaces a cancelled task as an error result.',
+        deferred:
+            'Tasks are experimental and the spec is being substantially revised. Scenarios deferred until the next spec revision settles.'
+    },
+    'mcpserver:tooltask:autopoll-failed': {
+        source: 'sdk',
+        behavior: 'Auto-polling surfaces a task that ends failed as the failed CallToolResult.',
+        deferred:
+            'Tasks are experimental and the spec is being substantially revised. Scenarios deferred until the next spec revision settles.'
+    },
+    'mcpserver:tooltask:forbidden-throws': {
+        source: 'sdk',
+        behavior: "registerToolTask throws at registration if taskSupport:'forbidden'.",
+        deferred:
+            'Tasks are experimental and the spec is being substantially revised. Scenarios deferred until the next spec revision settles.'
+    },
+    'mcpserver:tooltask:optional-autopoll': {
+        source: 'sdk',
+        behavior:
+            "A taskSupport:'optional' tool called without task augmentation transparently creates and polls the task, returning the final CallToolResult.",
+        deferred:
+            'Tasks are experimental and the spec is being substantially revised. Scenarios deferred until the next spec revision settles.'
+    },
+    'mcpserver:tooltask:required-with-task': {
+        source: 'sdk',
+        behavior: "A taskSupport:'required' tool called with task augmentation returns CreateTaskResult.",
+        deferred:
+            'Tasks are experimental and the spec is being substantially revised. Scenarios deferred until the next spec revision settles.'
+    },
+    'mcpserver:tooltask:required-without-task': {
+        source: 'sdk',
+        behavior: "A registerToolTask tool with taskSupport:'required' returns isError when called without task augmentation.",
+        deferred:
+            'Tasks are experimental and the spec is being substantially revised. Scenarios deferred until the next spec revision settles.'
+    },
+
+    // Client streaming API (SDK)
+
+    'client:stream:non-task-single': {
+        source: 'sdk',
+        behavior: 'requestStream() on a non-task request yields exactly the final result.',
+        deferred: 'client.stream() is a thin wrapper over tasks; deferred with tasks.'
+    },
+    'client:stream:task-elicitation': {
+        source: 'sdk',
+        behavior:
+            'callToolStream() over a task-augmented tool with mid-task elicitation delivers it to the client handler and yields the final result.',
+        deferred: 'client.stream() is a thin wrapper over tasks; deferred with tasks.'
+    },
+    'client:stream:terminal-error': {
+        source: 'sdk',
+        behavior:
+            'requestStream() yields a terminal error message and nothing further on server error, timeout, abort, network error, or task failure.',
+        deferred: 'client.stream() is a thin wrapper over tasks; deferred with tasks.'
+    },
+    'client:stream:tool-validation': {
+        source: 'sdk',
+        behavior:
+            'callToolStream() applies the same outputSchema validation as callTool(); mismatch yields an error, isError skips validation.',
+        deferred:
+            'client.stream() is a thin wrapper over tasks; deferred with tasks, part of the task-streaming work and not transport-specific.'
+    },
+
+    // McpServer reach-through (SDK)
+
+    'mcpserver:reach-through:set-request-handler': {
+        transports: STATEFUL_TRANSPORTS,
+        source: 'sdk',
+        behavior:
+            'mcpServer.server is public: .server.setRequestHandler(Schema, fn) installs a low-level handler alongside high-level registrations. A handler for a method McpServer has not auto-wired (e.g. resources/list with no registerResource) is reachable by clients; if set before the first registerX of that kind, registerX throws via assertCanSetRequestHandler.',
+        note: 'Under stateless hosting each request is served by a new server instance, so state set up earlier in the session cannot be observed.'
+    },
+
+    // Validation (SDK)
+
+    'validation:cfworker-provider': {
+        source: 'sdk',
+        behavior:
+            'Passing jsonSchemaValidator: new CfWorkerJsonSchemaValidator() to the Client produces the same accept/reject outcomes as the default Ajv provider for client-side tool outputSchema validation.'
+    },
+    'validation:pluggable-provider': {
+        source: 'sdk',
+        behavior:
+            'ClientOptions.jsonSchemaValidator swaps the JSON Schema validator implementation: the configured provider is the one consulted for client-side tool outputSchema validation and its verdicts are honored.'
+    },
+
+    // Hosting: session lifecycle
+
+    'hosting:session:cors-expose': {
+        source: 'sdk',
+        behavior: 'CORS configuration exposes the Mcp-Session-Id header so browser clients can read it.',
+        transports: ['streamableHttp'],
+        note: 'This exercises the HTTP hosting layer and session management; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'hosting:session:create': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#session-management',
+        behavior: 'An initialize POST without a session id creates a session and returns Mcp-Session-Id in the response headers.',
+        transports: ['streamableHttp'],
+        note: 'This exercises the HTTP hosting layer and session management; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'hosting:session:delete': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#session-management',
+        behavior: 'DELETE with a valid Mcp-Session-Id terminates the session.',
+        transports: ['streamableHttp'],
+        note: 'This exercises the HTTP hosting layer and session management; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'hosting:session:id-charset': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#session-management',
+        behavior: 'Generated Mcp-Session-Id values contain only visible ASCII characters.',
+        transports: ['streamableHttp'],
+        note: 'This exercises the HTTP hosting layer and session management; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'hosting:session:isolation': {
+        source: 'sdk',
+        behavior: 'Each session gets its own server instance; closing one session does not affect others.',
+        transports: ['streamableHttp'],
+        note: 'This exercises the HTTP hosting layer and session management; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'hosting:session:missing-id': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#session-management',
+        behavior: 'A non-initialize POST without Mcp-Session-Id in stateful mode returns 400.',
+        transports: ['streamableHttp'],
+        note: 'This exercises the HTTP hosting layer and session management; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'hosting:session:reinitialize': {
+        source: 'sdk',
+        behavior: 'A second initialize on an already-initialized session transport is rejected.',
+        transports: ['streamableHttp'],
+        note: 'This exercises the HTTP hosting layer and session management; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'hosting:session:reuse': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#session-management',
+        behavior: "A POST carrying a valid Mcp-Session-Id routes to that session's transport with state preserved.",
+        transports: ['streamableHttp'],
+        note: 'This exercises the HTTP hosting layer and session management; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'hosting:session:unknown-id': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#session-management',
+        behavior: 'A POST, GET, or DELETE with an unknown Mcp-Session-Id returns 404.',
+        transports: ['streamableHttp'],
+        note: 'This exercises the HTTP hosting layer and session management; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.',
+        knownFailures: [
+            {
+                note: "The SDK's documented hosting pattern rejects unknown session ids with 400 at the app level (see src/examples servers); the transport's own validateSession 404 is never reached, while the spec requires 404."
+            }
+        ]
+    },
+    'hosting:stateless:concurrent-clients': {
+        source: 'sdk',
+        behavior: 'Multiple independent clients can connect to a stateless server concurrently.',
+        transports: ['streamableHttp'],
+        note: 'This exercises the HTTP hosting layer and stateless mode; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'hosting:stateless:no-reuse': {
+        source: 'sdk',
+        behavior: 'A stateless per-request transport cannot be reused for a second request.',
+        transports: ['streamableHttp'],
+        note: 'This exercises the HTTP hosting layer and stateless mode; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'hosting:stateless:no-session-id': {
+        source: 'sdk',
+        behavior: 'In stateless mode no Mcp-Session-Id is emitted and no session validation is performed.',
+        transports: ['streamableHttp'],
+        note: 'This exercises the HTTP hosting layer and stateless mode; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'hosting:session:delete-cancels-inflight': {
+        source: 'sdk',
+        behavior:
+            "DELETE on a session aborts every in-flight request handler's RequestHandlerExtra.signal; their POST-initiated SSE streams close without a JSON-RPC response being written.",
+        transports: ['streamableHttp'],
+        note: 'This exercises the HTTP hosting layer and session management; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'hosting:stateless:get-delete-405': {
+        source: 'sdk',
+        behavior:
+            'In stateless mode (sessionIdGenerator: undefined), GET (standalone SSE) and DELETE on /mcp return 405 Method Not Allowed — there is no session to stream to or terminate.',
+        transports: ['streamableHttp'],
+        note: 'This exercises the HTTP hosting layer and stateless mode; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.',
+        knownFailures: [
+            {
+                note: 'webStandardStreamableHttp.ts:833-836: validateSession() returns undefined in stateless mode, so GET opens an SSE stream and DELETE succeeds with 200 instead of 405.'
+            }
+        ]
+    },
+    'hosting:stateless:progress-in-post-stream': {
+        source: 'sdk',
+        behavior:
+            "In stateless mode (sessionIdGenerator: undefined), notifications/progress emitted by a tool handler via sendNotification are delivered on the POST-initiated SSE stream and reach the client's onprogress before the result resolves.",
+        transports: ['streamableHttp'],
+        note: 'This exercises the HTTP hosting layer and stateless mode; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'transport:streamable-http:stateless-restrictions': {
+        source: 'sdk',
+        behavior:
+            'A handler that attempts a server-initiated request in stateless mode fails with an error result, because there is no session to call back through.',
+        transports: ['streamableHttpStateless'],
+        note: 'The exercised behavior depends on stateless hosting; the test runs as streamableHttpStateless to test the specific stateless condition.',
+        knownFailures: [
+            {
+                note: 'Under stateless hosting a server-to-client request (e.g. sampling/createMessage) with no GET stream and no relatedRequestId is silently dropped by send(), so the tool call hangs instead of failing fast with an error result.'
+            }
+        ]
+    },
+
+    // Hosting: auth
+
+    'hosting:auth:as-router': {
+        source: 'sdk',
+        behavior:
+            'The authorization-server routes expose the authorize, token, and registration endpoints (and revocation when supported).',
+        transports: ['streamableHttp'],
+        note: 'These exercise the HTTP hosting/auth layer (mostly over real Express); the matrix transport arg is ignored, so they run as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'hosting:auth:aud-validation': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#access-token-usage',
+        behavior: 'The resource server validates that the token audience matches its resource identifier.',
+        transports: ['streamableHttp'],
+        note: 'These exercise the HTTP hosting/auth layer (mostly over real Express); the matrix transport arg is ignored, so they run as a single streamableHttp-labelled cell to avoid duplicate runs.',
+        knownFailures: [
+            {
+                note: 'src/server/auth/middleware/bearerAuth.ts: authInfo.resource is never compared to the resource identifier — audience validation missing.'
+            }
+        ]
+    },
+    'hosting:auth:authinfo-propagates': {
+        source: 'sdk',
+        behavior: "A valid token's auth info is exposed to request handlers.",
+        transports: ['streamableHttp'],
+        note: 'These exercise the HTTP hosting/auth layer (mostly over real Express); the matrix transport arg is ignored, so they run as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'hosting:auth:expired-401': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#token-handling',
+        behavior: 'An expired token returns 401 invalid_token.',
+        transports: ['streamableHttp'],
+        note: 'These exercise the HTTP hosting/auth layer (mostly over real Express); the matrix transport arg is ignored, so they run as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'hosting:auth:invalid-401': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#token-handling',
+        behavior: 'A malformed bearer token or token-verification failure returns 401 with WWW-Authenticate.',
+        transports: ['streamableHttp'],
+        note: 'These exercise the HTTP hosting/auth layer (mostly over real Express); the matrix transport arg is ignored, so they run as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'hosting:auth:metadata-endpoints': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#authorization-server-location',
+        behavior:
+            'The MCP server publishes protected-resource metadata at its well-known endpoint, and the authorization server (which the SDK can also host) publishes authorization-server metadata at its own.',
+        transports: ['streamableHttp'],
+        note: 'These exercise the HTTP hosting/auth layer (mostly over real Express); the matrix transport arg is ignored, so they run as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'hosting:auth:missing-401': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#error-handling',
+        behavior:
+            "A request without an Authorization header is rejected with 401; the WWW-Authenticate header carries resource_metadata (one of the spec's two permitted discovery mechanisms).",
+        transports: ['streamableHttp'],
+        note: 'These exercise the HTTP hosting/auth layer (mostly over real Express); the matrix transport arg is ignored, so they run as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'hosting:auth:prm:authorization-servers-field': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#authorization-server-location',
+        behavior: 'The protected-resource metadata document includes an authorization_servers array with at least one entry.',
+        transports: ['streamableHttp'],
+        note: 'These exercise the HTTP hosting/auth layer (mostly over real Express); the matrix transport arg is ignored, so they run as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'hosting:auth:scope-403': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#runtime-insufficient-scope-errors',
+        behavior:
+            'A token lacking a required scope returns 403 with WWW-Authenticate carrying insufficient_scope, the required scope, and resource_metadata.',
+        transports: ['streamableHttp'],
+        note: 'These exercise the HTTP hosting/auth layer (mostly over real Express); the matrix transport arg is ignored, so they run as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'hosting:auth:proxy-provider': {
+        source: 'sdk',
+        behavior:
+            'ProxyOAuthServerProvider plugged into mcpAuthRouter mounts the /authorize, /token, and /revoke endpoints and serves them.',
+        transports: ['streamableHttp'],
+        note: 'These exercise the HTTP hosting/auth layer (mostly over real Express); the matrix transport arg is ignored, so they run as a single streamableHttp-labelled cell to avoid duplicate runs. Asserting that requests are forwarded to the configured upstream AS endpoints is post-ship backlog.'
+    },
+
+    // Hosting: resumability
+
+    'typescript:hosting:resume:bad-event-id': {
+        source: 'sdk',
+        behavior: 'Last-Event-ID that cannot be mapped to a stream returns 400; replay failure returns 500.',
+        transports: ['streamableHttp'],
+        note: 'Resumability requires a per-session transport with an EventStore and a standalone GET stream; stateless hosting has neither.'
+    },
+    'hosting:resume:buffered-replay': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#resumability-and-redelivery',
+        behavior: 'Notifications emitted while no client is connected are replayed in order on reconnect.',
+        transports: ['streamableHttp'],
+        note: 'Resumability requires a per-session transport with an EventStore and a standalone GET stream; stateless hosting has neither.'
+    },
+    'hosting:resume:close-stream': {
+        source: 'sdk',
+        behavior: 'Handlers can close an SSE stream cleanly when an event store is configured.',
+        transports: ['streamableHttp'],
+        note: 'Resumability requires a per-session transport with an EventStore and a standalone GET stream; stateless hosting has neither.'
+    },
+    'hosting:resume:event-ids': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#resumability-and-redelivery',
+        behavior: 'With an event store configured, every SSE event carries an id field.',
+        transports: ['streamableHttp'],
+        note: 'Resumability requires a per-session transport with an EventStore and a standalone GET stream; stateless hosting has neither.'
+    },
+    'hosting:resume:priming': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#sending-messages-to-the-server',
+        behavior: 'With eventStore + new protocol, POST SSE streams begin with a priming event carrying the configured retry: interval.',
+        transports: ['streamableHttp'],
+        note: 'Resumability requires a per-session transport with an EventStore and a standalone GET stream; stateless hosting has neither.'
+    },
+    'hosting:resume:replay': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#resumability-and-redelivery',
+        behavior: 'GET with Last-Event-ID replays stored events for that stream after the given id.',
+        transports: ['streamableHttp'],
+        note: 'Resumability requires a per-session transport with an EventStore and a standalone GET stream; stateless hosting has neither.'
+    },
+    'hosting:resume:stream-scoped': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#resumability-and-redelivery',
+        behavior: 'Replay via Last-Event-ID returns only messages from the stream that event id belongs to.',
+        transports: ['streamableHttp'],
+        note: 'Resumability requires a per-session transport with an EventStore and a standalone GET stream; stateless hosting has neither.'
+    },
+
+    // Hosting: HTTP semantics
+
+    'hosting:http:accept-406': {
+        source: 'sdk',
+        behavior: 'A request whose Accept header does not allow the response representation returns 406.',
+        transports: ['streamableHttp'],
+        note: 'These test the per-session host layer (via hostPerSession helper); stateless transport tests use hostStateless which has different request routing.'
+    },
+    'hosting:http:batch': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#sending-messages-to-the-server',
+        behavior:
+            'POST body is a single JSON-RPC message; batched arrays are accepted only as an SDK back-compat affordance for pre-2025-06-18 clients (spec forbids batches).',
+        transports: ['streamableHttp'],
+        note: 'This exercises the HTTP hosting layer; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'hosting:http:content-type-415': {
+        source: 'sdk',
+        behavior: 'A POST with a Content-Type other than application/json returns 415.',
+        transports: ['streamableHttp'],
+        note: 'This exercises the HTTP hosting layer; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'hosting:http:disconnect-not-cancel': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#sending-messages-to-the-server',
+        behavior:
+            'A client connection drop during an in-flight request does not cancel the server-side handler; the request continues and its result remains retrievable.',
+        transports: ['streamableHttp'],
+        note: 'This exercises the HTTP hosting layer; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'hosting:http:dns-rebinding': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#security-warning',
+        behavior: 'With DNS-rebinding protection enabled, disallowed Host/Origin returns 403; missing Origin is accepted.',
+        transports: ['streamableHttp'],
+        note: 'This exercises the HTTP hosting layer; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'hosting:http:json-response-mode': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#sending-messages-to-the-server',
+        behavior: 'With JSON response mode enabled, POST returns application/json instead of SSE.',
+        transports: ['streamableHttp'],
+        note: 'This exercises the HTTP hosting layer; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'hosting:http:method-405': {
+        source: 'sdk',
+        behavior: 'An unsupported HTTP method on the MCP endpoint returns 405.',
+        transports: ['streamableHttp'],
+        note: 'This exercises the HTTP hosting layer; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'hosting:http:no-broadcast': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#multiple-connections',
+        behavior:
+            'When multiple SSE streams are open for a session, each server-originated message is sent on exactly one stream, never duplicated.',
+        transports: ['streamableHttp'],
+        note: 'This exercises the HTTP hosting layer; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'hosting:http:notifications-202': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#sending-messages-to-the-server',
+        behavior: 'A POST containing only notifications or responses returns 202 with no body.',
+        transports: ['streamableHttp'],
+        note: 'This exercises the HTTP hosting layer; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'hosting:http:onerror': {
+        source: 'sdk',
+        behavior: 'Transport-level rejections are reported through an error callback on the server transport.',
+        transports: ['streamableHttp'],
+        note: 'This exercises the HTTP hosting layer; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'hosting:http:parse-error-400': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#sending-messages-to-the-server',
+        behavior:
+            'A POST body that is not valid JSON or not a valid JSON-RPC message is rejected with HTTP 400; the body may carry a JSON-RPC error response (the SDK sends a Parse error body).',
+        transports: ['streamableHttp'],
+        note: 'This exercises the HTTP hosting layer; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'hosting:http:protocol-version-400': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#protocol-version-header',
+        behavior: 'An invalid or unsupported MCP-Protocol-Version header returns 400 Bad Request.',
+        transports: ['streamableHttp'],
+        note: 'This exercises the HTTP hosting layer; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'hosting:http:response-same-connection': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#sending-messages-to-the-server',
+        behavior:
+            "A response is delivered on the SSE stream opened by the POST that carried its request (or that stream's resumed continuation), not on an unrelated stream.",
+        transports: ['streamableHttp'],
+        note: 'This exercises the HTTP hosting layer; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'hosting:http:second-sse-rejected': {
+        source: 'sdk',
+        behavior: 'A second concurrent standalone GET SSE stream on the same session is rejected.',
+        transports: ['streamableHttp'],
+        note: 'This exercises the HTTP hosting layer; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'hosting:http:sse-close-after-response': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#sending-messages-to-the-server',
+        behavior: 'The server terminates a POST-initiated SSE stream after writing the JSON-RPC response.',
+        transports: ['streamableHttp'],
+        note: 'This exercises the HTTP hosting layer; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'hosting:http:standalone-sse': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#listening-for-messages-from-the-server',
+        behavior: 'GET opens a standalone SSE stream that receives server-initiated messages.',
+        transports: ['streamableHttp'],
+        note: 'This exercises the HTTP hosting layer; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'hosting:http:standalone-sse-no-response': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#listening-for-messages-from-the-server',
+        behavior:
+            'The standalone GET SSE stream carries server requests and notifications but never a JSON-RPC response, except when resuming a prior request stream.',
+        transports: ['streamableHttp'],
+        note: 'This exercises the HTTP hosting layer; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'hosting:express-app-helper': {
+        transports: ['streamableHttp'],
+        source: 'sdk',
+        behavior:
+            'createMcpExpressApp() returns an Express app with JSON body parsing and localhost host-header validation pre-applied: an MCP endpoint mounted on it serves an initialize POST over real HTTP from 127.0.0.1 and rejects a spoofed Host header with 403.',
+        note: 'This exercises the Express hosting layer; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'hosting:http:host-validation-middleware': {
+        transports: ['streamableHttp'],
+        source: 'sdk',
+        behavior:
+            "hostHeaderValidation()/localhostHostValidation() Express middleware reject requests whose Host header is missing or not in the allow-list with 403 (port-agnostic), independent of the transport's enableDnsRebindingProtection.",
+        note: 'This exercises the Express hosting layer; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'hosting:http:send-no-listener-noop': {
+        source: 'sdk',
+        behavior:
+            'A server-initiated notification sent on a stateful session with no open standalone GET SSE stream does not throw; it is silently dropped (or stored for replay when an eventStore is configured).',
+        transports: ['streamableHttp'],
+        note: 'This exercises the HTTP hosting layer; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'hosting:auth:as:redirect-uri-scheme': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#communication-security',
+        behavior: 'The bundled registration endpoint accepts only redirect URIs that use HTTPS or target a loopback host.',
+        transports: ['streamableHttp'],
+        note: 'These exercise the HTTP hosting/auth layer (mostly over real Express); the matrix transport arg is ignored, so they run as a single streamableHttp-labelled cell to avoid duplicate runs.',
+        knownFailures: [
+            {
+                note: 'The bundled registration endpoint validates redirect_uris only with SafeUrlSchema, so a non-HTTPS, non-loopback URI like http://attacker.example.com/callback is registered with 201 instead of being rejected with 400 invalid_client_metadata.'
+            }
+        ]
+    },
+    'hosting:auth:as:redirect-uri-binding': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#open-redirection',
+        behavior:
+            "The bundled token endpoint rejects an authorization-code exchange whose `redirect_uri` differs from the one used at authorize; the bundled authorize endpoint rejects a `redirect_uri` not in the client's registered list without redirecting to it.",
+        transports: ['streamableHttp'],
+        note: 'These exercise the HTTP hosting/auth layer (mostly over real Express); the matrix transport arg is ignored, so they run as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'hosting:session:post-termination-404': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#session-management',
+        behavior: 'After a session is terminated, any further request carrying that session ID is answered with 404 Not Found.',
+        transports: ['streamableHttp'],
+        note: 'This exercises the HTTP hosting layer and session management; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.',
+        knownFailures: [
+            {
+                note: 'The documented per-session hosting pattern (hostPerSession) removes the transport from the session map on DELETE via onsessionclosed and answers any later request carrying the stale Mcp-Session-Id with 400 at the app level, so the spec-required 404 is never produced.'
+            }
+        ]
+    },
+    'hosting:auth:query-token-ignored': {
+        source: 'sdk',
+        behavior: 'An access token presented in the URI query string is not accepted; the request is treated as unauthenticated.',
+        transports: ['streamableHttp'],
+        note: 'These exercise the HTTP hosting/auth layer (mostly over real Express); the matrix transport arg is ignored, so they run as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'hosting:auth:as:authorize-requires-pkce': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#authorization-code-protection',
+        behavior: 'The bundled authorization endpoint rejects an authorize request that omits `code_challenge` with `invalid_request`.',
+        transports: ['streamableHttp'],
+        note: 'These exercise the HTTP hosting/auth layer (mostly over real Express); the matrix transport arg is ignored, so they run as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'hosting:auth:as:verifier-mismatch': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#authorization-code-protection',
+        behavior:
+            'The bundled token endpoint rejects an authorization-code exchange whose `code_verifier` does not hash to the stored `code_challenge` with `invalid_grant`.',
+        transports: ['streamableHttp'],
+        note: 'These exercise the HTTP hosting/auth layer (mostly over real Express); the matrix transport arg is ignored, so they run as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'hosting:auth:as:code-single-use': {
+        source: 'sdk',
+        behavior:
+            'An authorization code can be exchanged exactly once; a second exchange of the same code is rejected with `invalid_grant`. Enforced by the provider deleting the code on first use; the handler relies on `the stored authorization code` returning None.',
+        transports: ['streamableHttp'],
+        note: 'These exercise the HTTP hosting/auth layer (mostly over real Express); the matrix transport arg is ignored, so they run as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'hosting:http:protocol-version-default': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#protocol-version-header',
+        behavior:
+            'When no MCP-Protocol-Version header is received and the version cannot be determined another way, the server assumes protocol version 2025-03-26.',
+        transports: ['streamableHttp'],
+        note: 'This exercises the HTTP hosting layer; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+
+    // Client transport: streamableHttp
+
+    'client-transport:http:404-surfaces': {
+        source: 'sdk',
+        behavior: 'A 404 (session expired) on a request surfaces as an error to the caller.',
+        transports: ['streamableHttp'],
+        note: 'Session-id continuity testing requires the per-session host (404 is session-not-found).'
+    },
+    'client-transport:http:session-404-reinitialize': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#session-management',
+        behavior:
+            'A 404 in response to a request carrying a session ID makes the client start a new session with a fresh InitializeRequest and no session ID attached.',
+        transports: ['streamableHttp'],
+        note: 'This exercises the StreamableHTTP client transport directly; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.',
+        knownFailures: [
+            {
+                note: 'On a 404 for an existing session the transport throws StreamableHTTPError (streamableHttp.ts:551) and never re-initializes — no session recovery is attempted.'
+            }
+        ]
+    },
+    'client-transport:http:accept-header-get': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#listening-for-messages-from-the-server',
+        behavior: 'The client GET to the MCP endpoint includes an Accept header listing text/event-stream.',
+        transports: ['streamableHttp'],
+        note: 'This exercises the StreamableHTTP client transport directly; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'client-transport:http:accept-header-post': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#sending-messages-to-the-server',
+        behavior: 'Every client POST to the MCP endpoint includes an Accept header listing both application/json and text/event-stream.',
+        transports: ['streamableHttp'],
+        note: 'This exercises the StreamableHTTP client transport directly; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'client-transport:http:concurrent-streams': {
+        source: 'sdk',
+        behavior: 'Multiple concurrent POST-initiated SSE streams each deliver their response to the right caller.',
+        transports: ['streamableHttp'],
+        note: 'This exercises the StreamableHTTP client transport directly; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'typescript:client-transport:http:custom-fetch': {
+        source: 'sdk',
+        behavior: 'A custom fetch in options is used for all HTTP including OAuth; global fetch is not called.',
+        transports: ['streamableHttp'],
+        note: 'This exercises the StreamableHTTP client transport directly; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'client-transport:http:custom-headers': {
+        source: 'sdk',
+        behavior: 'Caller-supplied headers are sent on every POST, GET, and DELETE to the MCP endpoint.',
+        transports: ['streamableHttp'],
+        note: 'This exercises the StreamableHTTP client transport directly; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'client-transport:http:json-response-parsed': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#sending-messages-to-the-server',
+        behavior: 'A Content-Type application/json response is parsed as a single JSON-RPC message.',
+        transports: ['streamableHttp'],
+        note: 'This exercises the StreamableHTTP client transport directly; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'client-transport:http:no-reconnect-after-close': {
+        source: 'sdk',
+        behavior: 'After the transport is closed, no further reconnection attempts are scheduled.',
+        transports: ['streamableHttp'],
+        note: 'This exercises the StreamableHTTP client transport directly; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'client-transport:http:no-reconnect-after-response': {
+        source: 'sdk',
+        behavior: 'A POST-initiated stream that already delivered its response is not reconnected when it closes.',
+        transports: ['streamableHttp'],
+        note: 'This exercises the StreamableHTTP client transport directly; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'client-transport:http:protocol-version-header': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#protocol-version-header',
+        behavior: 'After initialization, the client sends the negotiated MCP-Protocol-Version header on every subsequent HTTP request.',
+        transports: ['streamableHttp'],
+        note: 'This exercises the StreamableHTTP client transport directly; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'typescript:client-transport:http:protocol-version-stored': {
+        source: 'sdk',
+        behavior: 'transport.protocolVersion is populated after connect() completes.',
+        transports: ['streamableHttp'],
+        note: 'This exercises the StreamableHTTP client transport directly; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'client-transport:http:reconnect-get': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#resumability-and-redelivery',
+        behavior: 'A standalone GET SSE stream that errors is reconnected with the Last-Event-ID of the last received event.',
+        transports: ['streamableHttp'],
+        note: 'This exercises the StreamableHTTP client transport directly; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'client-transport:http:reconnect-post-priming': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#sending-messages-to-the-server',
+        behavior:
+            'A POST-initiated SSE stream that errors before delivering its response is reconnected only if a priming event (an event carrying an ID) was received on it.',
+        transports: ['streamableHttp'],
+        note: 'This exercises the StreamableHTTP client transport directly; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'client-transport:http:reconnect-retry-value': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#sending-messages-to-the-server',
+        behavior: 'Reconnection delay uses the SSE retry: value if sent; otherwise exponential backoff up to maxRetries.',
+        transports: ['streamableHttp'],
+        note: 'This exercises the StreamableHTTP client transport directly; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'client-transport:http:resume-stream-api': {
+        source: 'sdk',
+        behavior: 'The client can capture a resumption token, reconnect with the same session id, and receive the notifications it missed.',
+        transports: ['streamableHttp'],
+        note: 'This exercises the StreamableHTTP client transport directly; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'client-transport:http:session-stored': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#session-management',
+        behavior: 'The Mcp-Session-Id returned by initialize is stored by the client transport and sent on every subsequent request.',
+        transports: ['streamableHttp'],
+        note: 'This exercises the StreamableHTTP client transport directly; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'client-transport:http:sse-405-tolerated': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#listening-for-messages-from-the-server',
+        behavior: 'Opening the standalone GET SSE stream tolerates a 405 response without failing the connection.',
+        transports: ['streamableHttp'],
+        note: 'This exercises the StreamableHTTP client transport directly; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'client-transport:http:terminate-405-ok': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#session-management',
+        behavior: 'Session termination succeeds without error if the server answers 405 (termination unsupported).',
+        transports: ['streamableHttp'],
+        note: 'This exercises the StreamableHTTP client transport directly; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'client-transport:http:body-stream-error-preserved': {
+        source: 'sdk',
+        behavior:
+            'When the SSE response body stream errors during read, transport.onerror is invoked with an Error that preserves the original thrown error (as the instance itself or via .cause), not a string-interpolated wrapper that discards its type and stack.',
+        transports: ['streamableHttp'],
+        note: 'Session-id continuity testing requires the per-session host (validates session recovery/GET stream behavior).',
+        knownFailures: [
+            {
+                note: 'src/client/streamableHttp.ts error-wrapping code: SSE body-stream errors wrapped as new Error(`SSE stream disconnected: ...`) with no .cause, losing original instance/stack.'
+            }
+        ]
+    },
+
+    // Client auth
+
+    'client-auth:401-after-auth-throws': {
+        source: 'sdk',
+        behavior: 'If the server still returns 401 after a successful authorization, the client fails instead of looping.',
+        transports: ['streamableHttp'],
+        note: 'These exercise the HTTP hosting/auth layer (mostly over real Express); the matrix transport arg is ignored, so they run as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'client-auth:401-triggers-flow': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#protected-resource-metadata-discovery-requirements',
+        behavior: 'A 401 on a request triggers the OAuth authorization flow once.',
+        transports: ['streamableHttp'],
+        note: 'This exercises the HTTP hosting/auth layer and OAuth client; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'client-auth:403-scope-upgrade': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#step-up-authorization-flow',
+        behavior: 'A 403 with WWW-Authenticate triggers a scope-upgrade authorization attempt; repeated 403s do not loop.',
+        transports: ['streamableHttp'],
+        note: 'This exercises the HTTP hosting/auth layer and OAuth client; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'client-auth:as-metadata-discovery:priority-order': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#authorization-server-metadata-discovery',
+        behavior:
+            'The client discovers authorization-server metadata by trying, in order, the OAuth path-inserted, OIDC path-inserted, and OIDC path-appended well-known URLs (with the root-path forms when the issuer URL has no path).',
+        transports: ['streamableHttp'],
+        note: 'This exercises the HTTP hosting/auth layer and OAuth client; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'client-auth:bearer-header:every-request': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#token-requirements',
+        behavior:
+            'Once authorized, the client sends the bearer token in the Authorization header on every HTTP request to the MCP server, never in the query string.',
+        transports: ['streamableHttp'],
+        note: 'This exercises the HTTP hosting/auth layer and OAuth client; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'client-auth:cimd': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#client-id-metadata-document',
+        behavior: 'The client can use a client-ID metadata document URL as its OAuth client_id instead of registration.',
+        transports: ['streamableHttp'],
+        note: 'This exercises the HTTP hosting/auth layer and OAuth client; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'client-auth:client-credentials': {
+        source: 'sdk',
+        behavior:
+            'A client-credentials provider obtains a token without user interaction and the resulting bearer token authorizes subsequent requests.',
+        transports: ['streamableHttp'],
+        note: 'This exercises the HTTP hosting/auth layer and OAuth client; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'client-auth:dcr': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#dynamic-client-registration',
+        behavior: 'The client performs dynamic client registration against the authorization server when no client_id is preconfigured.',
+        transports: ['streamableHttp'],
+        note: 'This exercises the HTTP hosting/auth layer and OAuth client; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'client-auth:invalid-client-clears-all': {
+        source: 'sdk',
+        behavior: 'An invalid-client or unauthorized-client error during authorization invalidates all stored credentials.',
+        transports: ['streamableHttp'],
+        note: 'This exercises the HTTP hosting/auth layer and OAuth client; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'client-auth:invalid-grant-clears-tokens': {
+        source: 'sdk',
+        behavior: 'An invalid-grant error during authorization invalidates only the stored tokens.',
+        transports: ['streamableHttp'],
+        note: 'This exercises the HTTP hosting/auth layer and OAuth client; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'client-auth:pkce:refuse-if-unsupported': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#authorization-code-protection',
+        behavior: 'Client refuses to proceed when AS metadata advertises code_challenge_methods_supported without S256.',
+        transports: ['streamableHttp'],
+        note: 'This exercises the HTTP hosting/auth layer and OAuth client; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'client-auth:pkce:s256': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#authorization-code-protection',
+        behavior: 'The authorization request includes a PKCE S256 code challenge and the token request includes the matching verifier.',
+        transports: ['streamableHttp'],
+        note: 'This exercises the HTTP hosting/auth layer and OAuth client; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'client-auth:pre-registration': {
+        source: 'sdk',
+        behavior: 'A client with statically preconfigured credentials skips dynamic registration and uses them directly.',
+        transports: ['streamableHttp'],
+        note: 'This exercises the HTTP hosting/auth layer and OAuth client; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'client-auth:private-key-jwt': {
+        source: 'sdk',
+        behavior: 'The client can authenticate the client-credentials grant with a signed JWT assertion.',
+        transports: ['streamableHttp'],
+        note: 'This exercises the HTTP hosting/auth layer and OAuth client; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'client-auth:prm-discovery:fallback-order': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#protected-resource-metadata-discovery-requirements',
+        behavior:
+            'The client uses resource_metadata from WWW-Authenticate when present, then falls back to the well-known protected-resource locations in the documented order.',
+        transports: ['streamableHttp'],
+        note: 'This exercises the HTTP hosting/auth layer and OAuth client; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'client-auth:prm-resource-mismatch': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#authorization-server-location',
+        behavior:
+            "The client refuses to proceed when the protected-resource metadata's resource field does not match the server URL it is connecting to.",
+        transports: ['streamableHttp'],
+        note: 'This exercises the HTTP hosting/auth layer and OAuth client; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'client-auth:resource-parameter': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#resource-parameter-implementation',
+        behavior:
+            'The client includes the canonical server URI as the resource parameter in both the authorization request and the token request.',
+        transports: ['streamableHttp'],
+        note: 'This exercises the HTTP hosting/auth layer and OAuth client; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'client-auth:scope-selection:priority': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#scope-selection-strategy',
+        behavior:
+            'Client selects requested scope from the WWW-Authenticate scope param if present; otherwise uses scopes_supported from the PRM document; otherwise omits scope.',
+        transports: ['streamableHttp'],
+        note: 'This exercises the HTTP hosting/auth layer and OAuth client; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'typescript:client-auth:state:verify': {
+        source: 'sdk',
+        behavior: 'SDK calls provider.state?.() and includes the returned value as the state parameter in the authorize URL.',
+        transports: ['streamableHttp'],
+        note: 'This exercises the HTTP hosting/auth layer and OAuth client; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'client-auth:token-endpoint-auth-method': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#token-request',
+        behavior: 'The client authenticates to the token endpoint using the auth method established at registration.',
+        transports: ['streamableHttp'],
+        note: 'This exercises the HTTP hosting/auth layer and OAuth client; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'client-auth:low-level:discover-and-exchange': {
+        source: 'sdk',
+        behavior:
+            'The low-level auth helpers compose standalone: discoverOAuthProtectedResourceMetadata → discoverAuthorizationServerMetadata → startAuthorization → exchangeAuthorization, called directly (without the auth() orchestrator or an OAuthClientProvider), chain their outputs to inputs and yield valid OAuthTokens against a live AS.',
+        transports: ['streamableHttp'],
+        note: 'This exercises the HTTP hosting/auth layer and OAuth client; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'client-auth:middleware:with-oauth': {
+        source: 'sdk',
+        behavior:
+            'withOAuth(provider, baseUrl) wraps a fetch: adds Authorization: Bearer from provider.tokens(); on 401 it runs the auth() flow (discovery/refresh) and retries once with the fresh token; a REDIRECT result or a second 401 throws UnauthorizedError.',
+        transports: ['streamableHttp'],
+        note: 'This exercises the HTTP hosting/auth layer and OAuth client; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'client-auth:private-key-jwt:static-assertion': {
+        source: 'sdk',
+        behavior:
+            'StaticPrivateKeyJwtProvider authenticates the client_credentials grant by sending a caller-supplied pre-built JWT verbatim as client_assertion (jwt-bearer), with a fixed client_id so DCR is skipped — no per-request signing.',
+        transports: ['streamableHttp'],
+        note: 'This exercises the HTTP hosting/auth layer and OAuth client; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'client-auth:refresh:transparent': {
+        source: 'sdk',
+        behavior:
+            'An access token the client considers expired is transparently refreshed before the next request, using the stored refresh token; the refresh request includes the resource indicator and the new token is persisted.',
+        transports: ['streamableHttp'],
+        note: 'This exercises the HTTP hosting/auth layer and OAuth client; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'client-auth:as-metadata-discovery:issuer-validation': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#authorization-server-metadata-discovery',
+        behavior:
+            'The client rejects authorization-server metadata whose issuer does not match the URL the metadata was retrieved from (RFC 8414 section 3.3).',
+        transports: ['streamableHttp'],
+        note: 'This exercises the HTTP hosting/auth layer and OAuth client; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.',
+        knownFailures: [
+            {
+                note: 'discoverAuthorizationServerMetadata never validates that the returned issuer matches the authorization-server URL the metadata was fetched from (RFC 8414 section 3.3), so spoofed-issuer metadata is accepted and the OAuth flow proceeds to registration and redirect.'
+            }
+        ]
+    },
+    'client-auth:prm-discovery:no-prm-fallback': {
+        source: 'sdk',
+        behavior:
+            "When every protected-resource metadata probe fails, the client falls back to discovering authorization-server metadata directly at the MCP server's origin (the legacy 2025-03-26 path) rather than aborting.",
+        transports: ['streamableHttp'],
+        note: 'This exercises the HTTP hosting/auth layer and OAuth client; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+
+    // Client middleware (SDK)
+
+    'client-middleware:compose': {
+        source: 'sdk',
+        behavior:
+            'applyMiddlewares(...mw) chains createMiddleware-built handlers in declaration order around a base fetch; passed as the transport fetch option, each layer can read/mutate request init and the result reaches the server.',
+        transports: ['streamableHttp'],
+        note: 'Exercises the client fetch middleware over HTTP; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'client-middleware:with-logging': {
+        source: 'sdk',
+        behavior:
+            'withLogging() wraps fetch: invokes the configured logger once per HTTP request with {method, url, status, duration} and passes the response through unmodified so the MCP call result is unaffected.',
+        transports: ['streamableHttp'],
+        note: 'Exercises the client fetch middleware over HTTP; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+
+    // stdio transport
+
+    'transport:stdio:clean-shutdown': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle#shutdown',
+        behavior: "Closing the client transport closes the child process's stdin and the server exits cleanly.",
+        transports: ['stdio'],
+        note: 'Spawn-based tests against the real StdioClientTransport child process; only meaningful on stdio.'
+    },
+    'transport:stdio:no-embedded-newlines': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#stdio',
+        behavior: 'Serialized JSON-RPC messages on stdio contain no embedded newlines; one message per line.',
+        transports: ['stdio'],
+        note: 'Spawn-based tests against the real StdioClientTransport child process; only meaningful on stdio.'
+    },
+    'transport:stdio:shutdown-escalation': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle#stdio',
+        behavior:
+            'If the server process does not exit after stdin is closed, the client transport terminates it (and kills it if still alive) after a grace period.',
+        transports: ['stdio'],
+        note: 'Spawn-based tests against the real StdioClientTransport child process; only meaningful on stdio.'
+    },
+    'transport:stdio:stderr-passthrough': {
+        source: 'sdk',
+        behavior: 'Server stderr is available to the client and is not consumed by the transport.',
+        transports: ['stdio'],
+        note: 'Spawn-based tests against the real StdioClientTransport child process; only meaningful on stdio.'
+    },
+    'transport:stdio:default-env-safelist': {
+        source: 'sdk',
+        behavior:
+            'StdioClientTransport spawned with no `env` option passes only DEFAULT_INHERITED_ENV_VARS (PATH, HOME, USER, …) to the child; arbitrary parent process.env entries (secrets) are not inherited. getDefaultEnvironment() is the public helper that produces this safelist.',
+        transports: ['stdio'],
+        note: 'Spawn-based tests against the real StdioClientTransport child process; only meaningful on stdio.'
+    },
+
+    // Composite end-to-end flows
+
+    'flow:compat:dual-transport-server': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#backwards-compatibility',
+        behavior:
+            'A single server instance can serve streamable HTTP and the legacy SSE transport concurrently; clients on either transport can call the same tools.',
+        transports: ['streamableHttp'],
+        note: 'Deferred flows test legacy SSE; transport restriction reflects test infrastructure, not behavioral exclusion.',
+        deferred: 'Legacy SSE transport is deprecated in the spec. Back-compat flows that require an SSE server are deferred.'
+    },
+    'flow:compat:streamable-then-sse-fallback': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#backwards-compatibility',
+        behavior:
+            'When a streamable HTTP initialize fails with 400, 404, or 405, falling back to the legacy SSE client transport against the same server connects successfully.',
+        transports: ['streamableHttp'],
+        note: 'This is an HTTP-specific compatibility flow; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.',
+        deferred: 'Legacy SSE transport is deprecated in the spec. Back-compat flows that require an SSE server are deferred.'
+    },
+    'flow:elicitation:multi-step-form': {
+        transports: STATEFUL_TRANSPORTS,
+        source: 'sdk',
+        behavior:
+            'A single tool handler issues sequential elicitations; an accept on one step feeds the next, and a decline or cancel at any step short-circuits to a final result.',
+        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
+    },
+    'flow:elicitation:url-at-session-init': {
+        transports: ['streamableHttp'],
+        source: 'sdk',
+        behavior:
+            'The server can issue a URL-mode elicitation over the standalone GET stream immediately after session initialization, before any client request.',
+        note: 'This is an HTTP-specific flow requiring session management and a standalone GET stream; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'flow:elicitation:url-required-then-retry': {
+        transports: STATEFUL_TRANSPORTS,
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation#url-elicitation-required-error',
+        behavior:
+            'A tool call rejected with the URL-elicitation-required error can be retried successfully after the client completes the URL flow and the server announces completion.',
+        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
+    },
+    'flow:multi-client:stateful-isolation': {
+        transports: ['streamableHttp'],
+        source: 'sdk',
+        behavior:
+            'Independent clients connected to one stateful server each receive a distinct session and only the notifications produced by their own requests.',
+        note: 'This is an HTTP-specific flow requiring session management; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'flow:oauth:authorization-code-roundtrip': {
+        transports: ['streamableHttp'],
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#authorization-flow-steps',
+        behavior:
+            'Connecting to a protected server walks the authorization-code flow end to end: the first attempt requires authorization, the code is exchanged, and a subsequent connection succeeds.',
+        note: 'End-to-end authorization-code journey (401 → discovery → DCR → redirect → finishAuth → authorized reconnect); the individual mechanisms are covered by the client-auth:* requirements. This exercises the HTTP hosting/auth layer and OAuth client; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'flow:resume:tool-call-resumption-token': {
+        transports: ['streamableHttp'],
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#resumability-and-redelivery',
+        behavior:
+            'A tool call interrupted mid-stream is transparently resumed by the client transport using the last-seen event id, delivering only the remaining notifications and the final result.',
+        note: 'Resumability requires a per-session transport with an EventStore and a standalone GET stream; stateless hosting has neither.'
+    },
+    'flow:session:terminate-then-reconnect': {
+        transports: ['streamableHttp'],
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#session-management',
+        behavior: 'After terminating a session, a fresh connection obtains a new session id and operations succeed.',
+        note: 'This is an HTTP-specific flow requiring session management; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'flow:tool-result:resource-link-follow': {
+        transports: STATEFUL_TRANSPORTS,
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/server/tools#resource-links',
+        behavior:
+            'A resource_link returned by a tool call can be followed with resources/read on the linked URI to retrieve the referenced contents.',
+        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
+    },
+    'flow:proxy:forward-tools-resources': {
+        transports: ['inMemory', 'streamableHttp'],
+        source: 'sdk',
+        behavior:
+            "A proxy node composing a low-level Server (downstream) with a Client (upstream) forwards tools/list and resources/list; the downstream caller receives the upstream server's tool and resource lists with names, schemas, and _meta intact (mcp-proxy / mcp-remote / firebase-tools shape).",
+        note: 'This is a multi-hop proxy flow that should work across transports; restricted to inMemory and streamableHttp to avoid test matrix bloat.'
+    }
+} satisfies Record<string, Requirement>;
+
+export type RequirementId = keyof typeof REQUIREMENTS;

--- a/test/e2e/requirements.ts
+++ b/test/e2e/requirements.ts
@@ -2316,6 +2316,268 @@ export const REQUIREMENTS: Record<string, Requirement> = {
         behavior:
             "A proxy node composing a low-level Server (downstream) with a Client (upstream) forwards tools/list and resources/list; the downstream caller receives the upstream server's tool and resource lists with names, schemas, and _meta intact (mcp-proxy / mcp-remote / firebase-tools shape).",
         note: 'This is a multi-hop proxy flow that should work across transports; restricted to inMemory and streamableHttp to avoid test matrix bloat.'
+    },
+    // v2 features
+    'standardschema:tool:valibot-input': {
+        source: 'sdk',
+        behavior:
+            "registerTool() accepts a valibot object schema wrapped with @valibot/to-json-schema's toStandardJsonSchema() as inputSchema: tools/list advertises the derived JSON Schema and tools/call passes validated, parsed arguments to the handler."
+    },
+    'standardschema:tool:arktype-input': {
+        source: 'sdk',
+        behavior:
+            'registerTool() accepts an arktype type as inputSchema: tools/list advertises the JSON Schema derived from it and tools/call passes validated, parsed arguments to the handler.'
+    },
+    'standardschema:tool:output-schema-validation': {
+        source: 'sdk',
+        behavior:
+            'When a tool declares outputSchema, a handler return whose structuredContent does not conform is rejected by the server with JSON-RPC -32602 instead of being returned to the caller.',
+        knownFailures: [
+            {
+                note: "McpServer's tools/call handler catches the output-validation ProtocolError (-32602) and returns it as an isError result instead of a JSON-RPC error; the nonconforming structuredContent is still withheld from the caller."
+            }
+        ]
+    },
+    'standardschema:prompt:args-schema': {
+        source: 'sdk',
+        behavior:
+            'registerPrompt() accepts any Standard Schema as argsSchema: prompts/list exposes the argument names derived from it and prompts/get arguments are validated against it before the callback runs.'
+    },
+    'standardschema:tool:invalid-args-rejected': {
+        source: 'sdk',
+        behavior:
+            'tools/call arguments that fail the registered Standard Schema validation are rejected with JSON-RPC -32602 (Input validation error) and the tool handler is not invoked.',
+        knownFailures: [
+            {
+                note: "McpServer's tools/call handler catches the input-validation ProtocolError (-32602) and returns it as an isError result, so callTool() resolves instead of rejecting; the handler is still not invoked."
+            }
+        ]
+    },
+    'validators:from-json-schema:tool-roundtrip': {
+        source: 'sdk',
+        behavior:
+            'A tool registered with fromJsonSchema(rawJsonSchema) advertises that JSON Schema in tools/list and accepts conforming arguments end to end.'
+    },
+    'validators:from-json-schema:invalid-args-rejected': {
+        source: 'sdk',
+        behavior:
+            'tools/call arguments violating the JSON Schema wrapped by fromJsonSchema() are rejected with JSON-RPC -32602 and the handler is not invoked.',
+        knownFailures: [
+            {
+                note: "McpServer's tools/call handler catches the input-validation ProtocolError (-32602) and returns it as an isError result, so callTool() resolves instead of rejecting; the handler is still not invoked."
+            }
+        ]
+    },
+    'validators:custom-validator:override': {
+        source: 'sdk',
+        behavior:
+            'fromJsonSchema(schema, validator) uses the supplied jsonSchemaValidator implementation for argument validation instead of the runtime default.'
+    },
+    'guards:spec-type:call-tool-result': {
+        source: 'sdk',
+        behavior:
+            'isSpecType.CallToolResult() returns true for a CallToolResult produced by a real tools/call and false for a structurally non-conforming value, narrowing the type for the caller.'
+    },
+    'guards:spec-type-schemas:sync-validate': {
+        source: 'sdk',
+        behavior:
+            "specTypeSchemas.X['~standard'].validate() validates synchronously: it returns an object (not a Promise) carrying value for conforming input and issues for non-conforming input."
+    },
+    'hosting:hono:basic-flow': {
+        source: 'sdk',
+        behavior:
+            "createMcpHonoApp() hosts an McpServer over real HTTP: a StreamableHTTPClientTransport pointed at the served app completes initialize, tools/list and tools/call against a WebStandardStreamableHTTPServerTransport mounted on the app's /mcp routes.",
+        transports: ['streamableHttp'],
+        note: 'This exercises the Hono hosting adapter over a real HTTP listener; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'hosting:hono:host-header-validation': {
+        source: 'sdk',
+        behavior:
+            'A createMcpHonoApp() bound to the default localhost host rejects requests whose Host header is not an allowed localhost name with HTTP 403 (DNS-rebinding protection), while requests with a localhost Host succeed.',
+        transports: ['streamableHttp'],
+        note: 'This exercises the Hono hosting adapter over a real HTTP listener; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'hosting:fastify:basic-flow': {
+        source: 'sdk',
+        behavior:
+            'createMcpFastifyApp() hosts an McpServer over real HTTP: a StreamableHTTPClientTransport pointed at the listening Fastify instance completes initialize, tools/list and tools/call against a WebStandardStreamableHTTPServerTransport wired to its /mcp routes.',
+        transports: ['streamableHttp'],
+        note: 'This exercises the Fastify hosting adapter over a real HTTP listener; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'hosting:fastify:host-header-validation': {
+        source: 'sdk',
+        behavior:
+            'A createMcpFastifyApp() bound to the default localhost host rejects requests whose Host header is not an allowed localhost name with HTTP 403 (DNS-rebinding protection), while requests with a localhost Host succeed.',
+        transports: ['streamableHttp'],
+        note: 'This exercises the Fastify hosting adapter over a real HTTP listener; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'hosting:express:adapter-basic-flow': {
+        source: 'sdk',
+        behavior:
+            'createMcpExpressApp() returns an Express app that, with a streamable HTTP server transport mounted on a POST route, serves a full initialize and tools/call exchange.',
+        transports: ['streamableHttp'],
+        note: 'This exercises the HTTP hosting layer; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'hosting:express:adapter-host-header-validation': {
+        source: 'sdk',
+        behavior:
+            'An app created by createMcpExpressApp() with the default localhost host applies DNS-rebinding protection: a request whose Host header is not an allowed local host is rejected with 403 before reaching the MCP transport.',
+        transports: ['streamableHttp'],
+        note: 'This exercises the HTTP hosting layer; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'custom-methods:server-handler:roundtrip': {
+        source: 'sdk',
+        behavior:
+            "A server handler registered with setRequestHandler('<vendor>/method', { params, result }, handler) for a non-spec method receives schema-validated params and its return value is delivered to a client calling request() with the matching result schema."
+    },
+    'custom-methods:client-handler:roundtrip': {
+        source: 'sdk',
+        behavior:
+            "A client handler registered with setRequestHandler('<vendor>/method', { params, result }, handler) for a non-spec method serves requests sent by the server via request() with the matching result schema.",
+        transports: STATEFUL_TRANSPORTS,
+        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
+    },
+    'custom-methods:params-validation-error': {
+        source: 'sdk',
+        behavior:
+            'A non-spec request whose params fail the params schema given at setRequestHandler() is answered with JSON-RPC -32602 and the handler is not invoked.'
+    },
+    'custom-methods:notification-handler': {
+        source: 'sdk',
+        behavior:
+            'A notification handler registered for a non-spec method with a params schema receives schema-validated custom notifications sent by the remote side.',
+        transports: STATEFUL_TRANSPORTS,
+        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
+    },
+    'typescript:method-string-handlers:result-type-inference': {
+        source: 'sdk',
+        behavior:
+            'client.request() called with a spec method string and no result schema resolves with the result already parsed and validated for that method (ResultTypeMap inference), e.g. tools/list yields a usable tools array without passing a schema.'
+    },
+    'protocol:result-validation:invalid-result-sdkerror': {
+        source: 'sdk',
+        behavior:
+            'A response whose result does not conform to the expected result schema causes the requesting side to reject with SdkError code InvalidResult instead of resolving with the malformed result.'
+    },
+    'mcpserver:context:log-from-handler': {
+        source: 'sdk',
+        behavior:
+            'ctx.mcpReq.log() inside a registered tool handler emits a notifications/message logging notification that the client receives while the call is in flight.',
+        transports: STATEFUL_TRANSPORTS,
+        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
+    },
+    'mcpserver:context:elicit-from-handler': {
+        source: 'sdk',
+        behavior:
+            "ctx.mcpReq.elicitInput() inside a tool handler sends elicitation/create to the client and resolves with the client's ElicitResult, which the handler can fold into its tool result.",
+        transports: STATEFUL_TRANSPORTS,
+        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
+    },
+    'mcpserver:context:sampling-from-handler': {
+        source: 'sdk',
+        behavior:
+            "ctx.mcpReq.requestSampling() inside a tool handler sends sampling/createMessage to the client and resolves with the client's CreateMessageResult.",
+        transports: STATEFUL_TRANSPORTS,
+        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
+    },
+    'hosting:context:web-request-headers': {
+        source: 'sdk',
+        behavior:
+            "Under HTTP hosting, a request handler's ctx.http.req exposes the incoming HTTP request's headers as Fetch Headers, so a custom header sent by the client transport is readable inside the handler.",
+        transports: ['streamableHttp'],
+        note: 'This exercises the HTTP hosting layer; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'errors:timeout:sdkerror-request-timeout': {
+        source: 'sdk',
+        behavior:
+            'A request that exceeds its timeout option rejects with an SdkError whose code is RequestTimeout, and the rejection carries the timeout details rather than a generic Error.'
+    },
+    'errors:capability:sdkerror-capability-not-supported': {
+        source: 'sdk',
+        behavior:
+            'Invoking an operation whose capability the remote side did not declare rejects locally with an SdkError whose code is CapabilityNotSupported (no request is sent).',
+        transports: STATEFUL_TRANSPORTS,
+        note: 'The clearest probe is a server→client operation (createMessage without client sampling capability), which needs a live server instance bound to the session.'
+    },
+    'errors:wire:protocolerror-invalid-params': {
+        source: 'sdk',
+        behavior:
+            'A JSON-RPC error response surfaces on the requesting side as a ProtocolError carrying the wire error code (e.g. -32602) and message, distinguishable from SDK-side SdkErrors.'
+    },
+    'errors:http:sdkhttperror-status': {
+        source: 'sdk',
+        behavior:
+            'An HTTP-level failure from the server endpoint (non-2xx response that is not an auth retry) surfaces on the client as an SdkHttpError exposing the HTTP status code via .status.',
+        transports: ['streamableHttp'],
+        note: 'This exercises the HTTP hosting layer; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'client-auth:oauth-error:consolidated-class': {
+        source: 'sdk',
+        behavior:
+            'OAuth error responses surface as OAuthError instances carrying a machine-readable OAuthErrorCode (e.g. invalid_grant, invalid_token) instead of the per-code subclasses removed in v2.',
+        transports: ['streamableHttp'],
+        note: 'This exercises the HTTP auth layer against a mock authorization server; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'client-auth:authprovider:token-attached': {
+        source: 'sdk',
+        behavior:
+            'An AuthProvider supplied to StreamableHTTPClientTransport has token() called before each request and the returned token is attached as an Authorization: Bearer header on the HTTP requests.',
+        transports: ['streamableHttp'],
+        note: "This exercises the HTTP client transport's auth hook; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs."
+    },
+    'client-auth:authprovider:onunauthorized-retry': {
+        source: 'sdk',
+        behavior:
+            'When the server answers 401, the transport awaits AuthProvider.onUnauthorized() and retries the request once with the refreshed token; a second 401 (or a provider without onUnauthorized) surfaces as UnauthorizedError.',
+        transports: ['streamableHttp'],
+        note: "This exercises the HTTP client transport's auth hook; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.",
+        knownFailures: [
+            {
+                test: 'second 401 after retry surfaces as UnauthorizedError',
+                note: 'A second 401 after onUnauthorized() re-authentication surfaces as SdkHttpError (ClientHttpAuthentication) instead of the UnauthorizedError documented on AuthProvider.onUnauthorized().'
+            }
+        ]
+    },
+    'client-auth:authprovider:oauth-provider-adapted': {
+        source: 'sdk',
+        behavior:
+            'Passing a full OAuthClientProvider as authProvider still works: the transport adapts it internally and attaches its access token as the bearer token on requests.',
+        transports: ['streamableHttp'],
+        note: "This exercises the HTTP client transport's auth hook; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs."
+    },
+    'client-transport:http:reconnection-scheduler': {
+        source: 'sdk',
+        behavior:
+            'A reconnectionScheduler supplied to StreamableHTTPClientTransport is invoked with (reconnect, delay, attemptCount) when an SSE stream drops, and invoking the provided reconnect callback re-establishes the stream (replacing the default backoff timer).',
+        transports: ['streamableHttp'],
+        note: "This exercises the HTTP client transport's reconnection path; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs."
+    },
+    'lifecycle:version:custom-supported-versions': {
+        source: 'sdk',
+        behavior:
+            'supportedProtocolVersions passed in Client/Server options overrides the negotiation list: a client requesting a version the server supports gets that version back, and both sides report the negotiated version after connect.'
+    },
+    'lifecycle:version:no-overlap-rejects': {
+        source: 'sdk',
+        behavior:
+            "When the server's negotiated protocol version is not in the client's supportedProtocolVersions list, client.connect() rejects and the connection is not established."
+    },
+    'lifecycle:capability:list-empty-when-not-advertised': {
+        source: 'sdk',
+        behavior:
+            'Client.listTools(), listPrompts(), listResources() and listResourceTemplates() resolve with empty result lists, without sending a request, when the server did not advertise the corresponding capability.'
+    },
+    'lifecycle:capability:strict-mode-throws': {
+        source: 'sdk',
+        behavior:
+            'With enforceStrictCapabilities: true, calling a list method for a capability the server did not advertise rejects with a capability error instead of resolving empty.'
+    },
+    'tasks:result:failed-task-stored-result': {
+        source: 'sdk',
+        behavior:
+            'When a task-augmented tool call fails, the failure is stored with status failed and a subsequent tasks/result request for that task returns the stored error result instead of losing it.',
+        transports: STATEFUL_TRANSPORTS,
+        note: 'Task polling and result retrieval need the same server instance across requests, which stateless hosting does not provide.'
     }
 } satisfies Record<string, Requirement>;
 

--- a/test/e2e/requirements.ts
+++ b/test/e2e/requirements.ts
@@ -2578,6 +2578,521 @@ export const REQUIREMENTS: Record<string, Requirement> = {
             'When a task-augmented tool call fails, the failure is stored with status failed and a subsequent tasks/result request for that task returns the stored error result instead of losing it.',
         transports: STATEFUL_TRANSPORTS,
         note: 'Task polling and result retrieval need the same server instance across requests, which stateless hosting does not provide.'
+    },
+
+    // ════════════════════════════════════════════════════════════════════════
+    // 2026-06 spec release backlog — SEP-2260 + the stateless cluster (SEP-2575/2567).
+    // Every entry below is a stub: the cited test fails deliberately and is marked
+    // as a knownFailure. Implementing a requirement = replace the stub with a real
+    // assertion, make it pass, delete the knownFailure. Sub-batch labels (P0, G0,
+    // S1–S9) give the proposed implementation order; see the backlog PR description.
+    // Stubs register on a single representative transport for now; transports
+    // broaden (and version-gating via addedInSpecVersion is added) as each
+    // sub-batch is implemented.
+    // ════════════════════════════════════════════════════════════════════════
+
+    // ── P0 · SEP-2260 server-request association (current spec, parallelizable) ──
+    'protocol:assoc:nested-on-originating-stream': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#sending-messages-to-the-server',
+        behavior:
+            "[SEP-2260] Server-to-client requests (elicitation/sampling/roots) are sent only in association with an originating client request: they arrive on that request's response stream, never on a separate channel. (R-2260-1)",
+        transports: ['streamableHttp'],
+        note: 'Stub: registered on one representative transport for now; transports broaden when the real assertion is written.',
+        knownFailures: [{ note: 'stub — assertion not yet written (P0); see the 2026-06 backlog PR for the sub-batch plan' }]
+    },
+    'protocol:assoc:keepalive-during-nested': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/transports',
+        behavior:
+            '[SEP-2260] During a nested server-to-client request wait, the server keeps the SSE response stream alive (keepalives observed). (R-2260-4)',
+        transports: ['streamableHttp'],
+        note: 'Stub: registered on one representative transport for now; transports broaden when the real assertion is written.',
+        knownFailures: [{ note: 'stub — assertion not yet written (P0)' }]
+    },
+    'protocol:assoc:client-rejects-unsolicited': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/client/sampling',
+        behavior:
+            '[SEP-2260] A client that receives a server-to-client request with no associated outbound request responds with -32602 Invalid Params. (R-2260-5)',
+        transports: ['streamableHttp'],
+        note: 'Stub: registered on one representative transport for now; transports broaden when the real assertion is written.',
+        knownFailures: [{ note: 'stub — assertion not yet written (P0)' }]
+    },
+    'protocol:assoc:get-stream-no-requests': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#listening-for-messages-from-the-server',
+        behavior:
+            '[SEP-2260] On GET-initiated standalone SSE streams the server never sends roots/list, sampling/createMessage, or elicitation/create — only notifications and pings. (R-2260-6)',
+        transports: ['streamableHttp'],
+        note: 'Stub: registered on one representative transport for now; transports broaden when the real assertion is written.',
+        knownFailures: [{ note: 'stub — assertion not yet written (P0)' }]
+    },
+    'protocol:assoc:no-unsolicited-api': {
+        source: 'sdk',
+        behavior: '[SEP-2260] The SDK exposes no API to send an unsolicited (request-unassociated) server-to-client request. (R-2260-3)',
+        transports: ['streamableHttp'],
+        note: 'Stub: registered on one representative transport for now; transports broaden when the real assertion is written.',
+        knownFailures: [{ note: 'stub — assertion not yet written (P0)' }]
+    },
+    'protocol:assoc:ping-exempt': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/ping',
+        behavior:
+            '[SEP-2260] ping is exempt from the association rule and may be sent by either party at any time on an established connection. (R-2260-8)',
+        transports: ['streamableHttp'],
+        note: 'Stub: registered on one representative transport for now; transports broaden when the real assertion is written.',
+        knownFailures: [{ note: 'stub — assertion not yet written (P0)' }]
+    },
+
+    // ── G0 · Groundwork: version negotiation + the NotImplemented gate ──
+    'lifecycle:version:2026-pin-per-instance': {
+        source: 'sdk',
+        behavior:
+            '[SEP-2575] Client and Server can each be constructed restricted to an explicit protocol-version list including 2026-06 and refuse to negotiate outside it.',
+        transports: ['streamableHttp'],
+        note: 'Stub: registered on one representative transport for now; transports broaden when the real assertion is written.',
+        knownFailures: [{ note: 'stub — assertion not yet written (G0)' }]
+    },
+    'lifecycle:version:2026-negotiable': {
+        source: 'https://modelcontextprotocol.io/specification/draft/basic/lifecycle#protocol-version-negotiation',
+        behavior:
+            '[SEP-2575] A client and server that both support the 2026-06 version can agree on it (via discover or direct per-request use); the agreed version is observable on both sides.',
+        transports: ['streamableHttp'],
+        note: 'Stub: registered on one representative transport for now; transports broaden when the real assertion is written.',
+        knownFailures: [{ note: 'stub — assertion not yet written (G0)' }]
+    },
+    'lifecycle:version:2026-gate-not-implemented': {
+        source: 'sdk',
+        behavior:
+            '[SEP-2575] Once 2026-06 is the operative version, operations whose 2026 behavior is not yet implemented fail fast with a NotImplemented error (never silently fall back to 2025 semantics); 2025-negotiated traffic on the same server is unaffected. Retired when the last NotImplemented throw is removed (post-S8).',
+        transports: ['streamableHttp'],
+        note: 'Stub: registered on one representative transport for now; transports broaden when the real assertion is written.',
+        knownFailures: [{ note: 'stub — assertion not yet written (G0)' }]
+    },
+    'protocol:envelope:ctx-version-readable': {
+        source: 'sdk',
+        behavior:
+            '[SEP-2575] A server request handler can read the protocol version governing the current request from its context, in both 2025 (negotiated) and 2026 (per-request) modes.',
+        transports: ['streamableHttp'],
+        note: 'Stub: registered on one representative transport for now; transports broaden when the real assertion is written.',
+        knownFailures: [{ note: 'stub — assertion not yet written (G0)' }]
+    },
+
+    // ── S1 · server/discover + version-negotiation errors ──
+    'discover:basic': {
+        source: 'https://modelcontextprotocol.io/specification/draft/server/discover',
+        behavior: '[SEP-2575] Server implements server/discover, returning supportedVersions, capabilities, and serverInfo. (R-2575-5)',
+        transports: ['streamableHttp'],
+        note: 'Stub: registered on one representative transport for now; transports broaden when the real assertion is written.',
+        knownFailures: [{ note: 'stub — assertion not yet written (S1)' }]
+    },
+    'lifecycle:version:unsupported-error-32004': {
+        source: 'https://modelcontextprotocol.io/specification/draft/basic/lifecycle#protocol-version-negotiation',
+        behavior:
+            '[SEP-2575] A request carrying an unsupported protocol version is answered with UnsupportedProtocolVersionError (-32004) listing the supported versions. (R-2575-9)',
+        transports: ['streamableHttp'],
+        note: 'Stub: registered on one representative transport for now; transports broaden when the real assertion is written.',
+        knownFailures: [{ note: 'stub — assertion not yet written (S1)' }]
+    },
+    'lifecycle:version:unknown-method-32601': {
+        source: 'https://modelcontextprotocol.io/specification/draft/basic/transports',
+        behavior:
+            '[SEP-2575] An unknown RPC method under a valid 2026 envelope returns -32601 Method not found (HTTP 404 on streamable HTTP). (R-2575-10b)',
+        transports: ['streamableHttp'],
+        note: 'Stub: registered on one representative transport for now; transports broaden when the real assertion is written.',
+        knownFailures: [{ note: 'stub — assertion not yet written (S1)' }]
+    },
+    'lifecycle:version:client-retries-from-supported': {
+        source: 'https://modelcontextprotocol.io/specification/draft/basic/lifecycle',
+        behavior:
+            '[SEP-2575] On UnsupportedProtocolVersionError from a modern server, the client selects a mutually supported version from supported[] and retries — it does not fall back to initialize. (R-2575-12)',
+        transports: ['streamableHttp'],
+        note: 'Stub: registered on one representative transport for now; transports broaden when the real assertion is written.',
+        knownFailures: [{ note: 'stub — assertion not yet written (S1)' }]
+    },
+    'lifecycle:version:client-retry-any-request': {
+        source: 'https://modelcontextprotocol.io/specification/draft/basic/lifecycle',
+        behavior:
+            '[SEP-2575] The supported[]-retry behavior applies to any request that hits -32004, not only an explicit discover probe. (R-2575-17c)',
+        transports: ['streamableHttp'],
+        note: 'Stub: registered on one representative transport for now; transports broaden when the real assertion is written.',
+        knownFailures: [{ note: 'stub — assertion not yet written (S1)' }]
+    },
+
+    // ── S2 · client _meta envelope stamping ──
+    'client-transport:meta:protocol-version-every-request': {
+        source: 'https://modelcontextprotocol.io/specification/draft/basic/index#meta',
+        behavior: '[SEP-2575] Every outbound 2026 request carries _meta io.modelcontextprotocol/protocolVersion. (client side of R-2575-1)',
+        transports: ['streamableHttp'],
+        note: 'Stub: registered on one representative transport for now; transports broaden when the real assertion is written.',
+        knownFailures: [{ note: 'stub — assertion not yet written (S2)' }]
+    },
+    'client-transport:meta:clientinfo-every-request': {
+        source: 'https://modelcontextprotocol.io/specification/draft/basic/index#meta',
+        behavior: '[SEP-2575] Every outbound 2026 request carries _meta clientInfo with name and version. (R-2575-2)',
+        transports: ['streamableHttp'],
+        note: 'Stub: registered on one representative transport for now; transports broaden when the real assertion is written.',
+        knownFailures: [{ note: 'stub — assertion not yet written (S2)' }]
+    },
+    'client-transport:meta:capabilities-every-request': {
+        source: 'https://modelcontextprotocol.io/specification/draft/basic/index#meta',
+        behavior: '[SEP-2575] Every outbound 2026 request carries _meta clientCapabilities (an empty object when none). (R-2575-3)',
+        transports: ['streamableHttp'],
+        note: 'Stub: registered on one representative transport for now; transports broaden when the real assertion is written.',
+        knownFailures: [{ note: 'stub — assertion not yet written (S2)' }]
+    },
+    'client-transport:http:version-header-every-post': {
+        source: 'https://modelcontextprotocol.io/specification/draft/basic/transports',
+        behavior: '[SEP-2575] The client sends MCP-Protocol-Version on every POST, matching the _meta protocolVersion. (R-2575-15b)',
+        transports: ['streamableHttp'],
+        note: 'Stub: registered on one representative transport for now; transports broaden when the real assertion is written.',
+        knownFailures: [{ note: 'stub — assertion not yet written (S2)' }]
+    },
+    'client-transport:stdio:meta-envelope': {
+        source: 'https://modelcontextprotocol.io/specification/draft/basic/transports#stdio',
+        behavior: '[SEP-2575] The same _meta envelope (version, clientInfo, capabilities) is stamped over stdio, where no header exists.',
+        transports: ['stdio'],
+        note: 'Stub: registered on one representative transport for now; transports broaden when the real assertion is written.',
+        knownFailures: [{ note: 'stub — assertion not yet written (S2)' }]
+    },
+
+    // ── S3 · server envelope acceptance + enforcement ──
+    'protocol:envelope:missing-version-rejected': {
+        source: 'https://modelcontextprotocol.io/specification/draft/basic/index#meta',
+        behavior: '[SEP-2575] A 2026-mode request missing _meta protocolVersion is rejected as malformed (-32602). (R-2575-1)',
+        transports: ['streamableHttp'],
+        note: 'Stub: registered on one representative transport for now; transports broaden when the real assertion is written.',
+        knownFailures: [{ note: 'stub — assertion not yet written (S3)' }]
+    },
+    'protocol:envelope:missing-clientinfo-rejected': {
+        source: 'https://modelcontextprotocol.io/specification/draft/basic/index#meta',
+        behavior: '[SEP-2575] A 2026-mode request missing _meta clientInfo is rejected as malformed (-32602). (R-2575-15)',
+        transports: ['streamableHttp'],
+        note: 'Stub: registered on one representative transport for now; transports broaden when the real assertion is written.',
+        knownFailures: [{ note: 'stub — assertion not yet written (S3)' }]
+    },
+    'hosting:http:header-meta-version-mismatch-400': {
+        source: 'https://modelcontextprotocol.io/specification/draft/basic/transports',
+        behavior:
+            '[SEP-2575] If the MCP-Protocol-Version header does not match the _meta protocolVersion, the server returns 400. (R-2575-4)',
+        transports: ['streamableHttp'],
+        note: 'Stub: registered on one representative transport for now; transports broaden when the real assertion is written.',
+        knownFailures: [{ note: 'stub — assertion not yet written (S3)' }]
+    },
+    'protocol:envelope:caps-not-inherited-across-requests': {
+        source: 'https://modelcontextprotocol.io/specification/draft/basic/lifecycle',
+        behavior:
+            '[SEP-2575] Capabilities are not inherited from prior requests on the same connection: a request whose _meta capabilities lack what the handler needs gets -32003 even if an earlier request declared it. (R-2575-7)',
+        transports: ['streamableHttp'],
+        note: 'Stub: registered on one representative transport for now; transports broaden when the real assertion is written.',
+        knownFailures: [{ note: 'stub — assertion not yet written (S3)' }]
+    },
+    'protocol:envelope:undeclared-capability-32003': {
+        source: 'https://modelcontextprotocol.io/specification/draft/basic/index#meta',
+        behavior:
+            '[SEP-2575] A handler that requires a client capability not declared in the request _meta fails with MissingRequiredClientCapabilityError (-32003). (R-2575-20)',
+        transports: ['streamableHttp'],
+        note: 'Stub: registered on one representative transport for now; transports broaden when the real assertion is written.',
+        knownFailures: [{ note: 'stub — assertion not yet written (S3)' }]
+    },
+    'hosting:http:no-version-header-treated-legacy': {
+        source: 'https://modelcontextprotocol.io/specification/draft/basic/transports',
+        behavior:
+            '[SEP-2575] A request without a version header (and without _meta version) is treated as 2025-03-26 legacy traffic, not rejected. (R-2575-35)',
+        transports: ['streamableHttp'],
+        note: 'Stub: registered on one representative transport for now; transports broaden when the real assertion is written.',
+        knownFailures: [{ note: 'stub — assertion not yet written (S3)' }]
+    },
+
+    // ── S4 · backward-compatibility probe matrix ──
+    'lifecycle:compat:dual-server-answers-initialize': {
+        source: 'https://modelcontextprotocol.io/specification/draft/basic/lifecycle#backward-compatibility-with-initialization-based-versions',
+        behavior:
+            '[SEP-2575] A dual-stack server still answers a legacy initialize handshake and serves that client with 2025 semantics. (R-A-BC-1)',
+        transports: ['streamableHttp'],
+        note: 'Stub: registered on one representative transport for now; transports broaden when the real assertion is written.',
+        knownFailures: [{ note: 'stub — assertion not yet written (S4)' }]
+    },
+    'lifecycle:compat:client-probes-discover-stdio': {
+        source: 'https://modelcontextprotocol.io/specification/draft/basic/lifecycle#backward-compatibility-with-initialization-based-versions',
+        behavior:
+            '[SEP-2575] A dual-era client over stdio probes with server/discover first, carrying its preferred modern version in _meta. (R-2575-10)',
+        transports: ['stdio'],
+        note: 'Stub: registered on one representative transport for now; transports broaden when the real assertion is written.',
+        knownFailures: [{ note: 'stub — assertion not yet written (S4)' }]
+    },
+    'lifecycle:compat:client-falls-back-to-initialize': {
+        source: 'https://modelcontextprotocol.io/specification/draft/basic/lifecycle#backward-compatibility-with-initialization-based-versions',
+        behavior:
+            '[SEP-2575] On -32601 from the discover probe, the client falls back to the legacy initialize handshake and continues with the legacy version. (R-2575-11)',
+        transports: ['streamableHttp'],
+        note: 'Stub: registered on one representative transport for now; transports broaden when the real assertion is written.',
+        knownFailures: [{ note: 'stub — assertion not yet written (S4)' }]
+    },
+    'lifecycle:compat:mixed-era-one-pipe': {
+        source: 'https://modelcontextprotocol.io/specification/draft/basic/lifecycle',
+        behavior:
+            '[SEP-2575] One server instance handles a modern discover followed by a legacy initialize on the same stdio pipe (per-message handling, no connection mode-lock). (R-A-BC-3)',
+        transports: ['stdio'],
+        note: 'Stub: registered on one representative transport for now; transports broaden when the real assertion is written.',
+        knownFailures: [{ note: 'stub — assertion not yet written (S4)' }]
+    },
+
+    // ── S5 · sessionless + stateless HTTP ──
+    'hosting:sessionless:no-session-header': {
+        source: 'https://modelcontextprotocol.io/specification/draft/basic/transports',
+        behavior:
+            '[SEP-2567] In 2026 mode the server neither requires nor emits Mcp-Session-Id; requests without it are handled normally. (R-2567-19)',
+        transports: ['streamableHttp'],
+        note: 'Stub: registered on one representative transport for now; transports broaden when the real assertion is written.',
+        knownFailures: [{ note: 'stub — assertion not yet written (S5)' }]
+    },
+    'transport:base:no-session-concept': {
+        source: 'sdk',
+        behavior: '[SEP-2567] The 2026 transport surface exposes no session identifier on the base interface. (R-2567-4)',
+        transports: ['streamableHttp'],
+        note: 'Stub: registered on one representative transport for now; transports broaden when the real assertion is written.',
+        knownFailures: [{ note: 'stub — assertion not yet written (S5)' }]
+    },
+    'hosting:sessionless:get-405': {
+        source: 'https://modelcontextprotocol.io/specification/draft/basic/transports',
+        behavior:
+            '[SEP-2575] In 2026 mode GET to the MCP endpoint returns 405 — there is no standalone server-to-client stream. (R-2575-11b)',
+        transports: ['streamableHttp'],
+        note: 'Stub: registered on one representative transport for now; transports broaden when the real assertion is written.',
+        knownFailures: [{ note: 'stub — assertion not yet written (S5)' }]
+    },
+    'hosting:sessionless:no-batching': {
+        source: 'https://modelcontextprotocol.io/specification/draft/basic/transports',
+        behavior: '[SEP-2575] A POST whose body is a JSON-RPC batch array is rejected with 400. (R-2575-14)',
+        transports: ['streamableHttp'],
+        note: 'Stub: registered on one representative transport for now; transports broaden when the real assertion is written.',
+        knownFailures: [{ note: 'stub — assertion not yet written (S5)' }]
+    },
+    'hosting:sessionless:per-request-auth': {
+        source: 'https://modelcontextprotocol.io/specification/draft/basic/transports',
+        behavior:
+            '[SEP-2575] Every request is independently authenticated; a request without auth is rejected even if a prior request on the same connection was authenticated. (R-2575-28)',
+        transports: ['streamableHttp'],
+        note: 'Stub: registered on one representative transport for now; transports broaden when the real assertion is written.',
+        knownFailures: [{ note: 'stub — assertion not yet written (S5)' }]
+    },
+    'hosting:sessionless:no-connection-affinity': {
+        source: 'https://modelcontextprotocol.io/specification/draft/basic/lifecycle',
+        behavior:
+            '[SEP-2575] The same two requests sent over one connection or over two separate connections produce identical results — the server requires no connection reuse. (R-2575-8)',
+        transports: ['streamableHttp'],
+        note: 'Stub: registered on one representative transport for now; transports broaden when the real assertion is written.',
+        knownFailures: [{ note: 'stub — assertion not yet written (S5)' }]
+    },
+    'protocol:stateless:list-connection-independent': {
+        source: 'https://modelcontextprotocol.io/specification/draft/server/tools',
+        behavior:
+            '[SEP-2567] tools/list results do not depend on per-connection or prior-call state: two clients with the same auth see identical lists. (R-2567-1)',
+        transports: ['streamableHttp'],
+        note: 'Stub: registered on one representative transport for now; transports broaden when the real assertion is written.',
+        knownFailures: [{ note: 'stub — assertion not yet written (S5)' }]
+    },
+    'protocol:stateless:list-no-side-effects': {
+        source: 'https://modelcontextprotocol.io/specification/draft/server/tools',
+        behavior:
+            '[SEP-2567] tools/list is unchanged by intervening calls on the same connection (list, call, list is identical). (R-2567-2)',
+        transports: ['streamableHttp'],
+        note: 'Stub: registered on one representative transport for now; transports broaden when the real assertion is written.',
+        knownFailures: [{ note: 'stub — assertion not yet written (S5)' }]
+    },
+    'protocol:request-id:outstanding-scope': {
+        source: 'https://modelcontextprotocol.io/specification/draft/basic/index',
+        behavior:
+            '[SEP-2567] Request-id uniqueness is scoped to outstanding requests: an id may be reused after its request completes. (R-2567-3)',
+        transports: ['streamableHttp'],
+        note: 'Stub: registered on one representative transport for now; transports broaden when the real assertion is written.',
+        knownFailures: [{ note: 'stub — assertion not yet written (S5)' }]
+    },
+    'client-transport:http:accept-both-content-types': {
+        source: 'https://modelcontextprotocol.io/specification/draft/basic/transports',
+        behavior:
+            '[SEP-2575] The client sends Accept: application/json, text/event-stream on 2026 requests and handles either response form. (R-2575-32)',
+        transports: ['streamableHttp'],
+        note: 'Stub: registered on one representative transport for now; transports broaden when the real assertion is written.',
+        knownFailures: [{ note: 'stub — assertion not yet written (S5)' }]
+    },
+    'hosting:http:notification-202': {
+        source: 'https://modelcontextprotocol.io/specification/draft/basic/transports',
+        behavior: '[SEP-2575] An accepted notification POST is answered with 202 (4xx on rejection). (R-2575-33)',
+        transports: ['streamableHttp'],
+        note: 'Stub: registered on one representative transport for now; transports broaden when the real assertion is written.',
+        knownFailures: [{ note: 'stub — assertion not yet written (S5)' }]
+    },
+    'hosting:http:stream-notifications-relate-to-request': {
+        source: 'https://modelcontextprotocol.io/specification/draft/basic/transports',
+        behavior:
+            '[SEP-2575] Notifications on a POST response stream relate to the originating request (e.g. progress carries its progressToken). (R-2575-34)',
+        transports: ['streamableHttp'],
+        note: 'Stub: registered on one representative transport for now; transports broaden when the real assertion is written.',
+        knownFailures: [{ note: 'stub — assertion not yet written (S5)' }]
+    },
+
+    // ── S6 · removed RPCs + per-request logging ──
+    'protocol:removed:ping-32601': {
+        source: 'https://modelcontextprotocol.io/specification/draft/changelog',
+        behavior: '[SEP-2575] Under 2026, ping is not served: -32601. (R-2575-12b)',
+        transports: ['streamableHttp'],
+        note: 'Stub: registered on one representative transport for now; transports broaden when the real assertion is written.',
+        knownFailures: [{ note: 'stub — assertion not yet written (S6)' }]
+    },
+    'protocol:removed:subscribe-32601': {
+        source: 'https://modelcontextprotocol.io/specification/draft/changelog',
+        behavior: '[SEP-2575] Under 2026, resources/subscribe and resources/unsubscribe are not served: -32601. (R-2575-12b)',
+        transports: ['streamableHttp'],
+        note: 'Stub: registered on one representative transport for now; transports broaden when the real assertion is written.',
+        knownFailures: [{ note: 'stub — assertion not yet written (S6)' }]
+    },
+    'protocol:removed:setlevel-32601': {
+        source: 'https://modelcontextprotocol.io/specification/draft/changelog',
+        behavior: '[SEP-2575] Under 2026, logging/setLevel is not served: -32601. (R-2575-12b)',
+        transports: ['streamableHttp'],
+        note: 'Stub: registered on one representative transport for now; transports broaden when the real assertion is written.',
+        knownFailures: [{ note: 'stub — assertion not yet written (S6)' }]
+    },
+    'protocol:removed:initialize-32601-2026-only': {
+        source: 'https://modelcontextprotocol.io/specification/draft/basic/lifecycle',
+        behavior:
+            '[SEP-2575] A server configured 2026-only answers initialize with -32601 (the probe signal a dual-era client expects). (R-A-BC-2)',
+        transports: ['streamableHttp'],
+        note: 'Stub: registered on one representative transport for now; transports broaden when the real assertion is written.',
+        knownFailures: [{ note: 'stub — assertion not yet written (S6)' }]
+    },
+    'logging:per-request:loglevel-opt-in': {
+        source: 'https://modelcontextprotocol.io/specification/draft/basic/index#meta',
+        behavior:
+            '[SEP-2575] If a request carries no _meta logLevel, the server sends no notifications/message for that request. (R-2575-6)',
+        transports: ['streamableHttp'],
+        note: 'Stub: registered on one representative transport for now; transports broaden when the real assertion is written.',
+        knownFailures: [{ note: 'stub — assertion not yet written (S6)' }]
+    },
+    'logging:per-request:level-respected': {
+        source: 'https://modelcontextprotocol.io/specification/draft/basic/index#meta',
+        behavior: '[SEP-2575] When _meta logLevel is present, emitted log notifications respect that level for that request.',
+        transports: ['streamableHttp'],
+        note: 'Stub: registered on one representative transport for now; transports broaden when the real assertion is written.',
+        knownFailures: [{ note: 'stub — assertion not yet written (S6)' }]
+    },
+
+    // ── S7 · subscriptions/listen ──
+    'subscriptions:listen-basic': {
+        source: 'https://modelcontextprotocol.io/specification/draft/basic/utilities/subscriptions',
+        behavior:
+            '[SEP-2575] subscriptions/listen with a notifications filter opens a stream that delivers the opted-in notification types. (R-2575-21)',
+        transports: ['streamableHttp'],
+        note: 'Stub: registered on one representative transport for now; transports broaden when the real assertion is written.',
+        knownFailures: [{ note: 'stub — assertion not yet written (S7)' }]
+    },
+    'subscriptions:filter-required': {
+        source: 'https://modelcontextprotocol.io/specification/draft/basic/utilities/subscriptions',
+        behavior: '[SEP-2575] subscriptions/listen without a notifications filter is an error. (R-2575-21)',
+        transports: ['streamableHttp'],
+        note: 'Stub: registered on one representative transport for now; transports broaden when the real assertion is written.',
+        knownFailures: [{ note: 'stub — assertion not yet written (S7)' }]
+    },
+    'subscriptions:opt-in-only': {
+        source: 'https://modelcontextprotocol.io/specification/draft/basic/utilities/subscriptions',
+        behavior: '[SEP-2575] Notification types not opted into are not delivered on the subscription stream. (R-2575-13)',
+        transports: ['streamableHttp'],
+        note: 'Stub: registered on one representative transport for now; transports broaden when the real assertion is written.',
+        knownFailures: [{ note: 'stub — assertion not yet written (S7)' }]
+    },
+    'subscriptions:ack-first-message': {
+        source: 'https://modelcontextprotocol.io/specification/draft/basic/utilities/subscriptions',
+        behavior: '[SEP-2575] The first message on a listen stream is notifications/subscriptions/acknowledged. (R-2575-25)',
+        transports: ['streamableHttp'],
+        note: 'Stub: registered on one representative transport for now; transports broaden when the real assertion is written.',
+        knownFailures: [{ note: 'stub — assertion not yet written (S7)' }]
+    },
+    'subscriptions:subscription-id-on-notifications': {
+        source: 'https://modelcontextprotocol.io/specification/draft/basic/utilities/subscriptions',
+        behavior:
+            '[SEP-2575] Every notification delivered for a subscription carries _meta subscriptionId matching the listen request id. (R-2575-23)',
+        transports: ['streamableHttp'],
+        note: 'Stub: registered on one representative transport for now; transports broaden when the real assertion is written.',
+        knownFailures: [{ note: 'stub — assertion not yet written (S7)' }]
+    },
+    'subscriptions:cancel-stops-delivery': {
+        source: 'https://modelcontextprotocol.io/specification/draft/basic/utilities/subscriptions',
+        behavior: '[SEP-2575] After the client cancels a subscription, the server sends no further notifications for it. (R-2575-24)',
+        transports: ['streamableHttp'],
+        note: 'Stub: registered on one representative transport for now; transports broaden when the real assertion is written.',
+        knownFailures: [{ note: 'stub — assertion not yet written (S7)' }]
+    },
+    'subscriptions:server-teardown-closes': {
+        source: 'https://modelcontextprotocol.io/specification/draft/basic/utilities/subscriptions',
+        behavior:
+            '[SEP-2575] When the server tears a subscription down it closes the SSE stream (HTTP) or sends notifications/cancelled for the listen request (stdio). (R-2575-22)',
+        transports: ['streamableHttp'],
+        note: 'Stub: registered on one representative transport for now; transports broaden when the real assertion is written.',
+        knownFailures: [{ note: 'stub — assertion not yet written (S7)' }]
+    },
+    'subscriptions:no-requests-on-response-streams': {
+        source: 'https://modelcontextprotocol.io/specification/draft/basic/transports',
+        behavior:
+            '[SEP-2575] Response streams carry only notifications and the final result — never independent JSON-RPC requests. (R-2575-13b)',
+        transports: ['streamableHttp'],
+        note: 'Stub: registered on one representative transport for now; transports broaden when the real assertion is written.',
+        knownFailures: [{ note: 'stub — assertion not yet written (S7)' }]
+    },
+    'subscriptions:stdio-resubscribe-after-restart': {
+        source: 'https://modelcontextprotocol.io/specification/draft/basic/utilities/subscriptions',
+        behavior:
+            '[SEP-2575] After a stdio connection is re-established, the client re-sends subscriptions/listen with the same filter. (R-2575-26)',
+        transports: ['stdio'],
+        note: 'Stub: registered on one representative transport for now; transports broaden when the real assertion is written.',
+        knownFailures: [{ note: 'stub — assertion not yet written (S7)' }]
+    },
+    'subscriptions:client-routes-by-subscription-id': {
+        source: 'sdk',
+        behavior:
+            '[SEP-2575] With two concurrent subscriptions the client routes each notification to the right handler by subscriptionId. (R-2575-16c)',
+        transports: ['streamableHttp'],
+        note: 'Stub: registered on one representative transport for now; transports broaden when the real assertion is written.',
+        knownFailures: [{ note: 'stub — assertion not yet written (S7)' }]
+    },
+
+    // ── S8 · cancellation / SSE-close semantics ──
+    'protocol:cancel:sse-close-cancels': {
+        source: 'https://modelcontextprotocol.io/specification/draft/basic/transports',
+        behavior:
+            '[SEP-2575] Closing the SSE response stream mid-request is treated as cancellation: the handler abort fires and no further events are written. (R-2575-16b)',
+        transports: ['streamableHttp'],
+        note: 'Stub: registered on one representative transport for now; transports broaden when the real assertion is written.',
+        knownFailures: [{ note: 'stub — assertion not yet written (S8)' }]
+    },
+    'protocol:cancel:stdio-notification-2026': {
+        source: 'https://modelcontextprotocol.io/specification/draft/basic/transports#stdio',
+        behavior: '[SEP-2575] Over stdio under 2026, the client cancels by sending notifications/cancelled. (R-2575-17)',
+        transports: ['stdio'],
+        note: 'Stub: registered on one representative transport for now; transports broaden when the real assertion is written.',
+        knownFailures: [{ note: 'stub — assertion not yet written (S8)' }]
+    },
+    'protocol:cancel:no-messages-after-cancel-2026': {
+        source: 'https://modelcontextprotocol.io/specification/draft/basic/utilities/cancellation',
+        behavior: '[SEP-2575] After cancellation the server stops work and sends no further messages for that request. (R-2575-18)',
+        transports: ['streamableHttp'],
+        note: 'Stub: registered on one representative transport for now; transports broaden when the real assertion is written.',
+        knownFailures: [{ note: 'stub — assertion not yet written (S8)' }]
+    },
+    'hosting:resume:not-honored-2026': {
+        source: 'https://modelcontextprotocol.io/specification/draft/basic/transports',
+        behavior:
+            '[SEP-2575] Last-Event-ID resumption is not honored in 2026 mode: a reconnect with Last-Event-ID gets a fresh stream (or 400), never replayed events. (R-2575-18c)',
+        transports: ['streamableHttp'],
+        note: 'Stub: registered on one representative transport for now; transports broaden when the real assertion is written.',
+        knownFailures: [{ note: 'stub — assertion not yet written (S8)' }]
+    },
+
+    // ── S9 · lands with the MRTR (SEP-2322) series ──
+    'mrtr:roots-via-input-required': {
+        source: 'https://modelcontextprotocol.io/specification/draft/basic/utilities/mrtr',
+        behavior:
+            '[SEP-2575][SEP-2322] Roots are requested via the MRTR pattern (InputRequiredResult), not pushed as a server-initiated request. (R-2575-27)',
+        transports: ['streamableHttp'],
+        note: 'Stub: registered on one representative transport for now; transports broaden when the real assertion is written.',
+        knownFailures: [{ note: 'stub — assertion not yet written (implemented with the MRTR series)' }]
     }
 } satisfies Record<string, Requirement>;
 

--- a/test/e2e/requirements.ts
+++ b/test/e2e/requirements.ts
@@ -163,12 +163,7 @@ export const REQUIREMENTS: Record<string, Requirement> = {
     },
     'protocol:error:invalid-params': {
         source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic#responses',
-        behavior: 'A request with malformed params is answered with JSON-RPC error -32602 Invalid params.',
-        knownFailures: [
-            {
-                note: 'Protocol wraps schema-parse failures as -32603 (InternalError), not -32602 (InvalidParams) as required by JSON-RPC 2.0.'
-            }
-        ]
+        behavior: 'A request with malformed params is answered with JSON-RPC error -32602 Invalid params.'
     },
     'protocol:error:method-not-found': {
         source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic#responses',
@@ -322,13 +317,7 @@ export const REQUIREMENTS: Record<string, Requirement> = {
     },
     'tools:call:unknown-name': {
         source: 'https://modelcontextprotocol.io/specification/2025-11-25/server/tools#error-handling',
-        behavior: 'tools/call for a name the server does not recognise returns a JSON-RPC error.',
-        knownFailures: [
-            {
-                test: 'mcpserver',
-                note: "RULED 2026-05-26: spec violation (spec error-handling section shows -32602 protocol error for unknown tools). McpServer's blanket try/catch around the tools/call handler converts the McpError(InvalidParams, 'Tool {name} not found') into {isError:true} via createToolError(), so callTool() resolves instead of rejecting. Spec says unknown tool is a protocol error and MUST surface as a JSON-RPC error envelope."
-            }
-        ]
+        behavior: 'tools/call for a name the server does not recognise returns a JSON-RPC error.'
     },
     'tools:capability:declared': {
         source: 'https://modelcontextprotocol.io/specification/2025-11-25/server/tools#capabilities',
@@ -452,12 +441,15 @@ export const REQUIREMENTS: Record<string, Requirement> = {
     'client:call-tool:compat-result-schema': {
         source: 'sdk',
         behavior:
-            'Client.callTool(params, CompatibilityCallToolResultSchema) accepts a legacy protocol-2024-10-07 result ({toolResult: ...}, no content[]) without throwing and returns the parsed toolResult field.'
+            'Client.callTool(params, CompatibilityCallToolResultSchema) accepts a legacy protocol-2024-10-07 result ({toolResult: ...}, no content[]) without throwing and returns the parsed toolResult field.',
+        deferred:
+            'removed in v2: Client.callTool() no longer takes a result-schema parameter, so the legacy {toolResult} compatibility path is not reachable from the public API.'
     },
     'mcpserver:tool:variadic-forms': {
         source: 'sdk',
         behavior:
-            'Deprecated McpServer.tool() positional overloads — (name,cb), (name,desc,cb), (name,paramsSchema,cb), (name,desc,paramsSchema,cb), (name,desc,paramsSchema,annotations,cb), and the annotations-without-schema forms — register tools whose tools/list entry and tools/call result match an equivalent registerTool() registration.'
+            'Deprecated McpServer.tool() positional overloads — (name,cb), (name,desc,cb), (name,paramsSchema,cb), (name,desc,paramsSchema,cb), (name,desc,paramsSchema,annotations,cb), and the annotations-without-schema forms — register tools whose tools/list entry and tools/call result match an equivalent registerTool() registration.',
+        deferred: 'removed in v2: the deprecated McpServer.tool() positional overloads were dropped; only registerTool() exists.'
     },
 
     // Resources
@@ -508,12 +500,7 @@ export const REQUIREMENTS: Record<string, Requirement> = {
     },
     'resources:read:unknown-uri': {
         source: 'https://modelcontextprotocol.io/specification/2025-11-25/server/resources#error-handling',
-        behavior: 'resources/read for an unknown URI returns JSON-RPC error -32002 (resource not found).',
-        knownFailures: [
-            {
-                note: 'SDK emits -32602 (InvalidParams) instead of spec-mandated -32002 (ResourceNotFound). ErrorCode enum lacks ResourceNotFound member.'
-            }
-        ]
+        behavior: 'resources/read for an unknown URI returns JSON-RPC error -32002 (resource not found).'
     },
     'resources:subscribe:capability-required': {
         source: 'https://modelcontextprotocol.io/specification/2025-11-25/server/resources#capabilities',
@@ -573,7 +560,8 @@ export const REQUIREMENTS: Record<string, Requirement> = {
     'mcpserver:resource:legacy-overload': {
         source: 'sdk',
         behavior:
-            'The deprecated McpServer.resource() overloads (fixed-URI and ResourceTemplate, with and without the optional metadata arg) register a resource that surfaces in resources/list and reads via resources/read identically to registerResource().'
+            'The deprecated McpServer.resource() overloads (fixed-URI and ResourceTemplate, with and without the optional metadata arg) register a resource that surfaces in resources/list and reads via resources/read identically to registerResource().',
+        deferred: 'removed in v2: the deprecated McpServer.resource() overloads were dropped; only registerResource() exists.'
     },
 
     // Prompts
@@ -658,7 +646,8 @@ export const REQUIREMENTS: Record<string, Requirement> = {
     'mcpserver:prompt:legacy-overload': {
         source: 'sdk',
         behavior:
-            'McpServer.prompt() (deprecated positional overloads: name+cb, name+desc+cb, name+args+cb, name+desc+args+cb) registers a prompt that appears in prompts/list with the given description/arguments and is callable via prompts/get.'
+            'McpServer.prompt() (deprecated positional overloads: name+cb, name+desc+cb, name+args+cb, name+desc+args+cb) registers a prompt that appears in prompts/list with the given description/arguments and is callable via prompts/get.',
+        deferred: 'removed in v2: the deprecated McpServer.prompt() positional overloads were dropped; only registerPrompt() exists.'
     },
 
     // Completion
@@ -818,8 +807,7 @@ export const REQUIREMENTS: Record<string, Requirement> = {
         source: 'https://modelcontextprotocol.io/specification/2025-11-25/client/sampling#tool-result-messages',
         behavior:
             'A user SamplingMessage containing tool_result content MUST contain only tool_result blocks; mixing with text/image/audio is rejected by the client with -32602 Invalid params.',
-        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.',
-        knownFailures: [{ note: 'client does not validate tool_result-only constraint' }]
+        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
     },
     'sampling:tool-use:result-balance': {
         transports: STATEFUL_TRANSPORTS,
@@ -827,7 +815,11 @@ export const REQUIREMENTS: Record<string, Requirement> = {
         behavior:
             'In a sampling/createMessage request, every assistant tool_use block in messages MUST be matched by a tool_result with the same toolUseId in the immediately-following user message; an unmatched tool_use is rejected with -32602 Invalid params.',
         note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.',
-        knownFailures: [{ note: 'client does not validate tool_use/tool_result balance' }]
+        knownFailures: [
+            {
+                note: 'changed in v2: mismatched toolUseId pairs are now rejected, but an assistant tool_use in the final message with no following user message is still accepted.'
+            }
+        ]
     },
     'sampling:tools:server-gated-by-capability': {
         transports: STATEFUL_TRANSPORTS,
@@ -999,12 +991,7 @@ export const REQUIREMENTS: Record<string, Requirement> = {
         behavior:
             'Form-mode requested schemas are flat objects with primitive-typed properties only; nested structures and arrays of objects are not used.',
         transports: ['inMemory', 'stdio', 'streamableHttp'],
-        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.',
-        knownFailures: [
-            {
-                note: 'The client rejects a nested requestedSchema before the user handler, but via the raw ZodError from parseWithCompat in Protocol.setRequestHandler (src/shared/protocol.ts:1428-1431), which _onrequest maps to -32603 InternalError (~line 823) instead of -32602 InvalidParams; the InvalidParams guard in src/client/index.ts (~363-368) is unreachable.'
-            }
-        ]
+        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
     },
 
     // Roots
@@ -1512,7 +1499,12 @@ export const REQUIREMENTS: Record<string, Requirement> = {
         source: 'sdk',
         behavior: 'A stateless per-request transport cannot be reused for a second request.',
         transports: ['streamableHttp'],
-        note: 'This exercises the HTTP hosting layer and stateless mode; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+        note: 'This exercises the HTTP hosting layer and stateless mode; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.',
+        knownFailures: [
+            {
+                note: 'changed in v2: the stateless reuse guard was removed, so a second request on the same per-request transport is processed instead of rejected.'
+            }
+        ]
     },
     'hosting:stateless:no-session-id': {
         source: 'sdk',
@@ -1566,7 +1558,9 @@ export const REQUIREMENTS: Record<string, Requirement> = {
         behavior:
             'The authorization-server routes expose the authorize, token, and registration endpoints (and revocation when supported).',
         transports: ['streamableHttp'],
-        note: 'These exercise the HTTP hosting/auth layer (mostly over real Express); the matrix transport arg is ignored, so they run as a single streamableHttp-labelled cell to avoid duplicate runs.'
+        note: 'These exercise the HTTP hosting/auth layer (mostly over real Express); the matrix transport arg is ignored, so they run as a single streamableHttp-labelled cell to avoid duplicate runs.',
+        deferred:
+            'removed in v2: the bundled OAuth authorization server (mcpAuthRouter, OAuthServerProvider) is no longer part of the SDK; only requireBearerAuth, mcpAuthMetadataRouter and hostHeaderValidation remain.'
     },
     'hosting:auth:aud-validation': {
         source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#access-token-usage',
@@ -1629,7 +1623,9 @@ export const REQUIREMENTS: Record<string, Requirement> = {
         behavior:
             'ProxyOAuthServerProvider plugged into mcpAuthRouter mounts the /authorize, /token, and /revoke endpoints and serves them.',
         transports: ['streamableHttp'],
-        note: 'These exercise the HTTP hosting/auth layer (mostly over real Express); the matrix transport arg is ignored, so they run as a single streamableHttp-labelled cell to avoid duplicate runs. Asserting that requests are forwarded to the configured upstream AS endpoints is post-ship backlog.'
+        note: 'These exercise the HTTP hosting/auth layer (mostly over real Express); the matrix transport arg is ignored, so they run as a single streamableHttp-labelled cell to avoid duplicate runs. Asserting that requests are forwarded to the configured upstream AS endpoints is post-ship backlog.',
+        deferred:
+            'removed in v2: ProxyOAuthServerProvider and mcpAuthRouter are no longer part of the SDK, so there is no public API to mount proxied authorization-server endpoints.'
     },
 
     // Hosting: resumability
@@ -1813,18 +1809,17 @@ export const REQUIREMENTS: Record<string, Requirement> = {
         behavior: 'The bundled registration endpoint accepts only redirect URIs that use HTTPS or target a loopback host.',
         transports: ['streamableHttp'],
         note: 'These exercise the HTTP hosting/auth layer (mostly over real Express); the matrix transport arg is ignored, so they run as a single streamableHttp-labelled cell to avoid duplicate runs.',
-        knownFailures: [
-            {
-                note: 'The bundled registration endpoint validates redirect_uris only with SafeUrlSchema, so a non-HTTPS, non-loopback URI like http://attacker.example.com/callback is registered with 201 instead of being rejected with 400 invalid_client_metadata.'
-            }
-        ]
+        deferred:
+            'removed in v2: the bundled dynamic client registration endpoint no longer exists, so its redirect_uri scheme validation cannot be exercised (this was a knownFailure on v1.x).'
     },
     'hosting:auth:as:redirect-uri-binding': {
         source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#open-redirection',
         behavior:
             "The bundled token endpoint rejects an authorization-code exchange whose `redirect_uri` differs from the one used at authorize; the bundled authorize endpoint rejects a `redirect_uri` not in the client's registered list without redirecting to it.",
         transports: ['streamableHttp'],
-        note: 'These exercise the HTTP hosting/auth layer (mostly over real Express); the matrix transport arg is ignored, so they run as a single streamableHttp-labelled cell to avoid duplicate runs.'
+        note: 'These exercise the HTTP hosting/auth layer (mostly over real Express); the matrix transport arg is ignored, so they run as a single streamableHttp-labelled cell to avoid duplicate runs.',
+        deferred:
+            'removed in v2: the bundled authorize and token endpoints no longer exist, so redirect_uri binding across authorize and token cannot be exercised.'
     },
     'hosting:session:post-termination-404': {
         source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#session-management',
@@ -1847,21 +1842,27 @@ export const REQUIREMENTS: Record<string, Requirement> = {
         source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#authorization-code-protection',
         behavior: 'The bundled authorization endpoint rejects an authorize request that omits `code_challenge` with `invalid_request`.',
         transports: ['streamableHttp'],
-        note: 'These exercise the HTTP hosting/auth layer (mostly over real Express); the matrix transport arg is ignored, so they run as a single streamableHttp-labelled cell to avoid duplicate runs.'
+        note: 'These exercise the HTTP hosting/auth layer (mostly over real Express); the matrix transport arg is ignored, so they run as a single streamableHttp-labelled cell to avoid duplicate runs.',
+        deferred:
+            'removed in v2: the bundled authorization endpoint no longer exists, so PKCE enforcement at authorize cannot be exercised.'
     },
     'hosting:auth:as:verifier-mismatch': {
         source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#authorization-code-protection',
         behavior:
             'The bundled token endpoint rejects an authorization-code exchange whose `code_verifier` does not hash to the stored `code_challenge` with `invalid_grant`.',
         transports: ['streamableHttp'],
-        note: 'These exercise the HTTP hosting/auth layer (mostly over real Express); the matrix transport arg is ignored, so they run as a single streamableHttp-labelled cell to avoid duplicate runs.'
+        note: 'These exercise the HTTP hosting/auth layer (mostly over real Express); the matrix transport arg is ignored, so they run as a single streamableHttp-labelled cell to avoid duplicate runs.',
+        deferred:
+            'removed in v2: the bundled token endpoint no longer exists, so code_verifier checking at token exchange cannot be exercised.'
     },
     'hosting:auth:as:code-single-use': {
         source: 'sdk',
         behavior:
             'An authorization code can be exchanged exactly once; a second exchange of the same code is rejected with `invalid_grant`. Enforced by the provider deleting the code on first use; the handler relies on `the stored authorization code` returning None.',
         transports: ['streamableHttp'],
-        note: 'These exercise the HTTP hosting/auth layer (mostly over real Express); the matrix transport arg is ignored, so they run as a single streamableHttp-labelled cell to avoid duplicate runs.'
+        note: 'These exercise the HTTP hosting/auth layer (mostly over real Express); the matrix transport arg is ignored, so they run as a single streamableHttp-labelled cell to avoid duplicate runs.',
+        deferred:
+            'removed in v2: the bundled token endpoint no longer exists, so single-use authorization-code exchange cannot be exercised.'
     },
     'hosting:http:protocol-version-default': {
         source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#protocol-version-header',

--- a/test/e2e/scenarios/client-auth.test.ts
+++ b/test/e2e/scenarios/client-auth.test.ts
@@ -7,32 +7,30 @@
  */
 
 import { createHash, generateKeyPairSync, sign } from 'node:crypto';
-import { LATEST_PROTOCOL_VERSION, type IsomorphicHeaders } from '../../../src/types.js';
-
-import { importSPKI, jwtVerify } from 'jose';
-import { expect, vi } from 'vitest';
-import { z } from 'zod/v4';
-
-import { Client } from '../../../src/client/index.js';
 import {
+    Client,
     discoverAuthorizationServerMetadata,
     discoverOAuthProtectedResourceMetadata,
     exchangeAuthorization,
     OAuthClientProvider,
     startAuthorization,
-    UnauthorizedError
-} from '../../../src/client/auth.js';
-import { applyMiddlewares, createMiddleware, withLogging, withOAuth } from '../../../src/client/middleware.js';
-import { StreamableHTTPClientTransport, StreamableHTTPError } from '../../../src/client/streamableHttp.js';
-import { ClientCredentialsProvider, PrivateKeyJwtProvider, StaticPrivateKeyJwtProvider } from '../../../src/client/auth-extensions.js';
-import { McpServer } from '../../../src/server/mcp.js';
+    UnauthorizedError,
+    StreamableHTTPClientTransport,
+    SdkError
+} from '@modelcontextprotocol/client';
 import {
+    LATEST_PROTOCOL_VERSION,
+    McpServer,
     AuthorizationServerMetadata,
     OAuthClientInformationFull,
     OAuthClientInformationMixed,
     OAuthTokens
-} from '../../../src/shared/auth.js';
-
+} from '@modelcontextprotocol/server';
+import { importSPKI, jwtVerify } from 'jose';
+import { expect, vi } from 'vitest';
+import { z } from 'zod/v4';
+import { applyMiddlewares, createMiddleware, withLogging, withOAuth } from '@modelcontextprotocol/client';
+import { ClientCredentialsProvider, PrivateKeyJwtProvider, StaticPrivateKeyJwtProvider } from '@modelcontextprotocol/client';
 import { hostPerSession } from '../helpers/index.js';
 import type { TestArgs } from '../types.js';
 import { verifies } from '../helpers/verifies.js';
@@ -242,8 +240,8 @@ class RecordingOAuthClientProvider implements OAuthClientProvider {
 function createAuthenticatedHost(validToken: string) {
     return hostPerSession(() => {
         const s = new McpServer({ name: 's', version: '0' });
-        s.registerTool('probe', { inputSchema: z.object({}) }, (_args, extra) => {
-            if (extra.authInfo?.token !== validToken) {
+        s.registerTool('probe', { inputSchema: z.object({}) }, (_args, ctx) => {
+            if (ctx.http?.authInfo?.token !== validToken) {
                 throw new Error('Invalid token');
             }
             return { content: [{ type: 'text', text: 'ok' }] };
@@ -347,7 +345,7 @@ verifies('client-auth:401-after-auth-throws', async (_args: TestArgs) => {
 
     try {
         const connectPromise = client.connect(transport);
-        await expect(connectPromise).rejects.toBeInstanceOf(StreamableHTTPError);
+        await expect(connectPromise).rejects.toBeInstanceOf(SdkError);
         await expect(connectPromise).rejects.toThrow(/401 after successful authentication/);
 
         // Auth ran exactly once (refresh grant), and the transport stopped after one retry instead of looping.
@@ -425,7 +423,7 @@ verifies('client-auth:403-scope-upgrade', async (_args: TestArgs) => {
 
     try {
         const connectPromise = refreshClient.connect(refreshTransport);
-        await expect(connectPromise).rejects.toBeInstanceOf(StreamableHTTPError);
+        await expect(connectPromise).rejects.toBeInstanceOf(SdkError);
         await expect(connectPromise).rejects.toThrow(/403 after trying upscoping/);
 
         expect(refreshAs.tokenCalls).toHaveLength(1);
@@ -1323,11 +1321,11 @@ verifies('client-middleware:compose', async (_args: TestArgs) => {
         return next(input, { ...init, headers });
     });
 
-    const seenByServer: IsomorphicHeaders[] = [];
+    const seenByServer: Headers[] = [];
     const mcpHost = hostPerSession(() => {
         const s = new McpServer({ name: 's', version: '0' });
-        s.registerTool('report-headers', { inputSchema: z.object({}) }, (_a, extra) => {
-            seenByServer.push(extra.requestInfo?.headers ?? {});
+        s.registerTool('report-headers', { inputSchema: z.object({}) }, (_a, ctx) => {
+            seenByServer.push(ctx.http?.req?.headers ?? {});
             return { content: [{ type: 'text', text: 'ok' }] };
         });
         return s;

--- a/test/e2e/scenarios/client-auth.test.ts
+++ b/test/e2e/scenarios/client-auth.test.ts
@@ -7,37 +7,49 @@
  */
 
 import { createHash, generateKeyPairSync, sign } from 'node:crypto';
+
+import type { OAuthClientProvider } from '@modelcontextprotocol/client';
 import {
+    applyMiddlewares,
     Client,
+    ClientCredentialsProvider,
+    createMiddleware,
     discoverAuthorizationServerMetadata,
     discoverOAuthProtectedResourceMetadata,
     exchangeAuthorization,
-    OAuthClientProvider,
+    PrivateKeyJwtProvider,
+    SdkError,
     startAuthorization,
-    UnauthorizedError,
+    StaticPrivateKeyJwtProvider,
     StreamableHTTPClientTransport,
-    SdkError
+    UnauthorizedError,
+    withLogging,
+    withOAuth
 } from '@modelcontextprotocol/client';
-import {
-    LATEST_PROTOCOL_VERSION,
-    McpServer,
+import type {
     AuthorizationServerMetadata,
     OAuthClientInformationFull,
     OAuthClientInformationMixed,
     OAuthTokens
 } from '@modelcontextprotocol/server';
+import { LATEST_PROTOCOL_VERSION, McpServer } from '@modelcontextprotocol/server';
 import { importSPKI, jwtVerify } from 'jose';
 import { expect, vi } from 'vitest';
 import { z } from 'zod/v4';
-import { applyMiddlewares, createMiddleware, withLogging, withOAuth } from '@modelcontextprotocol/client';
-import { ClientCredentialsProvider, PrivateKeyJwtProvider, StaticPrivateKeyJwtProvider } from '@modelcontextprotocol/client';
+
 import { hostPerSession } from '../helpers/index.js';
-import type { TestArgs } from '../types.js';
 import { verifies } from '../helpers/verifies.js';
+import type { TestArgs } from '../types.js';
 
 const ISSUER = 'https://auth.example.com';
 const MCP_URL = 'http://in-process/mcp';
 const RESOURCE = 'http://in-process/mcp';
+
+// Narrows indexed-access results that the surrounding count assertions have already proven to exist.
+function defined<T>(value: T | undefined, label: string): T {
+    if (value === undefined) throw new Error(`Expected ${label} to be defined`);
+    return value;
+}
 
 interface MockASConfig {
     tokenResponses?: Array<Partial<OAuthTokens>>;
@@ -88,7 +100,7 @@ function createMockAuthorizationServer(config: MockASConfig = {}) {
             if (config.noPRMDiscovery) {
                 return new Response('Not Found', { status: 404 });
             }
-            return new Response(JSON.stringify(prmMetadata), {
+            return Response.json(prmMetadata, {
                 status: 200,
                 headers: { 'Content-Type': 'application/json' }
             });
@@ -99,7 +111,7 @@ function createMockAuthorizationServer(config: MockASConfig = {}) {
             if (config.noASDiscovery) {
                 return new Response('Not Found', { status: 404 });
             }
-            return new Response(JSON.stringify(asMetadata), {
+            return Response.json(asMetadata, {
                 status: 200,
                 headers: { 'Content-Type': 'application/json' }
             });
@@ -114,28 +126,28 @@ function createMockAuthorizationServer(config: MockASConfig = {}) {
             const bodyText = await req.text();
             const body = new URLSearchParams(bodyText);
             const headers: Record<string, string> = {};
-            req.headers.forEach((v, k) => {
+            for (const [k, v] of req.headers.entries()) {
                 headers[k] = v;
-            });
+            }
             tokenCalls.push({ method: req.method, headers, body });
 
             if (config.tokenErrorResponses && tokenErrorIndex < config.tokenErrorResponses.length) {
                 const err = config.tokenErrorResponses[tokenErrorIndex++];
-                return new Response(JSON.stringify(err), {
+                return Response.json(err, {
                     status: 400,
                     headers: { 'Content-Type': 'application/json' }
                 });
             }
 
             const response = config.tokenResponses?.[tokenIndex++] ?? { access_token: 'mock-token', token_type: 'Bearer' };
-            return new Response(JSON.stringify(response), {
+            return Response.json(response, {
                 status: 200,
                 headers: { 'Content-Type': 'application/json' }
             });
         }
 
         if (path === '/register' && req.method === 'POST') {
-            const body: Record<string, unknown> = await req.json();
+            const body = z.record(z.string(), z.unknown()).parse(await req.json());
             registerCalls.push({ body });
             // RFC 7591: the registration response echoes the submitted metadata plus issued credentials.
             const response = {
@@ -145,7 +157,7 @@ function createMockAuthorizationServer(config: MockASConfig = {}) {
                 token_endpoint_auth_method: 'client_secret_basic',
                 ...config.registerResponse
             };
-            return new Response(JSON.stringify(response), {
+            return Response.json(response, {
                 status: 201,
                 headers: { 'Content-Type': 'application/json' }
             });
@@ -303,8 +315,9 @@ verifies('client-auth:401-triggers-flow', async (_args: TestArgs) => {
         // Flow ran exactly once: a single 401'd POST, a single redirect to the authorization endpoint.
         expect(mcpPosts).toHaveLength(1);
         expect(provider.redirectedTo).toHaveLength(1);
-        expect(provider.redirectedTo[0].origin).toBe(ISSUER);
-        expect(provider.redirectedTo[0].pathname).toBe('/authorize');
+        const redirect = defined(provider.redirectedTo[0], 'authorization redirect URL');
+        expect(redirect.origin).toBe(ISSUER);
+        expect(redirect.pathname).toBe('/authorize');
         expect(provider.saved.codeVerifier).toBeDefined();
 
         expect(as.discoveryCalls.some(p => p.includes('/.well-known/oauth-protected-resource'))).toBe(true);
@@ -346,12 +359,13 @@ verifies('client-auth:401-after-auth-throws', async (_args: TestArgs) => {
     try {
         const connectPromise = client.connect(transport);
         await expect(connectPromise).rejects.toBeInstanceOf(SdkError);
-        await expect(connectPromise).rejects.toThrow(/401 after successful authentication/);
+        await expect(connectPromise).rejects.toThrow(/Server returned 401 after re-authentication/);
 
         // Auth ran exactly once (refresh grant), and the transport stopped after one retry instead of looping.
         expect(as.tokenCalls).toHaveLength(1);
-        expect(as.tokenCalls[0].body.get('grant_type')).toBe('refresh_token');
-        expect(as.tokenCalls[0].body.get('refresh_token')).toBe('stale-refresh-token');
+        const refreshCall = defined(as.tokenCalls[0], 'token call');
+        expect(refreshCall.body.get('grant_type')).toBe('refresh_token');
+        expect(refreshCall.body.get('refresh_token')).toBe('stale-refresh-token');
         expect(mcpPosts).toHaveLength(2);
         expect(provider.redirectedTo).toHaveLength(0);
     } finally {
@@ -390,7 +404,8 @@ verifies('client-auth:403-scope-upgrade', async (_args: TestArgs) => {
         await expect(interactiveClient.connect(interactiveTransport)).rejects.toThrow(UnauthorizedError);
 
         expect(interactiveProvider.redirectedTo).toHaveLength(1);
-        expect(interactiveProvider.redirectedTo[0].searchParams.get('scope')).toBe(UPGRADED_SCOPE);
+        const upgradeRedirect = defined(interactiveProvider.redirectedTo[0], 'authorization redirect URL');
+        expect(upgradeRedirect.searchParams.get('scope')).toBe(UPGRADED_SCOPE);
         expect(interactiveMcpRequests).toHaveLength(1);
     } finally {
         await interactiveClient.close();
@@ -427,7 +442,7 @@ verifies('client-auth:403-scope-upgrade', async (_args: TestArgs) => {
         await expect(connectPromise).rejects.toThrow(/403 after trying upscoping/);
 
         expect(refreshAs.tokenCalls).toHaveLength(1);
-        expect(refreshAs.tokenCalls[0].body.get('grant_type')).toBe('refresh_token');
+        expect(defined(refreshAs.tokenCalls[0], 'token call').body.get('grant_type')).toBe('refresh_token');
         expect(refreshMcpRequests).toHaveLength(2);
     } finally {
         await refreshClient.close();
@@ -458,7 +473,7 @@ verifies('client-auth:as-metadata-discovery:priority-order', async (_args: TestA
             const urlObj = typeof url === 'string' ? new URL(url) : url;
             calls.push(urlObj.pathname);
             if (urlObj.pathname === servedPath) {
-                return new Response(JSON.stringify(payload), { status: 200, headers: { 'Content-Type': 'application/json' } });
+                return Response.json(payload, { status: 200, headers: { 'Content-Type': 'application/json' } });
             }
             return new Response('Not Found', { status: 404 });
         };
@@ -521,9 +536,9 @@ verifies('client-auth:bearer-header:every-request', async (_args: TestArgs) => {
     const requests: Array<{ method: string; url: string; headers: Record<string, string> }> = [];
     const recordingFetch = async (url: URL | string, init?: RequestInit) => {
         const headers: Record<string, string> = {};
-        new Headers(init?.headers).forEach((v, k) => {
+        for (const [k, v] of new Headers(init?.headers).entries()) {
             headers[k] = v;
-        });
+        }
         requests.push({ method: init?.method ?? 'GET', url: String(url), headers });
         return mcpHost.handleRequest(new Request(url, init));
     };
@@ -572,7 +587,7 @@ verifies('client-auth:cimd', async (_args: TestArgs) => {
         // The CIMD URL is used directly as the client_id; no dynamic registration happens.
         expect(provider.saved.clientInformation?.client_id).toBe(cimdUrl);
         expect(provider.redirectedTo).toHaveLength(1);
-        expect(provider.redirectedTo[0].searchParams.get('client_id')).toBe(cimdUrl);
+        expect(defined(provider.redirectedTo[0], 'authorization redirect URL').searchParams.get('client_id')).toBe(cimdUrl);
         expect(as.registerCalls).toHaveLength(0);
     } finally {
         await client.close();
@@ -612,10 +627,11 @@ verifies('client-auth:client-credentials', async (_args: TestArgs) => {
 
         // Token obtained via the client_credentials grant, authenticated with the configured secret.
         expect(as.tokenCalls).toHaveLength(1);
-        expect(as.tokenCalls[0].body.get('grant_type')).toBe('client_credentials');
-        const basicHeader = as.tokenCalls[0].headers['authorization'];
+        const tokenCall = defined(as.tokenCalls[0], 'token call');
+        expect(tokenCall.body.get('grant_type')).toBe('client_credentials');
+        const basicHeader = defined(tokenCall.headers['authorization'], 'Basic authorization header');
         expect(basicHeader).toMatch(/^Basic /);
-        expect(Buffer.from(basicHeader.split(' ')[1], 'base64').toString()).toBe(`${CLIENT_ID}:${CLIENT_SECRET}`);
+        expect(Buffer.from(basicHeader.replace(/^Basic /, ''), 'base64').toString()).toBe(`${CLIENT_ID}:${CLIENT_SECRET}`);
 
         // No user interaction: the authorization endpoint is never visited.
         expect(as.authorizeCalls).toHaveLength(0);
@@ -647,13 +663,14 @@ verifies('client-auth:dcr', async (_args: TestArgs) => {
 
         // No client_id was preconfigured, so the SDK must register at the AS /register endpoint.
         expect(as.registerCalls).toHaveLength(1);
-        expect(as.registerCalls[0].body.client_name).toBe('Test Client');
-        expect(as.registerCalls[0].body.redirect_uris).toContain('http://localhost:3000/callback');
+        const registerCall = defined(as.registerCalls[0], 'registration call');
+        expect(registerCall.body.client_name).toBe('Test Client');
+        expect(registerCall.body.redirect_uris).toContain('http://localhost:3000/callback');
 
         // The issued client_id is persisted and used for the authorization request.
         expect(provider.saved.clientInformation?.client_id).toBe('registered-client-id');
         expect(provider.redirectedTo).toHaveLength(1);
-        expect(provider.redirectedTo[0].searchParams.get('client_id')).toBe('registered-client-id');
+        expect(defined(provider.redirectedTo[0], 'authorization redirect URL').searchParams.get('client_id')).toBe('registered-client-id');
     } finally {
         await client.close();
         await mcpHost.close();
@@ -681,7 +698,7 @@ verifies('client-auth:invalid-client-clears-all', async (_args: TestArgs) => {
 
             // The refresh attempt with the stale registration is what surfaced the error.
             expect(as.tokenCalls).toHaveLength(1);
-            expect(as.tokenCalls[0].body.get('grant_type')).toBe('refresh_token');
+            expect(defined(as.tokenCalls[0], 'token call').body.get('grant_type')).toBe('refresh_token');
 
             // Everything is invalidated: tokens are gone and the stale client_id was discarded,
             // forcing a fresh dynamic registration on the retry.
@@ -715,7 +732,7 @@ verifies('client-auth:invalid-grant-clears-tokens', async (_args: TestArgs) => {
 
         // The refresh attempt with the expired grant is what surfaced the error.
         expect(as.tokenCalls).toHaveLength(1);
-        expect(as.tokenCalls[0].body.get('grant_type')).toBe('refresh_token');
+        expect(defined(as.tokenCalls[0], 'token call').body.get('grant_type')).toBe('refresh_token');
 
         // Only tokens are invalidated; the client registration is kept and reused (no re-registration).
         expect(provider.invalidatedCredentials).toContain('tokens');
@@ -765,19 +782,19 @@ verifies('client-auth:pkce:s256', async (_args: TestArgs) => {
     try {
         await expect(client.connect(transport)).rejects.toThrow(UnauthorizedError);
 
-        const authorizeUrl = provider.redirectedTo[0];
+        const authorizeUrl = defined(provider.redirectedTo[0], 'authorization redirect URL');
         expect(authorizeUrl.searchParams.get('code_challenge_method')).toBe('S256');
         const challenge = authorizeUrl.searchParams.get('code_challenge');
         expect(challenge).toBeTruthy();
 
-        const verifier = provider.saved.codeVerifier!;
+        const verifier = defined(provider.saved.codeVerifier, 'saved code verifier');
         expect(verifier).toMatch(/^[A-Za-z0-9\-._~]{43,128}$/);
         const expectedChallenge = createHash('sha256').update(verifier).digest('base64url');
         expect(challenge).toBe(expectedChallenge);
 
         await transport.finishAuth('mock-code');
         expect(as.tokenCalls).toHaveLength(1);
-        expect(as.tokenCalls[0].body.get('code_verifier')).toBe(verifier);
+        expect(defined(as.tokenCalls[0], 'token call').body.get('code_verifier')).toBe(verifier);
     } finally {
         await client.close();
         await mcpHost.close();
@@ -801,17 +818,19 @@ verifies('client-auth:pre-registration', async (_args: TestArgs) => {
         // DCR is skipped: the preconfigured client_id is what reaches the AS authorize endpoint.
         expect(as.registerCalls).toHaveLength(0);
         expect(provider.redirectedTo).toHaveLength(1);
-        expect(provider.redirectedTo[0].origin).toBe(ISSUER);
-        expect(provider.redirectedTo[0].pathname).toBe('/authorize');
-        expect(provider.redirectedTo[0].searchParams.get('client_id')).toBe('pre-registered-client');
+        const redirect = defined(provider.redirectedTo[0], 'authorization redirect URL');
+        expect(redirect.origin).toBe(ISSUER);
+        expect(redirect.pathname).toBe('/authorize');
+        expect(redirect.searchParams.get('client_id')).toBe('pre-registered-client');
 
         // The token exchange authenticates with the preconfigured secret.
         await transport.finishAuth('granted-authorization-code');
         expect(as.tokenCalls).toHaveLength(1);
-        expect(as.tokenCalls[0].body.get('grant_type')).toBe('authorization_code');
-        const basicHeader = as.tokenCalls[0].headers['authorization'];
+        const tokenCall = defined(as.tokenCalls[0], 'token call');
+        expect(tokenCall.body.get('grant_type')).toBe('authorization_code');
+        const basicHeader = defined(tokenCall.headers['authorization'], 'Basic authorization header');
         expect(basicHeader).toMatch(/^Basic /);
-        expect(Buffer.from(basicHeader.split(' ')[1], 'base64').toString()).toBe('pre-registered-client:pre-registered-secret');
+        expect(Buffer.from(basicHeader.replace(/^Basic /, ''), 'base64').toString()).toBe('pre-registered-client:pre-registered-secret');
     } finally {
         await client.close();
         await mcpHost.close();
@@ -843,18 +862,20 @@ verifies('client-auth:private-key-jwt', async (_args: TestArgs) => {
         expect(tools.some(t => t.name === 'probe')).toBe(true);
 
         expect(as.tokenCalls).toHaveLength(1);
-        const body = as.tokenCalls[0].body;
+        const tokenCall = defined(as.tokenCalls[0], 'token call');
+        const body = tokenCall.body;
         expect(body.get('grant_type')).toBe('client_credentials');
         expect(body.get('client_assertion_type')).toBe('urn:ietf:params:oauth:client-assertion-type:jwt-bearer');
 
         // The client authenticates with a JWT signed by its private key — no shared secret anywhere.
         expect(body.get('client_secret')).toBeNull();
-        expect(as.tokenCalls[0].headers['authorization']).toBeUndefined();
+        expect(tokenCall.headers['authorization']).toBeUndefined();
 
         const assertion = body.get('client_assertion');
         expect(assertion).toBeTruthy();
+        if (assertion === null) throw new Error('Expected a client_assertion in the token request body');
         const verificationKey = await importSPKI(publicKeyPem, 'RS256');
-        const { payload } = await jwtVerify(assertion!, verificationKey);
+        const { payload } = await jwtVerify(assertion, verificationKey);
         expect(payload.iss).toBe(CLIENT_ID);
         expect(payload.sub).toBe(CLIENT_ID);
         expect(payload.aud).toBe(ISSUER);
@@ -878,7 +899,7 @@ verifies('client-auth:prm-discovery:fallback-order', async (_args: TestArgs) => 
         discoveryCalls.push(path);
 
         if (path === '/.well-known/oauth-protected-resource/mcp') {
-            return new Response(JSON.stringify(prmMetadata), {
+            return Response.json(prmMetadata, {
                 status: 200,
                 headers: { 'Content-Type': 'application/json' }
             });
@@ -935,14 +956,16 @@ verifies('client-auth:prm-discovery:no-prm-fallback', async (_args: TestArgs) =>
 
         // The flow proceeds with the authorization endpoint from the origin-discovered metadata instead of aborting.
         expect(provider.redirectedTo).toHaveLength(1);
-        expect(provider.redirectedTo[0].origin + provider.redirectedTo[0].pathname).toBe(`${ISSUER}/authorize`);
-        expect(provider.redirectedTo[0].searchParams.get('client_id')).toBe('legacy-fallback-client');
+        const redirect = defined(provider.redirectedTo[0], 'authorization redirect URL');
+        expect(redirect.origin + redirect.pathname).toBe(`${ISSUER}/authorize`);
+        expect(redirect.searchParams.get('client_id')).toBe('legacy-fallback-client');
 
         // The same origin-discovered metadata drives the code exchange at the AS token endpoint.
         await transport.finishAuth('granted-authorization-code');
         expect(as.tokenCalls).toHaveLength(1);
-        expect(as.tokenCalls[0].body.get('grant_type')).toBe('authorization_code');
-        expect(as.tokenCalls[0].body.get('code')).toBe('granted-authorization-code');
+        const tokenCall = defined(as.tokenCalls[0], 'token call');
+        expect(tokenCall.body.get('grant_type')).toBe('authorization_code');
+        expect(tokenCall.body.get('code')).toBe('granted-authorization-code');
     } finally {
         await client.close();
         await mcpHost.close();
@@ -1010,9 +1033,10 @@ verifies('client-auth:refresh:transparent', async (_args: TestArgs) => {
 
         // Exactly one refresh_token grant, carrying the stored refresh token and the resource indicator.
         expect(as.tokenCalls).toHaveLength(1);
-        expect(as.tokenCalls[0].body.get('grant_type')).toBe('refresh_token');
-        expect(as.tokenCalls[0].body.get('refresh_token')).toBe('long-lived-refresh-token');
-        expect(as.tokenCalls[0].body.get('resource')).toBe(RESOURCE);
+        const refreshCall = defined(as.tokenCalls[0], 'token call');
+        expect(refreshCall.body.get('grant_type')).toBe('refresh_token');
+        expect(refreshCall.body.get('refresh_token')).toBe('long-lived-refresh-token');
+        expect(refreshCall.body.get('resource')).toBe(RESOURCE);
 
         // The refresh is transparent (no user-facing redirect) and the rotated token set is persisted.
         expect(provider.redirectedTo).toHaveLength(0);
@@ -1040,11 +1064,11 @@ verifies('client-auth:resource-parameter', async (_args: TestArgs) => {
     try {
         await expect(client.connect(transport)).rejects.toThrow(UnauthorizedError);
 
-        const authorizeUrl = provider.redirectedTo[0];
+        const authorizeUrl = defined(provider.redirectedTo[0], 'authorization redirect URL');
         expect(authorizeUrl.searchParams.get('resource')).toBe(RESOURCE);
 
         await transport.finishAuth('mock-code');
-        expect(as.tokenCalls[0].body.get('resource')).toBe(RESOURCE);
+        expect(defined(as.tokenCalls[0], 'token call').body.get('resource')).toBe(RESOURCE);
     } finally {
         await client.close();
         await mcpHost.close();
@@ -1080,7 +1104,7 @@ verifies('client-auth:scope-selection:priority', async (_args: TestArgs) => {
 
     try {
         await expect(client.connect(transport)).rejects.toThrow(UnauthorizedError);
-        const authorizeUrl = provider.redirectedTo[0];
+        const authorizeUrl = defined(provider.redirectedTo[0], 'authorization redirect URL');
         expect(authorizeUrl.searchParams.get('scope')).toBe('mcp:custom');
     } finally {
         await client.close();
@@ -1115,7 +1139,7 @@ verifies('typescript:client-auth:state:verify', async (_args: TestArgs) => {
 
     try {
         await expect(client.connect(transport)).rejects.toThrow(UnauthorizedError);
-        const authorizeUrl = provider.redirectedTo[0];
+        const authorizeUrl = defined(provider.redirectedTo[0], 'authorization redirect URL');
         expect(authorizeUrl.searchParams.get('state')).toBe(provider.saved.state);
         expect(provider.saved.state).toMatch(/^state-\d+$/);
     } finally {
@@ -1152,13 +1176,13 @@ verifies('client-auth:token-endpoint-auth-method', async (_args: TestArgs) => {
             await transport.finishAuth('granted-authorization-code');
 
             expect(as.tokenCalls).toHaveLength(1);
-            const tokenCall = as.tokenCalls[0];
+            const tokenCall = defined(as.tokenCalls[0], 'token call');
             expect(tokenCall.body.get('grant_type')).toBe('authorization_code');
 
             if (method === 'client_secret_basic') {
-                const authHeader = tokenCall.headers['authorization'];
+                const authHeader = defined(tokenCall.headers['authorization'], 'Basic authorization header');
                 expect(authHeader).toMatch(/^Basic /);
-                expect(Buffer.from(authHeader.split(' ')[1], 'base64').toString()).toBe(`${REGISTERED_ID}:${REGISTERED_SECRET}`);
+                expect(Buffer.from(authHeader.replace(/^Basic /, ''), 'base64').toString()).toBe(`${REGISTERED_ID}:${REGISTERED_SECRET}`);
                 expect(tokenCall.body.get('client_secret')).toBeNull();
             } else if (method === 'client_secret_post') {
                 // client_secret_post: credentials travel in the form body, not the Authorization header.
@@ -1232,7 +1256,7 @@ verifies('client-auth:low-level:discover-and-exchange', async (_args: TestArgs) 
 
     expect(tokens.access_token).toBe('low-level-access-token');
     expect(as.tokenCalls).toHaveLength(1);
-    const tokenBody = as.tokenCalls[0].body;
+    const tokenBody = defined(as.tokenCalls[0], 'token call').body;
     expect(tokenBody.get('grant_type')).toBe('authorization_code');
     expect(tokenBody.get('code')).toBe('granted-authorization-code');
     expect(tokenBody.get('code_verifier')).toBe(codeVerifier);
@@ -1284,7 +1308,7 @@ verifies('client-auth:private-key-jwt:static-assertion', async (_args: TestArgs)
 
         // The pre-built assertion is sent verbatim — no per-request signing changes it.
         expect(as.tokenCalls).toHaveLength(1);
-        const body = as.tokenCalls[0].body;
+        const body = defined(as.tokenCalls[0], 'token call').body;
         expect(body.get('grant_type')).toBe('client_credentials');
         expect(body.get('client_assertion')).toBe(preBuiltJwt);
         expect(body.get('client_assertion_type')).toBe('urn:ietf:params:oauth:client-assertion-type:jwt-bearer');
@@ -1325,7 +1349,7 @@ verifies('client-middleware:compose', async (_args: TestArgs) => {
     const mcpHost = hostPerSession(() => {
         const s = new McpServer({ name: 's', version: '0' });
         s.registerTool('report-headers', { inputSchema: z.object({}) }, (_a, ctx) => {
-            seenByServer.push(ctx.http?.req?.headers ?? {});
+            seenByServer.push(ctx.http?.req?.headers ?? new Headers());
             return { content: [{ type: 'text', text: 'ok' }] };
         });
         return s;
@@ -1334,9 +1358,9 @@ verifies('client-middleware:compose', async (_args: TestArgs) => {
     const baseRequests: Array<{ method: string; headers: Record<string, string> }> = [];
     const baseFetch = async (url: URL | string, init?: RequestInit) => {
         const headers: Record<string, string> = {};
-        new Headers(init?.headers).forEach((v, k) => {
+        for (const [k, v] of new Headers(init?.headers).entries()) {
             headers[k] = v;
-        });
+        }
         baseRequests.push({ method: init?.method ?? 'GET', headers });
         return mcpHost.handleRequest(new Request(url, init));
     };
@@ -1359,9 +1383,10 @@ verifies('client-middleware:compose', async (_args: TestArgs) => {
 
         // The middleware-set headers arrived at the MCP server on the tools/call request.
         expect(seenByServer).toHaveLength(1);
-        expect(seenByServer[0]['x-mw-first']).toBe('1');
-        expect(seenByServer[0]['x-mw-second']).toBe('1');
-        expect(seenByServer[0][TRACE]).toBe('second>first');
+        const serverHeaders = defined(seenByServer[0], 'tools/call request headers');
+        expect(serverHeaders.get('x-mw-first')).toBe('1');
+        expect(serverHeaders.get('x-mw-second')).toBe('1');
+        expect(serverHeaders.get(TRACE)).toBe('second>first');
     } finally {
         await client.close();
         await mcpHost.close();
@@ -1453,8 +1478,9 @@ verifies('client-auth:middleware:with-oauth', async (_args: TestArgs) => {
 
         expect(refreshProvider.saved.tokens?.access_token).toBe(REFRESHED);
         expect(refreshAs.tokenCalls).toHaveLength(1);
-        expect(refreshAs.tokenCalls[0].body.get('grant_type')).toBe('refresh_token');
-        expect(refreshAs.tokenCalls[0].body.get('refresh_token')).toBe('initial-refresh-token');
+        const refreshCall = defined(refreshAs.tokenCalls[0], 'token call');
+        expect(refreshCall.body.get('grant_type')).toBe('refresh_token');
+        expect(refreshCall.body.get('refresh_token')).toBe('initial-refresh-token');
 
         expect(mcpAuthHeaders.length).toBeGreaterThanOrEqual(2);
         expect(mcpAuthHeaders[0]).toBe(`Bearer ${STALE}`);

--- a/test/e2e/scenarios/client-auth.test.ts
+++ b/test/e2e/scenarios/client-auth.test.ts
@@ -8,7 +8,7 @@
 
 import { createHash, generateKeyPairSync, sign } from 'node:crypto';
 
-import type { OAuthClientProvider } from '@modelcontextprotocol/client';
+import type { AuthProvider, OAuthClientProvider } from '@modelcontextprotocol/client';
 import {
     applyMiddlewares,
     Client,
@@ -17,6 +17,8 @@ import {
     discoverAuthorizationServerMetadata,
     discoverOAuthProtectedResourceMetadata,
     exchangeAuthorization,
+    OAuthError,
+    OAuthErrorCode,
     PrivateKeyJwtProvider,
     SdkError,
     startAuthorization,
@@ -1536,4 +1538,272 @@ verifies('client-auth:middleware:with-oauth', async (_args: TestArgs) => {
     await expect(stubbornAttempt).rejects.toThrow(/Authentication failed for/);
     expect(stubbornAs.tokenCalls).toHaveLength(1);
     expect(stubbornMcpRequests).toBe(2);
+});
+
+verifies('client-auth:oauth-error:consolidated-class', async (_args: TestArgs) => {
+    // Each token-endpoint error response must surface as the single consolidated OAuthError class with a machine-readable code.
+    const cases = [
+        { errorCode: 'invalid_grant', description: 'Authorization code expired', expectedCode: OAuthErrorCode.InvalidGrant },
+        { errorCode: 'invalid_client', description: 'Client authentication failed', expectedCode: OAuthErrorCode.InvalidClient }
+    ];
+
+    for (const { errorCode, description, expectedCode } of cases) {
+        const as = createMockAuthorizationServer({ tokenErrorResponses: [{ error: errorCode, error_description: description }] });
+        const tokenFetch = (url: URL | string, init?: RequestInit) => as.handleRequest(new Request(url, init));
+
+        let failure: unknown;
+        try {
+            await exchangeAuthorization(ISSUER, {
+                metadata: {
+                    issuer: ISSUER,
+                    authorization_endpoint: `${ISSUER}/authorize`,
+                    token_endpoint: `${ISSUER}/token`,
+                    response_types_supported: ['code']
+                },
+                clientInformation: { client_id: 'oauth-error-client' },
+                authorizationCode: 'granted-authorization-code',
+                codeVerifier: 'oauth-error-code-verifier',
+                redirectUri: 'http://localhost:3000/callback',
+                fetchFn: tokenFetch
+            });
+        } catch (error) {
+            failure = error;
+        }
+        expect(failure).toBeInstanceOf(OAuthError);
+        if (!(failure instanceof OAuthError)) throw new Error('Expected exchangeAuthorization to reject with OAuthError');
+
+        // The consolidated class is thrown directly (not a per-code subclass) and carries the wire error code on .code.
+        expect(Object.getPrototypeOf(failure)).toBe(OAuthError.prototype);
+        expect(failure.name).toBe('OAuthError');
+        expect(failure.code).toBe(expectedCode);
+        expect(failure.message).toBe(description);
+        expect(failure.toResponseObject()).toEqual({ error: errorCode, error_description: description });
+
+        // The error came from the single token request the exchange made.
+        expect(as.tokenCalls).toHaveLength(1);
+    }
+});
+
+verifies('client-auth:authprovider:token-attached', async (_args: TestArgs) => {
+    const TOKEN = 'minimal-provider-bearer-token';
+
+    let tokenCalls = 0;
+    // Minimal AuthProvider shape: token() only — no OAuth machinery, no onUnauthorized.
+    const authProvider: AuthProvider = {
+        token: async () => {
+            tokenCalls += 1;
+            return TOKEN;
+        }
+    };
+
+    const authorizationSeenByServer: Array<string | null> = [];
+    const mcpHost = hostPerSession(() => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool('probe', { inputSchema: z.object({}) }, (_a, ctx) => {
+            authorizationSeenByServer.push(ctx.http?.req?.headers.get('authorization') ?? null);
+            return { content: [{ type: 'text', text: 'ok' }] };
+        });
+        return s;
+    });
+
+    const requests: Array<{ method: string; authorization: string | null }> = [];
+    const recordingFetch = async (url: URL | string, init?: RequestInit) => {
+        requests.push({ method: init?.method ?? 'GET', authorization: new Headers(init?.headers).get('authorization') });
+        return mcpHost.handleRequest(new Request(url, init));
+    };
+
+    const client = new Client({ name: 'c', version: '0' });
+    const transport = new StreamableHTTPClientTransport(new URL(MCP_URL), { authProvider, fetch: recordingFetch });
+
+    try {
+        await client.connect(transport);
+        const result = await client.callTool({ name: 'probe', arguments: {} });
+        expect(result.content).toEqual([{ type: 'text', text: 'ok' }]);
+
+        // The standalone SSE GET is opened fire-and-forget after initialize; wait for it so it is checked too.
+        await vi.waitFor(() => expect(requests.some(r => r.method === 'GET')).toBe(true));
+
+        // Exactly three POSTs (initialize, notifications/initialized, tools/call) plus the standalone SSE GET.
+        expect(requests.filter(r => r.method === 'POST')).toHaveLength(3);
+        expect(requests.filter(r => r.method === 'GET')).toHaveLength(1);
+        for (const req of requests) {
+            expect(req.authorization).toBe(`Bearer ${TOKEN}`);
+        }
+
+        // token() was consulted once per HTTP request the transport made.
+        expect(tokenCalls).toBe(requests.length);
+
+        // The bearer header reached the server intact on the tools/call request.
+        expect(authorizationSeenByServer).toEqual([`Bearer ${TOKEN}`]);
+    } finally {
+        await client.close();
+        await mcpHost.close();
+    }
+});
+
+verifies('client-auth:authprovider:onunauthorized-retry', async (_args: TestArgs) => {
+    const STALE = 'stale-bearer-token';
+    const FRESH = 'fresh-bearer-token';
+
+    // Phase 1: 401 → onUnauthorized refreshes the token → the transport retries once and the request succeeds.
+    let currentToken = STALE;
+    const unauthorizedCalls: Array<{ status: number; serverUrl: string }> = [];
+    const refreshingProvider: AuthProvider = {
+        token: async () => currentToken,
+        onUnauthorized: async ctx => {
+            unauthorizedCalls.push({ status: ctx.response.status, serverUrl: String(ctx.serverUrl) });
+            currentToken = FRESH;
+        }
+    };
+
+    const mcpHost = hostPerSession(() => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool('probe', { inputSchema: z.object({}) }, () => ({ content: [{ type: 'text', text: 'ok' }] }));
+        return s;
+    });
+
+    const postBearers: Array<string | null> = [];
+    // Token validity is enforced at the HTTP layer: anything but the fresh token is rejected with 401.
+    const guardedFetch = async (url: URL | string, init?: RequestInit): Promise<Response> => {
+        const authorization = new Headers(init?.headers).get('authorization');
+        if (init?.method === 'POST') {
+            postBearers.push(authorization);
+        }
+        if (authorization !== `Bearer ${FRESH}`) {
+            return new Response(null, { status: 401 });
+        }
+        return mcpHost.handleRequest(new Request(url, init));
+    };
+
+    const client = new Client({ name: 'c', version: '0' });
+    const transport = new StreamableHTTPClientTransport(new URL(MCP_URL), { authProvider: refreshingProvider, fetch: guardedFetch });
+
+    try {
+        await client.connect(transport);
+        const result = await client.callTool({ name: 'probe', arguments: {} });
+        expect(result.content).toEqual([{ type: 'text', text: 'ok' }]);
+
+        // onUnauthorized was awaited exactly once, with the 401 response and the MCP server URL.
+        expect(unauthorizedCalls).toEqual([{ status: 401, serverUrl: MCP_URL }]);
+
+        // Exactly one retry: the rejected initialize, its retry with the fresh token, notifications/initialized, tools/call.
+        expect(postBearers).toEqual([`Bearer ${STALE}`, `Bearer ${FRESH}`, `Bearer ${FRESH}`, `Bearer ${FRESH}`]);
+    } finally {
+        await client.close();
+        await mcpHost.close();
+    }
+
+    // Phase 2: a provider without onUnauthorized cannot recover, so the 401 surfaces as UnauthorizedError without a retry.
+    let tokenOnlyPosts = 0;
+    const tokenOnlyProvider: AuthProvider = { token: async () => STALE };
+    const alwaysUnauthorizedFetch = async (_url: URL | string, init?: RequestInit): Promise<Response> => {
+        if (init?.method === 'POST') {
+            tokenOnlyPosts += 1;
+        }
+        return new Response(null, { status: 401 });
+    };
+
+    const tokenOnlyClient = new Client({ name: 'c', version: '0' });
+    const tokenOnlyTransport = new StreamableHTTPClientTransport(new URL(MCP_URL), {
+        authProvider: tokenOnlyProvider,
+        fetch: alwaysUnauthorizedFetch
+    });
+
+    try {
+        await expect(tokenOnlyClient.connect(tokenOnlyTransport)).rejects.toThrow(UnauthorizedError);
+        expect(tokenOnlyPosts).toBe(1);
+    } finally {
+        await tokenOnlyClient.close();
+    }
+});
+
+verifies(
+    'client-auth:authprovider:onunauthorized-retry',
+    async (_args: TestArgs) => {
+        const STALE = 'stale-bearer-token';
+        const ROTATED = 'rotated-but-still-rejected-token';
+
+        // The provider refreshes on 401 but the resource keeps rejecting: the retry's 401 must surface as UnauthorizedError.
+        let currentToken = STALE;
+        let unauthorizedCalls = 0;
+        const provider: AuthProvider = {
+            token: async () => currentToken,
+            onUnauthorized: async () => {
+                unauthorizedCalls += 1;
+                currentToken = ROTATED;
+            }
+        };
+
+        const postBearers: Array<string | null> = [];
+        const alwaysUnauthorizedFetch = async (_url: URL | string, init?: RequestInit): Promise<Response> => {
+            if (init?.method === 'POST') {
+                postBearers.push(new Headers(init?.headers).get('authorization'));
+            }
+            return new Response(null, { status: 401 });
+        };
+
+        const client = new Client({ name: 'c', version: '0' });
+        const transport = new StreamableHTTPClientTransport(new URL(MCP_URL), { authProvider: provider, fetch: alwaysUnauthorizedFetch });
+
+        try {
+            await expect(client.connect(transport)).rejects.toThrow(UnauthorizedError);
+
+            // onUnauthorized ran once and the transport retried exactly once before giving up.
+            expect(unauthorizedCalls).toBe(1);
+            expect(postBearers).toEqual([`Bearer ${STALE}`, `Bearer ${ROTATED}`]);
+        } finally {
+            await client.close();
+        }
+    },
+    { title: 'second 401 after retry surfaces as UnauthorizedError' }
+);
+
+verifies('client-auth:authprovider:oauth-provider-adapted', async (_args: TestArgs) => {
+    const ACCESS_TOKEN = 'adapted-oauth-access-token';
+    // A full OAuthClientProvider (not the minimal AuthProvider shape) with an access token already stored.
+    const provider = new RecordingOAuthClientProvider({
+        tokens: { access_token: ACCESS_TOKEN, token_type: 'Bearer' },
+        clientInformation: { client_id: 'adapted-oauth-client' }
+    });
+
+    const authorizationSeenByServer: Array<string | null> = [];
+    const mcpHost = hostPerSession(() => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool('probe', { inputSchema: z.object({}) }, (_a, ctx) => {
+            authorizationSeenByServer.push(ctx.http?.req?.headers.get('authorization') ?? null);
+            return { content: [{ type: 'text', text: 'ok' }] };
+        });
+        return s;
+    });
+
+    const requests: Array<{ method: string; authorization: string | null }> = [];
+    const recordingFetch = async (url: URL | string, init?: RequestInit) => {
+        requests.push({ method: init?.method ?? 'GET', authorization: new Headers(init?.headers).get('authorization') });
+        return mcpHost.handleRequest(new Request(url, init));
+    };
+
+    const client = new Client({ name: 'c', version: '0' });
+    const transport = new StreamableHTTPClientTransport(new URL(MCP_URL), { authProvider: provider, fetch: recordingFetch });
+
+    try {
+        await client.connect(transport);
+        const result = await client.callTool({ name: 'probe', arguments: {} });
+        expect(result.content).toEqual([{ type: 'text', text: 'ok' }]);
+
+        // The standalone SSE GET is opened fire-and-forget after initialize; wait for it so it is checked too.
+        await vi.waitFor(() => expect(requests.some(r => r.method === 'GET')).toBe(true));
+
+        // The provider's stored access_token is the bearer token on every request the transport made.
+        expect(requests.filter(r => r.method === 'POST')).toHaveLength(3);
+        for (const req of requests) {
+            expect(req.authorization).toBe(`Bearer ${ACCESS_TOKEN}`);
+        }
+        expect(authorizationSeenByServer).toEqual([`Bearer ${ACCESS_TOKEN}`]);
+
+        // No interactive auth flow was needed: the stored token was adapted and used as-is.
+        expect(provider.redirectedTo).toHaveLength(0);
+    } finally {
+        await client.close();
+        await mcpHost.close();
+    }
 });

--- a/test/e2e/scenarios/client-auth.test.ts
+++ b/test/e2e/scenarios/client-auth.test.ts
@@ -1,0 +1,1515 @@
+/**
+ * Self-contained test bodies for the client-auth surface (OAuth client flows + middleware).
+ *
+ * All tests use streamableHttp transport. A reusable mock Authorization Server
+ * (routing function) handles discovery, DCR, and token exchange; a recording
+ * OAuthClientProvider tracks state transitions and SDK calls.
+ */
+
+import { createHash, generateKeyPairSync, sign } from 'node:crypto';
+import { LATEST_PROTOCOL_VERSION, type IsomorphicHeaders } from '../../../src/types.js';
+
+import { importSPKI, jwtVerify } from 'jose';
+import { expect, vi } from 'vitest';
+import { z } from 'zod/v4';
+
+import { Client } from '../../../src/client/index.js';
+import {
+    discoverAuthorizationServerMetadata,
+    discoverOAuthProtectedResourceMetadata,
+    exchangeAuthorization,
+    OAuthClientProvider,
+    startAuthorization,
+    UnauthorizedError
+} from '../../../src/client/auth.js';
+import { applyMiddlewares, createMiddleware, withLogging, withOAuth } from '../../../src/client/middleware.js';
+import { StreamableHTTPClientTransport, StreamableHTTPError } from '../../../src/client/streamableHttp.js';
+import { ClientCredentialsProvider, PrivateKeyJwtProvider, StaticPrivateKeyJwtProvider } from '../../../src/client/auth-extensions.js';
+import { McpServer } from '../../../src/server/mcp.js';
+import {
+    AuthorizationServerMetadata,
+    OAuthClientInformationFull,
+    OAuthClientInformationMixed,
+    OAuthTokens
+} from '../../../src/shared/auth.js';
+
+import { hostPerSession } from '../helpers/index.js';
+import type { TestArgs } from '../types.js';
+import { verifies } from '../helpers/verifies.js';
+
+const ISSUER = 'https://auth.example.com';
+const MCP_URL = 'http://in-process/mcp';
+const RESOURCE = 'http://in-process/mcp';
+
+interface MockASConfig {
+    tokenResponses?: Array<Partial<OAuthTokens>>;
+    tokenErrorResponses?: Array<{ error: string; error_description?: string }>;
+    registerResponse?: Partial<OAuthClientInformationFull>;
+    asMetadata?: Partial<AuthorizationServerMetadata>;
+    prmMetadata?: Record<string, unknown>;
+    noPRMDiscovery?: boolean;
+    noASDiscovery?: boolean;
+    refusePKCE?: boolean;
+    resourceMismatch?: boolean;
+}
+
+function createMockAuthorizationServer(config: MockASConfig = {}) {
+    const tokenCalls: Array<{ method: string; headers: Record<string, string>; body: URLSearchParams }> = [];
+    const authorizeCalls: Array<{ url: URL; params: URLSearchParams }> = [];
+    const registerCalls: Array<{ body: Record<string, unknown> }> = [];
+    const discoveryCalls: string[] = [];
+
+    let tokenIndex = 0;
+    let tokenErrorIndex = 0;
+
+    const asMetadata: AuthorizationServerMetadata = {
+        issuer: ISSUER,
+        authorization_endpoint: `${ISSUER}/authorize`,
+        token_endpoint: `${ISSUER}/token`,
+        response_types_supported: ['code'],
+        registration_endpoint: `${ISSUER}/register`,
+        code_challenge_methods_supported: config.refusePKCE ? ['plain'] : ['S256'],
+        token_endpoint_auth_methods_supported: ['client_secret_basic', 'client_secret_post', 'none'],
+        grant_types_supported: ['authorization_code', 'refresh_token', 'client_credentials'],
+        ...config.asMetadata
+    };
+
+    const prmMetadata = {
+        resource: config.resourceMismatch ? 'https://wrong.example.com' : RESOURCE,
+        authorization_servers: [ISSUER],
+        scopes_supported: ['mcp:read', 'mcp:write'],
+        ...config.prmMetadata
+    };
+
+    const handleRequest = async (req: Request): Promise<Response> => {
+        const url = new URL(req.url);
+        const path = url.pathname;
+
+        if (path.includes('/.well-known/oauth-protected-resource')) {
+            discoveryCalls.push(path);
+            if (config.noPRMDiscovery) {
+                return new Response('Not Found', { status: 404 });
+            }
+            return new Response(JSON.stringify(prmMetadata), {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' }
+            });
+        }
+
+        if (path.includes('/.well-known/oauth-authorization-server') || path.includes('/.well-known/openid-configuration')) {
+            discoveryCalls.push(path);
+            if (config.noASDiscovery) {
+                return new Response('Not Found', { status: 404 });
+            }
+            return new Response(JSON.stringify(asMetadata), {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' }
+            });
+        }
+
+        if (path === '/authorize') {
+            authorizeCalls.push({ url, params: new URLSearchParams(url.search) });
+            return new Response('Authorization page', { status: 200 });
+        }
+
+        if (path === '/token' && req.method === 'POST') {
+            const bodyText = await req.text();
+            const body = new URLSearchParams(bodyText);
+            const headers: Record<string, string> = {};
+            req.headers.forEach((v, k) => {
+                headers[k] = v;
+            });
+            tokenCalls.push({ method: req.method, headers, body });
+
+            if (config.tokenErrorResponses && tokenErrorIndex < config.tokenErrorResponses.length) {
+                const err = config.tokenErrorResponses[tokenErrorIndex++];
+                return new Response(JSON.stringify(err), {
+                    status: 400,
+                    headers: { 'Content-Type': 'application/json' }
+                });
+            }
+
+            const response = config.tokenResponses?.[tokenIndex++] ?? { access_token: 'mock-token', token_type: 'Bearer' };
+            return new Response(JSON.stringify(response), {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' }
+            });
+        }
+
+        if (path === '/register' && req.method === 'POST') {
+            const body: Record<string, unknown> = await req.json();
+            registerCalls.push({ body });
+            // RFC 7591: the registration response echoes the submitted metadata plus issued credentials.
+            const response = {
+                ...body,
+                client_id: 'registered-client-id',
+                client_secret: 'registered-client-secret',
+                token_endpoint_auth_method: 'client_secret_basic',
+                ...config.registerResponse
+            };
+            return new Response(JSON.stringify(response), {
+                status: 201,
+                headers: { 'Content-Type': 'application/json' }
+            });
+        }
+
+        return new Response('Not Found', { status: 404 });
+    };
+
+    return { handleRequest, tokenCalls, authorizeCalls, registerCalls, discoveryCalls };
+}
+
+class RecordingOAuthClientProvider implements OAuthClientProvider {
+    redirectedTo: URL[] = [];
+    invalidatedCredentials: Array<'tokens' | 'all'> = [];
+    saved: {
+        tokens?: OAuthTokens;
+        clientInformation?: OAuthClientInformationMixed;
+        codeVerifier?: string;
+        state?: string;
+    } = {};
+
+    constructor(
+        private readonly initial: {
+            tokens?: OAuthTokens;
+            clientInformation?: OAuthClientInformationMixed;
+            clientMetadataUrl?: string;
+        } = {}
+    ) {
+        if (initial.tokens) this.saved.tokens = initial.tokens;
+        if (initial.clientInformation) this.saved.clientInformation = initial.clientInformation;
+    }
+
+    get redirectUrl() {
+        return 'http://localhost:3000/callback';
+    }
+
+    get clientMetadataUrl() {
+        return this.initial.clientMetadataUrl;
+    }
+
+    get clientMetadata() {
+        return {
+            client_name: 'Test Client',
+            redirect_uris: [this.redirectUrl]
+        };
+    }
+
+    state() {
+        this.saved.state = `state-${Date.now()}`;
+        return this.saved.state;
+    }
+
+    clientInformation() {
+        return this.saved.clientInformation;
+    }
+
+    saveClientInformation(info: OAuthClientInformationMixed) {
+        this.saved.clientInformation = info;
+    }
+
+    tokens() {
+        return this.saved.tokens;
+    }
+
+    saveTokens(tokens: OAuthTokens) {
+        this.saved.tokens = tokens;
+    }
+
+    redirectToAuthorization(url: URL) {
+        this.redirectedTo.push(url);
+    }
+
+    saveCodeVerifier(verifier: string) {
+        this.saved.codeVerifier = verifier;
+    }
+
+    codeVerifier() {
+        if (!this.saved.codeVerifier) throw new Error('No code verifier saved');
+        return this.saved.codeVerifier;
+    }
+
+    invalidateCredentials(what: 'tokens' | 'all') {
+        this.invalidatedCredentials.push(what);
+        if (what === 'tokens') {
+            delete this.saved.tokens;
+        } else {
+            this.saved = {};
+        }
+    }
+}
+
+function createAuthenticatedHost(validToken: string) {
+    return hostPerSession(() => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool('probe', { inputSchema: z.object({}) }, (_args, extra) => {
+            if (extra.authInfo?.token !== validToken) {
+                throw new Error('Invalid token');
+            }
+            return { content: [{ type: 'text', text: 'ok' }] };
+        });
+        return s;
+    });
+}
+
+function createCombinedFetch(params: {
+    as: ReturnType<typeof createMockAuthorizationServer>;
+    mcpHost: ReturnType<typeof createAuthenticatedHost>;
+    validToken?: string;
+    requireAuth?: boolean;
+}) {
+    const { as, mcpHost, validToken, requireAuth = true } = params;
+    return async (url: URL | string, init?: RequestInit): Promise<Response> => {
+        const urlObj = typeof url === 'string' ? new URL(url) : url;
+        if (urlObj.origin === ISSUER || urlObj.pathname.includes('/.well-known/')) {
+            return as.handleRequest(new Request(url, init));
+        }
+        if (requireAuth) {
+            const h = new Headers(init?.headers);
+            if (!h.has('authorization')) {
+                return new Response(null, {
+                    status: 401,
+                    headers: { 'WWW-Authenticate': `Bearer resource_metadata="${MCP_URL}/.well-known/oauth-protected-resource"` }
+                });
+            }
+            if (validToken && h.get('authorization') !== `Bearer ${validToken}`) {
+                return new Response(null, { status: 401 });
+            }
+        }
+        return mcpHost.handleRequest(new Request(url, init));
+    };
+}
+
+verifies('client-auth:401-triggers-flow', async (_args: TestArgs) => {
+    const as = createMockAuthorizationServer();
+    const provider = new RecordingOAuthClientProvider();
+    const validToken = 'flow-token';
+    const mcpHost = createAuthenticatedHost(validToken);
+    const baseFetch = createCombinedFetch({ as, mcpHost, validToken });
+
+    const mcpPosts: string[] = [];
+    const combinedFetch = async (url: URL | string, init?: RequestInit): Promise<Response> => {
+        const urlObj = typeof url === 'string' ? new URL(url) : url;
+        if (urlObj.origin !== ISSUER && !urlObj.pathname.includes('/.well-known/') && init?.method === 'POST') {
+            mcpPosts.push(urlObj.pathname);
+        }
+        return baseFetch(url, init);
+    };
+
+    const client = new Client({ name: 'c', version: '0' });
+    const transport = new StreamableHTTPClientTransport(new URL(MCP_URL), { authProvider: provider, fetch: combinedFetch });
+
+    try {
+        await expect(client.connect(transport)).rejects.toThrow(UnauthorizedError);
+
+        // Flow ran exactly once: a single 401'd POST, a single redirect to the authorization endpoint.
+        expect(mcpPosts).toHaveLength(1);
+        expect(provider.redirectedTo).toHaveLength(1);
+        expect(provider.redirectedTo[0].origin).toBe(ISSUER);
+        expect(provider.redirectedTo[0].pathname).toBe('/authorize');
+        expect(provider.saved.codeVerifier).toBeDefined();
+
+        expect(as.discoveryCalls.some(p => p.includes('/.well-known/oauth-protected-resource'))).toBe(true);
+        expect(as.discoveryCalls).toContain('/.well-known/oauth-authorization-server');
+    } finally {
+        await client.close();
+        await mcpHost.close();
+    }
+});
+
+verifies('client-auth:401-after-auth-throws', async (_args: TestArgs) => {
+    const as = createMockAuthorizationServer({
+        tokenResponses: [{ access_token: 'refreshed-access-token', token_type: 'Bearer' }]
+    });
+    const provider = new RecordingOAuthClientProvider({
+        tokens: { access_token: 'stale-access-token', token_type: 'Bearer', refresh_token: 'stale-refresh-token' },
+        clientInformation: { client_id: 'pre-registered-client' }
+    });
+
+    const mcpPosts: string[] = [];
+    // The protected resource keeps rejecting with 401 even after the auth flow refreshes the token.
+    const combinedFetch = async (url: URL | string, init?: RequestInit): Promise<Response> => {
+        const urlObj = typeof url === 'string' ? new URL(url) : url;
+        if (urlObj.origin === ISSUER || urlObj.pathname.includes('/.well-known/')) {
+            return as.handleRequest(new Request(url, init));
+        }
+        if (init?.method === 'POST') {
+            mcpPosts.push(urlObj.pathname);
+        }
+        return new Response(null, {
+            status: 401,
+            headers: { 'WWW-Authenticate': `Bearer resource_metadata="${MCP_URL}/.well-known/oauth-protected-resource"` }
+        });
+    };
+
+    const client = new Client({ name: 'c', version: '0' });
+    const transport = new StreamableHTTPClientTransport(new URL(MCP_URL), { authProvider: provider, fetch: combinedFetch });
+
+    try {
+        const connectPromise = client.connect(transport);
+        await expect(connectPromise).rejects.toBeInstanceOf(StreamableHTTPError);
+        await expect(connectPromise).rejects.toThrow(/401 after successful authentication/);
+
+        // Auth ran exactly once (refresh grant), and the transport stopped after one retry instead of looping.
+        expect(as.tokenCalls).toHaveLength(1);
+        expect(as.tokenCalls[0].body.get('grant_type')).toBe('refresh_token');
+        expect(as.tokenCalls[0].body.get('refresh_token')).toBe('stale-refresh-token');
+        expect(mcpPosts).toHaveLength(2);
+        expect(provider.redirectedTo).toHaveLength(0);
+    } finally {
+        await client.close();
+    }
+});
+
+verifies('client-auth:403-scope-upgrade', async (_args: TestArgs) => {
+    const UPGRADED_SCOPE = 'mcp:read mcp:write mcp:admin';
+    const insufficientScopeHeader = `Bearer error="insufficient_scope", scope="${UPGRADED_SCOPE}", resource_metadata="${MCP_URL}/.well-known/oauth-protected-resource"`;
+
+    // Phase 1: 403 with insufficient_scope triggers a fresh auth attempt requesting the broader scope.
+    const interactiveAs = createMockAuthorizationServer();
+    const interactiveProvider = new RecordingOAuthClientProvider({
+        tokens: { access_token: 'narrow-scope-token', token_type: 'Bearer' },
+        clientInformation: { client_id: 'pre-registered-client' }
+    });
+
+    const interactiveMcpRequests: string[] = [];
+    const interactiveFetch = async (url: URL | string, init?: RequestInit): Promise<Response> => {
+        const urlObj = typeof url === 'string' ? new URL(url) : url;
+        if (urlObj.origin === ISSUER || urlObj.pathname.includes('/.well-known/')) {
+            return interactiveAs.handleRequest(new Request(url, init));
+        }
+        interactiveMcpRequests.push(urlObj.pathname);
+        return new Response(null, { status: 403, headers: { 'WWW-Authenticate': insufficientScopeHeader } });
+    };
+
+    const interactiveClient = new Client({ name: 'c', version: '0' });
+    const interactiveTransport = new StreamableHTTPClientTransport(new URL(MCP_URL), {
+        authProvider: interactiveProvider,
+        fetch: interactiveFetch
+    });
+
+    try {
+        await expect(interactiveClient.connect(interactiveTransport)).rejects.toThrow(UnauthorizedError);
+
+        expect(interactiveProvider.redirectedTo).toHaveLength(1);
+        expect(interactiveProvider.redirectedTo[0].searchParams.get('scope')).toBe(UPGRADED_SCOPE);
+        expect(interactiveMcpRequests).toHaveLength(1);
+    } finally {
+        await interactiveClient.close();
+    }
+
+    // Phase 2: when the upscoped token is still rejected with the same header, the transport stops instead of looping.
+    const refreshAs = createMockAuthorizationServer({
+        tokenResponses: [{ access_token: 'upscoped-access-token', token_type: 'Bearer' }]
+    });
+    const refreshProvider = new RecordingOAuthClientProvider({
+        tokens: { access_token: 'narrow-scope-token', token_type: 'Bearer', refresh_token: 'narrow-refresh-token' },
+        clientInformation: { client_id: 'pre-registered-client' }
+    });
+
+    const refreshMcpRequests: string[] = [];
+    const refreshFetch = async (url: URL | string, init?: RequestInit): Promise<Response> => {
+        const urlObj = typeof url === 'string' ? new URL(url) : url;
+        if (urlObj.origin === ISSUER || urlObj.pathname.includes('/.well-known/')) {
+            return refreshAs.handleRequest(new Request(url, init));
+        }
+        refreshMcpRequests.push(urlObj.pathname);
+        return new Response(null, { status: 403, headers: { 'WWW-Authenticate': insufficientScopeHeader } });
+    };
+
+    const refreshClient = new Client({ name: 'c', version: '0' });
+    const refreshTransport = new StreamableHTTPClientTransport(new URL(MCP_URL), {
+        authProvider: refreshProvider,
+        fetch: refreshFetch
+    });
+
+    try {
+        const connectPromise = refreshClient.connect(refreshTransport);
+        await expect(connectPromise).rejects.toBeInstanceOf(StreamableHTTPError);
+        await expect(connectPromise).rejects.toThrow(/403 after trying upscoping/);
+
+        expect(refreshAs.tokenCalls).toHaveLength(1);
+        expect(refreshAs.tokenCalls[0].body.get('grant_type')).toBe('refresh_token');
+        expect(refreshMcpRequests).toHaveLength(2);
+    } finally {
+        await refreshClient.close();
+    }
+});
+
+verifies('client-auth:as-metadata-discovery:priority-order', async (_args: TestArgs) => {
+    const oauthMetadata: AuthorizationServerMetadata = {
+        issuer: ISSUER,
+        authorization_endpoint: `${ISSUER}/authorize`,
+        token_endpoint: `${ISSUER}/token`,
+        response_types_supported: ['code']
+    };
+    const oidcMetadata = {
+        issuer: ISSUER,
+        authorization_endpoint: `${ISSUER}/authorize`,
+        token_endpoint: `${ISSUER}/token`,
+        jwks_uri: `${ISSUER}/jwks`,
+        response_types_supported: ['code'],
+        subject_types_supported: ['public'],
+        id_token_signing_alg_values_supported: ['RS256']
+    };
+
+    // Serves metadata only at one path; everything else 404s so the fallback chain keeps probing.
+    const makeDiscoveryFetch = (servedPath: string, payload: object) => {
+        const calls: string[] = [];
+        const fetchFn = async (url: URL | string, _init?: RequestInit) => {
+            const urlObj = typeof url === 'string' ? new URL(url) : url;
+            calls.push(urlObj.pathname);
+            if (urlObj.pathname === servedPath) {
+                return new Response(JSON.stringify(payload), { status: 200, headers: { 'Content-Type': 'application/json' } });
+            }
+            return new Response('Not Found', { status: 404 });
+        };
+        return { calls, fetchFn };
+    };
+
+    // Path-less issuer: OAuth AS metadata is tried first and, when found, discovery stops there.
+    const oauthFirst = makeDiscoveryFetch('/.well-known/oauth-authorization-server', oauthMetadata);
+    expect(await discoverAuthorizationServerMetadata(ISSUER, { fetchFn: oauthFirst.fetchFn })).toMatchObject(oauthMetadata);
+    expect(oauthFirst.calls).toEqual(['/.well-known/oauth-authorization-server']);
+
+    // Path-less issuer without OAuth metadata: OIDC discovery is tried second.
+    const oidcFallback = makeDiscoveryFetch('/.well-known/openid-configuration', oidcMetadata);
+    expect(await discoverAuthorizationServerMetadata(ISSUER, { fetchFn: oidcFallback.fetchFn })).toMatchObject(oidcMetadata);
+    expect(oidcFallback.calls).toEqual(['/.well-known/oauth-authorization-server', '/.well-known/openid-configuration']);
+
+    // Path-bearing issuer: path-inserted OAuth, then path-inserted OIDC, then path-appended OIDC.
+    const tenantIssuer = `${ISSUER}/tenant1`;
+    const tenantOidcMetadata = { ...oidcMetadata, issuer: tenantIssuer };
+    const tenantFallback = makeDiscoveryFetch('/tenant1/.well-known/openid-configuration', tenantOidcMetadata);
+    expect(await discoverAuthorizationServerMetadata(tenantIssuer, { fetchFn: tenantFallback.fetchFn })).toMatchObject(tenantOidcMetadata);
+    expect(tenantFallback.calls).toEqual([
+        '/.well-known/oauth-authorization-server/tenant1',
+        '/.well-known/openid-configuration/tenant1',
+        '/tenant1/.well-known/openid-configuration'
+    ]);
+});
+
+verifies('client-auth:as-metadata-discovery:issuer-validation', async (_args: TestArgs) => {
+    // RFC 8414 §3.3: metadata fetched from the AS URL claims a different issuer, so the document must be rejected.
+    const as = createMockAuthorizationServer({ asMetadata: { issuer: 'https://attacker.example.com' } });
+    const provider = new RecordingOAuthClientProvider();
+    const mcpHost = createAuthenticatedHost('token-never-issued');
+    const combinedFetch = createCombinedFetch({ as, mcpHost, validToken: 'token-never-issued' });
+
+    const client = new Client({ name: 'c', version: '0' });
+    const transport = new StreamableHTTPClientTransport(new URL(MCP_URL), { authProvider: provider, fetch: combinedFetch });
+
+    try {
+        await expect(client.connect(transport)).rejects.toThrow(/issuer/i);
+
+        // The mismatched metadata is rejected before registering, redirecting the user, or requesting tokens.
+        expect(as.registerCalls).toHaveLength(0);
+        expect(provider.redirectedTo).toHaveLength(0);
+        expect(as.tokenCalls).toHaveLength(0);
+    } finally {
+        await client.close();
+        await mcpHost.close();
+    }
+});
+
+verifies('client-auth:bearer-header:every-request', async (_args: TestArgs) => {
+    const validToken = 'bearer-test-token';
+    const provider = new RecordingOAuthClientProvider({
+        tokens: { access_token: validToken, token_type: 'Bearer' },
+        clientInformation: { client_id: 'test-client' }
+    });
+    const mcpHost = createAuthenticatedHost(validToken);
+
+    const requests: Array<{ method: string; url: string; headers: Record<string, string> }> = [];
+    const recordingFetch = async (url: URL | string, init?: RequestInit) => {
+        const headers: Record<string, string> = {};
+        new Headers(init?.headers).forEach((v, k) => {
+            headers[k] = v;
+        });
+        requests.push({ method: init?.method ?? 'GET', url: String(url), headers });
+        return mcpHost.handleRequest(new Request(url, init));
+    };
+
+    const client = new Client({ name: 'c', version: '0' });
+    const transport = new StreamableHTTPClientTransport(new URL(MCP_URL), { authProvider: provider, fetch: recordingFetch });
+
+    try {
+        await client.connect(transport);
+        await client.callTool({ name: 'probe', arguments: {} });
+
+        // The standalone SSE GET is opened fire-and-forget after initialize; wait for it so it is checked too.
+        await vi.waitFor(() => expect(requests.some(r => r.method === 'GET')).toBe(true));
+
+        const mcpRequests = requests.filter(r => new URL(r.url).pathname === '/mcp');
+        expect(mcpRequests).toHaveLength(requests.length);
+        // Exactly three POSTs: initialize, notifications/initialized, tools/call.
+        expect(mcpRequests.filter(r => r.method === 'POST')).toHaveLength(3);
+
+        for (const req of mcpRequests) {
+            expect(req.headers['authorization']).toBe(`Bearer ${validToken}`);
+            expect(new URL(req.url).search).not.toContain(validToken);
+            expect(new URL(req.url).search).not.toMatch(/access_token/i);
+        }
+    } finally {
+        await client.close();
+        await mcpHost.close();
+    }
+});
+
+verifies('client-auth:cimd', async (_args: TestArgs) => {
+    const cimdUrl = 'https://client.example.com/.well-known/client-metadata.json';
+    const as = createMockAuthorizationServer({
+        asMetadata: { client_id_metadata_document_supported: true }
+    });
+    const provider = new RecordingOAuthClientProvider({ clientMetadataUrl: cimdUrl });
+    const mcpHost = createAuthenticatedHost('cimd-token');
+    const combinedFetch = createCombinedFetch({ as, mcpHost, validToken: 'cimd-token' });
+
+    const client = new Client({ name: 'c', version: '0' });
+    const transport = new StreamableHTTPClientTransport(new URL(MCP_URL), { authProvider: provider, fetch: combinedFetch });
+
+    try {
+        await expect(client.connect(transport)).rejects.toThrow(UnauthorizedError);
+
+        // The CIMD URL is used directly as the client_id; no dynamic registration happens.
+        expect(provider.saved.clientInformation?.client_id).toBe(cimdUrl);
+        expect(provider.redirectedTo).toHaveLength(1);
+        expect(provider.redirectedTo[0].searchParams.get('client_id')).toBe(cimdUrl);
+        expect(as.registerCalls).toHaveLength(0);
+    } finally {
+        await client.close();
+        await mcpHost.close();
+    }
+});
+
+verifies('client-auth:client-credentials', async (_args: TestArgs) => {
+    const ISSUED = 'cc-issued-access-token';
+    const CLIENT_ID = 'machine-client';
+    const CLIENT_SECRET = 'machine-client-secret';
+
+    const as = createMockAuthorizationServer({
+        tokenResponses: [{ access_token: ISSUED, token_type: 'Bearer' }]
+    });
+    const mcpHost = createAuthenticatedHost(ISSUED);
+    const baseFetch = createCombinedFetch({ as, mcpHost, validToken: ISSUED });
+
+    const mcpAuthHeaders: Array<string | null> = [];
+    const combinedFetch = async (url: URL | string, init?: RequestInit): Promise<Response> => {
+        const urlObj = typeof url === 'string' ? new URL(url) : url;
+        if (urlObj.origin !== ISSUER && !urlObj.pathname.includes('/.well-known/')) {
+            mcpAuthHeaders.push(new Headers(init?.headers).get('authorization'));
+        }
+        return baseFetch(url, init);
+    };
+
+    const provider = new ClientCredentialsProvider({ clientId: CLIENT_ID, clientSecret: CLIENT_SECRET });
+
+    const client = new Client({ name: 'c', version: '0' });
+    const transport = new StreamableHTTPClientTransport(new URL(MCP_URL), { authProvider: provider, fetch: combinedFetch });
+
+    try {
+        await client.connect(transport);
+        const { tools } = await client.listTools();
+        expect(tools.some(t => t.name === 'probe')).toBe(true);
+
+        // Token obtained via the client_credentials grant, authenticated with the configured secret.
+        expect(as.tokenCalls).toHaveLength(1);
+        expect(as.tokenCalls[0].body.get('grant_type')).toBe('client_credentials');
+        const basicHeader = as.tokenCalls[0].headers['authorization'];
+        expect(basicHeader).toMatch(/^Basic /);
+        expect(Buffer.from(basicHeader.split(' ')[1], 'base64').toString()).toBe(`${CLIENT_ID}:${CLIENT_SECRET}`);
+
+        // No user interaction: the authorization endpoint is never visited.
+        expect(as.authorizeCalls).toHaveLength(0);
+
+        // The issued bearer token authorizes every subsequent MCP request.
+        expect(provider.tokens()?.access_token).toBe(ISSUED);
+        expect(mcpAuthHeaders[0]).toBeNull();
+        expect(mcpAuthHeaders.length).toBeGreaterThanOrEqual(2);
+        for (const header of mcpAuthHeaders.slice(1)) {
+            expect(header).toBe(`Bearer ${ISSUED}`);
+        }
+    } finally {
+        await client.close();
+        await mcpHost.close();
+    }
+});
+
+verifies('client-auth:dcr', async (_args: TestArgs) => {
+    const as = createMockAuthorizationServer();
+    const provider = new RecordingOAuthClientProvider();
+    const mcpHost = createAuthenticatedHost('dcr-token');
+    const combinedFetch = createCombinedFetch({ as, mcpHost, validToken: 'dcr-token' });
+
+    const client = new Client({ name: 'c', version: '0' });
+    const transport = new StreamableHTTPClientTransport(new URL(MCP_URL), { authProvider: provider, fetch: combinedFetch });
+
+    try {
+        await expect(client.connect(transport)).rejects.toThrow(UnauthorizedError);
+
+        // No client_id was preconfigured, so the SDK must register at the AS /register endpoint.
+        expect(as.registerCalls).toHaveLength(1);
+        expect(as.registerCalls[0].body.client_name).toBe('Test Client');
+        expect(as.registerCalls[0].body.redirect_uris).toContain('http://localhost:3000/callback');
+
+        // The issued client_id is persisted and used for the authorization request.
+        expect(provider.saved.clientInformation?.client_id).toBe('registered-client-id');
+        expect(provider.redirectedTo).toHaveLength(1);
+        expect(provider.redirectedTo[0].searchParams.get('client_id')).toBe('registered-client-id');
+    } finally {
+        await client.close();
+        await mcpHost.close();
+    }
+});
+
+verifies('client-auth:invalid-client-clears-all', async (_args: TestArgs) => {
+    // Both error codes must clear all stored credentials (client registration and tokens).
+    for (const errorCode of ['invalid_client', 'unauthorized_client']) {
+        const as = createMockAuthorizationServer({
+            tokenErrorResponses: [{ error: errorCode, error_description: 'Client registration is no longer valid' }]
+        });
+        const provider = new RecordingOAuthClientProvider({
+            tokens: { access_token: 'stale-access-token', token_type: 'Bearer', refresh_token: 'stale-refresh-token' },
+            clientInformation: { client_id: 'revoked-client-id', client_secret: 'revoked-client-secret' }
+        });
+        const mcpHost = createAuthenticatedHost('token-never-issued');
+        const combinedFetch = createCombinedFetch({ as, mcpHost, validToken: 'token-never-issued' });
+
+        const client = new Client({ name: 'c', version: '0' });
+        const transport = new StreamableHTTPClientTransport(new URL(MCP_URL), { authProvider: provider, fetch: combinedFetch });
+
+        try {
+            await expect(client.connect(transport)).rejects.toThrow(UnauthorizedError);
+
+            // The refresh attempt with the stale registration is what surfaced the error.
+            expect(as.tokenCalls).toHaveLength(1);
+            expect(as.tokenCalls[0].body.get('grant_type')).toBe('refresh_token');
+
+            // Everything is invalidated: tokens are gone and the stale client_id was discarded,
+            // forcing a fresh dynamic registration on the retry.
+            expect(provider.invalidatedCredentials).toContain('all');
+            expect(provider.saved.tokens).toBeUndefined();
+            expect(as.registerCalls).toHaveLength(1);
+            expect(provider.saved.clientInformation?.client_id).toBe('registered-client-id');
+        } finally {
+            await client.close();
+            await mcpHost.close();
+        }
+    }
+});
+
+verifies('client-auth:invalid-grant-clears-tokens', async (_args: TestArgs) => {
+    const as = createMockAuthorizationServer({
+        tokenErrorResponses: [{ error: 'invalid_grant', error_description: 'Refresh token expired' }]
+    });
+    const provider = new RecordingOAuthClientProvider({
+        tokens: { access_token: 'expired-access-token', token_type: 'Bearer', refresh_token: 'expired-refresh-token' },
+        clientInformation: { client_id: 'still-valid-client' }
+    });
+    const mcpHost = createAuthenticatedHost('token-never-issued');
+    const combinedFetch = createCombinedFetch({ as, mcpHost, validToken: 'token-never-issued' });
+
+    const client = new Client({ name: 'c', version: '0' });
+    const transport = new StreamableHTTPClientTransport(new URL(MCP_URL), { authProvider: provider, fetch: combinedFetch });
+
+    try {
+        await expect(client.connect(transport)).rejects.toThrow(UnauthorizedError);
+
+        // The refresh attempt with the expired grant is what surfaced the error.
+        expect(as.tokenCalls).toHaveLength(1);
+        expect(as.tokenCalls[0].body.get('grant_type')).toBe('refresh_token');
+
+        // Only tokens are invalidated; the client registration is kept and reused (no re-registration).
+        expect(provider.invalidatedCredentials).toContain('tokens');
+        expect(provider.invalidatedCredentials).not.toContain('all');
+        expect(provider.saved.tokens).toBeUndefined();
+        expect(provider.saved.clientInformation?.client_id).toBe('still-valid-client');
+        expect(as.registerCalls).toHaveLength(0);
+    } finally {
+        await client.close();
+        await mcpHost.close();
+    }
+});
+
+verifies('client-auth:pkce:refuse-if-unsupported', async (_args: TestArgs) => {
+    // AS metadata advertises code_challenge_methods_supported without S256 (only "plain").
+    const as = createMockAuthorizationServer({ refusePKCE: true });
+    const provider = new RecordingOAuthClientProvider({ clientInformation: { client_id: 'pkce-strict-client' } });
+    const mcpHost = createAuthenticatedHost('token-never-issued');
+    const combinedFetch = createCombinedFetch({ as, mcpHost, validToken: 'token-never-issued' });
+
+    const client = new Client({ name: 'c', version: '0' });
+    const transport = new StreamableHTTPClientTransport(new URL(MCP_URL), { authProvider: provider, fetch: combinedFetch });
+
+    try {
+        await expect(client.connect(transport)).rejects.toThrow(/S256/);
+
+        // The flow stops before any user redirect or token request.
+        expect(provider.redirectedTo).toHaveLength(0);
+        expect(as.authorizeCalls).toHaveLength(0);
+        expect(as.tokenCalls).toHaveLength(0);
+    } finally {
+        await client.close();
+        await mcpHost.close();
+    }
+});
+
+verifies('client-auth:pkce:s256', async (_args: TestArgs) => {
+    const as = createMockAuthorizationServer({ tokenResponses: [{ access_token: 'pkce-token', token_type: 'Bearer' }] });
+    const provider = new RecordingOAuthClientProvider({ clientInformation: { client_id: 'pkce-client' } });
+    const mcpHost = createAuthenticatedHost('pkce-token');
+
+    const combinedFetch = createCombinedFetch({ as, mcpHost, validToken: 'pkce-token' });
+
+    const client = new Client({ name: 'c', version: '0' });
+    const transport = new StreamableHTTPClientTransport(new URL(MCP_URL), { authProvider: provider, fetch: combinedFetch });
+
+    try {
+        await expect(client.connect(transport)).rejects.toThrow(UnauthorizedError);
+
+        const authorizeUrl = provider.redirectedTo[0];
+        expect(authorizeUrl.searchParams.get('code_challenge_method')).toBe('S256');
+        const challenge = authorizeUrl.searchParams.get('code_challenge');
+        expect(challenge).toBeTruthy();
+
+        const verifier = provider.saved.codeVerifier!;
+        expect(verifier).toMatch(/^[A-Za-z0-9\-._~]{43,128}$/);
+        const expectedChallenge = createHash('sha256').update(verifier).digest('base64url');
+        expect(challenge).toBe(expectedChallenge);
+
+        await transport.finishAuth('mock-code');
+        expect(as.tokenCalls).toHaveLength(1);
+        expect(as.tokenCalls[0].body.get('code_verifier')).toBe(verifier);
+    } finally {
+        await client.close();
+        await mcpHost.close();
+    }
+});
+
+verifies('client-auth:pre-registration', async (_args: TestArgs) => {
+    const as = createMockAuthorizationServer({ tokenResponses: [{ access_token: 'pre-reg-token', token_type: 'Bearer' }] });
+    const provider = new RecordingOAuthClientProvider({
+        clientInformation: { client_id: 'pre-registered-client', client_secret: 'pre-registered-secret' }
+    });
+    const mcpHost = createAuthenticatedHost('pre-reg-token');
+    const combinedFetch = createCombinedFetch({ as, mcpHost, validToken: 'pre-reg-token' });
+
+    const client = new Client({ name: 'c', version: '0' });
+    const transport = new StreamableHTTPClientTransport(new URL(MCP_URL), { authProvider: provider, fetch: combinedFetch });
+
+    try {
+        await expect(client.connect(transport)).rejects.toThrow(UnauthorizedError);
+
+        // DCR is skipped: the preconfigured client_id is what reaches the AS authorize endpoint.
+        expect(as.registerCalls).toHaveLength(0);
+        expect(provider.redirectedTo).toHaveLength(1);
+        expect(provider.redirectedTo[0].origin).toBe(ISSUER);
+        expect(provider.redirectedTo[0].pathname).toBe('/authorize');
+        expect(provider.redirectedTo[0].searchParams.get('client_id')).toBe('pre-registered-client');
+
+        // The token exchange authenticates with the preconfigured secret.
+        await transport.finishAuth('granted-authorization-code');
+        expect(as.tokenCalls).toHaveLength(1);
+        expect(as.tokenCalls[0].body.get('grant_type')).toBe('authorization_code');
+        const basicHeader = as.tokenCalls[0].headers['authorization'];
+        expect(basicHeader).toMatch(/^Basic /);
+        expect(Buffer.from(basicHeader.split(' ')[1], 'base64').toString()).toBe('pre-registered-client:pre-registered-secret');
+    } finally {
+        await client.close();
+        await mcpHost.close();
+    }
+});
+
+verifies('client-auth:private-key-jwt', async (_args: TestArgs) => {
+    const ISSUED = 'jwt-issued-access-token';
+    const CLIENT_ID = 'jwt-machine-client';
+
+    const as = createMockAuthorizationServer({
+        tokenResponses: [{ access_token: ISSUED, token_type: 'Bearer' }]
+    });
+    const mcpHost = createAuthenticatedHost(ISSUED);
+    const combinedFetch = createCombinedFetch({ as, mcpHost, validToken: ISSUED });
+
+    const keyPair = generateKeyPairSync('rsa', { modulusLength: 2048 });
+    const privateKeyPem = keyPair.privateKey.export({ type: 'pkcs8', format: 'pem' }).toString();
+    const publicKeyPem = keyPair.publicKey.export({ type: 'spki', format: 'pem' }).toString();
+
+    const provider = new PrivateKeyJwtProvider({ clientId: CLIENT_ID, privateKey: privateKeyPem, algorithm: 'RS256' });
+
+    const client = new Client({ name: 'c', version: '0' });
+    const transport = new StreamableHTTPClientTransport(new URL(MCP_URL), { authProvider: provider, fetch: combinedFetch });
+
+    try {
+        await client.connect(transport);
+        const { tools } = await client.listTools();
+        expect(tools.some(t => t.name === 'probe')).toBe(true);
+
+        expect(as.tokenCalls).toHaveLength(1);
+        const body = as.tokenCalls[0].body;
+        expect(body.get('grant_type')).toBe('client_credentials');
+        expect(body.get('client_assertion_type')).toBe('urn:ietf:params:oauth:client-assertion-type:jwt-bearer');
+
+        // The client authenticates with a JWT signed by its private key — no shared secret anywhere.
+        expect(body.get('client_secret')).toBeNull();
+        expect(as.tokenCalls[0].headers['authorization']).toBeUndefined();
+
+        const assertion = body.get('client_assertion');
+        expect(assertion).toBeTruthy();
+        const verificationKey = await importSPKI(publicKeyPem, 'RS256');
+        const { payload } = await jwtVerify(assertion!, verificationKey);
+        expect(payload.iss).toBe(CLIENT_ID);
+        expect(payload.sub).toBe(CLIENT_ID);
+        expect(payload.aud).toBe(ISSUER);
+
+        // No user interaction was needed.
+        expect(as.authorizeCalls).toHaveLength(0);
+        expect(provider.tokens()?.access_token).toBe(ISSUED);
+    } finally {
+        await client.close();
+        await mcpHost.close();
+    }
+});
+
+verifies('client-auth:prm-discovery:fallback-order', async (_args: TestArgs) => {
+    const discoveryCalls: string[] = [];
+    const prmMetadata = { resource: RESOURCE, authorization_servers: [ISSUER] };
+
+    const discoveryFetch = async (url: URL | string) => {
+        const urlObj = typeof url === 'string' ? new URL(url) : url;
+        const path = urlObj.pathname;
+        discoveryCalls.push(path);
+
+        if (path === '/.well-known/oauth-protected-resource/mcp') {
+            return new Response(JSON.stringify(prmMetadata), {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' }
+            });
+        }
+
+        return new Response('Not Found', { status: 404 });
+    };
+
+    const result = await discoverOAuthProtectedResourceMetadata(MCP_URL, { protocolVersion: LATEST_PROTOCOL_VERSION }, discoveryFetch);
+    expect(result).toMatchObject(prmMetadata);
+    expect(discoveryCalls[0]).toBe('/.well-known/oauth-protected-resource/mcp');
+});
+
+verifies('client-auth:prm-discovery:no-prm-fallback', async (_args: TestArgs) => {
+    const VALID = 'legacy-fallback-token';
+    const as = createMockAuthorizationServer({
+        noPRMDiscovery: true,
+        tokenResponses: [{ access_token: VALID, token_type: 'Bearer' }]
+    });
+    const provider = new RecordingOAuthClientProvider({ clientInformation: { client_id: 'legacy-fallback-client' } });
+    const mcpHost = createAuthenticatedHost(VALID);
+
+    const wellKnownRequests: string[] = [];
+    // Legacy-style resource server: 401 challenges carry no resource_metadata hint, so the client must probe on its own.
+    const combinedFetch = async (url: URL | string, init?: RequestInit): Promise<Response> => {
+        const urlObj = typeof url === 'string' ? new URL(url) : url;
+        if (urlObj.pathname.includes('/.well-known/')) {
+            wellKnownRequests.push(`${urlObj.origin}${urlObj.pathname}`);
+            return as.handleRequest(new Request(url, init));
+        }
+        if (urlObj.origin === ISSUER) {
+            return as.handleRequest(new Request(url, init));
+        }
+        const h = new Headers(init?.headers);
+        if (h.get('authorization') !== `Bearer ${VALID}`) {
+            return new Response(null, { status: 401, headers: { 'WWW-Authenticate': 'Bearer realm="mcp"' } });
+        }
+        return mcpHost.handleRequest(new Request(url, init));
+    };
+
+    const client = new Client({ name: 'c', version: '0' });
+    const transport = new StreamableHTTPClientTransport(new URL(MCP_URL), { authProvider: provider, fetch: combinedFetch });
+
+    try {
+        await expect(client.connect(transport)).rejects.toThrow(UnauthorizedError);
+
+        // Both PRM probes 404, then AS metadata is discovered directly at the MCP server's origin (legacy 2025-03-26 path).
+        const origin = new URL(MCP_URL).origin;
+        expect(wellKnownRequests).toEqual([
+            `${origin}/.well-known/oauth-protected-resource/mcp`,
+            `${origin}/.well-known/oauth-protected-resource`,
+            `${origin}/.well-known/oauth-authorization-server`
+        ]);
+
+        // The flow proceeds with the authorization endpoint from the origin-discovered metadata instead of aborting.
+        expect(provider.redirectedTo).toHaveLength(1);
+        expect(provider.redirectedTo[0].origin + provider.redirectedTo[0].pathname).toBe(`${ISSUER}/authorize`);
+        expect(provider.redirectedTo[0].searchParams.get('client_id')).toBe('legacy-fallback-client');
+
+        // The same origin-discovered metadata drives the code exchange at the AS token endpoint.
+        await transport.finishAuth('granted-authorization-code');
+        expect(as.tokenCalls).toHaveLength(1);
+        expect(as.tokenCalls[0].body.get('grant_type')).toBe('authorization_code');
+        expect(as.tokenCalls[0].body.get('code')).toBe('granted-authorization-code');
+    } finally {
+        await client.close();
+        await mcpHost.close();
+    }
+});
+
+verifies('client-auth:prm-resource-mismatch', async (_args: TestArgs) => {
+    // PRM document declares a resource that is not the MCP server the client is connecting to.
+    const as = createMockAuthorizationServer({ resourceMismatch: true });
+    const provider = new RecordingOAuthClientProvider();
+    const mcpHost = createAuthenticatedHost('token-never-issued');
+    const combinedFetch = createCombinedFetch({ as, mcpHost, validToken: 'token-never-issued' });
+
+    const client = new Client({ name: 'c', version: '0' });
+    const transport = new StreamableHTTPClientTransport(new URL(MCP_URL), { authProvider: provider, fetch: combinedFetch });
+
+    try {
+        await expect(client.connect(transport)).rejects.toThrow(/resource.*does not match/i);
+
+        // The client refuses before registering, redirecting, or requesting tokens.
+        expect(as.registerCalls).toHaveLength(0);
+        expect(provider.redirectedTo).toHaveLength(0);
+        expect(as.tokenCalls).toHaveLength(0);
+    } finally {
+        await client.close();
+        await mcpHost.close();
+    }
+});
+
+verifies('client-auth:refresh:transparent', async (_args: TestArgs) => {
+    const STALE = 'expired-access-token';
+    const REFRESHED = 'refreshed-access-token';
+
+    const as = createMockAuthorizationServer({
+        tokenResponses: [{ access_token: REFRESHED, token_type: 'Bearer', refresh_token: 'rotated-refresh-token' }]
+    });
+    const provider = new RecordingOAuthClientProvider({
+        tokens: { access_token: STALE, token_type: 'Bearer', refresh_token: 'long-lived-refresh-token' },
+        clientInformation: { client_id: 'refresh-client' }
+    });
+    // Token validity is enforced at the HTTP layer (createCombinedFetch), so the tool itself carries no auth check.
+    const mcpHost = hostPerSession(() => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool('probe', { inputSchema: z.object({}) }, () => ({ content: [{ type: 'text', text: 'ok' }] }));
+        return s;
+    });
+    const baseFetch = createCombinedFetch({ as, mcpHost, validToken: REFRESHED });
+
+    const mcpPostBearers: Array<string | null> = [];
+    const combinedFetch = async (url: URL | string, init?: RequestInit): Promise<Response> => {
+        const urlObj = typeof url === 'string' ? new URL(url) : url;
+        if (urlObj.origin !== ISSUER && !urlObj.pathname.includes('/.well-known/') && init?.method === 'POST') {
+            mcpPostBearers.push(new Headers(init?.headers).get('authorization'));
+        }
+        return baseFetch(url, init);
+    };
+
+    const client = new Client({ name: 'c', version: '0' });
+    const transport = new StreamableHTTPClientTransport(new URL(MCP_URL), { authProvider: provider, fetch: combinedFetch });
+
+    try {
+        await client.connect(transport);
+        const result = await client.callTool({ name: 'probe', arguments: {} });
+        expect(result.content).toEqual([{ type: 'text', text: 'ok' }]);
+
+        // Exactly one refresh_token grant, carrying the stored refresh token and the resource indicator.
+        expect(as.tokenCalls).toHaveLength(1);
+        expect(as.tokenCalls[0].body.get('grant_type')).toBe('refresh_token');
+        expect(as.tokenCalls[0].body.get('refresh_token')).toBe('long-lived-refresh-token');
+        expect(as.tokenCalls[0].body.get('resource')).toBe(RESOURCE);
+
+        // The refresh is transparent (no user-facing redirect) and the rotated token set is persisted.
+        expect(provider.redirectedTo).toHaveLength(0);
+        expect(provider.saved.tokens?.access_token).toBe(REFRESHED);
+        expect(provider.saved.tokens?.refresh_token).toBe('rotated-refresh-token');
+
+        // Only the rejected initialize used the expired bearer; its retry, initialized, and tools/call all use the new one.
+        expect(mcpPostBearers).toEqual([`Bearer ${STALE}`, `Bearer ${REFRESHED}`, `Bearer ${REFRESHED}`, `Bearer ${REFRESHED}`]);
+    } finally {
+        await client.close();
+        await mcpHost.close();
+    }
+});
+
+verifies('client-auth:resource-parameter', async (_args: TestArgs) => {
+    const as = createMockAuthorizationServer({ tokenResponses: [{ access_token: 'resource-param-token', token_type: 'Bearer' }] });
+    const provider = new RecordingOAuthClientProvider({ clientInformation: { client_id: 'resource-test-client' } });
+    const mcpHost = createAuthenticatedHost('resource-param-token');
+
+    const combinedFetch = createCombinedFetch({ as, mcpHost, validToken: 'resource-param-token' });
+
+    const client = new Client({ name: 'c', version: '0' });
+    const transport = new StreamableHTTPClientTransport(new URL(MCP_URL), { authProvider: provider, fetch: combinedFetch });
+
+    try {
+        await expect(client.connect(transport)).rejects.toThrow(UnauthorizedError);
+
+        const authorizeUrl = provider.redirectedTo[0];
+        expect(authorizeUrl.searchParams.get('resource')).toBe(RESOURCE);
+
+        await transport.finishAuth('mock-code');
+        expect(as.tokenCalls[0].body.get('resource')).toBe(RESOURCE);
+    } finally {
+        await client.close();
+        await mcpHost.close();
+    }
+});
+
+verifies('client-auth:scope-selection:priority', async (_args: TestArgs) => {
+    const as = createMockAuthorizationServer({ tokenResponses: [{ access_token: 'scope-token', token_type: 'Bearer' }] });
+    const provider = new RecordingOAuthClientProvider({ clientInformation: { client_id: 'scope-client' } });
+    const mcpHost = createAuthenticatedHost('scope-token');
+
+    const combinedFetch = (url: URL | string, init?: RequestInit) => {
+        const urlObj = typeof url === 'string' ? new URL(url) : url;
+        if (urlObj.origin === ISSUER) {
+            return as.handleRequest(new Request(url, init));
+        }
+        const h = new Headers(init?.headers);
+        if (!h.has('authorization')) {
+            return Promise.resolve(
+                new Response(null, {
+                    status: 401,
+                    headers: {
+                        'WWW-Authenticate': `Bearer resource_metadata="${MCP_URL}/.well-known/oauth-protected-resource" scope="mcp:custom"`
+                    }
+                })
+            );
+        }
+        return mcpHost.handleRequest(new Request(url, init));
+    };
+
+    const client = new Client({ name: 'c', version: '0' });
+    const transport = new StreamableHTTPClientTransport(new URL(MCP_URL), { authProvider: provider, fetch: combinedFetch });
+
+    try {
+        await expect(client.connect(transport)).rejects.toThrow(UnauthorizedError);
+        const authorizeUrl = provider.redirectedTo[0];
+        expect(authorizeUrl.searchParams.get('scope')).toBe('mcp:custom');
+    } finally {
+        await client.close();
+        await mcpHost.close();
+    }
+});
+
+verifies('typescript:client-auth:state:verify', async (_args: TestArgs) => {
+    const as = createMockAuthorizationServer();
+    const provider = new RecordingOAuthClientProvider({ clientInformation: { client_id: 'state-client' } });
+    const mcpHost = createAuthenticatedHost('state-token');
+
+    const combinedFetch = (url: URL | string, init?: RequestInit) => {
+        const urlObj = typeof url === 'string' ? new URL(url) : url;
+        if (urlObj.origin === ISSUER) {
+            return as.handleRequest(new Request(url, init));
+        }
+        const h = new Headers(init?.headers);
+        if (!h.has('authorization')) {
+            return Promise.resolve(
+                new Response(null, {
+                    status: 401,
+                    headers: { 'WWW-Authenticate': `Bearer resource_metadata="${MCP_URL}/.well-known/oauth-protected-resource"` }
+                })
+            );
+        }
+        return mcpHost.handleRequest(new Request(url, init));
+    };
+
+    const client = new Client({ name: 'c', version: '0' });
+    const transport = new StreamableHTTPClientTransport(new URL(MCP_URL), { authProvider: provider, fetch: combinedFetch });
+
+    try {
+        await expect(client.connect(transport)).rejects.toThrow(UnauthorizedError);
+        const authorizeUrl = provider.redirectedTo[0];
+        expect(authorizeUrl.searchParams.get('state')).toBe(provider.saved.state);
+        expect(provider.saved.state).toMatch(/^state-\d+$/);
+    } finally {
+        await client.close();
+        await mcpHost.close();
+    }
+});
+
+verifies('client-auth:token-endpoint-auth-method', async (_args: TestArgs) => {
+    // The registration response dictates how the client authenticates to /token.
+    const REGISTERED_ID = 'auth-method-client';
+    const REGISTERED_SECRET = 'auth-method-client-secret';
+
+    for (const method of ['client_secret_basic', 'client_secret_post', 'none'] as const) {
+        const as = createMockAuthorizationServer({
+            tokenResponses: [{ access_token: 'auth-method-access-token', token_type: 'Bearer' }],
+            registerResponse:
+                method === 'none'
+                    ? // Public client: client_secret: undefined suppresses the mock's default issued secret.
+                      { client_id: REGISTERED_ID, client_secret: undefined, token_endpoint_auth_method: method }
+                    : { client_id: REGISTERED_ID, client_secret: REGISTERED_SECRET, token_endpoint_auth_method: method }
+        });
+        const provider = new RecordingOAuthClientProvider();
+        const mcpHost = createAuthenticatedHost('auth-method-access-token');
+        const combinedFetch = createCombinedFetch({ as, mcpHost, validToken: 'auth-method-access-token' });
+
+        const client = new Client({ name: 'c', version: '0' });
+        const transport = new StreamableHTTPClientTransport(new URL(MCP_URL), { authProvider: provider, fetch: combinedFetch });
+
+        try {
+            await expect(client.connect(transport)).rejects.toThrow(UnauthorizedError);
+            expect(provider.saved.clientInformation?.client_id).toBe(REGISTERED_ID);
+
+            await transport.finishAuth('granted-authorization-code');
+
+            expect(as.tokenCalls).toHaveLength(1);
+            const tokenCall = as.tokenCalls[0];
+            expect(tokenCall.body.get('grant_type')).toBe('authorization_code');
+
+            if (method === 'client_secret_basic') {
+                const authHeader = tokenCall.headers['authorization'];
+                expect(authHeader).toMatch(/^Basic /);
+                expect(Buffer.from(authHeader.split(' ')[1], 'base64').toString()).toBe(`${REGISTERED_ID}:${REGISTERED_SECRET}`);
+                expect(tokenCall.body.get('client_secret')).toBeNull();
+            } else if (method === 'client_secret_post') {
+                // client_secret_post: credentials travel in the form body, not the Authorization header.
+                expect(tokenCall.headers['authorization']).toBeUndefined();
+                expect(tokenCall.body.get('client_id')).toBe(REGISTERED_ID);
+                expect(tokenCall.body.get('client_secret')).toBe(REGISTERED_SECRET);
+            } else {
+                // none: public client identifies via client_id in the body only — no secret, no Authorization header.
+                expect(tokenCall.headers['authorization']).toBeUndefined();
+                expect(tokenCall.body.get('client_id')).toBe(REGISTERED_ID);
+                expect(tokenCall.body.get('client_secret')).toBeNull();
+            }
+        } finally {
+            await client.close();
+            await mcpHost.close();
+        }
+    }
+});
+
+verifies('client-auth:low-level:discover-and-exchange', async (_args: TestArgs) => {
+    const as = createMockAuthorizationServer({
+        tokenResponses: [{ access_token: 'low-level-access-token', token_type: 'Bearer' }]
+    });
+    const discoveryFetch = (url: URL | string, init?: RequestInit) => as.handleRequest(new Request(url, init));
+
+    const clientInformation = { client_id: 'low-level-public-client' };
+    const redirectUri = 'http://localhost:3000/callback';
+
+    const prm = await discoverOAuthProtectedResourceMetadata(MCP_URL, { protocolVersion: LATEST_PROTOCOL_VERSION }, discoveryFetch);
+    expect(prm.resource).toBe(RESOURCE);
+    expect(prm.authorization_servers).toContain(ISSUER);
+
+    const authorizationServer = prm.authorization_servers?.[0];
+    if (!authorizationServer) throw new Error('protected resource metadata did not list an authorization server');
+
+    const asMetadata = await discoverAuthorizationServerMetadata(authorizationServer, {
+        protocolVersion: LATEST_PROTOCOL_VERSION,
+        fetchFn: discoveryFetch
+    });
+    if (!asMetadata) throw new Error('authorization server metadata discovery returned undefined');
+    expect(asMetadata.authorization_endpoint).toBe(`${ISSUER}/authorize`);
+    expect(asMetadata.token_endpoint).toBe(`${ISSUER}/token`);
+
+    const { authorizationUrl, codeVerifier } = await startAuthorization(authorizationServer, {
+        metadata: asMetadata,
+        clientInformation,
+        redirectUrl: redirectUri,
+        scope: prm.scopes_supported?.join(' '),
+        resource: new URL(prm.resource)
+    });
+
+    expect(authorizationUrl.origin + authorizationUrl.pathname).toBe(asMetadata.authorization_endpoint);
+    expect(authorizationUrl.searchParams.get('response_type')).toBe('code');
+    expect(authorizationUrl.searchParams.get('client_id')).toBe(clientInformation.client_id);
+    expect(authorizationUrl.searchParams.get('redirect_uri')).toBe(redirectUri);
+    expect(authorizationUrl.searchParams.get('resource')).toBe(prm.resource);
+    expect(authorizationUrl.searchParams.get('scope')).toBe('mcp:read mcp:write');
+    expect(authorizationUrl.searchParams.get('code_challenge_method')).toBe('S256');
+    // The challenge in the URL must be the S256 transform of the verifier the helper handed back.
+    expect(authorizationUrl.searchParams.get('code_challenge')).toBe(createHash('sha256').update(codeVerifier).digest('base64url'));
+
+    const tokens = await exchangeAuthorization(authorizationServer, {
+        metadata: asMetadata,
+        clientInformation,
+        authorizationCode: 'granted-authorization-code',
+        redirectUri,
+        codeVerifier,
+        resource: new URL(prm.resource),
+        fetchFn: discoveryFetch
+    });
+
+    expect(tokens.access_token).toBe('low-level-access-token');
+    expect(as.tokenCalls).toHaveLength(1);
+    const tokenBody = as.tokenCalls[0].body;
+    expect(tokenBody.get('grant_type')).toBe('authorization_code');
+    expect(tokenBody.get('code')).toBe('granted-authorization-code');
+    expect(tokenBody.get('code_verifier')).toBe(codeVerifier);
+    expect(tokenBody.get('redirect_uri')).toBe(redirectUri);
+    expect(tokenBody.get('resource')).toBe(prm.resource);
+    expect(tokenBody.get('client_id')).toBe(clientInformation.client_id);
+});
+
+verifies('client-auth:private-key-jwt:static-assertion', async (_args: TestArgs) => {
+    const ISSUED = 'static-jwt-issued-access-token';
+    const CLIENT_ID = 'static-assertion-client';
+
+    const keyPair = generateKeyPairSync('rsa', { modulusLength: 2048 });
+    const privateKeyPem = keyPair.privateKey.export({ type: 'pkcs8', format: 'pem' }).toString();
+
+    const payload = JSON.stringify({
+        iss: CLIENT_ID,
+        sub: CLIENT_ID,
+        aud: `${ISSUER}/token`,
+        exp: Math.floor(Date.now() / 1000) + 3600,
+        iat: Math.floor(Date.now() / 1000)
+    });
+
+    const header = JSON.stringify({ alg: 'RS256', typ: 'JWT' });
+    const encodedHeader = Buffer.from(header).toString('base64url');
+    const encodedPayload = Buffer.from(payload).toString('base64url');
+    const signatureInput = `${encodedHeader}.${encodedPayload}`;
+    const signature = sign('sha256', Buffer.from(signatureInput), privateKeyPem);
+    const preBuiltJwt = `${signatureInput}.${signature.toString('base64url')}`;
+
+    const as = createMockAuthorizationServer({
+        tokenResponses: [{ access_token: ISSUED, token_type: 'Bearer' }]
+    });
+    const mcpHost = createAuthenticatedHost(ISSUED);
+    const combinedFetch = createCombinedFetch({ as, mcpHost, validToken: ISSUED });
+
+    const provider = new StaticPrivateKeyJwtProvider({
+        clientId: CLIENT_ID,
+        jwtBearerAssertion: preBuiltJwt
+    });
+
+    const client = new Client({ name: 'c', version: '0' });
+    const transport = new StreamableHTTPClientTransport(new URL(MCP_URL), { authProvider: provider, fetch: combinedFetch });
+
+    try {
+        await client.connect(transport);
+        const { tools } = await client.listTools();
+        expect(tools.some(t => t.name === 'probe')).toBe(true);
+
+        // The pre-built assertion is sent verbatim — no per-request signing changes it.
+        expect(as.tokenCalls).toHaveLength(1);
+        const body = as.tokenCalls[0].body;
+        expect(body.get('grant_type')).toBe('client_credentials');
+        expect(body.get('client_assertion')).toBe(preBuiltJwt);
+        expect(body.get('client_assertion_type')).toBe('urn:ietf:params:oauth:client-assertion-type:jwt-bearer');
+
+        // Fixed client_id, so DCR is skipped and no user interaction occurs.
+        expect(as.registerCalls).toHaveLength(0);
+        expect(as.authorizeCalls).toHaveLength(0);
+        expect(provider.tokens()?.access_token).toBe(ISSUED);
+    } finally {
+        await client.close();
+        await mcpHost.close();
+    }
+});
+
+verifies('client-middleware:compose', async (_args: TestArgs) => {
+    const TRACE = 'x-mw-trace';
+
+    const appendTrace = (init: RequestInit | undefined, tag: string): Headers => {
+        const headers = new Headers(init?.headers);
+        const prior = headers.get(TRACE);
+        headers.set(TRACE, prior ? `${prior}>${tag}` : tag);
+        return headers;
+    };
+
+    const first = createMiddleware(async (next, input, init) => {
+        const headers = appendTrace(init, 'first');
+        headers.set('x-mw-first', '1');
+        return next(input, { ...init, headers });
+    });
+
+    const second = createMiddleware(async (next, input, init) => {
+        const headers = appendTrace(init, 'second');
+        headers.set('x-mw-second', '1');
+        return next(input, { ...init, headers });
+    });
+
+    const seenByServer: IsomorphicHeaders[] = [];
+    const mcpHost = hostPerSession(() => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool('report-headers', { inputSchema: z.object({}) }, (_a, extra) => {
+            seenByServer.push(extra.requestInfo?.headers ?? {});
+            return { content: [{ type: 'text', text: 'ok' }] };
+        });
+        return s;
+    });
+
+    const baseRequests: Array<{ method: string; headers: Record<string, string> }> = [];
+    const baseFetch = async (url: URL | string, init?: RequestInit) => {
+        const headers: Record<string, string> = {};
+        new Headers(init?.headers).forEach((v, k) => {
+            headers[k] = v;
+        });
+        baseRequests.push({ method: init?.method ?? 'GET', headers });
+        return mcpHost.handleRequest(new Request(url, init));
+    };
+
+    const client = new Client({ name: 'c', version: '0' });
+    const transport = new StreamableHTTPClientTransport(new URL(MCP_URL), { fetch: applyMiddlewares(first, second)(baseFetch) });
+
+    try {
+        await client.connect(transport);
+        const result = await client.callTool({ name: 'report-headers', arguments: {} });
+        expect(result.content).toEqual([{ type: 'text', text: 'ok' }]);
+
+        // Every HTTP request the transport made passed through both layers before the base fetch.
+        expect(baseRequests.filter(r => r.method === 'POST')).toHaveLength(3);
+        for (const req of baseRequests) {
+            expect(req.headers['x-mw-first']).toBe('1');
+            expect(req.headers['x-mw-second']).toBe('1');
+            expect(req.headers[TRACE]).toBe('second>first');
+        }
+
+        // The middleware-set headers arrived at the MCP server on the tools/call request.
+        expect(seenByServer).toHaveLength(1);
+        expect(seenByServer[0]['x-mw-first']).toBe('1');
+        expect(seenByServer[0]['x-mw-second']).toBe('1');
+        expect(seenByServer[0][TRACE]).toBe('second>first');
+    } finally {
+        await client.close();
+        await mcpHost.close();
+    }
+});
+
+verifies('client-middleware:with-logging', async (_args: TestArgs) => {
+    const logs: Array<{ method: string; url: string | URL; status: number; duration: number }> = [];
+    const logger = (input: { method: string; url: string | URL; status: number; duration: number }) => {
+        logs.push({ method: input.method, url: input.url, status: input.status, duration: input.duration });
+    };
+
+    const mcpHost = hostPerSession(() => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool('greet', { inputSchema: z.object({ name: z.string() }) }, ({ name }) => ({
+            content: [{ type: 'text', text: `Hello, ${name}!` }]
+        }));
+        return s;
+    });
+
+    const httpRequests: Array<{ method: string; url: string }> = [];
+    const baseFetch = async (url: URL | string, init?: RequestInit) => {
+        httpRequests.push({ method: init?.method ?? 'GET', url: String(url) });
+        return mcpHost.handleRequest(new Request(url, init));
+    };
+
+    const client = new Client({ name: 'c', version: '0' });
+    const transport = new StreamableHTTPClientTransport(new URL(MCP_URL), { fetch: withLogging({ logger })(baseFetch) });
+
+    try {
+        await client.connect(transport);
+        const result = await client.callTool({ name: 'greet', arguments: { name: 'Ada' } });
+
+        // The response is passed through unmodified: the MCP call result is exactly what the server returned.
+        expect(result.content).toEqual([{ type: 'text', text: 'Hello, Ada!' }]);
+
+        // Restrict to POSTs: the standalone SSE GET is fire-and-forget, so its log entry timing is not deterministic.
+        const postRequests = httpRequests.filter(r => r.method === 'POST');
+        const postLogs = logs.filter(l => l.method === 'POST');
+        expect(postRequests).toHaveLength(3);
+        // One log entry per HTTP request: initialize (200), notifications/initialized (202), tools/call (200).
+        expect(postLogs.map(l => l.status)).toEqual([200, 202, 200]);
+        for (const log of postLogs) {
+            expect(String(log.url)).toBe(MCP_URL);
+            expect(log.duration).toBeGreaterThan(0);
+        }
+    } finally {
+        await client.close();
+        await mcpHost.close();
+    }
+});
+
+verifies('client-auth:middleware:with-oauth', async (_args: TestArgs) => {
+    const STALE = 'stale-access-token';
+    const REFRESHED = 'refreshed-access-token';
+    const wwwAuthenticate = `Bearer resource_metadata="${MCP_URL}/.well-known/oauth-protected-resource"`;
+
+    // Phase 1: bearer header from tokens(); on 401 the middleware refreshes and retries once with the new token.
+    const refreshAs = createMockAuthorizationServer({
+        tokenResponses: [{ access_token: REFRESHED, token_type: 'Bearer', refresh_token: 'rotated-refresh-token' }]
+    });
+    const mcpHost = createAuthenticatedHost(REFRESHED);
+    const refreshProvider = new RecordingOAuthClientProvider({
+        clientInformation: { client_id: 'oauth-middleware-client' },
+        tokens: { access_token: STALE, token_type: 'Bearer', refresh_token: 'initial-refresh-token' }
+    });
+
+    const mcpAuthHeaders: Array<string | null> = [];
+    const refreshBaseFetch = async (url: URL | string, init?: RequestInit): Promise<Response> => {
+        const urlObj = typeof url === 'string' ? new URL(url) : url;
+        if (urlObj.origin === ISSUER || urlObj.pathname.includes('/.well-known/')) {
+            return refreshAs.handleRequest(new Request(url, init));
+        }
+        const authHeader = new Headers(init?.headers).get('authorization');
+        mcpAuthHeaders.push(authHeader);
+        if (authHeader !== `Bearer ${REFRESHED}`) {
+            return new Response(null, { status: 401, headers: { 'WWW-Authenticate': wwwAuthenticate } });
+        }
+        return mcpHost.handleRequest(new Request(url, init));
+    };
+
+    const client = new Client({ name: 'c', version: '0' });
+    const transport = new StreamableHTTPClientTransport(new URL(MCP_URL), {
+        fetch: withOAuth(refreshProvider, MCP_URL)(refreshBaseFetch)
+    });
+
+    try {
+        await client.connect(transport);
+
+        expect(refreshProvider.saved.tokens?.access_token).toBe(REFRESHED);
+        expect(refreshAs.tokenCalls).toHaveLength(1);
+        expect(refreshAs.tokenCalls[0].body.get('grant_type')).toBe('refresh_token');
+        expect(refreshAs.tokenCalls[0].body.get('refresh_token')).toBe('initial-refresh-token');
+
+        expect(mcpAuthHeaders.length).toBeGreaterThanOrEqual(2);
+        expect(mcpAuthHeaders[0]).toBe(`Bearer ${STALE}`);
+        for (const header of mcpAuthHeaders.slice(1)) {
+            expect(header).toBe(`Bearer ${REFRESHED}`);
+        }
+    } finally {
+        await client.close();
+        await mcpHost.close();
+    }
+
+    // Phase 2: a REDIRECT auth result (no refresh token, interactive flow needed) surfaces as UnauthorizedError.
+    const redirectAs = createMockAuthorizationServer();
+    const redirectProvider = new RecordingOAuthClientProvider({
+        clientInformation: { client_id: 'oauth-middleware-client' },
+        tokens: { access_token: STALE, token_type: 'Bearer' }
+    });
+    const redirectBaseFetch = async (url: URL | string, init?: RequestInit): Promise<Response> => {
+        const urlObj = typeof url === 'string' ? new URL(url) : url;
+        if (urlObj.origin === ISSUER || urlObj.pathname.includes('/.well-known/')) {
+            return redirectAs.handleRequest(new Request(url, init));
+        }
+        return new Response(null, { status: 401, headers: { 'WWW-Authenticate': wwwAuthenticate } });
+    };
+    const redirectingFetch = withOAuth(redirectProvider, MCP_URL)(redirectBaseFetch);
+
+    const redirectAttempt = redirectingFetch(MCP_URL, { method: 'POST' });
+    await expect(redirectAttempt).rejects.toBeInstanceOf(UnauthorizedError);
+    await expect(redirectAttempt).rejects.toThrow(/redirect initiated/);
+    expect(redirectProvider.redirectedTo).toHaveLength(1);
+
+    // Phase 3: a second 401 after a successful re-auth throws instead of retrying again.
+    const stubbornAs = createMockAuthorizationServer({
+        tokenResponses: [{ access_token: REFRESHED, token_type: 'Bearer' }]
+    });
+    const stubbornProvider = new RecordingOAuthClientProvider({
+        clientInformation: { client_id: 'oauth-middleware-client' },
+        tokens: { access_token: STALE, token_type: 'Bearer', refresh_token: 'initial-refresh-token' }
+    });
+    let stubbornMcpRequests = 0;
+    const stubbornBaseFetch = async (url: URL | string, init?: RequestInit): Promise<Response> => {
+        const urlObj = typeof url === 'string' ? new URL(url) : url;
+        if (urlObj.origin === ISSUER || urlObj.pathname.includes('/.well-known/')) {
+            return stubbornAs.handleRequest(new Request(url, init));
+        }
+        stubbornMcpRequests++;
+        return new Response(null, { status: 401, headers: { 'WWW-Authenticate': wwwAuthenticate } });
+    };
+    const stubbornFetch = withOAuth(stubbornProvider, MCP_URL)(stubbornBaseFetch);
+
+    const stubbornAttempt = stubbornFetch(MCP_URL, { method: 'POST' });
+    await expect(stubbornAttempt).rejects.toBeInstanceOf(UnauthorizedError);
+    await expect(stubbornAttempt).rejects.toThrow(/Authentication failed for/);
+    expect(stubbornAs.tokenCalls).toHaveLength(1);
+    expect(stubbornMcpRequests).toBe(2);
+});

--- a/test/e2e/scenarios/completion.test.ts
+++ b/test/e2e/scenarios/completion.test.ts
@@ -1,0 +1,355 @@
+/**
+ * Self-contained test bodies for the completion surface.
+ *
+ * Completion provides autocompletion for prompt arguments and resource template
+ * variables. The server declares the `completions` capability and handles
+ * `completion/complete` requests, returning up to 100 string suggestions based
+ * on the partial value and optional context (already-resolved variables).
+ */
+
+import { expect } from 'vitest';
+import { z } from 'zod/v4';
+
+import { Client } from '../../../src/client/index.js';
+import { Server } from '../../../src/server/index.js';
+import { completable } from '../../../src/server/completable.js';
+import { McpServer, ResourceTemplate } from '../../../src/server/mcp.js';
+import {
+    CompleteRequestSchema,
+    CompleteResultSchema,
+    ErrorCode,
+    ListPromptsRequestSchema,
+    ListResourcesRequestSchema,
+    McpError,
+    ReadResourceRequestSchema
+} from '../../../src/types.js';
+
+import { wire } from '../helpers/index.js';
+import type { TestArgs } from '../types.js';
+import { verifies } from '../helpers/verifies.js';
+
+const COLORS = ['red', 'green', 'blue', 'rebeccapurple'] as const;
+const FILE_PATHS = ['README.md', 'src/index.ts', 'src/types.ts'] as const;
+const REPOS_BY_OWNER: Record<string, readonly string[]> = {
+    'acme-corp': ['widget-sdk', 'gadget-sdk', 'docs'],
+    globex: ['frobnicator', 'reticulator']
+};
+const MANY_TOTAL = 150;
+
+const newClient = () => new Client({ name: 'c', version: '0' });
+
+function colorCompletionServer(): McpServer {
+    const s = new McpServer({ name: 's', version: '0' });
+    s.registerPrompt(
+        'complete-color',
+        { argsSchema: { color: completable(z.string(), value => COLORS.filter(c => c.startsWith(value))) } },
+        ({ color }) => ({ messages: [{ role: 'user', content: { type: 'text', text: `color=${color}` } }] })
+    );
+    return s;
+}
+
+verifies('completion:capability:declared', async ({ transport }: TestArgs) => {
+    const client = newClient();
+    await using _ = await wire(transport, colorCompletionServer, client);
+
+    const caps = client.getServerCapabilities();
+    expect(caps?.completions).toBeDefined();
+    expect(typeof caps?.completions).toBe('object');
+
+    const result = await client.complete({
+        ref: { type: 'ref/prompt', name: 'complete-color' },
+        argument: { name: 'color', value: '' }
+    });
+    expect(Array.isArray(result.completion.values)).toBe(true);
+});
+
+verifies('completion:complete:not-supported', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerPrompt('summarize-code', { argsSchema: { code: z.string() } }, ({ code }) => ({
+            messages: [{ role: 'user', content: { type: 'text', text: `Summarize the following code:\n${code}` } }]
+        }));
+        return s;
+    };
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    const caps = client.getServerCapabilities();
+    expect(caps).toBeDefined();
+    expect(caps?.completions).toBeUndefined();
+    expect(caps?.prompts).toBeDefined();
+
+    // Raw request bypasses any client-side capability gating, so the rejection observed is the server's own.
+    await expect(
+        client.request(
+            {
+                method: 'completion/complete',
+                params: { ref: { type: 'ref/prompt', name: 'summarize-code' }, argument: { name: 'code', value: 'co' } }
+            },
+            CompleteResultSchema
+        )
+    ).rejects.toMatchObject({ code: ErrorCode.MethodNotFound });
+});
+
+verifies('completion:context-arguments', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerResource(
+            'github-repo',
+            new ResourceTemplate('github://{owner}/{repo}', {
+                list: undefined,
+                complete: {
+                    repo: (value, context) => {
+                        const owner = context?.arguments?.owner;
+                        if (!owner || typeof owner !== 'string') return [];
+                        const repos = REPOS_BY_OWNER[owner] ?? [];
+                        return repos.filter(r => r.startsWith(value));
+                    }
+                }
+            }),
+            { mimeType: 'text/plain' },
+            (uri, { owner, repo }) => ({ contents: [{ uri: uri.href, mimeType: 'text/plain', text: `${owner}/${repo}` }] })
+        );
+        return s;
+    };
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    const acme = await client.complete({
+        ref: { type: 'ref/resource', uri: 'github://{owner}/{repo}' },
+        argument: { name: 'repo', value: '' },
+        context: { arguments: { owner: 'acme-corp' } }
+    });
+    expect(acme.completion.values).toEqual(['widget-sdk', 'gadget-sdk', 'docs']);
+
+    const globex = await client.complete({
+        ref: { type: 'ref/resource', uri: 'github://{owner}/{repo}' },
+        argument: { name: 'repo', value: '' },
+        context: { arguments: { owner: 'globex' } }
+    });
+    expect(globex.completion.values).toEqual(['frobnicator', 'reticulator']);
+    expect(acme.completion.values).not.toEqual(globex.completion.values);
+
+    const bare = await client.complete({
+        ref: { type: 'ref/resource', uri: 'github://{owner}/{repo}' },
+        argument: { name: 'repo', value: '' }
+    });
+    expect(bare.completion.values).toEqual([]);
+});
+
+verifies(
+    'completion:error:invalid-ref',
+    async ({ transport }: TestArgs) => {
+        const client = newClient();
+        await using _ = await wire(transport, colorCompletionServer, client);
+
+        await expect(
+            client.complete({ ref: { type: 'ref/prompt', name: 'no-such-prompt' }, argument: { name: 'whatever', value: '' } })
+        ).rejects.toMatchObject({ code: ErrorCode.InvalidParams });
+
+        await expect(
+            client.complete({ ref: { type: 'ref/resource', uri: 'nosuchscheme://nowhere/{x}' }, argument: { name: 'x', value: '' } })
+        ).rejects.toMatchObject({ code: ErrorCode.InvalidParams });
+    },
+    { title: 'mcpserver' }
+);
+
+verifies(
+    'completion:error:invalid-ref',
+    async ({ transport }: TestArgs) => {
+        const makeServer = () => {
+            const s = new Server({ name: 's', version: '0' }, { capabilities: { completions: {} } });
+            s.setRequestHandler(CompleteRequestSchema, req => {
+                if (req.params.ref.type === 'ref/prompt' && req.params.ref.name === 'known') {
+                    return { completion: { values: ['ok'] } };
+                }
+                throw new McpError(ErrorCode.InvalidParams, `No completion target: ${JSON.stringify(req.params.ref)}`);
+            });
+            return s;
+        };
+        const client = newClient();
+        await using _ = await wire(transport, makeServer, client);
+
+        const known = await client.complete({ ref: { type: 'ref/prompt', name: 'known' }, argument: { name: 'a', value: '' } });
+        expect(known.completion.values).toEqual(['ok']);
+
+        await expect(
+            client.complete({ ref: { type: 'ref/prompt', name: 'no-such-prompt' }, argument: { name: 'a', value: '' } })
+        ).rejects.toMatchObject({ code: ErrorCode.InvalidParams });
+    },
+    { title: 'raw server' }
+);
+
+verifies('completion:prompt-arg', async ({ transport }: TestArgs) => {
+    const client = newClient();
+    await using _ = await wire(transport, colorCompletionServer, client);
+
+    const result = await client.complete({
+        ref: { type: 'ref/prompt', name: 'complete-color' },
+        argument: { name: 'color', value: 're' }
+    });
+
+    const expected = COLORS.filter(c => c.startsWith('re'));
+    expect(result.completion.values).toEqual(expected);
+    expect(result.completion.hasMore ?? false).toBe(false);
+});
+
+verifies('completion:resource-template-arg', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerResource(
+            'file-path',
+            new ResourceTemplate('completion://files/{path}', {
+                list: undefined,
+                complete: { path: value => FILE_PATHS.filter(p => p.startsWith(value)) }
+            }),
+            { mimeType: 'text/plain' },
+            (uri, { path }) => ({ contents: [{ uri: uri.href, mimeType: 'text/plain', text: `path=${path}` }] })
+        );
+        s.registerResource(
+            'github-repo',
+            new ResourceTemplate('github://{owner}/{repo}', {
+                list: undefined,
+                complete: { owner: () => [] }
+            }),
+            { mimeType: 'text/plain' },
+            (uri, { owner, repo }) => ({ contents: [{ uri: uri.href, mimeType: 'text/plain', text: `${owner}/${repo}` }] })
+        );
+        return s;
+    };
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    const result = await client.complete({
+        ref: { type: 'ref/resource', uri: 'completion://files/{path}' },
+        argument: { name: 'path', value: 'src/' }
+    });
+
+    expect(result.completion.values).toEqual(['src/index.ts', 'src/types.ts']);
+    expect(result.completion.hasMore ?? false).toBe(false);
+
+    const other = await client.complete({
+        ref: { type: 'ref/resource', uri: 'github://{owner}/{repo}' },
+        argument: { name: 'path', value: 'src/' }
+    });
+
+    expect(other.completion.values).toEqual([]);
+});
+
+verifies('completion:result-shape', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerPrompt(
+            'complete-color',
+            { argsSchema: { color: completable(z.string(), value => COLORS.filter(c => c.startsWith(value))) } },
+            ({ color }) => ({ messages: [{ role: 'user', content: { type: 'text', text: `color=${color}` } }] })
+        );
+        const many = Array.from({ length: MANY_TOTAL }, (_, i) => `item-${String(i).padStart(3, '0')}`);
+        s.registerPrompt(
+            'complete-many',
+            { argsSchema: { n: completable(z.string(), value => many.filter(s => s.startsWith(value))) } },
+            ({ n }) => ({ messages: [{ role: 'user', content: { type: 'text', text: n } }] })
+        );
+        return s;
+    };
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    const small = await client.complete({
+        ref: { type: 'ref/prompt', name: 'complete-color' },
+        argument: { name: 'color', value: 're' }
+    });
+
+    expect(Array.isArray(small.completion.values)).toBe(true);
+    expect(small.completion.values).toEqual(COLORS.filter(c => c.startsWith('re')));
+    expect(small.completion.values.length).toBeLessThanOrEqual(100);
+    expect(small.completion.total).toBe(small.completion.values.length);
+    expect(small.completion.total).toBe(2);
+    expect(small.completion.hasMore).toBe(false);
+
+    const empty = await client.complete({
+        ref: { type: 'ref/prompt', name: 'complete-color' },
+        argument: { name: 'no-such-arg', value: '' }
+    });
+
+    expect(empty.completion.values).toEqual([]);
+    expect(empty.completion.total).toBeUndefined();
+    expect(empty.completion.hasMore).toBe(false);
+
+    const many = await client.complete({
+        ref: { type: 'ref/prompt', name: 'complete-many' },
+        argument: { name: 'n', value: '' }
+    });
+
+    expect(many.completion.values).toHaveLength(100);
+    expect(many.completion.values.every(v => typeof v === 'string')).toBe(true);
+    expect(many.completion.values[0]).toBe('item-000');
+    expect(many.completion.values[99]).toBe('item-099');
+    expect(many.completion.total).toBe(MANY_TOTAL);
+    expect(many.completion.hasMore).toBe(true);
+});
+
+verifies(
+    'mcpserver:completion:capability-auto',
+    async ({ transport }: TestArgs) => {
+        const makeServer = () => {
+            const s = new McpServer({ name: 's', version: '0' });
+            s.registerPrompt('non-completable', { argsSchema: { arg: z.string() } }, ({ arg }) => ({
+                messages: [{ role: 'user', content: { type: 'text', text: arg } }]
+            }));
+            s.registerResource(
+                'plain-resource',
+                new ResourceTemplate('plain://resource/{id}', { list: undefined }),
+                { mimeType: 'text/plain' },
+                (uri, { id }) => ({ contents: [{ uri: uri.href, mimeType: 'text/plain', text: `id=${id}` }] })
+            );
+            return s;
+        };
+
+        const client = newClient();
+        await using _ = await wire(transport, makeServer, client);
+
+        const caps = client.getServerCapabilities();
+        expect(caps).toBeDefined();
+        expect(caps?.completions).toBeUndefined();
+        expect(caps?.prompts).toBeDefined();
+        expect(caps?.resources).toBeDefined();
+
+        await expect(
+            client.complete({
+                ref: { type: 'ref/prompt', name: 'non-completable' },
+                argument: { name: 'arg', value: '' }
+            })
+        ).rejects.toThrow();
+    },
+    { title: 'mcpserver' }
+);
+
+verifies(
+    'mcpserver:completion:capability-auto',
+    async ({ transport }: TestArgs) => {
+        const makeServer = () => {
+            const s = new Server({ name: 's', version: '0' }, { capabilities: { prompts: {}, resources: {} } });
+            s.setRequestHandler(ListPromptsRequestSchema, () => ({ prompts: [{ name: 'plain', arguments: [] }] }));
+            s.setRequestHandler(ListResourcesRequestSchema, () => ({ resources: [] }));
+            s.setRequestHandler(ReadResourceRequestSchema, () => ({ contents: [] }));
+            return s;
+        };
+
+        const client = newClient();
+        await using _ = await wire(transport, makeServer, client);
+
+        const caps = client.getServerCapabilities();
+        expect(caps?.completions).toBeUndefined();
+        expect(caps?.prompts).toBeDefined();
+        expect(caps?.resources).toBeDefined();
+
+        await expect(
+            client.complete({
+                ref: { type: 'ref/prompt', name: 'plain' },
+                argument: { name: 'arg', value: '' }
+            })
+        ).rejects.toThrow();
+    },
+    { title: 'raw server' }
+);

--- a/test/e2e/scenarios/completion.test.ts
+++ b/test/e2e/scenarios/completion.test.ts
@@ -9,21 +9,8 @@
 
 import { expect } from 'vitest';
 import { z } from 'zod/v4';
-
-import { Client } from '../../../src/client/index.js';
-import { Server } from '../../../src/server/index.js';
-import { completable } from '../../../src/server/completable.js';
-import { McpServer, ResourceTemplate } from '../../../src/server/mcp.js';
-import {
-    CompleteRequestSchema,
-    CompleteResultSchema,
-    ErrorCode,
-    ListPromptsRequestSchema,
-    ListResourcesRequestSchema,
-    McpError,
-    ReadResourceRequestSchema
-} from '../../../src/types.js';
-
+import { Server, completable, McpServer, ResourceTemplate, ProtocolError, ProtocolErrorCode } from '@modelcontextprotocol/server';
+import { Client } from '@modelcontextprotocol/client';
 import { wire } from '../helpers/index.js';
 import type { TestArgs } from '../types.js';
 import { verifies } from '../helpers/verifies.js';
@@ -42,7 +29,7 @@ function colorCompletionServer(): McpServer {
     const s = new McpServer({ name: 's', version: '0' });
     s.registerPrompt(
         'complete-color',
-        { argsSchema: { color: completable(z.string(), value => COLORS.filter(c => c.startsWith(value))) } },
+        { argsSchema: z.object({ color: completable(z.string(), value => COLORS.filter(c => c.startsWith(value))) }) },
         ({ color }) => ({ messages: [{ role: 'user', content: { type: 'text', text: `color=${color}` } }] })
     );
     return s;
@@ -66,7 +53,7 @@ verifies('completion:capability:declared', async ({ transport }: TestArgs) => {
 verifies('completion:complete:not-supported', async ({ transport }: TestArgs) => {
     const makeServer = () => {
         const s = new McpServer({ name: 's', version: '0' });
-        s.registerPrompt('summarize-code', { argsSchema: { code: z.string() } }, ({ code }) => ({
+        s.registerPrompt('summarize-code', { argsSchema: z.object({ code: z.string() }) }, ({ code }) => ({
             messages: [{ role: 'user', content: { type: 'text', text: `Summarize the following code:\n${code}` } }]
         }));
         return s;
@@ -81,14 +68,11 @@ verifies('completion:complete:not-supported', async ({ transport }: TestArgs) =>
 
     // Raw request bypasses any client-side capability gating, so the rejection observed is the server's own.
     await expect(
-        client.request(
-            {
-                method: 'completion/complete',
-                params: { ref: { type: 'ref/prompt', name: 'summarize-code' }, argument: { name: 'code', value: 'co' } }
-            },
-            CompleteResultSchema
-        )
-    ).rejects.toMatchObject({ code: ErrorCode.MethodNotFound });
+        client.request({
+            method: 'completion/complete',
+            params: { ref: { type: 'ref/prompt', name: 'summarize-code' }, argument: { name: 'code', value: 'co' } }
+        })
+    ).rejects.toMatchObject({ code: ProtocolErrorCode.MethodNotFound });
 });
 
 verifies('completion:context-arguments', async ({ transport }: TestArgs) => {
@@ -145,11 +129,11 @@ verifies(
 
         await expect(
             client.complete({ ref: { type: 'ref/prompt', name: 'no-such-prompt' }, argument: { name: 'whatever', value: '' } })
-        ).rejects.toMatchObject({ code: ErrorCode.InvalidParams });
+        ).rejects.toMatchObject({ code: ProtocolErrorCode.InvalidParams });
 
         await expect(
             client.complete({ ref: { type: 'ref/resource', uri: 'nosuchscheme://nowhere/{x}' }, argument: { name: 'x', value: '' } })
-        ).rejects.toMatchObject({ code: ErrorCode.InvalidParams });
+        ).rejects.toMatchObject({ code: ProtocolErrorCode.InvalidParams });
     },
     { title: 'mcpserver' }
 );
@@ -159,11 +143,11 @@ verifies(
     async ({ transport }: TestArgs) => {
         const makeServer = () => {
             const s = new Server({ name: 's', version: '0' }, { capabilities: { completions: {} } });
-            s.setRequestHandler(CompleteRequestSchema, req => {
+            s.setRequestHandler('completion/complete', req => {
                 if (req.params.ref.type === 'ref/prompt' && req.params.ref.name === 'known') {
                     return { completion: { values: ['ok'] } };
                 }
-                throw new McpError(ErrorCode.InvalidParams, `No completion target: ${JSON.stringify(req.params.ref)}`);
+                throw new ProtocolError(ProtocolErrorCode.InvalidParams, `No completion target: ${JSON.stringify(req.params.ref)}`);
             });
             return s;
         };
@@ -175,7 +159,7 @@ verifies(
 
         await expect(
             client.complete({ ref: { type: 'ref/prompt', name: 'no-such-prompt' }, argument: { name: 'a', value: '' } })
-        ).rejects.toMatchObject({ code: ErrorCode.InvalidParams });
+        ).rejects.toMatchObject({ code: ProtocolErrorCode.InvalidParams });
     },
     { title: 'raw server' }
 );
@@ -241,13 +225,13 @@ verifies('completion:result-shape', async ({ transport }: TestArgs) => {
         const s = new McpServer({ name: 's', version: '0' });
         s.registerPrompt(
             'complete-color',
-            { argsSchema: { color: completable(z.string(), value => COLORS.filter(c => c.startsWith(value))) } },
+            { argsSchema: z.object({ color: completable(z.string(), value => COLORS.filter(c => c.startsWith(value))) }) },
             ({ color }) => ({ messages: [{ role: 'user', content: { type: 'text', text: `color=${color}` } }] })
         );
         const many = Array.from({ length: MANY_TOTAL }, (_, i) => `item-${String(i).padStart(3, '0')}`);
         s.registerPrompt(
             'complete-many',
-            { argsSchema: { n: completable(z.string(), value => many.filter(s => s.startsWith(value))) } },
+            { argsSchema: z.object({ n: completable(z.string(), value => many.filter(s => s.startsWith(value))) }) },
             ({ n }) => ({ messages: [{ role: 'user', content: { type: 'text', text: n } }] })
         );
         return s;
@@ -294,7 +278,7 @@ verifies(
     async ({ transport }: TestArgs) => {
         const makeServer = () => {
             const s = new McpServer({ name: 's', version: '0' });
-            s.registerPrompt('non-completable', { argsSchema: { arg: z.string() } }, ({ arg }) => ({
+            s.registerPrompt('non-completable', { argsSchema: z.object({ arg: z.string() }) }, ({ arg }) => ({
                 messages: [{ role: 'user', content: { type: 'text', text: arg } }]
             }));
             s.registerResource(
@@ -330,9 +314,9 @@ verifies(
     async ({ transport }: TestArgs) => {
         const makeServer = () => {
             const s = new Server({ name: 's', version: '0' }, { capabilities: { prompts: {}, resources: {} } });
-            s.setRequestHandler(ListPromptsRequestSchema, () => ({ prompts: [{ name: 'plain', arguments: [] }] }));
-            s.setRequestHandler(ListResourcesRequestSchema, () => ({ resources: [] }));
-            s.setRequestHandler(ReadResourceRequestSchema, () => ({ contents: [] }));
+            s.setRequestHandler('prompts/list', () => ({ prompts: [{ name: 'plain', arguments: [] }] }));
+            s.setRequestHandler('resources/list', () => ({ resources: [] }));
+            s.setRequestHandler('resources/read', () => ({ contents: [] }));
             return s;
         };
 

--- a/test/e2e/scenarios/completion.test.ts
+++ b/test/e2e/scenarios/completion.test.ts
@@ -7,13 +7,14 @@
  * on the partial value and optional context (already-resolved variables).
  */
 
+import { Client } from '@modelcontextprotocol/client';
+import { completable, McpServer, ProtocolError, ProtocolErrorCode, ResourceTemplate, Server } from '@modelcontextprotocol/server';
 import { expect } from 'vitest';
 import { z } from 'zod/v4';
-import { Server, completable, McpServer, ResourceTemplate, ProtocolError, ProtocolErrorCode } from '@modelcontextprotocol/server';
-import { Client } from '@modelcontextprotocol/client';
+
 import { wire } from '../helpers/index.js';
-import type { TestArgs } from '../types.js';
 import { verifies } from '../helpers/verifies.js';
+import type { TestArgs } from '../types.js';
 
 const COLORS = ['red', 'green', 'blue', 'rebeccapurple'] as const;
 const FILE_PATHS = ['README.md', 'src/index.ts', 'src/types.ts'] as const;

--- a/test/e2e/scenarios/custom-methods.test.ts
+++ b/test/e2e/scenarios/custom-methods.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Self-contained test bodies for custom (non-spec, vendor-prefixed) methods.
+ *
+ * v2 registers these via the schema'd overloads: `setRequestHandler('<vendor>/x',
+ * { params, result }, handler)` and `setNotificationHandler('<vendor>/x',
+ * { params }, handler)`; the requesting side passes the matching result schema to
+ * `request()`. Each test builds its own server (via factory) and client, wires
+ * them with {@link wire} (with `allowCustomMethods` so the wire sniffer permits
+ * the vendor methods), and asserts. Params schemas carry a defaulted field so
+ * the handler observably receives the schema's parse output, not raw wire params.
+ */
+
+import { Client } from '@modelcontextprotocol/client';
+import { McpServer, ProtocolErrorCode, Server } from '@modelcontextprotocol/server';
+import { expect, vi } from 'vitest';
+import { z } from 'zod/v4';
+
+import { wire } from '../helpers/index.js';
+import { verifies } from '../helpers/verifies.js';
+import type { TestArgs } from '../types.js';
+
+verifies('custom-methods:server-handler:roundtrip', async ({ transport }: TestArgs) => {
+    const SearchParams = z.object({ query: z.string(), limit: z.number().int().default(5) });
+    const SearchResult = z.object({ hits: z.array(z.string()), total: z.number() });
+
+    const received: Array<z.output<typeof SearchParams>> = [];
+    const makeServer = () => {
+        const s = new Server({ name: 's', version: '0' }, { capabilities: {} });
+        s.setRequestHandler('acme/search', { params: SearchParams, result: SearchResult }, params => {
+            received.push(params);
+            return { hits: [`doc-1 for ${params.query}`, `doc-2 for ${params.query}`].slice(0, params.limit), total: 2 };
+        });
+        return s;
+    };
+    const client = new Client({ name: 'c', version: '0' });
+
+    await using _ = await wire(transport, makeServer, client, { allowCustomMethods: true });
+
+    const full = await client.request({ method: 'acme/search', params: { query: 'streamable http' } }, SearchResult);
+    // The defaulted `limit` proves the handler got the schema's parse output, not the raw wire params.
+    expect(received).toEqual([{ query: 'streamable http', limit: 5 }]);
+    expect(full).toEqual({ hits: ['doc-1 for streamable http', 'doc-2 for streamable http'], total: 2 });
+
+    const limited = await client.request({ method: 'acme/search', params: { query: 'sse', limit: 1 } }, SearchResult);
+    expect(received).toEqual([
+        { query: 'streamable http', limit: 5 },
+        { query: 'sse', limit: 1 }
+    ]);
+    expect(limited).toEqual({ hits: ['doc-1 for sse'], total: 2 });
+});
+
+verifies('custom-methods:client-handler:roundtrip', async ({ transport }: TestArgs) => {
+    const LookupParams = z.object({ key: z.string(), scope: z.string().default('workspace') });
+    const LookupResult = z.object({ value: z.string(), found: z.boolean() });
+
+    const received: Array<z.output<typeof LookupParams>> = [];
+    const lookups: Array<z.output<typeof LookupResult>> = [];
+
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool('read-config', { inputSchema: z.object({ key: z.string() }) }, async ({ key }, ctx) => {
+            // relatedRequestId keeps the server→client request on the in-flight POST stream for streamableHttp.
+            const lookup = await s.server.request({ method: 'acme/configLookup', params: { key } }, LookupResult, {
+                relatedRequestId: ctx.mcpReq.id
+            });
+            lookups.push(lookup);
+            return { content: [{ type: 'text', text: `${key}=${lookup.value}` }] };
+        });
+        return s;
+    };
+
+    const client = new Client({ name: 'c', version: '0' });
+    client.setRequestHandler('acme/configLookup', { params: LookupParams, result: LookupResult }, params => {
+        received.push(params);
+        return { value: `resolved:${params.key}`, found: true };
+    });
+
+    await using _ = await wire(transport, makeServer, client, { allowCustomMethods: true });
+
+    const result = await client.callTool({ name: 'read-config', arguments: { key: 'editor.theme' } });
+
+    // The defaulted `scope` proves the client handler got the schema's parse output, not the raw wire params.
+    expect(received).toEqual([{ key: 'editor.theme', scope: 'workspace' }]);
+    expect(lookups).toEqual([{ value: 'resolved:editor.theme', found: true }]);
+    expect(result.content).toEqual([{ type: 'text', text: 'editor.theme=resolved:editor.theme' }]);
+});
+
+verifies('custom-methods:params-validation-error', async ({ transport }: TestArgs) => {
+    const ConvertParams = z.object({ celsius: z.number() });
+    const ConvertResult = z.object({ fahrenheit: z.number() });
+
+    const invocations: Array<z.output<typeof ConvertParams>> = [];
+    const makeServer = () => {
+        const s = new Server({ name: 's', version: '0' }, { capabilities: {} });
+        s.setRequestHandler('acme/convertTemperature', { params: ConvertParams, result: ConvertResult }, params => {
+            invocations.push(params);
+            return { fahrenheit: params.celsius * 1.8 + 32 };
+        });
+        return s;
+    };
+    const client = new Client({ name: 'c', version: '0' });
+
+    await using _ = await wire(transport, makeServer, client, { allowCustomMethods: true });
+
+    // A conforming call first proves the handler is reachable, so the later "not invoked" check is meaningful.
+    await expect(client.request({ method: 'acme/convertTemperature', params: { celsius: 20 } }, ConvertResult)).resolves.toEqual({
+        fahrenheit: 68
+    });
+    expect(invocations).toEqual([{ celsius: 20 }]);
+
+    expect(ProtocolErrorCode.InvalidParams).toBe(-32_602);
+    await expect(client.request({ method: 'acme/convertTemperature', params: { celsius: 'warm' } }, ConvertResult)).rejects.toMatchObject({
+        code: ProtocolErrorCode.InvalidParams,
+        message: expect.stringContaining('Invalid params for acme/convertTemperature')
+    });
+    expect(invocations).toEqual([{ celsius: 20 }]);
+});
+
+verifies('custom-methods:notification-handler', async ({ transport }: TestArgs) => {
+    const HeartbeatParams = z.object({ seq: z.number().int(), source: z.string().default('unspecified') });
+
+    const clientReceived: Array<z.output<typeof HeartbeatParams>> = [];
+    const serverReceived: Array<z.output<typeof HeartbeatParams>> = [];
+
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.server.setNotificationHandler('acme/heartbeat', { params: HeartbeatParams }, params => {
+            serverReceived.push(params);
+        });
+        s.registerTool('sync-data', { inputSchema: z.object({ batches: z.number().int() }) }, async ({ batches }, ctx) => {
+            for (let seq = 1; seq <= batches; seq++) {
+                await ctx.mcpReq.notify({ method: 'acme/heartbeat', params: { seq, source: 'sync-job' } });
+            }
+            return { content: [{ type: 'text', text: `synced ${batches} batches` }] };
+        });
+        return s;
+    };
+
+    const client = new Client({ name: 'c', version: '0' });
+    client.setNotificationHandler('acme/heartbeat', { params: HeartbeatParams }, params => {
+        clientReceived.push(params);
+    });
+
+    await using _ = await wire(transport, makeServer, client, { allowCustomMethods: true });
+
+    const result = await client.callTool({ name: 'sync-data', arguments: { batches: 2 } });
+    expect(result.content).toEqual([{ type: 'text', text: 'synced 2 batches' }]);
+
+    await vi.waitFor(() => expect(clientReceived).toHaveLength(2));
+    expect(clientReceived).toEqual([
+        { seq: 1, source: 'sync-job' },
+        { seq: 2, source: 'sync-job' }
+    ]);
+
+    // Same registration works on the server side; `source` is omitted so the applied default proves schema validation ran.
+    await client.notification({ method: 'acme/heartbeat', params: { seq: 3 } });
+    await vi.waitFor(() => expect(serverReceived).toHaveLength(1));
+    expect(serverReceived).toEqual([{ seq: 3, source: 'unspecified' }]);
+});

--- a/test/e2e/scenarios/dynamic.test.ts
+++ b/test/e2e/scenarios/dynamic.test.ts
@@ -6,14 +6,15 @@
  * debounce, enable/disable, low-level handler reach-through).
  */
 
+import { Client } from '@modelcontextprotocol/client';
+import type { Prompt, RegisteredTool, Resource, Tool } from '@modelcontextprotocol/server';
+import { McpServer, ProtocolErrorCode, Server } from '@modelcontextprotocol/server';
 import { expect, vi } from 'vitest';
 import { z } from 'zod/v4';
-import { McpServer, Server } from '@modelcontextprotocol/server';
-import type { RegisteredTool, Prompt, Resource, Tool } from '@modelcontextprotocol/server';
-import { Client } from '@modelcontextprotocol/client';
+
 import { wire } from '../helpers/index.js';
-import type { TestArgs } from '../types.js';
 import { verifies } from '../helpers/verifies.js';
+import type { TestArgs } from '../types.js';
 
 const newClient = () => new Client({ name: 'c', version: '0' });
 
@@ -115,7 +116,7 @@ verifies('client:list-changed:capability-gated', async ({ transport }: TestArgs)
     await server.sendPromptListChanged();
     await server.sendResourceListChanged();
 
-    await waitUntil(() => toolsCalls.length >= 1);
+    await waitUntil(() => toolsCalls.length > 0);
     expect(toolsCalls[0]).toEqual({ err: null, items: null });
 
     await client.listTools();
@@ -165,15 +166,15 @@ verifies('client:list-changed:signal-only', async ({ transport }: TestArgs) => {
     resourceCalls.length = 0;
 
     server.registerTool('signal-only-tool', { inputSchema: z.object({}) }, () => ({ content: [] }));
-    await waitUntil(() => toolCalls.length >= 1);
+    await waitUntil(() => toolCalls.length > 0);
     expect(toolCalls[0]).toEqual({ error: null, items: null });
 
     server.registerPrompt('signal-only-prompt', { description: '' }, () => ({ messages: [] }));
-    await waitUntil(() => promptCalls.length >= 1);
+    await waitUntil(() => promptCalls.length > 0);
     expect(promptCalls[0]).toEqual({ error: null, items: null });
 
     server.registerResource('signal-only', 'test://signal-only', {}, () => ({ contents: [] }));
-    await waitUntil(() => resourceCalls.length >= 1);
+    await waitUntil(() => resourceCalls.length > 0);
     expect(resourceCalls[0]).toEqual({ error: null, items: null });
 
     const after = await client.listTools();
@@ -200,7 +201,8 @@ verifies('mcpserver:handle:enable-disable', async ({ transport }: TestArgs) => {
 
     await using _ = await wire(transport, makeServer, client);
 
-    expect((await client.listTools()).tools.map(t => t.name)).toContain('toggle-probe');
+    const initialList = await client.listTools();
+    expect(initialList.tools.map(t => t.name)).toContain('toggle-probe');
     const baseline = await client.callTool({ name: 'toggle-probe', arguments: {} });
     expect(baseline.isError).toBeFalsy();
     expect(baseline.content).toEqual([{ type: 'text', text: 'toggle-probe' }]);
@@ -209,16 +211,20 @@ verifies('mcpserver:handle:enable-disable', async ({ transport }: TestArgs) => {
     handle.disable();
     await waitUntil(() => listChanged > beforeDisable);
 
-    expect((await client.listTools()).tools.map(t => t.name)).not.toContain('toggle-probe');
-    const disabledCall = await client.callTool({ name: 'toggle-probe', arguments: {} });
-    expect(disabledCall.isError).toBe(true);
-    expect(disabledCall.content).toEqual([{ type: 'text', text: expect.stringMatching(/disabled/i) }]);
+    const disabledList = await client.listTools();
+    expect(disabledList.tools.map(t => t.name)).not.toContain('toggle-probe');
+    // changed in v2: calling a disabled tool surfaces a JSON-RPC InvalidParams error instead of an isError result
+    await expect(client.callTool({ name: 'toggle-probe', arguments: {} })).rejects.toMatchObject({
+        code: ProtocolErrorCode.InvalidParams,
+        message: expect.stringMatching(/disabled/i)
+    });
 
     const beforeEnable = listChanged;
     handle.enable();
     await waitUntil(() => listChanged > beforeEnable);
 
-    expect((await client.listTools()).tools.map(t => t.name)).toContain('toggle-probe');
+    const restoredList = await client.listTools();
+    expect(restoredList.tools.map(t => t.name)).toContain('toggle-probe');
     const restored = await client.callTool({ name: 'toggle-probe', arguments: {} });
     expect(restored.isError).toBeFalsy();
     expect(restored.content).toEqual([{ type: 'text', text: 'toggle-probe' }]);
@@ -301,17 +307,20 @@ verifies('mcpserver:register:post-connect', async ({ transport }: TestArgs) => {
     seen.length = 0;
     server.registerTool('post-connect-tool', { inputSchema: z.object({}) }, () => ({ content: [] }));
     await waitUntil(() => seen.includes('tools'));
-    expect((await client.listTools()).tools.map(t => t.name)).toContain('post-connect-tool');
+    const { tools } = await client.listTools();
+    expect(tools.map(t => t.name)).toContain('post-connect-tool');
 
     seen.length = 0;
     server.registerResource('post-connect', 'test://post-connect', {}, () => ({ contents: [] }));
     await waitUntil(() => seen.includes('resources'));
-    expect((await client.listResources()).resources.map(r => r.uri)).toContain('test://post-connect');
+    const { resources } = await client.listResources();
+    expect(resources.map(r => r.uri)).toContain('test://post-connect');
 
     seen.length = 0;
     server.registerPrompt('post-connect-prompt', { description: '' }, () => ({ messages: [] }));
     await waitUntil(() => seen.includes('prompts'));
-    expect((await client.listPrompts()).prompts.map(p => p.name)).toContain('post-connect-prompt');
+    const { prompts } = await client.listPrompts();
+    expect(prompts.map(p => p.name)).toContain('post-connect-prompt');
 });
 
 verifies('mcpserver:reach-through:set-request-handler', async ({ transport }: TestArgs) => {

--- a/test/e2e/scenarios/dynamic.test.ts
+++ b/test/e2e/scenarios/dynamic.test.ts
@@ -8,23 +8,9 @@
 
 import { expect, vi } from 'vitest';
 import { z } from 'zod/v4';
-
-import { Client } from '../../../src/client/index.js';
-import { McpServer, type RegisteredTool } from '../../../src/server/mcp.js';
-import { Server } from '../../../src/server/index.js';
-import {
-    ListPromptsRequestSchema,
-    ListResourcesRequestSchema,
-    ListToolsRequestSchema,
-    PromptListChangedNotificationSchema,
-    ResourceListChangedNotificationSchema,
-    SubscribeRequestSchema,
-    ToolListChangedNotificationSchema,
-    type Prompt,
-    type Resource,
-    type Tool
-} from '../../../src/types.js';
-
+import { McpServer, Server } from '@modelcontextprotocol/server';
+import type { RegisteredTool, Prompt, Resource, Tool } from '@modelcontextprotocol/server';
+import { Client } from '@modelcontextprotocol/client';
 import { wire } from '../helpers/index.js';
 import type { TestArgs } from '../types.js';
 import { verifies } from '../helpers/verifies.js';
@@ -89,9 +75,9 @@ verifies('client:list-changed:capability-gated', async ({ transport }: TestArgs)
     let server!: Server;
     const makeServer = () => {
         server = new Server({ name: 's', version: '0' }, { capabilities: { tools: { listChanged: true }, prompts: {}, resources: {} } });
-        server.setRequestHandler(ListToolsRequestSchema, () => ({ tools: [] }));
-        server.setRequestHandler(ListPromptsRequestSchema, () => ({ prompts: [] }));
-        server.setRequestHandler(ListResourcesRequestSchema, () => ({ resources: [] }));
+        server.setRequestHandler('tools/list', () => ({ tools: [] }));
+        server.setRequestHandler('prompts/list', () => ({ prompts: [] }));
+        server.setRequestHandler('resources/list', () => ({ resources: [] }));
         return server;
     };
 
@@ -208,7 +194,7 @@ verifies('mcpserver:handle:enable-disable', async ({ transport }: TestArgs) => {
 
     let listChanged = 0;
     const client = newClient();
-    client.setNotificationHandler(ToolListChangedNotificationSchema, () => {
+    client.setNotificationHandler('notifications/tools/list_changed', () => {
         listChanged++;
     });
 
@@ -262,9 +248,9 @@ verifies('mcpserver:list-changed:debounce', async ({ transport }: TestArgs) => {
 
     const counts = { tools: 0, resources: 0, prompts: 0 };
     const client = newClient();
-    client.setNotificationHandler(ToolListChangedNotificationSchema, () => void counts.tools++);
-    client.setNotificationHandler(ResourceListChangedNotificationSchema, () => void counts.resources++);
-    client.setNotificationHandler(PromptListChangedNotificationSchema, () => void counts.prompts++);
+    client.setNotificationHandler('notifications/tools/list_changed', () => void counts.tools++);
+    client.setNotificationHandler('notifications/resources/list_changed', () => void counts.resources++);
+    client.setNotificationHandler('notifications/prompts/list_changed', () => void counts.prompts++);
 
     await using _ = await wire(transport, makeServer, client);
 
@@ -306,9 +292,9 @@ verifies('mcpserver:register:post-connect', async ({ transport }: TestArgs) => {
 
     const seen: string[] = [];
     const client = newClient();
-    client.setNotificationHandler(ToolListChangedNotificationSchema, () => void seen.push('tools'));
-    client.setNotificationHandler(ResourceListChangedNotificationSchema, () => void seen.push('resources'));
-    client.setNotificationHandler(PromptListChangedNotificationSchema, () => void seen.push('prompts'));
+    client.setNotificationHandler('notifications/tools/list_changed', () => void seen.push('tools'));
+    client.setNotificationHandler('notifications/resources/list_changed', () => void seen.push('resources'));
+    client.setNotificationHandler('notifications/prompts/list_changed', () => void seen.push('prompts'));
 
     await using _ = await wire(transport, makeServer, client);
 
@@ -344,7 +330,7 @@ verifies('mcpserver:reach-through:set-request-handler', async ({ transport }: Te
     const client = newClient();
     await using _ = await wire(transport, makeServer, client);
 
-    server.server.setRequestHandler(SubscribeRequestSchema, async request => {
+    server.server.setRequestHandler('resources/subscribe', async request => {
         handlerHits.push(request.params.uri);
         return {};
     });

--- a/test/e2e/scenarios/dynamic.test.ts
+++ b/test/e2e/scenarios/dynamic.test.ts
@@ -1,0 +1,359 @@
+/**
+ * Self-contained test bodies for dynamic (list_changed) behaviors.
+ *
+ * Tests for client-side listChanged handlers (auto-refresh, capability gating,
+ * signal-only mode) and server-side dynamic registration (post-connect,
+ * debounce, enable/disable, low-level handler reach-through).
+ */
+
+import { expect, vi } from 'vitest';
+import { z } from 'zod/v4';
+
+import { Client } from '../../../src/client/index.js';
+import { McpServer, type RegisteredTool } from '../../../src/server/mcp.js';
+import { Server } from '../../../src/server/index.js';
+import {
+    ListPromptsRequestSchema,
+    ListResourcesRequestSchema,
+    ListToolsRequestSchema,
+    PromptListChangedNotificationSchema,
+    ResourceListChangedNotificationSchema,
+    SubscribeRequestSchema,
+    ToolListChangedNotificationSchema,
+    type Prompt,
+    type Resource,
+    type Tool
+} from '../../../src/types.js';
+
+import { wire } from '../helpers/index.js';
+import type { TestArgs } from '../types.js';
+import { verifies } from '../helpers/verifies.js';
+
+const newClient = () => new Client({ name: 'c', version: '0' });
+
+// vi.waitFor only retries on throw, not on falsy return — wrap predicates so a
+// false result throws and the poll continues.
+const waitUntil = (pred: () => boolean) => vi.waitFor(() => expect(pred()).toBe(true));
+
+verifies('client:list-changed:auto-refresh', async ({ transport }: TestArgs) => {
+    const toolCalls: Array<{ error: Error | null; items: Tool[] | null }> = [];
+    const promptCalls: Array<{ error: Error | null; items: Prompt[] | null }> = [];
+    const resourceCalls: Array<{ error: Error | null; items: Resource[] | null }> = [];
+
+    let server!: McpServer;
+    const makeServer = () => {
+        server = new McpServer({ name: 's', version: '0' });
+        server.registerTool('seed', { inputSchema: z.object({}) }, () => ({ content: [] }));
+        server.registerPrompt('seed', { description: '' }, () => ({ messages: [] }));
+        server.registerResource('seed', 'test://seed', {}, () => ({ contents: [] }));
+        return server;
+    };
+
+    const client = new Client(
+        { name: 'c', version: '0' },
+        {
+            listChanged: {
+                tools: { debounceMs: 0, onChanged: (error, items) => toolCalls.push({ error, items }) },
+                prompts: { debounceMs: 0, onChanged: (error, items) => promptCalls.push({ error, items }) },
+                resources: { debounceMs: 0, onChanged: (error, items) => resourceCalls.push({ error, items }) }
+            }
+        }
+    );
+
+    await using _ = await wire(transport, makeServer, client);
+
+    server.registerTool('probe-tool', { inputSchema: z.object({}) }, () => ({ content: [] }));
+    await waitUntil(() => toolCalls.some(c => c.items?.some(t => t.name === 'probe-tool')));
+    const toolCall = toolCalls.find(c => c.items?.some(t => t.name === 'probe-tool'));
+    expect(toolCall?.error).toBeNull();
+    expect(toolCall?.items?.map(t => t.name)).toContain('probe-tool');
+
+    server.registerPrompt('probe-prompt', { description: '' }, () => ({ messages: [] }));
+    await waitUntil(() => promptCalls.some(c => c.items?.some(p => p.name === 'probe-prompt')));
+    const promptCall = promptCalls.find(c => c.items?.some(p => p.name === 'probe-prompt'));
+    expect(promptCall?.error).toBeNull();
+    expect(promptCall?.items?.map(p => p.name)).toContain('probe-prompt');
+
+    server.registerResource('probe', 'test://probe', {}, () => ({ contents: [] }));
+    await waitUntil(() => resourceCalls.some(c => c.items?.some(r => r.uri === 'test://probe')));
+    const resourceCall = resourceCalls.find(c => c.items?.some(r => r.uri === 'test://probe'));
+    expect(resourceCall?.error).toBeNull();
+    expect(resourceCall?.items?.map(r => r.uri)).toContain('test://probe');
+});
+
+verifies('client:list-changed:capability-gated', async ({ transport }: TestArgs) => {
+    const toolsCalls: unknown[] = [];
+    const promptsCalls: unknown[] = [];
+    const resourcesCalls: unknown[] = [];
+
+    let server!: Server;
+    const makeServer = () => {
+        server = new Server({ name: 's', version: '0' }, { capabilities: { tools: { listChanged: true }, prompts: {}, resources: {} } });
+        server.setRequestHandler(ListToolsRequestSchema, () => ({ tools: [] }));
+        server.setRequestHandler(ListPromptsRequestSchema, () => ({ prompts: [] }));
+        server.setRequestHandler(ListResourcesRequestSchema, () => ({ resources: [] }));
+        return server;
+    };
+
+    const client = new Client(
+        { name: 'c', version: '0' },
+        {
+            listChanged: {
+                tools: { autoRefresh: false, debounceMs: 0, onChanged: (err, items) => toolsCalls.push({ err, items }) },
+                prompts: {
+                    autoRefresh: false,
+                    debounceMs: 0,
+                    onChanged: (err, items) => promptsCalls.push({ err, items })
+                },
+                resources: {
+                    autoRefresh: false,
+                    debounceMs: 0,
+                    onChanged: (err, items) => resourcesCalls.push({ err, items })
+                }
+            }
+        }
+    );
+
+    await using _ = await wire(transport, makeServer, client);
+
+    const caps = client.getServerCapabilities();
+    expect(caps?.tools?.listChanged).toBe(true);
+    expect(caps?.prompts?.listChanged).toBeFalsy();
+    expect(caps?.resources?.listChanged).toBeFalsy();
+
+    toolsCalls.length = 0;
+    promptsCalls.length = 0;
+    resourcesCalls.length = 0;
+
+    await server.sendToolListChanged();
+    await server.sendPromptListChanged();
+    await server.sendResourceListChanged();
+
+    await waitUntil(() => toolsCalls.length >= 1);
+    expect(toolsCalls[0]).toEqual({ err: null, items: null });
+
+    await client.listTools();
+    expect(promptsCalls).toHaveLength(0);
+    expect(resourcesCalls).toHaveLength(0);
+});
+
+verifies('client:list-changed:signal-only', async ({ transport }: TestArgs) => {
+    const toolCalls: Array<{ error: Error | null; items: Tool[] | null }> = [];
+    const promptCalls: Array<{ error: Error | null; items: Prompt[] | null }> = [];
+    const resourceCalls: Array<{ error: Error | null; items: Resource[] | null }> = [];
+
+    let server!: McpServer;
+    const makeServer = () => {
+        server = new McpServer({ name: 's', version: '0' });
+        server.registerTool('seed', { inputSchema: z.object({}) }, () => ({ content: [] }));
+        server.registerPrompt('seed', { description: '' }, () => ({ messages: [] }));
+        server.registerResource('seed', 'test://seed', {}, () => ({ contents: [] }));
+        return server;
+    };
+
+    const client = new Client(
+        { name: 'c', version: '0' },
+        {
+            listChanged: {
+                tools: { autoRefresh: false, debounceMs: 0, onChanged: (error, items) => toolCalls.push({ error, items }) },
+                prompts: {
+                    autoRefresh: false,
+                    debounceMs: 0,
+                    onChanged: (error, items) => promptCalls.push({ error, items })
+                },
+                resources: {
+                    autoRefresh: false,
+                    debounceMs: 0,
+                    onChanged: (error, items) => resourceCalls.push({ error, items })
+                }
+            }
+        }
+    );
+
+    await using _ = await wire(transport, makeServer, client);
+
+    const before = await client.listTools();
+
+    toolCalls.length = 0;
+    promptCalls.length = 0;
+    resourceCalls.length = 0;
+
+    server.registerTool('signal-only-tool', { inputSchema: z.object({}) }, () => ({ content: [] }));
+    await waitUntil(() => toolCalls.length >= 1);
+    expect(toolCalls[0]).toEqual({ error: null, items: null });
+
+    server.registerPrompt('signal-only-prompt', { description: '' }, () => ({ messages: [] }));
+    await waitUntil(() => promptCalls.length >= 1);
+    expect(promptCalls[0]).toEqual({ error: null, items: null });
+
+    server.registerResource('signal-only', 'test://signal-only', {}, () => ({ contents: [] }));
+    await waitUntil(() => resourceCalls.length >= 1);
+    expect(resourceCalls[0]).toEqual({ error: null, items: null });
+
+    const after = await client.listTools();
+    expect(after.tools.length).toBe(before.tools.length + 1);
+});
+
+verifies('mcpserver:handle:enable-disable', async ({ transport }: TestArgs) => {
+    let handle!: RegisteredTool;
+    let server!: McpServer;
+
+    const makeServer = () => {
+        server = new McpServer({ name: 's', version: '0' });
+        handle = server.registerTool('toggle-probe', { inputSchema: z.object({}) }, () => ({
+            content: [{ type: 'text', text: 'toggle-probe' }]
+        }));
+        return server;
+    };
+
+    let listChanged = 0;
+    const client = newClient();
+    client.setNotificationHandler(ToolListChangedNotificationSchema, () => {
+        listChanged++;
+    });
+
+    await using _ = await wire(transport, makeServer, client);
+
+    expect((await client.listTools()).tools.map(t => t.name)).toContain('toggle-probe');
+    const baseline = await client.callTool({ name: 'toggle-probe', arguments: {} });
+    expect(baseline.isError).toBeFalsy();
+    expect(baseline.content).toEqual([{ type: 'text', text: 'toggle-probe' }]);
+
+    const beforeDisable = listChanged;
+    handle.disable();
+    await waitUntil(() => listChanged > beforeDisable);
+
+    expect((await client.listTools()).tools.map(t => t.name)).not.toContain('toggle-probe');
+    const disabledCall = await client.callTool({ name: 'toggle-probe', arguments: {} });
+    expect(disabledCall.isError).toBe(true);
+    expect(disabledCall.content).toEqual([{ type: 'text', text: expect.stringMatching(/disabled/i) }]);
+
+    const beforeEnable = listChanged;
+    handle.enable();
+    await waitUntil(() => listChanged > beforeEnable);
+
+    expect((await client.listTools()).tools.map(t => t.name)).toContain('toggle-probe');
+    const restored = await client.callTool({ name: 'toggle-probe', arguments: {} });
+    expect(restored.isError).toBeFalsy();
+    expect(restored.content).toEqual([{ type: 'text', text: 'toggle-probe' }]);
+});
+
+verifies('mcpserver:list-changed:debounce', async ({ transport }: TestArgs) => {
+    let server!: McpServer;
+    const makeServer = () => {
+        server = new McpServer(
+            { name: 's', version: '0' },
+            {
+                debouncedNotificationMethods: [
+                    'notifications/tools/list_changed',
+                    'notifications/resources/list_changed',
+                    'notifications/prompts/list_changed'
+                ]
+            }
+        );
+        // Seed one of each so capability registration + request handlers are set
+        // up pre-connect; post-connect registrations would otherwise try to
+        // registerCapabilities and throw.
+        server.registerTool('seed', { inputSchema: z.object({}) }, () => ({ content: [] }));
+        server.registerResource('seed', 'test://seed', {}, () => ({ contents: [] }));
+        server.registerPrompt('seed', { description: '' }, () => ({ messages: [] }));
+        return server;
+    };
+
+    const counts = { tools: 0, resources: 0, prompts: 0 };
+    const client = newClient();
+    client.setNotificationHandler(ToolListChangedNotificationSchema, () => void counts.tools++);
+    client.setNotificationHandler(ResourceListChangedNotificationSchema, () => void counts.resources++);
+    client.setNotificationHandler(PromptListChangedNotificationSchema, () => void counts.prompts++);
+
+    await using _ = await wire(transport, makeServer, client);
+
+    counts.tools = 0;
+    counts.resources = 0;
+    counts.prompts = 0;
+
+    server.registerTool('a', { inputSchema: z.object({}) }, () => ({ content: [] }));
+    server.registerTool('b', { inputSchema: z.object({}) }, () => ({ content: [] }));
+    server.registerTool('c', { inputSchema: z.object({}) }, () => ({ content: [] }));
+    server.registerResource('a', 'test://debounce/a', {}, () => ({ contents: [] }));
+    server.registerResource('b', 'test://debounce/b', {}, () => ({ contents: [] }));
+    server.registerResource('c', 'test://debounce/c', {}, () => ({ contents: [] }));
+    server.registerPrompt('a', { description: '' }, () => ({ messages: [] }));
+    server.registerPrompt('b', { description: '' }, () => ({ messages: [] }));
+    server.registerPrompt('c', { description: '' }, () => ({ messages: [] }));
+
+    await waitUntil(() => counts.tools >= 1 && counts.resources >= 1 && counts.prompts >= 1);
+
+    await client.listTools();
+    expect(counts.tools).toBe(1);
+    expect(counts.resources).toBe(1);
+    expect(counts.prompts).toBe(1);
+
+    const { tools } = await client.listTools();
+    expect(tools.map(t => t.name)).toEqual(expect.arrayContaining(['a', 'b', 'c']));
+});
+
+verifies('mcpserver:register:post-connect', async ({ transport }: TestArgs) => {
+    let server!: McpServer;
+    const makeServer = () => {
+        server = new McpServer({ name: 's', version: '0' });
+        // Seed so handlers + capabilities are wired pre-connect.
+        server.registerTool('seed', { inputSchema: z.object({}) }, () => ({ content: [] }));
+        server.registerResource('seed', 'test://seed', {}, () => ({ contents: [] }));
+        server.registerPrompt('seed', { description: '' }, () => ({ messages: [] }));
+        return server;
+    };
+
+    const seen: string[] = [];
+    const client = newClient();
+    client.setNotificationHandler(ToolListChangedNotificationSchema, () => void seen.push('tools'));
+    client.setNotificationHandler(ResourceListChangedNotificationSchema, () => void seen.push('resources'));
+    client.setNotificationHandler(PromptListChangedNotificationSchema, () => void seen.push('prompts'));
+
+    await using _ = await wire(transport, makeServer, client);
+
+    seen.length = 0;
+    server.registerTool('post-connect-tool', { inputSchema: z.object({}) }, () => ({ content: [] }));
+    await waitUntil(() => seen.includes('tools'));
+    expect((await client.listTools()).tools.map(t => t.name)).toContain('post-connect-tool');
+
+    seen.length = 0;
+    server.registerResource('post-connect', 'test://post-connect', {}, () => ({ contents: [] }));
+    await waitUntil(() => seen.includes('resources'));
+    expect((await client.listResources()).resources.map(r => r.uri)).toContain('test://post-connect');
+
+    seen.length = 0;
+    server.registerPrompt('post-connect-prompt', { description: '' }, () => ({ messages: [] }));
+    await waitUntil(() => seen.includes('prompts'));
+    expect((await client.listPrompts()).prompts.map(p => p.name)).toContain('post-connect-prompt');
+});
+
+verifies('mcpserver:reach-through:set-request-handler', async ({ transport }: TestArgs) => {
+    const handlerHits: string[] = [];
+    let server!: McpServer;
+
+    const makeServer = () => {
+        server = new McpServer({ name: 's', version: '0' }, { capabilities: { resources: { subscribe: true, listChanged: true } } });
+        server.registerResource('baseline', 'test://baseline', {}, () => ({ contents: [] }));
+        server.registerTool('echo', { inputSchema: z.object({ text: z.string() }) }, ({ text }) => ({
+            content: [{ type: 'text', text }]
+        }));
+        return server;
+    };
+
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    server.server.setRequestHandler(SubscribeRequestSchema, async request => {
+        handlerHits.push(request.params.uri);
+        return {};
+    });
+
+    await expect(client.subscribeResource({ uri: 'test://reach-through' })).resolves.toEqual({});
+    await waitUntil(() => handlerHits.includes('test://reach-through'));
+    expect(handlerHits).toEqual(['test://reach-through']);
+
+    const echo = await client.callTool({ name: 'echo', arguments: { text: 'still wired' } });
+    expect(echo.isError).toBeFalsy();
+    expect(echo.content).toEqual([{ type: 'text', text: 'still wired' }]);
+});

--- a/test/e2e/scenarios/elicitation.test.ts
+++ b/test/e2e/scenarios/elicitation.test.ts
@@ -11,23 +11,16 @@
 
 import { expect } from 'vitest';
 import { z } from 'zod/v4';
-
-import { Client } from '../../../src/client/index.js';
-import { Server } from '../../../src/server/index.js';
-import { McpServer } from '../../../src/server/mcp.js';
 import {
-    CallToolRequestSchema,
-    ElicitationCompleteNotificationSchema,
-    type ElicitRequest,
-    type ElicitRequestFormParams,
-    ElicitRequestSchema,
-    ElicitResultSchema,
-    ErrorCode,
-    ListToolsRequestSchema,
-    McpError,
-    UrlElicitationRequiredError
-} from '../../../src/types.js';
-
+    Server,
+    McpServer,
+    ProtocolError,
+    UrlElicitationRequiredError,
+    ProtocolErrorCode,
+    specTypeSchemas
+} from '@modelcontextprotocol/server';
+import type { ElicitRequest, ElicitRequestFormParams } from '@modelcontextprotocol/server';
+import { Client } from '@modelcontextprotocol/client';
 import { tapWire, wire } from '../helpers/index.js';
 import type { TestArgs } from '../types.js';
 import { verifies } from '../helpers/verifies.js';
@@ -59,7 +52,7 @@ verifies('elicitation:form:basic', async ({ transport }: TestArgs) => {
 
     const received: Array<{ method: string; params: unknown }> = [];
     const client = formClient();
-    client.setRequestHandler(ElicitRequestSchema, async req => {
+    client.setRequestHandler('elicitation/create', async req => {
         received.push({ method: req.method, params: req.params });
         return { action: 'accept', content: { name: 'Ada' } };
     });
@@ -97,7 +90,7 @@ verifies('elicitation:form:action:accept', async ({ transport }: TestArgs) => {
     };
 
     const client = formClient();
-    client.setRequestHandler(ElicitRequestSchema, async () => {
+    client.setRequestHandler('elicitation/create', async () => {
         return { action: 'accept', content: { name: 'Ada' } };
     });
 
@@ -124,7 +117,7 @@ verifies('elicitation:form:action:cancel', async ({ transport }: TestArgs) => {
     };
 
     const client = formClient();
-    client.setRequestHandler(ElicitRequestSchema, async () => {
+    client.setRequestHandler('elicitation/create', async () => {
         return { action: 'cancel' };
     });
 
@@ -151,7 +144,7 @@ verifies('elicitation:form:action:decline', async ({ transport }: TestArgs) => {
     };
 
     const client = formClient();
-    client.setRequestHandler(ElicitRequestSchema, async () => {
+    client.setRequestHandler('elicitation/create', async () => {
         return { action: 'decline' };
     });
 
@@ -183,7 +176,7 @@ verifies('elicitation:form:defaults', async ({ transport }: TestArgs) => {
     };
 
     const client = formClientWithDefaults();
-    client.setRequestHandler(ElicitRequestSchema, async () => ({ action: 'accept', content: { name: 'Ada' } }));
+    client.setRequestHandler('elicitation/create', async () => ({ action: 'accept', content: { name: 'Ada' } }));
 
     await using _ = await wire(transport, makeServer, client);
 
@@ -194,10 +187,10 @@ verifies('elicitation:form:defaults', async ({ transport }: TestArgs) => {
 verifies('elicitation:form:mode-omitted-default', async ({ transport }: TestArgs) => {
     const makeServer = () => {
         const s = new Server({ name: 's', version: '0' }, { capabilities: { tools: {} } });
-        s.setRequestHandler(ListToolsRequestSchema, () => ({ tools: [{ name: 'ask', inputSchema: { type: 'object' } }] }));
-        s.setRequestHandler(CallToolRequestSchema, async (_req, extra) => {
+        s.setRequestHandler('tools/list', () => ({ tools: [{ name: 'ask', inputSchema: { type: 'object' } }] }));
+        s.setRequestHandler('tools/call', async (_req, ctx) => {
             try {
-                const ans = await extra.sendRequest(
+                const ans = await ctx.mcpReq.send(
                     {
                         method: 'elicitation/create',
                         params: {
@@ -205,11 +198,11 @@ verifies('elicitation:form:mode-omitted-default', async ({ transport }: TestArgs
                             requestedSchema: { type: 'object', properties: { name: { type: 'string' } } }
                         }
                     },
-                    ElicitResultSchema
+                    specTypeSchemas.ElicitResult
                 );
                 return { content: [{ type: 'text', text: ans.action }] };
             } catch (e) {
-                if (!(e instanceof McpError)) throw e;
+                if (!(e instanceof ProtocolError)) throw e;
                 return { content: [{ type: 'text', text: `error:${e.code}` }] };
             }
         });
@@ -218,7 +211,7 @@ verifies('elicitation:form:mode-omitted-default', async ({ transport }: TestArgs
 
     const formReceived: ElicitRequest['params'][] = [];
     const formClientInstance = formClient();
-    formClientInstance.setRequestHandler(ElicitRequestSchema, async req => {
+    formClientInstance.setRequestHandler('elicitation/create', async req => {
         formReceived.push(req.params);
         return { action: 'accept', content: { name: 'Test' } };
     });
@@ -233,7 +226,7 @@ verifies('elicitation:form:mode-omitted-default', async ({ transport }: TestArgs
 
     let urlHandlerInvoked = 0;
     const urlClientInstance = urlClient();
-    urlClientInstance.setRequestHandler(ElicitRequestSchema, async () => {
+    urlClientInstance.setRequestHandler('elicitation/create', async () => {
         urlHandlerInvoked++;
         return { action: 'accept' };
     });
@@ -241,7 +234,7 @@ verifies('elicitation:form:mode-omitted-default', async ({ transport }: TestArgs
     await using _2 = await wire(transport, makeServer, urlClientInstance);
 
     const urlResult = await urlClientInstance.callTool({ name: 'ask', arguments: {} });
-    expect(urlResult.content).toEqual([{ type: 'text', text: `error:${ErrorCode.InvalidParams}` }]);
+    expect(urlResult.content).toEqual([{ type: 'text', text: `error:${ProtocolErrorCode.InvalidParams}` }]);
     expect(urlHandlerInvoked).toBe(0);
 });
 
@@ -268,7 +261,7 @@ verifies('elicitation:form:schema:primitives', async ({ transport }: TestArgs) =
     const expected = { name: 'Ada', email: 'ada@example.com', age: 30, score: 95.5, active: true };
     const received: ElicitRequest['params'][] = [];
     const client = formClient();
-    client.setRequestHandler(ElicitRequestSchema, async req => {
+    client.setRequestHandler('elicitation/create', async req => {
         received.push(req.params);
         return { action: 'accept', content: expected };
     });
@@ -316,7 +309,7 @@ verifies('elicitation:form:schema:enum-variants', async ({ transport }: TestArgs
     const expected = { bare: 'Red', titled: '#00FF00', multi: ['#FF0000', '#0000FF'] };
     const received: ElicitRequest['params'][] = [];
     const client = formClient();
-    client.setRequestHandler(ElicitRequestSchema, async req => {
+    client.setRequestHandler('elicitation/create', async req => {
         received.push(req.params);
         return { action: 'accept', content: expected };
     });
@@ -345,7 +338,7 @@ verifies('elicitation:form:response-validation', async ({ transport }: TestArgs)
                     content: [{ type: 'text', text: `SDK accepted invalid content: ${JSON.stringify(ans.content)}` }]
                 };
             } catch (e) {
-                if (!(e instanceof McpError)) throw e;
+                if (!(e instanceof ProtocolError)) throw e;
                 return { content: [{ type: 'text', text: `rejected:${e.code}:${e.message}` }] };
             }
         });
@@ -356,7 +349,7 @@ verifies('elicitation:form:response-validation', async ({ transport }: TestArgs)
     const invalidContents: Array<Record<string, string | number | boolean>> = [{ username: 42 }, {}];
     let handlerInvoked = 0;
     const client = formClient();
-    client.setRequestHandler(ElicitRequestSchema, async () => {
+    client.setRequestHandler('elicitation/create', async () => {
         const content = invalidContents[handlerInvoked];
         handlerInvoked++;
         return { action: 'accept', content };
@@ -364,7 +357,9 @@ verifies('elicitation:form:response-validation', async ({ transport }: TestArgs)
 
     await using _ = await wire(transport, makeServer, client);
 
-    const schemaRejection = expect.stringMatching(new RegExp(`^rejected:${ErrorCode.InvalidParams}:.*does not match requested schema`));
+    const schemaRejection = expect.stringMatching(
+        new RegExp(`^rejected:${ProtocolErrorCode.InvalidParams}:.*does not match requested schema`)
+    );
 
     const wrongType = await client.callTool({ name: 'signup', arguments: {} });
     expect(wrongType.isError).toBeFalsy();
@@ -380,10 +375,10 @@ verifies('elicitation:form:response-validation', async ({ transport }: TestArgs)
 verifies('elicitation:form:schema:restricted-subset', async ({ transport }: TestArgs) => {
     const makeServer = () => {
         const s = new Server({ name: 's', version: '0' }, { capabilities: { tools: {} } });
-        s.setRequestHandler(ListToolsRequestSchema, () => ({ tools: [{ name: 'profile', inputSchema: { type: 'object' } }] }));
-        s.setRequestHandler(CallToolRequestSchema, async (_req, extra) => {
+        s.setRequestHandler('tools/list', () => ({ tools: [{ name: 'profile', inputSchema: { type: 'object' } }] }));
+        s.setRequestHandler('tools/call', async (_req, ctx) => {
             try {
-                await extra.sendRequest(
+                await ctx.mcpReq.send(
                     {
                         method: 'elicitation/create',
                         params: {
@@ -404,11 +399,11 @@ verifies('elicitation:form:schema:restricted-subset', async ({ transport }: Test
                             }
                         }
                     },
-                    ElicitResultSchema
+                    specTypeSchemas.ElicitResult
                 );
                 return { content: [{ type: 'text', text: 'should-not-reach' }] };
             } catch (e) {
-                if (!(e instanceof McpError)) throw e;
+                if (!(e instanceof ProtocolError)) throw e;
                 return { content: [{ type: 'text', text: `error:${e.code}` }] };
             }
         });
@@ -417,7 +412,7 @@ verifies('elicitation:form:schema:restricted-subset', async ({ transport }: Test
 
     let handlerInvoked = 0;
     const client = formClient();
-    client.setRequestHandler(ElicitRequestSchema, async () => {
+    client.setRequestHandler('elicitation/create', async () => {
         handlerInvoked++;
         return { action: 'accept', content: {} };
     });
@@ -427,7 +422,7 @@ verifies('elicitation:form:schema:restricted-subset', async ({ transport }: Test
 
     const r = await client.callTool({ name: 'profile', arguments: {} });
     expect(r.isError).toBeFalsy();
-    expect(r.content).toEqual([{ type: 'text', text: `error:${ErrorCode.InvalidParams}` }]);
+    expect(r.content).toEqual([{ type: 'text', text: `error:${ProtocolErrorCode.InvalidParams}` }]);
     expect(handlerInvoked).toBe(0);
 });
 
@@ -448,7 +443,7 @@ verifies('elicitation:url:basic', async ({ transport }: TestArgs) => {
 
     const received: ElicitRequest['params'][] = [];
     const client = urlClient();
-    client.setRequestHandler(ElicitRequestSchema, async req => {
+    client.setRequestHandler('elicitation/create', async req => {
         received.push(req.params);
         return { action: 'accept' };
     });
@@ -485,7 +480,7 @@ verifies('elicitation:url:action:accept-no-content', async ({ transport }: TestA
     };
 
     const client = urlClient();
-    client.setRequestHandler(ElicitRequestSchema, async () => ({ action: 'accept' }));
+    client.setRequestHandler('elicitation/create', async () => ({ action: 'accept' }));
 
     await using _ = await wire(transport, makeServer, client);
 
@@ -511,7 +506,7 @@ verifies('elicitation:url:action:cancel', async ({ transport }: TestArgs) => {
     };
 
     const client = urlClient();
-    client.setRequestHandler(ElicitRequestSchema, async () => ({ action: 'cancel' }));
+    client.setRequestHandler('elicitation/create', async () => ({ action: 'cancel' }));
 
     await using _ = await wire(transport, makeServer, client);
 
@@ -538,7 +533,7 @@ verifies('elicitation:url:action:decline', async ({ transport }: TestArgs) => {
     };
 
     const client = urlClient();
-    client.setRequestHandler(ElicitRequestSchema, async () => ({ action: 'decline' }));
+    client.setRequestHandler('elicitation/create', async () => ({ action: 'decline' }));
 
     await using _ = await wire(transport, makeServer, client);
 
@@ -562,8 +557,8 @@ verifies('elicitation:url:complete-notification', async ({ transport }: TestArgs
                 }
             ]);
         });
-        s.registerTool('complete', { inputSchema: z.object({ elicitationId: z.string() }) }, async ({ elicitationId }, extra) => {
-            const notify = s.server.createElicitationCompletionNotifier(elicitationId, { relatedRequestId: extra.requestId });
+        s.registerTool('complete', { inputSchema: z.object({ elicitationId: z.string() }) }, async ({ elicitationId }, ctx) => {
+            const notify = s.server.createElicitationCompletionNotifier(elicitationId, { relatedRequestId: ctx.mcpReq.id });
             await notify();
             return { content: [{ type: 'text', text: 'notified' }] };
         });
@@ -571,7 +566,7 @@ verifies('elicitation:url:complete-notification', async ({ transport }: TestArgs
     };
 
     const client = urlClient();
-    client.setNotificationHandler(ElicitationCompleteNotificationSchema, n => {
+    client.setNotificationHandler('notifications/elicitation/complete', n => {
         notifications.push({ method: n.method, params: n.params });
     });
 
@@ -600,10 +595,10 @@ verifies('elicitation:url:complete-unknown-ignored', async ({ transport }: TestA
         });
         // Raw send: the server-side capability gate cannot pass on stateless (client capabilities never learned),
         // and the behavior under test is the client's handling of the notification.
-        s.registerTool('complete', { inputSchema: z.object({ elicitationId: z.string() }) }, async ({ elicitationId }, extra) => {
+        s.registerTool('complete', { inputSchema: z.object({ elicitationId: z.string() }) }, async ({ elicitationId }, ctx) => {
             await s.server.transport!.send(
                 { jsonrpc: '2.0', method: 'notifications/elicitation/complete', params: { elicitationId } },
-                { relatedRequestId: extra.requestId }
+                { relatedRequestId: ctx.mcpReq.id }
             );
             return { content: [{ type: 'text', text: 'sent' }] };
         });
@@ -615,7 +610,7 @@ verifies('elicitation:url:complete-unknown-ignored', async ({ transport }: TestA
     const errors: Error[] = [];
     const client = urlClient();
     client.onerror = e => errors.push(e);
-    client.setNotificationHandler(ElicitationCompleteNotificationSchema, n => {
+    client.setNotificationHandler('notifications/elicitation/complete', n => {
         notifications.push({ method: n.method, params: n.params });
     });
 
@@ -663,7 +658,7 @@ verifies('elicitation:url:required-error', async ({ transport }: TestArgs) => {
 
     const err = await client.callTool({ name: 'auth-required', arguments: {} }).catch(e => e);
     if (!(err instanceof UrlElicitationRequiredError)) throw new Error(`expected UrlElicitationRequiredError, got ${err}`);
-    expect(err.code).toBe(ErrorCode.UrlElicitationRequired);
+    expect(err.code).toBe(ProtocolErrorCode.UrlElicitationRequired);
     expect(err.elicitations).toHaveLength(1);
     expect(err.elicitations[0]).toMatchObject({
         mode: 'url',
@@ -688,7 +683,7 @@ verifies('elicitation:capability:empty-is-form', async ({ transport }: TestArgs)
     };
 
     const client = new Client({ name: 'c', version: '0' }, { capabilities: { elicitation: {} } });
-    client.setRequestHandler(ElicitRequestSchema, async () => {
+    client.setRequestHandler('elicitation/create', async () => {
         return { action: 'accept', content: { name: 'Test' } };
     });
 
@@ -701,19 +696,19 @@ verifies('elicitation:capability:empty-is-form', async ({ transport }: TestArgs)
 verifies('elicitation:capability:mode-mismatch', async ({ transport }: TestArgs) => {
     const makeServer = () => {
         const s = new Server({ name: 's', version: '0' }, { capabilities: { tools: {} } });
-        s.setRequestHandler(ListToolsRequestSchema, () => ({ tools: [{ name: 'auth', inputSchema: { type: 'object' } }] }));
-        s.setRequestHandler(CallToolRequestSchema, async (_req, extra) => {
+        s.setRequestHandler('tools/list', () => ({ tools: [{ name: 'auth', inputSchema: { type: 'object' } }] }));
+        s.setRequestHandler('tools/call', async (_req, ctx) => {
             try {
-                await extra.sendRequest(
+                await ctx.mcpReq.send(
                     {
                         method: 'elicitation/create',
                         params: { mode: 'url', message: 'Sign in', elicitationId: 'mismatch-1', url: 'https://example.com/auth' }
                     },
-                    ElicitResultSchema
+                    specTypeSchemas.ElicitResult
                 );
                 return { content: [{ type: 'text', text: 'should-not-reach' }] };
             } catch (e) {
-                if (!(e instanceof McpError)) throw e;
+                if (!(e instanceof ProtocolError)) throw e;
                 return { content: [{ type: 'text', text: `error:${e.code}` }] };
             }
         });
@@ -722,7 +717,7 @@ verifies('elicitation:capability:mode-mismatch', async ({ transport }: TestArgs)
 
     let handlerInvoked = 0;
     const client = formClient();
-    client.setRequestHandler(ElicitRequestSchema, async () => {
+    client.setRequestHandler('elicitation/create', async () => {
         handlerInvoked++;
         return { action: 'accept', content: {} };
     });
@@ -730,7 +725,7 @@ verifies('elicitation:capability:mode-mismatch', async ({ transport }: TestArgs)
     await using _ = await wire(transport, makeServer, client);
 
     const r = await client.callTool({ name: 'auth', arguments: {} });
-    expect(r.content).toEqual([{ type: 'text', text: `error:${ErrorCode.InvalidParams}` }]);
+    expect(r.content).toEqual([{ type: 'text', text: `error:${ProtocolErrorCode.InvalidParams}` }]);
     expect(handlerInvoked).toBe(0);
 });
 
@@ -755,7 +750,7 @@ verifies('elicitation:capability:server-respects-mode', async ({ transport }: Te
     };
 
     const client = formClient();
-    client.setRequestHandler(ElicitRequestSchema, async () => {
+    client.setRequestHandler('elicitation/create', async () => {
         reachedClient++;
         return { action: 'accept' };
     });

--- a/test/e2e/scenarios/elicitation.test.ts
+++ b/test/e2e/scenarios/elicitation.test.ts
@@ -1,0 +1,817 @@
+/**
+ * Self-contained test bodies for elicitation (form and URL modes).
+ *
+ * Each export is a {@link TestCase}: it builds its own server, client, wires
+ * them with {@link wire}, and asserts. Elicitation is a server→client request
+ * flow, so tests inline `client.setRequestHandler(ElicitRequestSchema, ...)` to
+ * script the responses the server will receive.
+ *
+ * Function names mirror the requirement id in camelCase.
+ */
+
+import { expect } from 'vitest';
+import { z } from 'zod/v4';
+
+import { Client } from '../../../src/client/index.js';
+import { Server } from '../../../src/server/index.js';
+import { McpServer } from '../../../src/server/mcp.js';
+import {
+    CallToolRequestSchema,
+    ElicitationCompleteNotificationSchema,
+    type ElicitRequest,
+    type ElicitRequestFormParams,
+    ElicitRequestSchema,
+    ElicitResultSchema,
+    ErrorCode,
+    ListToolsRequestSchema,
+    McpError,
+    UrlElicitationRequiredError
+} from '../../../src/types.js';
+
+import { tapWire, wire } from '../helpers/index.js';
+import type { TestArgs } from '../types.js';
+import { verifies } from '../helpers/verifies.js';
+
+/** Client with form-mode elicitation support. */
+const formClient = () => new Client({ name: 'c', version: '0' }, { capabilities: { elicitation: { form: {} } } });
+
+/** Client with form-mode elicitation AND applyDefaults support. */
+const formClientWithDefaults = () =>
+    new Client({ name: 'c', version: '0' }, { capabilities: { elicitation: { form: { applyDefaults: true } } } });
+
+/** Client with URL-mode elicitation support. */
+const urlClient = () => new Client({ name: 'c', version: '0' }, { capabilities: { elicitation: { url: {} } } });
+
+verifies('elicitation:form:basic', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool('ask-name', { inputSchema: z.object({}) }, async () => {
+            const ans = await s.server.elicitInput({
+                mode: 'form',
+                message: 'What is your name?',
+                requestedSchema: { type: 'object', properties: { name: { type: 'string' } }, required: ['name'] }
+            });
+            const name = ans.action === 'accept' ? String(ans.content?.name) : '<declined>';
+            return { content: [{ type: 'text', text: `Hello, ${name}` }] };
+        });
+        return s;
+    };
+
+    const received: Array<{ method: string; params: unknown }> = [];
+    const client = formClient();
+    client.setRequestHandler(ElicitRequestSchema, async req => {
+        received.push({ method: req.method, params: req.params });
+        return { action: 'accept', content: { name: 'Ada' } };
+    });
+
+    await using _ = await wire(transport, makeServer, client);
+
+    const r = await client.callTool({ name: 'ask-name', arguments: {} });
+
+    expect(received).toHaveLength(1);
+    expect(received[0].method).toBe('elicitation/create');
+    expect(received[0].params).toMatchObject({
+        mode: 'form',
+        message: 'What is your name?',
+        requestedSchema: { type: 'object', properties: { name: { type: 'string' } }, required: ['name'] }
+    });
+
+    expect(r.isError).toBeFalsy();
+    expect(r.content).toEqual([{ type: 'text', text: 'Hello, Ada' }]);
+});
+
+verifies('elicitation:form:action:accept', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool('ask', { inputSchema: z.object({}) }, async () => {
+            const ans = await s.server.elicitInput({
+                mode: 'form',
+                message: 'Enter name',
+                requestedSchema: { type: 'object', properties: { name: { type: 'string' } }, required: ['name'] }
+            });
+            return {
+                content: [{ type: 'text', text: ans.action === 'accept' ? String(ans.content?.name) : 'none' }]
+            };
+        });
+        return s;
+    };
+
+    const client = formClient();
+    client.setRequestHandler(ElicitRequestSchema, async () => {
+        return { action: 'accept', content: { name: 'Ada' } };
+    });
+
+    await using _ = await wire(transport, makeServer, client);
+
+    const r = await client.callTool({ name: 'ask', arguments: {} });
+    expect(r.content).toEqual([{ type: 'text', text: 'Ada' }]);
+});
+
+verifies('elicitation:form:action:cancel', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool('ask', { inputSchema: z.object({}) }, async () => {
+            const ans = await s.server.elicitInput({
+                mode: 'form',
+                message: 'Enter name',
+                requestedSchema: { type: 'object', properties: { name: { type: 'string' } } }
+            });
+            return {
+                content: [{ type: 'text', text: `action:${ans.action},hasContent:${'content' in ans && ans.content !== undefined}` }]
+            };
+        });
+        return s;
+    };
+
+    const client = formClient();
+    client.setRequestHandler(ElicitRequestSchema, async () => {
+        return { action: 'cancel' };
+    });
+
+    await using _ = await wire(transport, makeServer, client);
+
+    const r = await client.callTool({ name: 'ask', arguments: {} });
+    expect(r.content).toEqual([{ type: 'text', text: 'action:cancel,hasContent:false' }]);
+});
+
+verifies('elicitation:form:action:decline', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool('ask', { inputSchema: z.object({}) }, async () => {
+            const ans = await s.server.elicitInput({
+                mode: 'form',
+                message: 'Enter name',
+                requestedSchema: { type: 'object', properties: { name: { type: 'string' } } }
+            });
+            return {
+                content: [{ type: 'text', text: `action:${ans.action},hasContent:${'content' in ans && ans.content !== undefined}` }]
+            };
+        });
+        return s;
+    };
+
+    const client = formClient();
+    client.setRequestHandler(ElicitRequestSchema, async () => {
+        return { action: 'decline' };
+    });
+
+    await using _ = await wire(transport, makeServer, client);
+
+    const r = await client.callTool({ name: 'ask', arguments: {} });
+    expect(r.content).toEqual([{ type: 'text', text: 'action:decline,hasContent:false' }]);
+});
+
+verifies('elicitation:form:defaults', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool('ask', { inputSchema: z.object({}) }, async () => {
+            const ans = await s.server.elicitInput({
+                mode: 'form',
+                message: 'Fill form',
+                requestedSchema: {
+                    type: 'object',
+                    properties: {
+                        name: { type: 'string', default: 'anon' },
+                        age: { type: 'integer', default: 42 },
+                        subscribe: { type: 'boolean', default: true }
+                    }
+                }
+            });
+            return { content: [], structuredContent: ans.action === 'accept' ? ans.content : undefined };
+        });
+        return s;
+    };
+
+    const client = formClientWithDefaults();
+    client.setRequestHandler(ElicitRequestSchema, async () => ({ action: 'accept', content: { name: 'Ada' } }));
+
+    await using _ = await wire(transport, makeServer, client);
+
+    const r = await client.callTool({ name: 'ask', arguments: {} });
+    expect(r.structuredContent).toEqual({ name: 'Ada', age: 42, subscribe: true });
+});
+
+verifies('elicitation:form:mode-omitted-default', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        const s = new Server({ name: 's', version: '0' }, { capabilities: { tools: {} } });
+        s.setRequestHandler(ListToolsRequestSchema, () => ({ tools: [{ name: 'ask', inputSchema: { type: 'object' } }] }));
+        s.setRequestHandler(CallToolRequestSchema, async (_req, extra) => {
+            try {
+                const ans = await extra.sendRequest(
+                    {
+                        method: 'elicitation/create',
+                        params: {
+                            message: 'Enter name',
+                            requestedSchema: { type: 'object', properties: { name: { type: 'string' } } }
+                        }
+                    },
+                    ElicitResultSchema
+                );
+                return { content: [{ type: 'text', text: ans.action }] };
+            } catch (e) {
+                if (!(e instanceof McpError)) throw e;
+                return { content: [{ type: 'text', text: `error:${e.code}` }] };
+            }
+        });
+        return s;
+    };
+
+    const formReceived: ElicitRequest['params'][] = [];
+    const formClientInstance = formClient();
+    formClientInstance.setRequestHandler(ElicitRequestSchema, async req => {
+        formReceived.push(req.params);
+        return { action: 'accept', content: { name: 'Test' } };
+    });
+
+    await using _1 = await wire(transport, makeServer, formClientInstance);
+
+    const formResult = await formClientInstance.callTool({ name: 'ask', arguments: {} });
+
+    expect(formReceived).toHaveLength(1);
+    expect(formReceived[0].mode).toBeUndefined();
+    expect(formResult.content).toEqual([{ type: 'text', text: 'accept' }]);
+
+    let urlHandlerInvoked = 0;
+    const urlClientInstance = urlClient();
+    urlClientInstance.setRequestHandler(ElicitRequestSchema, async () => {
+        urlHandlerInvoked++;
+        return { action: 'accept' };
+    });
+
+    await using _2 = await wire(transport, makeServer, urlClientInstance);
+
+    const urlResult = await urlClientInstance.callTool({ name: 'ask', arguments: {} });
+    expect(urlResult.content).toEqual([{ type: 'text', text: `error:${ErrorCode.InvalidParams}` }]);
+    expect(urlHandlerInvoked).toBe(0);
+});
+
+verifies('elicitation:form:schema:primitives', async ({ transport }: TestArgs) => {
+    const requestedSchema: ElicitRequestFormParams['requestedSchema'] = {
+        type: 'object',
+        properties: {
+            name: { type: 'string' },
+            email: { type: 'string', format: 'email' },
+            age: { type: 'integer' },
+            score: { type: 'number' },
+            active: { type: 'boolean' }
+        }
+    };
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool('ask', { inputSchema: z.object({}) }, async () => {
+            const ans = await s.server.elicitInput({ mode: 'form', message: 'Fill form', requestedSchema });
+            return { content: [], structuredContent: ans.action === 'accept' ? ans.content : undefined };
+        });
+        return s;
+    };
+
+    const expected = { name: 'Ada', email: 'ada@example.com', age: 30, score: 95.5, active: true };
+    const received: ElicitRequest['params'][] = [];
+    const client = formClient();
+    client.setRequestHandler(ElicitRequestSchema, async req => {
+        received.push(req.params);
+        return { action: 'accept', content: expected };
+    });
+
+    await using _ = await wire(transport, makeServer, client);
+
+    const r = await client.callTool({ name: 'ask', arguments: {} });
+    expect(received).toHaveLength(1);
+    expect(received[0]).toEqual({ mode: 'form', message: 'Fill form', requestedSchema });
+    expect(r.structuredContent).toEqual(expected);
+});
+
+verifies('elicitation:form:schema:enum-variants', async ({ transport }: TestArgs) => {
+    const requestedSchema: ElicitRequestFormParams['requestedSchema'] = {
+        type: 'object',
+        properties: {
+            bare: { type: 'string', enum: ['Red', 'Green', 'Blue'] },
+            titled: {
+                type: 'string',
+                oneOf: [
+                    { const: '#FF0000', title: 'Red' },
+                    { const: '#00FF00', title: 'Green' }
+                ]
+            },
+            multi: {
+                type: 'array',
+                items: {
+                    anyOf: [
+                        { const: '#FF0000', title: 'Red' },
+                        { const: '#0000FF', title: 'Blue' }
+                    ]
+                }
+            }
+        }
+    };
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool('ask', { inputSchema: z.object({}) }, async () => {
+            const ans = await s.server.elicitInput({ mode: 'form', message: 'Pick colors', requestedSchema });
+            return { content: [], structuredContent: ans.action === 'accept' ? ans.content : undefined };
+        });
+        return s;
+    };
+
+    const expected = { bare: 'Red', titled: '#00FF00', multi: ['#FF0000', '#0000FF'] };
+    const received: ElicitRequest['params'][] = [];
+    const client = formClient();
+    client.setRequestHandler(ElicitRequestSchema, async req => {
+        received.push(req.params);
+        return { action: 'accept', content: expected };
+    });
+
+    await using _ = await wire(transport, makeServer, client);
+
+    const r = await client.callTool({ name: 'ask', arguments: {} });
+    expect(received).toHaveLength(1);
+    expect(received[0]).toEqual({ mode: 'form', message: 'Pick colors', requestedSchema });
+    expect(r.structuredContent).toEqual(expected);
+});
+
+verifies('elicitation:form:response-validation', async ({ transport }: TestArgs) => {
+    const requestedSchema: ElicitRequestFormParams['requestedSchema'] = {
+        type: 'object',
+        properties: { username: { type: 'string' } },
+        required: ['username']
+    };
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool('signup', { inputSchema: z.object({}) }, async () => {
+            try {
+                const ans = await s.server.elicitInput({ mode: 'form', message: 'Choose a username', requestedSchema });
+                return {
+                    isError: true,
+                    content: [{ type: 'text', text: `SDK accepted invalid content: ${JSON.stringify(ans.content)}` }]
+                };
+            } catch (e) {
+                if (!(e instanceof McpError)) throw e;
+                return { content: [{ type: 'text', text: `rejected:${e.code}:${e.message}` }] };
+            }
+        });
+        return s;
+    };
+
+    // Each accepted response violates the requested schema: wrong type for `username`, then missing required `username`.
+    const invalidContents: Array<Record<string, string | number | boolean>> = [{ username: 42 }, {}];
+    let handlerInvoked = 0;
+    const client = formClient();
+    client.setRequestHandler(ElicitRequestSchema, async () => {
+        const content = invalidContents[handlerInvoked];
+        handlerInvoked++;
+        return { action: 'accept', content };
+    });
+
+    await using _ = await wire(transport, makeServer, client);
+
+    const schemaRejection = expect.stringMatching(new RegExp(`^rejected:${ErrorCode.InvalidParams}:.*does not match requested schema`));
+
+    const wrongType = await client.callTool({ name: 'signup', arguments: {} });
+    expect(wrongType.isError).toBeFalsy();
+    expect(wrongType.content).toEqual([{ type: 'text', text: schemaRejection }]);
+
+    const missingRequired = await client.callTool({ name: 'signup', arguments: {} });
+    expect(missingRequired.isError).toBeFalsy();
+    expect(missingRequired.content).toEqual([{ type: 'text', text: schemaRejection }]);
+
+    expect(handlerInvoked).toBe(2);
+});
+
+verifies('elicitation:form:schema:restricted-subset', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        const s = new Server({ name: 's', version: '0' }, { capabilities: { tools: {} } });
+        s.setRequestHandler(ListToolsRequestSchema, () => ({ tools: [{ name: 'profile', inputSchema: { type: 'object' } }] }));
+        s.setRequestHandler(CallToolRequestSchema, async (_req, extra) => {
+            try {
+                await extra.sendRequest(
+                    {
+                        method: 'elicitation/create',
+                        params: {
+                            mode: 'form',
+                            message: 'Profile details',
+                            requestedSchema: {
+                                type: 'object',
+                                properties: {
+                                    address: {
+                                        type: 'object',
+                                        properties: { street: { type: 'string' }, city: { type: 'string' } }
+                                    },
+                                    contacts: {
+                                        type: 'array',
+                                        items: { type: 'object', properties: { name: { type: 'string' } } }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    ElicitResultSchema
+                );
+                return { content: [{ type: 'text', text: 'should-not-reach' }] };
+            } catch (e) {
+                if (!(e instanceof McpError)) throw e;
+                return { content: [{ type: 'text', text: `error:${e.code}` }] };
+            }
+        });
+        return s;
+    };
+
+    let handlerInvoked = 0;
+    const client = formClient();
+    client.setRequestHandler(ElicitRequestSchema, async () => {
+        handlerInvoked++;
+        return { action: 'accept', content: {} };
+    });
+
+    // strictValidation off: the nested requestedSchema deliberately violates the spec's flat-primitive restriction on the wire.
+    await using _ = await wire(transport, makeServer, client, { strictValidation: false });
+
+    const r = await client.callTool({ name: 'profile', arguments: {} });
+    expect(r.isError).toBeFalsy();
+    expect(r.content).toEqual([{ type: 'text', text: `error:${ErrorCode.InvalidParams}` }]);
+    expect(handlerInvoked).toBe(0);
+});
+
+verifies('elicitation:url:basic', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool('auth', { inputSchema: z.object({}) }, async () => {
+            const ans = await s.server.elicitInput({
+                mode: 'url',
+                message: 'Please sign in',
+                elicitationId: 'url-1',
+                url: 'https://example.com/auth?state=test'
+            });
+            return { content: [{ type: 'text', text: ans.action }] };
+        });
+        return s;
+    };
+
+    const received: ElicitRequest['params'][] = [];
+    const client = urlClient();
+    client.setRequestHandler(ElicitRequestSchema, async req => {
+        received.push(req.params);
+        return { action: 'accept' };
+    });
+
+    await using _ = await wire(transport, makeServer, client);
+
+    const r = await client.callTool({ name: 'auth', arguments: {} });
+
+    expect(received).toHaveLength(1);
+    expect(received[0]).toMatchObject({
+        mode: 'url',
+        message: 'Please sign in',
+        elicitationId: 'url-1',
+        url: 'https://example.com/auth?state=test'
+    });
+    expect(r.content).toEqual([{ type: 'text', text: 'accept' }]);
+});
+
+verifies('elicitation:url:action:accept-no-content', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool('auth', { inputSchema: z.object({}) }, async () => {
+            const ans = await s.server.elicitInput({
+                mode: 'url',
+                message: 'Please sign in',
+                elicitationId: 'url-2',
+                url: 'https://example.com/auth'
+            });
+            return {
+                content: [{ type: 'text', text: `action:${ans.action},hasContent:${'content' in ans && ans.content !== undefined}` }]
+            };
+        });
+        return s;
+    };
+
+    const client = urlClient();
+    client.setRequestHandler(ElicitRequestSchema, async () => ({ action: 'accept' }));
+
+    await using _ = await wire(transport, makeServer, client);
+
+    const r = await client.callTool({ name: 'auth', arguments: {} });
+    expect(r.content).toEqual([{ type: 'text', text: 'action:accept,hasContent:false' }]);
+});
+
+verifies('elicitation:url:action:cancel', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool('auth', { inputSchema: z.object({}) }, async () => {
+            const ans = await s.server.elicitInput({
+                mode: 'url',
+                message: 'Please sign in',
+                elicitationId: 'url-cancel-1',
+                url: 'https://example.com/auth'
+            });
+            return {
+                content: [{ type: 'text', text: `action:${ans.action},hasContent:${'content' in ans && ans.content !== undefined}` }]
+            };
+        });
+        return s;
+    };
+
+    const client = urlClient();
+    client.setRequestHandler(ElicitRequestSchema, async () => ({ action: 'cancel' }));
+
+    await using _ = await wire(transport, makeServer, client);
+
+    const r = await client.callTool({ name: 'auth', arguments: {} });
+    expect(r.isError).toBeFalsy();
+    expect(r.content).toEqual([{ type: 'text', text: 'action:cancel,hasContent:false' }]);
+});
+
+verifies('elicitation:url:action:decline', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool('auth', { inputSchema: z.object({}) }, async () => {
+            const ans = await s.server.elicitInput({
+                mode: 'url',
+                message: 'Please sign in',
+                elicitationId: 'url-decline-1',
+                url: 'https://example.com/auth'
+            });
+            return {
+                content: [{ type: 'text', text: `action:${ans.action},hasContent:${'content' in ans && ans.content !== undefined}` }]
+            };
+        });
+        return s;
+    };
+
+    const client = urlClient();
+    client.setRequestHandler(ElicitRequestSchema, async () => ({ action: 'decline' }));
+
+    await using _ = await wire(transport, makeServer, client);
+
+    const r = await client.callTool({ name: 'auth', arguments: {} });
+    expect(r.isError).toBeFalsy();
+    expect(r.content).toEqual([{ type: 'text', text: 'action:decline,hasContent:false' }]);
+});
+
+verifies('elicitation:url:complete-notification', async ({ transport }: TestArgs) => {
+    const notifications: Array<{ method: string; params: unknown }> = [];
+
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool('auth', { inputSchema: z.object({}) }, async () => {
+            throw new UrlElicitationRequiredError([
+                {
+                    mode: 'url',
+                    message: 'Sign in required',
+                    elicitationId: 'complete-1',
+                    url: 'https://example.com/auth'
+                }
+            ]);
+        });
+        s.registerTool('complete', { inputSchema: z.object({ elicitationId: z.string() }) }, async ({ elicitationId }, extra) => {
+            const notify = s.server.createElicitationCompletionNotifier(elicitationId, { relatedRequestId: extra.requestId });
+            await notify();
+            return { content: [{ type: 'text', text: 'notified' }] };
+        });
+        return s;
+    };
+
+    const client = urlClient();
+    client.setNotificationHandler(ElicitationCompleteNotificationSchema, n => {
+        notifications.push({ method: n.method, params: n.params });
+    });
+
+    await using _ = await wire(transport, makeServer, client);
+
+    const err = await client.callTool({ name: 'auth', arguments: {} }).catch(e => e);
+    if (!(err instanceof UrlElicitationRequiredError)) throw new Error(`expected UrlElicitationRequiredError, got ${err}`);
+    const elicitationId = err.elicitations[0].elicitationId;
+
+    await client.callTool({ name: 'complete', arguments: { elicitationId } });
+
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0]).toEqual({
+        method: 'notifications/elicitation/complete',
+        params: { elicitationId: 'complete-1' }
+    });
+});
+
+verifies('elicitation:url:complete-unknown-ignored', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool('auth', { inputSchema: z.object({}) }, () => {
+            throw new UrlElicitationRequiredError([
+                { mode: 'url', message: 'Sign in required', elicitationId: 'seen-1', url: 'https://example.com/auth' }
+            ]);
+        });
+        // Raw send: the server-side capability gate cannot pass on stateless (client capabilities never learned),
+        // and the behavior under test is the client's handling of the notification.
+        s.registerTool('complete', { inputSchema: z.object({ elicitationId: z.string() }) }, async ({ elicitationId }, extra) => {
+            await s.server.transport!.send(
+                { jsonrpc: '2.0', method: 'notifications/elicitation/complete', params: { elicitationId } },
+                { relatedRequestId: extra.requestId }
+            );
+            return { content: [{ type: 'text', text: 'sent' }] };
+        });
+        s.registerTool('noop', { inputSchema: z.object({}) }, () => ({ content: [] }));
+        return s;
+    };
+
+    const notifications: Array<{ method: string; params: unknown }> = [];
+    const errors: Error[] = [];
+    const client = urlClient();
+    client.onerror = e => errors.push(e);
+    client.setNotificationHandler(ElicitationCompleteNotificationSchema, n => {
+        notifications.push({ method: n.method, params: n.params });
+    });
+
+    await using _ = await wire(transport, makeServer, client);
+
+    const err = await client.callTool({ name: 'auth', arguments: {} }).catch(e => e);
+    if (!(err instanceof UrlElicitationRequiredError)) throw new Error(`expected UrlElicitationRequiredError, got ${err}`);
+    const seenId = err.elicitations[0].elicitationId;
+
+    await client.callTool({ name: 'complete', arguments: { elicitationId: seenId } });
+    // Already-completed id, then an id the client never saw: both must be ignored without error.
+    await client.callTool({ name: 'complete', arguments: { elicitationId: seenId } });
+    await client.callTool({ name: 'complete', arguments: { elicitationId: 'never-issued' } });
+
+    expect(notifications).toEqual([
+        { method: 'notifications/elicitation/complete', params: { elicitationId: 'seen-1' } },
+        { method: 'notifications/elicitation/complete', params: { elicitationId: 'seen-1' } },
+        { method: 'notifications/elicitation/complete', params: { elicitationId: 'never-issued' } }
+    ]);
+    expect(errors).toEqual([]);
+
+    const after = await client.callTool({ name: 'noop', arguments: {} });
+    expect(after.isError).toBeFalsy();
+    expect(after.content).toEqual([]);
+});
+
+verifies('elicitation:url:required-error', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool('auth-required', { inputSchema: z.object({}) }, () => {
+            throw new UrlElicitationRequiredError([
+                {
+                    mode: 'url',
+                    message: 'Please authenticate',
+                    elicitationId: 'err-1',
+                    url: 'https://example.com/oauth'
+                }
+            ]);
+        });
+        return s;
+    };
+
+    const client = urlClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    const err = await client.callTool({ name: 'auth-required', arguments: {} }).catch(e => e);
+    if (!(err instanceof UrlElicitationRequiredError)) throw new Error(`expected UrlElicitationRequiredError, got ${err}`);
+    expect(err.code).toBe(ErrorCode.UrlElicitationRequired);
+    expect(err.elicitations).toHaveLength(1);
+    expect(err.elicitations[0]).toMatchObject({
+        mode: 'url',
+        message: 'Please authenticate',
+        elicitationId: 'err-1',
+        url: 'https://example.com/oauth'
+    });
+});
+
+verifies('elicitation:capability:empty-is-form', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool('ask', { inputSchema: z.object({}) }, async () => {
+            const ans = await s.server.elicitInput({
+                mode: 'form',
+                message: 'Name?',
+                requestedSchema: { type: 'object', properties: { name: { type: 'string' } } }
+            });
+            return { content: [{ type: 'text', text: ans.action }] };
+        });
+        return s;
+    };
+
+    const client = new Client({ name: 'c', version: '0' }, { capabilities: { elicitation: {} } });
+    client.setRequestHandler(ElicitRequestSchema, async () => {
+        return { action: 'accept', content: { name: 'Test' } };
+    });
+
+    await using _ = await wire(transport, makeServer, client);
+
+    const r = await client.callTool({ name: 'ask', arguments: {} });
+    expect(r.content).toEqual([{ type: 'text', text: 'accept' }]);
+});
+
+verifies('elicitation:capability:mode-mismatch', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        const s = new Server({ name: 's', version: '0' }, { capabilities: { tools: {} } });
+        s.setRequestHandler(ListToolsRequestSchema, () => ({ tools: [{ name: 'auth', inputSchema: { type: 'object' } }] }));
+        s.setRequestHandler(CallToolRequestSchema, async (_req, extra) => {
+            try {
+                await extra.sendRequest(
+                    {
+                        method: 'elicitation/create',
+                        params: { mode: 'url', message: 'Sign in', elicitationId: 'mismatch-1', url: 'https://example.com/auth' }
+                    },
+                    ElicitResultSchema
+                );
+                return { content: [{ type: 'text', text: 'should-not-reach' }] };
+            } catch (e) {
+                if (!(e instanceof McpError)) throw e;
+                return { content: [{ type: 'text', text: `error:${e.code}` }] };
+            }
+        });
+        return s;
+    };
+
+    let handlerInvoked = 0;
+    const client = formClient();
+    client.setRequestHandler(ElicitRequestSchema, async () => {
+        handlerInvoked++;
+        return { action: 'accept', content: {} };
+    });
+
+    await using _ = await wire(transport, makeServer, client);
+
+    const r = await client.callTool({ name: 'auth', arguments: {} });
+    expect(r.content).toEqual([{ type: 'text', text: `error:${ErrorCode.InvalidParams}` }]);
+    expect(handlerInvoked).toBe(0);
+});
+
+verifies('elicitation:capability:server-respects-mode', async ({ transport }: TestArgs) => {
+    let reachedClient = 0;
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool('auth', { inputSchema: z.object({}) }, async () => {
+            try {
+                await s.server.elicitInput({
+                    mode: 'url',
+                    message: 'Sign in',
+                    elicitationId: 'gate-1',
+                    url: 'https://example.com/auth'
+                });
+                return { isError: true, content: [{ type: 'text', text: 'SDK let it through' }] };
+            } catch (e) {
+                return { content: [{ type: 'text', text: `refused:${e instanceof Error ? e.message : e}` }] };
+            }
+        });
+        return s;
+    };
+
+    const client = formClient();
+    client.setRequestHandler(ElicitRequestSchema, async () => {
+        reachedClient++;
+        return { action: 'accept' };
+    });
+
+    await using _ = await wire(transport, makeServer, client);
+
+    const r = await client.callTool({ name: 'auth', arguments: {} });
+    expect(r.isError).toBeFalsy();
+    expect(r.content).toEqual([{ type: 'text', text: expect.stringMatching(/^refused:.*url elicitation/i) }]);
+    expect(reachedClient).toBe(0);
+});
+
+verifies('elicitation:capability:not-declared', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool('ask-form', { inputSchema: z.object({}) }, async () => {
+            try {
+                await s.server.elicitInput({
+                    mode: 'form',
+                    message: 'What is your name?',
+                    requestedSchema: { type: 'object', properties: { name: { type: 'string' } }, required: ['name'] }
+                });
+                return { isError: true, content: [{ type: 'text', text: 'SDK let the form elicitation through' }] };
+            } catch (e) {
+                return { content: [{ type: 'text', text: `refused:${e instanceof Error ? e.message : e}` }] };
+            }
+        });
+        s.registerTool('ask-url', { inputSchema: z.object({}) }, async () => {
+            try {
+                await s.server.elicitInput({
+                    mode: 'url',
+                    message: 'Please sign in',
+                    elicitationId: 'no-cap-1',
+                    url: 'https://example.com/auth'
+                });
+                return { isError: true, content: [{ type: 'text', text: 'SDK let the url elicitation through' }] };
+            } catch (e) {
+                return { content: [{ type: 'text', text: `refused:${e instanceof Error ? e.message : e}` }] };
+            }
+        });
+        return s;
+    };
+
+    // No elicitation capability declared at all — neither mode may reach the wire.
+    const client = new Client({ name: 'c', version: '0' });
+
+    await using _ = await wire(transport, makeServer, client);
+    const tap = tapWire(client);
+
+    const form = await client.callTool({ name: 'ask-form', arguments: {} });
+    expect(form.isError).toBeFalsy();
+    expect(form.content).toEqual([{ type: 'text', text: 'refused:Client does not support form elicitation.' }]);
+
+    const url = await client.callTool({ name: 'ask-url', arguments: {} });
+    expect(url.isError).toBeFalsy();
+    expect(url.content).toEqual([{ type: 'text', text: 'refused:Client does not support url elicitation.' }]);
+
+    expect(tap.received.filter(m => 'method' in m && m.method === 'elicitation/create')).toEqual([]);
+});

--- a/test/e2e/scenarios/elicitation.test.ts
+++ b/test/e2e/scenarios/elicitation.test.ts
@@ -9,21 +9,22 @@
  * Function names mirror the requirement id in camelCase.
  */
 
-import { expect } from 'vitest';
-import { z } from 'zod/v4';
+import { Client } from '@modelcontextprotocol/client';
+import type { ElicitRequest, ElicitRequestFormParams } from '@modelcontextprotocol/server';
 import {
-    Server,
     McpServer,
     ProtocolError,
-    UrlElicitationRequiredError,
     ProtocolErrorCode,
-    specTypeSchemas
+    Server,
+    specTypeSchemas,
+    UrlElicitationRequiredError
 } from '@modelcontextprotocol/server';
-import type { ElicitRequest, ElicitRequestFormParams } from '@modelcontextprotocol/server';
-import { Client } from '@modelcontextprotocol/client';
+import { expect } from 'vitest';
+import { z } from 'zod/v4';
+
 import { tapWire, wire } from '../helpers/index.js';
-import type { TestArgs } from '../types.js';
 import { verifies } from '../helpers/verifies.js';
+import type { TestArgs } from '../types.js';
 
 /** Client with form-mode elicitation support. */
 const formClient = () => new Client({ name: 'c', version: '0' }, { capabilities: { elicitation: { form: {} } } });
@@ -62,8 +63,10 @@ verifies('elicitation:form:basic', async ({ transport }: TestArgs) => {
     const r = await client.callTool({ name: 'ask-name', arguments: {} });
 
     expect(received).toHaveLength(1);
-    expect(received[0].method).toBe('elicitation/create');
-    expect(received[0].params).toMatchObject({
+    const firstRequest = received[0];
+    if (firstRequest === undefined) throw new Error('expected exactly one elicitation request');
+    expect(firstRequest.method).toBe('elicitation/create');
+    expect(firstRequest.params).toMatchObject({
         mode: 'form',
         message: 'What is your name?',
         requestedSchema: { type: 'object', properties: { name: { type: 'string' } }, required: ['name'] }
@@ -201,9 +204,9 @@ verifies('elicitation:form:mode-omitted-default', async ({ transport }: TestArgs
                     specTypeSchemas.ElicitResult
                 );
                 return { content: [{ type: 'text', text: ans.action }] };
-            } catch (e) {
-                if (!(e instanceof ProtocolError)) throw e;
-                return { content: [{ type: 'text', text: `error:${e.code}` }] };
+            } catch (error) {
+                if (!(error instanceof ProtocolError)) throw error;
+                return { content: [{ type: 'text', text: `error:${error.code}` }] };
             }
         });
         return s;
@@ -216,13 +219,17 @@ verifies('elicitation:form:mode-omitted-default', async ({ transport }: TestArgs
         return { action: 'accept', content: { name: 'Test' } };
     });
 
-    await using _1 = await wire(transport, makeServer, formClientInstance);
+    {
+        await using _ = await wire(transport, makeServer, formClientInstance);
 
-    const formResult = await formClientInstance.callTool({ name: 'ask', arguments: {} });
+        const formResult = await formClientInstance.callTool({ name: 'ask', arguments: {} });
 
-    expect(formReceived).toHaveLength(1);
-    expect(formReceived[0].mode).toBeUndefined();
-    expect(formResult.content).toEqual([{ type: 'text', text: 'accept' }]);
+        expect(formReceived).toHaveLength(1);
+        const firstFormRequest = formReceived[0];
+        if (firstFormRequest === undefined) throw new Error('expected exactly one form elicitation request');
+        expect(firstFormRequest.mode).toBeUndefined();
+        expect(formResult.content).toEqual([{ type: 'text', text: 'accept' }]);
+    }
 
     let urlHandlerInvoked = 0;
     const urlClientInstance = urlClient();
@@ -231,11 +238,13 @@ verifies('elicitation:form:mode-omitted-default', async ({ transport }: TestArgs
         return { action: 'accept' };
     });
 
-    await using _2 = await wire(transport, makeServer, urlClientInstance);
+    {
+        await using _ = await wire(transport, makeServer, urlClientInstance);
 
-    const urlResult = await urlClientInstance.callTool({ name: 'ask', arguments: {} });
-    expect(urlResult.content).toEqual([{ type: 'text', text: `error:${ProtocolErrorCode.InvalidParams}` }]);
-    expect(urlHandlerInvoked).toBe(0);
+        const urlResult = await urlClientInstance.callTool({ name: 'ask', arguments: {} });
+        expect(urlResult.content).toEqual([{ type: 'text', text: `error:${ProtocolErrorCode.InvalidParams}` }]);
+        expect(urlHandlerInvoked).toBe(0);
+    }
 });
 
 verifies('elicitation:form:schema:primitives', async ({ transport }: TestArgs) => {
@@ -337,9 +346,9 @@ verifies('elicitation:form:response-validation', async ({ transport }: TestArgs)
                     isError: true,
                     content: [{ type: 'text', text: `SDK accepted invalid content: ${JSON.stringify(ans.content)}` }]
                 };
-            } catch (e) {
-                if (!(e instanceof ProtocolError)) throw e;
-                return { content: [{ type: 'text', text: `rejected:${e.code}:${e.message}` }] };
+            } catch (error) {
+                if (!(error instanceof ProtocolError)) throw error;
+                return { content: [{ type: 'text', text: `rejected:${error.code}:${error.message}` }] };
             }
         });
         return s;
@@ -402,9 +411,9 @@ verifies('elicitation:form:schema:restricted-subset', async ({ transport }: Test
                     specTypeSchemas.ElicitResult
                 );
                 return { content: [{ type: 'text', text: 'should-not-reach' }] };
-            } catch (e) {
-                if (!(e instanceof ProtocolError)) throw e;
-                return { content: [{ type: 'text', text: `error:${e.code}` }] };
+            } catch (error) {
+                if (!(error instanceof ProtocolError)) throw error;
+                return { content: [{ type: 'text', text: `error:${error.code}` }] };
             }
         });
         return s;
@@ -572,9 +581,11 @@ verifies('elicitation:url:complete-notification', async ({ transport }: TestArgs
 
     await using _ = await wire(transport, makeServer, client);
 
-    const err = await client.callTool({ name: 'auth', arguments: {} }).catch(e => e);
+    const err = await client.callTool({ name: 'auth', arguments: {} }).catch(error => error);
     if (!(err instanceof UrlElicitationRequiredError)) throw new Error(`expected UrlElicitationRequiredError, got ${err}`);
-    const elicitationId = err.elicitations[0].elicitationId;
+    const pending = err.elicitations[0];
+    if (pending === undefined) throw new Error('expected one pending elicitation');
+    const elicitationId = pending.elicitationId;
 
     await client.callTool({ name: 'complete', arguments: { elicitationId } });
 
@@ -596,7 +607,9 @@ verifies('elicitation:url:complete-unknown-ignored', async ({ transport }: TestA
         // Raw send: the server-side capability gate cannot pass on stateless (client capabilities never learned),
         // and the behavior under test is the client's handling of the notification.
         s.registerTool('complete', { inputSchema: z.object({ elicitationId: z.string() }) }, async ({ elicitationId }, ctx) => {
-            await s.server.transport!.send(
+            const tx = s.server.transport;
+            if (!tx) throw new Error('server transport not connected');
+            await tx.send(
                 { jsonrpc: '2.0', method: 'notifications/elicitation/complete', params: { elicitationId } },
                 { relatedRequestId: ctx.mcpReq.id }
             );
@@ -616,9 +629,11 @@ verifies('elicitation:url:complete-unknown-ignored', async ({ transport }: TestA
 
     await using _ = await wire(transport, makeServer, client);
 
-    const err = await client.callTool({ name: 'auth', arguments: {} }).catch(e => e);
+    const err = await client.callTool({ name: 'auth', arguments: {} }).catch(error => error);
     if (!(err instanceof UrlElicitationRequiredError)) throw new Error(`expected UrlElicitationRequiredError, got ${err}`);
-    const seenId = err.elicitations[0].elicitationId;
+    const seenPending = err.elicitations[0];
+    if (seenPending === undefined) throw new Error('expected one pending elicitation');
+    const seenId = seenPending.elicitationId;
 
     await client.callTool({ name: 'complete', arguments: { elicitationId: seenId } });
     // Already-completed id, then an id the client never saw: both must be ignored without error.
@@ -656,7 +671,7 @@ verifies('elicitation:url:required-error', async ({ transport }: TestArgs) => {
     const client = urlClient();
     await using _ = await wire(transport, makeServer, client);
 
-    const err = await client.callTool({ name: 'auth-required', arguments: {} }).catch(e => e);
+    const err = await client.callTool({ name: 'auth-required', arguments: {} }).catch(error => error);
     if (!(err instanceof UrlElicitationRequiredError)) throw new Error(`expected UrlElicitationRequiredError, got ${err}`);
     expect(err.code).toBe(ProtocolErrorCode.UrlElicitationRequired);
     expect(err.elicitations).toHaveLength(1);
@@ -707,9 +722,9 @@ verifies('elicitation:capability:mode-mismatch', async ({ transport }: TestArgs)
                     specTypeSchemas.ElicitResult
                 );
                 return { content: [{ type: 'text', text: 'should-not-reach' }] };
-            } catch (e) {
-                if (!(e instanceof ProtocolError)) throw e;
-                return { content: [{ type: 'text', text: `error:${e.code}` }] };
+            } catch (error) {
+                if (!(error instanceof ProtocolError)) throw error;
+                return { content: [{ type: 'text', text: `error:${error.code}` }] };
             }
         });
         return s;
@@ -742,8 +757,8 @@ verifies('elicitation:capability:server-respects-mode', async ({ transport }: Te
                     url: 'https://example.com/auth'
                 });
                 return { isError: true, content: [{ type: 'text', text: 'SDK let it through' }] };
-            } catch (e) {
-                return { content: [{ type: 'text', text: `refused:${e instanceof Error ? e.message : e}` }] };
+            } catch (error) {
+                return { content: [{ type: 'text', text: `refused:${error instanceof Error ? error.message : error}` }] };
             }
         });
         return s;
@@ -774,8 +789,8 @@ verifies('elicitation:capability:not-declared', async ({ transport }: TestArgs) 
                     requestedSchema: { type: 'object', properties: { name: { type: 'string' } }, required: ['name'] }
                 });
                 return { isError: true, content: [{ type: 'text', text: 'SDK let the form elicitation through' }] };
-            } catch (e) {
-                return { content: [{ type: 'text', text: `refused:${e instanceof Error ? e.message : e}` }] };
+            } catch (error) {
+                return { content: [{ type: 'text', text: `refused:${error instanceof Error ? error.message : error}` }] };
             }
         });
         s.registerTool('ask-url', { inputSchema: z.object({}) }, async () => {
@@ -787,8 +802,8 @@ verifies('elicitation:capability:not-declared', async ({ transport }: TestArgs) 
                     url: 'https://example.com/auth'
                 });
                 return { isError: true, content: [{ type: 'text', text: 'SDK let the url elicitation through' }] };
-            } catch (e) {
-                return { content: [{ type: 'text', text: `refused:${e instanceof Error ? e.message : e}` }] };
+            } catch (error) {
+                return { content: [{ type: 'text', text: `refused:${error instanceof Error ? error.message : error}` }] };
             }
         });
         return s;

--- a/test/e2e/scenarios/errors.test.ts
+++ b/test/e2e/scenarios/errors.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Error-surface tests: which error class reaches the caller for each failure mode.
+ *
+ * The SDK splits failures into local {@link SdkError}s that never cross the wire
+ * (timeouts, capability gating), wire-level {@link ProtocolError}s carrying the
+ * JSON-RPC error code from an error response, and {@link SdkHttpError}s for HTTP
+ * transport failures exposing the status code. Each test builds its own server
+ * (factory) and client, triggers exactly one failure mode and asserts the class,
+ * code and carried details of the rejection.
+ */
+
+import { Client, StreamableHTTPClientTransport } from '@modelcontextprotocol/client';
+import type { JSONRPCMessage } from '@modelcontextprotocol/server';
+import {
+    isJSONRPCErrorResponse,
+    McpServer,
+    ProtocolError,
+    ProtocolErrorCode,
+    SdkError,
+    SdkErrorCode,
+    SdkHttpError,
+    Server
+} from '@modelcontextprotocol/server';
+import { expect } from 'vitest';
+import { z } from 'zod/v4';
+
+import { hostPerSession, tapWire, wire } from '../helpers/index.js';
+import { verifies } from '../helpers/verifies.js';
+import type { TestArgs } from '../types.js';
+
+const newClient = () => new Client({ name: 'c', version: '0' });
+
+/** Awaits a promise that must reject and returns the rejection value for exact assertions. */
+async function rejectionOf(promise: Promise<unknown>): Promise<unknown> {
+    return promise.then(
+        () => {
+            throw new Error('expected the promise to reject');
+        },
+        (error: unknown) => error
+    );
+}
+
+verifies('errors:timeout:sdkerror-request-timeout', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool(
+            'generate_report',
+            { inputSchema: z.object({ source: z.string() }) },
+            async () =>
+                new Promise(() => {
+                    /* never resolves: the per-request timeout must fire before any response exists */
+                })
+        );
+        return s;
+    };
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    const rejection = await rejectionOf(
+        client.callTool({ name: 'generate_report', arguments: { source: 'sales-q3.csv' } }, { timeout: 100 })
+    );
+
+    expect(rejection).toBeInstanceOf(SdkError);
+    if (!(rejection instanceof SdkError)) throw new Error('rejection is not an SdkError');
+    expect(rejection.code).toBe(SdkErrorCode.RequestTimeout);
+    expect(rejection.message).toMatch(/timed out/i);
+    // The configured timeout value rides on the error, not just a generic message.
+    expect(rejection.data).toEqual({ timeout: 100 });
+    // A timeout is a local SDK error, not a JSON-RPC error response from the server.
+    expect(rejection).not.toBeInstanceOf(ProtocolError);
+});
+
+verifies('errors:capability:sdkerror-capability-not-supported', async ({ transport }: TestArgs) => {
+    let server: Server | undefined;
+    const makeServer = () => {
+        // Server-side gating of outbound requests on the client's declared capabilities is opt-in.
+        server = new Server({ name: 's', version: '0' }, { capabilities: {}, enforceStrictCapabilities: true });
+        return server;
+    };
+    // Client declares no sampling capability and registers no sampling handler.
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    if (!server) throw new Error('server not created');
+    const serverTx = server.transport;
+    if (!serverTx) throw new Error('server transport not connected');
+    const serverOutbound: JSONRPCMessage[] = [];
+    const origSend = serverTx.send.bind(serverTx);
+    serverTx.send = async (m, opts) => {
+        serverOutbound.push(m);
+        return origSend(m, opts);
+    };
+
+    const rejection = await rejectionOf(
+        server.createMessage({
+            messages: [{ role: 'user', content: { type: 'text', text: 'Summarize the latest build log.' } }],
+            maxTokens: 100
+        })
+    );
+
+    expect(rejection).toBeInstanceOf(SdkError);
+    // Rejected locally: not a JSON-RPC error that crossed the wire.
+    expect(rejection).not.toBeInstanceOf(ProtocolError);
+    if (!(rejection instanceof SdkError)) throw new Error('rejection is not an SdkError');
+    expect(rejection.code).toBe(SdkErrorCode.CapabilityNotSupported);
+    expect(rejection.message).toMatch(/does not support sampling/i);
+
+    // No sampling/createMessage request was ever handed to the transport.
+    expect(serverOutbound.filter(m => 'method' in m && m.method === 'sampling/createMessage')).toEqual([]);
+    // The session stays healthy after the local rejection.
+    await expect(client.ping()).resolves.toBeDefined();
+});
+
+verifies('errors:wire:protocolerror-invalid-params', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool(
+            'get_weather',
+            { inputSchema: z.object({ latitude: z.number(), longitude: z.number() }) },
+            ({ latitude, longitude }) => ({ content: [{ type: 'text', text: `Sunny at ${latitude},${longitude}` }] })
+        );
+        return s;
+    };
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    const tap = tapWire(client);
+
+    // Calling a tool the server never registered produces a -32602 error response server-side.
+    const rejection = await rejectionOf(client.callTool({ name: 'get_forecast', arguments: { latitude: 48.1, longitude: 11.6 } }));
+
+    expect(rejection).toBeInstanceOf(ProtocolError);
+    // Wire-level JSON-RPC errors and local SDK errors are distinct hierarchies.
+    expect(rejection).not.toBeInstanceOf(SdkError);
+    if (!(rejection instanceof ProtocolError)) throw new Error('rejection is not a ProtocolError');
+    expect(rejection.code).toBe(ProtocolErrorCode.InvalidParams);
+    expect(rejection.code).toBe(-32_602);
+    expect(rejection.message).toMatch(/tool get_forecast not found/i);
+
+    // The error genuinely arrived as a JSON-RPC error response carrying the same code and message.
+    const errorResponses = tap.received.filter(m => isJSONRPCErrorResponse(m));
+    expect(errorResponses).toHaveLength(1);
+    const wireError = errorResponses[0];
+    if (!wireError) throw new Error('no JSON-RPC error response captured');
+    expect(wireError.error.code).toBe(-32_602);
+    expect(wireError.error.message).toBe(rejection.message);
+});
+
+verifies('errors:http:sdkhttperror-status', async (_: TestArgs) => {
+    // HTTP-hosting specific: builds its own StreamableHTTPClientTransport, so the matrix transport arg is unused.
+
+    // An endpoint that is down entirely: the initialize POST gets a plain 500.
+    const downClient = newClient();
+    const downTransport = new StreamableHTTPClientTransport(new URL('http://in-process/mcp'), {
+        fetch: async () => new Response('upstream exploded', { status: 500, statusText: 'Internal Server Error' })
+    });
+    try {
+        const rejection = await rejectionOf(downClient.connect(downTransport));
+
+        expect(rejection).toBeInstanceOf(SdkHttpError);
+        if (!(rejection instanceof SdkHttpError)) throw new Error('rejection is not an SdkHttpError');
+        expect(rejection.status).toBe(500);
+        expect(rejection.statusText).toBe('Internal Server Error');
+    } finally {
+        await downClient.close();
+    }
+
+    // A healthy session whose endpoint then starts answering POSTs with 503.
+    const handle = hostPerSession(() => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool('echo', { inputSchema: z.object({ text: z.string() }) }, ({ text }) => ({ content: [{ type: 'text', text }] }));
+        return s;
+    });
+    let postFailureStatus: number | undefined;
+    const flakyFetch = async (url: URL | string, init?: RequestInit) => {
+        if (postFailureStatus !== undefined && init?.method === 'POST') {
+            return new Response('Service Unavailable', { status: postFailureStatus, statusText: 'Service Unavailable' });
+        }
+        return handle.handleRequest(new Request(url, init));
+    };
+    const client = newClient();
+    const clientTransport = new StreamableHTTPClientTransport(new URL('http://in-process/mcp'), { fetch: flakyFetch });
+    try {
+        await client.connect(clientTransport);
+        // The session works before the outage.
+        const ok = await client.callTool({ name: 'echo', arguments: { text: 'before outage' } });
+        expect(ok.content).toEqual([{ type: 'text', text: 'before outage' }]);
+
+        postFailureStatus = 503;
+        const rejection = await rejectionOf(client.callTool({ name: 'echo', arguments: { text: 'during outage' } }));
+
+        expect(rejection).toBeInstanceOf(SdkHttpError);
+        if (!(rejection instanceof SdkHttpError)) throw new Error('rejection is not an SdkHttpError');
+        expect(rejection.status).toBe(503);
+        expect(rejection.statusText).toBe('Service Unavailable');
+    } finally {
+        await client.close();
+        await handle.close();
+    }
+});

--- a/test/e2e/scenarios/flow.test.ts
+++ b/test/e2e/scenarios/flow.test.ts
@@ -10,30 +10,20 @@
 
 import { expect, vi } from 'vitest';
 import { z } from 'zod/v4';
-
-import { Client } from '../../../src/client/index.js';
-import { type OAuthClientProvider, UnauthorizedError } from '../../../src/client/auth.js';
-import { StreamableHTTPClientTransport } from '../../../src/client/streamableHttp.js';
-import { Server } from '../../../src/server/index.js';
-import { McpServer } from '../../../src/server/mcp.js';
-import type { EventStore } from '../../../src/server/webStandardStreamableHttp.js';
-import { type OAuthTokens, type OAuthClientMetadata, type OAuthClientInformationMixed } from '../../../src/shared/auth.js';
-import {
-    type CallToolResult,
-    ElicitationCompleteNotificationSchema,
-    type ElicitRequest,
-    type ElicitResult,
-    ElicitRequestSchema,
-    ElicitResultSchema,
-    ErrorCode,
-    type JSONRPCMessage,
-    ListResourcesRequestSchema,
-    ListToolsRequestSchema,
-    type Progress,
-    ReadResourceRequestSchema,
-    UrlElicitationRequiredError
-} from '../../../src/types.js';
-
+import { Server, McpServer, UrlElicitationRequiredError, ProtocolErrorCode, specTypeSchemas } from '@modelcontextprotocol/server';
+import type {
+    EventStore,
+    OAuthTokens,
+    OAuthClientMetadata,
+    OAuthClientInformationMixed,
+    CallToolResult,
+    ElicitRequest,
+    ElicitResult,
+    JSONRPCMessage,
+    Progress
+} from '@modelcontextprotocol/server';
+import { Client, UnauthorizedError, StreamableHTTPClientTransport } from '@modelcontextprotocol/client';
+import type { OAuthClientProvider } from '@modelcontextprotocol/client';
 import { hostPerSession, hostResumable, wire } from '../helpers/index.js';
 import type { TestArgs } from '../types.js';
 import { verifies } from '../helpers/verifies.js';
@@ -42,8 +32,8 @@ verifies('flow:elicitation:multi-step-form', async ({ transport }: TestArgs) => 
     // Server: tool that issues three sequential elicitation/create requests
     const makeServer = () => {
         const s = new McpServer({ name: 's', version: '0' });
-        s.registerTool('multi-step', { inputSchema: z.object({}) }, async (_args, extra) => {
-            const step1 = await extra.sendRequest(
+        s.registerTool('multi-step', { inputSchema: z.object({}) }, async (_args, ctx) => {
+            const step1 = await ctx.mcpReq.send(
                 {
                     method: 'elicitation/create',
                     params: {
@@ -52,14 +42,14 @@ verifies('flow:elicitation:multi-step-form', async ({ transport }: TestArgs) => 
                         requestedSchema: { type: 'object', properties: { name: { type: 'string' } }, required: ['name'] }
                     }
                 },
-                ElicitResultSchema
+                specTypeSchemas.ElicitResult
             );
             if (step1.action !== 'accept' || typeof step1.content?.name !== 'string') {
                 return { content: [{ type: 'text', text: `aborted at step 1: ${step1.action}` }] };
             }
             const name = step1.content.name;
 
-            const step2 = await extra.sendRequest(
+            const step2 = await ctx.mcpReq.send(
                 {
                     method: 'elicitation/create',
                     params: {
@@ -68,14 +58,14 @@ verifies('flow:elicitation:multi-step-form', async ({ transport }: TestArgs) => 
                         requestedSchema: { type: 'object', properties: { color: { type: 'string' } }, required: ['color'] }
                     }
                 },
-                ElicitResultSchema
+                specTypeSchemas.ElicitResult
             );
             if (step2.action !== 'accept' || typeof step2.content?.color !== 'string') {
                 return { content: [{ type: 'text', text: `aborted at step 2: ${step2.action}` }] };
             }
             const color = step2.content.color;
 
-            const step3 = await extra.sendRequest(
+            const step3 = await ctx.mcpReq.send(
                 {
                     method: 'elicitation/create',
                     params: {
@@ -84,7 +74,7 @@ verifies('flow:elicitation:multi-step-form', async ({ transport }: TestArgs) => 
                         requestedSchema: { type: 'object', properties: { confirm: { type: 'boolean' } }, required: ['confirm'] }
                     }
                 },
-                ElicitResultSchema
+                specTypeSchemas.ElicitResult
             );
             if (step3.action !== 'accept') {
                 return { content: [{ type: 'text', text: `aborted at step 3: ${step3.action}` }] };
@@ -99,7 +89,7 @@ verifies('flow:elicitation:multi-step-form', async ({ transport }: TestArgs) => 
     const received: ElicitRequest[] = [];
     const queued: ElicitResult[] = [];
     const client = new Client({ name: 'c', version: '0' }, { capabilities: { elicitation: { form: {} } } });
-    client.setRequestHandler(ElicitRequestSchema, async req => {
+    client.setRequestHandler('elicitation/create', async req => {
         received.push(req);
         const resp = queued.shift();
         if (!resp) throw new Error('no queued elicitation response');
@@ -160,13 +150,13 @@ verifies('flow:elicitation:url-at-session-init', async (_args: TestArgs) => {
                     .catch(() => {});
             }, 0);
         };
-        s.setRequestHandler(ListToolsRequestSchema, () => ({ tools: [] }));
+        s.setRequestHandler('tools/list', () => ({ tools: [] }));
         return s;
     };
 
     const received: ElicitRequest[] = [];
     const client = new Client({ name: 'c', version: '0' }, { capabilities: { elicitation: { url: {} } } });
-    client.setRequestHandler(ElicitRequestSchema, async req => {
+    client.setRequestHandler('elicitation/create', async req => {
         received.push(req);
         return { action: 'accept' };
     });
@@ -234,7 +224,7 @@ verifies('flow:elicitation:url-required-then-retry', async ({ transport }: TestA
 
     const client = new Client({ name: 'c', version: '0' }, { capabilities: { elicitation: { url: {} } } });
     const completionsSeen: string[] = [];
-    client.setNotificationHandler(ElicitationCompleteNotificationSchema, async n => {
+    client.setNotificationHandler('notifications/elicitation/complete', async n => {
         completionsSeen.push(n.params.elicitationId);
     });
     await using _ = await wire(transport, makeServer, client);
@@ -243,7 +233,7 @@ verifies('flow:elicitation:url-required-then-retry', async ({ transport }: TestA
     const err = await client.callTool({ name: 'url-gated', arguments: {} }).catch(e => e);
     expect(err).toBeInstanceOf(UrlElicitationRequiredError);
     const required = err as UrlElicitationRequiredError;
-    expect(required.code).toBe(ErrorCode.UrlElicitationRequired);
+    expect(required.code).toBe(ProtocolErrorCode.UrlElicitationRequired);
     expect(required.elicitations).toHaveLength(1);
     const elicitation = required.elicitations[0];
     expect(elicitation.mode).toBe('url');
@@ -268,11 +258,11 @@ verifies('flow:multi-client:stateful-isolation', async (_args: TestArgs) => {
     // Server: per-session McpServer with progress tool
     const makeServer = () => {
         const s = new McpServer({ name: 's', version: '0' });
-        s.registerTool('progress', { inputSchema: z.object({ steps: z.number().int().positive() }) }, async ({ steps }, extra) => {
-            const token = extra._meta?.progressToken;
+        s.registerTool('progress', { inputSchema: z.object({ steps: z.number().int().positive() }) }, async ({ steps }, ctx) => {
+            const token = ctx.mcpReq._meta?.progressToken;
             if (token !== undefined) {
                 for (let i = 1; i <= steps; i++) {
-                    await extra.sendNotification({
+                    await ctx.mcpReq.notify({
                         method: 'notifications/progress',
                         params: { progressToken: token, progress: i, total: steps, message: `step ${i}/${steps}` }
                     });
@@ -514,15 +504,15 @@ verifies('flow:resume:tool-call-resumption-token', async (_args: TestArgs) => {
     let toolRuns = 0;
     const makeServer = () => {
         const s = new McpServer({ name: 's', version: '0' });
-        s.registerTool('import-records', { inputSchema: z.object({ steps: z.number().int().positive() }) }, async ({ steps }, extra) => {
+        s.registerTool('import-records', { inputSchema: z.object({ steps: z.number().int().positive() }) }, async ({ steps }, ctx) => {
             toolRuns++;
-            const token = extra._meta?.progressToken;
+            const token = ctx.mcpReq._meta?.progressToken;
             if (token === undefined) throw new Error('import-records expects a progressToken');
             for (let i = 1; i <= steps; i++) {
                 if (i === DELIVERED_BEFORE_DISCONNECT + 1) {
                     await remainingStepsReleased;
                 }
-                await extra.sendNotification({
+                await ctx.mcpReq.notify({
                     method: 'notifications/progress',
                     params: { progressToken: token, progress: i, total: steps }
                 });
@@ -801,15 +791,15 @@ verifies('flow:proxy:forward-tools-resources', async ({ transport }: TestArgs) =
     const upstreamClient = new Client({ name: 'proxy-upstream', version: '0' });
     const proxyServer = new Server({ name: 'proxy', version: '0' }, { capabilities: { tools: {}, resources: {} } });
 
-    proxyServer.setRequestHandler(ListToolsRequestSchema, async req => {
+    proxyServer.setRequestHandler('tools/list', async req => {
         const result = await upstreamClient.listTools(req.params);
         return { tools: result.tools, nextCursor: result.nextCursor };
     });
-    proxyServer.setRequestHandler(ListResourcesRequestSchema, async req => {
+    proxyServer.setRequestHandler('resources/list', async req => {
         const result = await upstreamClient.listResources(req.params);
         return { resources: result.resources, nextCursor: result.nextCursor };
     });
-    proxyServer.setRequestHandler(ReadResourceRequestSchema, async req => {
+    proxyServer.setRequestHandler('resources/read', async req => {
         return upstreamClient.readResource(req.params);
     });
 

--- a/test/e2e/scenarios/flow.test.ts
+++ b/test/e2e/scenarios/flow.test.ts
@@ -8,25 +8,25 @@
  * Client) rather than importing shared fixtures.
  */
 
-import { expect, vi } from 'vitest';
-import { z } from 'zod/v4';
-import { Server, McpServer, UrlElicitationRequiredError, ProtocolErrorCode, specTypeSchemas } from '@modelcontextprotocol/server';
+import type { OAuthClientProvider } from '@modelcontextprotocol/client';
+import { Client, StreamableHTTPClientTransport, UnauthorizedError } from '@modelcontextprotocol/client';
 import type {
-    EventStore,
-    OAuthTokens,
-    OAuthClientMetadata,
-    OAuthClientInformationMixed,
-    CallToolResult,
     ElicitRequest,
     ElicitResult,
+    EventStore,
     JSONRPCMessage,
+    OAuthClientInformationMixed,
+    OAuthClientMetadata,
+    OAuthTokens,
     Progress
 } from '@modelcontextprotocol/server';
-import { Client, UnauthorizedError, StreamableHTTPClientTransport } from '@modelcontextprotocol/client';
-import type { OAuthClientProvider } from '@modelcontextprotocol/client';
+import { McpServer, ProtocolErrorCode, Server, specTypeSchemas, UrlElicitationRequiredError } from '@modelcontextprotocol/server';
+import { expect, vi } from 'vitest';
+import { z } from 'zod/v4';
+
 import { hostPerSession, hostResumable, wire } from '../helpers/index.js';
-import type { TestArgs } from '../types.js';
 import { verifies } from '../helpers/verifies.js';
+import type { TestArgs } from '../types.js';
 
 verifies('flow:elicitation:multi-step-form', async ({ transport }: TestArgs) => {
     // Server: tool that issues three sequential elicitation/create requests
@@ -99,33 +99,35 @@ verifies('flow:elicitation:multi-step-form', async ({ transport }: TestArgs) => 
     await using _ = await wire(transport, makeServer, client);
 
     // Happy path: accept all three steps
-    queued.push({ action: 'accept', content: { name: 'Ada' } });
-    queued.push({ action: 'accept', content: { color: 'blue' } });
-    queued.push({ action: 'accept', content: { confirm: true } });
+    queued.push(
+        { action: 'accept', content: { name: 'Ada' } },
+        { action: 'accept', content: { color: 'blue' } },
+        { action: 'accept', content: { confirm: true } }
+    );
 
     const ok = await client.callTool({ name: 'multi-step', arguments: {} });
     expect(ok.isError).toBeFalsy();
     expect(ok.content).toEqual([{ type: 'text', text: "Ada's favorite color is blue" }]);
 
     expect(received).toHaveLength(3);
-    expect(received[0].params).toMatchObject({ mode: 'form', requestedSchema: { properties: { name: { type: 'string' } } } });
-    expect(received[1].params.message).toContain('Ada');
-    expect(received[1].params).toMatchObject({ mode: 'form', requestedSchema: { properties: { color: { type: 'string' } } } });
-    expect(received[2].params.message).toContain('Ada');
-    expect(received[2].params.message).toContain('blue');
-    expect(received[2].params).toMatchObject({ mode: 'form', requestedSchema: { properties: { confirm: { type: 'boolean' } } } });
+    const [firstStep, secondStep, thirdStep] = received;
+    if (!firstStep || !secondStep || !thirdStep) throw new Error('expected three elicitation requests');
+    expect(firstStep.params).toMatchObject({ mode: 'form', requestedSchema: { properties: { name: { type: 'string' } } } });
+    expect(secondStep.params.message).toContain('Ada');
+    expect(secondStep.params).toMatchObject({ mode: 'form', requestedSchema: { properties: { color: { type: 'string' } } } });
+    expect(thirdStep.params.message).toContain('Ada');
+    expect(thirdStep.params.message).toContain('blue');
+    expect(thirdStep.params).toMatchObject({ mode: 'form', requestedSchema: { properties: { confirm: { type: 'boolean' } } } });
 
     // Decline at step 2
-    queued.push({ action: 'accept', content: { name: 'Bob' } });
-    queued.push({ action: 'decline' });
+    queued.push({ action: 'accept', content: { name: 'Bob' } }, { action: 'decline' });
     const declined = await client.callTool({ name: 'multi-step', arguments: {} });
     expect(declined.isError).toBeFalsy();
     expect(declined.content).toEqual([{ type: 'text', text: 'aborted at step 2: decline' }]);
     expect(received).toHaveLength(5);
 
     // Cancel at step 1
-    queued.push({ action: 'cancel' });
-    queued.push({ action: 'accept', content: { color: 'red' } }); // sentinel: must not be consumed
+    queued.push({ action: 'cancel' }, { action: 'accept', content: { color: 'red' } }); // sentinel: must not be consumed
     const cancelled = await client.callTool({ name: 'multi-step', arguments: {} });
     expect(cancelled.isError).toBeFalsy();
     expect(cancelled.content).toEqual([{ type: 'text', text: 'aborted at step 1: cancel' }]);
@@ -167,10 +169,14 @@ verifies('flow:elicitation:url-at-session-init', async (_args: TestArgs) => {
     const transport = new StreamableHTTPClientTransport(url, { fetch: customFetch });
 
     // Tap wire before connecting
-    const sent: Array<{ method?: string }> = [];
+    const sent: JSONRPCMessage[] = [];
     const origSend = transport.send.bind(transport);
     transport.send = async (m, opts) => {
-        sent.push(m as { method?: string });
+        if (Array.isArray(m)) {
+            sent.push(...m);
+        } else {
+            sent.push(m);
+        }
         return origSend(m, opts);
     };
 
@@ -181,8 +187,10 @@ verifies('flow:elicitation:url-at-session-init', async (_args: TestArgs) => {
         await vi.waitFor(() => expect(received.length).toBeGreaterThanOrEqual(1));
 
         expect(received).toHaveLength(1);
-        expect(received[0].method).toBe('elicitation/create');
-        const params = received[0].params;
+        const [initElicitation] = received;
+        if (!initElicitation) throw new Error('expected one elicitation request');
+        expect(initElicitation.method).toBe('elicitation/create');
+        const params = initElicitation.params;
         if (params.mode !== 'url') throw new Error('expected url mode');
         expect(params.elicitationId).toBe('session-init-elicit');
         expect(() => new URL(params.url)).not.toThrow();
@@ -201,7 +209,7 @@ verifies('flow:elicitation:url-at-session-init', async (_args: TestArgs) => {
 verifies('flow:elicitation:url-required-then-retry', async ({ transport }: TestArgs) => {
     // Server: tool that throws UrlElicitationRequiredError until elicitation is completed
     const completed = new Set<string>();
-    let server!: McpServer;
+    let server: McpServer | undefined;
     const makeServer = () => {
         const s = new McpServer({ name: 's', version: '0' });
         s.registerTool('url-gated', { inputSchema: z.object({}) }, () => {
@@ -230,12 +238,13 @@ verifies('flow:elicitation:url-required-then-retry', async ({ transport }: TestA
     await using _ = await wire(transport, makeServer, client);
 
     // Step 1: first call rejects with UrlElicitationRequiredError
-    const err = await client.callTool({ name: 'url-gated', arguments: {} }).catch(e => e);
+    const err = await client.callTool({ name: 'url-gated', arguments: {} }).catch((error: unknown) => error);
     expect(err).toBeInstanceOf(UrlElicitationRequiredError);
-    const required = err as UrlElicitationRequiredError;
-    expect(required.code).toBe(ProtocolErrorCode.UrlElicitationRequired);
-    expect(required.elicitations).toHaveLength(1);
-    const elicitation = required.elicitations[0];
+    if (!(err instanceof UrlElicitationRequiredError)) throw new Error('expected UrlElicitationRequiredError');
+    expect(err.code).toBe(ProtocolErrorCode.UrlElicitationRequired);
+    expect(err.elicitations).toHaveLength(1);
+    const [elicitation] = err.elicitations;
+    if (!elicitation) throw new Error('expected one required elicitation');
     expect(elicitation.mode).toBe('url');
     expect(typeof elicitation.elicitationId).toBe('string');
     expect(elicitation.url).toMatch(/^https?:\/\//);
@@ -244,6 +253,7 @@ verifies('flow:elicitation:url-required-then-retry', async ({ transport }: TestA
     completed.add(elicitation.elicitationId);
 
     // Step 3: server emits notifications/elicitation/complete and the client receives it for that exact elicitation
+    if (!server) throw new Error('makeServer was never invoked');
     await server.server.createElicitationCompletionNotifier(elicitation.elicitationId)();
     await vi.waitFor(() => expect(completionsSeen).toEqual([elicitation.elicitationId]));
 
@@ -273,48 +283,53 @@ verifies('flow:multi-client:stateful-isolation', async (_args: TestArgs) => {
         return s;
     };
 
-    // Three clients connect to the same per-session host
-    const clientA = new Client({ name: 'a', version: '0' });
-    const clientB = new Client({ name: 'b', version: '0' });
-    const clientC = new Client({ name: 'c', version: '0' });
-
+    // Three clients connect to the same per-session host, each with distinct step counts
     const handle = hostPerSession(makeServer);
     const url = new URL('http://in-process/mcp');
     const customFetch = (u: URL | string, init?: RequestInit) => handle.handleRequest(new Request(u, init));
 
-    await clientA.connect(new StreamableHTTPClientTransport(url, { fetch: customFetch }));
-    await clientB.connect(new StreamableHTTPClientTransport(url, { fetch: customFetch }));
-    await clientC.connect(new StreamableHTTPClientTransport(url, { fetch: customFetch }));
+    interface SessionUnderTest {
+        client: Client;
+        transport: StreamableHTTPClientTransport;
+        steps: number;
+        errors: Error[];
+    }
+    const sessions: SessionUnderTest[] = [
+        { name: 'a', steps: 2 },
+        { name: 'b', steps: 3 },
+        { name: 'c', steps: 4 }
+    ].map(({ name, steps }) => ({
+        client: new Client({ name, version: '0' }),
+        transport: new StreamableHTTPClientTransport(url, { fetch: customFetch }),
+        steps,
+        errors: []
+    }));
 
     try {
-        const clients = [clientA, clientB, clientC] as const;
-        const sessionIds = clients.map(c => (c.transport as StreamableHTTPClientTransport).sessionId);
+        for (const session of sessions) {
+            session.client.onerror = error => session.errors.push(error);
+            await session.client.connect(session.transport);
+        }
 
+        const sessionIds = sessions.map(s => s.transport.sessionId);
         for (const id of sessionIds) {
             expect(id).toEqual(expect.any(String));
         }
         expect(new Set(sessionIds).size).toBe(3);
 
         // Concurrent progress calls with distinct step counts
-        const STEPS = [2, 3, 4] as const;
-        const errors: Error[][] = [[], [], []];
-        clients.forEach((cl, i) => {
-            cl.onerror = e => errors[i].push(e);
-        });
-
         const runs = await Promise.all(
-            clients.map(async (cl, i) => {
+            sessions.map(async ({ client, steps }) => {
                 const received: Progress[] = [];
-                const result = await cl.callTool({ name: 'progress', arguments: { steps: STEPS[i] } }, undefined, {
-                    onprogress: p => received.push({ progress: p.progress, total: p.total, message: p.message })
-                });
-                return { received, result };
+                const result = await client.callTool(
+                    { name: 'progress', arguments: { steps } },
+                    { onprogress: p => received.push({ progress: p.progress, total: p.total, message: p.message }) }
+                );
+                return { steps, received, result };
             })
         );
 
-        for (let i = 0; i < 3; i++) {
-            const steps = STEPS[i];
-            const { received, result } = runs[i];
+        for (const { steps, received, result } of runs) {
             expect(received).toEqual(
                 Array.from({ length: steps }, (_, k) => ({
                     progress: k + 1,
@@ -325,11 +340,11 @@ verifies('flow:multi-client:stateful-isolation', async (_args: TestArgs) => {
             expect(result.content).toEqual([{ type: 'text', text: `done after ${steps} steps` }]);
         }
 
-        for (const errs of errors) {
-            expect(errs).toEqual([]);
+        for (const session of sessions) {
+            expect(session.errors).toEqual([]);
         }
     } finally {
-        await Promise.all([clientA.close(), clientB.close(), clientC.close(), handle.close()]);
+        await Promise.all([...sessions.map(s => s.client.close()), handle.close()]);
     }
 });
 
@@ -347,8 +362,8 @@ verifies('flow:oauth:authorization-code-roundtrip', async (_args: TestArgs) => {
         const req = new Request(url, init);
         const u = new URL(req.url);
         if (u.pathname === '/.well-known/oauth-authorization-server') {
-            return new Response(
-                JSON.stringify({
+            return Response.json(
+                {
                     issuer: AS_ORIGIN,
                     authorization_endpoint: `${AS_ORIGIN}/authorize`,
                     token_endpoint: `${AS_ORIGIN}/token`,
@@ -356,25 +371,19 @@ verifies('flow:oauth:authorization-code-roundtrip', async (_args: TestArgs) => {
                     grant_types_supported: ['authorization_code'],
                     response_types_supported: ['code'],
                     code_challenge_methods_supported: ['S256']
-                }),
-                { status: 200, headers: { 'Content-Type': 'application/json' } }
+                },
+                { status: 200 }
             );
         }
         if (u.pathname === '/register' && req.method === 'POST') {
-            const body: Record<string, unknown> = await req.json();
+            const body = z.record(z.string(), z.unknown()).parse(await req.json());
             registerRequests.push(body);
             // RFC 7591: the registration response echoes the submitted metadata plus the issued client_id.
-            return new Response(JSON.stringify({ ...body, client_id: 'mock-client-id' }), {
-                status: 201,
-                headers: { 'Content-Type': 'application/json' }
-            });
+            return Response.json({ ...body, client_id: 'mock-client-id' }, { status: 201 });
         }
         if (u.pathname === '/token' && req.method === 'POST') {
             tokenRequests.push(new URLSearchParams(await req.text()));
-            return new Response(JSON.stringify({ access_token: ACCESS_TOKEN, token_type: 'Bearer', expires_in: 3600 }), {
-                status: 200,
-                headers: { 'Content-Type': 'application/json' }
-            });
+            return Response.json({ access_token: ACCESS_TOKEN, token_type: 'Bearer', expires_in: 3600 }, { status: 200 });
         }
         return new Response('Not Found', { status: 404 });
     };
@@ -429,10 +438,7 @@ verifies('flow:oauth:authorization-code-roundtrip', async (_args: TestArgs) => {
         const req = new Request(u, init);
         const requestUrl = new URL(req.url);
         if (requestUrl.pathname.startsWith(PRM_PATH)) {
-            return new Response(JSON.stringify({ resource: url.toString(), authorization_servers: [AS_ORIGIN] }), {
-                status: 200,
-                headers: { 'Content-Type': 'application/json' }
-            });
+            return Response.json({ resource: url.toString(), authorization_servers: [AS_ORIGIN] }, { status: 200 });
         }
         const auth = req.headers.get('authorization');
         if (auth !== `Bearer ${ACCESS_TOKEN}`) {
@@ -458,7 +464,9 @@ verifies('flow:oauth:authorization-code-roundtrip', async (_args: TestArgs) => {
         await expect(client.connect(transport1)).rejects.toBeInstanceOf(UnauthorizedError);
 
         expect(redirectedTo).toHaveLength(1);
-        const authorizeUrl = new URL(redirectedTo[0]);
+        const [authorizationRedirect] = redirectedTo;
+        if (!authorizationRedirect) throw new Error('expected a redirect to the authorization endpoint');
+        const authorizeUrl = new URL(authorizationRedirect);
         expect(authorizeUrl.origin).toBe(AS_ORIGIN);
         expect(authorizeUrl.pathname).toBe('/authorize');
         expect(authorizeUrl.searchParams.get('client_id')).toBe('mock-client-id');
@@ -473,10 +481,12 @@ verifies('flow:oauth:authorization-code-roundtrip', async (_args: TestArgs) => {
         await transport1.finishAuth(AUTH_CODE);
 
         expect(tokenRequests).toHaveLength(1);
-        expect(tokenRequests[0].get('grant_type')).toBe('authorization_code');
-        expect(tokenRequests[0].get('code')).toBe(AUTH_CODE);
-        expect(tokenRequests[0].get('code_verifier')).toBe(codeVerifier);
-        expect(tokenRequests[0].get('redirect_uri')).toBe('http://localhost/callback');
+        const [tokenRequest] = tokenRequests;
+        if (!tokenRequest) throw new Error('expected one token request');
+        expect(tokenRequest.get('grant_type')).toBe('authorization_code');
+        expect(tokenRequest.get('code')).toBe(AUTH_CODE);
+        expect(tokenRequest.get('code_verifier')).toBe(codeVerifier);
+        expect(tokenRequest.get('redirect_uri')).toBe('http://localhost/callback');
         expect(saved.tokens?.access_token).toBe(ACCESS_TOKEN);
 
         // Step 3: second connect with fresh transport succeeds and tools/list works
@@ -497,7 +507,9 @@ verifies('flow:resume:tool-call-resumption-token', async (_args: TestArgs) => {
 
     // The tool pauses after the first two progress notifications so the test can sever the call's SSE
     // stream before the remaining notifications and the result are produced.
-    let releaseRemainingSteps!: () => void;
+    let releaseRemainingSteps: () => void = () => {
+        throw new Error('remainingStepsReleased resolver not captured yet');
+    };
     const remainingStepsReleased = new Promise<void>(resolve => {
         releaseRemainingSteps = resolve;
     });
@@ -532,8 +544,9 @@ verifies('flow:resume:tool-call-resumption-token', async (_args: TestArgs) => {
         },
         replayEventsAfter: async (lastEventId, { send }) => {
             const lastIndex = storedEvents.findIndex(e => e.eventId === lastEventId);
-            if (lastIndex === -1) return '';
-            const { streamId } = storedEvents[lastIndex];
+            const lastEvent = storedEvents[lastIndex];
+            if (!lastEvent) return '';
+            const { streamId } = lastEvent;
             for (const event of storedEvents.slice(lastIndex + 1)) {
                 if (event.streamId === streamId) await send(event.eventId, event.message);
             }
@@ -552,7 +565,9 @@ verifies('flow:resume:tool-call-resumption-token', async (_args: TestArgs) => {
     let severToolCallStream: () => void = () => {
         throw new Error('tools/call SSE stream not opened yet');
     };
-    let originalStreamFinished!: () => void;
+    let originalStreamFinished: () => void = () => {
+        throw new Error('originalStreamComplete resolver not captured yet');
+    };
     const originalStreamComplete = new Promise<void>(resolve => {
         originalStreamFinished = resolve;
     });
@@ -609,14 +624,17 @@ verifies('flow:resume:tool-call-resumption-token', async (_args: TestArgs) => {
         const callSettled = vi.fn();
 
         // The one and only tools/call of this test: this same promise must resolve after the disconnect.
-        const call = client.callTool({ name: 'import-records', arguments: { steps: TOTAL_STEPS } }, undefined, {
-            onprogress: (p: Progress) => progressSeen.push(p.progress),
-            onresumptiontoken: id => eventIdsSeen.push(id)
-        });
+        const call = client.callTool(
+            { name: 'import-records', arguments: { steps: TOTAL_STEPS } },
+            {
+                onprogress: (p: Progress) => progressSeen.push(p.progress),
+                onresumptiontoken: id => eventIdsSeen.push(id)
+            }
+        );
         call.then(callSettled, callSettled);
 
         await vi.waitFor(() => expect(progressSeen).toEqual([1, 2]));
-        const lastEventIdBeforeDisconnect = eventIdsSeen[eventIdsSeen.length - 1];
+        const lastEventIdBeforeDisconnect = eventIdsSeen.at(-1);
 
         // Sever mid-call, then let the server finish steps 3..4 and the result while the client is disconnected.
         severToolCallStream();
@@ -653,16 +671,20 @@ verifies('flow:resume:tool-call-resumption-token', async (_args: TestArgs) => {
         ]);
         expect(eventIdsSeen).toEqual(toolCallStreamEvents.map(e => e.eventId));
         // Index DELIVERED_BEFORE_DISCONNECT skips the priming event, landing on the second progress notification.
-        expect(lastEventIdBeforeDisconnect).toBe(toolCallStreamEvents[DELIVERED_BEFORE_DISCONNECT].eventId);
+        const expectedLastDeliveredEvent = toolCallStreamEvents[DELIVERED_BEFORE_DISCONNECT];
+        if (!expectedLastDeliveredEvent) throw new Error('the tool-call stream did not retain the second progress notification');
+        expect(lastEventIdBeforeDisconnect).toBe(expectedLastDeliveredEvent.eventId);
 
         // Transparency: the caller never re-issued the call; the transport recovered with a single GET
         // carrying Last-Event-ID for the last event delivered before the disconnect, on the same session.
         expect(requests.filter(r => r.method === 'POST' && r.body?.includes('"tools/call"'))).toHaveLength(1);
         const recoveryGets = requests.filter(r => r.method === 'GET' && r.lastEventId !== undefined);
         expect(recoveryGets).toHaveLength(1);
-        expect(recoveryGets[0].lastEventId).toBe(lastEventIdBeforeDisconnect);
+        const [recoveryGet] = recoveryGets;
+        if (!recoveryGet) throw new Error('expected one recovery GET');
+        expect(recoveryGet.lastEventId).toBe(lastEventIdBeforeDisconnect);
         expect(transport.sessionId).toEqual(expect.any(String));
-        expect(recoveryGets[0].sessionId).toBe(transport.sessionId);
+        expect(recoveryGet.sessionId).toBe(transport.sessionId);
     } finally {
         await Promise.all([client.close(), handle.close()]);
     }
@@ -740,7 +762,7 @@ verifies('flow:tool-result:resource-link-follow', async ({ transport }: TestArgs
     await using _ = await wire(transport, makeServer, client);
 
     // Call tool and get resource_link
-    const toolResult = (await client.callTool({ name: 'resource-link', arguments: {} })) as CallToolResult;
+    const toolResult = await client.callTool({ name: 'resource-link', arguments: {} });
     expect(toolResult.isError).toBeFalsy();
 
     const link = toolResult.content.find(c => c.type === 'resource_link');
@@ -752,6 +774,7 @@ verifies('flow:tool-result:resource-link-follow', async ({ transport }: TestArgs
     const readResult = await client.readResource({ uri: link.uri });
     expect(readResult.contents).toHaveLength(1);
     const [entry] = readResult.contents;
+    if (!entry) throw new Error('expected one resource contents entry');
     expect(entry.uri).toBe(link.uri);
     expect(entry.mimeType).toBe('text/plain');
     if (entry.mimeType?.startsWith('text/')) {
@@ -806,25 +829,36 @@ verifies('flow:proxy:forward-tools-resources', async ({ transport }: TestArgs) =
     // Wire: downstream client → proxy server → upstream client → upstream server
     const downstreamClient = new Client({ name: 'downstream', version: '0' });
 
-    await using _upstreamW = await wire(transport, () => upstreamServer, upstreamClient);
-    await using _proxyW = await wire(transport, () => proxyServer, downstreamClient);
+    // Two wires must stay open for the whole body; explicit dispose in finally instead of two `await using` bindings.
+    const upstreamWired = await wire(transport, () => upstreamServer, upstreamClient);
+    try {
+        const proxyWired = await wire(transport, () => proxyServer, downstreamClient);
+        try {
+            // Downstream sees upstream tools
+            const { tools } = await downstreamClient.listTools();
+            const echo = tools.find(t => t.name === 'echo');
+            expect(echo).toBeDefined();
+            if (!echo) throw new Error('unreachable');
+            expect(echo.description).toBe('Echoes text');
+            expect(echo.inputSchema.properties).toMatchObject({ text: { type: 'string' } });
 
-    // Downstream sees upstream tools
-    const { tools } = await downstreamClient.listTools();
-    const echo = tools.find(t => t.name === 'echo');
-    expect(echo).toBeDefined();
-    expect(echo!.description).toBe('Echoes text');
-    expect(echo!.inputSchema.properties).toMatchObject({ text: { type: 'string' } });
+            const annotatedTool = tools.find(t => t.name === 'annotated');
+            expect(annotatedTool).toBeDefined();
+            if (!annotatedTool) throw new Error('unreachable');
+            expect(annotatedTool.annotations).toMatchObject({ readOnlyHint: true, idempotentHint: true });
+            expect(annotatedTool._meta).toEqual({ 'example.com/fixture': true });
 
-    const annotatedTool = tools.find(t => t.name === 'annotated');
-    expect(annotatedTool).toBeDefined();
-    expect(annotatedTool!.annotations).toMatchObject({ readOnlyHint: true, idempotentHint: true });
-    expect(annotatedTool!._meta).toEqual({ 'example.com/fixture': true });
-
-    // Downstream sees upstream resources
-    const { resources } = await downstreamClient.listResources();
-    const annotatedRes = resources.find(r => r.uri === 'file:///annotated.md');
-    expect(annotatedRes).toBeDefined();
-    expect(annotatedRes!.name).toBe('annotated');
-    expect(annotatedRes!._meta).toEqual({ 'example.com/fixture': true });
+            // Downstream sees upstream resources
+            const { resources } = await downstreamClient.listResources();
+            const annotatedRes = resources.find(r => r.uri === 'file:///annotated.md');
+            expect(annotatedRes).toBeDefined();
+            if (!annotatedRes) throw new Error('unreachable');
+            expect(annotatedRes.name).toBe('annotated');
+            expect(annotatedRes._meta).toEqual({ 'example.com/fixture': true });
+        } finally {
+            await proxyWired[Symbol.asyncDispose]();
+        }
+    } finally {
+        await upstreamWired[Symbol.asyncDispose]();
+    }
 });

--- a/test/e2e/scenarios/flow.test.ts
+++ b/test/e2e/scenarios/flow.test.ts
@@ -1,0 +1,840 @@
+/**
+ * Self-contained test bodies for composite end-to-end flows.
+ *
+ * These are longer journeys that combine multiple SDK features: multi-step
+ * elicitation, OAuth roundtrip, resumption, session management, proxy
+ * forwarding. Each builds whatever in-test pieces it needs (mock AS, minimal
+ * EventStore, secondary Clients, proxy McpServer delegating to an upstream
+ * Client) rather than importing shared fixtures.
+ */
+
+import { expect, vi } from 'vitest';
+import { z } from 'zod/v4';
+
+import { Client } from '../../../src/client/index.js';
+import { type OAuthClientProvider, UnauthorizedError } from '../../../src/client/auth.js';
+import { StreamableHTTPClientTransport } from '../../../src/client/streamableHttp.js';
+import { Server } from '../../../src/server/index.js';
+import { McpServer } from '../../../src/server/mcp.js';
+import type { EventStore } from '../../../src/server/webStandardStreamableHttp.js';
+import { type OAuthTokens, type OAuthClientMetadata, type OAuthClientInformationMixed } from '../../../src/shared/auth.js';
+import {
+    type CallToolResult,
+    ElicitationCompleteNotificationSchema,
+    type ElicitRequest,
+    type ElicitResult,
+    ElicitRequestSchema,
+    ElicitResultSchema,
+    ErrorCode,
+    type JSONRPCMessage,
+    ListResourcesRequestSchema,
+    ListToolsRequestSchema,
+    type Progress,
+    ReadResourceRequestSchema,
+    UrlElicitationRequiredError
+} from '../../../src/types.js';
+
+import { hostPerSession, hostResumable, wire } from '../helpers/index.js';
+import type { TestArgs } from '../types.js';
+import { verifies } from '../helpers/verifies.js';
+
+verifies('flow:elicitation:multi-step-form', async ({ transport }: TestArgs) => {
+    // Server: tool that issues three sequential elicitation/create requests
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool('multi-step', { inputSchema: z.object({}) }, async (_args, extra) => {
+            const step1 = await extra.sendRequest(
+                {
+                    method: 'elicitation/create',
+                    params: {
+                        mode: 'form',
+                        message: 'What is your name?',
+                        requestedSchema: { type: 'object', properties: { name: { type: 'string' } }, required: ['name'] }
+                    }
+                },
+                ElicitResultSchema
+            );
+            if (step1.action !== 'accept' || typeof step1.content?.name !== 'string') {
+                return { content: [{ type: 'text', text: `aborted at step 1: ${step1.action}` }] };
+            }
+            const name = step1.content.name;
+
+            const step2 = await extra.sendRequest(
+                {
+                    method: 'elicitation/create',
+                    params: {
+                        mode: 'form',
+                        message: `Hello ${name}, what is your favorite color?`,
+                        requestedSchema: { type: 'object', properties: { color: { type: 'string' } }, required: ['color'] }
+                    }
+                },
+                ElicitResultSchema
+            );
+            if (step2.action !== 'accept' || typeof step2.content?.color !== 'string') {
+                return { content: [{ type: 'text', text: `aborted at step 2: ${step2.action}` }] };
+            }
+            const color = step2.content.color;
+
+            const step3 = await extra.sendRequest(
+                {
+                    method: 'elicitation/create',
+                    params: {
+                        mode: 'form',
+                        message: `${name}, you picked ${color}. Confirm?`,
+                        requestedSchema: { type: 'object', properties: { confirm: { type: 'boolean' } }, required: ['confirm'] }
+                    }
+                },
+                ElicitResultSchema
+            );
+            if (step3.action !== 'accept') {
+                return { content: [{ type: 'text', text: `aborted at step 3: ${step3.action}` }] };
+            }
+
+            return { content: [{ type: 'text', text: `${name}'s favorite color is ${color}` }] };
+        });
+        return s;
+    };
+
+    // Client: registers handler for elicitation/create, queues responses
+    const received: ElicitRequest[] = [];
+    const queued: ElicitResult[] = [];
+    const client = new Client({ name: 'c', version: '0' }, { capabilities: { elicitation: { form: {} } } });
+    client.setRequestHandler(ElicitRequestSchema, async req => {
+        received.push(req);
+        const resp = queued.shift();
+        if (!resp) throw new Error('no queued elicitation response');
+        return resp;
+    });
+
+    await using _ = await wire(transport, makeServer, client);
+
+    // Happy path: accept all three steps
+    queued.push({ action: 'accept', content: { name: 'Ada' } });
+    queued.push({ action: 'accept', content: { color: 'blue' } });
+    queued.push({ action: 'accept', content: { confirm: true } });
+
+    const ok = await client.callTool({ name: 'multi-step', arguments: {} });
+    expect(ok.isError).toBeFalsy();
+    expect(ok.content).toEqual([{ type: 'text', text: "Ada's favorite color is blue" }]);
+
+    expect(received).toHaveLength(3);
+    expect(received[0].params).toMatchObject({ mode: 'form', requestedSchema: { properties: { name: { type: 'string' } } } });
+    expect(received[1].params.message).toContain('Ada');
+    expect(received[1].params).toMatchObject({ mode: 'form', requestedSchema: { properties: { color: { type: 'string' } } } });
+    expect(received[2].params.message).toContain('Ada');
+    expect(received[2].params.message).toContain('blue');
+    expect(received[2].params).toMatchObject({ mode: 'form', requestedSchema: { properties: { confirm: { type: 'boolean' } } } });
+
+    // Decline at step 2
+    queued.push({ action: 'accept', content: { name: 'Bob' } });
+    queued.push({ action: 'decline' });
+    const declined = await client.callTool({ name: 'multi-step', arguments: {} });
+    expect(declined.isError).toBeFalsy();
+    expect(declined.content).toEqual([{ type: 'text', text: 'aborted at step 2: decline' }]);
+    expect(received).toHaveLength(5);
+
+    // Cancel at step 1
+    queued.push({ action: 'cancel' });
+    queued.push({ action: 'accept', content: { color: 'red' } }); // sentinel: must not be consumed
+    const cancelled = await client.callTool({ name: 'multi-step', arguments: {} });
+    expect(cancelled.isError).toBeFalsy();
+    expect(cancelled.content).toEqual([{ type: 'text', text: 'aborted at step 1: cancel' }]);
+    expect(received).toHaveLength(6);
+    expect(queued).toHaveLength(1); // sentinel still queued
+});
+
+verifies('flow:elicitation:url-at-session-init', async (_args: TestArgs) => {
+    // Not wire(): a transport.send tap must be installed before connect to prove no client request precedes the unsolicited elicitation.
+    // Server: issues URL-mode elicitation immediately after onsessioninitialized
+    const makeServer = () => {
+        const s = new Server({ name: 's', version: '0' }, { capabilities: { tools: {} } });
+        s.oninitialized = () => {
+            setTimeout(() => {
+                void s
+                    .elicitInput({
+                        mode: 'url',
+                        message: 'Authorize the session',
+                        url: 'https://example.com/auth',
+                        elicitationId: 'session-init-elicit'
+                    })
+                    .catch(() => {});
+            }, 0);
+        };
+        s.setRequestHandler(ListToolsRequestSchema, () => ({ tools: [] }));
+        return s;
+    };
+
+    const received: ElicitRequest[] = [];
+    const client = new Client({ name: 'c', version: '0' }, { capabilities: { elicitation: { url: {} } } });
+    client.setRequestHandler(ElicitRequestSchema, async req => {
+        received.push(req);
+        return { action: 'accept' };
+    });
+
+    const handle = hostPerSession(makeServer);
+    const url = new URL('http://in-process/mcp');
+    const customFetch = (u: URL | string, init?: RequestInit) => handle.handleRequest(new Request(u, init));
+    const transport = new StreamableHTTPClientTransport(url, { fetch: customFetch });
+
+    // Tap wire before connecting
+    const sent: Array<{ method?: string }> = [];
+    const origSend = transport.send.bind(transport);
+    transport.send = async (m, opts) => {
+        sent.push(m as { method?: string });
+        return origSend(m, opts);
+    };
+
+    await client.connect(transport);
+
+    try {
+        // Wait for the unsolicited server→client elicitation/create
+        await vi.waitFor(() => expect(received.length).toBeGreaterThanOrEqual(1));
+
+        expect(received).toHaveLength(1);
+        expect(received[0].method).toBe('elicitation/create');
+        const params = received[0].params;
+        if (params.mode !== 'url') throw new Error('expected url mode');
+        expect(params.elicitationId).toBe('session-init-elicit');
+        expect(() => new URL(params.url)).not.toThrow();
+
+        // Client has only sent initialize so far (no post-init requests)
+        const requests = sent.filter(m => 'method' in m && 'id' in m);
+        expect(requests.map(r => r.method)).toEqual(['initialize']);
+
+        // Session survived
+        await expect(client.ping()).resolves.toBeDefined();
+    } finally {
+        await Promise.all([client.close(), handle.close()]);
+    }
+});
+
+verifies('flow:elicitation:url-required-then-retry', async ({ transport }: TestArgs) => {
+    // Server: tool that throws UrlElicitationRequiredError until elicitation is completed
+    const completed = new Set<string>();
+    let server!: McpServer;
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool('url-gated', { inputSchema: z.object({}) }, () => {
+            const elicitationId = 'url-elicit-1';
+            if (!completed.has(elicitationId)) {
+                throw new UrlElicitationRequiredError([
+                    {
+                        mode: 'url',
+                        message: 'Please sign in',
+                        elicitationId,
+                        url: 'https://example.com/auth'
+                    }
+                ]);
+            }
+            return { content: [{ type: 'text', text: 'authenticated' }] };
+        });
+        server = s;
+        return s;
+    };
+
+    const client = new Client({ name: 'c', version: '0' }, { capabilities: { elicitation: { url: {} } } });
+    const completionsSeen: string[] = [];
+    client.setNotificationHandler(ElicitationCompleteNotificationSchema, async n => {
+        completionsSeen.push(n.params.elicitationId);
+    });
+    await using _ = await wire(transport, makeServer, client);
+
+    // Step 1: first call rejects with UrlElicitationRequiredError
+    const err = await client.callTool({ name: 'url-gated', arguments: {} }).catch(e => e);
+    expect(err).toBeInstanceOf(UrlElicitationRequiredError);
+    const required = err as UrlElicitationRequiredError;
+    expect(required.code).toBe(ErrorCode.UrlElicitationRequired);
+    expect(required.elicitations).toHaveLength(1);
+    const elicitation = required.elicitations[0];
+    expect(elicitation.mode).toBe('url');
+    expect(typeof elicitation.elicitationId).toBe('string');
+    expect(elicitation.url).toMatch(/^https?:\/\//);
+
+    // Step 2: user "opens" the URL (out-of-band, simulated by marking complete)
+    completed.add(elicitation.elicitationId);
+
+    // Step 3: server emits notifications/elicitation/complete and the client receives it for that exact elicitation
+    await server.server.createElicitationCompletionNotifier(elicitation.elicitationId)();
+    await vi.waitFor(() => expect(completionsSeen).toEqual([elicitation.elicitationId]));
+
+    // Step 4: retry succeeds
+    const result = await client.callTool({ name: 'url-gated', arguments: {} });
+    expect(result.isError).toBeFalsy();
+    expect(result.content).toEqual([{ type: 'text', text: 'authenticated' }]);
+});
+
+verifies('flow:multi-client:stateful-isolation', async (_args: TestArgs) => {
+    // Not wire(): three clients share one host and the test reads each transport's sessionId; wire() binds a single client to its own host.
+    // Server: per-session McpServer with progress tool
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool('progress', { inputSchema: z.object({ steps: z.number().int().positive() }) }, async ({ steps }, extra) => {
+            const token = extra._meta?.progressToken;
+            if (token !== undefined) {
+                for (let i = 1; i <= steps; i++) {
+                    await extra.sendNotification({
+                        method: 'notifications/progress',
+                        params: { progressToken: token, progress: i, total: steps, message: `step ${i}/${steps}` }
+                    });
+                }
+            }
+            return { content: [{ type: 'text', text: `done after ${steps} steps` }] };
+        });
+        return s;
+    };
+
+    // Three clients connect to the same per-session host
+    const clientA = new Client({ name: 'a', version: '0' });
+    const clientB = new Client({ name: 'b', version: '0' });
+    const clientC = new Client({ name: 'c', version: '0' });
+
+    const handle = hostPerSession(makeServer);
+    const url = new URL('http://in-process/mcp');
+    const customFetch = (u: URL | string, init?: RequestInit) => handle.handleRequest(new Request(u, init));
+
+    await clientA.connect(new StreamableHTTPClientTransport(url, { fetch: customFetch }));
+    await clientB.connect(new StreamableHTTPClientTransport(url, { fetch: customFetch }));
+    await clientC.connect(new StreamableHTTPClientTransport(url, { fetch: customFetch }));
+
+    try {
+        const clients = [clientA, clientB, clientC] as const;
+        const sessionIds = clients.map(c => (c.transport as StreamableHTTPClientTransport).sessionId);
+
+        for (const id of sessionIds) {
+            expect(id).toEqual(expect.any(String));
+        }
+        expect(new Set(sessionIds).size).toBe(3);
+
+        // Concurrent progress calls with distinct step counts
+        const STEPS = [2, 3, 4] as const;
+        const errors: Error[][] = [[], [], []];
+        clients.forEach((cl, i) => {
+            cl.onerror = e => errors[i].push(e);
+        });
+
+        const runs = await Promise.all(
+            clients.map(async (cl, i) => {
+                const received: Progress[] = [];
+                const result = await cl.callTool({ name: 'progress', arguments: { steps: STEPS[i] } }, undefined, {
+                    onprogress: p => received.push({ progress: p.progress, total: p.total, message: p.message })
+                });
+                return { received, result };
+            })
+        );
+
+        for (let i = 0; i < 3; i++) {
+            const steps = STEPS[i];
+            const { received, result } = runs[i];
+            expect(received).toEqual(
+                Array.from({ length: steps }, (_, k) => ({
+                    progress: k + 1,
+                    total: steps,
+                    message: `step ${k + 1}/${steps}`
+                }))
+            );
+            expect(result.content).toEqual([{ type: 'text', text: `done after ${steps} steps` }]);
+        }
+
+        for (const errs of errors) {
+            expect(errs).toEqual([]);
+        }
+    } finally {
+        await Promise.all([clientA.close(), clientB.close(), clientC.close(), handle.close()]);
+    }
+});
+
+verifies('flow:oauth:authorization-code-roundtrip', async (_args: TestArgs) => {
+    // Not wire(): needs an authProvider-equipped client transport plus 401/PRM/AS fetch routing in front of the host, which wire() does not expose.
+    const ACCESS_TOKEN = 'roundtrip-access-token';
+    const AUTH_CODE = 'granted-authorization-code';
+    const AS_ORIGIN = 'https://as.example.com';
+    const PRM_PATH = '/.well-known/oauth-protected-resource';
+
+    // Mock Authorization Server: metadata discovery, dynamic client registration, code exchange.
+    const registerRequests: Array<Record<string, unknown>> = [];
+    const tokenRequests: URLSearchParams[] = [];
+    const mockASFetch = async (url: URL | string, init?: RequestInit): Promise<Response> => {
+        const req = new Request(url, init);
+        const u = new URL(req.url);
+        if (u.pathname === '/.well-known/oauth-authorization-server') {
+            return new Response(
+                JSON.stringify({
+                    issuer: AS_ORIGIN,
+                    authorization_endpoint: `${AS_ORIGIN}/authorize`,
+                    token_endpoint: `${AS_ORIGIN}/token`,
+                    registration_endpoint: `${AS_ORIGIN}/register`,
+                    grant_types_supported: ['authorization_code'],
+                    response_types_supported: ['code'],
+                    code_challenge_methods_supported: ['S256']
+                }),
+                { status: 200, headers: { 'Content-Type': 'application/json' } }
+            );
+        }
+        if (u.pathname === '/register' && req.method === 'POST') {
+            const body: Record<string, unknown> = await req.json();
+            registerRequests.push(body);
+            // RFC 7591: the registration response echoes the submitted metadata plus the issued client_id.
+            return new Response(JSON.stringify({ ...body, client_id: 'mock-client-id' }), {
+                status: 201,
+                headers: { 'Content-Type': 'application/json' }
+            });
+        }
+        if (u.pathname === '/token' && req.method === 'POST') {
+            tokenRequests.push(new URLSearchParams(await req.text()));
+            return new Response(JSON.stringify({ access_token: ACCESS_TOKEN, token_type: 'Bearer', expires_in: 3600 }), {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' }
+            });
+        }
+        return new Response('Not Found', { status: 404 });
+    };
+
+    // Mock OAuthClientProvider
+    const redirectedTo: string[] = [];
+    const saved: { tokens?: OAuthTokens; clientInfo?: OAuthClientInformationMixed; codeVerifier?: string } = {};
+    const provider: OAuthClientProvider = {
+        get redirectUrl() {
+            return 'http://localhost/callback';
+        },
+        get clientMetadata(): OAuthClientMetadata {
+            return {
+                client_name: 'test-client',
+                client_uri: 'http://localhost',
+                redirect_uris: ['http://localhost/callback']
+            };
+        },
+        clientInformation: () => saved.clientInfo,
+        saveClientInformation: async ci => {
+            saved.clientInfo = ci;
+        },
+        tokens: () => saved.tokens,
+        saveTokens: async t => {
+            saved.tokens = t;
+        },
+        codeVerifier: () => {
+            if (!saved.codeVerifier) throw new Error('No code verifier saved');
+            return saved.codeVerifier;
+        },
+        saveCodeVerifier: async v => {
+            saved.codeVerifier = v;
+        },
+        redirectToAuthorization: async url => {
+            redirectedTo.push(url.toString());
+        }
+    };
+
+    // Server with bearer auth
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool('echo', { inputSchema: z.object({ text: z.string() }) }, ({ text }) => ({
+            content: [{ type: 'text', text }]
+        }));
+        return s;
+    };
+
+    // Protected host: serves RFC 9728 resource metadata, otherwise requires the issued bearer token.
+    const handle = hostPerSession(makeServer);
+    const url = new URL('http://in-process/mcp');
+    const serverFetch = async (u: URL | string, init?: RequestInit): Promise<Response> => {
+        const req = new Request(u, init);
+        const requestUrl = new URL(req.url);
+        if (requestUrl.pathname.startsWith(PRM_PATH)) {
+            return new Response(JSON.stringify({ resource: url.toString(), authorization_servers: [AS_ORIGIN] }), {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' }
+            });
+        }
+        const auth = req.headers.get('authorization');
+        if (auth !== `Bearer ${ACCESS_TOKEN}`) {
+            return new Response(null, {
+                status: 401,
+                headers: { 'WWW-Authenticate': `Bearer resource_metadata="http://in-process${PRM_PATH}/mcp"` }
+            });
+        }
+        return handle.handleRequest(req);
+    };
+
+    const combinedFetch = async (u: URL | string, init?: RequestInit): Promise<Response> => {
+        const requestUrl = typeof u === 'string' ? new URL(u) : u;
+        if (requestUrl.hostname === 'as.example.com') return mockASFetch(requestUrl, init);
+        return serverFetch(requestUrl, init);
+    };
+
+    const client = new Client({ name: 'c', version: '0' });
+
+    try {
+        // Step 1: first connect fails with 401 → discovery + DCR + redirect to the authorization endpoint
+        const transport1 = new StreamableHTTPClientTransport(url, { authProvider: provider, fetch: combinedFetch });
+        await expect(client.connect(transport1)).rejects.toBeInstanceOf(UnauthorizedError);
+
+        expect(redirectedTo).toHaveLength(1);
+        const authorizeUrl = new URL(redirectedTo[0]);
+        expect(authorizeUrl.origin).toBe(AS_ORIGIN);
+        expect(authorizeUrl.pathname).toBe('/authorize');
+        expect(authorizeUrl.searchParams.get('client_id')).toBe('mock-client-id');
+        expect(authorizeUrl.searchParams.get('code_challenge')).toBeTruthy();
+        expect(registerRequests).toHaveLength(1);
+        expect(saved.tokens).toBeUndefined();
+
+        const codeVerifier = saved.codeVerifier;
+        if (!codeVerifier) throw new Error('No code verifier saved during the redirect step');
+
+        // Step 2: user completes redirect, finishAuth exchanges the code for tokens
+        await transport1.finishAuth(AUTH_CODE);
+
+        expect(tokenRequests).toHaveLength(1);
+        expect(tokenRequests[0].get('grant_type')).toBe('authorization_code');
+        expect(tokenRequests[0].get('code')).toBe(AUTH_CODE);
+        expect(tokenRequests[0].get('code_verifier')).toBe(codeVerifier);
+        expect(tokenRequests[0].get('redirect_uri')).toBe('http://localhost/callback');
+        expect(saved.tokens?.access_token).toBe(ACCESS_TOKEN);
+
+        // Step 3: second connect with fresh transport succeeds and tools/list works
+        const transport2 = new StreamableHTTPClientTransport(url, { authProvider: provider, fetch: combinedFetch });
+        await client.connect(transport2);
+
+        const { tools } = await client.listTools();
+        expect(tools.some(t => t.name === 'echo')).toBe(true);
+    } finally {
+        await Promise.all([client.close(), handle.close()]);
+    }
+});
+
+verifies('flow:resume:tool-call-resumption-token', async (_args: TestArgs) => {
+    // Not wire(): needs an EventStore-backed host and a severable fetch to simulate a mid-stream disconnect, which wire() does not expose.
+    const TOTAL_STEPS = 4;
+    const DELIVERED_BEFORE_DISCONNECT = 2;
+
+    // The tool pauses after the first two progress notifications so the test can sever the call's SSE
+    // stream before the remaining notifications and the result are produced.
+    let releaseRemainingSteps!: () => void;
+    const remainingStepsReleased = new Promise<void>(resolve => {
+        releaseRemainingSteps = resolve;
+    });
+    let toolRuns = 0;
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool('import-records', { inputSchema: z.object({ steps: z.number().int().positive() }) }, async ({ steps }, extra) => {
+            toolRuns++;
+            const token = extra._meta?.progressToken;
+            if (token === undefined) throw new Error('import-records expects a progressToken');
+            for (let i = 1; i <= steps; i++) {
+                if (i === DELIVERED_BEFORE_DISCONNECT + 1) {
+                    await remainingStepsReleased;
+                }
+                await extra.sendNotification({
+                    method: 'notifications/progress',
+                    params: { progressToken: token, progress: i, total: steps }
+                });
+            }
+            return { content: [{ type: 'text', text: `imported ${steps} record batches` }] };
+        });
+        return s;
+    };
+
+    // Insertion-ordered EventStore: replay order (and therefore the exact-sequence assertions below) must not depend on timestamps.
+    const storedEvents: Array<{ eventId: string; streamId: string; message: JSONRPCMessage }> = [];
+    const eventStore: EventStore = {
+        storeEvent: async (streamId, message) => {
+            const eventId = `${streamId}|${storedEvents.length + 1}`;
+            storedEvents.push({ eventId, streamId, message });
+            return eventId;
+        },
+        replayEventsAfter: async (lastEventId, { send }) => {
+            const lastIndex = storedEvents.findIndex(e => e.eventId === lastEventId);
+            if (lastIndex === -1) return '';
+            const { streamId } = storedEvents[lastIndex];
+            for (const event of storedEvents.slice(lastIndex + 1)) {
+                if (event.streamId === streamId) await send(event.eventId, event.message);
+            }
+            return streamId;
+        }
+    };
+
+    const handle = hostResumable(makeServer, { eventStore, retryInterval: 0 });
+    const url = new URL('http://in-process/mcp');
+
+    const requests: Array<{ method: string; lastEventId: string | undefined; sessionId: string | undefined; body: string | undefined }> =
+        [];
+
+    // The tools/call response is wrapped so the test can sever the stream the client is reading (a simulated
+    // network drop); the server keeps writing the rest of the stream, which only the EventStore retains.
+    let severToolCallStream: () => void = () => {
+        throw new Error('tools/call SSE stream not opened yet');
+    };
+    let originalStreamFinished!: () => void;
+    const originalStreamComplete = new Promise<void>(resolve => {
+        originalStreamFinished = resolve;
+    });
+
+    const customFetch = async (u: URL | string, init?: RequestInit): Promise<Response> => {
+        const request = new Request(u, init);
+        const lastEventId = request.headers.get('last-event-id') ?? undefined;
+        const body = typeof init?.body === 'string' ? init.body : undefined;
+        requests.push({ method: request.method, lastEventId, sessionId: request.headers.get('mcp-session-id') ?? undefined, body });
+
+        // Hold the transport's recovery GET until the server has finished the interrupted stream, so the
+        // replay deterministically contains every message the client missed.
+        if (request.method === 'GET' && lastEventId !== undefined) {
+            await originalStreamComplete;
+        }
+
+        const response = await handle.handleRequest(request);
+        if (request.method !== 'POST' || !body?.includes('"tools/call"') || !response.body) {
+            return response;
+        }
+
+        const upstream = response.body.getReader();
+        let severed = false;
+        const severable = new ReadableStream<Uint8Array>({
+            start: controller => {
+                severToolCallStream = () => {
+                    severed = true;
+                    controller.error(new Error('simulated mid-stream network drop'));
+                };
+                void (async () => {
+                    while (true) {
+                        const { value, done } = await upstream.read();
+                        if (done) break;
+                        if (!severed && value) controller.enqueue(value);
+                    }
+                    originalStreamFinished();
+                    if (!severed) controller.close();
+                })();
+            }
+        });
+        return new Response(severable, { status: response.status, headers: response.headers });
+    };
+
+    const client = new Client({ name: 'c', version: '0' });
+    const transport = new StreamableHTTPClientTransport(url, {
+        fetch: customFetch,
+        reconnectionOptions: { initialReconnectionDelay: 10, maxReconnectionDelay: 10, reconnectionDelayGrowFactor: 1, maxRetries: 2 }
+    });
+    await client.connect(transport);
+
+    try {
+        const progressSeen: number[] = [];
+        const eventIdsSeen: string[] = [];
+        const callSettled = vi.fn();
+
+        // The one and only tools/call of this test: this same promise must resolve after the disconnect.
+        const call = client.callTool({ name: 'import-records', arguments: { steps: TOTAL_STEPS } }, undefined, {
+            onprogress: (p: Progress) => progressSeen.push(p.progress),
+            onresumptiontoken: id => eventIdsSeen.push(id)
+        });
+        call.then(callSettled, callSettled);
+
+        await vi.waitFor(() => expect(progressSeen).toEqual([1, 2]));
+        const lastEventIdBeforeDisconnect = eventIdsSeen[eventIdsSeen.length - 1];
+
+        // Sever mid-call, then let the server finish steps 3..4 and the result while the client is disconnected.
+        severToolCallStream();
+        expect(callSettled).not.toHaveBeenCalled();
+        releaseRemainingSteps();
+        await originalStreamComplete;
+        expect(progressSeen).toEqual([1, 2]);
+        expect(callSettled).not.toHaveBeenCalled();
+
+        // The original promise resolves with the tool's result; the handler ran exactly once.
+        const result = await call;
+        expect(result.isError).toBeFalsy();
+        expect(result.content).toEqual([{ type: 'text', text: `imported ${TOTAL_STEPS} record batches` }]);
+        expect(toolRuns).toBe(1);
+
+        // Recovery delivered only the missed notifications: no duplicates, none missing.
+        expect(progressSeen).toEqual([1, 2, 3, 4]);
+
+        const lastEventBeforeDisconnect = storedEvents.find(e => e.eventId === lastEventIdBeforeDisconnect);
+        if (!lastEventBeforeDisconnect) throw new Error('the last event id delivered before the disconnect was never stored');
+        const toolCallStreamEvents = storedEvents.filter(e => e.streamId === lastEventBeforeDisconnect.streamId);
+
+        // The whole stream was persisted (priming placeholder, four progress notifications, result), and the
+        // client saw each of its events exactly once, in order, across the original stream and the replay.
+        expect(
+            toolCallStreamEvents.map(e => ('method' in e.message ? e.message.method : 'result' in e.message ? 'response' : 'priming'))
+        ).toEqual([
+            'priming',
+            'notifications/progress',
+            'notifications/progress',
+            'notifications/progress',
+            'notifications/progress',
+            'response'
+        ]);
+        expect(eventIdsSeen).toEqual(toolCallStreamEvents.map(e => e.eventId));
+        // Index DELIVERED_BEFORE_DISCONNECT skips the priming event, landing on the second progress notification.
+        expect(lastEventIdBeforeDisconnect).toBe(toolCallStreamEvents[DELIVERED_BEFORE_DISCONNECT].eventId);
+
+        // Transparency: the caller never re-issued the call; the transport recovered with a single GET
+        // carrying Last-Event-ID for the last event delivered before the disconnect, on the same session.
+        expect(requests.filter(r => r.method === 'POST' && r.body?.includes('"tools/call"'))).toHaveLength(1);
+        const recoveryGets = requests.filter(r => r.method === 'GET' && r.lastEventId !== undefined);
+        expect(recoveryGets).toHaveLength(1);
+        expect(recoveryGets[0].lastEventId).toBe(lastEventIdBeforeDisconnect);
+        expect(transport.sessionId).toEqual(expect.any(String));
+        expect(recoveryGets[0].sessionId).toBe(transport.sessionId);
+    } finally {
+        await Promise.all([client.close(), handle.close()]);
+    }
+});
+
+verifies('flow:session:terminate-then-reconnect', async (_args: TestArgs) => {
+    // Not wire(): drives StreamableHTTPClientTransport directly for sessionId/terminateSession() and connects a second transport to the same host.
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool('echo', { inputSchema: z.object({ text: z.string() }) }, ({ text }) => ({
+            content: [{ type: 'text', text }]
+        }));
+        return s;
+    };
+
+    const handle = hostPerSession(makeServer);
+    const url = new URL('http://in-process/mcp');
+    const customFetch = (u: URL | string, init?: RequestInit) => handle.handleRequest(new Request(u, init));
+
+    const client1 = new Client({ name: 'c', version: '0' });
+    const transport1 = new StreamableHTTPClientTransport(url, { fetch: customFetch });
+    await client1.connect(transport1);
+
+    try {
+        const originalSessionId = transport1.sessionId;
+        expect(originalSessionId).toEqual(expect.any(String));
+
+        // Terminate session
+        await transport1.terminateSession();
+        expect(transport1.sessionId).toBeUndefined();
+
+        // Close first client
+        await client1.close();
+
+        // Fresh client and transport obtain new session
+        const client2 = new Client({ name: 'c', version: '0' });
+        const transport2 = new StreamableHTTPClientTransport(url, { fetch: customFetch });
+        await client2.connect(transport2);
+
+        const newSessionId = transport2.sessionId;
+        expect(newSessionId).toEqual(expect.any(String));
+        expect(newSessionId).not.toBe(originalSessionId);
+
+        // Operations succeed on new session
+        const result = await client2.callTool({ name: 'echo', arguments: { text: 'after-reconnect' } });
+        expect(result.isError).toBeFalsy();
+        expect(result.content).toEqual([{ type: 'text', text: 'after-reconnect' }]);
+
+        await client2.close();
+    } finally {
+        await handle.close();
+    }
+});
+
+verifies('flow:tool-result:resource-link-follow', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool('resource-link', { inputSchema: z.object({}) }, () => ({
+            content: [
+                {
+                    type: 'resource_link',
+                    uri: 'file:///linked.txt',
+                    name: 'linked.txt',
+                    mimeType: 'text/plain'
+                }
+            ]
+        }));
+        s.registerResource('linked.txt', 'file:///linked.txt', { mimeType: 'text/plain' }, async () => ({
+            contents: [{ uri: 'file:///linked.txt', mimeType: 'text/plain', text: 'linked resource contents' }]
+        }));
+        return s;
+    };
+
+    const client = new Client({ name: 'c', version: '0' });
+    await using _ = await wire(transport, makeServer, client);
+
+    // Call tool and get resource_link
+    const toolResult = (await client.callTool({ name: 'resource-link', arguments: {} })) as CallToolResult;
+    expect(toolResult.isError).toBeFalsy();
+
+    const link = toolResult.content.find(c => c.type === 'resource_link');
+    expect(link).toBeDefined();
+    if (link?.type !== 'resource_link') throw new Error('unreachable');
+    expect(link.uri).toBe('file:///linked.txt');
+
+    // Follow the link with resources/read
+    const readResult = await client.readResource({ uri: link.uri });
+    expect(readResult.contents).toHaveLength(1);
+    const [entry] = readResult.contents;
+    expect(entry.uri).toBe(link.uri);
+    expect(entry.mimeType).toBe('text/plain');
+    if (entry.mimeType?.startsWith('text/')) {
+        expect('text' in entry ? entry.text : '').toBe('linked resource contents');
+    }
+});
+
+verifies('flow:proxy:forward-tools-resources', async ({ transport }: TestArgs) => {
+    // Upstream server with tools and resources
+    const upstreamServer = new McpServer({ name: 'upstream', version: '0' });
+    upstreamServer.registerTool('echo', { description: 'Echoes text', inputSchema: z.object({ text: z.string() }) }, ({ text }) => ({
+        content: [{ type: 'text', text }]
+    }));
+    upstreamServer.registerTool(
+        'annotated',
+        {
+            description: 'Annotated tool',
+            inputSchema: z.object({}),
+            annotations: { readOnlyHint: true, idempotentHint: true },
+            _meta: { 'example.com/fixture': true }
+        },
+        () => ({ content: [] })
+    );
+    upstreamServer.registerResource(
+        'annotated',
+        'file:///annotated.md',
+        {
+            mimeType: 'text/markdown',
+            _meta: { 'example.com/fixture': true }
+        },
+        async () => ({
+            contents: [{ uri: 'file:///annotated.md', mimeType: 'text/markdown', text: '# Annotated' }]
+        })
+    );
+
+    // Proxy: low-level Server downstream + Client upstream
+    const upstreamClient = new Client({ name: 'proxy-upstream', version: '0' });
+    const proxyServer = new Server({ name: 'proxy', version: '0' }, { capabilities: { tools: {}, resources: {} } });
+
+    proxyServer.setRequestHandler(ListToolsRequestSchema, async req => {
+        const result = await upstreamClient.listTools(req.params);
+        return { tools: result.tools, nextCursor: result.nextCursor };
+    });
+    proxyServer.setRequestHandler(ListResourcesRequestSchema, async req => {
+        const result = await upstreamClient.listResources(req.params);
+        return { resources: result.resources, nextCursor: result.nextCursor };
+    });
+    proxyServer.setRequestHandler(ReadResourceRequestSchema, async req => {
+        return upstreamClient.readResource(req.params);
+    });
+
+    // Wire: downstream client → proxy server → upstream client → upstream server
+    const downstreamClient = new Client({ name: 'downstream', version: '0' });
+
+    await using _upstreamW = await wire(transport, () => upstreamServer, upstreamClient);
+    await using _proxyW = await wire(transport, () => proxyServer, downstreamClient);
+
+    // Downstream sees upstream tools
+    const { tools } = await downstreamClient.listTools();
+    const echo = tools.find(t => t.name === 'echo');
+    expect(echo).toBeDefined();
+    expect(echo!.description).toBe('Echoes text');
+    expect(echo!.inputSchema.properties).toMatchObject({ text: { type: 'string' } });
+
+    const annotatedTool = tools.find(t => t.name === 'annotated');
+    expect(annotatedTool).toBeDefined();
+    expect(annotatedTool!.annotations).toMatchObject({ readOnlyHint: true, idempotentHint: true });
+    expect(annotatedTool!._meta).toEqual({ 'example.com/fixture': true });
+
+    // Downstream sees upstream resources
+    const { resources } = await downstreamClient.listResources();
+    const annotatedRes = resources.find(r => r.uri === 'file:///annotated.md');
+    expect(annotatedRes).toBeDefined();
+    expect(annotatedRes!.name).toBe('annotated');
+    expect(annotatedRes!._meta).toEqual({ 'example.com/fixture': true });
+});

--- a/test/e2e/scenarios/handler-context.test.ts
+++ b/test/e2e/scenarios/handler-context.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Self-contained test bodies for the ServerContext conveniences handed to
+ * request handlers: `ctx.mcpReq.log()`, `ctx.mcpReq.elicitInput()`,
+ * `ctx.mcpReq.requestSampling()`, and — under HTTP hosting — `ctx.http.req`
+ * exposing the incoming request's Fetch Headers.
+ *
+ * Each body builds its own server (via factory) and client, wires them with
+ * {@link wire} (or hosts directly with {@link hostPerSession} where the HTTP
+ * hosting layer is itself the subject), and asserts.
+ */
+
+import { Client, StreamableHTTPClientTransport } from '@modelcontextprotocol/client';
+import type { CreateMessageRequest, ElicitRequest, ElicitRequestFormParams, LoggingLevel } from '@modelcontextprotocol/server';
+import { McpServer } from '@modelcontextprotocol/server';
+import { expect, vi } from 'vitest';
+import { z } from 'zod/v4';
+
+import { hostPerSession, wire } from '../helpers/index.js';
+import { verifies } from '../helpers/verifies.js';
+import type { TestArgs } from '../types.js';
+
+verifies('mcpserver:context:log-from-handler', async ({ transport }: TestArgs) => {
+    let releaseHandler!: () => void;
+    const handlerGate = new Promise<void>(resolve => {
+        releaseHandler = resolve;
+    });
+
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' }, { capabilities: { logging: {} } });
+        s.registerTool('emit-log', { inputSchema: z.object({}) }, async (_args, ctx) => {
+            await ctx.mcpReq.log('info', { msg: 'from-handler' }, 'handler-logger');
+            // Hold the tool call open until the test has observed the notification, so receipt provably happens mid-call.
+            await handlerGate;
+            return { content: [{ type: 'text', text: 'done' }] };
+        });
+        return s;
+    };
+
+    const logs: Array<{ level: LoggingLevel; logger?: string; data: unknown }> = [];
+    const client = new Client({ name: 'c', version: '0' });
+    client.setNotificationHandler('notifications/message', n => {
+        logs.push(n.params);
+    });
+
+    await using _ = await wire(transport, makeServer, client);
+
+    const inFlightCall = client.callTool({ name: 'emit-log', arguments: {} });
+    try {
+        // The handler is parked on the gate, so the tools/call request is still in flight when the log arrives.
+        await vi.waitFor(() => expect(logs).toHaveLength(1));
+        expect(logs).toEqual([{ level: 'info', logger: 'handler-logger', data: { msg: 'from-handler' } }]);
+    } finally {
+        releaseHandler();
+    }
+
+    const result = await inFlightCall;
+    expect(result.isError).toBeFalsy();
+    expect(result.content).toEqual([{ type: 'text', text: 'done' }]);
+});
+
+verifies('mcpserver:context:elicit-from-handler', async ({ transport }: TestArgs) => {
+    const requestedSchema: ElicitRequestFormParams['requestedSchema'] = {
+        type: 'object',
+        properties: { color: { type: 'string' } },
+        required: ['color']
+    };
+
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool('ask-color', { inputSchema: z.object({}) }, async (_args, ctx) => {
+            const ans = await ctx.mcpReq.elicitInput({ mode: 'form', message: 'Favorite color?', requestedSchema });
+            const color = ans.action === 'accept' ? String(ans.content?.color) : '<none>';
+            return { content: [{ type: 'text', text: `${ans.action}:${color}` }] };
+        });
+        return s;
+    };
+
+    const received: ElicitRequest['params'][] = [];
+    const client = new Client({ name: 'c', version: '0' }, { capabilities: { elicitation: { form: {} } } });
+    client.setRequestHandler('elicitation/create', async req => {
+        received.push(req.params);
+        return { action: 'accept', content: { color: 'teal' } };
+    });
+
+    await using _ = await wire(transport, makeServer, client);
+
+    const result = await client.callTool({ name: 'ask-color', arguments: {} });
+
+    expect(received).toEqual([{ mode: 'form', message: 'Favorite color?', requestedSchema }]);
+    expect(result.isError).toBeFalsy();
+    expect(result.content).toEqual([{ type: 'text', text: 'accept:teal' }]);
+});
+
+verifies('mcpserver:context:sampling-from-handler', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool('summarize', { inputSchema: z.object({ topic: z.string() }) }, async ({ topic }, ctx) => {
+            const result = await ctx.mcpReq.requestSampling({
+                messages: [{ role: 'user', content: { type: 'text', text: `Summarize ${topic}` } }],
+                maxTokens: 50
+            });
+            // Without tools in the request the stub client returns a single text block; arrays would mean a tool-use flow.
+            const text = !Array.isArray(result.content) && result.content.type === 'text' ? result.content.text : '<unexpected>';
+            return { content: [{ type: 'text', text: `${result.model}|${result.role}|${text}` }] };
+        });
+        return s;
+    };
+
+    const received: CreateMessageRequest[] = [];
+    const client = new Client({ name: 'c', version: '0' }, { capabilities: { sampling: {} } });
+    client.setRequestHandler('sampling/createMessage', async req => {
+        received.push(req);
+        return { model: 'stub-model', role: 'assistant', stopReason: 'endTurn', content: { type: 'text', text: 'a short summary' } };
+    });
+
+    await using _ = await wire(transport, makeServer, client);
+
+    const result = await client.callTool({ name: 'summarize', arguments: { topic: 'mcp' } });
+
+    expect(received).toHaveLength(1);
+    const samplingRequest = received[0];
+    if (samplingRequest === undefined) throw new Error('expected exactly one sampling request');
+    expect(samplingRequest.method).toBe('sampling/createMessage');
+    expect(samplingRequest.params.messages).toEqual([{ role: 'user', content: { type: 'text', text: 'Summarize mcp' } }]);
+    expect(samplingRequest.params.maxTokens).toBe(50);
+
+    expect(result.isError).toBeFalsy();
+    expect(result.content).toEqual([{ type: 'text', text: 'stub-model|assistant|a short summary' }]);
+});
+
+verifies('hosting:context:web-request-headers', async (_args: TestArgs) => {
+    const PROBE_HEADER = 'x-e2e-probe';
+    const PROBE_VALUE = 'probe-7d1f';
+
+    const seenByTool: Array<{ isFetchHeaders: boolean; probe: string | null }> = [];
+    const mcpHost = hostPerSession(() => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool('read-probe-header', { inputSchema: z.object({}) }, (_toolArgs, ctx) => {
+            const headers = ctx.http?.req?.headers;
+            seenByTool.push({
+                isFetchHeaders: headers instanceof Headers,
+                probe: headers instanceof Headers ? headers.get(PROBE_HEADER) : null
+            });
+            return { content: [{ type: 'text', text: headers?.get(PROBE_HEADER) ?? '<missing>' }] };
+        });
+        return s;
+    });
+
+    const client = new Client({ name: 'c', version: '0' });
+    const httpTransport = new StreamableHTTPClientTransport(new URL('http://in-process/mcp'), {
+        fetch: (url, init) => mcpHost.handleRequest(new Request(url, init)),
+        requestInit: { headers: { [PROBE_HEADER]: PROBE_VALUE } }
+    });
+
+    try {
+        await client.connect(httpTransport);
+        const result = await client.callTool({ name: 'read-probe-header', arguments: {} });
+
+        // The custom header set on the client transport is readable as Fetch Headers inside the handler.
+        expect(seenByTool).toEqual([{ isFetchHeaders: true, probe: PROBE_VALUE }]);
+        expect(result.isError).toBeFalsy();
+        expect(result.content).toEqual([{ type: 'text', text: PROBE_VALUE }]);
+    } finally {
+        await client.close();
+        await mcpHost.close();
+    }
+});

--- a/test/e2e/scenarios/hosting-auth.test.ts
+++ b/test/e2e/scenarios/hosting-auth.test.ts
@@ -27,13 +27,9 @@ import { randomUUID } from 'node:crypto';
 
 import { expect } from 'vitest';
 import { z } from 'zod/v4';
-
-import { Client } from '../../../src/client/index.js';
-import { StreamableHTTPClientTransport } from '../../../src/client/streamableHttp.js';
-import type { AuthInfo } from '../../../src/server/auth/types.js';
-import { McpServer } from '../../../src/server/mcp.js';
-import { WebStandardStreamableHTTPServerTransport } from '../../../src/server/webStandardStreamableHttp.js';
-
+import { McpServer, WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/server';
+import type { AuthInfo } from '@modelcontextprotocol/server';
+import { Client, StreamableHTTPClientTransport } from '@modelcontextprotocol/client';
 import type { TestArgs } from '../types.js';
 import { verifies } from '../helpers/verifies.js';
 
@@ -63,13 +59,15 @@ verifies('hosting:auth:authinfo-propagates', async (_args: TestArgs) => {
         s.registerTool(
             'whoami',
             { description: 'Reports the authenticated caller derived from extra.authInfo.', inputSchema: z.object({}) },
-            (_a, extra) => {
-                seenByTool.push(extra.authInfo);
+            (_a, ctx) => {
+                seenByTool.push(ctx.http?.authInfo);
                 return {
                     content: [
                         {
                             type: 'text',
-                            text: extra.authInfo ? `${extra.authInfo.clientId} [${extra.authInfo.scopes.join(' ')}]` : 'no-auth-info'
+                            text: ctx.http?.authInfo
+                                ? `${ctx.http?.authInfo.clientId} [${ctx.http?.authInfo.scopes.join(' ')}]`
+                                : 'no-auth-info'
                         }
                     ]
                 };

--- a/test/e2e/scenarios/hosting-auth.test.ts
+++ b/test/e2e/scenarios/hosting-auth.test.ts
@@ -25,13 +25,14 @@
 
 import { randomUUID } from 'node:crypto';
 
+import { Client, StreamableHTTPClientTransport } from '@modelcontextprotocol/client';
+import type { AuthInfo } from '@modelcontextprotocol/server';
+import { McpServer, WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/server';
 import { expect } from 'vitest';
 import { z } from 'zod/v4';
-import { McpServer, WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/server';
-import type { AuthInfo } from '@modelcontextprotocol/server';
-import { Client, StreamableHTTPClientTransport } from '@modelcontextprotocol/client';
-import type { TestArgs } from '../types.js';
+
 import { verifies } from '../helpers/verifies.js';
+import type { TestArgs } from '../types.js';
 
 const VALID_TOKEN = 'analytics-dashboard-access-token';
 
@@ -83,10 +84,13 @@ verifies('hosting:auth:authinfo-propagates', async (_args: TestArgs) => {
         if (req.method === 'POST') postAuthHeaders.push(req.headers.get('authorization'));
         const authInfo = verifyBearer(req.headers.get('authorization'));
         if (!authInfo) {
-            return new Response(JSON.stringify({ error: 'invalid_token' }), {
-                status: 401,
-                headers: { 'content-type': 'application/json', 'www-authenticate': 'Bearer error="invalid_token"' }
-            });
+            return Response.json(
+                { error: 'invalid_token' },
+                {
+                    status: 401,
+                    headers: { 'content-type': 'application/json', 'www-authenticate': 'Bearer error="invalid_token"' }
+                }
+            );
         }
 
         const sid = req.headers.get('mcp-session-id') ?? undefined;

--- a/test/e2e/scenarios/hosting-auth.test.ts
+++ b/test/e2e/scenarios/hosting-auth.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Self-contained test bodies for server-side bearer auth on StreamableHTTP
+ * hosting.
+ *
+ * The SDK ships its bearer-auth enforcement (`requireBearerAuth`), AS router
+ * (`mcpAuthRouter`) and discovery-metadata router (`mcpAuthMetadataRouter`)
+ * as Express `RequestHandler`s only — they consume Express `req`/`res`, so
+ * they cannot be driven in-process with Web-standard Request/Response the way
+ * this suite hosts StreamableHTTP. The requirements those components alone
+ * satisfy (401/403 challenges, audience validation, AS endpoint mounting,
+ * `.well-known` publication) are therefore not covered here: re-implementing
+ * that behavior in a test wrapper and asserting on the wrapper would prove
+ * nothing about the SDK. What this file does cover is the hosting-integration
+ * path the Web-standard transport supports natively: a user-shaped bearer
+ * gate verifies the Authorization header, then delegates to
+ * `WebStandardStreamableHTTPServerTransport.handleRequest(req, { authInfo })`,
+ * and the SDK must surface that verified AuthInfo to tool handlers as
+ * `extra.authInfo`.
+ *
+ * Function names mirror the requirement id in camelCase. Bodies are
+ * streamableHttp-only and host the transport themselves (the gate has to sit
+ * between the client's fetch and the transport), so `TestArgs.transport` is
+ * ignored.
+ */
+
+import { randomUUID } from 'node:crypto';
+
+import { expect } from 'vitest';
+import { z } from 'zod/v4';
+
+import { Client } from '../../../src/client/index.js';
+import { StreamableHTTPClientTransport } from '../../../src/client/streamableHttp.js';
+import type { AuthInfo } from '../../../src/server/auth/types.js';
+import { McpServer } from '../../../src/server/mcp.js';
+import { WebStandardStreamableHTTPServerTransport } from '../../../src/server/webStandardStreamableHttp.js';
+
+import type { TestArgs } from '../types.js';
+import { verifies } from '../helpers/verifies.js';
+
+const VALID_TOKEN = 'analytics-dashboard-access-token';
+
+verifies('hosting:auth:authinfo-propagates', async (_args: TestArgs) => {
+    const expiresAt = Math.floor(Date.now() / 1000) + 3600;
+    // What the user's verifier derives from VALID_TOKEN; a fresh object is built
+    // per request so the handler-side assertion checks delivery, not identity.
+    const verifyBearer = (header: string | null): AuthInfo | undefined =>
+        header === `Bearer ${VALID_TOKEN}`
+            ? {
+                  token: VALID_TOKEN,
+                  clientId: 'analytics-dashboard',
+                  scopes: ['mcp:tools:read', 'mcp:tools:call'],
+                  expiresAt,
+                  extra: { userId: 'user-42' }
+              }
+            : undefined;
+
+    // Recorders live outside the per-session factory.
+    const seenByTool: Array<AuthInfo | undefined> = [];
+    const postAuthHeaders: Array<string | null> = [];
+
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool(
+            'whoami',
+            { description: 'Reports the authenticated caller derived from extra.authInfo.', inputSchema: z.object({}) },
+            (_a, extra) => {
+                seenByTool.push(extra.authInfo);
+                return {
+                    content: [
+                        {
+                            type: 'text',
+                            text: extra.authInfo ? `${extra.authInfo.clientId} [${extra.authInfo.scopes.join(' ')}]` : 'no-auth-info'
+                        }
+                    ]
+                };
+            }
+        );
+        return s;
+    };
+
+    // User-shaped hosting: a bearer gate verifies the Authorization header and
+    // hands the verified AuthInfo to the SDK transport via handleRequest options.
+    const sessions = new Map<string, WebStandardStreamableHTTPServerTransport>();
+    const handleRequest = async (req: Request): Promise<Response> => {
+        if (req.method === 'POST') postAuthHeaders.push(req.headers.get('authorization'));
+        const authInfo = verifyBearer(req.headers.get('authorization'));
+        if (!authInfo) {
+            return new Response(JSON.stringify({ error: 'invalid_token' }), {
+                status: 401,
+                headers: { 'content-type': 'application/json', 'www-authenticate': 'Bearer error="invalid_token"' }
+            });
+        }
+
+        const sid = req.headers.get('mcp-session-id') ?? undefined;
+        const existing = sid ? sessions.get(sid) : undefined;
+        if (existing) return existing.handleRequest(req, { authInfo });
+
+        const tx = new WebStandardStreamableHTTPServerTransport({
+            sessionIdGenerator: randomUUID,
+            onsessioninitialized: id => void sessions.set(id, tx),
+            onsessionclosed: id => void sessions.delete(id)
+        });
+        await makeServer().connect(tx);
+        return tx.handleRequest(req, { authInfo });
+    };
+
+    const client = new Client({ name: 'c', version: '0' });
+    await using _ = {
+        [Symbol.asyncDispose]: async () => {
+            await client.close();
+            for (const t of sessions.values()) await t.close();
+        }
+    };
+
+    await client.connect(
+        new StreamableHTTPClientTransport(new URL('http://in-process/mcp'), {
+            fetch: (url, init) => handleRequest(new Request(url, init)),
+            requestInit: { headers: { Authorization: `Bearer ${VALID_TOKEN}` } }
+        })
+    );
+
+    const r = await client.callTool({ name: 'whoami', arguments: {} });
+    expect(r.isError).toBeFalsy();
+    expect(r.content).toEqual([{ type: 'text', text: 'analytics-dashboard [mcp:tools:read mcp:tools:call]' }]);
+
+    // The SDK transport delivered the verified AuthInfo into the tool handler's
+    // RequestHandlerExtra unchanged — not dropped, not replaced by a placeholder.
+    expect(seenByTool).toHaveLength(1);
+    expect(seenByTool[0]).toEqual({
+        token: VALID_TOKEN,
+        clientId: 'analytics-dashboard',
+        scopes: ['mcp:tools:read', 'mcp:tools:call'],
+        expiresAt,
+        extra: { userId: 'user-42' }
+    });
+
+    // Sanity: the bearer was on the wire for every POST the SDK client sent
+    // (initialize, notifications/initialized, tools/call).
+    expect(postAuthHeaders).toEqual([`Bearer ${VALID_TOKEN}`, `Bearer ${VALID_TOKEN}`, `Bearer ${VALID_TOKEN}`]);
+});

--- a/test/e2e/scenarios/hosting-express.test.ts
+++ b/test/e2e/scenarios/hosting-express.test.ts
@@ -1,40 +1,34 @@
 /**
  * Self-contained test bodies for Express-bound hosting surfaces.
  *
- * These tests cover the SDK's Express-bound surface (auth middleware/routers, host
- * validation, createMcpExpressApp) over real HTTP — the layer a server operator
- * deploys and remote clients depend on; Client/Server are not the subject.
+ * These tests cover the SDK's Express-bound surface (bearer-token middleware,
+ * OAuth metadata router, host validation, createMcpExpressApp) over real HTTP —
+ * the layer a server operator deploys and remote clients depend on; Client/Server
+ * are not the subject.
  *
- * The SDK's requireBearerAuth, mcpAuthRouter, mcpAuthMetadataRouter, and host-
- * header validation middleware are Express RequestHandlers; they cannot be
- * exercised with in-process Web-standard Request/Response. These tests build
- * real Express apps, listen on ephemeral ports (127.0.0.1), drive them with
- * fetch(), and assert exact HTTP status + header + body shapes.
+ * The SDK's requireBearerAuth, mcpAuthMetadataRouter, and host-header validation
+ * middleware are Express RequestHandlers; they cannot be exercised with
+ * in-process Web-standard Request/Response. These tests build real Express apps,
+ * listen on ephemeral ports (127.0.0.1), drive them with fetch(), and assert
+ * exact HTTP status + header + body shapes.
  *
  * Function names mirror the requirement id in camelCase. NO casts, exact
  * assertions, closure recorders outside factories (for stateless compat),
  * minimal comments, every server closed in finally.
  */
 
-import crypto from 'node:crypto';
 import http from 'node:http';
 
-import express, { type RequestHandler } from 'express';
+import { createMcpExpressApp, mcpAuthMetadataRouter, requireBearerAuth } from '@modelcontextprotocol/express';
+import type { OAuthMetadata } from '@modelcontextprotocol/server';
+import { OAuthError, OAuthErrorCode } from '@modelcontextprotocol/server';
+import type { RequestHandler } from 'express';
+import express from 'express';
 import { expect } from 'vitest';
-import type { OAuthClientInformationFull } from '@modelcontextprotocol/server';
-import { createMcpExpressApp } from '@modelcontextprotocol/express';
-import {
-    createOAuthMetadata,
-    mcpAuthMetadataRouter,
-    mcpAuthRouter,
-    ProxyOAuthServerProvider,
-    requireBearerAuth
-} from '@modelcontextprotocol/express';
-import type { OAuthServerProvider } from '@modelcontextprotocol/express';
-import { InvalidGrantError, InvalidTokenError } from '@modelcontextprotocol/server';
-import type { TestArgs } from '../types.js';
-import { startExpressMinimal, startExpressWithHostValidation, type ExpressHost } from '../helpers/express.js';
+
+import { startExpressMinimal, startExpressWithHostValidation } from '../helpers/express.js';
 import { verifies } from '../helpers/verifies.js';
+import type { TestArgs } from '../types.js';
 
 const RESOURCE_METADATA_URL = 'https://mcp.example.com/.well-known/oauth-protected-resource';
 const VALID_TOKEN = 'analytics-dashboard-token';
@@ -99,7 +93,7 @@ verifies('hosting:auth:missing-401', async (_args: TestArgs) => {
 verifies('hosting:auth:invalid-401', async (_args: TestArgs) => {
     const verifier = {
         verifyAccessToken: async (token: string) => {
-            if (token === MALFORMED_TOKEN) throw new InvalidTokenError('Token verification failed');
+            if (token === MALFORMED_TOKEN) throw new OAuthError(OAuthErrorCode.InvalidToken, 'Token verification failed');
             return { token, clientId: 'test', scopes: [], expiresAt: 1e12 };
         }
     };
@@ -245,23 +239,19 @@ verifies('hosting:auth:aud-validation', async (_args: TestArgs) => {
 
 verifies('hosting:auth:metadata-endpoints', async (_args: TestArgs) => {
     const issuer = new URL('https://auth.example.com');
-    const provider = {
-        authorize: async () => {
-            throw new Error('not needed');
-        },
-        challengeForAuthorizationCode: async () => 'test-challenge',
-        exchangeAuthorizationCode: async () => ({ access_token: 'test-token', token_type: 'Bearer' }),
-        exchangeRefreshToken: async () => ({ access_token: 'test-token', token_type: 'Bearer' }),
-        verifyAccessToken: async () => ({ token: '', clientId: '', scopes: [], expiresAt: 1e12 }),
-        clientsStore: { getClient: async () => undefined }
+    const oauthMetadata: OAuthMetadata = {
+        issuer: issuer.href,
+        authorization_endpoint: new URL('/authorize', issuer).href,
+        token_endpoint: new URL('/token', issuer).href,
+        response_types_supported: ['code']
     };
 
     const app = express();
     app.use(express.json());
     app.use(
-        mcpAuthRouter({
-            provider,
-            issuerUrl: issuer
+        mcpAuthMetadataRouter({
+            oauthMetadata,
+            resourceServerUrl: new URL('https://mcp.example.com')
         })
     );
 
@@ -281,19 +271,12 @@ verifies('hosting:auth:metadata-endpoints', async (_args: TestArgs) => {
 
 verifies('hosting:auth:prm:authorization-servers-field', async (_args: TestArgs) => {
     const issuer = new URL('https://auth.example.com');
-    const oauthMetadata = createOAuthMetadata({
-        provider: {
-            authorize: async () => {
-                throw new Error('stub');
-            },
-            challengeForAuthorizationCode: async () => 'test',
-            exchangeAuthorizationCode: async () => ({ access_token: 'test', token_type: 'Bearer' }),
-            exchangeRefreshToken: async () => ({ access_token: 'test', token_type: 'Bearer' }),
-            verifyAccessToken: async () => ({ token: '', clientId: '', scopes: [], expiresAt: 1e12 }),
-            clientsStore: { getClient: async () => undefined }
-        },
-        issuerUrl: issuer
-    });
+    const oauthMetadata: OAuthMetadata = {
+        issuer: issuer.href,
+        authorization_endpoint: new URL('/authorize', issuer).href,
+        token_endpoint: new URL('/token', issuer).href,
+        response_types_supported: ['code']
+    };
 
     const app = express();
     app.use(
@@ -311,126 +294,6 @@ verifies('hosting:auth:prm:authorization-servers-field', async (_args: TestArgs)
     expect(body.authorization_servers).toBeInstanceOf(Array);
     expect(body.authorization_servers?.length).toBeGreaterThan(0);
     expect(body.authorization_servers).toContain(issuer.href);
-});
-
-verifies('hosting:auth:as-router', async (_args: TestArgs) => {
-    const issuer = new URL('https://auth.example.com');
-    const provider: OAuthServerProvider = {
-        authorize: async (_client, _params, res) => {
-            res.redirect(302, 'https://example.com/callback?code=test-code&state=test');
-        },
-        challengeForAuthorizationCode: async () => 'test-challenge',
-        exchangeAuthorizationCode: async () => ({ access_token: 'test-token', token_type: 'Bearer' }),
-        exchangeRefreshToken: async () => ({ access_token: 'test-token', token_type: 'Bearer' }),
-        verifyAccessToken: async (token: string) => ({ token, clientId: 'test', scopes: [], expiresAt: 1e12 }),
-        clientsStore: {
-            getClient: async (id: string) =>
-                id === 'test-client'
-                    ? ({
-                          client_id: 'test-client',
-                          client_secret: 'secret',
-                          redirect_uris: ['https://example.com/callback']
-                      } as OAuthClientInformationFull)
-                    : undefined,
-            registerClient: async () =>
-                ({
-                    client_id: 'new-client',
-                    client_secret: 'new-secret',
-                    redirect_uris: ['https://example.com/callback']
-                }) as OAuthClientInformationFull
-        },
-        revokeToken: async () => {}
-    };
-
-    const app = express();
-    app.use(express.json());
-    app.use(mcpAuthRouter({ provider, issuerUrl: issuer }));
-
-    await using host = await startExpressMinimal(app);
-
-    const authRes = await fetch(new URL('/authorize', host.baseUrl));
-    expect(authRes.status).not.toBe(404);
-
-    const tokenRes = await fetch(new URL('/token', host.baseUrl), { method: 'POST' });
-    expect(tokenRes.status).not.toBe(404);
-
-    const registerRes = await fetch(new URL('/register', host.baseUrl), {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ redirect_uris: ['https://example.com/callback'] })
-    });
-    expect(registerRes.status).not.toBe(404);
-    const registerBody = (await registerRes.json()) as { client_id?: string };
-    expect(registerBody.client_id).toBeTruthy();
-
-    const revokeRes = await fetch(new URL('/revoke', host.baseUrl), {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-        body: 'token=old-token&client_id=test-client&client_secret=secret'
-    });
-    expect([200, 400]).toContain(revokeRes.status);
-});
-
-verifies('hosting:auth:proxy-provider', async (_args: TestArgs) => {
-    const upstreamRequests: Array<{ url: string; method: string; body?: string }> = [];
-
-    const upstreamAS = express();
-    upstreamAS.use(express.json());
-    upstreamAS.use(express.urlencoded({ extended: true }));
-    upstreamAS.get('/authorize', (req, res) => {
-        upstreamRequests.push({ url: req.url, method: req.method });
-        res.redirect(302, `https://example.com/callback?code=upstream-code&state=${req.query.state ?? ''}`);
-    });
-    upstreamAS.post('/token', (req, res) => {
-        upstreamRequests.push({ url: req.url, method: req.method, body: JSON.stringify(req.body) });
-        res.json({ access_token: 'upstream-token', token_type: 'Bearer' });
-    });
-    upstreamAS.post('/revoke', (req, res) => {
-        upstreamRequests.push({ url: req.url, method: req.method, body: JSON.stringify(req.body) });
-        res.sendStatus(200);
-    });
-
-    await using upstream = await startExpressMinimal(upstreamAS);
-
-    const provider = new ProxyOAuthServerProvider({
-        endpoints: {
-            authorizationUrl: new URL('/authorize', upstream.baseUrl).href,
-            tokenUrl: new URL('/token', upstream.baseUrl).href,
-            revocationUrl: new URL('/revoke', upstream.baseUrl).href
-        },
-        verifyAccessToken: async token => ({ token, clientId: 'proxy-client', scopes: [], expiresAt: 1e12 }),
-        getClient: async (id: string) =>
-            id === 'proxy-client'
-                ? ({
-                      client_id: 'proxy-client',
-                      client_secret: 'proxy-secret',
-                      redirect_uris: ['https://example.com/cb']
-                  } as OAuthClientInformationFull)
-                : undefined
-    });
-
-    const app = express();
-    app.use(express.json());
-    app.use(mcpAuthRouter({ provider, issuerUrl: new URL('https://proxy.example.com') }));
-
-    await using proxy = await startExpressMinimal(app);
-
-    const authRes = await fetch(new URL('/authorize', proxy.baseUrl));
-    expect(authRes.status).not.toBe(404);
-
-    const tokenRes = await fetch(new URL('/token', proxy.baseUrl), {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-        body: 'grant_type=authorization_code&code=test&redirect_uri=https://example.com/cb&client_id=proxy-client&code_verifier=test'
-    });
-    expect(tokenRes.status).not.toBe(404);
-
-    const revokeRes = await fetch(new URL('/revoke', proxy.baseUrl), {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-        body: 'token=old-token&client_id=proxy-client&client_secret=proxy-secret'
-    });
-    expect([200, 400]).toContain(revokeRes.status);
 });
 
 verifies('hosting:http:host-validation-middleware', async (_args: TestArgs) => {
@@ -476,200 +339,11 @@ verifies('hosting:express-app-helper', async (_args: TestArgs) => {
     expect(body.error?.message).toMatch(/Invalid Host/i);
 });
 
-// ---------------------------------------------------------------------------
-// Bundled authorization-server endpoints (/register, /authorize, /token):
-// in-memory provider + dynamic registration drive the SDK's own handlers
-// over real HTTP, mirroring what a real OAuth client would send.
-// ---------------------------------------------------------------------------
-
-const AS_REDIRECT_URI = 'https://client.example.com/callback';
-
-interface IssuedAuthorizationCode {
-    clientId: string;
-    codeChallenge: string;
-    redirectUri: string;
-}
-
-function createAuthorizationServerProvider(): OAuthServerProvider {
-    const clients = new Map<string, OAuthClientInformationFull>();
-    const codes = new Map<string, IssuedAuthorizationCode>();
-    let clientCount = 0;
-    let codeCount = 0;
-
-    return {
-        clientsStore: {
-            getClient: async (clientId: string) => clients.get(clientId),
-            registerClient: async client => {
-                clientCount += 1;
-                const registered: OAuthClientInformationFull = { ...client, client_id: `registered-client-${clientCount}` };
-                clients.set(registered.client_id, registered);
-                return registered;
-            }
-        },
-        authorize: async (client, params, res) => {
-            codeCount += 1;
-            const code = `authorization-code-${codeCount}`;
-            codes.set(code, { clientId: client.client_id, codeChallenge: params.codeChallenge, redirectUri: params.redirectUri });
-            const target = new URL(params.redirectUri);
-            target.searchParams.set('code', code);
-            if (params.state !== undefined) {
-                target.searchParams.set('state', params.state);
-            }
-            res.redirect(302, target.href);
-        },
-        challengeForAuthorizationCode: async (_client, authorizationCode) => {
-            const issued = codes.get(authorizationCode);
-            if (!issued) {
-                throw new InvalidGrantError('authorization code does not exist');
-            }
-            return issued.codeChallenge;
-        },
-        exchangeAuthorizationCode: async (client, authorizationCode, _codeVerifier, redirectUri) => {
-            const issued = codes.get(authorizationCode);
-            if (!issued) {
-                throw new InvalidGrantError('authorization code does not exist');
-            }
-            if (issued.clientId !== client.client_id) {
-                throw new InvalidGrantError('authorization code was issued to a different client');
-            }
-            if (redirectUri !== undefined && redirectUri !== issued.redirectUri) {
-                throw new InvalidGrantError('redirect_uri does not match the one used at authorization');
-            }
-            // Single-use: the first successful exchange consumes the code.
-            codes.delete(authorizationCode);
-            return { access_token: `access-token-for-${authorizationCode}`, token_type: 'Bearer' };
-        },
-        exchangeRefreshToken: async () => {
-            throw new InvalidGrantError('refresh tokens are not issued by this provider');
-        },
-        verifyAccessToken: async (token: string) => ({
-            token,
-            clientId: 'registered-client-1',
-            scopes: [],
-            expiresAt: Date.now() / 1000 + 3600
-        })
-    };
-}
-
-async function startAuthorizationServer(): Promise<ExpressHost> {
-    const app = express();
-    app.use(express.json());
-    app.use(mcpAuthRouter({ provider: createAuthorizationServerProvider(), issuerUrl: new URL('https://auth.example.com') }));
-    return startExpressMinimal(app);
-}
-
-function createPkcePair(): { verifier: string; challenge: string } {
-    const verifier = crypto.randomBytes(32).toString('base64url');
-    const challenge = crypto.createHash('sha256').update(verifier).digest('base64url');
-    return { verifier, challenge };
-}
-
-function postRegistration(baseUrl: URL, redirectUris: string[]): Promise<Response> {
-    return fetch(new URL('/register', baseUrl), {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ client_name: 'analytics-dashboard', redirect_uris: redirectUris })
-    });
-}
-
-async function registerConfidentialClient(baseUrl: URL): Promise<{ clientId: string; clientSecret: string }> {
-    const res = await postRegistration(baseUrl, [AS_REDIRECT_URI]);
-    expect(res.status).toBe(201);
-    const body = (await res.json()) as { client_id?: string; client_secret?: string };
-    if (typeof body.client_id !== 'string' || typeof body.client_secret !== 'string') {
-        throw new Error('registration response did not include client_id and client_secret');
-    }
-    return { clientId: body.client_id, clientSecret: body.client_secret };
-}
-
-async function mintAuthorizationCode(baseUrl: URL, clientId: string, codeChallenge: string): Promise<string> {
-    const authorizeUrl = new URL('/authorize', baseUrl);
-    authorizeUrl.searchParams.set('response_type', 'code');
-    authorizeUrl.searchParams.set('client_id', clientId);
-    authorizeUrl.searchParams.set('redirect_uri', AS_REDIRECT_URI);
-    authorizeUrl.searchParams.set('code_challenge', codeChallenge);
-    authorizeUrl.searchParams.set('code_challenge_method', 'S256');
-    authorizeUrl.searchParams.set('state', 'request-state');
-
-    const res = await fetch(authorizeUrl, { redirect: 'manual' });
-    expect(res.status).toBe(302);
-    const location = res.headers.get('location');
-    if (location === null) {
-        throw new Error('authorize response did not include a Location header');
-    }
-    const redirect = new URL(location);
-    expect(redirect.origin + redirect.pathname).toBe(AS_REDIRECT_URI);
-    expect(redirect.searchParams.get('state')).toBe('request-state');
-    const code = redirect.searchParams.get('code');
-    if (code === null) {
-        throw new Error('authorize redirect did not include a code parameter');
-    }
-    return code;
-}
-
-function postTokenExchange(baseUrl: URL, form: Record<string, string>): Promise<Response> {
-    return fetch(new URL('/token', baseUrl), {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-        body: new URLSearchParams(form).toString()
-    });
-}
-
-verifies('hosting:auth:as:redirect-uri-scheme', async (_args: TestArgs) => {
-    await using host = await startAuthorizationServer();
-
-    const httpsRegistration = await postRegistration(host.baseUrl, ['https://client.example.com/callback']);
-    expect(httpsRegistration.status).toBe(201);
-
-    const loopbackRegistration = await postRegistration(host.baseUrl, ['http://127.0.0.1:49152/callback']);
-    expect(loopbackRegistration.status).toBe(201);
-
-    const nonLoopbackHttp = await postRegistration(host.baseUrl, ['http://attacker.example.com/callback']);
-    expect(nonLoopbackHttp.status).toBe(400);
-    const body = (await nonLoopbackHttp.json()) as { error?: string };
-    expect(body.error).toBe('invalid_client_metadata');
-});
-
-verifies('hosting:auth:as:redirect-uri-binding', async (_args: TestArgs) => {
-    await using host = await startAuthorizationServer();
-    const { clientId, clientSecret } = await registerConfidentialClient(host.baseUrl);
-    const { verifier, challenge } = createPkcePair();
-
-    // Authorize leg: an unregistered redirect_uri gets a direct 400, never a redirect to the attacker URI.
-    const authorizeUrl = new URL('/authorize', host.baseUrl);
-    authorizeUrl.searchParams.set('response_type', 'code');
-    authorizeUrl.searchParams.set('client_id', clientId);
-    authorizeUrl.searchParams.set('redirect_uri', 'https://attacker.example.com/callback');
-    authorizeUrl.searchParams.set('code_challenge', challenge);
-    authorizeUrl.searchParams.set('code_challenge_method', 'S256');
-
-    const authorizeRes = await fetch(authorizeUrl, { redirect: 'manual' });
-    expect(authorizeRes.status).toBe(400);
-    expect(authorizeRes.headers.get('location')).toBeNull();
-    expect(await authorizeRes.json()).toEqual({ error: 'invalid_request', error_description: 'Unregistered redirect_uri' });
-
-    // Token leg: the handler forwards the request's redirect_uri to the provider, which rejects a value differing from authorize.
-    const code = await mintAuthorizationCode(host.baseUrl, clientId, challenge);
-    const tokenRes = await postTokenExchange(host.baseUrl, {
-        grant_type: 'authorization_code',
-        client_id: clientId,
-        client_secret: clientSecret,
-        code,
-        code_verifier: verifier,
-        redirect_uri: 'https://client.example.com/callback/other'
-    });
-    expect(tokenRes.status).toBe(400);
-    expect(await tokenRes.json()).toEqual({
-        error: 'invalid_grant',
-        error_description: 'redirect_uri does not match the one used at authorization'
-    });
-});
-
 verifies('hosting:auth:query-token-ignored', async (_args: TestArgs) => {
     const verifier = {
         verifyAccessToken: async (token: string) => {
             if (token !== VALID_TOKEN) {
-                throw new InvalidTokenError('Token verification failed');
+                throw new OAuthError(OAuthErrorCode.InvalidToken, 'Token verification failed');
             }
             return { token, clientId: 'analytics-client', scopes: [], expiresAt: Date.now() / 1000 + 3600 };
         }
@@ -707,76 +381,4 @@ verifies('hosting:auth:query-token-ignored', async (_args: TestArgs) => {
         body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} })
     });
     expect(headerRes.status).toBe(200);
-});
-
-verifies('hosting:auth:as:authorize-requires-pkce', async (_args: TestArgs) => {
-    await using host = await startAuthorizationServer();
-    const { clientId } = await registerConfidentialClient(host.baseUrl);
-
-    const authorizeUrl = new URL('/authorize', host.baseUrl);
-    authorizeUrl.searchParams.set('response_type', 'code');
-    authorizeUrl.searchParams.set('client_id', clientId);
-    authorizeUrl.searchParams.set('redirect_uri', AS_REDIRECT_URI);
-    authorizeUrl.searchParams.set('state', 'pkce-required-state');
-
-    const res = await fetch(authorizeUrl, { redirect: 'manual' });
-
-    expect(res.status).toBe(302);
-    const location = res.headers.get('location');
-    if (location === null) {
-        throw new Error('authorize response did not include a Location header');
-    }
-    const redirect = new URL(location);
-    expect(redirect.origin + redirect.pathname).toBe(AS_REDIRECT_URI);
-    expect(redirect.searchParams.get('error')).toBe('invalid_request');
-    expect(redirect.searchParams.get('error_description')).toContain('code_challenge');
-    expect(redirect.searchParams.get('code')).toBeNull();
-});
-
-verifies('hosting:auth:as:verifier-mismatch', async (_args: TestArgs) => {
-    await using host = await startAuthorizationServer();
-    const { clientId, clientSecret } = await registerConfidentialClient(host.baseUrl);
-
-    const { challenge } = createPkcePair();
-    const code = await mintAuthorizationCode(host.baseUrl, clientId, challenge);
-
-    // A well-formed verifier from a different PKCE pair cannot hash to the stored challenge.
-    const { verifier: wrongVerifier } = createPkcePair();
-    const res = await postTokenExchange(host.baseUrl, {
-        grant_type: 'authorization_code',
-        client_id: clientId,
-        client_secret: clientSecret,
-        code,
-        code_verifier: wrongVerifier,
-        redirect_uri: AS_REDIRECT_URI
-    });
-
-    expect(res.status).toBe(400);
-    expect(await res.json()).toEqual({ error: 'invalid_grant', error_description: 'code_verifier does not match the challenge' });
-});
-
-verifies('hosting:auth:as:code-single-use', async (_args: TestArgs) => {
-    await using host = await startAuthorizationServer();
-    const { clientId, clientSecret } = await registerConfidentialClient(host.baseUrl);
-
-    const { verifier, challenge } = createPkcePair();
-    const code = await mintAuthorizationCode(host.baseUrl, clientId, challenge);
-    const form = {
-        grant_type: 'authorization_code',
-        client_id: clientId,
-        client_secret: clientSecret,
-        code,
-        code_verifier: verifier,
-        redirect_uri: AS_REDIRECT_URI
-    };
-
-    const first = await postTokenExchange(host.baseUrl, form);
-    expect(first.status).toBe(200);
-    const firstBody = (await first.json()) as { access_token?: string; token_type?: string };
-    expect(firstBody.token_type).toBe('Bearer');
-    expect(firstBody.access_token).toBe(`access-token-for-${code}`);
-
-    const second = await postTokenExchange(host.baseUrl, form);
-    expect(second.status).toBe(400);
-    expect(await second.json()).toEqual({ error: 'invalid_grant', error_description: 'authorization code does not exist' });
 });

--- a/test/e2e/scenarios/hosting-express.test.ts
+++ b/test/e2e/scenarios/hosting-express.test.ts
@@ -21,15 +21,17 @@ import http from 'node:http';
 
 import express, { type RequestHandler } from 'express';
 import { expect } from 'vitest';
-
-import { requireBearerAuth } from '../../../src/server/auth/middleware/bearerAuth.js';
-import { mcpAuthRouter, mcpAuthMetadataRouter, createOAuthMetadata } from '../../../src/server/auth/router.js';
-import { ProxyOAuthServerProvider } from '../../../src/server/auth/providers/proxyProvider.js';
-import type { OAuthServerProvider } from '../../../src/server/auth/provider.js';
-import { InvalidGrantError, InvalidTokenError } from '../../../src/server/auth/errors.js';
-import { createMcpExpressApp } from '../../../src/server/express.js';
-import type { OAuthClientInformationFull } from '../../../src/shared/auth.js';
-
+import type { OAuthClientInformationFull } from '@modelcontextprotocol/server';
+import { createMcpExpressApp } from '@modelcontextprotocol/express';
+import {
+    createOAuthMetadata,
+    mcpAuthMetadataRouter,
+    mcpAuthRouter,
+    ProxyOAuthServerProvider,
+    requireBearerAuth
+} from '@modelcontextprotocol/express';
+import type { OAuthServerProvider } from '@modelcontextprotocol/express';
+import { InvalidGrantError, InvalidTokenError } from '@modelcontextprotocol/server';
 import type { TestArgs } from '../types.js';
 import { startExpressMinimal, startExpressWithHostValidation, type ExpressHost } from '../helpers/express.js';
 import { verifies } from '../helpers/verifies.js';

--- a/test/e2e/scenarios/hosting-express.test.ts
+++ b/test/e2e/scenarios/hosting-express.test.ts
@@ -17,14 +17,18 @@
  * minimal comments, every server closed in finally.
  */
 
+import { randomUUID } from 'node:crypto';
 import http from 'node:http';
 
+import { Client, StreamableHTTPClientTransport } from '@modelcontextprotocol/client';
 import { createMcpExpressApp, mcpAuthMetadataRouter, requireBearerAuth } from '@modelcontextprotocol/express';
+import { NodeStreamableHTTPServerTransport } from '@modelcontextprotocol/node';
 import type { OAuthMetadata } from '@modelcontextprotocol/server';
-import { OAuthError, OAuthErrorCode } from '@modelcontextprotocol/server';
-import type { RequestHandler } from 'express';
+import { McpServer, OAuthError, OAuthErrorCode } from '@modelcontextprotocol/server';
+import type { Express, RequestHandler } from 'express';
 import express from 'express';
 import { expect } from 'vitest';
+import { z } from 'zod/v4';
 
 import { startExpressMinimal, startExpressWithHostValidation } from '../helpers/express.js';
 import { verifies } from '../helpers/verifies.js';
@@ -381,4 +385,107 @@ verifies('hosting:auth:query-token-ignored', async (_args: TestArgs) => {
         body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} })
     });
     expect(headerRes.status).toBe(200);
+});
+
+/** Listen `app` (already fully configured by the adapter under test) on an ephemeral 127.0.0.1 port; callers close() in finally. */
+function listenExpressApp(app: Express): Promise<{ baseUrl: URL; close: () => Promise<void> }> {
+    return new Promise((resolve, reject) => {
+        const server = app.listen(0, '127.0.0.1', () => {
+            const addr = server.address();
+            if (!addr || typeof addr === 'string') {
+                reject(new Error(`listen failed: ${String(addr)}`));
+                return;
+            }
+            resolve({
+                baseUrl: new URL(`http://127.0.0.1:${addr.port}`),
+                close: () =>
+                    new Promise<void>((res, rej) => {
+                        server.close(err => (err ? rej(err) : res()));
+                    })
+            });
+        });
+        server.on('error', reject);
+    });
+}
+
+verifies('hosting:express:adapter-basic-flow', async (_args: TestArgs) => {
+    const mcpServer = new McpServer({ name: 'express-adapter-server', version: '1.0.0' });
+    mcpServer.registerTool(
+        'lookup-order-status',
+        { description: 'Look up the shipping status of an order.', inputSchema: z.object({ orderId: z.string() }) },
+        ({ orderId }) => ({ content: [{ type: 'text', text: `Order ${orderId} is in transit.` }] })
+    );
+
+    const serverTransport = new NodeStreamableHTTPServerTransport({ sessionIdGenerator: () => randomUUID() });
+    await mcpServer.connect(serverTransport);
+
+    const app = createMcpExpressApp();
+    app.post('/mcp', async (req, res) => {
+        await serverTransport.handleRequest(req, res, req.body);
+    });
+
+    const { baseUrl, close } = await listenExpressApp(app);
+    const client = new Client({ name: 'express-adapter-client', version: '1.0.0' });
+    try {
+        await client.connect(new StreamableHTTPClientTransport(new URL('/mcp', baseUrl)));
+
+        // Initialize completed over the Express-hosted POST route: the negotiated server identity is visible on the client.
+        expect(client.getServerVersion()).toEqual({ name: 'express-adapter-server', version: '1.0.0' });
+
+        const result = await client.callTool({ name: 'lookup-order-status', arguments: { orderId: 'ORD-1042' } });
+        expect(result.content).toEqual([{ type: 'text', text: 'Order ORD-1042 is in transit.' }]);
+    } finally {
+        await client.close();
+        await mcpServer.close();
+        await close();
+    }
+});
+
+verifies('hosting:express:adapter-host-header-validation', async ({ protocolVersion }: TestArgs) => {
+    const mcpServer = new McpServer({ name: 'rebind-protected-server', version: '1.0.0' });
+    // JSON response mode keeps the allowed-host control assertable as a plain JSON initialize result.
+    const serverTransport = new NodeStreamableHTTPServerTransport({ sessionIdGenerator: () => randomUUID(), enableJsonResponse: true });
+    await mcpServer.connect(serverTransport);
+
+    let mcpRouteHits = 0;
+    const app = createMcpExpressApp();
+    app.post('/mcp', async (req, res) => {
+        mcpRouteHits += 1;
+        await serverTransport.handleRequest(req, res, req.body);
+    });
+
+    const { baseUrl, close } = await listenExpressApp(app);
+    try {
+        const initializeBody = JSON.stringify({
+            jsonrpc: '2.0',
+            id: 1,
+            method: 'initialize',
+            params: { protocolVersion, capabilities: {}, clientInfo: { name: 'rebind-client', version: '1.0.0' } }
+        });
+
+        const spoofed = await postWithHost(new URL('/mcp', baseUrl), 'evil.example.com', initializeBody);
+        expect(spoofed.status).toBe(403);
+        const spoofedJson: unknown = JSON.parse(spoofed.body);
+        expect(spoofedJson).toEqual({
+            jsonrpc: '2.0',
+            error: { code: -32_000, message: 'Invalid Host: evil.example.com' },
+            id: null
+        });
+        // Rejected by the default localhost DNS-rebinding middleware before the MCP transport route ever ran.
+        expect(mcpRouteHits).toBe(0);
+
+        // Control: the identical request with the real localhost Host reaches the transport and initializes normally.
+        const allowed = await postWithHost(new URL('/mcp', baseUrl), `127.0.0.1:${baseUrl.port}`, initializeBody);
+        expect(allowed.status).toBe(200);
+        const allowedJson: unknown = JSON.parse(allowed.body);
+        expect(allowedJson).toMatchObject({
+            jsonrpc: '2.0',
+            id: 1,
+            result: { protocolVersion, serverInfo: { name: 'rebind-protected-server', version: '1.0.0' } }
+        });
+        expect(mcpRouteHits).toBe(1);
+    } finally {
+        await mcpServer.close();
+        await close();
+    }
 });

--- a/test/e2e/scenarios/hosting-express.test.ts
+++ b/test/e2e/scenarios/hosting-express.test.ts
@@ -1,0 +1,780 @@
+/**
+ * Self-contained test bodies for Express-bound hosting surfaces.
+ *
+ * These tests cover the SDK's Express-bound surface (auth middleware/routers, host
+ * validation, createMcpExpressApp) over real HTTP — the layer a server operator
+ * deploys and remote clients depend on; Client/Server are not the subject.
+ *
+ * The SDK's requireBearerAuth, mcpAuthRouter, mcpAuthMetadataRouter, and host-
+ * header validation middleware are Express RequestHandlers; they cannot be
+ * exercised with in-process Web-standard Request/Response. These tests build
+ * real Express apps, listen on ephemeral ports (127.0.0.1), drive them with
+ * fetch(), and assert exact HTTP status + header + body shapes.
+ *
+ * Function names mirror the requirement id in camelCase. NO casts, exact
+ * assertions, closure recorders outside factories (for stateless compat),
+ * minimal comments, every server closed in finally.
+ */
+
+import crypto from 'node:crypto';
+import http from 'node:http';
+
+import express, { type RequestHandler } from 'express';
+import { expect } from 'vitest';
+
+import { requireBearerAuth } from '../../../src/server/auth/middleware/bearerAuth.js';
+import { mcpAuthRouter, mcpAuthMetadataRouter, createOAuthMetadata } from '../../../src/server/auth/router.js';
+import { ProxyOAuthServerProvider } from '../../../src/server/auth/providers/proxyProvider.js';
+import type { OAuthServerProvider } from '../../../src/server/auth/provider.js';
+import { InvalidGrantError, InvalidTokenError } from '../../../src/server/auth/errors.js';
+import { createMcpExpressApp } from '../../../src/server/express.js';
+import type { OAuthClientInformationFull } from '../../../src/shared/auth.js';
+
+import type { TestArgs } from '../types.js';
+import { startExpressMinimal, startExpressWithHostValidation, type ExpressHost } from '../helpers/express.js';
+import { verifies } from '../helpers/verifies.js';
+
+const RESOURCE_METADATA_URL = 'https://mcp.example.com/.well-known/oauth-protected-resource';
+const VALID_TOKEN = 'analytics-dashboard-token';
+const EXPIRED_TOKEN = 'expired-access-token';
+const MALFORMED_TOKEN = 'not-a-valid-jwt';
+
+/**
+ * POST `body` to `url` via `node:http`, forcing `Host: <host>`.
+ * Unlike undici fetch(), node:http sends caller-supplied Host header verbatim.
+ */
+function postWithHost(url: URL, host: string, body: string): Promise<{ status: number; body: string; headers: http.IncomingHttpHeaders }> {
+    return new Promise((resolve, reject) => {
+        const req = http.request(
+            {
+                hostname: url.hostname,
+                port: url.port,
+                path: url.pathname,
+                method: 'POST',
+                headers: {
+                    Host: host,
+                    'Content-Type': 'application/json',
+                    Accept: 'application/json, text/event-stream',
+                    'Content-Length': Buffer.byteLength(body)
+                }
+            },
+            res => {
+                let data = '';
+                res.setEncoding('utf8');
+                res.on('data', chunk => (data += chunk));
+                res.on('end', () => resolve({ status: res.statusCode ?? 0, body: data, headers: res.headers }));
+                res.on('error', reject);
+            }
+        );
+        req.on('error', reject);
+        req.end(body);
+    });
+}
+
+verifies('hosting:auth:missing-401', async (_args: TestArgs) => {
+    const verifier = { verifyAccessToken: async (_token: string) => ({ token: '', clientId: 'test', scopes: [], expiresAt: 1e12 }) };
+
+    await using host = await startExpressMinimal(requireBearerAuth({ verifier, resourceMetadataUrl: RESOURCE_METADATA_URL }));
+
+    const res = await fetch(new URL('/mcp', host.baseUrl), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+        body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} })
+    });
+
+    expect(res.status).toBe(401);
+
+    const wwwAuth = res.headers.get('www-authenticate');
+    expect(wwwAuth).toBeTruthy();
+    expect(wwwAuth).toMatch(/^Bearer\b/i);
+    expect(wwwAuth).toContain('error="invalid_token"');
+    expect(wwwAuth).toContain(`resource_metadata="${RESOURCE_METADATA_URL}"`);
+
+    const body = (await res.json()) as { error?: string };
+    expect(body.error).toBe('invalid_token');
+});
+
+verifies('hosting:auth:invalid-401', async (_args: TestArgs) => {
+    const verifier = {
+        verifyAccessToken: async (token: string) => {
+            if (token === MALFORMED_TOKEN) throw new InvalidTokenError('Token verification failed');
+            return { token, clientId: 'test', scopes: [], expiresAt: 1e12 };
+        }
+    };
+
+    await using host = await startExpressMinimal(requireBearerAuth({ verifier }));
+
+    const res = await fetch(new URL('/mcp', host.baseUrl), {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            Accept: 'application/json',
+            Authorization: `Bearer ${MALFORMED_TOKEN}`
+        },
+        body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} })
+    });
+
+    expect(res.status).toBe(401);
+
+    const wwwAuth = res.headers.get('www-authenticate');
+    expect(wwwAuth).toBeTruthy();
+    expect(wwwAuth).toMatch(/^Bearer\b/i);
+    expect(wwwAuth).toContain('error="invalid_token"');
+});
+
+verifies('hosting:auth:expired-401', async (_args: TestArgs) => {
+    const PAST_EXPIRY = 1;
+    const verifier = {
+        verifyAccessToken: async (token: string) => ({
+            token,
+            clientId: 'test-client',
+            scopes: [],
+            expiresAt: token === EXPIRED_TOKEN ? PAST_EXPIRY : Date.now() / 1000 + 3600
+        })
+    };
+
+    await using host = await startExpressMinimal(requireBearerAuth({ verifier }));
+
+    const res = await fetch(new URL('/mcp', host.baseUrl), {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            Accept: 'application/json',
+            Authorization: `Bearer ${EXPIRED_TOKEN}`
+        },
+        body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} })
+    });
+
+    expect(res.status).toBe(401);
+
+    const wwwAuth = res.headers.get('www-authenticate');
+    expect(wwwAuth).toBeTruthy();
+    expect(wwwAuth).toContain('error="invalid_token"');
+});
+
+verifies('hosting:auth:scope-403', async (_args: TestArgs) => {
+    const verifier = {
+        verifyAccessToken: async (token: string) => ({
+            token,
+            clientId: 'test-client',
+            scopes: token === VALID_TOKEN ? ['mcp:tools:read'] : ['mcp:tools:call'],
+            expiresAt: Date.now() / 1000 + 3600
+        })
+    };
+
+    await using host = await startExpressMinimal(
+        requireBearerAuth({
+            verifier,
+            requiredScopes: ['mcp:tools:read', 'mcp:tools:call'],
+            resourceMetadataUrl: RESOURCE_METADATA_URL
+        })
+    );
+
+    const res = await fetch(new URL('/mcp', host.baseUrl), {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            Accept: 'application/json',
+            Authorization: `Bearer ${VALID_TOKEN}`
+        },
+        body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} })
+    });
+
+    expect(res.status).toBe(403);
+
+    const wwwAuth = res.headers.get('www-authenticate');
+    expect(wwwAuth).toBeTruthy();
+    expect(wwwAuth).toMatch(/^Bearer\b/i);
+    expect(wwwAuth).toContain('error="insufficient_scope"');
+    expect(wwwAuth).toContain('scope="mcp:tools:read mcp:tools:call"');
+    expect(wwwAuth).toContain(`resource_metadata="${RESOURCE_METADATA_URL}"`);
+
+    const body = (await res.json()) as { error?: string };
+    expect(body.error).toBe('insufficient_scope');
+});
+
+verifies('hosting:auth:aud-validation', async (_args: TestArgs) => {
+    const SERVER_RESOURCE_ID = 'https://mcp.example.com/api';
+    const WRONG_AUDIENCE = 'https://other.example.com/api';
+
+    const verifier = {
+        verifyAccessToken: async (token: string) => {
+            const aud = token === 'wrong-aud-token' ? WRONG_AUDIENCE : SERVER_RESOURCE_ID;
+            return {
+                token,
+                clientId: 'test-client',
+                scopes: [],
+                expiresAt: Date.now() / 1000 + 3600,
+                resource: new URL(aud)
+            };
+        }
+    };
+
+    const app = express();
+    app.use(express.json());
+    app.use(requireBearerAuth({ verifier, resourceMetadataUrl: SERVER_RESOURCE_ID }));
+    app.post('/mcp', (_req, res) => {
+        res.json({ jsonrpc: '2.0', id: 1, result: { ok: true } });
+    });
+
+    await using host = await startExpressMinimal(app);
+
+    const wrongAud = await fetch(new URL('/mcp', host.baseUrl), {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            Accept: 'application/json',
+            Authorization: 'Bearer wrong-aud-token'
+        },
+        body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} })
+    });
+
+    expect(wrongAud.status).toBeGreaterThanOrEqual(401);
+    expect(wrongAud.status).toBeLessThanOrEqual(403);
+
+    const wwwAuth = wrongAud.headers.get('www-authenticate');
+    expect(wwwAuth).toBeTruthy();
+    expect(wwwAuth).toMatch(/^Bearer\b/i);
+    expect(wwwAuth).toContain('error=');
+
+    const body = (await wrongAud.json()) as { error?: string };
+    expect(body.error).toBeTruthy();
+});
+
+verifies('hosting:auth:metadata-endpoints', async (_args: TestArgs) => {
+    const issuer = new URL('https://auth.example.com');
+    const provider = {
+        authorize: async () => {
+            throw new Error('not needed');
+        },
+        challengeForAuthorizationCode: async () => 'test-challenge',
+        exchangeAuthorizationCode: async () => ({ access_token: 'test-token', token_type: 'Bearer' }),
+        exchangeRefreshToken: async () => ({ access_token: 'test-token', token_type: 'Bearer' }),
+        verifyAccessToken: async () => ({ token: '', clientId: '', scopes: [], expiresAt: 1e12 }),
+        clientsStore: { getClient: async () => undefined }
+    };
+
+    const app = express();
+    app.use(express.json());
+    app.use(
+        mcpAuthRouter({
+            provider,
+            issuerUrl: issuer
+        })
+    );
+
+    await using host = await startExpressMinimal(app);
+
+    const asMetadata = await fetch(new URL('/.well-known/oauth-authorization-server', host.baseUrl));
+    expect(asMetadata.status).toBe(200);
+    const asBody = (await asMetadata.json()) as { issuer?: string; authorization_endpoint?: string };
+    expect(asBody.issuer).toBe(issuer.href);
+    expect(asBody.authorization_endpoint).toBeTruthy();
+
+    const prmMetadata = await fetch(new URL('/.well-known/oauth-protected-resource', host.baseUrl));
+    expect(prmMetadata.status).toBe(200);
+    const prmBody = (await prmMetadata.json()) as { resource?: string; authorization_servers?: string[] };
+    expect(prmBody.authorization_servers).toContain(issuer.href);
+});
+
+verifies('hosting:auth:prm:authorization-servers-field', async (_args: TestArgs) => {
+    const issuer = new URL('https://auth.example.com');
+    const oauthMetadata = createOAuthMetadata({
+        provider: {
+            authorize: async () => {
+                throw new Error('stub');
+            },
+            challengeForAuthorizationCode: async () => 'test',
+            exchangeAuthorizationCode: async () => ({ access_token: 'test', token_type: 'Bearer' }),
+            exchangeRefreshToken: async () => ({ access_token: 'test', token_type: 'Bearer' }),
+            verifyAccessToken: async () => ({ token: '', clientId: '', scopes: [], expiresAt: 1e12 }),
+            clientsStore: { getClient: async () => undefined }
+        },
+        issuerUrl: issuer
+    });
+
+    const app = express();
+    app.use(
+        mcpAuthMetadataRouter({
+            oauthMetadata,
+            resourceServerUrl: new URL('https://mcp.example.com')
+        })
+    );
+
+    await using host = await startExpressMinimal(app);
+
+    const res = await fetch(new URL('/.well-known/oauth-protected-resource', host.baseUrl));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { authorization_servers?: string[] };
+    expect(body.authorization_servers).toBeInstanceOf(Array);
+    expect(body.authorization_servers?.length).toBeGreaterThan(0);
+    expect(body.authorization_servers).toContain(issuer.href);
+});
+
+verifies('hosting:auth:as-router', async (_args: TestArgs) => {
+    const issuer = new URL('https://auth.example.com');
+    const provider: OAuthServerProvider = {
+        authorize: async (_client, _params, res) => {
+            res.redirect(302, 'https://example.com/callback?code=test-code&state=test');
+        },
+        challengeForAuthorizationCode: async () => 'test-challenge',
+        exchangeAuthorizationCode: async () => ({ access_token: 'test-token', token_type: 'Bearer' }),
+        exchangeRefreshToken: async () => ({ access_token: 'test-token', token_type: 'Bearer' }),
+        verifyAccessToken: async (token: string) => ({ token, clientId: 'test', scopes: [], expiresAt: 1e12 }),
+        clientsStore: {
+            getClient: async (id: string) =>
+                id === 'test-client'
+                    ? ({
+                          client_id: 'test-client',
+                          client_secret: 'secret',
+                          redirect_uris: ['https://example.com/callback']
+                      } as OAuthClientInformationFull)
+                    : undefined,
+            registerClient: async () =>
+                ({
+                    client_id: 'new-client',
+                    client_secret: 'new-secret',
+                    redirect_uris: ['https://example.com/callback']
+                }) as OAuthClientInformationFull
+        },
+        revokeToken: async () => {}
+    };
+
+    const app = express();
+    app.use(express.json());
+    app.use(mcpAuthRouter({ provider, issuerUrl: issuer }));
+
+    await using host = await startExpressMinimal(app);
+
+    const authRes = await fetch(new URL('/authorize', host.baseUrl));
+    expect(authRes.status).not.toBe(404);
+
+    const tokenRes = await fetch(new URL('/token', host.baseUrl), { method: 'POST' });
+    expect(tokenRes.status).not.toBe(404);
+
+    const registerRes = await fetch(new URL('/register', host.baseUrl), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ redirect_uris: ['https://example.com/callback'] })
+    });
+    expect(registerRes.status).not.toBe(404);
+    const registerBody = (await registerRes.json()) as { client_id?: string };
+    expect(registerBody.client_id).toBeTruthy();
+
+    const revokeRes = await fetch(new URL('/revoke', host.baseUrl), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: 'token=old-token&client_id=test-client&client_secret=secret'
+    });
+    expect([200, 400]).toContain(revokeRes.status);
+});
+
+verifies('hosting:auth:proxy-provider', async (_args: TestArgs) => {
+    const upstreamRequests: Array<{ url: string; method: string; body?: string }> = [];
+
+    const upstreamAS = express();
+    upstreamAS.use(express.json());
+    upstreamAS.use(express.urlencoded({ extended: true }));
+    upstreamAS.get('/authorize', (req, res) => {
+        upstreamRequests.push({ url: req.url, method: req.method });
+        res.redirect(302, `https://example.com/callback?code=upstream-code&state=${req.query.state ?? ''}`);
+    });
+    upstreamAS.post('/token', (req, res) => {
+        upstreamRequests.push({ url: req.url, method: req.method, body: JSON.stringify(req.body) });
+        res.json({ access_token: 'upstream-token', token_type: 'Bearer' });
+    });
+    upstreamAS.post('/revoke', (req, res) => {
+        upstreamRequests.push({ url: req.url, method: req.method, body: JSON.stringify(req.body) });
+        res.sendStatus(200);
+    });
+
+    await using upstream = await startExpressMinimal(upstreamAS);
+
+    const provider = new ProxyOAuthServerProvider({
+        endpoints: {
+            authorizationUrl: new URL('/authorize', upstream.baseUrl).href,
+            tokenUrl: new URL('/token', upstream.baseUrl).href,
+            revocationUrl: new URL('/revoke', upstream.baseUrl).href
+        },
+        verifyAccessToken: async token => ({ token, clientId: 'proxy-client', scopes: [], expiresAt: 1e12 }),
+        getClient: async (id: string) =>
+            id === 'proxy-client'
+                ? ({
+                      client_id: 'proxy-client',
+                      client_secret: 'proxy-secret',
+                      redirect_uris: ['https://example.com/cb']
+                  } as OAuthClientInformationFull)
+                : undefined
+    });
+
+    const app = express();
+    app.use(express.json());
+    app.use(mcpAuthRouter({ provider, issuerUrl: new URL('https://proxy.example.com') }));
+
+    await using proxy = await startExpressMinimal(app);
+
+    const authRes = await fetch(new URL('/authorize', proxy.baseUrl));
+    expect(authRes.status).not.toBe(404);
+
+    const tokenRes = await fetch(new URL('/token', proxy.baseUrl), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: 'grant_type=authorization_code&code=test&redirect_uri=https://example.com/cb&client_id=proxy-client&code_verifier=test'
+    });
+    expect(tokenRes.status).not.toBe(404);
+
+    const revokeRes = await fetch(new URL('/revoke', proxy.baseUrl), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: 'token=old-token&client_id=proxy-client&client_secret=proxy-secret'
+    });
+    expect([200, 400]).toContain(revokeRes.status);
+});
+
+verifies('hosting:http:host-validation-middleware', async (_args: TestArgs) => {
+    const handler: RequestHandler = (_req, res) => {
+        res.json({ ok: true });
+    };
+
+    await using host = await startExpressWithHostValidation(['localhost', '127.0.0.1'], handler);
+
+    const good = await fetch(new URL('/test', host.baseUrl));
+    expect(good.status).toBe(200);
+
+    const spoofed = await postWithHost(new URL('/test', host.baseUrl), 'evil.example.com', JSON.stringify({ test: 'data' }));
+    expect(spoofed.status).toBe(403);
+    const body = JSON.parse(spoofed.body) as { error?: { message?: string } };
+    expect(body.error?.message).toMatch(/Invalid Host/i);
+});
+
+verifies('hosting:express-app-helper', async (_args: TestArgs) => {
+    const app = createMcpExpressApp();
+    app.post('/mcp', (_req, res) => {
+        res.json({ jsonrpc: '2.0', id: 1, result: { ok: true } });
+    });
+
+    await using host = await startExpressMinimal(app);
+
+    expect(host.baseUrl.hostname).toBe('127.0.0.1');
+
+    const good = await fetch(new URL('/mcp', host.baseUrl), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+        body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} })
+    });
+    expect(good.status).toBe(200);
+
+    const spoofed = await postWithHost(
+        new URL('/mcp', host.baseUrl),
+        'evil.example.com',
+        JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} })
+    );
+    expect(spoofed.status).toBe(403);
+    const body = JSON.parse(spoofed.body) as { error?: { message?: string } };
+    expect(body.error?.message).toMatch(/Invalid Host/i);
+});
+
+// ---------------------------------------------------------------------------
+// Bundled authorization-server endpoints (/register, /authorize, /token):
+// in-memory provider + dynamic registration drive the SDK's own handlers
+// over real HTTP, mirroring what a real OAuth client would send.
+// ---------------------------------------------------------------------------
+
+const AS_REDIRECT_URI = 'https://client.example.com/callback';
+
+interface IssuedAuthorizationCode {
+    clientId: string;
+    codeChallenge: string;
+    redirectUri: string;
+}
+
+function createAuthorizationServerProvider(): OAuthServerProvider {
+    const clients = new Map<string, OAuthClientInformationFull>();
+    const codes = new Map<string, IssuedAuthorizationCode>();
+    let clientCount = 0;
+    let codeCount = 0;
+
+    return {
+        clientsStore: {
+            getClient: async (clientId: string) => clients.get(clientId),
+            registerClient: async client => {
+                clientCount += 1;
+                const registered: OAuthClientInformationFull = { ...client, client_id: `registered-client-${clientCount}` };
+                clients.set(registered.client_id, registered);
+                return registered;
+            }
+        },
+        authorize: async (client, params, res) => {
+            codeCount += 1;
+            const code = `authorization-code-${codeCount}`;
+            codes.set(code, { clientId: client.client_id, codeChallenge: params.codeChallenge, redirectUri: params.redirectUri });
+            const target = new URL(params.redirectUri);
+            target.searchParams.set('code', code);
+            if (params.state !== undefined) {
+                target.searchParams.set('state', params.state);
+            }
+            res.redirect(302, target.href);
+        },
+        challengeForAuthorizationCode: async (_client, authorizationCode) => {
+            const issued = codes.get(authorizationCode);
+            if (!issued) {
+                throw new InvalidGrantError('authorization code does not exist');
+            }
+            return issued.codeChallenge;
+        },
+        exchangeAuthorizationCode: async (client, authorizationCode, _codeVerifier, redirectUri) => {
+            const issued = codes.get(authorizationCode);
+            if (!issued) {
+                throw new InvalidGrantError('authorization code does not exist');
+            }
+            if (issued.clientId !== client.client_id) {
+                throw new InvalidGrantError('authorization code was issued to a different client');
+            }
+            if (redirectUri !== undefined && redirectUri !== issued.redirectUri) {
+                throw new InvalidGrantError('redirect_uri does not match the one used at authorization');
+            }
+            // Single-use: the first successful exchange consumes the code.
+            codes.delete(authorizationCode);
+            return { access_token: `access-token-for-${authorizationCode}`, token_type: 'Bearer' };
+        },
+        exchangeRefreshToken: async () => {
+            throw new InvalidGrantError('refresh tokens are not issued by this provider');
+        },
+        verifyAccessToken: async (token: string) => ({
+            token,
+            clientId: 'registered-client-1',
+            scopes: [],
+            expiresAt: Date.now() / 1000 + 3600
+        })
+    };
+}
+
+async function startAuthorizationServer(): Promise<ExpressHost> {
+    const app = express();
+    app.use(express.json());
+    app.use(mcpAuthRouter({ provider: createAuthorizationServerProvider(), issuerUrl: new URL('https://auth.example.com') }));
+    return startExpressMinimal(app);
+}
+
+function createPkcePair(): { verifier: string; challenge: string } {
+    const verifier = crypto.randomBytes(32).toString('base64url');
+    const challenge = crypto.createHash('sha256').update(verifier).digest('base64url');
+    return { verifier, challenge };
+}
+
+function postRegistration(baseUrl: URL, redirectUris: string[]): Promise<Response> {
+    return fetch(new URL('/register', baseUrl), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ client_name: 'analytics-dashboard', redirect_uris: redirectUris })
+    });
+}
+
+async function registerConfidentialClient(baseUrl: URL): Promise<{ clientId: string; clientSecret: string }> {
+    const res = await postRegistration(baseUrl, [AS_REDIRECT_URI]);
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { client_id?: string; client_secret?: string };
+    if (typeof body.client_id !== 'string' || typeof body.client_secret !== 'string') {
+        throw new Error('registration response did not include client_id and client_secret');
+    }
+    return { clientId: body.client_id, clientSecret: body.client_secret };
+}
+
+async function mintAuthorizationCode(baseUrl: URL, clientId: string, codeChallenge: string): Promise<string> {
+    const authorizeUrl = new URL('/authorize', baseUrl);
+    authorizeUrl.searchParams.set('response_type', 'code');
+    authorizeUrl.searchParams.set('client_id', clientId);
+    authorizeUrl.searchParams.set('redirect_uri', AS_REDIRECT_URI);
+    authorizeUrl.searchParams.set('code_challenge', codeChallenge);
+    authorizeUrl.searchParams.set('code_challenge_method', 'S256');
+    authorizeUrl.searchParams.set('state', 'request-state');
+
+    const res = await fetch(authorizeUrl, { redirect: 'manual' });
+    expect(res.status).toBe(302);
+    const location = res.headers.get('location');
+    if (location === null) {
+        throw new Error('authorize response did not include a Location header');
+    }
+    const redirect = new URL(location);
+    expect(redirect.origin + redirect.pathname).toBe(AS_REDIRECT_URI);
+    expect(redirect.searchParams.get('state')).toBe('request-state');
+    const code = redirect.searchParams.get('code');
+    if (code === null) {
+        throw new Error('authorize redirect did not include a code parameter');
+    }
+    return code;
+}
+
+function postTokenExchange(baseUrl: URL, form: Record<string, string>): Promise<Response> {
+    return fetch(new URL('/token', baseUrl), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams(form).toString()
+    });
+}
+
+verifies('hosting:auth:as:redirect-uri-scheme', async (_args: TestArgs) => {
+    await using host = await startAuthorizationServer();
+
+    const httpsRegistration = await postRegistration(host.baseUrl, ['https://client.example.com/callback']);
+    expect(httpsRegistration.status).toBe(201);
+
+    const loopbackRegistration = await postRegistration(host.baseUrl, ['http://127.0.0.1:49152/callback']);
+    expect(loopbackRegistration.status).toBe(201);
+
+    const nonLoopbackHttp = await postRegistration(host.baseUrl, ['http://attacker.example.com/callback']);
+    expect(nonLoopbackHttp.status).toBe(400);
+    const body = (await nonLoopbackHttp.json()) as { error?: string };
+    expect(body.error).toBe('invalid_client_metadata');
+});
+
+verifies('hosting:auth:as:redirect-uri-binding', async (_args: TestArgs) => {
+    await using host = await startAuthorizationServer();
+    const { clientId, clientSecret } = await registerConfidentialClient(host.baseUrl);
+    const { verifier, challenge } = createPkcePair();
+
+    // Authorize leg: an unregistered redirect_uri gets a direct 400, never a redirect to the attacker URI.
+    const authorizeUrl = new URL('/authorize', host.baseUrl);
+    authorizeUrl.searchParams.set('response_type', 'code');
+    authorizeUrl.searchParams.set('client_id', clientId);
+    authorizeUrl.searchParams.set('redirect_uri', 'https://attacker.example.com/callback');
+    authorizeUrl.searchParams.set('code_challenge', challenge);
+    authorizeUrl.searchParams.set('code_challenge_method', 'S256');
+
+    const authorizeRes = await fetch(authorizeUrl, { redirect: 'manual' });
+    expect(authorizeRes.status).toBe(400);
+    expect(authorizeRes.headers.get('location')).toBeNull();
+    expect(await authorizeRes.json()).toEqual({ error: 'invalid_request', error_description: 'Unregistered redirect_uri' });
+
+    // Token leg: the handler forwards the request's redirect_uri to the provider, which rejects a value differing from authorize.
+    const code = await mintAuthorizationCode(host.baseUrl, clientId, challenge);
+    const tokenRes = await postTokenExchange(host.baseUrl, {
+        grant_type: 'authorization_code',
+        client_id: clientId,
+        client_secret: clientSecret,
+        code,
+        code_verifier: verifier,
+        redirect_uri: 'https://client.example.com/callback/other'
+    });
+    expect(tokenRes.status).toBe(400);
+    expect(await tokenRes.json()).toEqual({
+        error: 'invalid_grant',
+        error_description: 'redirect_uri does not match the one used at authorization'
+    });
+});
+
+verifies('hosting:auth:query-token-ignored', async (_args: TestArgs) => {
+    const verifier = {
+        verifyAccessToken: async (token: string) => {
+            if (token !== VALID_TOKEN) {
+                throw new InvalidTokenError('Token verification failed');
+            }
+            return { token, clientId: 'analytics-client', scopes: [], expiresAt: Date.now() / 1000 + 3600 };
+        }
+    };
+
+    const app = express();
+    app.use(express.json());
+    app.use(requireBearerAuth({ verifier, resourceMetadataUrl: RESOURCE_METADATA_URL }));
+    app.post('/mcp', (_req, res) => {
+        res.json({ jsonrpc: '2.0', id: 1, result: { ok: true } });
+    });
+
+    await using host = await startExpressMinimal(app);
+
+    const queryUrl = new URL('/mcp', host.baseUrl);
+    queryUrl.searchParams.set('access_token', VALID_TOKEN);
+    const queryRes = await fetch(queryUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+        body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} })
+    });
+
+    expect(queryRes.status).toBe(401);
+    const wwwAuth = queryRes.headers.get('www-authenticate');
+    expect(wwwAuth).toBeTruthy();
+    expect(wwwAuth).toMatch(/^Bearer\b/i);
+    expect(wwwAuth).toContain('error="invalid_token"');
+    const queryBody = (await queryRes.json()) as { error?: string };
+    expect(queryBody.error).toBe('invalid_token');
+
+    // Control: the same token in the Authorization header authenticates, proving only the query-string placement was ignored.
+    const headerRes = await fetch(new URL('/mcp', host.baseUrl), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Accept: 'application/json', Authorization: `Bearer ${VALID_TOKEN}` },
+        body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} })
+    });
+    expect(headerRes.status).toBe(200);
+});
+
+verifies('hosting:auth:as:authorize-requires-pkce', async (_args: TestArgs) => {
+    await using host = await startAuthorizationServer();
+    const { clientId } = await registerConfidentialClient(host.baseUrl);
+
+    const authorizeUrl = new URL('/authorize', host.baseUrl);
+    authorizeUrl.searchParams.set('response_type', 'code');
+    authorizeUrl.searchParams.set('client_id', clientId);
+    authorizeUrl.searchParams.set('redirect_uri', AS_REDIRECT_URI);
+    authorizeUrl.searchParams.set('state', 'pkce-required-state');
+
+    const res = await fetch(authorizeUrl, { redirect: 'manual' });
+
+    expect(res.status).toBe(302);
+    const location = res.headers.get('location');
+    if (location === null) {
+        throw new Error('authorize response did not include a Location header');
+    }
+    const redirect = new URL(location);
+    expect(redirect.origin + redirect.pathname).toBe(AS_REDIRECT_URI);
+    expect(redirect.searchParams.get('error')).toBe('invalid_request');
+    expect(redirect.searchParams.get('error_description')).toContain('code_challenge');
+    expect(redirect.searchParams.get('code')).toBeNull();
+});
+
+verifies('hosting:auth:as:verifier-mismatch', async (_args: TestArgs) => {
+    await using host = await startAuthorizationServer();
+    const { clientId, clientSecret } = await registerConfidentialClient(host.baseUrl);
+
+    const { challenge } = createPkcePair();
+    const code = await mintAuthorizationCode(host.baseUrl, clientId, challenge);
+
+    // A well-formed verifier from a different PKCE pair cannot hash to the stored challenge.
+    const { verifier: wrongVerifier } = createPkcePair();
+    const res = await postTokenExchange(host.baseUrl, {
+        grant_type: 'authorization_code',
+        client_id: clientId,
+        client_secret: clientSecret,
+        code,
+        code_verifier: wrongVerifier,
+        redirect_uri: AS_REDIRECT_URI
+    });
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'invalid_grant', error_description: 'code_verifier does not match the challenge' });
+});
+
+verifies('hosting:auth:as:code-single-use', async (_args: TestArgs) => {
+    await using host = await startAuthorizationServer();
+    const { clientId, clientSecret } = await registerConfidentialClient(host.baseUrl);
+
+    const { verifier, challenge } = createPkcePair();
+    const code = await mintAuthorizationCode(host.baseUrl, clientId, challenge);
+    const form = {
+        grant_type: 'authorization_code',
+        client_id: clientId,
+        client_secret: clientSecret,
+        code,
+        code_verifier: verifier,
+        redirect_uri: AS_REDIRECT_URI
+    };
+
+    const first = await postTokenExchange(host.baseUrl, form);
+    expect(first.status).toBe(200);
+    const firstBody = (await first.json()) as { access_token?: string; token_type?: string };
+    expect(firstBody.token_type).toBe('Bearer');
+    expect(firstBody.access_token).toBe(`access-token-for-${code}`);
+
+    const second = await postTokenExchange(host.baseUrl, form);
+    expect(second.status).toBe(400);
+    expect(await second.json()).toEqual({ error: 'invalid_grant', error_description: 'authorization code does not exist' });
+});

--- a/test/e2e/scenarios/hosting-fastify.test.ts
+++ b/test/e2e/scenarios/hosting-fastify.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Self-contained test bodies for the Fastify hosting adapter (@modelcontextprotocol/fastify).
+ *
+ * These tests cover createMcpFastifyApp() over real HTTP: the Fastify instance listens on an
+ * ephemeral 127.0.0.1 port, per-session WebStandardStreamableHTTPServerTransport instances are
+ * mounted on its /mcp routes via a small Node-to-web-standard Request adapter (Fastify parses
+ * JSON bodies natively), and a StreamableHTTPClientTransport (or raw HTTP for hostile-Host
+ * probes) drives it from outside. The hosting adapter is the subject, so the matrix transport
+ * arg is ignored and every listener, transport, and server is closed in finally.
+ */
+
+import { randomUUID } from 'node:crypto';
+import http from 'node:http';
+
+import { Client, StreamableHTTPClientTransport } from '@modelcontextprotocol/client';
+import { createMcpFastifyApp } from '@modelcontextprotocol/fastify';
+import { McpServer, WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/server';
+import type { FastifyInstance, FastifyRequest } from 'fastify';
+import { expect } from 'vitest';
+import { z } from 'zod/v4';
+
+import { verifies } from '../helpers/verifies.js';
+import type { TestArgs } from '../types.js';
+
+function forecastServer(): McpServer {
+    const s = new McpServer({ name: 'forecast-server', version: '0.3.0' });
+    s.registerTool(
+        'get_forecast',
+        { description: 'Returns tomorrow’s weather forecast for a city.', inputSchema: z.object({ city: z.string() }) },
+        ({ city }) => ({ content: [{ type: 'text', text: `Forecast for ${city}: sunny, high of 22C.` }] })
+    );
+    return s;
+}
+
+/** Adapt Fastify's request (Node IncomingMessage plus natively parsed JSON body) to the web-standard Request the transport consumes. */
+function toWebRequest(request: FastifyRequest): Request {
+    const headers = new Headers();
+    for (const [name, value] of Object.entries(request.headers)) {
+        // content-length is dropped because the body below is re-serialized from Fastify's parsed JSON
+        if (name === 'content-length') continue;
+        if (typeof value === 'string') headers.set(name, value);
+        else if (Array.isArray(value)) for (const item of value) headers.append(name, item);
+    }
+    return new Request(new URL(request.url, `http://${request.headers.host ?? '127.0.0.1'}`), {
+        method: request.method,
+        headers,
+        body: request.body === undefined ? undefined : JSON.stringify(request.body)
+    });
+}
+
+/**
+ * Mount per-session WebStandard streamable HTTP transports on the app's /mcp routes,
+ * handing each raw Fastify request to the transport and replying with the web-standard Response.
+ */
+function mountMcp(app: FastifyInstance, makeServer: () => McpServer): { close(): Promise<void> } {
+    const sessions = new Map<string, WebStandardStreamableHTTPServerTransport>();
+    const servers: McpServer[] = [];
+    const bySession = (request: FastifyRequest): WebStandardStreamableHTTPServerTransport | undefined => {
+        const sessionId = request.headers['mcp-session-id'];
+        return typeof sessionId === 'string' ? sessions.get(sessionId) : undefined;
+    };
+
+    app.post('/mcp', async (request, reply) => {
+        const existing = bySession(request);
+        if (existing) return reply.send(await existing.handleRequest(toWebRequest(request)));
+        const tx = new WebStandardStreamableHTTPServerTransport({
+            sessionIdGenerator: randomUUID,
+            onsessioninitialized: id => void sessions.set(id, tx),
+            onsessionclosed: id => void sessions.delete(id)
+        });
+        const server = makeServer();
+        servers.push(server);
+        await server.connect(tx);
+        return reply.send(await tx.handleRequest(toWebRequest(request)));
+    });
+    app.get('/mcp', async (request, reply) => {
+        const existing = bySession(request);
+        if (existing) return reply.send(await existing.handleRequest(toWebRequest(request)));
+        return reply
+            .code(400)
+            .send({ jsonrpc: '2.0', error: { code: -32_000, message: 'Bad Request: No valid session ID provided' }, id: null });
+    });
+    app.delete('/mcp', async (request, reply) => {
+        const existing = bySession(request);
+        if (existing) return reply.send(await existing.handleRequest(toWebRequest(request)));
+        return reply
+            .code(400)
+            .send({ jsonrpc: '2.0', error: { code: -32_000, message: 'Bad Request: No valid session ID provided' }, id: null });
+    });
+
+    return {
+        close: async () => {
+            for (const server of servers) await server.close();
+            for (const tx of sessions.values()) await tx.close();
+            sessions.clear();
+        }
+    };
+}
+
+/**
+ * POST `body` to `url` via `node:http`, forcing `Host: <host>`.
+ * Unlike undici fetch(), node:http sends caller-supplied Host headers verbatim.
+ */
+function postWithHost(url: URL, host: string, body: string): Promise<{ status: number; body: string }> {
+    return new Promise((resolve, reject) => {
+        const req = http.request(
+            {
+                hostname: url.hostname,
+                port: url.port,
+                path: url.pathname,
+                method: 'POST',
+                headers: {
+                    Host: host,
+                    'Content-Type': 'application/json',
+                    Accept: 'application/json, text/event-stream',
+                    'Content-Length': Buffer.byteLength(body)
+                }
+            },
+            res => {
+                let data = '';
+                res.setEncoding('utf8');
+                res.on('data', chunk => (data += chunk));
+                res.on('end', () => resolve({ status: res.statusCode ?? 0, body: data }));
+                res.on('error', reject);
+            }
+        );
+        req.on('error', reject);
+        req.end(body);
+    });
+}
+
+verifies('hosting:fastify:basic-flow', async (_args: TestArgs) => {
+    const app = createMcpFastifyApp();
+    const mounted = mountMcp(app, forecastServer);
+    const client = new Client({ name: 'fastify-e2e-client', version: '0.1.0' });
+
+    try {
+        const baseUrl = new URL(await app.listen({ port: 0, host: '127.0.0.1' }));
+        const clientTransport = new StreamableHTTPClientTransport(new URL('/mcp', baseUrl));
+        await client.connect(clientTransport);
+
+        expect(client.getServerVersion()).toEqual({ name: 'forecast-server', version: '0.3.0' });
+        expect(clientTransport.sessionId).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+
+        const { tools } = await client.listTools();
+        expect(tools.map(t => ({ name: t.name, description: t.description }))).toEqual([
+            { name: 'get_forecast', description: 'Returns tomorrow’s weather forecast for a city.' }
+        ]);
+
+        const result = await client.callTool({ name: 'get_forecast', arguments: { city: 'Lisbon' } });
+        expect(result.content).toEqual([{ type: 'text', text: 'Forecast for Lisbon: sunny, high of 22C.' }]);
+    } finally {
+        await client.close();
+        await mounted.close();
+        await app.close();
+    }
+});
+
+verifies('hosting:fastify:host-header-validation', async ({ protocolVersion }: TestArgs) => {
+    let serversBuilt = 0;
+    const app = createMcpFastifyApp();
+    const mounted = mountMcp(app, () => {
+        serversBuilt += 1;
+        return forecastServer();
+    });
+    const client = new Client({ name: 'fastify-e2e-client', version: '0.1.0' });
+
+    try {
+        const baseUrl = new URL(await app.listen({ port: 0, host: '127.0.0.1' }));
+
+        const rejected = await postWithHost(
+            new URL('/mcp', baseUrl),
+            'evil.example.com',
+            JSON.stringify({
+                jsonrpc: '2.0',
+                id: 1,
+                method: 'initialize',
+                params: { protocolVersion, capabilities: {}, clientInfo: { name: 'rebinding-probe', version: '0.0.1' } }
+            })
+        );
+        expect(rejected.status).toBe(403);
+        expect(JSON.parse(rejected.body)).toEqual({
+            jsonrpc: '2.0',
+            error: { code: -32_000, message: 'Invalid Host: evil.example.com' },
+            id: null
+        });
+        // Rejected by the onRequest hook before reaching the MCP layer: no server was ever constructed for the hostile request.
+        expect(serversBuilt).toBe(0);
+
+        // Control: the same endpoint accepts a client whose requests carry the localhost Host header (127.0.0.1).
+        await client.connect(new StreamableHTTPClientTransport(new URL('/mcp', baseUrl)));
+
+        const { tools } = await client.listTools();
+        expect(tools.map(t => t.name)).toEqual(['get_forecast']);
+        expect(serversBuilt).toBe(1);
+    } finally {
+        await client.close();
+        await mounted.close();
+        await app.close();
+    }
+});

--- a/test/e2e/scenarios/hosting-hono.test.ts
+++ b/test/e2e/scenarios/hosting-hono.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Self-contained test bodies for the Hono hosting adapter (@modelcontextprotocol/hono).
+ *
+ * These tests cover createMcpHonoApp() over real HTTP: the app is served with
+ * @hono/node-server on an ephemeral 127.0.0.1 port, WebStandardStreamableHTTPServerTransport
+ * instances are mounted on the /mcp routes (the documented Hono hosting pattern), and a
+ * StreamableHTTPClientTransport (or raw HTTP for hostile-Host probes) drives it from outside.
+ * The hosting adapter is the subject, so the matrix transport arg is ignored and every
+ * listener, transport, and server is closed in finally.
+ */
+
+import { randomUUID } from 'node:crypto';
+import http from 'node:http';
+
+import { serve } from '@hono/node-server';
+import { Client, StreamableHTTPClientTransport } from '@modelcontextprotocol/client';
+import { createMcpHonoApp } from '@modelcontextprotocol/hono';
+import { McpServer, WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/server';
+import type { Hono } from 'hono';
+import { expect } from 'vitest';
+import { z } from 'zod/v4';
+
+import { verifies } from '../helpers/verifies.js';
+import type { TestArgs } from '../types.js';
+
+function recipeServer(): McpServer {
+    const s = new McpServer({ name: 'recipe-server', version: '1.2.0' });
+    s.registerTool(
+        'get_recipe',
+        { description: 'Returns the preparation steps for a named dish.', inputSchema: z.object({ dish: z.string() }) },
+        ({ dish }) => ({ content: [{ type: 'text', text: `Steps for ${dish}: mix, bake, serve.` }] })
+    );
+    return s;
+}
+
+/**
+ * Mount per-session WebStandard streamable HTTP transports on the app's /mcp routes,
+ * mirroring the documented Hono hosting pattern (handlers pass c.req.raw to the transport).
+ */
+function mountMcp(app: Hono, makeServer: () => McpServer): { close(): Promise<void> } {
+    const sessions = new Map<string, WebStandardStreamableHTTPServerTransport>();
+    const servers: McpServer[] = [];
+    const bySession = (sessionId: string | undefined) => (sessionId === undefined ? undefined : sessions.get(sessionId));
+
+    app.post('/mcp', async c => {
+        const existing = bySession(c.req.header('mcp-session-id'));
+        if (existing) return existing.handleRequest(c.req.raw);
+        const tx = new WebStandardStreamableHTTPServerTransport({
+            sessionIdGenerator: randomUUID,
+            onsessioninitialized: id => void sessions.set(id, tx),
+            onsessionclosed: id => void sessions.delete(id)
+        });
+        const server = makeServer();
+        servers.push(server);
+        await server.connect(tx);
+        return tx.handleRequest(c.req.raw);
+    });
+    app.get('/mcp', async c => {
+        const existing = bySession(c.req.header('mcp-session-id'));
+        if (existing) return existing.handleRequest(c.req.raw);
+        return c.json({ jsonrpc: '2.0', error: { code: -32_000, message: 'Bad Request: No valid session ID provided' }, id: null }, 400);
+    });
+    app.delete('/mcp', async c => {
+        const existing = bySession(c.req.header('mcp-session-id'));
+        if (existing) return existing.handleRequest(c.req.raw);
+        return c.json({ jsonrpc: '2.0', error: { code: -32_000, message: 'Bad Request: No valid session ID provided' }, id: null }, 400);
+    });
+
+    return {
+        close: async () => {
+            for (const server of servers) await server.close();
+            for (const tx of sessions.values()) await tx.close();
+            sessions.clear();
+        }
+    };
+}
+
+/** Serve a Hono app on an ephemeral 127.0.0.1 port via @hono/node-server, resolving once it is listening. */
+function listenHono(app: Hono): Promise<{ baseUrl: URL; close(): Promise<void> }> {
+    return new Promise(resolve => {
+        const server = serve({ fetch: app.fetch, hostname: '127.0.0.1', port: 0 }, info => {
+            resolve({
+                baseUrl: new URL(`http://127.0.0.1:${info.port}`),
+                close: () =>
+                    new Promise<void>((res, rej) => {
+                        server.close(err => (err ? rej(err) : res()));
+                    })
+            });
+        });
+    });
+}
+
+/**
+ * POST `body` to `url` via `node:http`, forcing `Host: <host>`.
+ * Unlike undici fetch(), node:http sends caller-supplied Host headers verbatim.
+ */
+function postWithHost(url: URL, host: string, body: string): Promise<{ status: number; body: string }> {
+    return new Promise((resolve, reject) => {
+        const req = http.request(
+            {
+                hostname: url.hostname,
+                port: url.port,
+                path: url.pathname,
+                method: 'POST',
+                headers: {
+                    Host: host,
+                    'Content-Type': 'application/json',
+                    Accept: 'application/json, text/event-stream',
+                    'Content-Length': Buffer.byteLength(body)
+                }
+            },
+            res => {
+                let data = '';
+                res.setEncoding('utf8');
+                res.on('data', chunk => (data += chunk));
+                res.on('end', () => resolve({ status: res.statusCode ?? 0, body: data }));
+                res.on('error', reject);
+            }
+        );
+        req.on('error', reject);
+        req.end(body);
+    });
+}
+
+verifies('hosting:hono:basic-flow', async (_args: TestArgs) => {
+    const app = createMcpHonoApp();
+    const mounted = mountMcp(app, recipeServer);
+    const listener = await listenHono(app);
+    const client = new Client({ name: 'hono-e2e-client', version: '0.1.0' });
+    const clientTransport = new StreamableHTTPClientTransport(new URL('/mcp', listener.baseUrl));
+
+    try {
+        await client.connect(clientTransport);
+
+        expect(client.getServerVersion()).toEqual({ name: 'recipe-server', version: '1.2.0' });
+        expect(clientTransport.sessionId).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+
+        const { tools } = await client.listTools();
+        expect(tools.map(t => ({ name: t.name, description: t.description }))).toEqual([
+            { name: 'get_recipe', description: 'Returns the preparation steps for a named dish.' }
+        ]);
+
+        const result = await client.callTool({ name: 'get_recipe', arguments: { dish: 'shakshuka' } });
+        expect(result.content).toEqual([{ type: 'text', text: 'Steps for shakshuka: mix, bake, serve.' }]);
+    } finally {
+        await client.close();
+        await mounted.close();
+        await listener.close();
+    }
+});
+
+verifies('hosting:hono:host-header-validation', async (_args: TestArgs) => {
+    let serversBuilt = 0;
+    const app = createMcpHonoApp();
+    const mounted = mountMcp(app, () => {
+        serversBuilt += 1;
+        return recipeServer();
+    });
+    const listener = await listenHono(app);
+    const client = new Client({ name: 'hono-e2e-client', version: '0.1.0' });
+
+    try {
+        const rejected = await postWithHost(
+            new URL('/mcp', listener.baseUrl),
+            'evil.example.com',
+            JSON.stringify({
+                jsonrpc: '2.0',
+                id: 1,
+                method: 'initialize',
+                params: { protocolVersion: '2025-06-18', capabilities: {}, clientInfo: { name: 'rebinding-probe', version: '0.0.1' } }
+            })
+        );
+        expect(rejected.status).toBe(403);
+        expect(JSON.parse(rejected.body)).toEqual({
+            jsonrpc: '2.0',
+            error: { code: -32_000, message: 'Invalid Host: evil.example.com' },
+            id: null
+        });
+        // Rejected before reaching the MCP layer: no server was ever constructed for the hostile request.
+        expect(serversBuilt).toBe(0);
+
+        // Control: the same endpoint accepts a client whose requests carry the localhost Host header (127.0.0.1).
+        await client.connect(new StreamableHTTPClientTransport(new URL('/mcp', listener.baseUrl)));
+
+        const { tools } = await client.listTools();
+        expect(tools.map(t => t.name)).toEqual(['get_recipe']);
+        expect(serversBuilt).toBe(1);
+    } finally {
+        await client.close();
+        await mounted.close();
+        await listener.close();
+    }
+});

--- a/test/e2e/scenarios/hosting-http.test.ts
+++ b/test/e2e/scenarios/hosting-http.test.ts
@@ -13,13 +13,15 @@
 
 import { randomUUID } from 'node:crypto';
 
+import type { JSONRPCMessage } from '@modelcontextprotocol/server';
+import { LATEST_PROTOCOL_VERSION, McpServer, WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/server';
 import { expect, vi } from 'vitest';
 import { z } from 'zod/v4';
-import { McpServer, WebStandardStreamableHTTPServerTransport, LATEST_PROTOCOL_VERSION } from '@modelcontextprotocol/server';
-import type { JSONRPCMessage } from '@modelcontextprotocol/server';
-import { hostPerSession, hostStateless, type HttpHandler } from '../helpers/index.js';
-import type { TestArgs } from '../types.js';
+
+import type { HttpHandler } from '../helpers/index.js';
+import { hostPerSession, hostStateless } from '../helpers/index.js';
 import { verifies } from '../helpers/verifies.js';
+import type { TestArgs } from '../types.js';
 
 function echoServer(): McpServer {
     const s = new McpServer({ name: 's', version: '0' });
@@ -29,12 +31,12 @@ function echoServer(): McpServer {
     return s;
 }
 
-const initializeBody = (clientInfo = { name: 'probe', version: '0' }) =>
+const initializeBody = (clientInfo?: { name: string; version: string }) =>
     JSON.stringify({
         jsonrpc: '2.0',
         id: 1,
         method: 'initialize',
-        params: { protocolVersion: LATEST_PROTOCOL_VERSION, capabilities: {}, clientInfo }
+        params: { protocolVersion: LATEST_PROTOCOL_VERSION, capabilities: {}, clientInfo: clientInfo ?? { name: 'probe', version: '0' } }
     });
 
 function sseTap(body: ReadableStream<Uint8Array>) {
@@ -318,7 +320,7 @@ verifies('hosting:http:dns-rebinding', async (_args: TestArgs) => {
         );
         expect(badOriginGet.status).toBe(403);
     } finally {
-        for (const t of Array.from(sessions.values())) await t.close();
+        for (const t of sessions.values()) await t.close();
         sessions.clear();
     }
 });
@@ -362,7 +364,7 @@ verifies('hosting:http:method-405', async (_args: TestArgs) => {
             );
             expect(res.status).toBe(405);
             expect(res.headers.get('allow')).toBe('GET, POST, DELETE');
-            expect(await res.json()).toMatchObject({ jsonrpc: '2.0', error: { code: -32000, message: 'Method not allowed.' } });
+            expect(await res.json()).toMatchObject({ jsonrpc: '2.0', error: { code: -32_000, message: 'Method not allowed.' } });
         }
     } finally {
         await tx.close();
@@ -447,13 +449,14 @@ verifies('hosting:http:no-broadcast', async (_args: TestArgs) => {
             }
 
             expect(received).toHaveLength(1);
-            expect(received[0].stream).toBe('get');
-            expect(received[0].msg).toMatchObject({ method: 'notifications/message', params: { level: 'info', data: 'probe' } });
+            expect(received[0]?.stream).toBe('get');
+            expect(received[0]?.msg).toMatchObject({ method: 'notifications/message', params: { level: 'info', data: 'probe' } });
 
             release();
             let response: JSONRPCMessage | undefined;
             for (let i = 0; i < 10 && response === undefined; i++) {
-                response = (await postTap.poll(50)).find(m => 'id' in m && m.id === 2);
+                const polled = await postTap.poll(50);
+                response = polled.find(m => 'id' in m && m.id === 2);
             }
             expect(response).toMatchObject({ jsonrpc: '2.0', id: 2 });
         } finally {
@@ -524,7 +527,7 @@ verifies('hosting:http:onerror', async (_args: TestArgs) => {
         const ok = { ...base, 'mcp-session-id': sessionId, 'content-type': 'application/json', accept };
         const listBody = JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} });
 
-        const rejections: Array<{ req: Request; status: number; message: string }> = [
+        const rejections: Array<{ req: Request; status: number; message: string | RegExp }> = [
             {
                 req: new Request('http://in-process/mcp', { method: 'PUT', headers: ok }),
                 status: 405,
@@ -551,7 +554,8 @@ verifies('hosting:http:onerror', async (_args: TestArgs) => {
             {
                 req: new Request('http://in-process/mcp', { method: 'POST', headers: ok, body: 'not json' }),
                 status: 400,
-                message: 'Parse error: Invalid JSON'
+                // changed in v2: onerror receives the raw SyntaxError rather than a wrapped 'Parse error: Invalid JSON'
+                message: /JSON/
             },
             {
                 req: new Request('http://in-process/mcp', {
@@ -569,7 +573,11 @@ verifies('hosting:http:onerror', async (_args: TestArgs) => {
             const res = await tx.handleRequest(req);
             expect(res.status).toBe(status);
             expect(errors).toHaveLength(before + 1);
-            expect(errors[before].message).toBe(message);
+            if (message instanceof RegExp) {
+                expect(errors[before]?.message).toMatch(message);
+            } else {
+                expect(errors[before]?.message).toBe(message);
+            }
         }
     } finally {
         await tx.close();
@@ -593,7 +601,7 @@ verifies('hosting:http:parse-error-400', async (_args: TestArgs) => {
         );
         expect(badJson.status).toBe(400);
         const body = await badJson.json();
-        expect(body).toMatchObject({ jsonrpc: '2.0', error: { code: -32700 } });
+        expect(body).toMatchObject({ jsonrpc: '2.0', error: { code: -32_700 } });
     } finally {
         await close();
     }
@@ -738,7 +746,8 @@ verifies('hosting:http:response-same-connection', async (_args: TestArgs) => {
         try {
             let response: JSONRPCMessage | undefined;
             for (let i = 0; i < 10 && response === undefined; i++) {
-                response = (await postTap.poll(50)).find(m => 'id' in m && m.id === 2);
+                const polled = await postTap.poll(50);
+                response = polled.find(m => 'id' in m && m.id === 2);
             }
             expect(response).toMatchObject({ jsonrpc: '2.0', id: 2, result: { tools: [{ name: 'echo' }] } });
 
@@ -871,9 +880,9 @@ verifies('hosting:http:sse-close-after-response', async (_args: TestArgs) => {
                 if (done) break;
                 buf += decoder.decode(value, { stream: true });
 
-                const m = buf.match(/^data: (.+)$/m);
-                if (m) {
-                    const msg = JSON.parse(m[1]);
+                const data = buf.match(/^data: (.+)$/m)?.[1];
+                if (data !== undefined) {
+                    const msg: JSONRPCMessage = JSON.parse(data);
                     if ('result' in msg) {
                         foundResult = true;
                     }
@@ -930,7 +939,8 @@ verifies('hosting:http:standalone-sse', async (_args: TestArgs) => {
 
             let received: JSONRPCMessage | undefined;
             for (let i = 0; i < 20 && received === undefined; i++) {
-                received = (await tap.poll(50)).find(m => 'method' in m && m.method === 'notifications/message');
+                const polled = await tap.poll(50);
+                received = polled.find(m => 'method' in m && m.method === 'notifications/message');
             }
             expect(received).toMatchObject({ method: 'notifications/message', params: { level: 'info', data: 'probe' } });
         } finally {

--- a/test/e2e/scenarios/hosting-http.test.ts
+++ b/test/e2e/scenarios/hosting-http.test.ts
@@ -15,11 +15,8 @@ import { randomUUID } from 'node:crypto';
 
 import { expect, vi } from 'vitest';
 import { z } from 'zod/v4';
-
-import { McpServer } from '../../../src/server/mcp.js';
-import { WebStandardStreamableHTTPServerTransport } from '../../../src/server/webStandardStreamableHttp.js';
-import { LATEST_PROTOCOL_VERSION, type JSONRPCMessage } from '../../../src/types.js';
-
+import { McpServer, WebStandardStreamableHTTPServerTransport, LATEST_PROTOCOL_VERSION } from '@modelcontextprotocol/server';
+import type { JSONRPCMessage } from '@modelcontextprotocol/server';
 import { hostPerSession, hostStateless, type HttpHandler } from '../helpers/index.js';
 import type { TestArgs } from '../types.js';
 import { verifies } from '../helpers/verifies.js';
@@ -208,9 +205,9 @@ verifies('hosting:http:disconnect-not-cancel', async (_args: TestArgs) => {
     });
     const makeServer = () => {
         const s = new McpServer({ name: 's', version: '0' });
-        s.registerTool('slow', { inputSchema: z.object({}) }, async (_args, extra) => {
+        s.registerTool('slow', { inputSchema: z.object({}) }, async (_args, ctx) => {
             await gate;
-            completions.push(extra.signal.aborted ? 'aborted' : 'completed');
+            completions.push(ctx.mcpReq.signal.aborted ? 'aborted' : 'completed');
             return { content: [{ type: 'text', text: 'done' }] };
         });
         return s;

--- a/test/e2e/scenarios/hosting-http.test.ts
+++ b/test/e2e/scenarios/hosting-http.test.ts
@@ -1,0 +1,1031 @@
+/**
+ * Self-contained test bodies for hosting:http requirements.
+ *
+ * These pin the WebStandard server transport's HTTP/SSE semantics — the wire
+ * surface ANY client implementation depends on — so they drive raw Request/Response rather than our Client.
+ *
+ * These tests cover WebStandardStreamableHTTPServerTransport behavior: HTTP
+ * semantics (status codes, headers, content negotiation), SSE mechanics,
+ * DNS-rebinding protection, and JSON response mode. Most tests make raw
+ * Request/Response assertions against the handler returned by
+ * hostPerSession() or hostStateless() from helpers/index.ts.
+ */
+
+import { randomUUID } from 'node:crypto';
+
+import { expect, vi } from 'vitest';
+import { z } from 'zod/v4';
+
+import { McpServer } from '../../../src/server/mcp.js';
+import { WebStandardStreamableHTTPServerTransport } from '../../../src/server/webStandardStreamableHttp.js';
+import { LATEST_PROTOCOL_VERSION, type JSONRPCMessage } from '../../../src/types.js';
+
+import { hostPerSession, hostStateless, type HttpHandler } from '../helpers/index.js';
+import type { TestArgs } from '../types.js';
+import { verifies } from '../helpers/verifies.js';
+
+function echoServer(): McpServer {
+    const s = new McpServer({ name: 's', version: '0' });
+    s.registerTool('echo', { inputSchema: z.object({ text: z.string() }) }, ({ text }) => ({
+        content: [{ type: 'text', text }]
+    }));
+    return s;
+}
+
+const initializeBody = (clientInfo = { name: 'probe', version: '0' }) =>
+    JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: { protocolVersion: LATEST_PROTOCOL_VERSION, capabilities: {}, clientInfo }
+    });
+
+function sseTap(body: ReadableStream<Uint8Array>) {
+    const reader = body.getReader();
+    const decoder = new TextDecoder();
+    let buf = '';
+    let pending: ReturnType<typeof reader.read> | null = null;
+    return {
+        // Re-awaits the same in-flight read after a timeout so no chunk is ever dropped.
+        async poll(timeoutMs: number): Promise<JSONRPCMessage[]> {
+            pending ??= reader.read();
+            const result = await Promise.race([pending, new Promise<null>(resolve => setTimeout(resolve, timeoutMs, null))]);
+            if (result === null) return [];
+            pending = null;
+            if (result.done || !result.value) return [];
+            buf += decoder.decode(result.value, { stream: true });
+            const lines = buf.split('\n');
+            buf = lines.pop()!;
+            return lines.filter(l => l.startsWith('data: ')).map((l): JSONRPCMessage => JSON.parse(l.slice(6)));
+        },
+        cancel: (): Promise<void> => reader.cancel()
+    };
+}
+
+async function readAllSseMessages(body: ReadableStream<Uint8Array>): Promise<JSONRPCMessage[]> {
+    const reader = body.getReader();
+    const decoder = new TextDecoder();
+    let buf = '';
+    for (;;) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buf += decoder.decode(value, { stream: true });
+    }
+    return buf
+        .split('\n')
+        .filter(l => l.startsWith('data: '))
+        .map((l): JSONRPCMessage => JSON.parse(l.slice(6)));
+}
+
+verifies('hosting:http:accept-406', async (_args: TestArgs) => {
+    const { handleRequest, close } = hostPerSession(echoServer);
+
+    try {
+        const base = { 'mcp-protocol-version': LATEST_PROTOCOL_VERSION };
+        const body = JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} });
+
+        const initRes = await handleRequest(
+            new Request('http://in-process/mcp', {
+                method: 'POST',
+                headers: { ...base, 'content-type': 'application/json', accept: 'application/json, text/event-stream' },
+                body: initializeBody()
+            })
+        );
+        expect(initRes.status).toBe(200);
+        const sessionId = initRes.headers.get('mcp-session-id');
+        expect(sessionId).toBeTruthy();
+        const sessionHeaders = { ...base, 'mcp-session-id': sessionId! };
+
+        const getWrongAccept = await handleRequest(
+            new Request('http://in-process/mcp', { method: 'GET', headers: { ...sessionHeaders, accept: 'application/json' } })
+        );
+        expect(getWrongAccept.status).toBe(406);
+
+        const getNoAccept = await handleRequest(new Request('http://in-process/mcp', { method: 'GET', headers: sessionHeaders }));
+        expect(getNoAccept.status).toBe(406);
+
+        const postJsonOnly = await handleRequest(
+            new Request('http://in-process/mcp', {
+                method: 'POST',
+                headers: { ...sessionHeaders, 'content-type': 'application/json', accept: 'application/json' },
+                body
+            })
+        );
+        expect(postJsonOnly.status).toBe(406);
+
+        const postSseOnly = await handleRequest(
+            new Request('http://in-process/mcp', {
+                method: 'POST',
+                headers: { ...sessionHeaders, 'content-type': 'application/json', accept: 'text/event-stream' },
+                body
+            })
+        );
+        expect(postSseOnly.status).toBe(406);
+
+        const postNoAccept = await handleRequest(
+            new Request('http://in-process/mcp', {
+                method: 'POST',
+                headers: { ...sessionHeaders, 'content-type': 'application/json' },
+                body
+            })
+        );
+        expect(postNoAccept.status).toBe(406);
+    } finally {
+        await close();
+    }
+});
+
+verifies('hosting:http:batch', async (_args: TestArgs) => {
+    const { handleRequest, close } = hostStateless(echoServer);
+
+    try {
+        const headers = {
+            'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+            'content-type': 'application/json',
+            accept: 'application/json, text/event-stream'
+        };
+
+        const single = JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} });
+        const singleRes = await handleRequest(new Request('http://in-process/mcp', { method: 'POST', headers, body: single }));
+        expect(singleRes.status).toBe(200);
+        const singleMessages = await readAllSseMessages(singleRes.body!);
+        expect(singleMessages).toHaveLength(1);
+        expect(singleMessages[0]).toMatchObject({ jsonrpc: '2.0', id: 1, result: { tools: [{ name: 'echo' }] } });
+
+        const batch = JSON.stringify([
+            { jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} },
+            { jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} }
+        ]);
+        const batchRes = await handleRequest(new Request('http://in-process/mcp', { method: 'POST', headers, body: batch }));
+        expect(batchRes.status).toBe(200);
+        const batchMessages = await readAllSseMessages(batchRes.body!);
+        expect(batchMessages).toHaveLength(2);
+        expect(batchMessages).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    jsonrpc: '2.0',
+                    id: 1,
+                    result: expect.objectContaining({ tools: [expect.objectContaining({ name: 'echo' })] })
+                }),
+                expect.objectContaining({
+                    jsonrpc: '2.0',
+                    id: 2,
+                    result: expect.objectContaining({ tools: [expect.objectContaining({ name: 'echo' })] })
+                })
+            ])
+        );
+    } finally {
+        await close();
+    }
+});
+
+verifies('hosting:http:content-type-415', async (_args: TestArgs) => {
+    const { handleRequest, close } = hostStateless(echoServer);
+
+    try {
+        const wrongType = await handleRequest(
+            new Request('http://in-process/mcp', {
+                method: 'POST',
+                headers: {
+                    'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+                    'content-type': 'text/plain',
+                    accept: 'application/json, text/event-stream'
+                },
+                body: initializeBody()
+            })
+        );
+        expect(wrongType.status).toBe(415);
+    } finally {
+        await close();
+    }
+});
+
+verifies('hosting:http:disconnect-not-cancel', async (_args: TestArgs) => {
+    const completions: string[] = [];
+    let release!: () => void;
+    const gate = new Promise<void>(resolve => {
+        release = resolve;
+    });
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool('slow', { inputSchema: z.object({}) }, async (_args, extra) => {
+            await gate;
+            completions.push(extra.signal.aborted ? 'aborted' : 'completed');
+            return { content: [{ type: 'text', text: 'done' }] };
+        });
+        return s;
+    };
+    const { handleRequest, close } = hostPerSession(makeServer);
+
+    try {
+        const initRes = await handleRequest(
+            new Request('http://in-process/mcp', {
+                method: 'POST',
+                headers: {
+                    'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+                    'content-type': 'application/json',
+                    accept: 'application/json, text/event-stream'
+                },
+                body: initializeBody()
+            })
+        );
+        const sessionId = initRes.headers.get('mcp-session-id');
+
+        const res = await handleRequest(
+            new Request('http://in-process/mcp', {
+                method: 'POST',
+                headers: {
+                    'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+                    'mcp-session-id': sessionId!,
+                    'content-type': 'application/json',
+                    accept: 'application/json, text/event-stream'
+                },
+                body: JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'tools/call', params: { name: 'slow', arguments: {} } })
+            })
+        );
+        expect(res.status).toBe(200);
+        expect(res.headers.get('content-type')).toMatch(/text\/event-stream/);
+
+        // Cancelling the SSE response body is the transport's only disconnect observable.
+        await res.body!.cancel();
+
+        release();
+        await vi.waitFor(() => expect(completions).toEqual(['completed']));
+    } finally {
+        release();
+        await close();
+    }
+});
+
+verifies('hosting:http:dns-rebinding', async (_args: TestArgs) => {
+    const makeServer = () => echoServer();
+    const sessions = new Map<string, WebStandardStreamableHTTPServerTransport>();
+    const handleRequest: HttpHandler = async req => {
+        const sid = req.headers.get('mcp-session-id') ?? undefined;
+        const existing = sid ? sessions.get(sid) : undefined;
+        if (existing) return existing.handleRequest(req);
+
+        const tx = new WebStandardStreamableHTTPServerTransport({
+            sessionIdGenerator: randomUUID,
+            onsessioninitialized: id => void sessions.set(id, tx),
+            onsessionclosed: id => void sessions.delete(id),
+            enableDnsRebindingProtection: true,
+            allowedHosts: ['localhost'],
+            allowedOrigins: ['http://localhost']
+        });
+        await makeServer().connect(tx);
+        return tx.handleRequest(req);
+    };
+
+    try {
+        const headers = {
+            'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+            'content-type': 'application/json',
+            accept: 'application/json, text/event-stream'
+        };
+
+        const badHost = await handleRequest(
+            new Request('http://in-process/mcp', {
+                method: 'POST',
+                headers: { ...headers, host: 'localhost.evil.com' },
+                body: initializeBody()
+            })
+        );
+        expect(badHost.status).toBe(403);
+
+        const badOrigin = await handleRequest(
+            new Request('http://in-process/mcp', {
+                method: 'POST',
+                headers: { ...headers, host: 'localhost', origin: 'http://localhost.evil.com' },
+                body: initializeBody()
+            })
+        );
+        expect(badOrigin.status).toBe(403);
+
+        const noOrigin = await handleRequest(
+            new Request('http://in-process/mcp', { method: 'POST', headers: { ...headers, host: 'localhost' }, body: initializeBody() })
+        );
+        expect(noOrigin.status).toBe(200);
+        const sessionId = noOrigin.headers.get('mcp-session-id');
+
+        const badOriginGet = await handleRequest(
+            new Request('http://in-process/mcp', {
+                method: 'GET',
+                headers: {
+                    accept: 'text/event-stream',
+                    host: 'localhost',
+                    'mcp-session-id': sessionId!,
+                    origin: 'http://localhost.evil.com'
+                }
+            })
+        );
+        expect(badOriginGet.status).toBe(403);
+    } finally {
+        for (const t of Array.from(sessions.values())) await t.close();
+        sessions.clear();
+    }
+});
+
+verifies('hosting:http:json-response-mode', async (_args: TestArgs) => {
+    const makeServer = () => echoServer();
+    const tx = new WebStandardStreamableHTTPServerTransport({ sessionIdGenerator: undefined, enableJsonResponse: true });
+    await makeServer().connect(tx);
+
+    try {
+        const res = await tx.handleRequest(
+            new Request('http://in-process/mcp', {
+                method: 'POST',
+                headers: {
+                    'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+                    'content-type': 'application/json',
+                    accept: 'application/json, text/event-stream'
+                },
+                body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} })
+            })
+        );
+
+        expect(res.status).toBe(200);
+        expect(res.headers.get('content-type')).toMatch(/application\/json/);
+        const json = await res.json();
+        expect(json).toHaveProperty('result');
+    } finally {
+        await tx.close();
+    }
+});
+
+verifies('hosting:http:method-405', async (_args: TestArgs) => {
+    // Direct transport so the 405 comes from the SDK, not a hosting helper's method check.
+    const tx = new WebStandardStreamableHTTPServerTransport({ sessionIdGenerator: randomUUID });
+    await echoServer().connect(tx);
+
+    try {
+        for (const method of ['PUT', 'PATCH']) {
+            const res = await tx.handleRequest(
+                new Request('http://in-process/mcp', { method, headers: { 'mcp-protocol-version': LATEST_PROTOCOL_VERSION } })
+            );
+            expect(res.status).toBe(405);
+            expect(res.headers.get('allow')).toBe('GET, POST, DELETE');
+            expect(await res.json()).toMatchObject({ jsonrpc: '2.0', error: { code: -32000, message: 'Method not allowed.' } });
+        }
+    } finally {
+        await tx.close();
+    }
+});
+
+verifies('hosting:http:no-broadcast', async (_args: TestArgs) => {
+    let server!: McpServer;
+    let release!: () => void;
+    const gate = new Promise<void>(resolve => {
+        release = resolve;
+    });
+    const makeServer = () => {
+        server = new McpServer({ name: 's', version: '0' }, { capabilities: { logging: {} } });
+        server.registerTool('wait', { inputSchema: z.object({}) }, async () => {
+            await gate;
+            return { content: [{ type: 'text', text: 'done' }] };
+        });
+        return server;
+    };
+    const { handleRequest, close } = hostPerSession(makeServer);
+
+    try {
+        const initRes = await handleRequest(
+            new Request('http://in-process/mcp', {
+                method: 'POST',
+                headers: {
+                    'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+                    'content-type': 'application/json',
+                    accept: 'application/json, text/event-stream'
+                },
+                body: initializeBody()
+            })
+        );
+        const sessionId = initRes.headers.get('mcp-session-id')!;
+
+        const sse = await handleRequest(
+            new Request('http://in-process/mcp', {
+                method: 'GET',
+                headers: { accept: 'text/event-stream', 'mcp-protocol-version': LATEST_PROTOCOL_VERSION, 'mcp-session-id': sessionId }
+            })
+        );
+        expect(sse.status).toBe(200);
+        const getTap = sseTap(sse.body!);
+
+        // In-flight tools/call keeps a second (POST-initiated) SSE stream open concurrently.
+        const post = await handleRequest(
+            new Request('http://in-process/mcp', {
+                method: 'POST',
+                headers: {
+                    'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+                    'mcp-session-id': sessionId,
+                    'content-type': 'application/json',
+                    accept: 'application/json, text/event-stream'
+                },
+                body: JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'tools/call', params: { name: 'wait', arguments: {} } })
+            })
+        );
+        expect(post.status).toBe(200);
+        expect(post.headers.get('content-type')).toMatch(/text\/event-stream/);
+        const postTap = sseTap(post.body!);
+
+        try {
+            await server.server.sendLoggingMessage({ level: 'info', data: 'probe' });
+
+            const received: Array<{ stream: 'get' | 'post'; msg: JSONRPCMessage }> = [];
+            const drain = async () => {
+                for (const msg of await getTap.poll(50)) {
+                    if ('method' in msg && msg.method === 'notifications/message') received.push({ stream: 'get', msg });
+                }
+                for (const msg of await postTap.poll(50)) {
+                    if ('method' in msg && msg.method === 'notifications/message') received.push({ stream: 'post', msg });
+                }
+            };
+
+            for (let i = 0; i < 10 && received.length === 0; i++) {
+                await drain();
+            }
+            // Keep draining both streams after the first copy so a late duplicate would be caught.
+            for (let i = 0; i < 4; i++) {
+                await drain();
+            }
+
+            expect(received).toHaveLength(1);
+            expect(received[0].stream).toBe('get');
+            expect(received[0].msg).toMatchObject({ method: 'notifications/message', params: { level: 'info', data: 'probe' } });
+
+            release();
+            let response: JSONRPCMessage | undefined;
+            for (let i = 0; i < 10 && response === undefined; i++) {
+                response = (await postTap.poll(50)).find(m => 'id' in m && m.id === 2);
+            }
+            expect(response).toMatchObject({ jsonrpc: '2.0', id: 2 });
+        } finally {
+            release();
+            await getTap.cancel();
+            await postTap.cancel();
+        }
+    } finally {
+        await close();
+    }
+});
+
+verifies('hosting:http:notifications-202', async (_args: TestArgs) => {
+    const { handleRequest, close } = hostPerSession(echoServer);
+
+    try {
+        const initRes = await handleRequest(
+            new Request('http://in-process/mcp', {
+                method: 'POST',
+                headers: {
+                    'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+                    'content-type': 'application/json',
+                    accept: 'application/json, text/event-stream'
+                },
+                body: initializeBody()
+            })
+        );
+        const sessionId = initRes.headers.get('mcp-session-id')!;
+
+        const notificationOnly = await handleRequest(
+            new Request('http://in-process/mcp', {
+                method: 'POST',
+                headers: {
+                    'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+                    'mcp-session-id': sessionId,
+                    'content-type': 'application/json',
+                    accept: 'application/json, text/event-stream'
+                },
+                body: JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' })
+            })
+        );
+        expect(notificationOnly.status).toBe(202);
+        expect(await notificationOnly.text()).toBe('');
+    } finally {
+        await close();
+    }
+});
+
+verifies('hosting:http:onerror', async (_args: TestArgs) => {
+    const errors: Error[] = [];
+    const tx = new WebStandardStreamableHTTPServerTransport({ sessionIdGenerator: randomUUID });
+    tx.onerror = e => errors.push(e);
+    await echoServer().connect(tx);
+
+    try {
+        const accept = 'application/json, text/event-stream';
+        const base = { 'mcp-protocol-version': LATEST_PROTOCOL_VERSION };
+        const init = await tx.handleRequest(
+            new Request('http://in-process/mcp', {
+                method: 'POST',
+                headers: { ...base, 'content-type': 'application/json', accept },
+                body: initializeBody()
+            })
+        );
+        expect(init.status).toBe(200);
+        expect(errors).toHaveLength(0);
+        const sessionId = init.headers.get('mcp-session-id')!;
+        const ok = { ...base, 'mcp-session-id': sessionId, 'content-type': 'application/json', accept };
+        const listBody = JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} });
+
+        const rejections: Array<{ req: Request; status: number; message: string }> = [
+            {
+                req: new Request('http://in-process/mcp', { method: 'PUT', headers: ok }),
+                status: 405,
+                message: 'Method not allowed.'
+            },
+            {
+                req: new Request('http://in-process/mcp', {
+                    method: 'POST',
+                    headers: { ...ok, accept: 'application/json' },
+                    body: listBody
+                }),
+                status: 406,
+                message: 'Not Acceptable: Client must accept both application/json and text/event-stream'
+            },
+            {
+                req: new Request('http://in-process/mcp', {
+                    method: 'POST',
+                    headers: { ...ok, 'content-type': 'text/plain' },
+                    body: listBody
+                }),
+                status: 415,
+                message: 'Unsupported Media Type: Content-Type must be application/json'
+            },
+            {
+                req: new Request('http://in-process/mcp', { method: 'POST', headers: ok, body: 'not json' }),
+                status: 400,
+                message: 'Parse error: Invalid JSON'
+            },
+            {
+                req: new Request('http://in-process/mcp', {
+                    method: 'POST',
+                    headers: { ...base, 'content-type': 'application/json', accept },
+                    body: listBody
+                }),
+                status: 400,
+                message: 'Bad Request: Mcp-Session-Id header is required'
+            }
+        ];
+
+        for (const { req, status, message } of rejections) {
+            const before = errors.length;
+            const res = await tx.handleRequest(req);
+            expect(res.status).toBe(status);
+            expect(errors).toHaveLength(before + 1);
+            expect(errors[before].message).toBe(message);
+        }
+    } finally {
+        await tx.close();
+    }
+});
+
+verifies('hosting:http:parse-error-400', async (_args: TestArgs) => {
+    const { handleRequest, close } = hostStateless(echoServer);
+
+    try {
+        const badJson = await handleRequest(
+            new Request('http://in-process/mcp', {
+                method: 'POST',
+                headers: {
+                    'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+                    'content-type': 'application/json',
+                    accept: 'application/json, text/event-stream'
+                },
+                body: 'not json'
+            })
+        );
+        expect(badJson.status).toBe(400);
+        const body = await badJson.json();
+        expect(body).toMatchObject({ jsonrpc: '2.0', error: { code: -32700 } });
+    } finally {
+        await close();
+    }
+});
+
+verifies('hosting:http:protocol-version-400', async (_args: TestArgs) => {
+    const { handleRequest, close } = hostPerSession(echoServer);
+
+    try {
+        // Create a session with supported version
+        const initRes = await handleRequest(
+            new Request('http://in-process/mcp', {
+                method: 'POST',
+                headers: {
+                    'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+                    'content-type': 'application/json',
+                    accept: 'application/json, text/event-stream'
+                },
+                body: initializeBody()
+            })
+        );
+        expect(initRes.status).toBe(200);
+        const sessionId = initRes.headers.get('mcp-session-id')!;
+
+        // POST with unsupported version on established session
+        const unsupported = await handleRequest(
+            new Request('http://in-process/mcp', {
+                method: 'POST',
+                headers: {
+                    'mcp-protocol-version': '1999-01-01',
+                    'mcp-session-id': sessionId,
+                    'content-type': 'application/json',
+                    accept: 'application/json, text/event-stream'
+                },
+                body: JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} })
+            })
+        );
+
+        expect(unsupported.status).toBe(400);
+        const text = await unsupported.text();
+        expect(text).toContain(LATEST_PROTOCOL_VERSION);
+    } finally {
+        await close();
+    }
+});
+
+verifies('hosting:http:protocol-version-default', async (_args: TestArgs) => {
+    const { handleRequest, close } = hostPerSession(echoServer);
+
+    try {
+        const initRes = await handleRequest(
+            new Request('http://in-process/mcp', {
+                method: 'POST',
+                headers: {
+                    'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+                    'content-type': 'application/json',
+                    accept: 'application/json, text/event-stream'
+                },
+                body: initializeBody()
+            })
+        );
+        expect(initRes.status).toBe(200);
+        const sessionId = initRes.headers.get('mcp-session-id')!;
+
+        // Only Accept, Content-Type, and the session ID — no MCP-Protocol-Version header at all.
+        const noVersionHeaders = {
+            'mcp-session-id': sessionId,
+            'content-type': 'application/json',
+            accept: 'application/json, text/event-stream'
+        };
+
+        // 202 proves the notification was accepted under the assumed default version (2025-03-26).
+        const notification = await handleRequest(
+            new Request('http://in-process/mcp', {
+                method: 'POST',
+                headers: noVersionHeaders,
+                body: JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' })
+            })
+        );
+        expect(notification.status).toBe(202);
+
+        const listRes = await handleRequest(
+            new Request('http://in-process/mcp', {
+                method: 'POST',
+                headers: noVersionHeaders,
+                body: JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} })
+            })
+        );
+        expect(listRes.status).toBe(200);
+        const messages = await readAllSseMessages(listRes.body!);
+        expect(messages).toHaveLength(1);
+        expect(messages[0]).toMatchObject({ jsonrpc: '2.0', id: 2, result: { tools: [{ name: 'echo' }] } });
+    } finally {
+        await close();
+    }
+});
+
+verifies('hosting:http:response-same-connection', async (_args: TestArgs) => {
+    const { handleRequest, close } = hostPerSession(echoServer);
+
+    try {
+        const initRes = await handleRequest(
+            new Request('http://in-process/mcp', {
+                method: 'POST',
+                headers: {
+                    'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+                    'content-type': 'application/json',
+                    accept: 'application/json, text/event-stream'
+                },
+                body: initializeBody()
+            })
+        );
+        const sessionId = initRes.headers.get('mcp-session-id')!;
+
+        // A concurrently open standalone GET stream is the alternative connection the response must NOT use.
+        const sse = await handleRequest(
+            new Request('http://in-process/mcp', {
+                method: 'GET',
+                headers: { accept: 'text/event-stream', 'mcp-protocol-version': LATEST_PROTOCOL_VERSION, 'mcp-session-id': sessionId }
+            })
+        );
+        expect(sse.status).toBe(200);
+        const getTap = sseTap(sse.body!);
+
+        const res = await handleRequest(
+            new Request('http://in-process/mcp', {
+                method: 'POST',
+                headers: {
+                    'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+                    'mcp-session-id': sessionId,
+                    'content-type': 'application/json',
+                    accept: 'application/json, text/event-stream'
+                },
+                body: JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} })
+            })
+        );
+
+        expect(res.status).toBe(200);
+        expect(res.headers.get('content-type')).toMatch(/text\/event-stream/);
+        const postTap = sseTap(res.body!);
+
+        try {
+            let response: JSONRPCMessage | undefined;
+            for (let i = 0; i < 10 && response === undefined; i++) {
+                response = (await postTap.poll(50)).find(m => 'id' in m && m.id === 2);
+            }
+            expect(response).toMatchObject({ jsonrpc: '2.0', id: 2, result: { tools: [{ name: 'echo' }] } });
+
+            for (let i = 0; i < 4; i++) {
+                for (const msg of await getTap.poll(50)) {
+                    expect(msg).not.toHaveProperty('result');
+                    expect(msg).not.toHaveProperty('error');
+                }
+            }
+        } finally {
+            await getTap.cancel();
+            await postTap.cancel();
+        }
+    } finally {
+        await close();
+    }
+});
+
+verifies('hosting:http:second-sse-rejected', async (_args: TestArgs) => {
+    const { handleRequest, close } = hostPerSession(echoServer);
+
+    try {
+        const initRes = await handleRequest(
+            new Request('http://in-process/mcp', {
+                method: 'POST',
+                headers: {
+                    'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+                    'content-type': 'application/json',
+                    accept: 'application/json, text/event-stream'
+                },
+                body: initializeBody()
+            })
+        );
+        const sessionId = initRes.headers.get('mcp-session-id')!;
+
+        const sse1 = await handleRequest(
+            new Request('http://in-process/mcp', {
+                method: 'GET',
+                headers: { accept: 'text/event-stream', 'mcp-protocol-version': LATEST_PROTOCOL_VERSION, 'mcp-session-id': sessionId }
+            })
+        );
+        expect(sse1.status).toBe(200);
+        const reader1 = sse1.body!.getReader();
+
+        let reader2: ReadableStreamDefaultReader<Uint8Array> | null = null;
+        try {
+            const sse2 = await handleRequest(
+                new Request('http://in-process/mcp', {
+                    method: 'GET',
+                    headers: { accept: 'text/event-stream', 'mcp-protocol-version': LATEST_PROTOCOL_VERSION, 'mcp-session-id': sessionId }
+                })
+            );
+            expect(sse2.status).toBe(409);
+
+            // Verify first stream remains usable after rejection
+            const testNotif = await handleRequest(
+                new Request('http://in-process/mcp', {
+                    method: 'POST',
+                    headers: {
+                        'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+                        'mcp-session-id': sessionId,
+                        'content-type': 'application/json',
+                        accept: 'application/json, text/event-stream'
+                    },
+                    body: JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' })
+                })
+            );
+            expect(testNotif.status).toBe(202);
+
+            // First stream should be readable
+            const { done } = await Promise.race([
+                reader1.read(),
+                new Promise<{ done: boolean }>(r => setTimeout(() => r({ done: false }), 100))
+            ]);
+            expect(done).toBe(false);
+
+            if (sse2.status === 200) {
+                reader2 = sse2.body!.getReader();
+            }
+        } finally {
+            await reader1.cancel();
+            if (reader2) await reader2.cancel();
+        }
+    } finally {
+        await close();
+    }
+});
+
+verifies('hosting:http:sse-close-after-response', async (_args: TestArgs) => {
+    const { handleRequest, close } = hostPerSession(echoServer);
+
+    try {
+        const initRes = await handleRequest(
+            new Request('http://in-process/mcp', {
+                method: 'POST',
+                headers: {
+                    'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+                    'content-type': 'application/json',
+                    accept: 'application/json, text/event-stream'
+                },
+                body: initializeBody()
+            })
+        );
+        const sessionId = initRes.headers.get('mcp-session-id')!;
+
+        const res = await handleRequest(
+            new Request('http://in-process/mcp', {
+                method: 'POST',
+                headers: {
+                    'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+                    'mcp-session-id': sessionId,
+                    'content-type': 'application/json',
+                    accept: 'application/json, text/event-stream'
+                },
+                body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} })
+            })
+        );
+
+        expect(res.status).toBe(200);
+        expect(res.headers.get('content-type')).toMatch(/text\/event-stream/);
+
+        const reader = res.body!.getReader();
+        try {
+            const decoder = new TextDecoder();
+            let buf = '';
+            let foundResult = false;
+
+            for (;;) {
+                const { value, done } = await reader.read();
+                if (done) break;
+                buf += decoder.decode(value, { stream: true });
+
+                const m = buf.match(/^data: (.+)$/m);
+                if (m) {
+                    const msg = JSON.parse(m[1]);
+                    if ('result' in msg) {
+                        foundResult = true;
+                    }
+                }
+            }
+
+            expect(foundResult).toBe(true);
+        } finally {
+            await reader.cancel();
+        }
+    } finally {
+        await close();
+    }
+});
+
+verifies('hosting:http:standalone-sse', async (_args: TestArgs) => {
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' }, { capabilities: { logging: {} } });
+        return s;
+    };
+    let server!: McpServer;
+    const factory = () => {
+        server = makeServer();
+        return server;
+    };
+    const { handleRequest, close } = hostPerSession(factory);
+
+    try {
+        const initRes = await handleRequest(
+            new Request('http://in-process/mcp', {
+                method: 'POST',
+                headers: {
+                    'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+                    'content-type': 'application/json',
+                    accept: 'application/json, text/event-stream'
+                },
+                body: initializeBody()
+            })
+        );
+        const sessionId = initRes.headers.get('mcp-session-id')!;
+
+        const sse = await handleRequest(
+            new Request('http://in-process/mcp', {
+                method: 'GET',
+                headers: { accept: 'text/event-stream', 'mcp-protocol-version': LATEST_PROTOCOL_VERSION, 'mcp-session-id': sessionId }
+            })
+        );
+        expect(sse.status).toBe(200);
+        expect(sse.headers.get('content-type')).toMatch(/text\/event-stream/);
+
+        const tap = sseTap(sse.body!);
+        try {
+            await server.server.sendLoggingMessage({ level: 'info', data: 'probe' });
+
+            let received: JSONRPCMessage | undefined;
+            for (let i = 0; i < 20 && received === undefined; i++) {
+                received = (await tap.poll(50)).find(m => 'method' in m && m.method === 'notifications/message');
+            }
+            expect(received).toMatchObject({ method: 'notifications/message', params: { level: 'info', data: 'probe' } });
+        } finally {
+            await tap.cancel();
+        }
+    } finally {
+        await close();
+    }
+});
+
+verifies('hosting:http:standalone-sse-no-response', async (_args: TestArgs) => {
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' }, { capabilities: { logging: {} } });
+        return s;
+    };
+    let server!: McpServer;
+    const factory = () => {
+        server = makeServer();
+        return server;
+    };
+    const { handleRequest, close } = hostPerSession(factory);
+
+    try {
+        const initRes = await handleRequest(
+            new Request('http://in-process/mcp', {
+                method: 'POST',
+                headers: {
+                    'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+                    'content-type': 'application/json',
+                    accept: 'application/json, text/event-stream'
+                },
+                body: initializeBody()
+            })
+        );
+        const sessionId = initRes.headers.get('mcp-session-id')!;
+
+        const sse = await handleRequest(
+            new Request('http://in-process/mcp', {
+                method: 'GET',
+                headers: { accept: 'text/event-stream', 'mcp-protocol-version': LATEST_PROTOCOL_VERSION, 'mcp-session-id': sessionId }
+            })
+        );
+        expect(sse.status).toBe(200);
+        expect(sse.headers.get('content-type')).toMatch(/text\/event-stream/);
+        const tap = sseTap(sse.body!);
+
+        try {
+            await server.server.sendLoggingMessage({ level: 'info', data: 'notification' });
+
+            let received: JSONRPCMessage | undefined;
+            for (let i = 0; i < 20 && received === undefined; i++) {
+                for (const msg of await tap.poll(50)) {
+                    expect(msg).not.toHaveProperty('result');
+                    expect(msg).not.toHaveProperty('error');
+                    if ('method' in msg && msg.method === 'notifications/message') {
+                        received = msg;
+                    }
+                }
+            }
+            expect(received).toMatchObject({ method: 'notifications/message', params: { level: 'info', data: 'notification' } });
+        } finally {
+            await tap.cancel();
+        }
+    } finally {
+        await close();
+    }
+});
+
+verifies('hosting:http:send-no-listener-noop', async (_args: TestArgs) => {
+    let server!: McpServer;
+    const makeServer = () => {
+        server = new McpServer({ name: 's', version: '0' }, { capabilities: { logging: {} } });
+        return server;
+    };
+    const { handleRequest, close } = hostPerSession(makeServer);
+
+    try {
+        const initRes = await handleRequest(
+            new Request('http://in-process/mcp', {
+                method: 'POST',
+                headers: {
+                    'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+                    'content-type': 'application/json',
+                    accept: 'application/json, text/event-stream'
+                },
+                body: initializeBody()
+            })
+        );
+        expect(initRes.status).toBe(200);
+
+        await expect(server.server.sendLoggingMessage({ level: 'info', data: 'dropped' })).resolves.not.toThrow();
+    } finally {
+        await close();
+    }
+});

--- a/test/e2e/scenarios/hosting-resume.test.ts
+++ b/test/e2e/scenarios/hosting-resume.test.ts
@@ -1,0 +1,840 @@
+/**
+ * Self-contained test bodies for hosting resume (StreamableHTTP resumability/EventStore).
+ *
+ * Each export is a {@link TestCase}: it builds its own server (via a factory),
+ * builds its own client, wires them with {@link wire}, and asserts. SSE stream
+ * parsing and raw GET requests drive resume scenarios.
+ */
+
+import { expect, vi } from 'vitest';
+import { z } from 'zod/v4';
+
+import { Client } from '../../../src/client/index.js';
+import { StreamableHTTPClientTransport } from '../../../src/client/streamableHttp.js';
+import type { EventStore, EventId, StreamId } from '../../../src/server/webStandardStreamableHttp.js';
+import { McpServer } from '../../../src/server/mcp.js';
+import type { JSONRPCMessage } from '../../../src/types.js';
+
+import { hostResumable } from '../helpers/index.js';
+import type { TestArgs } from '../types.js';
+import { LATEST_PROTOCOL_VERSION } from '../../../src/types.js';
+import { verifies } from '../helpers/verifies.js';
+
+/**
+ * These three tests assert the raw frame sequence of the POST SSE stream itself, so they cannot run their traffic through a connected client.
+ */
+async function completeHandshake(
+    url: URL,
+    fetch: (u: URL | string, init?: RequestInit) => Promise<Response>,
+    capabilities: Record<string, unknown> = {}
+): Promise<{ sessionId: string; baseHeaders: Record<string, string> }> {
+    const initRes = await fetch(url, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', accept: 'application/json, text/event-stream' },
+        body: JSON.stringify({
+            jsonrpc: '2.0',
+            id: 0,
+            method: 'initialize',
+            params: {
+                protocolVersion: LATEST_PROTOCOL_VERSION,
+                capabilities,
+                clientInfo: { name: 'test', version: '0' }
+            }
+        })
+    });
+
+    if (!initRes.ok) throw new Error(`Initialize failed: ${initRes.status}`);
+
+    const sessionId = initRes.headers.get('mcp-session-id');
+    if (!sessionId) throw new Error('No session ID in initialize response');
+
+    await initRes.body?.cancel();
+
+    const baseHeaders = { 'mcp-session-id': sessionId, 'mcp-protocol-version': LATEST_PROTOCOL_VERSION };
+
+    const notifRes = await fetch(url, {
+        method: 'POST',
+        headers: {
+            ...baseHeaders,
+            'content-type': 'application/json',
+            accept: 'application/json, text/event-stream'
+        },
+        body: JSON.stringify({
+            jsonrpc: '2.0',
+            method: 'notifications/initialized'
+        })
+    });
+
+    if (!notifRes.ok) throw new Error(`notifications/initialized failed: ${notifRes.status}`);
+    await notifRes.body?.cancel();
+
+    return { sessionId, baseHeaders };
+}
+
+/**
+ * Minimal in-memory EventStore for tests. Models user implementation.
+ * Ids are `<streamId>_<seq>` for deterministic ordering.
+ */
+class InMemoryEventStore implements EventStore {
+    private events: Array<{ id: string; streamId: string; message: JSONRPCMessage }> = [];
+    private seq = 0;
+
+    async storeEvent(streamId: StreamId, message: JSONRPCMessage): Promise<EventId> {
+        const id = `${streamId}_${String(this.seq++).padStart(6, '0')}`;
+        this.events.push({ id, streamId, message });
+        return id;
+    }
+
+    async getStreamIdForEventId(eventId: EventId): Promise<StreamId | undefined> {
+        const found = this.events.find(e => e.id === eventId);
+        return found?.streamId;
+    }
+
+    async replayEventsAfter(
+        lastEventId: EventId,
+        { send }: { send: (eventId: EventId, message: JSONRPCMessage) => Promise<void> }
+    ): Promise<StreamId> {
+        const idx = this.events.findIndex(e => e.id === lastEventId);
+        if (idx < 0) return '';
+        const streamId = this.events[idx].streamId;
+        for (const e of this.events.slice(idx + 1)) {
+            if (e.streamId === streamId) await send(e.id, e.message);
+        }
+        return streamId;
+    }
+
+    reset(): void {
+        this.events.length = 0;
+        this.seq = 0;
+    }
+
+    getStoredEvents(): ReadonlyArray<{ id: string; streamId: string; message: JSONRPCMessage }> {
+        return this.events;
+    }
+}
+
+/** Parse SSE blocks with non-empty data lines from an SSE body. */
+function parseSseFrames(body: string): Array<{ id: string; data: string }> {
+    const frames: Array<{ id: string; data: string }> = [];
+    for (const block of body.split(/\r?\n\r?\n/)) {
+        const idMatch = block.match(/^id:\s*(.+)$/m);
+        const dataMatch = block.match(/^data:\s*(.+)$/m);
+        if (idMatch?.[1]?.trim() && dataMatch?.[1]) {
+            frames.push({ id: idMatch[1].trim(), data: dataMatch[1] });
+        }
+    }
+    return frames;
+}
+
+/** Read an SSE Response body to completion. */
+async function readSseBody(body: ReadableStream<Uint8Array>): Promise<string> {
+    const reader = body.getReader();
+    const decoder = new TextDecoder();
+    let buf = '';
+    try {
+        while (true) {
+            const { value, done } = await reader.read();
+            if (value) buf += decoder.decode(value, { stream: true });
+            if (done) break;
+        }
+    } finally {
+        await reader.cancel().catch(() => {});
+    }
+    return buf;
+}
+
+/** Read SSE frames until we have at least `count` frames, then cancel. */
+async function readSseFramesUntil(body: ReadableStream<Uint8Array>, count: number, maxIterations = 64): Promise<string> {
+    const reader = body.getReader();
+    const decoder = new TextDecoder();
+    let buf = '';
+    try {
+        for (let i = 0; i < maxIterations; i++) {
+            const { value, done } = await reader.read();
+            if (value) buf += decoder.decode(value, { stream: true });
+            const frames = parseSseFrames(buf);
+            if (frames.length >= count) break;
+            if (done) break;
+        }
+    } finally {
+        await reader.cancel().catch(() => {});
+    }
+    return buf;
+}
+
+verifies('hosting:resume:event-ids', async (_args: TestArgs) => {
+    const eventStore = new InMemoryEventStore();
+
+    let serverRef: McpServer | undefined;
+
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' }, { capabilities: { logging: {} } });
+        s.registerTool('progress', { inputSchema: z.object({ steps: z.number().int().positive() }) }, async ({ steps }, extra) => {
+            const token = extra._meta?.progressToken;
+            if (token !== undefined) {
+                for (let i = 1; i <= steps; i++) {
+                    await extra.sendNotification({
+                        method: 'notifications/progress',
+                        params: { progressToken: token, progress: i, total: steps }
+                    });
+                }
+            }
+            return { content: [{ type: 'text', text: `done ${steps}` }] };
+        });
+        serverRef = s;
+        return s;
+    };
+
+    const handle = hostResumable(makeServer, { eventStore });
+
+    const url = new URL('http://in-process/mcp');
+    const fetch = (u: URL | string, init?: RequestInit) => handle.handleRequest(new Request(u, init));
+
+    try {
+        const { baseHeaders } = await completeHandshake(url, fetch, { logging: {} });
+
+        if (!serverRef) throw new Error('serverRef not set');
+
+        const postRes = await fetch(url, {
+            method: 'POST',
+            headers: { ...baseHeaders, 'content-type': 'application/json', accept: 'application/json, text/event-stream' },
+            body: JSON.stringify({
+                jsonrpc: '2.0',
+                id: 'evt-1',
+                method: 'tools/call',
+                params: { name: 'progress', arguments: { steps: 3 }, _meta: { progressToken: 'evt-1' } }
+            })
+        });
+        expect(postRes.status).toBe(200);
+        expect(postRes.headers.get('content-type')).toMatch(/text\/event-stream/);
+
+        const postBody = await readSseBody(postRes.body!);
+
+        const postBlocks = postBody.split(/\r?\n\r?\n/).filter(b => b.trim().length > 0);
+        expect(postBlocks).toHaveLength(5);
+        const postIds = postBlocks.map(b => b.match(/^id: (\S+)$/m)?.[1]).filter((id): id is string => id !== undefined);
+        expect(postIds).toHaveLength(postBlocks.length);
+
+        const postMessages = postBlocks
+            .map(b => b.match(/^data: (.+)$/m)?.[1])
+            .filter((d): d is string => d !== undefined && d.trim().length > 0)
+            .map(d => JSON.parse(d) as JSONRPCMessage);
+        expect(postMessages.filter(m => 'method' in m && m.method === 'notifications/progress')).toHaveLength(3);
+        expect(postMessages.filter(m => 'id' in m && m.id === 'evt-1')).toHaveLength(1);
+
+        const getRes = await fetch(url, {
+            method: 'GET',
+            headers: { ...baseHeaders, accept: 'application/json, text/event-stream' }
+        });
+        expect(getRes.status).toBe(200);
+        expect(getRes.headers.get('content-type')).toMatch(/text\/event-stream/);
+
+        await serverRef.sendLoggingMessage({ level: 'info', data: 'standalone-1' });
+        await serverRef.sendLoggingMessage({ level: 'warning', data: 'standalone-2' });
+
+        const getBuf = await readSseFramesUntil(getRes.body!, 2);
+
+        const getBlocks = getBuf.split(/\r?\n\r?\n/).filter(b => b.trim().length > 0);
+        expect(getBlocks).toHaveLength(2);
+        const getIds = getBlocks.map(b => b.match(/^id: (\S+)$/m)?.[1]).filter((id): id is string => id !== undefined);
+        expect(getIds).toHaveLength(getBlocks.length);
+
+        const storedIds = eventStore.getStoredEvents().map(e => e.id);
+        for (const id of [...postIds, ...getIds]) {
+            expect(storedIds).toContain(id);
+        }
+    } finally {
+        await handle.close();
+    }
+});
+
+verifies('hosting:resume:replay', async (_args: TestArgs) => {
+    const eventStore = new InMemoryEventStore();
+
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool('progress', { inputSchema: z.object({ steps: z.number().int().positive() }) }, async ({ steps }, extra) => {
+            const token = extra._meta?.progressToken;
+            if (token !== undefined) {
+                for (let i = 1; i <= steps; i++) {
+                    await extra.sendNotification({
+                        method: 'notifications/progress',
+                        params: { progressToken: token, progress: i, total: steps }
+                    });
+                }
+            }
+            return { content: [{ type: 'text', text: `done ${steps}` }] };
+        });
+        return s;
+    };
+
+    const handle = hostResumable(makeServer, { eventStore });
+
+    const url = new URL('http://in-process/mcp');
+    const fetch = (u: URL | string, init?: RequestInit) => handle.handleRequest(new Request(u, init));
+
+    const client = new Client({ name: 'c', version: '0' });
+    const transport = new StreamableHTTPClientTransport(url, { fetch });
+
+    try {
+        await client.connect(transport);
+
+        const sessionId = transport.sessionId!;
+        const baseHeaders = { 'mcp-session-id': sessionId };
+
+        const postRes = await fetch(url, {
+            method: 'POST',
+            headers: { ...baseHeaders, 'content-type': 'application/json', accept: 'application/json, text/event-stream' },
+            body: JSON.stringify({
+                jsonrpc: '2.0',
+                id: 'replay-1',
+                method: 'tools/call',
+                params: { name: 'progress', arguments: { steps: 3 }, _meta: { progressToken: 'replay-1' } }
+            })
+        });
+        expect(postRes.status).toBe(200);
+        const postBody = await readSseBody(postRes.body!);
+        const originalFrames = parseSseFrames(postBody);
+        expect(originalFrames.length).toBeGreaterThanOrEqual(2);
+
+        const anchorId = originalFrames[0].id;
+        const expectedAfterIds = originalFrames.slice(1).map(f => f.id);
+
+        const resumeRes = await fetch(url, {
+            method: 'GET',
+            headers: { ...baseHeaders, accept: 'application/json, text/event-stream', 'last-event-id': anchorId }
+        });
+        expect(resumeRes.status).toBe(200);
+        expect(resumeRes.headers.get('content-type')).toMatch(/text\/event-stream/);
+
+        const resumeBody = await readSseFramesUntil(resumeRes.body!, expectedAfterIds.length);
+        const replayedFrames = parseSseFrames(resumeBody);
+        const replayedIds = replayedFrames.map(f => f.id);
+
+        expect(replayedIds).toEqual(expectedAfterIds);
+        expect(replayedIds).not.toContain(anchorId);
+
+        for (const f of replayedFrames) {
+            const msg = JSON.parse(f.data) as JSONRPCMessage;
+            expect(msg).toHaveProperty('jsonrpc', '2.0');
+        }
+    } finally {
+        await client.close();
+        await handle.close();
+    }
+});
+
+verifies('hosting:resume:buffered-replay', async (_args: TestArgs) => {
+    const eventStore = new InMemoryEventStore();
+
+    let serverRef: McpServer | undefined;
+
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' }, { capabilities: { logging: {} } });
+        serverRef = s;
+        return s;
+    };
+
+    const handle = hostResumable(makeServer, { eventStore });
+
+    const url = new URL('http://in-process/mcp');
+    const fetch = (u: URL | string, init?: RequestInit) => handle.handleRequest(new Request(u, init));
+
+    try {
+        const initRes = await fetch(url, {
+            method: 'POST',
+            headers: { 'content-type': 'application/json', accept: 'application/json, text/event-stream' },
+            body: JSON.stringify({
+                jsonrpc: '2.0',
+                id: 'init-1',
+                method: 'initialize',
+                params: { protocolVersion: '2024-11-05', capabilities: { logging: {} }, clientInfo: { name: 'c', version: '0' } }
+            })
+        });
+        expect(initRes.status).toBe(200);
+        const sessionId = initRes.headers.get('mcp-session-id');
+        expect(sessionId).toBeTruthy();
+
+        await readSseBody(initRes.body!);
+
+        const baseHeaders = { 'mcp-session-id': sessionId! };
+
+        await fetch(url, {
+            method: 'POST',
+            headers: { ...baseHeaders, 'content-type': 'application/json' },
+            body: JSON.stringify({
+                jsonrpc: '2.0',
+                method: 'notifications/initialized',
+                params: {}
+            })
+        });
+
+        if (!serverRef) throw new Error('serverRef not set');
+
+        const getRes = await fetch(url, {
+            method: 'GET',
+            headers: { ...baseHeaders, accept: 'application/json, text/event-stream' }
+        });
+        expect(getRes.status).toBe(200);
+
+        const reader = getRes.body!.getReader();
+        const decoder = new TextDecoder();
+        let anchorBuf = '';
+
+        await serverRef.sendLoggingMessage({ level: 'info', data: 'anchor' });
+
+        try {
+            for (let i = 0; i < 32; i++) {
+                const { value, done } = await reader.read();
+                if (value) anchorBuf += decoder.decode(value, { stream: true });
+                const frames = parseSseFrames(anchorBuf);
+                if (frames.length >= 1) break;
+                if (done) break;
+            }
+        } finally {
+            await reader.cancel().catch(() => {});
+        }
+
+        const anchorFrames = parseSseFrames(anchorBuf);
+        expect(anchorFrames.length).toBeGreaterThanOrEqual(1);
+        const anchorId = anchorFrames[anchorFrames.length - 1].id;
+
+        await serverRef.sendLoggingMessage({ level: 'info', data: 'buffered-1' });
+        await serverRef.sendLoggingMessage({ level: 'warning', data: 'buffered-2' });
+        await serverRef.sendLoggingMessage({ level: 'error', data: 'buffered-3' });
+
+        const resumeRes = await fetch(url, {
+            method: 'GET',
+            headers: { ...baseHeaders, accept: 'application/json, text/event-stream', 'last-event-id': anchorId }
+        });
+        expect(resumeRes.status).toBe(200);
+
+        const resumeBody = await readSseFramesUntil(resumeRes.body!, 3);
+        const replayedFrames = parseSseFrames(resumeBody);
+        expect(replayedFrames.length).toBeGreaterThanOrEqual(3);
+
+        const logData = replayedFrames
+            .map(f => {
+                const msg = JSON.parse(f.data) as JSONRPCMessage;
+                if ('method' in msg && msg.method === 'notifications/message' && 'params' in msg) {
+                    const params = msg.params as { data: unknown };
+                    return params.data;
+                }
+                return undefined;
+            })
+            .filter((d): d is unknown => d !== undefined);
+
+        expect(logData.slice(0, 3)).toEqual(['buffered-1', 'buffered-2', 'buffered-3']);
+        expect(logData).not.toContain('anchor');
+    } finally {
+        await handle.close();
+    }
+});
+
+verifies('typescript:hosting:resume:bad-event-id', async (_args: TestArgs) => {
+    const UNMAPPABLE_EVENT_ID = 'evt-unmappable';
+    const THROWING_EVENT_ID = 'evt-replay-throws';
+
+    const scriptedEventStore: EventStore = {
+        async storeEvent(streamId) {
+            return `${streamId}_stored`;
+        },
+        async getStreamIdForEventId(eventId) {
+            if (eventId === UNMAPPABLE_EVENT_ID) return undefined;
+            if (eventId === THROWING_EVENT_ID) return 'stream-will-throw';
+            return undefined;
+        },
+        async replayEventsAfter(lastEventId) {
+            if (lastEventId === THROWING_EVENT_ID) {
+                throw new Error('boom: replay failed');
+            }
+            return 'unused-stream';
+        }
+    };
+
+    const makeServer = () => new McpServer({ name: 's', version: '0' });
+
+    const handle = hostResumable(makeServer, { eventStore: scriptedEventStore });
+
+    const url = new URL('http://in-process/mcp');
+    const fetch = (u: URL | string, init?: RequestInit) => handle.handleRequest(new Request(u, init));
+
+    const client = new Client({ name: 'c', version: '0' });
+    const transport = new StreamableHTTPClientTransport(url, { fetch });
+
+    try {
+        await client.connect(transport);
+
+        const sessionId = transport.sessionId!;
+        const baseHeaders = { 'mcp-session-id': sessionId };
+
+        const unmappedRes = await fetch(url, {
+            method: 'GET',
+            headers: { ...baseHeaders, accept: 'application/json, text/event-stream', 'last-event-id': UNMAPPABLE_EVENT_ID }
+        });
+        expect(unmappedRes.status).toBe(400);
+        const unmappedBody = await unmappedRes.json();
+        expect(unmappedBody.error?.code).toBe(-32000);
+
+        const failedRes = await fetch(url, {
+            method: 'GET',
+            headers: { ...baseHeaders, accept: 'application/json, text/event-stream', 'last-event-id': THROWING_EVENT_ID }
+        });
+        expect(failedRes.status).toBe(500);
+        const failedBody = await failedRes.json();
+        expect(failedBody.error?.code).toBe(-32000);
+    } finally {
+        await client.close();
+        await handle.close();
+    }
+});
+
+verifies('hosting:resume:priming', async (_args: TestArgs) => {
+    const RETRY_MS = 7331;
+    const eventStore = new InMemoryEventStore();
+
+    const makeServer = () => new McpServer({ name: 's', version: '0' });
+
+    const handle = hostResumable(makeServer, {
+        eventStore,
+        retryInterval: RETRY_MS
+    });
+
+    const url = new URL('http://in-process/mcp');
+    const fetch = (u: URL | string, init?: RequestInit) => handle.handleRequest(new Request(u, init));
+
+    try {
+        const { baseHeaders } = await completeHandshake(url, fetch);
+
+        const postRes = await fetch(url, {
+            method: 'POST',
+            headers: { ...baseHeaders, 'content-type': 'application/json', accept: 'application/json, text/event-stream' },
+            body: JSON.stringify({
+                jsonrpc: '2.0',
+                id: 'priming-probe',
+                method: 'tools/list',
+                params: {}
+            })
+        });
+
+        expect(postRes.status).toBe(200);
+        expect(postRes.headers.get('content-type')).toMatch(/text\/event-stream/);
+
+        const body = await readSseBody(postRes.body!);
+        const events = body.split('\n\n').filter(e => e.trim().length > 0);
+        expect(events.length).toBeGreaterThanOrEqual(2);
+
+        const priming = events[0];
+        const primingLines = priming.split('\n');
+
+        const idLine = primingLines.find(l => l.startsWith('id:'));
+        expect(idLine).toBeDefined();
+        expect(idLine!.slice('id:'.length).trim().length).toBeGreaterThan(0);
+
+        expect(primingLines).toContain(`retry: ${RETRY_MS}`);
+
+        const dataLine = primingLines.find(l => l.startsWith('data:'));
+        expect(dataLine).toBeDefined();
+        expect(dataLine!.replace(/^data:\s?/, '')).toBe('');
+
+        expect(priming).not.toMatch(/^event: message$/m);
+
+        const responseEvent = events.find(e => /^event: message$/m.test(e));
+        expect(responseEvent).toBeDefined();
+        expect(events.indexOf(responseEvent!)).toBeGreaterThan(0);
+    } finally {
+        await handle.close();
+    }
+});
+
+verifies('hosting:resume:stream-scoped', async (_args: TestArgs) => {
+    const eventStore = new InMemoryEventStore();
+
+    let serverRef: McpServer | undefined;
+
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' }, { capabilities: { logging: {} } });
+        s.registerTool('progress', { inputSchema: z.object({ steps: z.number().int().positive() }) }, async ({ steps }, extra) => {
+            const token = extra._meta?.progressToken;
+            if (token !== undefined) {
+                for (let i = 1; i <= steps; i++) {
+                    await extra.sendNotification({
+                        method: 'notifications/progress',
+                        params: { progressToken: token, progress: i, total: steps }
+                    });
+                }
+            }
+            return { content: [{ type: 'text', text: `done ${steps}` }] };
+        });
+        serverRef = s;
+        return s;
+    };
+
+    const handle = hostResumable(makeServer, { eventStore });
+
+    const url = new URL('http://in-process/mcp');
+    const fetch = (u: URL | string, init?: RequestInit) => handle.handleRequest(new Request(u, init));
+
+    try {
+        const initRes = await fetch(url, {
+            method: 'POST',
+            headers: { 'content-type': 'application/json', accept: 'application/json, text/event-stream' },
+            body: JSON.stringify({
+                jsonrpc: '2.0',
+                id: 'init-1',
+                method: 'initialize',
+                params: { protocolVersion: '2024-11-05', capabilities: { logging: {} }, clientInfo: { name: 'c', version: '0' } }
+            })
+        });
+        expect(initRes.status).toBe(200);
+        const sessionId = initRes.headers.get('mcp-session-id');
+        expect(sessionId).toBeTruthy();
+
+        await readSseBody(initRes.body!);
+
+        const baseHeaders = { 'mcp-session-id': sessionId! };
+
+        await fetch(url, {
+            method: 'POST',
+            headers: { ...baseHeaders, 'content-type': 'application/json' },
+            body: JSON.stringify({
+                jsonrpc: '2.0',
+                method: 'notifications/initialized',
+                params: {}
+            })
+        });
+
+        const getRes = await fetch(url, {
+            method: 'GET',
+            headers: { ...baseHeaders, accept: 'application/json, text/event-stream' }
+        });
+        expect(getRes.status).toBe(200);
+
+        const reader = getRes.body!.getReader();
+        const decoder = new TextDecoder();
+        let anchorBuf = '';
+
+        if (!serverRef) throw new Error('serverRef not set');
+        await serverRef.sendLoggingMessage({ level: 'info', data: 'anchor' });
+
+        try {
+            for (let i = 0; i < 32; i++) {
+                const { value, done } = await reader.read();
+                if (value) anchorBuf += decoder.decode(value, { stream: true });
+                const frames = parseSseFrames(anchorBuf);
+                if (frames.length >= 1) break;
+                if (done) break;
+            }
+        } finally {
+            await reader.cancel().catch(() => {});
+        }
+
+        const anchorFrames = parseSseFrames(anchorBuf);
+        expect(anchorFrames.length).toBeGreaterThanOrEqual(1);
+        const anchorId = anchorFrames[anchorFrames.length - 1].id;
+        const stored = eventStore.getStoredEvents();
+        const anchorEvent = stored.find(e => e.id === anchorId);
+        expect(anchorEvent).toBeDefined();
+        const streamAId = anchorEvent!.streamId;
+
+        const postRes = await fetch(url, {
+            method: 'POST',
+            headers: { ...baseHeaders, 'content-type': 'application/json', accept: 'application/json, text/event-stream' },
+            body: JSON.stringify({
+                jsonrpc: '2.0',
+                id: 'prog-1',
+                method: 'tools/call',
+                params: { name: 'progress', arguments: { steps: 2 }, _meta: { progressToken: 'prog-1' } }
+            })
+        });
+        expect(postRes.status).toBe(200);
+        await readSseBody(postRes.body!);
+
+        const storedAfterProgress = eventStore.getStoredEvents();
+        const streamBEvents = storedAfterProgress.filter(e => e.streamId !== streamAId);
+        expect(streamBEvents.length).toBeGreaterThan(0);
+
+        await serverRef.sendLoggingMessage({ level: 'info', data: 'after-1' });
+        await serverRef.sendLoggingMessage({ level: 'warning', data: 'after-2' });
+
+        const resumeRes = await fetch(url, {
+            method: 'GET',
+            headers: { ...baseHeaders, accept: 'application/json, text/event-stream', 'last-event-id': anchorId }
+        });
+        expect(resumeRes.status).toBe(200);
+
+        const resumeReader = resumeRes.body!.getReader();
+        const resumeDecoder = new TextDecoder();
+        let resumeBuf = '';
+        const readResumedUntil = async (haveEnough: (frames: ReturnType<typeof parseSseFrames>) => boolean) => {
+            for (let i = 0; i < 64 && !haveEnough(parseSseFrames(resumeBuf)); i++) {
+                const { value, done } = await resumeReader.read();
+                if (value) resumeBuf += resumeDecoder.decode(value, { stream: true });
+                if (done) break;
+            }
+            return parseSseFrames(resumeBuf);
+        };
+
+        try {
+            const replayedFrames = await readResumedUntil(frames => frames.length >= 2);
+            expect(replayedFrames.length).toBeGreaterThanOrEqual(2);
+
+            const replayedEvents = replayedFrames.map(f => ({
+                id: f.id,
+                message: JSON.parse(f.data) as JSONRPCMessage
+            }));
+
+            const storedFinal = eventStore.getStoredEvents();
+            const eventIdToStream = new Map(storedFinal.map(e => [e.id, e.streamId]));
+            for (const r of replayedEvents) {
+                expect(eventIdToStream.get(r.id)).toBe(streamAId);
+            }
+
+            const replayedMethods = replayedEvents
+                .map(r => ('method' in r.message ? r.message.method : undefined))
+                .filter((m): m is string => m !== undefined);
+            expect(replayedMethods).not.toContain('notifications/progress');
+
+            const logData = replayedEvents
+                .map(r => {
+                    if ('method' in r.message && r.message.method === 'notifications/message' && 'params' in r.message) {
+                        const params = r.message.params as { data: unknown };
+                        return params.data;
+                    }
+                    return undefined;
+                })
+                .filter((d): d is unknown => d !== undefined);
+            expect(logData.slice(0, 2)).toEqual(['after-1', 'after-2']);
+            expect(logData).not.toContain('anchor');
+
+            const livePostRes = await fetch(url, {
+                method: 'POST',
+                headers: { ...baseHeaders, 'content-type': 'application/json', accept: 'application/json, text/event-stream' },
+                body: JSON.stringify({
+                    jsonrpc: '2.0',
+                    id: 'live-1',
+                    method: 'tools/call',
+                    params: { name: 'progress', arguments: { steps: 2 }, _meta: { progressToken: 'live-1' } }
+                })
+            });
+            expect(livePostRes.status).toBe(200);
+            expect(livePostRes.headers.get('content-type')).toMatch(/text\/event-stream/);
+
+            const liveMessages = parseSseFrames(await readSseBody(livePostRes.body!))
+                .filter(f => f.data.trim().length > 0)
+                .map(f => JSON.parse(f.data) as JSONRPCMessage);
+            expect(liveMessages.filter(m => 'method' in m && m.method === 'notifications/progress')).toHaveLength(2);
+            expect(liveMessages.filter(m => 'id' in m && m.id === 'live-1')).toHaveLength(1);
+
+            await serverRef.sendLoggingMessage({ level: 'info', data: 'sentinel' });
+            const resumedFrames = await readResumedUntil(frames =>
+                frames.some(f => {
+                    const m = JSON.parse(f.data) as JSONRPCMessage;
+                    return 'method' in m && m.method === 'notifications/message' && (m.params as { data?: unknown })?.data === 'sentinel';
+                })
+            );
+            const resumedMessages = resumedFrames.map(f => JSON.parse(f.data) as JSONRPCMessage);
+            expect(
+                resumedMessages.some(
+                    m => 'method' in m && m.method === 'notifications/message' && (m.params as { data?: unknown })?.data === 'sentinel'
+                )
+            ).toBe(true);
+            expect(resumedMessages.filter(m => 'method' in m && m.method === 'notifications/progress')).toHaveLength(0);
+            expect(resumedMessages.filter(m => 'id' in m && m.id === 'live-1')).toHaveLength(0);
+        } finally {
+            await resumeReader.cancel().catch(() => {});
+        }
+    } finally {
+        await handle.close();
+    }
+});
+
+verifies('hosting:resume:close-stream', async (_args: TestArgs) => {
+    const eventStore = new InMemoryEventStore();
+
+    const hooksSeen: Array<{ closeRequestStream: boolean; closeStandalone: boolean }> = [];
+    let releaseTool: () => void = () => {};
+    const toolGate = new Promise<void>(resolve => {
+        releaseTool = resolve;
+    });
+
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool('generate-report', { inputSchema: z.object({}) }, async (_input, extra) => {
+            hooksSeen.push({
+                closeRequestStream: typeof extra.closeSSEStream === 'function',
+                closeStandalone: typeof extra.closeStandaloneSSEStream === 'function'
+            });
+            extra.closeStandaloneSSEStream?.();
+            extra.closeSSEStream?.();
+            await toolGate;
+            return { content: [{ type: 'text', text: 'report ready' }] };
+        });
+        return s;
+    };
+
+    const handle = hostResumable(makeServer, { eventStore });
+
+    const url = new URL('http://in-process/mcp');
+    const fetch = (u: URL | string, init?: RequestInit) => handle.handleRequest(new Request(u, init));
+
+    try {
+        const { baseHeaders } = await completeHandshake(url, fetch);
+
+        const standaloneRes = await fetch(url, {
+            method: 'GET',
+            headers: { ...baseHeaders, accept: 'application/json, text/event-stream' }
+        });
+        expect(standaloneRes.status).toBe(200);
+        expect(standaloneRes.headers.get('content-type')).toMatch(/text\/event-stream/);
+
+        const postRes = await fetch(url, {
+            method: 'POST',
+            headers: { ...baseHeaders, 'content-type': 'application/json', accept: 'application/json, text/event-stream' },
+            body: JSON.stringify({
+                jsonrpc: '2.0',
+                id: 'close-1',
+                method: 'tools/call',
+                params: { name: 'generate-report', arguments: {} }
+            })
+        });
+        expect(postRes.status).toBe(200);
+        expect(postRes.headers.get('content-type')).toMatch(/text\/event-stream/);
+
+        await vi.waitFor(() => expect(hooksSeen).toHaveLength(1));
+        expect(hooksSeen[0]).toEqual({ closeRequestStream: true, closeStandalone: true });
+
+        const postBody = await readSseBody(postRes.body!);
+        const standaloneBody = await readSseBody(standaloneRes.body!);
+
+        expect(standaloneBody).toBe('');
+        expect(postBody).not.toMatch(/^event: message$/m);
+
+        const primingIdMatch = postBody.match(/^id:\s*(.+)$/m);
+        expect(primingIdMatch?.[1]?.trim()).toBeTruthy();
+        const primingId = primingIdMatch![1].trim();
+
+        const resumeRes = await fetch(url, {
+            method: 'GET',
+            headers: { ...baseHeaders, accept: 'application/json, text/event-stream', 'last-event-id': primingId }
+        });
+        expect(resumeRes.status).toBe(200);
+        expect(resumeRes.headers.get('content-type')).toMatch(/text\/event-stream/);
+
+        releaseTool();
+
+        const resumeBody = await readSseBody(resumeRes.body!);
+        const resumeFrames = parseSseFrames(resumeBody);
+        expect(resumeFrames).toHaveLength(1);
+
+        const response: unknown = JSON.parse(resumeFrames[0].data);
+        expect(response).toMatchObject({
+            jsonrpc: '2.0',
+            id: 'close-1',
+            result: { content: [{ type: 'text', text: 'report ready' }] }
+        });
+    } finally {
+        releaseTool();
+        await handle.close();
+    }
+});

--- a/test/e2e/scenarios/hosting-resume.test.ts
+++ b/test/e2e/scenarios/hosting-resume.test.ts
@@ -6,14 +6,15 @@
  * parsing and raw GET requests drive resume scenarios.
  */
 
+import { Client, StreamableHTTPClientTransport } from '@modelcontextprotocol/client';
+import type { EventId, EventStore, JSONRPCMessage, StreamId } from '@modelcontextprotocol/server';
+import { LATEST_PROTOCOL_VERSION, McpServer, parseJSONRPCMessage } from '@modelcontextprotocol/server';
 import { expect, vi } from 'vitest';
 import { z } from 'zod/v4';
-import { McpServer, LATEST_PROTOCOL_VERSION } from '@modelcontextprotocol/server';
-import type { EventStore, EventId, StreamId, JSONRPCMessage } from '@modelcontextprotocol/server';
-import { Client, StreamableHTTPClientTransport } from '@modelcontextprotocol/client';
+
 import { hostResumable } from '../helpers/index.js';
-import type { TestArgs } from '../types.js';
 import { verifies } from '../helpers/verifies.js';
+import type { TestArgs } from '../types.js';
 
 /**
  * These three tests assert the raw frame sequence of the POST SSE stream itself, so they cannot run their traffic through a connected client.
@@ -89,10 +90,10 @@ class InMemoryEventStore implements EventStore {
         lastEventId: EventId,
         { send }: { send: (eventId: EventId, message: JSONRPCMessage) => Promise<void> }
     ): Promise<StreamId> {
-        const idx = this.events.findIndex(e => e.id === lastEventId);
-        if (idx < 0) return '';
-        const streamId = this.events[idx].streamId;
-        for (const e of this.events.slice(idx + 1)) {
+        const anchor = this.events.find(e => e.id === lastEventId);
+        if (!anchor) return '';
+        const streamId = anchor.streamId;
+        for (const e of this.events.slice(this.events.indexOf(anchor) + 1)) {
             if (e.streamId === streamId) await send(e.id, e.message);
         }
         return streamId;
@@ -119,6 +120,12 @@ function parseSseFrames(body: string): Array<{ id: string; data: string }> {
         }
     }
     return frames;
+}
+
+/** Narrow a Response's body for SSE reading. */
+function requireBody(res: Response): ReadableStream<Uint8Array> {
+    if (!res.body) throw new Error('Expected response to have a body');
+    return res.body;
 }
 
 /** Read an SSE Response body to completion. */
@@ -203,7 +210,7 @@ verifies('hosting:resume:event-ids', async (_args: TestArgs) => {
         expect(postRes.status).toBe(200);
         expect(postRes.headers.get('content-type')).toMatch(/text\/event-stream/);
 
-        const postBody = await readSseBody(postRes.body!);
+        const postBody = await readSseBody(requireBody(postRes));
 
         const postBlocks = postBody.split(/\r?\n\r?\n/).filter(b => b.trim().length > 0);
         expect(postBlocks).toHaveLength(5);
@@ -213,7 +220,7 @@ verifies('hosting:resume:event-ids', async (_args: TestArgs) => {
         const postMessages = postBlocks
             .map(b => b.match(/^data: (.+)$/m)?.[1])
             .filter((d): d is string => d !== undefined && d.trim().length > 0)
-            .map(d => JSON.parse(d) as JSONRPCMessage);
+            .map(d => parseJSONRPCMessage(JSON.parse(d)));
         expect(postMessages.filter(m => 'method' in m && m.method === 'notifications/progress')).toHaveLength(3);
         expect(postMessages.filter(m => 'id' in m && m.id === 'evt-1')).toHaveLength(1);
 
@@ -227,7 +234,7 @@ verifies('hosting:resume:event-ids', async (_args: TestArgs) => {
         await serverRef.sendLoggingMessage({ level: 'info', data: 'standalone-1' });
         await serverRef.sendLoggingMessage({ level: 'warning', data: 'standalone-2' });
 
-        const getBuf = await readSseFramesUntil(getRes.body!, 2);
+        const getBuf = await readSseFramesUntil(requireBody(getRes), 2);
 
         const getBlocks = getBuf.split(/\r?\n\r?\n/).filter(b => b.trim().length > 0);
         expect(getBlocks).toHaveLength(2);
@@ -274,7 +281,8 @@ verifies('hosting:resume:replay', async (_args: TestArgs) => {
     try {
         await client.connect(transport);
 
-        const sessionId = transport.sessionId!;
+        const sessionId = transport.sessionId;
+        if (!sessionId) throw new Error('No session ID after connect');
         const baseHeaders = { 'mcp-session-id': sessionId };
 
         const postRes = await fetch(url, {
@@ -288,12 +296,14 @@ verifies('hosting:resume:replay', async (_args: TestArgs) => {
             })
         });
         expect(postRes.status).toBe(200);
-        const postBody = await readSseBody(postRes.body!);
+        const postBody = await readSseBody(requireBody(postRes));
         const originalFrames = parseSseFrames(postBody);
         expect(originalFrames.length).toBeGreaterThanOrEqual(2);
 
-        const anchorId = originalFrames[0].id;
-        const expectedAfterIds = originalFrames.slice(1).map(f => f.id);
+        const [anchorFrame, ...framesAfterAnchor] = originalFrames;
+        if (!anchorFrame) throw new Error('No anchor frame in POST SSE body');
+        const anchorId = anchorFrame.id;
+        const expectedAfterIds = framesAfterAnchor.map(f => f.id);
 
         const resumeRes = await fetch(url, {
             method: 'GET',
@@ -302,7 +312,7 @@ verifies('hosting:resume:replay', async (_args: TestArgs) => {
         expect(resumeRes.status).toBe(200);
         expect(resumeRes.headers.get('content-type')).toMatch(/text\/event-stream/);
 
-        const resumeBody = await readSseFramesUntil(resumeRes.body!, expectedAfterIds.length);
+        const resumeBody = await readSseFramesUntil(requireBody(resumeRes), expectedAfterIds.length);
         const replayedFrames = parseSseFrames(resumeBody);
         const replayedIds = replayedFrames.map(f => f.id);
 
@@ -310,7 +320,7 @@ verifies('hosting:resume:replay', async (_args: TestArgs) => {
         expect(replayedIds).not.toContain(anchorId);
 
         for (const f of replayedFrames) {
-            const msg = JSON.parse(f.data) as JSONRPCMessage;
+            const msg: unknown = JSON.parse(f.data);
             expect(msg).toHaveProperty('jsonrpc', '2.0');
         }
     } finally {
@@ -349,10 +359,11 @@ verifies('hosting:resume:buffered-replay', async (_args: TestArgs) => {
         expect(initRes.status).toBe(200);
         const sessionId = initRes.headers.get('mcp-session-id');
         expect(sessionId).toBeTruthy();
+        if (!sessionId) throw new Error('No session ID in initialize response');
 
-        await readSseBody(initRes.body!);
+        await readSseBody(requireBody(initRes));
 
-        const baseHeaders = { 'mcp-session-id': sessionId! };
+        const baseHeaders = { 'mcp-session-id': sessionId };
 
         await fetch(url, {
             method: 'POST',
@@ -372,7 +383,7 @@ verifies('hosting:resume:buffered-replay', async (_args: TestArgs) => {
         });
         expect(getRes.status).toBe(200);
 
-        const reader = getRes.body!.getReader();
+        const reader = requireBody(getRes).getReader();
         const decoder = new TextDecoder();
         let anchorBuf = '';
 
@@ -383,7 +394,7 @@ verifies('hosting:resume:buffered-replay', async (_args: TestArgs) => {
                 const { value, done } = await reader.read();
                 if (value) anchorBuf += decoder.decode(value, { stream: true });
                 const frames = parseSseFrames(anchorBuf);
-                if (frames.length >= 1) break;
+                if (frames.length > 0) break;
                 if (done) break;
             }
         } finally {
@@ -392,7 +403,9 @@ verifies('hosting:resume:buffered-replay', async (_args: TestArgs) => {
 
         const anchorFrames = parseSseFrames(anchorBuf);
         expect(anchorFrames.length).toBeGreaterThanOrEqual(1);
-        const anchorId = anchorFrames[anchorFrames.length - 1].id;
+        const lastAnchorFrame = anchorFrames.at(-1);
+        if (!lastAnchorFrame) throw new Error('No anchor frame on the standalone GET stream');
+        const anchorId = lastAnchorFrame.id;
 
         await serverRef.sendLoggingMessage({ level: 'info', data: 'buffered-1' });
         await serverRef.sendLoggingMessage({ level: 'warning', data: 'buffered-2' });
@@ -404,20 +417,19 @@ verifies('hosting:resume:buffered-replay', async (_args: TestArgs) => {
         });
         expect(resumeRes.status).toBe(200);
 
-        const resumeBody = await readSseFramesUntil(resumeRes.body!, 3);
+        const resumeBody = await readSseFramesUntil(requireBody(resumeRes), 3);
         const replayedFrames = parseSseFrames(resumeBody);
         expect(replayedFrames.length).toBeGreaterThanOrEqual(3);
 
         const logData = replayedFrames
             .map(f => {
-                const msg = JSON.parse(f.data) as JSONRPCMessage;
-                if ('method' in msg && msg.method === 'notifications/message' && 'params' in msg) {
-                    const params = msg.params as { data: unknown };
-                    return params.data;
+                const msg = parseJSONRPCMessage(JSON.parse(f.data));
+                if ('method' in msg && msg.method === 'notifications/message') {
+                    return msg.params?.data;
                 }
-                return undefined;
+                return;
             })
-            .filter((d): d is unknown => d !== undefined);
+            .filter(d => d !== undefined);
 
         expect(logData.slice(0, 3)).toEqual(['buffered-1', 'buffered-2', 'buffered-3']);
         expect(logData).not.toContain('anchor');
@@ -435,9 +447,9 @@ verifies('typescript:hosting:resume:bad-event-id', async (_args: TestArgs) => {
             return `${streamId}_stored`;
         },
         async getStreamIdForEventId(eventId) {
-            if (eventId === UNMAPPABLE_EVENT_ID) return undefined;
+            if (eventId === UNMAPPABLE_EVENT_ID) return;
             if (eventId === THROWING_EVENT_ID) return 'stream-will-throw';
-            return undefined;
+            return;
         },
         async replayEventsAfter(lastEventId) {
             if (lastEventId === THROWING_EVENT_ID) {
@@ -460,7 +472,8 @@ verifies('typescript:hosting:resume:bad-event-id', async (_args: TestArgs) => {
     try {
         await client.connect(transport);
 
-        const sessionId = transport.sessionId!;
+        const sessionId = transport.sessionId;
+        if (!sessionId) throw new Error('No session ID after connect');
         const baseHeaders = { 'mcp-session-id': sessionId };
 
         const unmappedRes = await fetch(url, {
@@ -468,16 +481,16 @@ verifies('typescript:hosting:resume:bad-event-id', async (_args: TestArgs) => {
             headers: { ...baseHeaders, accept: 'application/json, text/event-stream', 'last-event-id': UNMAPPABLE_EVENT_ID }
         });
         expect(unmappedRes.status).toBe(400);
-        const unmappedBody = await unmappedRes.json();
-        expect(unmappedBody.error?.code).toBe(-32000);
+        const unmappedBody: unknown = await unmappedRes.json();
+        expect(unmappedBody).toMatchObject({ error: { code: -32_000 } });
 
         const failedRes = await fetch(url, {
             method: 'GET',
             headers: { ...baseHeaders, accept: 'application/json, text/event-stream', 'last-event-id': THROWING_EVENT_ID }
         });
         expect(failedRes.status).toBe(500);
-        const failedBody = await failedRes.json();
-        expect(failedBody.error?.code).toBe(-32000);
+        const failedBody: unknown = await failedRes.json();
+        expect(failedBody).toMatchObject({ error: { code: -32_000 } });
     } finally {
         await client.close();
         await handle.close();
@@ -515,28 +528,32 @@ verifies('hosting:resume:priming', async (_args: TestArgs) => {
         expect(postRes.status).toBe(200);
         expect(postRes.headers.get('content-type')).toMatch(/text\/event-stream/);
 
-        const body = await readSseBody(postRes.body!);
+        const body = await readSseBody(requireBody(postRes));
         const events = body.split('\n\n').filter(e => e.trim().length > 0);
         expect(events.length).toBeGreaterThanOrEqual(2);
 
         const priming = events[0];
+        if (priming === undefined) throw new Error('No priming event block in POST SSE body');
         const primingLines = priming.split('\n');
 
         const idLine = primingLines.find(l => l.startsWith('id:'));
         expect(idLine).toBeDefined();
-        expect(idLine!.slice('id:'.length).trim().length).toBeGreaterThan(0);
+        if (idLine === undefined) throw new Error('No id line in priming event');
+        expect(idLine.slice('id:'.length).trim().length).toBeGreaterThan(0);
 
         expect(primingLines).toContain(`retry: ${RETRY_MS}`);
 
         const dataLine = primingLines.find(l => l.startsWith('data:'));
         expect(dataLine).toBeDefined();
-        expect(dataLine!.replace(/^data:\s?/, '')).toBe('');
+        if (dataLine === undefined) throw new Error('No data line in priming event');
+        expect(dataLine.replace(/^data:\s?/, '')).toBe('');
 
         expect(priming).not.toMatch(/^event: message$/m);
 
         const responseEvent = events.find(e => /^event: message$/m.test(e));
         expect(responseEvent).toBeDefined();
-        expect(events.indexOf(responseEvent!)).toBeGreaterThan(0);
+        if (responseEvent === undefined) throw new Error('No response event in POST SSE body');
+        expect(events.indexOf(responseEvent)).toBeGreaterThan(0);
     } finally {
         await handle.close();
     }
@@ -584,10 +601,11 @@ verifies('hosting:resume:stream-scoped', async (_args: TestArgs) => {
         expect(initRes.status).toBe(200);
         const sessionId = initRes.headers.get('mcp-session-id');
         expect(sessionId).toBeTruthy();
+        if (!sessionId) throw new Error('No session ID in initialize response');
 
-        await readSseBody(initRes.body!);
+        await readSseBody(requireBody(initRes));
 
-        const baseHeaders = { 'mcp-session-id': sessionId! };
+        const baseHeaders = { 'mcp-session-id': sessionId };
 
         await fetch(url, {
             method: 'POST',
@@ -605,7 +623,7 @@ verifies('hosting:resume:stream-scoped', async (_args: TestArgs) => {
         });
         expect(getRes.status).toBe(200);
 
-        const reader = getRes.body!.getReader();
+        const reader = requireBody(getRes).getReader();
         const decoder = new TextDecoder();
         let anchorBuf = '';
 
@@ -617,7 +635,7 @@ verifies('hosting:resume:stream-scoped', async (_args: TestArgs) => {
                 const { value, done } = await reader.read();
                 if (value) anchorBuf += decoder.decode(value, { stream: true });
                 const frames = parseSseFrames(anchorBuf);
-                if (frames.length >= 1) break;
+                if (frames.length > 0) break;
                 if (done) break;
             }
         } finally {
@@ -626,11 +644,14 @@ verifies('hosting:resume:stream-scoped', async (_args: TestArgs) => {
 
         const anchorFrames = parseSseFrames(anchorBuf);
         expect(anchorFrames.length).toBeGreaterThanOrEqual(1);
-        const anchorId = anchorFrames[anchorFrames.length - 1].id;
+        const lastAnchorFrame = anchorFrames.at(-1);
+        if (!lastAnchorFrame) throw new Error('No anchor frame on the standalone GET stream');
+        const anchorId = lastAnchorFrame.id;
         const stored = eventStore.getStoredEvents();
         const anchorEvent = stored.find(e => e.id === anchorId);
         expect(anchorEvent).toBeDefined();
-        const streamAId = anchorEvent!.streamId;
+        if (!anchorEvent) throw new Error('Anchor event not found in event store');
+        const streamAId = anchorEvent.streamId;
 
         const postRes = await fetch(url, {
             method: 'POST',
@@ -643,7 +664,7 @@ verifies('hosting:resume:stream-scoped', async (_args: TestArgs) => {
             })
         });
         expect(postRes.status).toBe(200);
-        await readSseBody(postRes.body!);
+        await readSseBody(requireBody(postRes));
 
         const storedAfterProgress = eventStore.getStoredEvents();
         const streamBEvents = storedAfterProgress.filter(e => e.streamId !== streamAId);
@@ -658,7 +679,7 @@ verifies('hosting:resume:stream-scoped', async (_args: TestArgs) => {
         });
         expect(resumeRes.status).toBe(200);
 
-        const resumeReader = resumeRes.body!.getReader();
+        const resumeReader = requireBody(resumeRes).getReader();
         const resumeDecoder = new TextDecoder();
         let resumeBuf = '';
         const readResumedUntil = async (haveEnough: (frames: ReturnType<typeof parseSseFrames>) => boolean) => {
@@ -676,7 +697,7 @@ verifies('hosting:resume:stream-scoped', async (_args: TestArgs) => {
 
             const replayedEvents = replayedFrames.map(f => ({
                 id: f.id,
-                message: JSON.parse(f.data) as JSONRPCMessage
+                message: parseJSONRPCMessage(JSON.parse(f.data))
             }));
 
             const storedFinal = eventStore.getStoredEvents();
@@ -692,13 +713,12 @@ verifies('hosting:resume:stream-scoped', async (_args: TestArgs) => {
 
             const logData = replayedEvents
                 .map(r => {
-                    if ('method' in r.message && r.message.method === 'notifications/message' && 'params' in r.message) {
-                        const params = r.message.params as { data: unknown };
-                        return params.data;
+                    if ('method' in r.message && r.message.method === 'notifications/message') {
+                        return r.message.params?.data;
                     }
-                    return undefined;
+                    return;
                 })
-                .filter((d): d is unknown => d !== undefined);
+                .filter(d => d !== undefined);
             expect(logData.slice(0, 2)).toEqual(['after-1', 'after-2']);
             expect(logData).not.toContain('anchor');
 
@@ -715,25 +735,24 @@ verifies('hosting:resume:stream-scoped', async (_args: TestArgs) => {
             expect(livePostRes.status).toBe(200);
             expect(livePostRes.headers.get('content-type')).toMatch(/text\/event-stream/);
 
-            const liveMessages = parseSseFrames(await readSseBody(livePostRes.body!))
+            const livePostBody = await readSseBody(requireBody(livePostRes));
+            const liveMessages = parseSseFrames(livePostBody)
                 .filter(f => f.data.trim().length > 0)
-                .map(f => JSON.parse(f.data) as JSONRPCMessage);
+                .map(f => parseJSONRPCMessage(JSON.parse(f.data)));
             expect(liveMessages.filter(m => 'method' in m && m.method === 'notifications/progress')).toHaveLength(2);
             expect(liveMessages.filter(m => 'id' in m && m.id === 'live-1')).toHaveLength(1);
 
             await serverRef.sendLoggingMessage({ level: 'info', data: 'sentinel' });
             const resumedFrames = await readResumedUntil(frames =>
                 frames.some(f => {
-                    const m = JSON.parse(f.data) as JSONRPCMessage;
-                    return 'method' in m && m.method === 'notifications/message' && (m.params as { data?: unknown })?.data === 'sentinel';
+                    const m = parseJSONRPCMessage(JSON.parse(f.data));
+                    return 'method' in m && m.method === 'notifications/message' && m.params?.data === 'sentinel';
                 })
             );
-            const resumedMessages = resumedFrames.map(f => JSON.parse(f.data) as JSONRPCMessage);
-            expect(
-                resumedMessages.some(
-                    m => 'method' in m && m.method === 'notifications/message' && (m.params as { data?: unknown })?.data === 'sentinel'
-                )
-            ).toBe(true);
+            const resumedMessages = resumedFrames.map(f => parseJSONRPCMessage(JSON.parse(f.data)));
+            expect(resumedMessages.some(m => 'method' in m && m.method === 'notifications/message' && m.params?.data === 'sentinel')).toBe(
+                true
+            );
             expect(resumedMessages.filter(m => 'method' in m && m.method === 'notifications/progress')).toHaveLength(0);
             expect(resumedMessages.filter(m => 'id' in m && m.id === 'live-1')).toHaveLength(0);
         } finally {
@@ -799,15 +818,15 @@ verifies('hosting:resume:close-stream', async (_args: TestArgs) => {
         await vi.waitFor(() => expect(hooksSeen).toHaveLength(1));
         expect(hooksSeen[0]).toEqual({ closeRequestStream: true, closeStandalone: true });
 
-        const postBody = await readSseBody(postRes.body!);
-        const standaloneBody = await readSseBody(standaloneRes.body!);
+        const postBody = await readSseBody(requireBody(postRes));
+        const standaloneBody = await readSseBody(requireBody(standaloneRes));
 
         expect(standaloneBody).toBe('');
         expect(postBody).not.toMatch(/^event: message$/m);
 
-        const primingIdMatch = postBody.match(/^id:\s*(.+)$/m);
-        expect(primingIdMatch?.[1]?.trim()).toBeTruthy();
-        const primingId = primingIdMatch![1].trim();
+        const primingId = postBody.match(/^id:\s*(.+)$/m)?.[1]?.trim();
+        expect(primingId).toBeTruthy();
+        if (!primingId) throw new Error('No priming event id in POST SSE body');
 
         const resumeRes = await fetch(url, {
             method: 'GET',
@@ -818,11 +837,13 @@ verifies('hosting:resume:close-stream', async (_args: TestArgs) => {
 
         releaseTool();
 
-        const resumeBody = await readSseBody(resumeRes.body!);
+        const resumeBody = await readSseBody(requireBody(resumeRes));
         const resumeFrames = parseSseFrames(resumeBody);
         expect(resumeFrames).toHaveLength(1);
 
-        const response: unknown = JSON.parse(resumeFrames[0].data);
+        const resumeFrame = resumeFrames[0];
+        if (!resumeFrame) throw new Error('No frames on the resumed stream');
+        const response: unknown = JSON.parse(resumeFrame.data);
         expect(response).toMatchObject({
             jsonrpc: '2.0',
             id: 'close-1',

--- a/test/e2e/scenarios/hosting-resume.test.ts
+++ b/test/e2e/scenarios/hosting-resume.test.ts
@@ -8,16 +8,11 @@
 
 import { expect, vi } from 'vitest';
 import { z } from 'zod/v4';
-
-import { Client } from '../../../src/client/index.js';
-import { StreamableHTTPClientTransport } from '../../../src/client/streamableHttp.js';
-import type { EventStore, EventId, StreamId } from '../../../src/server/webStandardStreamableHttp.js';
-import { McpServer } from '../../../src/server/mcp.js';
-import type { JSONRPCMessage } from '../../../src/types.js';
-
+import { McpServer, LATEST_PROTOCOL_VERSION } from '@modelcontextprotocol/server';
+import type { EventStore, EventId, StreamId, JSONRPCMessage } from '@modelcontextprotocol/server';
+import { Client, StreamableHTTPClientTransport } from '@modelcontextprotocol/client';
 import { hostResumable } from '../helpers/index.js';
 import type { TestArgs } from '../types.js';
-import { LATEST_PROTOCOL_VERSION } from '../../../src/types.js';
 import { verifies } from '../helpers/verifies.js';
 
 /**
@@ -169,11 +164,11 @@ verifies('hosting:resume:event-ids', async (_args: TestArgs) => {
 
     const makeServer = () => {
         const s = new McpServer({ name: 's', version: '0' }, { capabilities: { logging: {} } });
-        s.registerTool('progress', { inputSchema: z.object({ steps: z.number().int().positive() }) }, async ({ steps }, extra) => {
-            const token = extra._meta?.progressToken;
+        s.registerTool('progress', { inputSchema: z.object({ steps: z.number().int().positive() }) }, async ({ steps }, ctx) => {
+            const token = ctx.mcpReq._meta?.progressToken;
             if (token !== undefined) {
                 for (let i = 1; i <= steps; i++) {
-                    await extra.sendNotification({
+                    await ctx.mcpReq.notify({
                         method: 'notifications/progress',
                         params: { progressToken: token, progress: i, total: steps }
                     });
@@ -253,11 +248,11 @@ verifies('hosting:resume:replay', async (_args: TestArgs) => {
 
     const makeServer = () => {
         const s = new McpServer({ name: 's', version: '0' });
-        s.registerTool('progress', { inputSchema: z.object({ steps: z.number().int().positive() }) }, async ({ steps }, extra) => {
-            const token = extra._meta?.progressToken;
+        s.registerTool('progress', { inputSchema: z.object({ steps: z.number().int().positive() }) }, async ({ steps }, ctx) => {
+            const token = ctx.mcpReq._meta?.progressToken;
             if (token !== undefined) {
                 for (let i = 1; i <= steps; i++) {
-                    await extra.sendNotification({
+                    await ctx.mcpReq.notify({
                         method: 'notifications/progress',
                         params: { progressToken: token, progress: i, total: steps }
                     });
@@ -554,11 +549,11 @@ verifies('hosting:resume:stream-scoped', async (_args: TestArgs) => {
 
     const makeServer = () => {
         const s = new McpServer({ name: 's', version: '0' }, { capabilities: { logging: {} } });
-        s.registerTool('progress', { inputSchema: z.object({ steps: z.number().int().positive() }) }, async ({ steps }, extra) => {
-            const token = extra._meta?.progressToken;
+        s.registerTool('progress', { inputSchema: z.object({ steps: z.number().int().positive() }) }, async ({ steps }, ctx) => {
+            const token = ctx.mcpReq._meta?.progressToken;
             if (token !== undefined) {
                 for (let i = 1; i <= steps; i++) {
-                    await extra.sendNotification({
+                    await ctx.mcpReq.notify({
                         method: 'notifications/progress',
                         params: { progressToken: token, progress: i, total: steps }
                     });
@@ -760,13 +755,13 @@ verifies('hosting:resume:close-stream', async (_args: TestArgs) => {
 
     const makeServer = () => {
         const s = new McpServer({ name: 's', version: '0' });
-        s.registerTool('generate-report', { inputSchema: z.object({}) }, async (_input, extra) => {
+        s.registerTool('generate-report', { inputSchema: z.object({}) }, async (_input, ctx) => {
             hooksSeen.push({
-                closeRequestStream: typeof extra.closeSSEStream === 'function',
-                closeStandalone: typeof extra.closeStandaloneSSEStream === 'function'
+                closeRequestStream: typeof ctx.http?.closeSSE === 'function',
+                closeStandalone: typeof ctx.http?.closeStandaloneSSE === 'function'
             });
-            extra.closeStandaloneSSEStream?.();
-            extra.closeSSEStream?.();
+            ctx.http?.closeStandaloneSSE?.();
+            ctx.http?.closeSSE?.();
             await toolGate;
             return { content: [{ type: 'text', text: 'report ready' }] };
         });

--- a/test/e2e/scenarios/hosting-session.test.ts
+++ b/test/e2e/scenarios/hosting-session.test.ts
@@ -1,0 +1,885 @@
+/**
+ * Self-contained test bodies for the hosting-session surface.
+ *
+ * These tests exercise HTTP server-side semantics: session management
+ * (create/reuse/delete), CORS headers, stateless vs. stateful hosting,
+ * and in-flight request cancellation. Most tests build the hosting layer
+ * directly with `hostPerSession()` or `hostStateless()` from helpers and
+ * drive it with raw HTTP (new Request(...)) to assert status codes and
+ * headers.
+ */
+
+import { randomUUID } from 'node:crypto';
+
+import cors from 'cors';
+import express from 'express';
+import { expect, vi } from 'vitest';
+import { z } from 'zod/v4';
+
+import { Client } from '../../../src/client/index.js';
+import { StreamableHTTPClientTransport } from '../../../src/client/streamableHttp.js';
+import { McpServer } from '../../../src/server/mcp.js';
+import { StreamableHTTPServerTransport } from '../../../src/server/streamableHttp.js';
+import { WebStandardStreamableHTTPServerTransport } from '../../../src/server/webStandardStreamableHttp.js';
+import { CreateMessageRequestSchema, LATEST_PROTOCOL_VERSION } from '../../../src/types.js';
+
+import { startExpressMinimal } from '../helpers/express.js';
+import { hostPerSession, hostStateless, wire } from '../helpers/index.js';
+import type { TestArgs } from '../types.js';
+import { verifies } from '../helpers/verifies.js';
+
+const newClient = () => new Client({ name: 'c', version: '0' });
+
+function echoServer(): McpServer {
+    const s = new McpServer({ name: 's', version: '0' });
+    s.registerTool(
+        'echo',
+        { description: 'Echoes the input text back as a text content block.', inputSchema: z.object({ text: z.string() }) },
+        ({ text }) => ({ content: [{ type: 'text', text }] })
+    );
+    return s;
+}
+
+verifies('hosting:session:create', async (_args: TestArgs) => {
+    const initializedSessions: string[] = [];
+    const server = echoServer();
+    const tx = new WebStandardStreamableHTTPServerTransport({
+        sessionIdGenerator: randomUUID,
+        onsessioninitialized: id => void initializedSessions.push(id)
+    });
+    await server.connect(tx);
+    const url = new URL('http://in-process/mcp');
+
+    try {
+        const res = await tx.handleRequest(
+            new Request(url, {
+                method: 'POST',
+                headers: {
+                    'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+                    'content-type': 'application/json',
+                    accept: 'application/json, text/event-stream'
+                },
+                body: JSON.stringify({
+                    jsonrpc: '2.0',
+                    id: 1,
+                    method: 'initialize',
+                    params: { protocolVersion: LATEST_PROTOCOL_VERSION, capabilities: {}, clientInfo: { name: 'c', version: '0' } }
+                })
+            })
+        );
+        expect(res.status).toBe(200);
+
+        const sessionId = res.headers.get('mcp-session-id');
+        if (sessionId === null) throw new Error('initialize response is missing the mcp-session-id header');
+        expect(sessionId).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+        expect(initializedSessions).toEqual([sessionId]);
+    } finally {
+        await server.close();
+    }
+});
+
+verifies('hosting:session:cors-expose', async (_args: TestArgs) => {
+    const browserOrigin = 'http://dashboard.example.com';
+    const servers: McpServer[] = [];
+
+    // The transport sets no CORS headers itself; the documented hosting layer is cors() with exposedHeaders.
+    const router = express.Router();
+    router.use(cors({ origin: browserOrigin, exposedHeaders: ['Mcp-Session-Id'] }));
+    router.post('/mcp', async (req, res) => {
+        const tx = new StreamableHTTPServerTransport({ sessionIdGenerator: randomUUID });
+        const server = echoServer();
+        await server.connect(tx);
+        servers.push(server);
+        await tx.handleRequest(req, res, req.body);
+    });
+
+    await using host = await startExpressMinimal(router);
+
+    try {
+        const res = await fetch(new URL('/mcp', host.baseUrl), {
+            method: 'POST',
+            headers: {
+                origin: browserOrigin,
+                'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+                'content-type': 'application/json',
+                accept: 'application/json, text/event-stream'
+            },
+            body: JSON.stringify({
+                jsonrpc: '2.0',
+                id: 1,
+                method: 'initialize',
+                params: { protocolVersion: LATEST_PROTOCOL_VERSION, capabilities: {}, clientInfo: { name: 'c', version: '0' } }
+            })
+        });
+
+        expect(res.status).toBe(200);
+        expect(res.headers.get('mcp-session-id')).not.toBeNull();
+        expect(res.headers.get('access-control-allow-origin')).toBe(browserOrigin);
+
+        const exposeHeaders = res.headers.get('access-control-expose-headers');
+        if (exposeHeaders === null) throw new Error('initialize response is missing the access-control-expose-headers header');
+        expect(exposeHeaders.toLowerCase()).toContain('mcp-session-id');
+
+        await res.text();
+    } finally {
+        for (const server of servers) await server.close();
+    }
+});
+
+verifies('hosting:session:reuse', async (_args: TestArgs) => {
+    const host = hostPerSession(() => echoServer());
+    const url = new URL('http://in-process/mcp');
+    const fetch = (u: URL | string, init?: RequestInit) => host.handleRequest(new Request(u, init));
+
+    const client = newClient();
+    await client.connect(new StreamableHTTPClientTransport(url, { fetch }));
+
+    const sessionId = (client.transport as StreamableHTTPClientTransport).sessionId;
+    expect(sessionId).toBeDefined();
+    expect(typeof sessionId).toBe('string');
+
+    const r1 = await client.listTools();
+    expect(r1.tools.map(t => t.name)).toContain('echo');
+
+    const r2 = await client.callTool({ name: 'echo', arguments: { text: 'reuse-test' } });
+    expect(r2.content).toEqual([{ type: 'text', text: 'reuse-test' }]);
+
+    const stillSameSession = (client.transport as StreamableHTTPClientTransport).sessionId;
+    expect(stillSameSession).toBe(sessionId);
+
+    await client.close();
+    await host.close();
+});
+
+verifies('hosting:session:unknown-id', async (_args: TestArgs) => {
+    const { handleRequest, close } = hostPerSession(echoServer);
+    try {
+        const init = await handleRequest(
+            new Request('http://in-process/mcp', {
+                method: 'POST',
+                headers: { 'content-type': 'application/json', accept: 'application/json, text/event-stream' },
+                body: JSON.stringify({
+                    jsonrpc: '2.0',
+                    id: 1,
+                    method: 'initialize',
+                    params: { protocolVersion: LATEST_PROTOCOL_VERSION, capabilities: {}, clientInfo: { name: 'c', version: '0' } }
+                })
+            })
+        );
+        expect(init.status).toBe(200);
+
+        const unknownId = randomUUID();
+        const headers = {
+            'mcp-session-id': unknownId,
+            'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+            'content-type': 'application/json',
+            accept: 'application/json, text/event-stream'
+        };
+        const post = await handleRequest(
+            new Request('http://in-process/mcp', {
+                method: 'POST',
+                headers,
+                body: JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} })
+            })
+        );
+        expect(post.status).toBe(404);
+
+        const get = await handleRequest(new Request('http://in-process/mcp', { method: 'GET', headers }));
+        expect(get.status).toBe(404);
+
+        const del = await handleRequest(new Request('http://in-process/mcp', { method: 'DELETE', headers }));
+        expect(del.status).toBe(404);
+    } finally {
+        await close();
+    }
+});
+
+verifies('hosting:session:missing-id', async (_args: TestArgs) => {
+    // Initialize the transport first so the missing-header branch is hit, not the uninitialized-server branch.
+    const server = echoServer();
+    const tx = new WebStandardStreamableHTTPServerTransport({ sessionIdGenerator: randomUUID });
+    await server.connect(tx);
+    const url = new URL('http://in-process/mcp');
+    const headers = {
+        'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+        'content-type': 'application/json',
+        accept: 'application/json, text/event-stream'
+    };
+
+    try {
+        const initRes = await tx.handleRequest(
+            new Request(url, {
+                method: 'POST',
+                headers,
+                body: JSON.stringify({
+                    jsonrpc: '2.0',
+                    id: 1,
+                    method: 'initialize',
+                    params: { protocolVersion: LATEST_PROTOCOL_VERSION, capabilities: {}, clientInfo: { name: 'c', version: '0' } }
+                })
+            })
+        );
+        expect(initRes.status).toBe(200);
+        expect(initRes.headers.get('mcp-session-id')).not.toBeNull();
+
+        const res = await tx.handleRequest(
+            new Request(url, {
+                method: 'POST',
+                headers,
+                body: JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} })
+            })
+        );
+        expect(res.status).toBe(400);
+
+        const body = (await res.json()) as { error?: { code?: number; message?: string } };
+        expect(body.error?.code).toBe(-32000);
+        expect(body.error?.message).toBe('Bad Request: Mcp-Session-Id header is required');
+    } finally {
+        await server.close();
+    }
+});
+
+verifies('hosting:session:delete', async (_args: TestArgs) => {
+    // hostPerSession owns its session callbacks, so build the per-session map inline to observe onsessionclosed.
+    const closedSessions: string[] = [];
+    const sessions = new Map<string, WebStandardStreamableHTTPServerTransport>();
+    const handle = async (req: Request): Promise<Response> => {
+        const sid = req.headers.get('mcp-session-id');
+        const existing = sid ? sessions.get(sid) : undefined;
+        if (existing) return existing.handleRequest(req);
+
+        const tx = new WebStandardStreamableHTTPServerTransport({
+            sessionIdGenerator: randomUUID,
+            onsessioninitialized: id => void sessions.set(id, tx),
+            onsessionclosed: id => {
+                closedSessions.push(id);
+                sessions.delete(id);
+            }
+        });
+        await echoServer().connect(tx);
+        return tx.handleRequest(req);
+    };
+
+    const url = new URL('http://in-process/mcp');
+    const headers = {
+        'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+        'content-type': 'application/json',
+        accept: 'application/json, text/event-stream'
+    };
+
+    try {
+        const initRes = await handle(
+            new Request(url, {
+                method: 'POST',
+                headers,
+                body: JSON.stringify({
+                    jsonrpc: '2.0',
+                    id: 1,
+                    method: 'initialize',
+                    params: { protocolVersion: LATEST_PROTOCOL_VERSION, capabilities: {}, clientInfo: { name: 'c', version: '0' } }
+                })
+            })
+        );
+        expect(initRes.status).toBe(200);
+        const sessionId = initRes.headers.get('mcp-session-id');
+        if (sessionId === null) throw new Error('initialize response is missing the mcp-session-id header');
+        expect(Array.from(sessions.keys())).toEqual([sessionId]);
+
+        const listRes = await handle(
+            new Request(url, {
+                method: 'POST',
+                headers: { ...headers, 'mcp-session-id': sessionId },
+                body: JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} })
+            })
+        );
+        expect(listRes.status).toBe(200);
+        expect(closedSessions).toEqual([]);
+
+        const deleteRes = await handle(
+            new Request(url, {
+                method: 'DELETE',
+                headers: { 'mcp-protocol-version': LATEST_PROTOCOL_VERSION, 'mcp-session-id': sessionId }
+            })
+        );
+        expect(deleteRes.status).toBe(200);
+        expect(closedSessions).toEqual([sessionId]);
+        expect(sessions.size).toBe(0);
+
+        // The old id no longer routes to a live transport once onsessionclosed removed it from the map.
+        const reuseRes = await handle(
+            new Request(url, {
+                method: 'POST',
+                headers: { ...headers, 'mcp-session-id': sessionId },
+                body: JSON.stringify({ jsonrpc: '2.0', id: 3, method: 'tools/list', params: {} })
+            })
+        );
+        expect(reuseRes.status).toBeGreaterThanOrEqual(400);
+    } finally {
+        for (const tx of sessions.values()) await tx.close();
+    }
+});
+
+verifies('hosting:session:post-termination-404', async (_args: TestArgs) => {
+    // The documented per-session hosting pattern is the layer that owns session lifetime, so termination is asserted through it.
+    const { handleRequest, close } = hostPerSession(echoServer);
+    const url = new URL('http://in-process/mcp');
+    const headers = {
+        'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+        'content-type': 'application/json',
+        accept: 'application/json, text/event-stream'
+    };
+
+    try {
+        const initRes = await handleRequest(
+            new Request(url, {
+                method: 'POST',
+                headers,
+                body: JSON.stringify({
+                    jsonrpc: '2.0',
+                    id: 1,
+                    method: 'initialize',
+                    params: { protocolVersion: LATEST_PROTOCOL_VERSION, capabilities: {}, clientInfo: { name: 'c', version: '0' } }
+                })
+            })
+        );
+        expect(initRes.status).toBe(200);
+        const sessionId = initRes.headers.get('mcp-session-id');
+        if (sessionId === null) throw new Error('initialize response is missing the mcp-session-id header');
+
+        // The session answers a request before termination, so any later 404 is attributable to the DELETE alone.
+        const liveRes = await handleRequest(
+            new Request(url, {
+                method: 'POST',
+                headers: { ...headers, 'mcp-session-id': sessionId },
+                body: JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} })
+            })
+        );
+        expect(liveRes.status).toBe(200);
+
+        const deleteRes = await handleRequest(
+            new Request(url, {
+                method: 'DELETE',
+                headers: { 'mcp-protocol-version': LATEST_PROTOCOL_VERSION, 'mcp-session-id': sessionId }
+            })
+        );
+        expect(deleteRes.status).toBe(200);
+
+        const staleHeaders = { ...headers, 'mcp-session-id': sessionId };
+        const stalePost = await handleRequest(
+            new Request(url, {
+                method: 'POST',
+                headers: staleHeaders,
+                body: JSON.stringify({ jsonrpc: '2.0', id: 3, method: 'tools/list', params: {} })
+            })
+        );
+        expect(stalePost.status).toBe(404);
+
+        const staleGet = await handleRequest(new Request(url, { method: 'GET', headers: staleHeaders }));
+        expect(staleGet.status).toBe(404);
+
+        const staleDelete = await handleRequest(new Request(url, { method: 'DELETE', headers: staleHeaders }));
+        expect(staleDelete.status).toBe(404);
+    } finally {
+        await close();
+    }
+});
+
+verifies('hosting:session:id-charset', async (_args: TestArgs) => {
+    // The SDK has no default generator; its contract is emitting the configured generator's value verbatim in the header.
+    const generatedIds = ['!session-0x21-low-boundary', '~session-0x7E-high-boundary', randomUUID()];
+    const url = new URL('http://in-process/mcp');
+
+    for (const generatedId of generatedIds) {
+        const server = echoServer();
+        const tx = new WebStandardStreamableHTTPServerTransport({ sessionIdGenerator: () => generatedId });
+        await server.connect(tx);
+
+        try {
+            const res = await tx.handleRequest(
+                new Request(url, {
+                    method: 'POST',
+                    headers: {
+                        'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+                        'content-type': 'application/json',
+                        accept: 'application/json, text/event-stream'
+                    },
+                    body: JSON.stringify({
+                        jsonrpc: '2.0',
+                        id: 1,
+                        method: 'initialize',
+                        params: { protocolVersion: LATEST_PROTOCOL_VERSION, capabilities: {}, clientInfo: { name: 'c', version: '0' } }
+                    })
+                })
+            );
+            expect(res.status).toBe(200);
+
+            const headerValue = res.headers.get('mcp-session-id');
+            if (headerValue === null) throw new Error('initialize response is missing the mcp-session-id header');
+            expect(headerValue).toBe(generatedId);
+
+            for (const ch of headerValue) {
+                const code = ch.charCodeAt(0);
+                expect(code).toBeGreaterThanOrEqual(0x21);
+                expect(code).toBeLessThanOrEqual(0x7e);
+            }
+        } finally {
+            await server.close();
+        }
+    }
+});
+
+verifies('hosting:session:reinitialize', async (_args: TestArgs) => {
+    const host = hostPerSession(() => echoServer());
+    const url = new URL('http://in-process/mcp');
+
+    const initReq = new Request(url, {
+        method: 'POST',
+        headers: {
+            'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+            'content-type': 'application/json',
+            accept: 'application/json, text/event-stream'
+        },
+        body: JSON.stringify({
+            jsonrpc: '2.0',
+            id: 1,
+            method: 'initialize',
+            params: { protocolVersion: LATEST_PROTOCOL_VERSION, capabilities: {}, clientInfo: { name: 'c', version: '0' } }
+        })
+    });
+
+    const initRes = await host.handleRequest(initReq);
+    expect(initRes.status).toBe(200);
+    const sessionId = initRes.headers.get('mcp-session-id');
+    expect(sessionId).toBeDefined();
+
+    const reinitReq = new Request(url, {
+        method: 'POST',
+        headers: {
+            'mcp-session-id': sessionId!,
+            'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+            'content-type': 'application/json',
+            accept: 'application/json, text/event-stream'
+        },
+        body: JSON.stringify({
+            jsonrpc: '2.0',
+            id: 2,
+            method: 'initialize',
+            params: { protocolVersion: LATEST_PROTOCOL_VERSION, capabilities: {}, clientInfo: { name: 'c', version: '0' } }
+        })
+    });
+
+    const reinitRes = await host.handleRequest(reinitReq);
+    expect(reinitRes.status).toBe(400);
+
+    await host.close();
+});
+
+verifies('hosting:session:isolation', async (_args: TestArgs) => {
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        let visits = 0;
+        s.registerTool(
+            'record_visit',
+            { description: 'Increments and returns the visit counter for this session.', inputSchema: z.object({}) },
+            () => {
+                visits += 1;
+                return { content: [{ type: 'text', text: `visits:${visits}` }] };
+            }
+        );
+        return s;
+    };
+
+    const host = hostPerSession(makeServer);
+    const url = new URL('http://in-process/mcp');
+    const fetch = (u: URL | string, init?: RequestInit) => host.handleRequest(new Request(u, init));
+
+    const clientA = newClient();
+    const txA = new StreamableHTTPClientTransport(url, { fetch });
+    await clientA.connect(txA);
+
+    const clientB = newClient();
+    const txB = new StreamableHTTPClientTransport(url, { fetch });
+    await clientB.connect(txB);
+
+    const sessionIdA = txA.sessionId;
+    const sessionIdB = txB.sessionId;
+    if (sessionIdA === undefined || sessionIdB === undefined) throw new Error('initialize did not assign a session id');
+    expect(sessionIdA).not.toBe(sessionIdB);
+
+    try {
+        const a1 = await clientA.callTool({ name: 'record_visit', arguments: {} });
+        expect(a1.content).toEqual([{ type: 'text', text: 'visits:1' }]);
+        const a2 = await clientA.callTool({ name: 'record_visit', arguments: {} });
+        expect(a2.content).toEqual([{ type: 'text', text: 'visits:2' }]);
+
+        // B starts at 1: counter state accumulated in A's McpServer instance never leaks into B's.
+        const b1 = await clientB.callTool({ name: 'record_visit', arguments: {} });
+        expect(b1.content).toEqual([{ type: 'text', text: 'visits:1' }]);
+
+        await clientB.close();
+
+        const deleteRes = await host.handleRequest(
+            new Request(url, {
+                method: 'DELETE',
+                headers: { 'mcp-protocol-version': LATEST_PROTOCOL_VERSION, 'mcp-session-id': sessionIdB }
+            })
+        );
+        expect(deleteRes.status).toBe(200);
+
+        const a3 = await clientA.callTool({ name: 'record_visit', arguments: {} });
+        expect(a3.content).toEqual([{ type: 'text', text: 'visits:3' }]);
+
+        const reuseRes = await host.handleRequest(
+            new Request(url, {
+                method: 'POST',
+                headers: {
+                    'mcp-session-id': sessionIdB,
+                    'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+                    'content-type': 'application/json',
+                    accept: 'application/json, text/event-stream'
+                },
+                body: JSON.stringify({ jsonrpc: '2.0', id: 9, method: 'tools/list', params: {} })
+            })
+        );
+        expect(reuseRes.status).toBeGreaterThanOrEqual(400);
+    } finally {
+        await clientA.close();
+        await host.close();
+    }
+});
+
+verifies('hosting:stateless:no-session-id', async (_args: TestArgs) => {
+    const host = hostStateless(() => echoServer());
+    const url = new URL('http://in-process/mcp');
+
+    const req = new Request(url, {
+        method: 'POST',
+        headers: {
+            'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+            'content-type': 'application/json',
+            accept: 'application/json, text/event-stream'
+        },
+        body: JSON.stringify({
+            jsonrpc: '2.0',
+            id: 1,
+            method: 'initialize',
+            params: { protocolVersion: LATEST_PROTOCOL_VERSION, capabilities: {}, clientInfo: { name: 'c', version: '0' } }
+        })
+    });
+
+    const res = await host.handleRequest(req);
+    expect(res.status).toBe(200);
+
+    const sessionId = res.headers.get('mcp-session-id');
+    expect(sessionId).toBeNull();
+
+    await host.close();
+});
+
+verifies('hosting:stateless:concurrent-clients', async (_args: TestArgs) => {
+    const host = hostStateless(() => echoServer());
+    const url = new URL('http://in-process/mcp');
+    const fetch = (u: URL | string, init?: RequestInit) => host.handleRequest(new Request(u, init));
+
+    const clients = [
+        new Client({ name: 'c1', version: '0' }),
+        new Client({ name: 'c2', version: '0' }),
+        new Client({ name: 'c3', version: '0' })
+    ];
+
+    await Promise.all(clients.map(c => c.connect(new StreamableHTTPClientTransport(url, { fetch }))));
+
+    const [r1, r2, r3] = await Promise.all([
+        clients[0].callTool({ name: 'echo', arguments: { text: 'client-1' } }),
+        clients[1].callTool({ name: 'echo', arguments: { text: 'client-2' } }),
+        clients[2].callTool({ name: 'echo', arguments: { text: 'client-3' } })
+    ]);
+
+    expect(r1.content).toEqual([{ type: 'text', text: 'client-1' }]);
+    expect(r2.content).toEqual([{ type: 'text', text: 'client-2' }]);
+    expect(r3.content).toEqual([{ type: 'text', text: 'client-3' }]);
+
+    await Promise.all(clients.map(c => c.close()));
+    await host.close();
+});
+
+verifies('hosting:stateless:get-delete-405', async (_args: TestArgs) => {
+    const url = new URL('http://in-process/mcp');
+    // hostStateless hand-rolls a 405 for non-POST before the SDK runs; hit the SDK transport directly so its own behavior is asserted.
+    const handleStateless = async (req: Request): Promise<Response> => {
+        const server = echoServer();
+        const tx = new WebStandardStreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+        await server.connect(tx);
+        try {
+            return await tx.handleRequest(req);
+        } finally {
+            await server.close();
+        }
+    };
+
+    const getRes = await handleStateless(
+        new Request(url, {
+            method: 'GET',
+            headers: { 'mcp-protocol-version': LATEST_PROTOCOL_VERSION, accept: 'text/event-stream' }
+        })
+    );
+    expect(getRes.status).toBe(405);
+
+    const deleteRes = await handleStateless(
+        new Request(url, { method: 'DELETE', headers: { 'mcp-protocol-version': LATEST_PROTOCOL_VERSION } })
+    );
+    expect(deleteRes.status).toBe(405);
+});
+
+verifies('hosting:stateless:progress-in-post-stream', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool('progress-tool', { inputSchema: z.object({ steps: z.number() }) }, async ({ steps }, extra) => {
+            const token = extra._meta?.progressToken;
+            if (token !== undefined) {
+                for (let i = 1; i <= steps; i++) {
+                    await extra.sendNotification({
+                        method: 'notifications/progress',
+                        params: { progressToken: token, progress: i, total: steps }
+                    });
+                }
+            }
+            return { content: [{ type: 'text', text: 'done' }] };
+        });
+        return s;
+    };
+
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    const progressEvents: Array<{ progress: number; total?: number }> = [];
+    let receivedAtResolve = -1;
+
+    const result = await client
+        .callTool({ name: 'progress-tool', arguments: { steps: 3 } }, undefined, {
+            onprogress: p => progressEvents.push({ progress: p.progress, total: p.total })
+        })
+        .then(res => {
+            receivedAtResolve = progressEvents.length;
+            return res;
+        });
+
+    expect(receivedAtResolve).toBe(3);
+    expect(progressEvents).toEqual([
+        { progress: 1, total: 3 },
+        { progress: 2, total: 3 },
+        { progress: 3, total: 3 }
+    ]);
+    expect(result.content).toEqual([{ type: 'text', text: 'done' }]);
+});
+
+verifies('hosting:stateless:no-reuse', async (_args: TestArgs) => {
+    // Build the transport directly: hostStateless creates a fresh transport per request, which would never hit the reuse guard.
+    const server = echoServer();
+    const tx = new WebStandardStreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+    await server.connect(tx);
+    const url = new URL('http://in-process/mcp');
+
+    try {
+        const initRes = await tx.handleRequest(
+            new Request(url, {
+                method: 'POST',
+                headers: {
+                    'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+                    'content-type': 'application/json',
+                    accept: 'application/json, text/event-stream'
+                },
+                body: JSON.stringify({
+                    jsonrpc: '2.0',
+                    id: 1,
+                    method: 'initialize',
+                    params: { protocolVersion: LATEST_PROTOCOL_VERSION, capabilities: {}, clientInfo: { name: 'c', version: '0' } }
+                })
+            })
+        );
+        expect(initRes.status).toBe(200);
+
+        const secondReq = new Request(url, {
+            method: 'POST',
+            headers: {
+                'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+                'content-type': 'application/json',
+                accept: 'application/json, text/event-stream'
+            },
+            body: JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} })
+        });
+
+        await expect(tx.handleRequest(secondReq)).rejects.toThrow(/cannot be reused across requests/);
+    } finally {
+        await server.close();
+        await tx.close();
+    }
+});
+
+verifies('transport:streamable-http:stateless-restrictions', async (_args: TestArgs) => {
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool(
+            'needs-sampling',
+            { description: 'Asks the client LLM to draft a one-line status update.', inputSchema: z.object({}) },
+            async () => {
+                try {
+                    const draft = await s.server.createMessage({
+                        messages: [{ role: 'user', content: { type: 'text', text: 'Draft a one-line status update.' } }],
+                        maxTokens: 50
+                    });
+                    return { content: [{ type: 'text', text: JSON.stringify(draft.content) }] };
+                } catch (err) {
+                    return { isError: true, content: [{ type: 'text', text: err instanceof Error ? err.message : String(err) }] };
+                }
+            }
+        );
+        return s;
+    };
+
+    const host = hostStateless(makeServer);
+    const url = new URL('http://in-process/mcp');
+    const client = new Client({ name: 'c', version: '0' }, { capabilities: { sampling: {} } });
+    // A real sampling handler proves any failure comes from the stateless hosting gap, not a missing client capability.
+    client.setRequestHandler(CreateMessageRequestSchema, async () => ({
+        model: 'mock-model',
+        role: 'assistant',
+        content: { type: 'text', text: 'A drafted status update.' }
+    }));
+
+    try {
+        await client.connect(new StreamableHTTPClientTransport(url, { fetch: (u, init) => host.handleRequest(new Request(u, init)) }));
+
+        let timer: NodeJS.Timeout | undefined;
+        const settled = client.callTool({ name: 'needs-sampling', arguments: {} }).then(
+            value => ({ kind: 'resolved' as const, value }),
+            (reason: unknown) => ({ kind: 'rejected' as const, reason })
+        );
+        const outcome = await Promise.race([
+            settled,
+            new Promise<{ kind: 'pending' }>(resolve => {
+                timer = setTimeout(() => resolve({ kind: 'pending' }), 1500);
+            })
+        ]);
+        clearTimeout(timer);
+
+        if (outcome.kind === 'pending') {
+            throw new Error('tools/call never settled: server.createMessage() hangs in stateless mode instead of rejecting promptly');
+        }
+        if (outcome.kind === 'rejected') {
+            throw new Error(`tools/call rejected instead of returning an isError result: ${String(outcome.reason)}`);
+        }
+
+        const result = outcome.value;
+        expect(result.isError).toBe(true);
+        if (!Array.isArray(result.content)) throw new Error('tools/call result has no content array');
+        expect(result.content).toHaveLength(1);
+        const block: unknown = result.content[0];
+        if (
+            typeof block !== 'object' ||
+            block === null ||
+            !('type' in block) ||
+            block.type !== 'text' ||
+            !('text' in block) ||
+            typeof block.text !== 'string'
+        ) {
+            throw new Error('tools/call error content is not a single text block');
+        }
+        expect(block.text.length).toBeGreaterThan(0);
+        expect(block.text).not.toMatch(/does not support sampling|method not found/i);
+    } finally {
+        await client.close();
+        await host.close();
+    }
+});
+
+verifies('hosting:session:delete-cancels-inflight', async (_args: TestArgs) => {
+    const started: string[] = [];
+    const aborted: string[] = [];
+
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        // Resolves only when its abort signal fires, so the call stays in flight until DELETE cancels it.
+        s.registerTool(
+            'index_repository',
+            { description: 'Indexes a source repository for code search.', inputSchema: z.object({ repository: z.string() }) },
+            ({ repository }, extra) =>
+                new Promise(resolve => {
+                    started.push(repository);
+                    extra.signal.addEventListener('abort', () => {
+                        aborted.push(repository);
+                        resolve({ content: [{ type: 'text', text: `${repository} indexing interrupted` }] });
+                    });
+                })
+        );
+        return s;
+    };
+
+    const host = hostPerSession(makeServer);
+    const url = new URL('http://in-process/mcp');
+    const headers = {
+        'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+        'content-type': 'application/json',
+        accept: 'application/json, text/event-stream'
+    };
+
+    try {
+        const initRes = await host.handleRequest(
+            new Request(url, {
+                method: 'POST',
+                headers,
+                body: JSON.stringify({
+                    jsonrpc: '2.0',
+                    id: 1,
+                    method: 'initialize',
+                    params: { protocolVersion: LATEST_PROTOCOL_VERSION, capabilities: {}, clientInfo: { name: 'c', version: '0' } }
+                })
+            })
+        );
+        expect(initRes.status).toBe(200);
+        const sessionId = initRes.headers.get('mcp-session-id');
+        expect(sessionId).toBeDefined();
+
+        const callRequest = (id: number, repository: string) =>
+            host.handleRequest(
+                new Request(url, {
+                    method: 'POST',
+                    headers: { ...headers, 'mcp-session-id': sessionId! },
+                    body: JSON.stringify({
+                        jsonrpc: '2.0',
+                        id,
+                        method: 'tools/call',
+                        params: { name: 'index_repository', arguments: { repository } }
+                    })
+                })
+            );
+
+        const firstCall = await callRequest(2, 'docs-site');
+        const secondCall = await callRequest(3, 'billing-service');
+        expect(firstCall.status).toBe(200);
+        expect(secondCall.status).toBe(200);
+        expect(firstCall.headers.get('content-type')).toMatch(/text\/event-stream/);
+        expect(secondCall.headers.get('content-type')).toMatch(/text\/event-stream/);
+
+        await vi.waitFor(() => expect([...started].sort()).toEqual(['billing-service', 'docs-site']));
+        expect(aborted).toEqual([]);
+
+        const deleteRes = await host.handleRequest(
+            new Request(url, {
+                method: 'DELETE',
+                headers: { 'mcp-protocol-version': LATEST_PROTOCOL_VERSION, 'mcp-session-id': sessionId! }
+            })
+        );
+        expect(deleteRes.status).toBe(200);
+
+        await vi.waitFor(() => expect([...aborted].sort()).toEqual(['billing-service', 'docs-site']));
+
+        // text() resolves only once the server ends the stream; no data event means no JSON-RPC response was written.
+        const bodies = await Promise.all([firstCall.text(), secondCall.text()]);
+        for (const body of bodies) {
+            expect(body.split('\n').filter(line => line.startsWith('data:'))).toEqual([]);
+        }
+    } finally {
+        await host.close();
+    }
+});

--- a/test/e2e/scenarios/hosting-session.test.ts
+++ b/test/e2e/scenarios/hosting-session.test.ts
@@ -11,17 +11,18 @@
 
 import { randomUUID } from 'node:crypto';
 
+import { Client, StreamableHTTPClientTransport } from '@modelcontextprotocol/client';
+import { NodeStreamableHTTPServerTransport } from '@modelcontextprotocol/node';
+import { LATEST_PROTOCOL_VERSION, McpServer, WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/server';
 import cors from 'cors';
 import express from 'express';
 import { expect, vi } from 'vitest';
 import { z } from 'zod/v4';
-import { NodeStreamableHTTPServerTransport } from '@modelcontextprotocol/node';
-import { McpServer, WebStandardStreamableHTTPServerTransport, LATEST_PROTOCOL_VERSION } from '@modelcontextprotocol/server';
-import { Client, StreamableHTTPClientTransport } from '@modelcontextprotocol/client';
+
 import { startExpressMinimal } from '../helpers/express.js';
 import { hostPerSession, hostStateless, wire } from '../helpers/index.js';
-import type { TestArgs } from '../types.js';
 import { verifies } from '../helpers/verifies.js';
+import type { TestArgs } from '../types.js';
 
 const newClient = () => new Client({ name: 'c', version: '0' });
 
@@ -127,23 +128,26 @@ verifies('hosting:session:reuse', async (_args: TestArgs) => {
     const fetch = (u: URL | string, init?: RequestInit) => host.handleRequest(new Request(u, init));
 
     const client = newClient();
-    await client.connect(new StreamableHTTPClientTransport(url, { fetch }));
+    const clientTx = new StreamableHTTPClientTransport(url, { fetch });
+    await client.connect(clientTx);
 
-    const sessionId = (client.transport as StreamableHTTPClientTransport).sessionId;
-    expect(sessionId).toBeDefined();
-    expect(typeof sessionId).toBe('string');
+    try {
+        const sessionId = clientTx.sessionId;
+        expect(sessionId).toBeDefined();
+        expect(typeof sessionId).toBe('string');
 
-    const r1 = await client.listTools();
-    expect(r1.tools.map(t => t.name)).toContain('echo');
+        const r1 = await client.listTools();
+        expect(r1.tools.map(t => t.name)).toContain('echo');
 
-    const r2 = await client.callTool({ name: 'echo', arguments: { text: 'reuse-test' } });
-    expect(r2.content).toEqual([{ type: 'text', text: 'reuse-test' }]);
+        const r2 = await client.callTool({ name: 'echo', arguments: { text: 'reuse-test' } });
+        expect(r2.content).toEqual([{ type: 'text', text: 'reuse-test' }]);
 
-    const stillSameSession = (client.transport as StreamableHTTPClientTransport).sessionId;
-    expect(stillSameSession).toBe(sessionId);
-
-    await client.close();
-    await host.close();
+        const stillSameSession = clientTx.sessionId;
+        expect(stillSameSession).toBe(sessionId);
+    } finally {
+        await client.close();
+        await host.close();
+    }
 });
 
 verifies('hosting:session:unknown-id', async (_args: TestArgs) => {
@@ -226,9 +230,16 @@ verifies('hosting:session:missing-id', async (_args: TestArgs) => {
         );
         expect(res.status).toBe(400);
 
-        const body = (await res.json()) as { error?: { code?: number; message?: string } };
-        expect(body.error?.code).toBe(-32000);
-        expect(body.error?.message).toBe('Bad Request: Mcp-Session-Id header is required');
+        const body: unknown = await res.json();
+        if (typeof body !== 'object' || body === null || !('error' in body)) {
+            throw new Error('400 response body does not contain a JSON-RPC error');
+        }
+        const rpcError = body.error;
+        if (typeof rpcError !== 'object' || rpcError === null || !('code' in rpcError) || !('message' in rpcError)) {
+            throw new Error('400 response error is missing code or message');
+        }
+        expect(rpcError.code).toBe(-32_000);
+        expect(rpcError.message).toBe('Bad Request: Mcp-Session-Id header is required');
     } finally {
         await server.close();
     }
@@ -278,7 +289,7 @@ verifies('hosting:session:delete', async (_args: TestArgs) => {
         expect(initRes.status).toBe(200);
         const sessionId = initRes.headers.get('mcp-session-id');
         if (sessionId === null) throw new Error('initialize response is missing the mcp-session-id header');
-        expect(Array.from(sessions.keys())).toEqual([sessionId]);
+        expect([...sessions.keys()]).toEqual([sessionId]);
 
         const listRes = await handle(
             new Request(url, {
@@ -413,7 +424,8 @@ verifies('hosting:session:id-charset', async (_args: TestArgs) => {
             expect(headerValue).toBe(generatedId);
 
             for (const ch of headerValue) {
-                const code = ch.charCodeAt(0);
+                const code = ch.codePointAt(0);
+                if (code === undefined) throw new Error('session id iteration yielded an empty character');
                 expect(code).toBeGreaterThanOrEqual(0x21);
                 expect(code).toBeLessThanOrEqual(0x7e);
             }
@@ -442,31 +454,33 @@ verifies('hosting:session:reinitialize', async (_args: TestArgs) => {
         })
     });
 
-    const initRes = await host.handleRequest(initReq);
-    expect(initRes.status).toBe(200);
-    const sessionId = initRes.headers.get('mcp-session-id');
-    expect(sessionId).toBeDefined();
+    try {
+        const initRes = await host.handleRequest(initReq);
+        expect(initRes.status).toBe(200);
+        const sessionId = initRes.headers.get('mcp-session-id');
+        if (sessionId === null) throw new Error('initialize response is missing the mcp-session-id header');
 
-    const reinitReq = new Request(url, {
-        method: 'POST',
-        headers: {
-            'mcp-session-id': sessionId!,
-            'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
-            'content-type': 'application/json',
-            accept: 'application/json, text/event-stream'
-        },
-        body: JSON.stringify({
-            jsonrpc: '2.0',
-            id: 2,
-            method: 'initialize',
-            params: { protocolVersion: LATEST_PROTOCOL_VERSION, capabilities: {}, clientInfo: { name: 'c', version: '0' } }
-        })
-    });
+        const reinitReq = new Request(url, {
+            method: 'POST',
+            headers: {
+                'mcp-session-id': sessionId,
+                'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+                'content-type': 'application/json',
+                accept: 'application/json, text/event-stream'
+            },
+            body: JSON.stringify({
+                jsonrpc: '2.0',
+                id: 2,
+                method: 'initialize',
+                params: { protocolVersion: LATEST_PROTOCOL_VERSION, capabilities: {}, clientInfo: { name: 'c', version: '0' } }
+            })
+        });
 
-    const reinitRes = await host.handleRequest(reinitReq);
-    expect(reinitRes.status).toBe(400);
-
-    await host.close();
+        const reinitRes = await host.handleRequest(reinitReq);
+        expect(reinitRes.status).toBe(400);
+    } finally {
+        await host.close();
+    }
 });
 
 verifies('hosting:session:isolation', async (_args: TestArgs) => {
@@ -562,13 +576,15 @@ verifies('hosting:stateless:no-session-id', async (_args: TestArgs) => {
         })
     });
 
-    const res = await host.handleRequest(req);
-    expect(res.status).toBe(200);
+    try {
+        const res = await host.handleRequest(req);
+        expect(res.status).toBe(200);
 
-    const sessionId = res.headers.get('mcp-session-id');
-    expect(sessionId).toBeNull();
-
-    await host.close();
+        const sessionId = res.headers.get('mcp-session-id');
+        expect(sessionId).toBeNull();
+    } finally {
+        await host.close();
+    }
 });
 
 verifies('hosting:stateless:concurrent-clients', async (_args: TestArgs) => {
@@ -576,26 +592,27 @@ verifies('hosting:stateless:concurrent-clients', async (_args: TestArgs) => {
     const url = new URL('http://in-process/mcp');
     const fetch = (u: URL | string, init?: RequestInit) => host.handleRequest(new Request(u, init));
 
-    const clients = [
-        new Client({ name: 'c1', version: '0' }),
-        new Client({ name: 'c2', version: '0' }),
-        new Client({ name: 'c3', version: '0' })
-    ];
+    const client1 = new Client({ name: 'c1', version: '0' });
+    const client2 = new Client({ name: 'c2', version: '0' });
+    const client3 = new Client({ name: 'c3', version: '0' });
+    const clients = [client1, client2, client3];
 
-    await Promise.all(clients.map(c => c.connect(new StreamableHTTPClientTransport(url, { fetch }))));
+    try {
+        await Promise.all(clients.map(c => c.connect(new StreamableHTTPClientTransport(url, { fetch }))));
 
-    const [r1, r2, r3] = await Promise.all([
-        clients[0].callTool({ name: 'echo', arguments: { text: 'client-1' } }),
-        clients[1].callTool({ name: 'echo', arguments: { text: 'client-2' } }),
-        clients[2].callTool({ name: 'echo', arguments: { text: 'client-3' } })
-    ]);
+        const [r1, r2, r3] = await Promise.all([
+            client1.callTool({ name: 'echo', arguments: { text: 'client-1' } }),
+            client2.callTool({ name: 'echo', arguments: { text: 'client-2' } }),
+            client3.callTool({ name: 'echo', arguments: { text: 'client-3' } })
+        ]);
 
-    expect(r1.content).toEqual([{ type: 'text', text: 'client-1' }]);
-    expect(r2.content).toEqual([{ type: 'text', text: 'client-2' }]);
-    expect(r3.content).toEqual([{ type: 'text', text: 'client-3' }]);
-
-    await Promise.all(clients.map(c => c.close()));
-    await host.close();
+        expect(r1.content).toEqual([{ type: 'text', text: 'client-1' }]);
+        expect(r2.content).toEqual([{ type: 'text', text: 'client-2' }]);
+        expect(r3.content).toEqual([{ type: 'text', text: 'client-3' }]);
+    } finally {
+        await Promise.all(clients.map(c => c.close()));
+        await host.close();
+    }
 });
 
 verifies('hosting:stateless:get-delete-405', async (_args: TestArgs) => {
@@ -651,9 +668,10 @@ verifies('hosting:stateless:progress-in-post-stream', async ({ transport }: Test
     let receivedAtResolve = -1;
 
     const result = await client
-        .callTool({ name: 'progress-tool', arguments: { steps: 3 } }, undefined, {
-            onprogress: p => progressEvents.push({ progress: p.progress, total: p.total })
-        })
+        .callTool(
+            { name: 'progress-tool', arguments: { steps: 3 } },
+            { onprogress: p => progressEvents.push({ progress: p.progress, total: p.total }) }
+        )
         .then(res => {
             receivedAtResolve = progressEvents.length;
             return res;
@@ -724,8 +742,8 @@ verifies('transport:streamable-http:stateless-restrictions', async (_args: TestA
                         maxTokens: 50
                     });
                     return { content: [{ type: 'text', text: JSON.stringify(draft.content) }] };
-                } catch (err) {
-                    return { isError: true, content: [{ type: 'text', text: err instanceof Error ? err.message : String(err) }] };
+                } catch (error) {
+                    return { isError: true, content: [{ type: 'text', text: error instanceof Error ? error.message : String(error) }] };
                 }
             }
         );
@@ -748,7 +766,7 @@ verifies('transport:streamable-http:stateless-restrictions', async (_args: TestA
         let timer: NodeJS.Timeout | undefined;
         const settled = client.callTool({ name: 'needs-sampling', arguments: {} }).then(
             value => ({ kind: 'resolved' as const, value }),
-            (reason: unknown) => ({ kind: 'rejected' as const, reason })
+            (error: unknown) => ({ kind: 'rejected' as const, reason: error })
         );
         const outcome = await Promise.race([
             settled,
@@ -833,13 +851,13 @@ verifies('hosting:session:delete-cancels-inflight', async (_args: TestArgs) => {
         );
         expect(initRes.status).toBe(200);
         const sessionId = initRes.headers.get('mcp-session-id');
-        expect(sessionId).toBeDefined();
+        if (sessionId === null) throw new Error('initialize response is missing the mcp-session-id header');
 
         const callRequest = (id: number, repository: string) =>
             host.handleRequest(
                 new Request(url, {
                     method: 'POST',
-                    headers: { ...headers, 'mcp-session-id': sessionId! },
+                    headers: { ...headers, 'mcp-session-id': sessionId },
                     body: JSON.stringify({
                         jsonrpc: '2.0',
                         id,
@@ -856,18 +874,18 @@ verifies('hosting:session:delete-cancels-inflight', async (_args: TestArgs) => {
         expect(firstCall.headers.get('content-type')).toMatch(/text\/event-stream/);
         expect(secondCall.headers.get('content-type')).toMatch(/text\/event-stream/);
 
-        await vi.waitFor(() => expect([...started].sort()).toEqual(['billing-service', 'docs-site']));
+        await vi.waitFor(() => expect(started.toSorted()).toEqual(['billing-service', 'docs-site']));
         expect(aborted).toEqual([]);
 
         const deleteRes = await host.handleRequest(
             new Request(url, {
                 method: 'DELETE',
-                headers: { 'mcp-protocol-version': LATEST_PROTOCOL_VERSION, 'mcp-session-id': sessionId! }
+                headers: { 'mcp-protocol-version': LATEST_PROTOCOL_VERSION, 'mcp-session-id': sessionId }
             })
         );
         expect(deleteRes.status).toBe(200);
 
-        await vi.waitFor(() => expect([...aborted].sort()).toEqual(['billing-service', 'docs-site']));
+        await vi.waitFor(() => expect(aborted.toSorted()).toEqual(['billing-service', 'docs-site']));
 
         // text() resolves only once the server ends the stream; no data event means no JSON-RPC response was written.
         const bodies = await Promise.all([firstCall.text(), secondCall.text()]);

--- a/test/e2e/scenarios/hosting-session.test.ts
+++ b/test/e2e/scenarios/hosting-session.test.ts
@@ -15,14 +15,9 @@ import cors from 'cors';
 import express from 'express';
 import { expect, vi } from 'vitest';
 import { z } from 'zod/v4';
-
-import { Client } from '../../../src/client/index.js';
-import { StreamableHTTPClientTransport } from '../../../src/client/streamableHttp.js';
-import { McpServer } from '../../../src/server/mcp.js';
-import { StreamableHTTPServerTransport } from '../../../src/server/streamableHttp.js';
-import { WebStandardStreamableHTTPServerTransport } from '../../../src/server/webStandardStreamableHttp.js';
-import { CreateMessageRequestSchema, LATEST_PROTOCOL_VERSION } from '../../../src/types.js';
-
+import { NodeStreamableHTTPServerTransport } from '@modelcontextprotocol/node';
+import { McpServer, WebStandardStreamableHTTPServerTransport, LATEST_PROTOCOL_VERSION } from '@modelcontextprotocol/server';
+import { Client, StreamableHTTPClientTransport } from '@modelcontextprotocol/client';
 import { startExpressMinimal } from '../helpers/express.js';
 import { hostPerSession, hostStateless, wire } from '../helpers/index.js';
 import type { TestArgs } from '../types.js';
@@ -86,7 +81,7 @@ verifies('hosting:session:cors-expose', async (_args: TestArgs) => {
     const router = express.Router();
     router.use(cors({ origin: browserOrigin, exposedHeaders: ['Mcp-Session-Id'] }));
     router.post('/mcp', async (req, res) => {
-        const tx = new StreamableHTTPServerTransport({ sessionIdGenerator: randomUUID });
+        const tx = new NodeStreamableHTTPServerTransport({ sessionIdGenerator: randomUUID });
         const server = echoServer();
         await server.connect(tx);
         servers.push(server);
@@ -634,11 +629,11 @@ verifies('hosting:stateless:get-delete-405', async (_args: TestArgs) => {
 verifies('hosting:stateless:progress-in-post-stream', async ({ transport }: TestArgs) => {
     const makeServer = () => {
         const s = new McpServer({ name: 's', version: '0' });
-        s.registerTool('progress-tool', { inputSchema: z.object({ steps: z.number() }) }, async ({ steps }, extra) => {
-            const token = extra._meta?.progressToken;
+        s.registerTool('progress-tool', { inputSchema: z.object({ steps: z.number() }) }, async ({ steps }, ctx) => {
+            const token = ctx.mcpReq._meta?.progressToken;
             if (token !== undefined) {
                 for (let i = 1; i <= steps; i++) {
-                    await extra.sendNotification({
+                    await ctx.mcpReq.notify({
                         method: 'notifications/progress',
                         params: { progressToken: token, progress: i, total: steps }
                     });
@@ -741,7 +736,7 @@ verifies('transport:streamable-http:stateless-restrictions', async (_args: TestA
     const url = new URL('http://in-process/mcp');
     const client = new Client({ name: 'c', version: '0' }, { capabilities: { sampling: {} } });
     // A real sampling handler proves any failure comes from the stateless hosting gap, not a missing client capability.
-    client.setRequestHandler(CreateMessageRequestSchema, async () => ({
+    client.setRequestHandler('sampling/createMessage', async () => ({
         model: 'mock-model',
         role: 'assistant',
         content: { type: 'text', text: 'A drafted status update.' }
@@ -803,10 +798,10 @@ verifies('hosting:session:delete-cancels-inflight', async (_args: TestArgs) => {
         s.registerTool(
             'index_repository',
             { description: 'Indexes a source repository for code search.', inputSchema: z.object({ repository: z.string() }) },
-            ({ repository }, extra) =>
+            ({ repository }, ctx) =>
                 new Promise(resolve => {
                     started.push(repository);
-                    extra.signal.addEventListener('abort', () => {
+                    ctx.mcpReq.signal.addEventListener('abort', () => {
                         aborted.push(repository);
                         resolve({ content: [{ type: 'text', text: `${repository} indexing interrupted` }] });
                     });

--- a/test/e2e/scenarios/lifecycle.test.ts
+++ b/test/e2e/scenarios/lifecycle.test.ts
@@ -10,17 +10,7 @@
  * names mirror the requirement id in camelCase.
  */
 
-import { expect } from 'vitest';
-import { z } from 'zod/v4';
-import {
-    Server,
-    McpServer,
-    isJSONRPCNotification,
-    isJSONRPCRequest,
-    isJSONRPCResultResponse,
-    LATEST_PROTOCOL_VERSION,
-    SUPPORTED_PROTOCOL_VERSIONS
-} from '@modelcontextprotocol/server';
+import { Client } from '@modelcontextprotocol/client';
 import type {
     ClientCapabilities,
     Implementation,
@@ -28,12 +18,29 @@ import type {
     JSONRPCMessage,
     ServerCapabilities
 } from '@modelcontextprotocol/server';
-import { Client } from '@modelcontextprotocol/client';
-import { tapWire, wire } from '../helpers/index.js';
-import type { TestArgs } from '../types.js';
-import { verifies } from '../helpers/verifies.js';
+import {
+    isJSONRPCNotification,
+    isJSONRPCRequest,
+    isJSONRPCResultResponse,
+    LATEST_PROTOCOL_VERSION,
+    McpServer,
+    Server,
+    SUPPORTED_PROTOCOL_VERSIONS
+} from '@modelcontextprotocol/server';
+import { expect } from 'vitest';
+import { z } from 'zod/v4';
 
-const OLDER_SUPPORTED_VERSION = SUPPORTED_PROTOCOL_VERSIONS.find(v => v !== LATEST_PROTOCOL_VERSION)!;
+import { tapWire, wire } from '../helpers/index.js';
+import { verifies } from '../helpers/verifies.js';
+import type { TestArgs } from '../types.js';
+
+function olderSupportedVersion(): string {
+    const older = SUPPORTED_PROTOCOL_VERSIONS.find(v => v !== LATEST_PROTOCOL_VERSION);
+    if (older === undefined) throw new Error('expected SUPPORTED_PROTOCOL_VERSIONS to include a version other than the latest');
+    return older;
+}
+
+const OLDER_SUPPORTED_VERSION = olderSupportedVersion();
 const BOGUS_VERSION = '1999-01-01';
 
 const DEFAULT_INSTRUCTIONS = 'This is the default server instruction set for lifecycle tests.';
@@ -114,9 +121,11 @@ verifies('lifecycle:initialize:basic', async ({ transport }: TestArgs) => {
 
     // Server saw an InitializeRequest with all spec-mandated fields populated.
     expect(initReqs).toHaveLength(1);
-    expect(initReqs[0].protocolVersion).toBe(LATEST_PROTOCOL_VERSION);
-    expect(initReqs[0].clientInfo).toEqual({ name: 'lifecycle-client', version: '0.0.0' });
-    expect(initReqs[0].capabilities).toEqual({ roots: {} });
+    const initParams = initReqs[0];
+    if (!initParams) throw new Error('expected the server to receive exactly one initialize request');
+    expect(initParams.protocolVersion).toBe(LATEST_PROTOCOL_VERSION);
+    expect(initParams.clientInfo).toEqual({ name: 'lifecycle-client', version: '0.0.0' });
+    expect(initParams.capabilities).toEqual({ roots: {} });
 
     // Client surfaces what the server returned.
     expect(client.getServerVersion()).toEqual({ name: 'lifecycle-server', version: '1.2.3' });
@@ -220,7 +229,9 @@ verifies('lifecycle:version:match', async ({ transport }: TestArgs) => {
     await using _ = await wire(transport, makeServer, client);
 
     expect(initReqs).toHaveLength(1);
-    expect(initReqs[0].protocolVersion).toBe(LATEST_PROTOCOL_VERSION);
+    const initParams = initReqs[0];
+    if (!initParams) throw new Error('expected the server to receive exactly one initialize request');
+    expect(initParams.protocolVersion).toBe(LATEST_PROTOCOL_VERSION);
 
     // Connect succeeded at the matched version: server state is populated.
     expect(client.getServerCapabilities()).toEqual({});
@@ -239,7 +250,9 @@ verifies('lifecycle:version:downgrade', async ({ transport }: TestArgs) => {
     // accepted the downgrade. There is no transport-agnostic SDK getter for the
     // negotiated version (`client.transport.protocolVersion` is HTTP-only).
     expect(initReqs).toHaveLength(1);
-    expect(initReqs[0].protocolVersion).toBe(LATEST_PROTOCOL_VERSION);
+    const initParams = initReqs[0];
+    if (!initParams) throw new Error('expected the server to receive exactly one initialize request');
+    expect(initParams.protocolVersion).toBe(LATEST_PROTOCOL_VERSION);
     expect(OLDER_SUPPORTED_VERSION).not.toBe(LATEST_PROTOCOL_VERSION);
     expect(client.getServerCapabilities()).toEqual({});
     expect(client.getServerVersion()).toEqual({ name: 's', version: '0' });

--- a/test/e2e/scenarios/lifecycle.test.ts
+++ b/test/e2e/scenarios/lifecycle.test.ts
@@ -1,0 +1,461 @@
+/**
+ * Self-contained test bodies for the lifecycle surface.
+ *
+ * Lifecycle tests cover the initialize handshake, version negotiation,
+ * the `notifications/initialized` ordering rule, ping, and the metadata
+ * accessors on both ends (`getServerVersion`/`getServerCapabilities` on the
+ * client, `getClientVersion`/`getClientCapabilities` on the server). Each
+ * export is a {@link TestCase}: it builds its own server (via a factory),
+ * builds its own client, wires them with {@link wire}, and asserts. Function
+ * names mirror the requirement id in camelCase.
+ */
+
+import { expect } from 'vitest';
+import { z } from 'zod/v4';
+
+import { Client } from '../../../src/client/index.js';
+import { Server } from '../../../src/server/index.js';
+import { McpServer } from '../../../src/server/mcp.js';
+import {
+    type ClientCapabilities,
+    CreateMessageRequestSchema,
+    ElicitRequestSchema,
+    type Implementation,
+    type InitializeRequest,
+    InitializeRequestSchema,
+    isJSONRPCNotification,
+    isJSONRPCRequest,
+    isJSONRPCResultResponse,
+    type JSONRPCMessage,
+    LATEST_PROTOCOL_VERSION,
+    ListRootsRequestSchema,
+    type ServerCapabilities,
+    SUPPORTED_PROTOCOL_VERSIONS
+} from '../../../src/types.js';
+
+import { tapWire, wire } from '../helpers/index.js';
+import type { TestArgs } from '../types.js';
+import { verifies } from '../helpers/verifies.js';
+
+const OLDER_SUPPORTED_VERSION = SUPPORTED_PROTOCOL_VERSIONS.find(v => v !== LATEST_PROTOCOL_VERSION)!;
+const BOGUS_VERSION = '1999-01-01';
+
+const DEFAULT_INSTRUCTIONS = 'This is the default server instruction set for lifecycle tests.';
+
+function minimalClient() {
+    return new Client({ name: 'minimal-client', version: '0.0.0' });
+}
+
+function minimalServer(): McpServer {
+    return new McpServer({ name: 'minimal-server', version: '0.0.0' });
+}
+
+/**
+ * Raw `Server` whose initialize handler echoes the inbound request to
+ * `received` and replies with the given `protocolVersion`. Used by the
+ * version-negotiation tests so both sides of the handshake are observable
+ * via public API only.
+ */
+function recordingInitServer(replyVersion: string, received: InitializeRequest['params'][]): Server {
+    const s = new Server({ name: 's', version: '0' }, { capabilities: {} });
+    s.setRequestHandler(InitializeRequestSchema, async req => {
+        received.push(req.params);
+        return { protocolVersion: replyVersion, capabilities: {}, serverInfo: { name: 's', version: '0' } };
+    });
+    return s;
+}
+
+interface HandshakeLogEntry {
+    direction: 'client-to-server' | 'server-to-client';
+    message: JSONRPCMessage;
+}
+
+/**
+ * Patch `client.connect` so the transport `wire()` hands it is tapped from the
+ * very first handshake message — `tapWire()` can only attach after connect, too
+ * late to observe initialize. `rewriteOutbound` lets a test alter client→server
+ * messages before they reach the wire (e.g. to request a protocol version the
+ * SDK client would never ask for itself).
+ */
+function tapHandshake(client: Client, rewriteOutbound?: (message: JSONRPCMessage) => JSONRPCMessage): HandshakeLogEntry[] {
+    const log: HandshakeLogEntry[] = [];
+    const originalConnect = client.connect.bind(client);
+    client.connect = (clientTransport, options) => {
+        const originalSend = clientTransport.send.bind(clientTransport);
+        clientTransport.send = (message, sendOptions) => {
+            const outbound = rewriteOutbound ? rewriteOutbound(message) : message;
+            log.push({ direction: 'client-to-server', message: outbound });
+            return originalSend(outbound, sendOptions);
+        };
+        // Protocol.connect chains a pre-set onmessage, so inbound messages are logged before the client reacts to them.
+        clientTransport.onmessage = message => {
+            log.push({ direction: 'server-to-client', message });
+        };
+        return originalConnect(clientTransport, options);
+    };
+    return log;
+}
+
+verifies('lifecycle:initialize:basic', async ({ transport }: TestArgs) => {
+    const SERVER_CAPS: ServerCapabilities = { tools: { listChanged: true }, logging: {} };
+
+    const initReqs: InitializeRequest['params'][] = [];
+    const makeServer = () => {
+        const s = new Server({ name: 'lifecycle-server', version: '1.2.3' }, { capabilities: SERVER_CAPS });
+        s.setRequestHandler(InitializeRequestSchema, async req => {
+            initReqs.push(req.params);
+            return {
+                protocolVersion: req.params.protocolVersion,
+                capabilities: SERVER_CAPS,
+                serverInfo: { name: 'lifecycle-server', version: '1.2.3' }
+            };
+        });
+        return s;
+    };
+    const client = new Client({ name: 'lifecycle-client', version: '0.0.0' }, { capabilities: { roots: {} } });
+
+    await using _ = await wire(transport, makeServer, client);
+
+    // Server saw an InitializeRequest with all spec-mandated fields populated.
+    expect(initReqs).toHaveLength(1);
+    expect(initReqs[0].protocolVersion).toBe(LATEST_PROTOCOL_VERSION);
+    expect(initReqs[0].clientInfo).toEqual({ name: 'lifecycle-client', version: '0.0.0' });
+    expect(initReqs[0].capabilities).toEqual({ roots: {} });
+
+    // Client surfaces what the server returned.
+    expect(client.getServerVersion()).toEqual({ name: 'lifecycle-server', version: '1.2.3' });
+    expect(client.getServerCapabilities()).toEqual(SERVER_CAPS);
+});
+
+verifies('lifecycle:initialize:instructions', async ({ transport }: TestArgs) => {
+    const makeServer = () => new McpServer({ name: 's', version: '0' }, { instructions: DEFAULT_INSTRUCTIONS });
+    const client = minimalClient();
+
+    await using _ = await wire(transport, makeServer, client);
+
+    expect(client.getInstructions()).toBe(DEFAULT_INSTRUCTIONS);
+});
+
+verifies('lifecycle:initialized-notification', async ({ transport }: TestArgs) => {
+    const order: string[] = [];
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' }, { capabilities: { tools: {} } });
+        s.server.oninitialized = () => order.push('initialized');
+        s.registerTool('marker', { inputSchema: z.object({}) }, () => {
+            order.push('request');
+            return { content: [{ type: 'text', text: 'ok' }] };
+        });
+        return s;
+    };
+    const client = minimalClient();
+
+    await using _ = await wire(transport, makeServer, client);
+    expect(order).toContain('initialized');
+
+    await client.callTool({ name: 'marker', arguments: {} });
+
+    // Wherever a request arrived, the immediately-preceding event in the
+    // server-side order log is the initialized hook firing — i.e., the client
+    // sent notifications/initialized before any other request.
+    const reqIdx = order.indexOf('request');
+    expect(reqIdx).toBeGreaterThan(0);
+    expect(order[reqIdx - 1]).toBe('initialized');
+});
+
+verifies('lifecycle:pre-initialization-ordering', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        const s = new McpServer({ name: 'weather-server', version: '1.0.0' });
+        s.registerTool('get_weather', { inputSchema: z.object({ city: z.string() }) }, ({ city }) => ({
+            content: [{ type: 'text', text: `Sunny in ${city}` }]
+        }));
+        return s;
+    };
+    const client = minimalClient();
+    const log = tapHandshake(client);
+
+    await using _ = await wire(transport, makeServer, client);
+
+    const result = await client.callTool({ name: 'get_weather', arguments: { city: 'Berlin' } });
+    expect(result.content).toEqual([{ type: 'text', text: 'Sunny in Berlin' }]);
+
+    const requestMethods = new Map<string | number, string>();
+    const summary = log.map(({ direction, message }) => {
+        if (isJSONRPCRequest(message)) {
+            requestMethods.set(message.id, message.method);
+            return `${direction} request ${message.method}`;
+        }
+        if (isJSONRPCNotification(message)) return `${direction} notification ${message.method}`;
+        if (isJSONRPCResultResponse(message)) return `${direction} result for ${requestMethods.get(message.id) ?? 'unknown request'}`;
+        return `${direction} error response`;
+    });
+
+    // Before initialization completes the client sends only initialize and the server only its result; the first feature request follows notifications/initialized.
+    expect(summary).toEqual([
+        'client-to-server request initialize',
+        'server-to-client result for initialize',
+        'client-to-server notification notifications/initialized',
+        'client-to-server request tools/call',
+        'server-to-client result for tools/call'
+    ]);
+});
+
+verifies('lifecycle:ping', async ({ transport }: TestArgs) => {
+    const client = minimalClient();
+    await using _ = await wire(transport, minimalServer, client);
+
+    const tap = tapWire(client);
+    const result = await client.ping();
+    expect(result).toEqual({});
+
+    const req = tap.sent.find(m => isJSONRPCRequest(m) && m.method === 'ping');
+    expect(req).toBeDefined();
+    if (!req || !isJSONRPCRequest(req)) throw new Error('expected ping request');
+
+    const res = tap.received.find(m => isJSONRPCResultResponse(m) && m.id === req.id);
+    if (!res || !isJSONRPCResultResponse(res)) throw new Error('expected ping result');
+    expect(res.result).toEqual({});
+});
+
+verifies('lifecycle:version:match', async ({ transport }: TestArgs) => {
+    const initReqs: InitializeRequest['params'][] = [];
+    const makeServer = () => recordingInitServer(LATEST_PROTOCOL_VERSION, initReqs);
+    const client = minimalClient();
+
+    await using _ = await wire(transport, makeServer, client);
+
+    expect(initReqs).toHaveLength(1);
+    expect(initReqs[0].protocolVersion).toBe(LATEST_PROTOCOL_VERSION);
+
+    // Connect succeeded at the matched version: server state is populated.
+    expect(client.getServerCapabilities()).toEqual({});
+    expect(client.getServerVersion()).toEqual({ name: 's', version: '0' });
+});
+
+verifies('lifecycle:version:downgrade', async ({ transport }: TestArgs) => {
+    const initReqs: InitializeRequest['params'][] = [];
+    const makeServer = () => recordingInitServer(OLDER_SUPPORTED_VERSION, initReqs);
+    const client = minimalClient();
+
+    await using _ = await wire(transport, makeServer, client);
+
+    // Client requested LATEST; server replied with an older supported version;
+    // connect resolved (no throw) and server state is populated, so the client
+    // accepted the downgrade. There is no transport-agnostic SDK getter for the
+    // negotiated version (`client.transport.protocolVersion` is HTTP-only).
+    expect(initReqs).toHaveLength(1);
+    expect(initReqs[0].protocolVersion).toBe(LATEST_PROTOCOL_VERSION);
+    expect(OLDER_SUPPORTED_VERSION).not.toBe(LATEST_PROTOCOL_VERSION);
+    expect(client.getServerCapabilities()).toEqual({});
+    expect(client.getServerVersion()).toEqual({ name: 's', version: '0' });
+});
+
+verifies('lifecycle:version:server-fallback-latest', async ({ transport }: TestArgs) => {
+    const client = minimalClient();
+    // The SDK client only ever requests the latest version, so the unsupported version is injected into the outbound initialize; the server runs the SDK's default initialize handler.
+    const log = tapHandshake(client, message =>
+        isJSONRPCRequest(message) && message.method === 'initialize'
+            ? { ...message, params: { ...message.params, protocolVersion: BOGUS_VERSION } }
+            : message
+    );
+
+    expect(SUPPORTED_PROTOCOL_VERSIONS).not.toContain(BOGUS_VERSION);
+
+    await using _ = await wire(transport, minimalServer, client);
+
+    const initRequest = log.find(
+        e => e.direction === 'client-to-server' && isJSONRPCRequest(e.message) && e.message.method === 'initialize'
+    );
+    if (!initRequest || !isJSONRPCRequest(initRequest.message)) throw new Error('expected an initialize request on the wire');
+    expect(initRequest.message.params?.protocolVersion).toBe(BOGUS_VERSION);
+    const initRequestId = initRequest.message.id;
+
+    const initResponse = log.find(
+        e => e.direction === 'server-to-client' && isJSONRPCResultResponse(e.message) && e.message.id === initRequestId
+    );
+    if (!initResponse || !isJSONRPCResultResponse(initResponse.message)) throw new Error('expected a result for the initialize request');
+    expect(initResponse.message.result.protocolVersion).toBe(LATEST_PROTOCOL_VERSION);
+
+    // The client accepted the fallback version: initialization completed and server state is populated.
+    expect(client.getServerVersion()).toEqual({ name: 'minimal-server', version: '0.0.0' });
+    expect(client.getServerCapabilities()).toEqual({});
+});
+
+verifies('lifecycle:version:reject-unsupported', async ({ transport }: TestArgs) => {
+    const initReqs: InitializeRequest['params'][] = [];
+    const makeServer = () => recordingInitServer(BOGUS_VERSION, initReqs);
+    const client = minimalClient();
+
+    await expect(wire(transport, makeServer, client)).rejects.toThrow(/protocol version.*not supported|1999-01-01/i);
+
+    expect(client.transport).toBeUndefined();
+    expect(client.getServerCapabilities()).toBeUndefined();
+    expect(client.getServerVersion()).toBeUndefined();
+});
+
+verifies('lifecycle:capability:client-not-declared', async ({ transport }: TestArgs) => {
+    let observedCaps: ClientCapabilities | undefined;
+    const makeServer = () => {
+        const s = minimalServer();
+        s.server.oninitialized = () => {
+            observedCaps = s.server.getClientCapabilities();
+        };
+        return s;
+    };
+    const client = new Client({ name: 'no-caps-client', version: '0.0.0' }, { capabilities: {} });
+
+    await using _ = await wire(transport, makeServer, client);
+
+    // Client side: cannot send notifications / register handlers for undeclared caps.
+    await expect(client.sendRootsListChanged()).rejects.toThrow(/roots.*list.?changed/i);
+    expect(() =>
+        client.setRequestHandler(CreateMessageRequestSchema, async () => ({
+            role: 'assistant',
+            content: { type: 'text', text: 'unreachable' },
+            model: 'stub'
+        }))
+    ).toThrow(/sampling/i);
+    expect(() => client.setRequestHandler(ElicitRequestSchema, async () => ({ action: 'cancel' }))).toThrow(/elicitation/i);
+    expect(() => client.setRequestHandler(ListRootsRequestSchema, async () => ({ roots: [] }))).toThrow(/roots/i);
+
+    // Server side: it sees the empty client capabilities. (Server-side request
+    // gating on these is opt-in via `enforceStrictCapabilities` and is covered
+    // by the elicitation/sampling capability tests, not here.)
+    expect(observedCaps).toEqual({});
+});
+
+verifies('lifecycle:capability:server-not-advertised', async ({ transport }: TestArgs) => {
+    const makeServer = () => new McpServer({ name: 's', version: '0' }, { capabilities: {} });
+    const client = new Client({ name: 'c', version: '0' }, { enforceStrictCapabilities: true });
+
+    await using _ = await wire(transport, makeServer, client);
+
+    const caps = client.getServerCapabilities();
+    expect(caps).toEqual({});
+
+    const calls: Array<[string, () => Promise<unknown>]> = [
+        ['tools', () => client.listTools()],
+        ['resources', () => client.listResources()],
+        ['resources', () => client.listResourceTemplates()],
+        ['prompts', () => client.listPrompts()],
+        ['logging', () => client.setLoggingLevel('debug')],
+        ['completions', () => client.complete({ ref: { type: 'ref/prompt', name: 'x' }, argument: { name: 'a', value: '' } })]
+    ];
+    for (const [cap, call] of calls) {
+        await expect(call(), `${cap} should be gated`).rejects.toThrow(new RegExp(cap, 'i'));
+    }
+});
+
+verifies('lifecycle:initialize:capabilities:minimal', async ({ transport }: TestArgs) => {
+    // Bare McpServer: no feature handlers registered and no capabilities option passed.
+    const client = minimalClient();
+
+    await using _ = await wire(transport, minimalServer, client);
+
+    // Exactly empty: no tools, resources, prompts, completions, or logging advertised.
+    expect(client.getServerCapabilities()).toEqual({});
+});
+
+verifies('lifecycle:capability:experimental-passthrough', async ({ transport }: TestArgs) => {
+    const SERVER_EXPERIMENTAL = {
+        'x-vendor/streaming': { version: 2, modes: ['delta', 'full'] },
+        'org.example.preview': { nested: { limit: 42 }, enabled: true }
+    };
+    const CLIENT_EXPERIMENTAL = {
+        'x-vendor/telemetry': { level: 'debug', sinks: ['stdout'] }
+    };
+
+    let observedClientCaps: ClientCapabilities | undefined;
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' }, { capabilities: { experimental: SERVER_EXPERIMENTAL } });
+        s.server.oninitialized = () => {
+            observedClientCaps = s.server.getClientCapabilities();
+        };
+        return s;
+    };
+
+    const client = new Client(
+        { name: 'c', version: '0' },
+        { capabilities: { roots: { listChanged: true }, experimental: CLIENT_EXPERIMENTAL } }
+    );
+
+    await using _ = await wire(transport, makeServer, client);
+
+    // Server → client direction.
+    const serverCaps = client.getServerCapabilities();
+    expect(serverCaps?.experimental).toEqual(SERVER_EXPERIMENTAL);
+    expect(serverCaps?.experimental?.['x-vendor/streaming']).toEqual({ version: 2, modes: ['delta', 'full'] });
+    expect(serverCaps?.experimental?.['x-vendor/undeclared']).toBeUndefined();
+
+    // Client → server direction (symmetric).
+    expect(observedClientCaps?.experimental).toEqual(CLIENT_EXPERIMENTAL);
+    expect(observedClientCaps?.experimental?.['x-vendor/undeclared']).toBeUndefined();
+});
+
+verifies('lifecycle:initialize:server-info', async ({ transport }: TestArgs) => {
+    const extendedServerInfo: Implementation = {
+        name: 'everything-extended',
+        version: '1.2.3',
+        title: 'Everything Server (Extended)',
+        websiteUrl: 'https://example.com/everything',
+        description: 'Reference everything-server with all optional Implementation fields populated.',
+        icons: [
+            { src: 'https://example.com/icon-48.png', mimeType: 'image/png', sizes: ['48x48'] },
+            { src: 'https://example.com/icon.svg', mimeType: 'image/svg+xml', sizes: ['any'] }
+        ]
+    };
+
+    const makeServer = () => new McpServer(extendedServerInfo);
+    const client = minimalClient();
+
+    await using _ = await wire(transport, makeServer, client);
+
+    expect(client.getServerVersion()).toEqual(extendedServerInfo);
+});
+
+verifies('lifecycle:initialize:client-info', async ({ transport }: TestArgs) => {
+    let observed: { before: Implementation | undefined; after: Implementation | undefined } | undefined;
+    const makeServer = () => {
+        const s = minimalServer();
+        const before = s.server.getClientVersion();
+        s.server.oninitialized = () => {
+            observed = { before, after: s.server.getClientVersion() };
+        };
+        return s;
+    };
+    const client = minimalClient();
+
+    await using _ = await wire(transport, makeServer, client);
+
+    expect(observed?.before).toBeUndefined();
+    expect(observed?.after).toEqual({ name: 'minimal-client', version: '0.0.0' });
+});
+
+verifies('typescript:server:get-client-capabilities', async ({ transport }: TestArgs) => {
+    const DECLARED = {
+        roots: { listChanged: true },
+        sampling: {},
+        experimental: { 'e2e-cap-marker': {} }
+    };
+
+    let observed:
+        | { before: ClientCapabilities | undefined; after: ClientCapabilities | undefined; second: ClientCapabilities | undefined }
+        | undefined;
+    const makeServer = () => {
+        const s = minimalServer();
+        const before = s.server.getClientCapabilities();
+        s.server.oninitialized = () => {
+            const after = s.server.getClientCapabilities();
+            observed = { before, after, second: s.server.getClientCapabilities() };
+        };
+        return s;
+    };
+    const client = new Client({ name: 'caps-probe-client', version: '0.0.0' }, { capabilities: DECLARED });
+
+    await using _ = await wire(transport, makeServer, client);
+
+    expect(observed?.before).toBeUndefined();
+    expect(observed?.after).toEqual(DECLARED);
+    expect(observed?.after?.elicitation).toBeUndefined();
+    // Stable reference across calls.
+    expect(observed?.second).toBe(observed?.after);
+});

--- a/test/e2e/scenarios/lifecycle.test.ts
+++ b/test/e2e/scenarios/lifecycle.test.ts
@@ -12,27 +12,23 @@
 
 import { expect } from 'vitest';
 import { z } from 'zod/v4';
-
-import { Client } from '../../../src/client/index.js';
-import { Server } from '../../../src/server/index.js';
-import { McpServer } from '../../../src/server/mcp.js';
 import {
-    type ClientCapabilities,
-    CreateMessageRequestSchema,
-    ElicitRequestSchema,
-    type Implementation,
-    type InitializeRequest,
-    InitializeRequestSchema,
+    Server,
+    McpServer,
     isJSONRPCNotification,
     isJSONRPCRequest,
     isJSONRPCResultResponse,
-    type JSONRPCMessage,
     LATEST_PROTOCOL_VERSION,
-    ListRootsRequestSchema,
-    type ServerCapabilities,
     SUPPORTED_PROTOCOL_VERSIONS
-} from '../../../src/types.js';
-
+} from '@modelcontextprotocol/server';
+import type {
+    ClientCapabilities,
+    Implementation,
+    InitializeRequest,
+    JSONRPCMessage,
+    ServerCapabilities
+} from '@modelcontextprotocol/server';
+import { Client } from '@modelcontextprotocol/client';
 import { tapWire, wire } from '../helpers/index.js';
 import type { TestArgs } from '../types.js';
 import { verifies } from '../helpers/verifies.js';
@@ -58,7 +54,7 @@ function minimalServer(): McpServer {
  */
 function recordingInitServer(replyVersion: string, received: InitializeRequest['params'][]): Server {
     const s = new Server({ name: 's', version: '0' }, { capabilities: {} });
-    s.setRequestHandler(InitializeRequestSchema, async req => {
+    s.setRequestHandler('initialize', async req => {
         received.push(req.params);
         return { protocolVersion: replyVersion, capabilities: {}, serverInfo: { name: 's', version: '0' } };
     });
@@ -102,7 +98,7 @@ verifies('lifecycle:initialize:basic', async ({ transport }: TestArgs) => {
     const initReqs: InitializeRequest['params'][] = [];
     const makeServer = () => {
         const s = new Server({ name: 'lifecycle-server', version: '1.2.3' }, { capabilities: SERVER_CAPS });
-        s.setRequestHandler(InitializeRequestSchema, async req => {
+        s.setRequestHandler('initialize', async req => {
             initReqs.push(req.params);
             return {
                 protocolVersion: req.params.protocolVersion,
@@ -308,14 +304,14 @@ verifies('lifecycle:capability:client-not-declared', async ({ transport }: TestA
     // Client side: cannot send notifications / register handlers for undeclared caps.
     await expect(client.sendRootsListChanged()).rejects.toThrow(/roots.*list.?changed/i);
     expect(() =>
-        client.setRequestHandler(CreateMessageRequestSchema, async () => ({
+        client.setRequestHandler('sampling/createMessage', async () => ({
             role: 'assistant',
             content: { type: 'text', text: 'unreachable' },
             model: 'stub'
         }))
     ).toThrow(/sampling/i);
-    expect(() => client.setRequestHandler(ElicitRequestSchema, async () => ({ action: 'cancel' }))).toThrow(/elicitation/i);
-    expect(() => client.setRequestHandler(ListRootsRequestSchema, async () => ({ roots: [] }))).toThrow(/roots/i);
+    expect(() => client.setRequestHandler('elicitation/create', async () => ({ action: 'cancel' }))).toThrow(/elicitation/i);
+    expect(() => client.setRequestHandler('roots/list', async () => ({ roots: [] }))).toThrow(/roots/i);
 
     // Server side: it sees the empty client capabilities. (Server-side request
     // gating on these is opt-in via `enforceStrictCapabilities` and is covered

--- a/test/e2e/scenarios/lifecycle.test.ts
+++ b/test/e2e/scenarios/lifecycle.test.ts
@@ -24,6 +24,8 @@ import {
     isJSONRPCResultResponse,
     LATEST_PROTOCOL_VERSION,
     McpServer,
+    SdkError,
+    SdkErrorCode,
     Server,
     SUPPORTED_PROTOCOL_VERSIONS
 } from '@modelcontextprotocol/server';
@@ -467,4 +469,93 @@ verifies('typescript:server:get-client-capabilities', async ({ transport }: Test
     expect(observed?.after?.elicitation).toBeUndefined();
     // Stable reference across calls.
     expect(observed?.second).toBe(observed?.after);
+});
+
+verifies('lifecycle:version:custom-supported-versions', async ({ transport }: TestArgs) => {
+    // The server's first entry is the latest version, so the older negotiated version can only come from honoring the client's request.
+    const makeServer = () =>
+        new McpServer(
+            { name: 'custom-versions-server', version: '0.0.0' },
+            { supportedProtocolVersions: [LATEST_PROTOCOL_VERSION, OLDER_SUPPORTED_VERSION] }
+        );
+    const client = new Client(
+        { name: 'custom-versions-client', version: '0.0.0' },
+        { supportedProtocolVersions: [OLDER_SUPPORTED_VERSION] }
+    );
+    const log = tapHandshake(client);
+
+    await using _ = await wire(transport, makeServer, client);
+
+    const initRequest = log.find(
+        e => e.direction === 'client-to-server' && isJSONRPCRequest(e.message) && e.message.method === 'initialize'
+    );
+    if (!initRequest || !isJSONRPCRequest(initRequest.message)) throw new Error('expected an initialize request on the wire');
+    // The override drives the requested version: a default client would have asked for the latest.
+    expect(initRequest.message.params?.protocolVersion).toBe(OLDER_SUPPORTED_VERSION);
+    const initRequestId = initRequest.message.id;
+
+    const initResponse = log.find(
+        e => e.direction === 'server-to-client' && isJSONRPCResultResponse(e.message) && e.message.id === initRequestId
+    );
+    if (!initResponse || !isJSONRPCResultResponse(initResponse.message)) throw new Error('expected a result for the initialize request');
+    // The server supports the requested version, so it echoes it back instead of falling back to its first entry.
+    expect(initResponse.message.result.protocolVersion).toBe(OLDER_SUPPORTED_VERSION);
+
+    // After connect both sides settled on the older version: the client reports it and the connection is established.
+    expect(client.getNegotiatedProtocolVersion()).toBe(OLDER_SUPPORTED_VERSION);
+    expect(client.getServerVersion()).toEqual({ name: 'custom-versions-server', version: '0.0.0' });
+});
+
+verifies('lifecycle:version:no-overlap-rejects', async ({ transport }: TestArgs) => {
+    // The server only negotiates the latest version while the client only accepts the older one — no overlap.
+    const makeServer = () =>
+        new McpServer({ name: 'no-overlap-server', version: '0.0.0' }, { supportedProtocolVersions: [LATEST_PROTOCOL_VERSION] });
+    const client = new Client({ name: 'no-overlap-client', version: '0.0.0' }, { supportedProtocolVersions: [OLDER_SUPPORTED_VERSION] });
+
+    await expect(wire(transport, makeServer, client)).rejects.toThrow(
+        `Server's protocol version is not supported: ${LATEST_PROTOCOL_VERSION}`
+    );
+
+    // The connection was never established: initialization state stays empty. (Transport closure itself is lifecycle:version:reject-unsupported's contract.)
+    expect(client.getNegotiatedProtocolVersion()).toBeUndefined();
+    expect(client.getServerCapabilities()).toBeUndefined();
+    expect(client.getServerVersion()).toBeUndefined();
+});
+
+verifies('lifecycle:capability:list-empty-when-not-advertised', async ({ transport }: TestArgs) => {
+    // Bare McpServer with no registrations advertises no tools/prompts/resources capabilities.
+    const client = minimalClient();
+
+    await using _ = await wire(transport, minimalServer, client);
+    expect(client.getServerCapabilities()).toEqual({});
+
+    const tap = tapWire(client);
+    await expect(client.listTools()).resolves.toEqual({ tools: [] });
+    await expect(client.listPrompts()).resolves.toEqual({ prompts: [] });
+    await expect(client.listResources()).resolves.toEqual({ resources: [] });
+    await expect(client.listResourceTemplates()).resolves.toEqual({ resourceTemplates: [] });
+
+    // None of the four list calls put a request on the wire.
+    expect(tap.sent).toEqual([]);
+});
+
+verifies('lifecycle:capability:strict-mode-throws', async ({ transport }: TestArgs) => {
+    const client = new Client({ name: 'strict-client', version: '0.0.0' }, { enforceStrictCapabilities: true });
+
+    await using _ = await wire(transport, minimalServer, client);
+    expect(client.getServerCapabilities()).toEqual({});
+
+    const listCalls: Array<[string, () => Promise<unknown>]> = [
+        ['tools', () => client.listTools()],
+        ['prompts', () => client.listPrompts()],
+        ['resources', () => client.listResources()],
+        ['resources', () => client.listResourceTemplates()]
+    ];
+    for (const [cap, call] of listCalls) {
+        const pending = call();
+        // Strict mode restores the v1 behavior: a capability error instead of an empty result.
+        await expect(pending).rejects.toBeInstanceOf(SdkError);
+        await expect(pending).rejects.toMatchObject({ code: SdkErrorCode.CapabilityNotSupported });
+        await expect(pending).rejects.toThrow(new RegExp(`Server does not support ${cap}`));
+    }
 });

--- a/test/e2e/scenarios/logging.test.ts
+++ b/test/e2e/scenarios/logging.test.ts
@@ -13,20 +13,9 @@
 
 import { expect, vi } from 'vitest';
 import { z } from 'zod/v4';
-
-import { Client } from '../../../src/client/index.js';
-import { Server } from '../../../src/server/index.js';
-import { McpServer } from '../../../src/server/mcp.js';
-import {
-    ErrorCode,
-    isJSONRPCRequest,
-    type LoggingLevel,
-    LoggingLevelSchema,
-    LoggingMessageNotificationSchema,
-    McpError,
-    RequestSchema
-} from '../../../src/types.js';
-
+import { Server, McpServer, isJSONRPCRequest, ProtocolError, ProtocolErrorCode, specTypeSchemas } from '@modelcontextprotocol/server';
+import type { LoggingLevel } from '@modelcontextprotocol/server';
+import { Client } from '@modelcontextprotocol/client';
 import { tapWire, wire } from '../helpers/index.js';
 import type { TestArgs } from '../types.js';
 import { verifies } from '../helpers/verifies.js';
@@ -55,20 +44,20 @@ verifies('logging:message:fields', async ({ transport }: TestArgs) => {
 
     const makeServer = () => {
         const s = new McpServer({ name: 's', version: '0' }, { capabilities: { logging: {} } });
-        s.registerTool('emit-logs', { inputSchema: z.object({ withLogger: z.boolean().optional() }) }, async ({ withLogger }, extra) => {
+        s.registerTool('emit-logs', { inputSchema: z.object({ withLogger: z.boolean().optional() }) }, async ({ withLogger }, ctx) => {
             if (withLogger) {
-                await extra.sendNotification({
+                await ctx.mcpReq.notify({
                     method: 'notifications/message',
                     params: { level: 'info', logger: 'test-logger', data: 'with-logger' }
                 });
             } else {
-                await extra.sendNotification({
+                await ctx.mcpReq.notify({
                     method: 'notifications/message',
                     params: { level: 'warning', data: 'without-logger' }
                 });
             }
             for (const level of ALL_LEVELS) {
-                await extra.sendNotification({
+                await ctx.mcpReq.notify({
                     method: 'notifications/message',
                     params: { level, logger: 'sweep', data: `level-${level}` }
                 });
@@ -79,7 +68,7 @@ verifies('logging:message:fields', async ({ transport }: TestArgs) => {
     };
 
     const client = newClient();
-    client.setNotificationHandler(LoggingMessageNotificationSchema, n => {
+    client.setNotificationHandler('notifications/message', n => {
         logs.push(n.params);
     });
 
@@ -103,9 +92,9 @@ verifies('logging:message:all-levels', async ({ transport }: TestArgs) => {
     let server!: McpServer;
     const makeServer = () => {
         server = new McpServer({ name: 's', version: '0' }, { capabilities: { logging: {} } });
-        server.registerTool('run-diagnostics', { inputSchema: z.object({}) }, async (_args, extra) => {
+        server.registerTool('run-diagnostics', { inputSchema: z.object({}) }, async (_args, ctx) => {
             for (const level of ALL_LEVELS) {
-                await server.sendLoggingMessage({ level, logger: 'diagnostics', data: `a ${level} event` }, extra.sessionId);
+                await server.sendLoggingMessage({ level, logger: 'diagnostics', data: `a ${level} event` }, ctx.sessionId);
             }
             return { content: [{ type: 'text', text: 'diagnostics complete' }] };
         });
@@ -114,7 +103,7 @@ verifies('logging:message:all-levels', async ({ transport }: TestArgs) => {
 
     const received: Array<{ level: LoggingLevel; logger?: string; data: unknown }> = [];
     const client = newClient();
-    client.setNotificationHandler(LoggingMessageNotificationSchema, n => {
+    client.setNotificationHandler('notifications/message', n => {
         received.push(n.params);
     });
 
@@ -132,9 +121,9 @@ verifies(['logging:message:filtered', 'logging:set-level'], async ({ transport }
     let server!: McpServer;
     const makeServer = () => {
         server = new McpServer({ name: 's', version: '0' }, { capabilities: { logging: {} } });
-        server.registerTool('emit-all', { inputSchema: z.object({}) }, async (_args, extra) => {
+        server.registerTool('emit-all', { inputSchema: z.object({}) }, async (_args, ctx) => {
             for (const level of ALL_LEVELS) {
-                await server.sendLoggingMessage({ level, data: level }, extra.sessionId);
+                await server.sendLoggingMessage({ level, data: level }, ctx.sessionId);
             }
             return { content: [{ type: 'text', text: 'done' }] };
         });
@@ -147,7 +136,7 @@ verifies(['logging:message:filtered', 'logging:set-level'], async ({ transport }
     for (const threshold of ALL_LEVELS) {
         const thresholdRank = ALL_LEVELS.indexOf(threshold);
         const logs: LoggingLevel[] = [];
-        client.setNotificationHandler(LoggingMessageNotificationSchema, n => {
+        client.setNotificationHandler('notifications/message', n => {
             logs.push(n.params.level);
         });
 
@@ -169,8 +158,8 @@ verifies(
         const tap = tapWire(client);
 
         // @ts-expect-error — sending an invalid enum value is the point of this test.
-        await expect(client.setLoggingLevel('superduper')).rejects.toMatchObject({ code: ErrorCode.InvalidParams });
-        expect(ErrorCode.InvalidParams).toBe(-32602);
+        await expect(client.setLoggingLevel('superduper')).rejects.toMatchObject({ code: ProtocolErrorCode.InvalidParams });
+        expect(ProtocolErrorCode.InvalidParams).toBe(-32602);
 
         const sent = tap.sent.filter(m => isJSONRPCRequest(m) && m.method === 'logging/setLevel');
         expect(sent).toHaveLength(1);
@@ -186,7 +175,7 @@ verifies(
         // The user-shaped manual implementation of spec-correct invalid-level handling:
         // a handler registered with a loose params schema so the dispatch-time parse
         // succeeds, validating the level itself and throwing InvalidParams.
-        const LooseSetLevelRequestSchema = RequestSchema.extend({
+        const LooseSetLevelRequestSchema = specTypeSchemas.Request.extend({
             method: z.literal('logging/setLevel'),
             params: z.object({ level: z.string() })
         });
@@ -195,11 +184,11 @@ verifies(
         const makeServer = () => {
             const s = new Server({ name: 's', version: '0' }, { capabilities: { logging: {} } });
             s.setRequestHandler(LooseSetLevelRequestSchema, req => {
-                const parsed = LoggingLevelSchema.safeParse(req.params.level);
-                if (!parsed.success) {
-                    throw new McpError(ErrorCode.InvalidParams, `Invalid logging level: ${req.params.level}`);
+                const parsed = specTypeSchemas.LoggingLevel['~standard'].validate(req.params.level);
+                if (parsed.issues !== undefined) {
+                    throw new ProtocolError(ProtocolErrorCode.InvalidParams, `Invalid logging level: ${req.params.level}`);
                 }
-                applied.push(parsed.data);
+                applied.push(parsed.value);
                 return {};
             });
             return s;
@@ -213,7 +202,7 @@ verifies(
 
         // @ts-expect-error — sending an invalid enum value is the point of this test.
         await expect(client.setLoggingLevel('superduper')).rejects.toMatchObject({
-            code: ErrorCode.InvalidParams,
+            code: ProtocolErrorCode.InvalidParams,
             message: expect.stringContaining('superduper')
         });
         expect(applied).toEqual(['warning']);
@@ -230,7 +219,7 @@ verifies('logging:out-of-band:basic', async ({ transport }: TestArgs) => {
     };
 
     const client = newClient();
-    client.setNotificationHandler(LoggingMessageNotificationSchema, n => {
+    client.setNotificationHandler('notifications/message', n => {
         received.push(n.params);
     });
 

--- a/test/e2e/scenarios/logging.test.ts
+++ b/test/e2e/scenarios/logging.test.ts
@@ -1,0 +1,244 @@
+/**
+ * Self-contained test bodies for the logging surface.
+ *
+ * Each export is a {@link TestCase}: it builds its own server (via a factory),
+ * builds its own client, wires them with {@link wire}, and asserts. There are
+ * no shared fixture imports; helpers local to multiple bodies live at the top
+ * of this file.
+ *
+ * Function names mirror the requirement id in camelCase; a `Raw` suffix marks
+ * a low-level {@link Server} variant where the behavior under test differs by
+ * tier.
+ */
+
+import { expect, vi } from 'vitest';
+import { z } from 'zod/v4';
+
+import { Client } from '../../../src/client/index.js';
+import { Server } from '../../../src/server/index.js';
+import { McpServer } from '../../../src/server/mcp.js';
+import {
+    ErrorCode,
+    isJSONRPCRequest,
+    type LoggingLevel,
+    LoggingLevelSchema,
+    LoggingMessageNotificationSchema,
+    McpError,
+    RequestSchema
+} from '../../../src/types.js';
+
+import { tapWire, wire } from '../helpers/index.js';
+import type { TestArgs } from '../types.js';
+import { verifies } from '../helpers/verifies.js';
+
+const ALL_LEVELS: LoggingLevel[] = ['debug', 'info', 'notice', 'warning', 'error', 'critical', 'alert', 'emergency'];
+
+/** Plain client with no extra capabilities declared. */
+const newClient = () => new Client({ name: 'c', version: '0' });
+
+/** McpServer factory that declares logging capability and can emit logs. */
+function loggingServer(): McpServer {
+    const s = new McpServer({ name: 's', version: '0' }, { capabilities: { logging: {} } });
+    s.registerTool('ping', { inputSchema: z.object({}) }, () => ({ content: [{ type: 'text', text: 'pong' }] }));
+    return s;
+}
+
+verifies('logging:capability:declared', async ({ transport }: TestArgs) => {
+    const client = newClient();
+    await using _ = await wire(transport, loggingServer, client);
+
+    expect(client.getServerCapabilities()?.logging).toEqual({});
+});
+
+verifies('logging:message:fields', async ({ transport }: TestArgs) => {
+    const logs: Array<{ level: LoggingLevel; logger?: string; data: unknown }> = [];
+
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' }, { capabilities: { logging: {} } });
+        s.registerTool('emit-logs', { inputSchema: z.object({ withLogger: z.boolean().optional() }) }, async ({ withLogger }, extra) => {
+            if (withLogger) {
+                await extra.sendNotification({
+                    method: 'notifications/message',
+                    params: { level: 'info', logger: 'test-logger', data: 'with-logger' }
+                });
+            } else {
+                await extra.sendNotification({
+                    method: 'notifications/message',
+                    params: { level: 'warning', data: 'without-logger' }
+                });
+            }
+            for (const level of ALL_LEVELS) {
+                await extra.sendNotification({
+                    method: 'notifications/message',
+                    params: { level, logger: 'sweep', data: `level-${level}` }
+                });
+            }
+            return { content: [{ type: 'text', text: 'done' }] };
+        });
+        return s;
+    };
+
+    const client = newClient();
+    client.setNotificationHandler(LoggingMessageNotificationSchema, n => {
+        logs.push(n.params);
+    });
+
+    await using _ = await wire(transport, makeServer, client);
+
+    await client.setLoggingLevel('debug');
+    await client.callTool({ name: 'emit-logs', arguments: { withLogger: true } });
+    await client.callTool({ name: 'emit-logs', arguments: { withLogger: false } });
+
+    const sweep = ALL_LEVELS.map(level => ({ level, logger: 'sweep', data: `level-${level}` }));
+    expect(logs).toEqual([
+        { level: 'info', logger: 'test-logger', data: 'with-logger' },
+        ...sweep,
+        { level: 'warning', data: 'without-logger' },
+        ...sweep
+    ]);
+    expect(logs[1 + ALL_LEVELS.length]).not.toHaveProperty('logger');
+});
+
+verifies('logging:message:all-levels', async ({ transport }: TestArgs) => {
+    let server!: McpServer;
+    const makeServer = () => {
+        server = new McpServer({ name: 's', version: '0' }, { capabilities: { logging: {} } });
+        server.registerTool('run-diagnostics', { inputSchema: z.object({}) }, async (_args, extra) => {
+            for (const level of ALL_LEVELS) {
+                await server.sendLoggingMessage({ level, logger: 'diagnostics', data: `a ${level} event` }, extra.sessionId);
+            }
+            return { content: [{ type: 'text', text: 'diagnostics complete' }] };
+        });
+        return server;
+    };
+
+    const received: Array<{ level: LoggingLevel; logger?: string; data: unknown }> = [];
+    const client = newClient();
+    client.setNotificationHandler(LoggingMessageNotificationSchema, n => {
+        received.push(n.params);
+    });
+
+    await using _ = await wire(transport, makeServer, client);
+
+    // No logging/setLevel is sent: with no threshold configured, every severity must be deliverable.
+    const result = await client.callTool({ name: 'run-diagnostics', arguments: {} });
+    expect(result.content).toEqual([{ type: 'text', text: 'diagnostics complete' }]);
+
+    await vi.waitFor(() => expect(received).toHaveLength(ALL_LEVELS.length));
+    expect(received).toEqual(ALL_LEVELS.map(level => ({ level, logger: 'diagnostics', data: `a ${level} event` })));
+});
+
+verifies(['logging:message:filtered', 'logging:set-level'], async ({ transport }: TestArgs) => {
+    let server!: McpServer;
+    const makeServer = () => {
+        server = new McpServer({ name: 's', version: '0' }, { capabilities: { logging: {} } });
+        server.registerTool('emit-all', { inputSchema: z.object({}) }, async (_args, extra) => {
+            for (const level of ALL_LEVELS) {
+                await server.sendLoggingMessage({ level, data: level }, extra.sessionId);
+            }
+            return { content: [{ type: 'text', text: 'done' }] };
+        });
+        return server;
+    };
+
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    for (const threshold of ALL_LEVELS) {
+        const thresholdRank = ALL_LEVELS.indexOf(threshold);
+        const logs: LoggingLevel[] = [];
+        client.setNotificationHandler(LoggingMessageNotificationSchema, n => {
+            logs.push(n.params.level);
+        });
+
+        await client.setLoggingLevel(threshold);
+        await client.callTool({ name: 'emit-all', arguments: {} });
+
+        await vi.waitFor(() => expect(logs).toContain('emergency'));
+
+        expect(logs).toEqual(ALL_LEVELS.slice(thresholdRank));
+    }
+});
+
+verifies(
+    'logging:set-level:invalid-level',
+    async ({ transport }: TestArgs) => {
+        const client = newClient();
+        await using _ = await wire(transport, loggingServer, client);
+
+        const tap = tapWire(client);
+
+        // @ts-expect-error — sending an invalid enum value is the point of this test.
+        await expect(client.setLoggingLevel('superduper')).rejects.toMatchObject({ code: ErrorCode.InvalidParams });
+        expect(ErrorCode.InvalidParams).toBe(-32602);
+
+        const sent = tap.sent.filter(m => isJSONRPCRequest(m) && m.method === 'logging/setLevel');
+        expect(sent).toHaveLength(1);
+        if (!isJSONRPCRequest(sent[0])) throw new Error('expected request');
+        expect(sent[0].params).toEqual({ level: 'superduper' });
+    },
+    { title: 'mcpserver' }
+);
+
+verifies(
+    'logging:set-level:invalid-level',
+    async ({ transport }: TestArgs) => {
+        // The user-shaped manual implementation of spec-correct invalid-level handling:
+        // a handler registered with a loose params schema so the dispatch-time parse
+        // succeeds, validating the level itself and throwing InvalidParams.
+        const LooseSetLevelRequestSchema = RequestSchema.extend({
+            method: z.literal('logging/setLevel'),
+            params: z.object({ level: z.string() })
+        });
+
+        const applied: LoggingLevel[] = [];
+        const makeServer = () => {
+            const s = new Server({ name: 's', version: '0' }, { capabilities: { logging: {} } });
+            s.setRequestHandler(LooseSetLevelRequestSchema, req => {
+                const parsed = LoggingLevelSchema.safeParse(req.params.level);
+                if (!parsed.success) {
+                    throw new McpError(ErrorCode.InvalidParams, `Invalid logging level: ${req.params.level}`);
+                }
+                applied.push(parsed.data);
+                return {};
+            });
+            return s;
+        };
+
+        const client = newClient();
+        await using _ = await wire(transport, makeServer, client, { strictValidation: false });
+
+        await client.setLoggingLevel('warning');
+        expect(applied).toEqual(['warning']);
+
+        // @ts-expect-error — sending an invalid enum value is the point of this test.
+        await expect(client.setLoggingLevel('superduper')).rejects.toMatchObject({
+            code: ErrorCode.InvalidParams,
+            message: expect.stringContaining('superduper')
+        });
+        expect(applied).toEqual(['warning']);
+    },
+    { title: 'raw server' }
+);
+
+verifies('logging:out-of-band:basic', async ({ transport }: TestArgs) => {
+    const received: Array<{ level: LoggingLevel; logger?: string; data: unknown }> = [];
+    let server!: McpServer;
+    const makeServer = () => {
+        server = new McpServer({ name: 's', version: '0' }, { capabilities: { logging: {} } });
+        return server;
+    };
+
+    const client = newClient();
+    client.setNotificationHandler(LoggingMessageNotificationSchema, n => {
+        received.push(n.params);
+    });
+
+    await using _ = await wire(transport, makeServer, client);
+
+    // No request is in flight: this is a server-initiated, out-of-band notification.
+    await server.sendLoggingMessage({ level: 'info', logger: 'job-runner', data: 'nightly index rebuild started' });
+
+    await vi.waitFor(() => expect(received).toHaveLength(1));
+    expect(received).toEqual([{ level: 'info', logger: 'job-runner', data: 'nightly index rebuild started' }]);
+});

--- a/test/e2e/scenarios/logging.test.ts
+++ b/test/e2e/scenarios/logging.test.ts
@@ -11,14 +11,15 @@
  * tier.
  */
 
+import { Client } from '@modelcontextprotocol/client';
+import type { LoggingLevel } from '@modelcontextprotocol/server';
+import { isJSONRPCRequest, McpServer, ProtocolError, ProtocolErrorCode, Server, specTypeSchemas } from '@modelcontextprotocol/server';
 import { expect, vi } from 'vitest';
 import { z } from 'zod/v4';
-import { Server, McpServer, isJSONRPCRequest, ProtocolError, ProtocolErrorCode, specTypeSchemas } from '@modelcontextprotocol/server';
-import type { LoggingLevel } from '@modelcontextprotocol/server';
-import { Client } from '@modelcontextprotocol/client';
+
 import { tapWire, wire } from '../helpers/index.js';
-import type { TestArgs } from '../types.js';
 import { verifies } from '../helpers/verifies.js';
+import type { TestArgs } from '../types.js';
 
 const ALL_LEVELS: LoggingLevel[] = ['debug', 'info', 'notice', 'warning', 'error', 'critical', 'alert', 'emergency'];
 
@@ -45,17 +46,15 @@ verifies('logging:message:fields', async ({ transport }: TestArgs) => {
     const makeServer = () => {
         const s = new McpServer({ name: 's', version: '0' }, { capabilities: { logging: {} } });
         s.registerTool('emit-logs', { inputSchema: z.object({ withLogger: z.boolean().optional() }) }, async ({ withLogger }, ctx) => {
-            if (withLogger) {
-                await ctx.mcpReq.notify({
-                    method: 'notifications/message',
-                    params: { level: 'info', logger: 'test-logger', data: 'with-logger' }
-                });
-            } else {
-                await ctx.mcpReq.notify({
-                    method: 'notifications/message',
-                    params: { level: 'warning', data: 'without-logger' }
-                });
-            }
+            await (withLogger
+                ? ctx.mcpReq.notify({
+                      method: 'notifications/message',
+                      params: { level: 'info', logger: 'test-logger', data: 'with-logger' }
+                  })
+                : ctx.mcpReq.notify({
+                      method: 'notifications/message',
+                      params: { level: 'warning', data: 'without-logger' }
+                  }));
             for (const level of ALL_LEVELS) {
                 await ctx.mcpReq.notify({
                     method: 'notifications/message',
@@ -153,13 +152,14 @@ verifies(
     'logging:set-level:invalid-level',
     async ({ transport }: TestArgs) => {
         const client = newClient();
-        await using _ = await wire(transport, loggingServer, client);
+        // strictValidation off: the invalid level must actually reach the server for it to reject.
+        await using _ = await wire(transport, loggingServer, client, { strictValidation: false });
 
         const tap = tapWire(client);
 
         // @ts-expect-error — sending an invalid enum value is the point of this test.
         await expect(client.setLoggingLevel('superduper')).rejects.toMatchObject({ code: ProtocolErrorCode.InvalidParams });
-        expect(ProtocolErrorCode.InvalidParams).toBe(-32602);
+        expect(ProtocolErrorCode.InvalidParams).toBe(-32_602);
 
         const sent = tap.sent.filter(m => isJSONRPCRequest(m) && m.method === 'logging/setLevel');
         expect(sent).toHaveLength(1);
@@ -175,18 +175,13 @@ verifies(
         // The user-shaped manual implementation of spec-correct invalid-level handling:
         // a handler registered with a loose params schema so the dispatch-time parse
         // succeeds, validating the level itself and throwing InvalidParams.
-        const LooseSetLevelRequestSchema = specTypeSchemas.Request.extend({
-            method: z.literal('logging/setLevel'),
-            params: z.object({ level: z.string() })
-        });
-
         const applied: LoggingLevel[] = [];
         const makeServer = () => {
             const s = new Server({ name: 's', version: '0' }, { capabilities: { logging: {} } });
-            s.setRequestHandler(LooseSetLevelRequestSchema, req => {
-                const parsed = specTypeSchemas.LoggingLevel['~standard'].validate(req.params.level);
+            s.setRequestHandler('logging/setLevel', { params: z.object({ level: z.string() }) }, params => {
+                const parsed = specTypeSchemas.LoggingLevel['~standard'].validate(params.level);
                 if (parsed.issues !== undefined) {
-                    throw new ProtocolError(ProtocolErrorCode.InvalidParams, `Invalid logging level: ${req.params.level}`);
+                    throw new ProtocolError(ProtocolErrorCode.InvalidParams, `Invalid logging level: ${params.level}`);
                 }
                 applied.push(parsed.value);
                 return {};

--- a/test/e2e/scenarios/pagination.test.ts
+++ b/test/e2e/scenarios/pagination.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Self-contained test bodies for cursor-pagination behaviors that span all
+ * paginated list operations (tools/list, resources/list,
+ * resources/templates/list, prompts/list).
+ */
+
+import { expect } from 'vitest';
+import { z } from 'zod/v4';
+
+import { Client } from '../../../src/client/index.js';
+import { Server } from '../../../src/server/index.js';
+import { McpServer, ResourceTemplate } from '../../../src/server/mcp.js';
+import { ErrorCode, isJSONRPCRequest, ListToolsRequestSchema, McpError, type Tool } from '../../../src/types.js';
+
+import { tapWire, wire } from '../helpers/index.js';
+import type { TestArgs } from '../types.js';
+import { verifies } from '../helpers/verifies.js';
+
+const newClient = () => new Client({ name: 'c', version: '0' });
+
+verifies('pagination:invalid-cursor', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool('echo', { inputSchema: z.object({}) }, () => ({ content: [] }));
+        s.registerResource('static', 'e2e://static', {}, uri => ({
+            contents: [{ uri: uri.href, mimeType: 'text/plain', text: 'hi' }]
+        }));
+        s.registerResource('tpl', new ResourceTemplate('e2e://item/{id}', { list: undefined }), {}, uri => ({
+            contents: [{ uri: uri.href, mimeType: 'text/plain', text: 'hi' }]
+        }));
+        s.registerPrompt('p', {}, () => ({ messages: [{ role: 'user', content: { type: 'text', text: 'hi' } }] }));
+        return s;
+    };
+
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    const badCursor = 'not-a-cursor-the-server-ever-issued';
+    const invalidParams = expect.objectContaining({ code: ErrorCode.InvalidParams });
+
+    await expect(client.listTools({ cursor: badCursor })).rejects.toBeInstanceOf(McpError);
+    await expect(client.listTools({ cursor: badCursor })).rejects.toEqual(invalidParams);
+    await expect(client.listResources({ cursor: badCursor })).rejects.toEqual(invalidParams);
+    await expect(client.listResourceTemplates({ cursor: badCursor })).rejects.toEqual(invalidParams);
+    await expect(client.listPrompts({ cursor: badCursor })).rejects.toEqual(invalidParams);
+});
+
+verifies('pagination:client:cursor-handling', async ({ transport }: TestArgs) => {
+    // Cursors are deliberately base64-padded / URL-unsafe / JSON-looking so any client-side parsing or normalization would corrupt them.
+    const cursorToPage2 = 'eyJvZmZzZXQiOjMsInYiOjF9==/page-2?after=get_alerts';
+    const cursorToPage3 = 'YWZ0ZXI+Y29udmVydF91bml0cw==';
+    // Page sizes of 3, 1, 2 prove the client follows nextCursor only and assumes no fixed page size.
+    const pages = new Map<string | undefined, { tools: Tool[]; nextCursor?: string }>([
+        [
+            undefined,
+            {
+                tools: [
+                    { name: 'get_weather', inputSchema: { type: 'object', properties: { city: { type: 'string' } } } },
+                    { name: 'get_forecast', inputSchema: { type: 'object', properties: { city: { type: 'string' } } } },
+                    { name: 'get_alerts', inputSchema: { type: 'object', properties: { region: { type: 'string' } } } }
+                ],
+                nextCursor: cursorToPage2
+            }
+        ],
+        [
+            cursorToPage2,
+            {
+                tools: [{ name: 'convert_units', inputSchema: { type: 'object', properties: { value: { type: 'number' } } } }],
+                nextCursor: cursorToPage3
+            }
+        ],
+        [
+            cursorToPage3,
+            {
+                tools: [
+                    { name: 'list_stations', inputSchema: { type: 'object', properties: {} } },
+                    { name: 'get_station', inputSchema: { type: 'object', properties: { id: { type: 'string' } } } }
+                ]
+            }
+        ]
+    ]);
+    const receivedCursors: Array<string | undefined> = [];
+
+    const makeServer = () => {
+        const s = new Server({ name: 's', version: '0' }, { capabilities: { tools: {} } });
+        s.setRequestHandler(ListToolsRequestSchema, req => {
+            const cursor = req.params?.cursor;
+            receivedCursors.push(cursor);
+            const page = pages.get(cursor);
+            if (!page) throw new McpError(ErrorCode.InvalidParams, `Unknown cursor: ${String(cursor)}`);
+            return { tools: page.tools, nextCursor: page.nextCursor };
+        });
+        return s;
+    };
+
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+    const tap = tapWire(client);
+
+    const collectedPages: string[][] = [];
+    let result = await client.listTools();
+    collectedPages.push(result.tools.map(t => t.name));
+    while (result.nextCursor !== undefined) {
+        // A run-away loop means the test fixture, not the SDK, is broken — fail fast instead of hitting the suite timeout.
+        if (collectedPages.length >= pages.size) throw new Error('nextCursor still present after the last page');
+        result = await client.listTools({ cursor: result.nextCursor });
+        collectedPages.push(result.tools.map(t => t.name));
+    }
+
+    // The handler got back exactly the cursors it issued, and every page arrived once, in order.
+    expect(receivedCursors).toEqual([undefined, cursorToPage2, cursorToPage3]);
+    expect(collectedPages).toEqual([['get_weather', 'get_forecast', 'get_alerts'], ['convert_units'], ['list_stations', 'get_station']]);
+
+    // The wire requests carried the server-issued strings byte-for-byte — opaque, unparsed, unmodified.
+    const wireListRequests = tap.sent.filter(isJSONRPCRequest).filter(m => m.method === 'tools/list');
+    expect(wireListRequests.map(m => m.params?.cursor)).toEqual([undefined, cursorToPage2, cursorToPage3]);
+});

--- a/test/e2e/scenarios/pagination.test.ts
+++ b/test/e2e/scenarios/pagination.test.ts
@@ -6,12 +6,9 @@
 
 import { expect } from 'vitest';
 import { z } from 'zod/v4';
-
-import { Client } from '../../../src/client/index.js';
-import { Server } from '../../../src/server/index.js';
-import { McpServer, ResourceTemplate } from '../../../src/server/mcp.js';
-import { ErrorCode, isJSONRPCRequest, ListToolsRequestSchema, McpError, type Tool } from '../../../src/types.js';
-
+import { Server, McpServer, ResourceTemplate, isJSONRPCRequest, ProtocolError, ProtocolErrorCode } from '@modelcontextprotocol/server';
+import type { Tool } from '@modelcontextprotocol/server';
+import { Client } from '@modelcontextprotocol/client';
 import { tapWire, wire } from '../helpers/index.js';
 import type { TestArgs } from '../types.js';
 import { verifies } from '../helpers/verifies.js';
@@ -36,9 +33,9 @@ verifies('pagination:invalid-cursor', async ({ transport }: TestArgs) => {
     await using _ = await wire(transport, makeServer, client);
 
     const badCursor = 'not-a-cursor-the-server-ever-issued';
-    const invalidParams = expect.objectContaining({ code: ErrorCode.InvalidParams });
+    const invalidParams = expect.objectContaining({ code: ProtocolErrorCode.InvalidParams });
 
-    await expect(client.listTools({ cursor: badCursor })).rejects.toBeInstanceOf(McpError);
+    await expect(client.listTools({ cursor: badCursor })).rejects.toBeInstanceOf(ProtocolError);
     await expect(client.listTools({ cursor: badCursor })).rejects.toEqual(invalidParams);
     await expect(client.listResources({ cursor: badCursor })).rejects.toEqual(invalidParams);
     await expect(client.listResourceTemplates({ cursor: badCursor })).rejects.toEqual(invalidParams);
@@ -83,11 +80,11 @@ verifies('pagination:client:cursor-handling', async ({ transport }: TestArgs) =>
 
     const makeServer = () => {
         const s = new Server({ name: 's', version: '0' }, { capabilities: { tools: {} } });
-        s.setRequestHandler(ListToolsRequestSchema, req => {
+        s.setRequestHandler('tools/list', req => {
             const cursor = req.params?.cursor;
             receivedCursors.push(cursor);
             const page = pages.get(cursor);
-            if (!page) throw new McpError(ErrorCode.InvalidParams, `Unknown cursor: ${String(cursor)}`);
+            if (!page) throw new ProtocolError(ProtocolErrorCode.InvalidParams, `Unknown cursor: ${String(cursor)}`);
             return { tools: page.tools, nextCursor: page.nextCursor };
         });
         return s;

--- a/test/e2e/scenarios/pagination.test.ts
+++ b/test/e2e/scenarios/pagination.test.ts
@@ -4,14 +4,15 @@
  * resources/templates/list, prompts/list).
  */
 
+import { Client } from '@modelcontextprotocol/client';
+import type { Tool } from '@modelcontextprotocol/server';
+import { isJSONRPCRequest, McpServer, ProtocolError, ProtocolErrorCode, ResourceTemplate, Server } from '@modelcontextprotocol/server';
 import { expect } from 'vitest';
 import { z } from 'zod/v4';
-import { Server, McpServer, ResourceTemplate, isJSONRPCRequest, ProtocolError, ProtocolErrorCode } from '@modelcontextprotocol/server';
-import type { Tool } from '@modelcontextprotocol/server';
-import { Client } from '@modelcontextprotocol/client';
+
 import { tapWire, wire } from '../helpers/index.js';
-import type { TestArgs } from '../types.js';
 import { verifies } from '../helpers/verifies.js';
+import type { TestArgs } from '../types.js';
 
 const newClient = () => new Client({ name: 'c', version: '0' });
 
@@ -109,6 +110,6 @@ verifies('pagination:client:cursor-handling', async ({ transport }: TestArgs) =>
     expect(collectedPages).toEqual([['get_weather', 'get_forecast', 'get_alerts'], ['convert_units'], ['list_stations', 'get_station']]);
 
     // The wire requests carried the server-issued strings byte-for-byte — opaque, unparsed, unmodified.
-    const wireListRequests = tap.sent.filter(isJSONRPCRequest).filter(m => m.method === 'tools/list');
+    const wireListRequests = tap.sent.filter(m => isJSONRPCRequest(m)).filter(m => m.method === 'tools/list');
     expect(wireListRequests.map(m => m.params?.cursor)).toEqual([undefined, cursorToPage2, cursorToPage3]);
 });

--- a/test/e2e/scenarios/prompts.test.ts
+++ b/test/e2e/scenarios/prompts.test.ts
@@ -8,14 +8,15 @@
  * tier.
  */
 
+import { Client } from '@modelcontextprotocol/client';
+import type { RegisteredPrompt } from '@modelcontextprotocol/server';
+import { McpServer, ProtocolError, ProtocolErrorCode, Server } from '@modelcontextprotocol/server';
 import { expect, vi } from 'vitest';
 import { z } from 'zod/v4';
-import { Server, McpServer, ProtocolError, ProtocolErrorCode } from '@modelcontextprotocol/server';
-import type { RegisteredPrompt } from '@modelcontextprotocol/server';
-import { Client } from '@modelcontextprotocol/client';
+
 import { wire } from '../helpers/index.js';
-import type { TestArgs } from '../types.js';
 import { verifies } from '../helpers/verifies.js';
+import type { TestArgs } from '../types.js';
 
 const TINY_PNG_BASE64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=';
 const TINY_WAV_BASE64 = 'UklGRiQAAABXQVZFZm10IBAAAAABAAEAQB8AAEAfAAABAAgAZGF0YQAAAAA=';
@@ -93,7 +94,7 @@ verifies('prompts:list:basic', async ({ transport }: TestArgs) => {
     const result = await client.listPrompts();
 
     expect(result.prompts).toHaveLength(3);
-    expect(result.prompts.map(p => p.name).sort()).toEqual(['code-review', 'explain-last-commit', 'summarize']);
+    expect(result.prompts.map(p => p.name).toSorted()).toEqual(['code-review', 'explain-last-commit', 'summarize']);
 
     expect(result.prompts.find(p => p.name === 'summarize')).toMatchObject({
         name: 'summarize',
@@ -158,7 +159,7 @@ verifies(
             const s = new Server({ name: 's', version: '0' }, { capabilities: { prompts: {} } });
             s.setRequestHandler('prompts/list', req => {
                 cursorsReceived.push(req.params?.cursor);
-                const start = req.params?.cursor === undefined ? 0 : parseInt(req.params.cursor, 10);
+                const start = req.params?.cursor === undefined ? 0 : Number.parseInt(req.params.cursor, 10);
                 const slice = all.slice(start, start + PAGE);
                 return {
                     prompts: slice.map(name => ({ name })),
@@ -201,7 +202,7 @@ verifies(
 );
 
 verifies('prompts:list-changed', async ({ transport }: TestArgs) => {
-    let server!: McpServer;
+    let server: McpServer | undefined;
     const makeServer = () => {
         server = new McpServer({ name: 's', version: '0' });
         server.registerPrompt('seed', {}, () => ({ messages: [] }));
@@ -215,17 +216,21 @@ verifies('prompts:list-changed', async ({ transport }: TestArgs) => {
     });
 
     await using _ = await wire(transport, makeServer, client);
+    if (server === undefined) throw new Error('wire() did not invoke the server factory');
 
-    expect((await client.listPrompts()).prompts).toHaveLength(1);
+    const initial = await client.listPrompts();
+    expect(initial.prompts).toHaveLength(1);
 
     const handle = server.registerPrompt('dynamic-probe', {}, () => ({ messages: [] }));
     await vi.waitFor(() => expect(listChanged).toBeGreaterThanOrEqual(1));
-    expect((await client.listPrompts()).prompts).toHaveLength(2);
+    const afterAddList = await client.listPrompts();
+    expect(afterAddList.prompts).toHaveLength(2);
     const afterAdd = listChanged;
 
     handle.remove();
     await vi.waitFor(() => expect(listChanged).toBeGreaterThan(afterAdd));
-    expect((await client.listPrompts()).prompts).toHaveLength(1);
+    const afterRemoveList = await client.listPrompts();
+    expect(afterRemoveList.prompts).toHaveLength(1);
 });
 
 verifies('prompts:get:no-args', async ({ transport }: TestArgs) => {
@@ -467,8 +472,8 @@ verifies('mcpserver:prompt:duplicate-name', async ({ transport }: TestArgs) => {
         s.registerPrompt('fresh', {}, () => ({ messages: [] }));
         try {
             s.registerPrompt('explain-last-commit', {}, () => ({ messages: [] }));
-        } catch (e) {
-            dupError = e;
+        } catch (error) {
+            dupError = error;
         }
         return s;
     };
@@ -478,7 +483,7 @@ verifies('mcpserver:prompt:duplicate-name', async ({ transport }: TestArgs) => {
     expect(dupError).toBeInstanceOf(Error);
     expect(String(dupError)).toMatch(/already registered/i);
 
-    const prompts = (await client.listPrompts()).prompts;
+    const { prompts } = await client.listPrompts();
     expect(prompts.filter(p => p.name === 'explain-last-commit')).toHaveLength(1);
     expect(prompts.map(p => p.name)).toContain('fresh');
     const r = await client.getPrompt({ name: 'explain-last-commit' });
@@ -486,7 +491,7 @@ verifies('mcpserver:prompt:duplicate-name', async ({ transport }: TestArgs) => {
 });
 
 verifies('mcpserver:prompt:handle-update-remove', async ({ transport }: TestArgs) => {
-    let handle!: RegisteredPrompt;
+    let handle: RegisteredPrompt | undefined;
     const makeServer = () => {
         const s = new McpServer({ name: 's', version: '0' });
         handle = s.registerPrompt('probe', { description: 'v1' }, () => ({
@@ -501,11 +506,14 @@ verifies('mcpserver:prompt:handle-update-remove', async ({ transport }: TestArgs
         listChanged++;
     });
     await using _ = await wire(transport, makeServer, client);
+    if (handle === undefined) throw new Error('wire() did not invoke the server factory');
 
-    expect((await client.listPrompts()).prompts).toHaveLength(1);
-    const before = (await client.listPrompts()).prompts.find(p => p.name === 'probe')!;
-    expect(before.description).toBe('v1');
-    expect((await client.getPrompt({ name: 'probe' })).messages).toEqual([{ role: 'user', content: { type: 'text', text: 'v1' } }]);
+    const initialList = await client.listPrompts();
+    expect(initialList.prompts).toHaveLength(1);
+    const before = initialList.prompts.find(p => p.name === 'probe');
+    expect(before?.description).toBe('v1');
+    const initialGet = await client.getPrompt({ name: 'probe' });
+    expect(initialGet.messages).toEqual([{ role: 'user', content: { type: 'text', text: 'v1' } }]);
 
     handle.update({
         description: 'v2',
@@ -513,10 +521,11 @@ verifies('mcpserver:prompt:handle-update-remove', async ({ transport }: TestArgs
     });
 
     await vi.waitFor(() => expect(listChanged).toBeGreaterThanOrEqual(1));
-    expect((await client.listPrompts()).prompts).toHaveLength(1);
+    const updatedList = await client.listPrompts();
+    expect(updatedList.prompts).toHaveLength(1);
 
-    const after = (await client.listPrompts()).prompts.find(p => p.name === 'probe')!;
-    expect(after.description).toBe('v2');
+    const after = updatedList.prompts.find(p => p.name === 'probe');
+    expect(after?.description).toBe('v2');
 
     const r = await client.getPrompt({ name: 'probe' });
     expect(r.messages).toEqual([{ role: 'user', content: { type: 'text', text: 'v2' } }]);
@@ -524,29 +533,10 @@ verifies('mcpserver:prompt:handle-update-remove', async ({ transport }: TestArgs
     const beforeRemove = listChanged;
     handle.remove();
     await vi.waitFor(() => expect(listChanged).toBeGreaterThan(beforeRemove));
-    expect((await client.listPrompts()).prompts).toHaveLength(0);
+    const removedList = await client.listPrompts();
+    expect(removedList.prompts).toHaveLength(0);
 
     await expect(client.getPrompt({ name: 'probe' })).rejects.toBeInstanceOf(ProtocolError);
-    expect((await client.listPrompts()).prompts.find(p => p.name === 'probe')).toBeUndefined();
-});
-
-verifies('mcpserver:prompt:legacy-overload', async ({ transport }: TestArgs) => {
-    const makeServer = () => {
-        const s = new McpServer({ name: 's', version: '0' });
-        s.registerPrompt('legacy-prompt', { description: 'Legacy prompt overload (name, description, cb).' }, () => ({
-            messages: [{ role: 'user', content: { type: 'text', text: 'Explain the project README.' } }]
-        }));
-        return s;
-    };
-    const client = newClient();
-    await using _ = await wire(transport, makeServer, client);
-
-    const { prompts } = await client.listPrompts();
-    const listed = prompts.find(p => p.name === 'legacy-prompt');
-    expect(listed).toBeDefined();
-    expect(listed!.description).toBe('Legacy prompt overload (name, description, cb).');
-    expect(listed!.arguments ?? []).toEqual([]);
-
-    const result = await client.getPrompt({ name: 'legacy-prompt' });
-    expect(result.messages).toEqual([{ role: 'user', content: { type: 'text', text: 'Explain the project README.' } }]);
+    const finalList = await client.listPrompts();
+    expect(finalList.prompts.find(p => p.name === 'probe')).toBeUndefined();
 });

--- a/test/e2e/scenarios/prompts.test.ts
+++ b/test/e2e/scenarios/prompts.test.ts
@@ -10,18 +10,9 @@
 
 import { expect, vi } from 'vitest';
 import { z } from 'zod/v4';
-
-import { Client } from '../../../src/client/index.js';
-import { Server } from '../../../src/server/index.js';
-import { McpServer, type RegisteredPrompt } from '../../../src/server/mcp.js';
-import {
-    ErrorCode,
-    GetPromptRequestSchema,
-    ListPromptsRequestSchema,
-    McpError,
-    PromptListChangedNotificationSchema
-} from '../../../src/types.js';
-
+import { Server, McpServer, ProtocolError, ProtocolErrorCode } from '@modelcontextprotocol/server';
+import type { RegisteredPrompt } from '@modelcontextprotocol/server';
+import { Client } from '@modelcontextprotocol/client';
 import { wire } from '../helpers/index.js';
 import type { TestArgs } from '../types.js';
 import { verifies } from '../helpers/verifies.js';
@@ -34,9 +25,13 @@ const newClient = () => new Client({ name: 'c', version: '0' });
 
 function summarizeServer(): McpServer {
     const s = new McpServer({ name: 's', version: '0' });
-    s.registerPrompt('summarize', { description: 'Summarize the provided text.', argsSchema: { text: z.string() } }, ({ text }) => ({
-        messages: [{ role: 'user', content: { type: 'text', text: `Summarize the following text:\n${text}` } }]
-    }));
+    s.registerPrompt(
+        'summarize',
+        { description: 'Summarize the provided text.', argsSchema: z.object({ text: z.string() }) },
+        ({ text }) => ({
+            messages: [{ role: 'user', content: { type: 'text', text: `Summarize the following text:\n${text}` } }]
+        })
+    );
     return s;
 }
 
@@ -60,14 +55,18 @@ verifies('prompts:capability:declared', async ({ transport }: TestArgs) => {
 verifies('prompts:list:basic', async ({ transport }: TestArgs) => {
     const makeServer = () => {
         const s = new McpServer({ name: 's', version: '0' });
-        s.registerPrompt('summarize', { description: 'Summarize the provided text.', argsSchema: { text: z.string() } }, ({ text }) => ({
-            messages: [{ role: 'user', content: { type: 'text', text: `Summarize the following text:\n${text}` } }]
-        }));
+        s.registerPrompt(
+            'summarize',
+            { description: 'Summarize the provided text.', argsSchema: z.object({ text: z.string() }) },
+            ({ text }) => ({
+                messages: [{ role: 'user', content: { type: 'text', text: `Summarize the following text:\n${text}` } }]
+            })
+        );
         s.registerPrompt(
             'code-review',
             {
                 description: 'Review a code snippet in the given language, optionally focused on one aspect.',
-                argsSchema: { language: z.enum(['ts', 'py']), focus: z.string().optional() }
+                argsSchema: z.object({ language: z.enum(['ts', 'py']), focus: z.string().optional() })
             },
             ({ language, focus }) => ({
                 messages: [
@@ -157,7 +156,7 @@ verifies(
 
         const makeServer = () => {
             const s = new Server({ name: 's', version: '0' }, { capabilities: { prompts: {} } });
-            s.setRequestHandler(ListPromptsRequestSchema, req => {
+            s.setRequestHandler('prompts/list', req => {
                 cursorsReceived.push(req.params?.cursor);
                 const start = req.params?.cursor === undefined ? 0 : parseInt(req.params.cursor, 10);
                 const slice = all.slice(start, start + PAGE);
@@ -166,7 +165,7 @@ verifies(
                     nextCursor: start + PAGE < TOTAL ? String(start + PAGE) : undefined
                 };
             });
-            s.setRequestHandler(GetPromptRequestSchema, req => ({
+            s.setRequestHandler('prompts/get', req => ({
                 messages: [{ role: 'user', content: { type: 'text', text: req.params.name } }]
             }));
             return s;
@@ -211,7 +210,7 @@ verifies('prompts:list-changed', async ({ transport }: TestArgs) => {
 
     let listChanged = 0;
     const client = newClient();
-    client.setNotificationHandler(PromptListChangedNotificationSchema, () => {
+    client.setNotificationHandler('notifications/prompts/list_changed', () => {
         listChanged++;
     });
 
@@ -286,7 +285,7 @@ verifies('prompts:get:missing-required-args', async ({ transport }: TestArgs) =>
     await using _ = await wire(transport, summarizeServer, client);
 
     await expect(client.getPrompt({ name: 'summarize', arguments: {} })).rejects.toMatchObject({
-        code: ErrorCode.InvalidParams,
+        code: ProtocolErrorCode.InvalidParams,
         message: expect.stringMatching(/text|required|invalid/i)
     });
 });
@@ -296,7 +295,7 @@ verifies('prompts:get:unknown-name', async ({ transport }: TestArgs) => {
     await using _ = await wire(transport, explainCommitServer, client);
 
     await expect(client.getPrompt({ name: 'no-such-prompt' })).rejects.toMatchObject({
-        code: ErrorCode.InvalidParams,
+        code: ProtocolErrorCode.InvalidParams,
         message: expect.stringMatching(/no-such-prompt|unknown|not found/i)
     });
 });
@@ -348,7 +347,7 @@ verifies('prompts:get:content:audio', async ({ transport }: TestArgs) => {
 verifies('prompts:get:content:embedded-resource', async ({ transport }: TestArgs) => {
     const makeServer = () => {
         const s = new McpServer({ name: 's', version: '0' });
-        s.registerPrompt('review-file', { argsSchema: { kind: z.enum(['text', 'blob']) } }, ({ kind }) => ({
+        s.registerPrompt('review-file', { argsSchema: z.object({ kind: z.enum(['text', 'blob']) }) }, ({ kind }) => ({
             messages: [
                 { role: 'user', content: { type: 'text', text: 'Review the attached file.' } },
                 {
@@ -399,7 +398,7 @@ verifies('mcpserver:prompt:args-validation', async ({ transport }: TestArgs) => 
         const s = new McpServer({ name: 's', version: '0' });
         s.registerPrompt(
             'code-review',
-            { argsSchema: { language: z.enum(['ts', 'py']), focus: z.string().optional() } },
+            { argsSchema: z.object({ language: z.enum(['ts', 'py']), focus: z.string().optional() }) },
             ({ language }) => {
                 handlerCalls.n++;
                 return { messages: [{ role: 'user', content: { type: 'text', text: `Review the following ${language} code:` } }] };
@@ -415,13 +414,13 @@ verifies('mcpserver:prompt:args-validation', async ({ transport }: TestArgs) => 
     expect(handlerCalls.n).toBe(1);
 
     await expect(client.getPrompt({ name: 'code-review', arguments: { language: 'rust' } })).rejects.toMatchObject({
-        code: ErrorCode.InvalidParams,
+        code: ProtocolErrorCode.InvalidParams,
         message: expect.stringMatching(/invalid arguments.*code-review/i)
     });
     expect(handlerCalls.n).toBe(1);
 
     await expect(client.getPrompt({ name: 'code-review', arguments: {} })).rejects.toMatchObject({
-        code: ErrorCode.InvalidParams,
+        code: ProtocolErrorCode.InvalidParams,
         message: expect.stringMatching(/invalid arguments/i)
     });
     expect(handlerCalls.n).toBe(1);
@@ -430,19 +429,23 @@ verifies('mcpserver:prompt:args-validation', async ({ transport }: TestArgs) => 
 verifies('mcpserver:prompt:optional-args', async ({ transport }: TestArgs) => {
     const makeServer = () => {
         const s = new McpServer({ name: 's', version: '0' });
-        s.registerPrompt('summarize', { argsSchema: { text: z.string(), max_words: z.string().optional() } }, ({ text, max_words }) => ({
-            messages: [
-                {
-                    role: 'user',
-                    content: {
-                        type: 'text',
-                        text: max_words
-                            ? `Summarize the following text in at most ${max_words} words:\n${text}`
-                            : `Summarize the following text:\n${text}`
+        s.registerPrompt(
+            'summarize',
+            { argsSchema: z.object({ text: z.string(), max_words: z.string().optional() }) },
+            ({ text, max_words }) => ({
+                messages: [
+                    {
+                        role: 'user',
+                        content: {
+                            type: 'text',
+                            text: max_words
+                                ? `Summarize the following text in at most ${max_words} words:\n${text}`
+                                : `Summarize the following text:\n${text}`
+                        }
                     }
-                }
-            ]
-        }));
+                ]
+            })
+        );
         return s;
     };
     const client = newClient();
@@ -494,7 +497,7 @@ verifies('mcpserver:prompt:handle-update-remove', async ({ transport }: TestArgs
 
     let listChanged = 0;
     const client = newClient();
-    client.setNotificationHandler(PromptListChangedNotificationSchema, () => {
+    client.setNotificationHandler('notifications/prompts/list_changed', () => {
         listChanged++;
     });
     await using _ = await wire(transport, makeServer, client);
@@ -523,14 +526,14 @@ verifies('mcpserver:prompt:handle-update-remove', async ({ transport }: TestArgs
     await vi.waitFor(() => expect(listChanged).toBeGreaterThan(beforeRemove));
     expect((await client.listPrompts()).prompts).toHaveLength(0);
 
-    await expect(client.getPrompt({ name: 'probe' })).rejects.toBeInstanceOf(McpError);
+    await expect(client.getPrompt({ name: 'probe' })).rejects.toBeInstanceOf(ProtocolError);
     expect((await client.listPrompts()).prompts.find(p => p.name === 'probe')).toBeUndefined();
 });
 
 verifies('mcpserver:prompt:legacy-overload', async ({ transport }: TestArgs) => {
     const makeServer = () => {
         const s = new McpServer({ name: 's', version: '0' });
-        s.prompt('legacy-prompt', 'Legacy prompt overload (name, description, cb).', () => ({
+        s.registerPrompt('legacy-prompt', { description: 'Legacy prompt overload (name, description, cb).' }, () => ({
             messages: [{ role: 'user', content: { type: 'text', text: 'Explain the project README.' } }]
         }));
         return s;

--- a/test/e2e/scenarios/prompts.test.ts
+++ b/test/e2e/scenarios/prompts.test.ts
@@ -1,0 +1,549 @@
+/**
+ * Self-contained test bodies for the prompts surface.
+ *
+ * Each export is a {@link TestCase}: it builds its own server (via a factory),
+ * builds its own client, wires them with {@link wire}, and asserts. Function
+ * names mirror the requirement id in camelCase; a `Raw` suffix marks
+ * a low-level {@link Server} variant where the behavior under test differs by
+ * tier.
+ */
+
+import { expect, vi } from 'vitest';
+import { z } from 'zod/v4';
+
+import { Client } from '../../../src/client/index.js';
+import { Server } from '../../../src/server/index.js';
+import { McpServer, type RegisteredPrompt } from '../../../src/server/mcp.js';
+import {
+    ErrorCode,
+    GetPromptRequestSchema,
+    ListPromptsRequestSchema,
+    McpError,
+    PromptListChangedNotificationSchema
+} from '../../../src/types.js';
+
+import { wire } from '../helpers/index.js';
+import type { TestArgs } from '../types.js';
+import { verifies } from '../helpers/verifies.js';
+
+const TINY_PNG_BASE64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=';
+const TINY_WAV_BASE64 = 'UklGRiQAAABXQVZFZm10IBAAAAABAAEAQB8AAEAfAAABAAgAZGF0YQAAAAA=';
+const TINY_BLOB_BASE64 = 'SGVsbG8sIE1DUCE=';
+
+const newClient = () => new Client({ name: 'c', version: '0' });
+
+function summarizeServer(): McpServer {
+    const s = new McpServer({ name: 's', version: '0' });
+    s.registerPrompt('summarize', { description: 'Summarize the provided text.', argsSchema: { text: z.string() } }, ({ text }) => ({
+        messages: [{ role: 'user', content: { type: 'text', text: `Summarize the following text:\n${text}` } }]
+    }));
+    return s;
+}
+
+function explainCommitServer(): McpServer {
+    const s = new McpServer({ name: 's', version: '0' });
+    s.registerPrompt('explain-last-commit', { description: 'Explain the most recent git commit.' }, () => ({
+        messages: [{ role: 'user', content: { type: 'text', text: 'Explain the most recent commit in this repository.' } }]
+    }));
+    return s;
+}
+
+verifies('prompts:capability:declared', async ({ transport }: TestArgs) => {
+    const client = newClient();
+    await using _ = await wire(transport, explainCommitServer, client);
+
+    const caps = client.getServerCapabilities();
+    expect(caps?.prompts).toBeDefined();
+    expect(caps?.prompts?.listChanged).toBe(true);
+});
+
+verifies('prompts:list:basic', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerPrompt('summarize', { description: 'Summarize the provided text.', argsSchema: { text: z.string() } }, ({ text }) => ({
+            messages: [{ role: 'user', content: { type: 'text', text: `Summarize the following text:\n${text}` } }]
+        }));
+        s.registerPrompt(
+            'code-review',
+            {
+                description: 'Review a code snippet in the given language, optionally focused on one aspect.',
+                argsSchema: { language: z.enum(['ts', 'py']), focus: z.string().optional() }
+            },
+            ({ language, focus }) => ({
+                messages: [
+                    {
+                        role: 'user',
+                        content: {
+                            type: 'text',
+                            text: focus
+                                ? `Review the following ${language} code, focusing on ${focus}:`
+                                : `Review the following ${language} code:`
+                        }
+                    }
+                ]
+            })
+        );
+        s.registerPrompt('explain-last-commit', { description: 'Explain the most recent git commit.' }, () => ({
+            messages: [{ role: 'user', content: { type: 'text', text: 'Explain the most recent commit in this repository.' } }]
+        }));
+        return s;
+    };
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    const result = await client.listPrompts();
+
+    expect(result.prompts).toHaveLength(3);
+    expect(result.prompts.map(p => p.name).sort()).toEqual(['code-review', 'explain-last-commit', 'summarize']);
+
+    expect(result.prompts.find(p => p.name === 'summarize')).toMatchObject({
+        name: 'summarize',
+        description: 'Summarize the provided text.',
+        arguments: [{ name: 'text', required: true }]
+    });
+
+    const codeReview = result.prompts.find(p => p.name === 'code-review');
+    expect(codeReview?.description).toBe('Review a code snippet in the given language, optionally focused on one aspect.');
+    expect(codeReview?.arguments).toEqual([
+        { name: 'language', required: true },
+        { name: 'focus', required: false }
+    ]);
+
+    const explain = result.prompts.find(p => p.name === 'explain-last-commit');
+    expect(explain?.description).toBe('Explain the most recent git commit.');
+    expect(explain?.arguments ?? []).toHaveLength(0);
+});
+
+verifies(
+    'prompts:list:pagination',
+    async ({ transport }: TestArgs) => {
+        const TOTAL = 25;
+        const makeServer = () => {
+            const s = new McpServer({ name: 's', version: '0' });
+            for (let i = 0; i < TOTAL; i++) {
+                s.registerPrompt(`bulk_${String(i).padStart(2, '0')}`, {}, () => ({ messages: [] }));
+            }
+            return s;
+        };
+        const client = newClient();
+        await using _ = await wire(transport, makeServer, client);
+
+        const first = await client.listPrompts();
+        expect(first.prompts.length).toBeLessThan(TOTAL);
+        expect(first.nextCursor).toBeDefined();
+
+        const seen = new Set(first.prompts.map(p => p.name));
+        let result = first;
+        let pages = 1;
+        while (result.nextCursor !== undefined) {
+            result = await client.listPrompts({ cursor: result.nextCursor });
+            for (const p of result.prompts) seen.add(p.name);
+            pages++;
+            expect(pages).toBeLessThan(50);
+        }
+        expect(seen.size).toBe(TOTAL);
+        expect(pages).toBeGreaterThan(1);
+    },
+    { title: 'mcpserver' }
+);
+
+verifies(
+    'prompts:list:pagination',
+    async ({ transport }: TestArgs) => {
+        const TOTAL = 25;
+        const PAGE = 10;
+        const all = Array.from({ length: TOTAL }, (_, i) => `prompt_${String(i).padStart(2, '0')}`);
+        const cursorsReceived: Array<string | undefined> = [];
+
+        const makeServer = () => {
+            const s = new Server({ name: 's', version: '0' }, { capabilities: { prompts: {} } });
+            s.setRequestHandler(ListPromptsRequestSchema, req => {
+                cursorsReceived.push(req.params?.cursor);
+                const start = req.params?.cursor === undefined ? 0 : parseInt(req.params.cursor, 10);
+                const slice = all.slice(start, start + PAGE);
+                return {
+                    prompts: slice.map(name => ({ name })),
+                    nextCursor: start + PAGE < TOTAL ? String(start + PAGE) : undefined
+                };
+            });
+            s.setRequestHandler(GetPromptRequestSchema, req => ({
+                messages: [{ role: 'user', content: { type: 'text', text: req.params.name } }]
+            }));
+            return s;
+        };
+        const client = newClient();
+        await using _ = await wire(transport, makeServer, client);
+
+        const seen = new Set<string>();
+        const cursorsSent: string[] = [];
+        let pages = 0;
+        let result = await client.listPrompts();
+        expect(result.nextCursor).toBeDefined();
+        for (;;) {
+            for (const p of result.prompts) {
+                expect(seen.has(p.name)).toBe(false);
+                seen.add(p.name);
+            }
+            pages++;
+            if (result.nextCursor === undefined) break;
+            cursorsSent.push(result.nextCursor);
+            result = await client.listPrompts({ cursor: result.nextCursor });
+            expect(pages).toBeLessThan(50);
+        }
+
+        expect(pages).toBe(3);
+        expect(seen.size).toBe(TOTAL);
+        for (const name of all) expect(seen.has(name)).toBe(true);
+
+        expect(cursorsReceived).toEqual([undefined, '10', '20']);
+        expect(cursorsSent).toEqual(['10', '20']);
+    },
+    { title: 'raw server' }
+);
+
+verifies('prompts:list-changed', async ({ transport }: TestArgs) => {
+    let server!: McpServer;
+    const makeServer = () => {
+        server = new McpServer({ name: 's', version: '0' });
+        server.registerPrompt('seed', {}, () => ({ messages: [] }));
+        return server;
+    };
+
+    let listChanged = 0;
+    const client = newClient();
+    client.setNotificationHandler(PromptListChangedNotificationSchema, () => {
+        listChanged++;
+    });
+
+    await using _ = await wire(transport, makeServer, client);
+
+    expect((await client.listPrompts()).prompts).toHaveLength(1);
+
+    const handle = server.registerPrompt('dynamic-probe', {}, () => ({ messages: [] }));
+    await vi.waitFor(() => expect(listChanged).toBeGreaterThanOrEqual(1));
+    expect((await client.listPrompts()).prompts).toHaveLength(2);
+    const afterAdd = listChanged;
+
+    handle.remove();
+    await vi.waitFor(() => expect(listChanged).toBeGreaterThan(afterAdd));
+    expect((await client.listPrompts()).prompts).toHaveLength(1);
+});
+
+verifies('prompts:get:no-args', async ({ transport }: TestArgs) => {
+    const client = newClient();
+    await using _ = await wire(transport, explainCommitServer, client);
+
+    const result = await client.getPrompt({ name: 'explain-last-commit' });
+
+    expect(result.messages).toEqual([
+        { role: 'user', content: { type: 'text', text: 'Explain the most recent commit in this repository.' } }
+    ]);
+});
+
+verifies('prompts:get:with-args', async ({ transport }: TestArgs) => {
+    const client = newClient();
+    await using _ = await wire(transport, summarizeServer, client);
+
+    const result = await client.getPrompt({
+        name: 'summarize',
+        arguments: { text: 'The quick brown fox jumps over the lazy dog.' }
+    });
+
+    expect(result.messages).toEqual([
+        {
+            role: 'user',
+            content: { type: 'text', text: 'Summarize the following text:\nThe quick brown fox jumps over the lazy dog.' }
+        }
+    ]);
+});
+
+verifies('prompts:get:multi-message', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerPrompt('geography-quiz', { description: 'A short multi-turn geography quiz.' }, () => ({
+            messages: [
+                { role: 'user', content: { type: 'text', text: 'What is the capital of France?' } },
+                { role: 'assistant', content: { type: 'text', text: 'The capital of France is Paris.' } },
+                { role: 'user', content: { type: 'text', text: 'And of Italy?' } }
+            ]
+        }));
+        return s;
+    };
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    const result = await client.getPrompt({ name: 'geography-quiz' });
+
+    expect(result.messages).toEqual([
+        { role: 'user', content: { type: 'text', text: 'What is the capital of France?' } },
+        { role: 'assistant', content: { type: 'text', text: 'The capital of France is Paris.' } },
+        { role: 'user', content: { type: 'text', text: 'And of Italy?' } }
+    ]);
+});
+
+verifies('prompts:get:missing-required-args', async ({ transport }: TestArgs) => {
+    const client = newClient();
+    await using _ = await wire(transport, summarizeServer, client);
+
+    await expect(client.getPrompt({ name: 'summarize', arguments: {} })).rejects.toMatchObject({
+        code: ErrorCode.InvalidParams,
+        message: expect.stringMatching(/text|required|invalid/i)
+    });
+});
+
+verifies('prompts:get:unknown-name', async ({ transport }: TestArgs) => {
+    const client = newClient();
+    await using _ = await wire(transport, explainCommitServer, client);
+
+    await expect(client.getPrompt({ name: 'no-such-prompt' })).rejects.toMatchObject({
+        code: ErrorCode.InvalidParams,
+        message: expect.stringMatching(/no-such-prompt|unknown|not found/i)
+    });
+});
+
+verifies('prompts:get:content:image', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerPrompt('describe-image', {}, () => ({
+            messages: [
+                { role: 'user', content: { type: 'text', text: 'Describe what you see in this image.' } },
+                { role: 'user', content: { type: 'image', data: TINY_PNG_BASE64, mimeType: 'image/png' } }
+            ]
+        }));
+        return s;
+    };
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    const result = await client.getPrompt({ name: 'describe-image' });
+
+    expect(result.messages).toEqual([
+        { role: 'user', content: { type: 'text', text: 'Describe what you see in this image.' } },
+        { role: 'user', content: { type: 'image', data: TINY_PNG_BASE64, mimeType: 'image/png' } }
+    ]);
+});
+
+verifies('prompts:get:content:audio', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerPrompt('transcribe-audio', {}, () => ({
+            messages: [
+                { role: 'user', content: { type: 'text', text: 'Transcribe the following audio clip.' } },
+                { role: 'user', content: { type: 'audio', data: TINY_WAV_BASE64, mimeType: 'audio/wav' } }
+            ]
+        }));
+        return s;
+    };
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    const result = await client.getPrompt({ name: 'transcribe-audio' });
+
+    expect(result.messages).toEqual([
+        { role: 'user', content: { type: 'text', text: 'Transcribe the following audio clip.' } },
+        { role: 'user', content: { type: 'audio', data: TINY_WAV_BASE64, mimeType: 'audio/wav' } }
+    ]);
+});
+
+verifies('prompts:get:content:embedded-resource', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerPrompt('review-file', { argsSchema: { kind: z.enum(['text', 'blob']) } }, ({ kind }) => ({
+            messages: [
+                { role: 'user', content: { type: 'text', text: 'Review the attached file.' } },
+                {
+                    role: 'user',
+                    content:
+                        kind === 'text'
+                            ? {
+                                  type: 'resource',
+                                  resource: { uri: 'file:///fixture.txt', mimeType: 'text/plain', text: 'embedded fixture text' }
+                              }
+                            : {
+                                  type: 'resource',
+                                  resource: { uri: 'file:///fixture.bin', mimeType: 'application/octet-stream', blob: TINY_BLOB_BASE64 }
+                              }
+                }
+            ]
+        }));
+        return s;
+    };
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    const text = await client.getPrompt({ name: 'review-file', arguments: { kind: 'text' } });
+    expect(text.messages).toEqual([
+        { role: 'user', content: { type: 'text', text: 'Review the attached file.' } },
+        {
+            role: 'user',
+            content: { type: 'resource', resource: { uri: 'file:///fixture.txt', mimeType: 'text/plain', text: 'embedded fixture text' } }
+        }
+    ]);
+
+    const blob = await client.getPrompt({ name: 'review-file', arguments: { kind: 'blob' } });
+    expect(blob.messages).toEqual([
+        { role: 'user', content: { type: 'text', text: 'Review the attached file.' } },
+        {
+            role: 'user',
+            content: {
+                type: 'resource',
+                resource: { uri: 'file:///fixture.bin', mimeType: 'application/octet-stream', blob: TINY_BLOB_BASE64 }
+            }
+        }
+    ]);
+});
+
+verifies('mcpserver:prompt:args-validation', async ({ transport }: TestArgs) => {
+    const handlerCalls = { n: 0 };
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerPrompt(
+            'code-review',
+            { argsSchema: { language: z.enum(['ts', 'py']), focus: z.string().optional() } },
+            ({ language }) => {
+                handlerCalls.n++;
+                return { messages: [{ role: 'user', content: { type: 'text', text: `Review the following ${language} code:` } }] };
+            }
+        );
+        return s;
+    };
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    const ok = await client.getPrompt({ name: 'code-review', arguments: { language: 'ts' } });
+    expect(ok.messages).toEqual([{ role: 'user', content: { type: 'text', text: 'Review the following ts code:' } }]);
+    expect(handlerCalls.n).toBe(1);
+
+    await expect(client.getPrompt({ name: 'code-review', arguments: { language: 'rust' } })).rejects.toMatchObject({
+        code: ErrorCode.InvalidParams,
+        message: expect.stringMatching(/invalid arguments.*code-review/i)
+    });
+    expect(handlerCalls.n).toBe(1);
+
+    await expect(client.getPrompt({ name: 'code-review', arguments: {} })).rejects.toMatchObject({
+        code: ErrorCode.InvalidParams,
+        message: expect.stringMatching(/invalid arguments/i)
+    });
+    expect(handlerCalls.n).toBe(1);
+});
+
+verifies('mcpserver:prompt:optional-args', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerPrompt('summarize', { argsSchema: { text: z.string(), max_words: z.string().optional() } }, ({ text, max_words }) => ({
+            messages: [
+                {
+                    role: 'user',
+                    content: {
+                        type: 'text',
+                        text: max_words
+                            ? `Summarize the following text in at most ${max_words} words:\n${text}`
+                            : `Summarize the following text:\n${text}`
+                    }
+                }
+            ]
+        }));
+        return s;
+    };
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    const withOpt = await client.getPrompt({ name: 'summarize', arguments: { text: 'lorem ipsum', max_words: '10' } });
+    expect(withOpt.messages).toEqual([
+        { role: 'user', content: { type: 'text', text: 'Summarize the following text in at most 10 words:\nlorem ipsum' } }
+    ]);
+
+    const withoutOpt = await client.getPrompt({ name: 'summarize', arguments: { text: 'lorem ipsum' } });
+    expect(withoutOpt.messages).toEqual([{ role: 'user', content: { type: 'text', text: 'Summarize the following text:\nlorem ipsum' } }]);
+});
+
+verifies('mcpserver:prompt:duplicate-name', async ({ transport }: TestArgs) => {
+    let dupError: unknown;
+    const makeServer = () => {
+        const s = explainCommitServer();
+        s.registerPrompt('fresh', {}, () => ({ messages: [] }));
+        try {
+            s.registerPrompt('explain-last-commit', {}, () => ({ messages: [] }));
+        } catch (e) {
+            dupError = e;
+        }
+        return s;
+    };
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    expect(dupError).toBeInstanceOf(Error);
+    expect(String(dupError)).toMatch(/already registered/i);
+
+    const prompts = (await client.listPrompts()).prompts;
+    expect(prompts.filter(p => p.name === 'explain-last-commit')).toHaveLength(1);
+    expect(prompts.map(p => p.name)).toContain('fresh');
+    const r = await client.getPrompt({ name: 'explain-last-commit' });
+    expect(r.messages).toEqual([{ role: 'user', content: { type: 'text', text: 'Explain the most recent commit in this repository.' } }]);
+});
+
+verifies('mcpserver:prompt:handle-update-remove', async ({ transport }: TestArgs) => {
+    let handle!: RegisteredPrompt;
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        handle = s.registerPrompt('probe', { description: 'v1' }, () => ({
+            messages: [{ role: 'user', content: { type: 'text', text: 'v1' } }]
+        }));
+        return s;
+    };
+
+    let listChanged = 0;
+    const client = newClient();
+    client.setNotificationHandler(PromptListChangedNotificationSchema, () => {
+        listChanged++;
+    });
+    await using _ = await wire(transport, makeServer, client);
+
+    expect((await client.listPrompts()).prompts).toHaveLength(1);
+    const before = (await client.listPrompts()).prompts.find(p => p.name === 'probe')!;
+    expect(before.description).toBe('v1');
+    expect((await client.getPrompt({ name: 'probe' })).messages).toEqual([{ role: 'user', content: { type: 'text', text: 'v1' } }]);
+
+    handle.update({
+        description: 'v2',
+        callback: () => ({ messages: [{ role: 'user', content: { type: 'text', text: 'v2' } }] })
+    });
+
+    await vi.waitFor(() => expect(listChanged).toBeGreaterThanOrEqual(1));
+    expect((await client.listPrompts()).prompts).toHaveLength(1);
+
+    const after = (await client.listPrompts()).prompts.find(p => p.name === 'probe')!;
+    expect(after.description).toBe('v2');
+
+    const r = await client.getPrompt({ name: 'probe' });
+    expect(r.messages).toEqual([{ role: 'user', content: { type: 'text', text: 'v2' } }]);
+
+    const beforeRemove = listChanged;
+    handle.remove();
+    await vi.waitFor(() => expect(listChanged).toBeGreaterThan(beforeRemove));
+    expect((await client.listPrompts()).prompts).toHaveLength(0);
+
+    await expect(client.getPrompt({ name: 'probe' })).rejects.toBeInstanceOf(McpError);
+    expect((await client.listPrompts()).prompts.find(p => p.name === 'probe')).toBeUndefined();
+});
+
+verifies('mcpserver:prompt:legacy-overload', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.prompt('legacy-prompt', 'Legacy prompt overload (name, description, cb).', () => ({
+            messages: [{ role: 'user', content: { type: 'text', text: 'Explain the project README.' } }]
+        }));
+        return s;
+    };
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    const { prompts } = await client.listPrompts();
+    const listed = prompts.find(p => p.name === 'legacy-prompt');
+    expect(listed).toBeDefined();
+    expect(listed!.description).toBe('Legacy prompt overload (name, description, cb).');
+    expect(listed!.arguments ?? []).toEqual([]);
+
+    const result = await client.getPrompt({ name: 'legacy-prompt' });
+    expect(result.messages).toEqual([{ role: 'user', content: { type: 'text', text: 'Explain the project README.' } }]);
+});

--- a/test/e2e/scenarios/protocol.test.ts
+++ b/test/e2e/scenarios/protocol.test.ts
@@ -1415,3 +1415,48 @@ verifies(
     },
     { title: 'raw Server' }
 );
+
+verifies('typescript:method-string-handlers:result-type-inference', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool('echo', { description: 'echoes text', inputSchema: z.object({ text: z.string() }) }, ({ text }) => ({
+            content: [{ type: 'text', text }]
+        }));
+        return s;
+    };
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    // Spec method string, no result schema: the result arrives parsed as ListToolsResult via ResultTypeMap inference.
+    const viaRequest = await client.request({ method: 'tools/list', params: {} });
+
+    // .tools is usable directly — no schema argument and no casts anywhere is the type-inference proof.
+    expect(viaRequest.tools.map(t => t.name)).toEqual(['echo']);
+    expect(viaRequest.tools[0]?.description).toBe('echoes text');
+
+    // The schema-less request agrees with the dedicated typed method for the same call.
+    const viaListTools = await client.listTools();
+    expect(viaRequest.tools).toEqual(viaListTools.tools);
+
+    // Another spec method, again schema-less: ping resolves with its parsed (empty) result.
+    await expect(client.request({ method: 'ping' })).resolves.toEqual({});
+});
+
+verifies('protocol:result-validation:invalid-result-sdkerror', async ({ transport }: TestArgs) => {
+    const WRONG_SHAPE_METHOD = 'x-e2e/wrong-shape';
+    // Handler declares no result schema, so it can legally return a shape the requesting side's schema rejects.
+    const makeServer = () => {
+        const s = new Server({ name: 's', version: '0' }, { capabilities: {} });
+        s.setRequestHandler(WRONG_SHAPE_METHOD, { params: z.object({}) }, () => ({ wrong: true }));
+        return s;
+    };
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client, { allowCustomMethods: true });
+
+    const call = client.request({ method: WRONG_SHAPE_METHOD, params: {} }, z.object({ right: z.string() }));
+
+    // The non-conforming result rejects as SdkError InvalidResult — never resolves, and no raw validation error leaks.
+    await expect(call).rejects.toBeInstanceOf(SdkError);
+    await expect(call).rejects.toMatchObject({ code: SdkErrorCode.InvalidResult });
+    await expect(call).rejects.toThrow(/Invalid result for x-e2e\/wrong-shape/);
+});

--- a/test/e2e/scenarios/protocol.test.ts
+++ b/test/e2e/scenarios/protocol.test.ts
@@ -8,36 +8,26 @@
 
 import { expect, vi } from 'vitest';
 import { z } from 'zod/v4';
-
-import { Client } from '../../../src/client/index.js';
-import { InMemoryTransport } from '../../../src/inMemory.js';
-import { Server } from '../../../src/server/index.js';
-import { McpServer } from '../../../src/server/mcp.js';
 import {
-    type CallToolRequest,
-    CallToolRequestSchema,
-    CreateMessageRequestSchema,
-    CreateMessageResultSchema,
-    ErrorCode,
-    type JSONRPCMessage,
-    type JSONRPCNotification,
-    type JSONRPCRequest,
-    type JSONRPCResponse,
-    ListRootsRequestSchema,
-    ListRootsResultSchema,
-    ListToolsRequestSchema,
-    McpError,
-    type Notification,
-    NotificationSchema,
-    PingRequestSchema,
-    type Progress,
-    PromptListChangedNotificationSchema,
-    type RequestId,
-    RequestSchema,
-    ResultSchema,
-    ToolListChangedNotificationSchema
-} from '../../../src/types.js';
-
+    InMemoryTransport,
+    Server,
+    McpServer,
+    ProtocolError,
+    ProtocolErrorCode,
+    SdkErrorCode,
+    specTypeSchemas
+} from '@modelcontextprotocol/server';
+import type {
+    CallToolRequest,
+    JSONRPCMessage,
+    JSONRPCNotification,
+    JSONRPCRequest,
+    JSONRPCResponse,
+    Notification,
+    Progress,
+    RequestId
+} from '@modelcontextprotocol/server';
+import { Client } from '@modelcontextprotocol/client';
 import { tapWire, wire } from '../helpers/index.js';
 import type { TestArgs } from '../types.js';
 import { verifies } from '../helpers/verifies.js';
@@ -48,7 +38,7 @@ const newClient = () => new Client({ name: 'c', version: '0' });
 function neverRespondingServer(): Server {
     const s = new Server({ name: 's', version: '0' }, { capabilities: { tools: {} } });
     s.setRequestHandler(
-        ListToolsRequestSchema,
+        'tools/list',
         () =>
             new Promise(() => {
                 /* never resolves */
@@ -84,7 +74,7 @@ verifies('protocol:cancel:abort-signal', async ({ transport }: TestArgs) => {
         s.registerTool(
             'echo',
             { inputSchema: z.object({ text: z.string() }) },
-            async ({ text }, extra) =>
+            async ({ text }, ctx) =>
                 new Promise(resolve => {
                     const t = setTimeout(() => resolve({ content: [{ type: 'text', text }] }), 60_000);
                     t.unref();
@@ -92,7 +82,7 @@ verifies('protocol:cancel:abort-signal', async ({ transport }: TestArgs) => {
                         clearTimeout(t);
                         resolve({ content: [{ type: 'text', text: 'late' }] });
                     });
-                    extra.signal.addEventListener('abort', () => {
+                    ctx.mcpReq.signal.addEventListener('abort', () => {
                         clearTimeout(t);
                     });
                 })
@@ -142,11 +132,11 @@ verifies('protocol:cancel:handler-abort-propagates', async ({ transport }: TestA
         s.registerTool(
             'cancellable',
             { inputSchema: z.object({}) },
-            async (_a, extra) =>
+            async (_a, ctx) =>
                 new Promise((resolve, reject) => {
-                    extra.signal.addEventListener('abort', () => {
-                        aborts.push({ requestId: extra.requestId, reason: extra.signal.reason });
-                        reject(new Error(extra.signal.reason));
+                    ctx.mcpReq.signal.addEventListener('abort', () => {
+                        aborts.push({ requestId: ctx.mcpReq.id, reason: ctx.mcpReq.signal.reason });
+                        reject(new Error(ctx.mcpReq.signal.reason));
                     });
                 })
         );
@@ -324,8 +314,8 @@ verifies('typescript:protocol:error:connection-closed', async ({ transport }: Te
     await client.close();
 
     for (const p of inFlight) {
-        await expect(p).rejects.toBeInstanceOf(McpError);
-        await expect(p).rejects.toMatchObject({ code: ErrorCode.ConnectionClosed });
+        await expect(p).rejects.toBeInstanceOf(ProtocolError);
+        await expect(p).rejects.toMatchObject({ code: SdkErrorCode.ConnectionClosed });
     }
     // onclose fires at least once (transport peers may echo a close back, so don't pin the count).
     await vi.waitFor(() => expect(onclose).toHaveBeenCalled());
@@ -336,8 +326,8 @@ verifies('protocol:error:internal-error', async ({ transport }: TestArgs) => {
     // catches handler exceptions and wraps as {isError:true} (covered in tools.ts).
     const makeServer = () => {
         const s = new Server({ name: 's', version: '0' }, { capabilities: { tools: {} } });
-        s.setRequestHandler(ListToolsRequestSchema, () => ({ tools: [] }));
-        s.setRequestHandler(CallToolRequestSchema, () => {
+        s.setRequestHandler('tools/list', () => ({ tools: [] }));
+        s.setRequestHandler('tools/call', () => {
             throw new Error('handler exploded');
         });
         return s;
@@ -347,10 +337,10 @@ verifies('protocol:error:internal-error', async ({ transport }: TestArgs) => {
 
     const call = client.callTool({ name: 'any', arguments: {} });
 
-    await expect(call).rejects.toBeInstanceOf(McpError);
-    await expect(call).rejects.toMatchObject({ code: ErrorCode.InternalError });
+    await expect(call).rejects.toBeInstanceOf(ProtocolError);
+    await expect(call).rejects.toMatchObject({ code: ProtocolErrorCode.InternalError });
     await expect(call).rejects.toThrow(/handler exploded/);
-    expect(ErrorCode.InternalError).toBe(-32603);
+    expect(ProtocolErrorCode.InternalError).toBe(-32603);
 });
 
 verifies('protocol:error:invalid-params', async ({ transport }: TestArgs) => {
@@ -359,8 +349,8 @@ verifies('protocol:error:invalid-params', async ({ transport }: TestArgs) => {
     // -32602 InvalidParams at the protocol layer (not McpServer's tool-arg validation).
     const makeServer = () => {
         const s = new Server({ name: 's', version: '0' }, { capabilities: { tools: {} } });
-        s.setRequestHandler(ListToolsRequestSchema, () => ({ tools: [] }));
-        s.setRequestHandler(CallToolRequestSchema, () => ({ content: [] }));
+        s.setRequestHandler('tools/list', () => ({ tools: [] }));
+        s.setRequestHandler('tools/call', () => ({ content: [] }));
         return s;
     };
     const client = newClient();
@@ -372,14 +362,14 @@ verifies('protocol:error:invalid-params', async ({ transport }: TestArgs) => {
     // Send tools/call without the required `name` field.
     const call = client.request({ method: 'tools/call', params: { arguments: {} } }, z.object({}).passthrough());
 
-    await expect(call).rejects.toBeInstanceOf(McpError);
+    await expect(call).rejects.toBeInstanceOf(ProtocolError);
 
     // The malformed request did reach the wire (failure is server-side, not client-side validation).
     const sent = outbound.filter(isRequest).find(m => m.method === 'tools/call');
     expect(sent?.params).toEqual({ arguments: {} });
 
-    expect(ErrorCode.InvalidParams).toBe(-32602);
-    await expect(call).rejects.toMatchObject({ code: ErrorCode.InvalidParams });
+    expect(ProtocolErrorCode.InvalidParams).toBe(-32602);
+    await expect(call).rejects.toMatchObject({ code: ProtocolErrorCode.InvalidParams });
 });
 
 verifies('protocol:error:method-not-found', async ({ transport }: TestArgs) => {
@@ -399,10 +389,10 @@ verifies('protocol:error:method-not-found', async ({ transport }: TestArgs) => {
 
     const call = client.request({ method: 'no/such/method' }, z.object({}));
 
-    await expect(call).rejects.toBeInstanceOf(McpError);
+    await expect(call).rejects.toBeInstanceOf(ProtocolError);
 
-    const err = await call.catch(e => e as McpError);
-    expect(err.code).toBe(ErrorCode.MethodNotFound);
+    const err = await call.catch(e => e as ProtocolError);
+    expect(err.code).toBe(ProtocolErrorCode.MethodNotFound);
     expect(err.code).toBe(-32601);
 
     const sent = outbound.filter(m => 'method' in m && m.method === 'no/such/method' && 'id' in m);
@@ -474,11 +464,11 @@ verifies('protocol:error:reconnect-no-stale-timers', async (_: TestArgs) => {
 verifies('protocol:progress:callback', async ({ transport }: TestArgs) => {
     const makeServer = () => {
         const s = new McpServer({ name: 's', version: '0' });
-        s.registerTool('progress', { inputSchema: z.object({ steps: z.number().int().positive() }) }, async ({ steps }, extra) => {
-            const token = extra._meta?.progressToken;
+        s.registerTool('progress', { inputSchema: z.object({ steps: z.number().int().positive() }) }, async ({ steps }, ctx) => {
+            const token = ctx.mcpReq._meta?.progressToken;
             if (token !== undefined) {
                 for (let i = 1; i <= steps; i++) {
-                    await extra.sendNotification({
+                    await ctx.mcpReq.notify({
                         method: 'notifications/progress',
                         params: {
                             progressToken: token,
@@ -514,12 +504,12 @@ verifies('typescript:protocol:progress:token-injected', async ({ transport }: Te
     const received: CallToolRequest['params'][] = [];
     const makeServer = () => {
         const s = new Server({ name: 's', version: '0' }, { capabilities: { tools: {} } });
-        s.setRequestHandler(ListToolsRequestSchema, () => ({ tools: [] }));
-        s.setRequestHandler(CallToolRequestSchema, async (req, extra) => {
+        s.setRequestHandler('tools/list', () => ({ tools: [] }));
+        s.setRequestHandler('tools/call', async (req, ctx) => {
             received.push(req.params);
             const token = req.params._meta?.progressToken;
             if (token !== undefined) {
-                await extra.sendNotification({
+                await ctx.mcpReq.notify({
                     method: 'notifications/progress',
                     params: { progressToken: token, progress: 1, total: 1 }
                 });
@@ -554,11 +544,11 @@ verifies('protocol:progress:token-unique', async ({ transport }: TestArgs) => {
     const tokens: Array<string | number> = [];
     const makeServer = () => {
         const s = new McpServer({ name: 's', version: '0' });
-        s.registerTool('probe', { inputSchema: z.object({}) }, async (_a, extra) => {
-            const token = extra._meta?.progressToken;
+        s.registerTool('probe', { inputSchema: z.object({}) }, async (_a, ctx) => {
+            const token = ctx.mcpReq._meta?.progressToken;
             if (token !== undefined) {
                 tokens.push(token);
-                await extra.sendNotification({
+                await ctx.mcpReq.notify({
                     method: 'notifications/progress',
                     params: { progressToken: token, progress: 1, total: 1 }
                 });
@@ -603,8 +593,8 @@ verifies('protocol:timeout:basic', async ({ transport }: TestArgs) => {
 
         await vi.advanceTimersByTimeAsync(2);
         expect(outcome?.kind).toBe('rejected');
-        expect(outcome?.value).toBeInstanceOf(McpError);
-        expect(outcome?.value).toMatchObject({ code: ErrorCode.RequestTimeout });
+        expect(outcome?.value).toBeInstanceOf(ProtocolError);
+        expect(outcome?.value).toMatchObject({ code: SdkErrorCode.RequestTimeout });
     } finally {
         vi.useRealTimers();
     }
@@ -618,12 +608,12 @@ verifies('protocol:timeout:max-total', async ({ transport }: TestArgs) => {
             s.registerTool(
                 'slow-progress',
                 { inputSchema: z.object({ delayMs: z.number(), steps: z.number() }) },
-                async ({ delayMs, steps }, extra) => {
-                    const token = extra._meta?.progressToken;
+                async ({ delayMs, steps }, ctx) => {
+                    const token = ctx.mcpReq._meta?.progressToken;
                     if (token !== undefined) {
                         for (let i = 1; i <= steps; i++) {
                             await new Promise(resolve => setTimeout(resolve, delayMs));
-                            await extra.sendNotification({
+                            await ctx.mcpReq.notify({
                                 method: 'notifications/progress',
                                 params: { progressToken: token, progress: i, total: steps }
                             });
@@ -655,9 +645,9 @@ verifies('protocol:timeout:max-total', async ({ transport }: TestArgs) => {
             await vi.advanceTimersByTimeAsync(delayMs);
         }
 
-        await expect(call).rejects.toBeInstanceOf(McpError);
-        const err = await call.catch(e => e as McpError);
-        expect(err.code).toBe(ErrorCode.RequestTimeout);
+        await expect(call).rejects.toBeInstanceOf(ProtocolError);
+        const err = await call.catch(e => e as ProtocolError);
+        expect(err.code).toBe(SdkErrorCode.RequestTimeout);
 
         expect(ticks.length).toBeGreaterThanOrEqual(3);
     } finally {
@@ -673,12 +663,12 @@ verifies('protocol:timeout:reset-on-progress', async ({ transport }: TestArgs) =
             s.registerTool(
                 'slow-progress',
                 { inputSchema: z.object({ steps: z.number(), delayMs: z.number() }) },
-                async ({ steps, delayMs }, extra) => {
-                    const token = extra._meta?.progressToken;
+                async ({ steps, delayMs }, ctx) => {
+                    const token = ctx.mcpReq._meta?.progressToken;
                     if (token !== undefined) {
                         for (let i = 1; i <= steps; i++) {
                             await new Promise(resolve => setTimeout(resolve, delayMs));
-                            await extra.sendNotification({
+                            await ctx.mcpReq.notify({
                                 method: 'notifications/progress',
                                 params: { progressToken: token, progress: i, total: steps }
                             });
@@ -746,8 +736,8 @@ verifies('protocol:timeout:sends-cancellation', async ({ transport }: TestArgs) 
 
         await vi.advanceTimersByTimeAsync(100);
 
-        await expect(pending).rejects.toBeInstanceOf(McpError);
-        await expect(pending).rejects.toMatchObject({ code: ErrorCode.RequestTimeout });
+        await expect(pending).rejects.toBeInstanceOf(ProtocolError);
+        await expect(pending).rejects.toMatchObject({ code: SdkErrorCode.RequestTimeout });
 
         expect(sentAtRejection).toBeDefined();
         const listReq = sentAtRejection!.filter(isRequest).find(m => m.method === 'tools/list');
@@ -814,7 +804,7 @@ verifies('mcpserver:onerror:reach-through', async ({ transport }: TestArgs) => {
 verifies('protocol:custom-method:notification', async ({ transport }: TestArgs) => {
     const HEARTBEAT_METHOD = 'myorg/heartbeat';
 
-    const CustomNotificationSchema = NotificationSchema.extend({
+    const CustomNotificationSchema = specTypeSchemas.Notification.extend({
         method: z.literal(HEARTBEAT_METHOD),
         params: z.object({ seq: z.number(), tag: z.string() })
     });
@@ -852,9 +842,9 @@ verifies('protocol:error:data-roundtrip', async ({ transport }: TestArgs) => {
     const data = { detail: 'x', nested: { n: 1 } };
     const makeServer = () => {
         const s = new Server({ name: 's', version: '0' }, { capabilities: { tools: {} } });
-        s.setRequestHandler(ListToolsRequestSchema, () => ({ tools: [] }));
-        s.setRequestHandler(CallToolRequestSchema, () => {
-            throw new McpError(ErrorCode.InternalError, 'boom', data);
+        s.setRequestHandler('tools/list', () => ({ tools: [] }));
+        s.setRequestHandler('tools/call', () => {
+            throw new ProtocolError(ProtocolErrorCode.InternalError, 'boom', data);
         });
         return s;
     };
@@ -863,9 +853,9 @@ verifies('protocol:error:data-roundtrip', async ({ transport }: TestArgs) => {
 
     const call = client.callTool({ name: 'any', arguments: {} });
 
-    await expect(call).rejects.toBeInstanceOf(McpError);
+    await expect(call).rejects.toBeInstanceOf(ProtocolError);
     await expect(call).rejects.toThrow(/boom/);
-    await expect(call).rejects.toMatchObject({ code: ErrorCode.InternalError, data });
+    await expect(call).rejects.toMatchObject({ code: ProtocolErrorCode.InternalError, data });
 });
 
 verifies('protocol:fallback-notification-handler', async ({ transport }: TestArgs) => {
@@ -877,11 +867,11 @@ verifies('protocol:fallback-notification-handler', async ({ transport }: TestArg
             { name: 's', version: '0' },
             { capabilities: { tools: { listChanged: true }, prompts: { listChanged: true } } }
         );
-        s.setRequestHandler(ListToolsRequestSchema, () => ({ tools: [] }));
-        s.setRequestHandler(CallToolRequestSchema, async (_req, extra) => {
-            await extra.sendNotification({ method: NEVER_REGISTERED });
-            await extra.sendNotification({ method: 'notifications/prompts/list_changed' });
-            await extra.sendNotification({ method: 'notifications/tools/list_changed' });
+        s.setRequestHandler('tools/list', () => ({ tools: [] }));
+        s.setRequestHandler('tools/call', async (_req, ctx) => {
+            await ctx.mcpReq.notify({ method: NEVER_REGISTERED });
+            await ctx.mcpReq.notify({ method: 'notifications/prompts/list_changed' });
+            await ctx.mcpReq.notify({ method: 'notifications/tools/list_changed' });
             return { content: [] };
         });
         return s;
@@ -893,10 +883,10 @@ verifies('protocol:fallback-notification-handler', async ({ transport }: TestArg
 
     await using _ = await wire(transport, makeServer, client, { allowCustomMethods: true });
 
-    client.setNotificationHandler(ToolListChangedNotificationSchema, async n => {
+    client.setNotificationHandler('notifications/tools/list_changed', async n => {
         specific.push(n);
     });
-    client.setNotificationHandler(PromptListChangedNotificationSchema, async n => {
+    client.setNotificationHandler('notifications/prompts/list_changed', async n => {
         specific.push(n);
     });
 
@@ -929,8 +919,8 @@ verifies('protocol:fallback-notification-handler', async ({ transport }: TestArg
 verifies('protocol:handler:re-register-replaces', async ({ transport }: TestArgs) => {
     const makeServer = () => {
         const s = new McpServer({ name: 's', version: '0' });
-        s.registerTool('list-roots', { inputSchema: z.object({}) }, async (_a, extra) => {
-            const result = await extra.sendRequest({ method: 'roots/list' }, ListRootsResultSchema);
+        s.registerTool('list-roots', { inputSchema: z.object({}) }, async (_a, ctx) => {
+            const result = await ctx.mcpReq.send({ method: 'roots/list' }, specTypeSchemas.ListRootsResult);
             return { structuredContent: { ok: true, result }, content: [] };
         });
         return s;
@@ -941,13 +931,13 @@ verifies('protocol:handler:re-register-replaces', async ({ transport }: TestArgs
     let firstCalls = 0;
     let secondCalls = 0;
 
-    client.setRequestHandler(ListRootsRequestSchema, async () => {
+    client.setRequestHandler('roots/list', async () => {
         firstCalls++;
         return { roots: [{ uri: 'file:///first', name: 'first' }] };
     });
 
     expect(() =>
-        client.setRequestHandler(ListRootsRequestSchema, async () => {
+        client.setRequestHandler('roots/list', async () => {
             secondCalls++;
             return { roots: [{ uri: 'file:///second', name: 'second' }] };
         })
@@ -966,11 +956,11 @@ verifies('protocol:handler:re-register-replaces', async ({ transport }: TestArgs
 });
 
 const X_ECHO_METHOD = 'x-e2e/echo';
-const XEchoRequestSchema = RequestSchema.extend({
+const XEchoRequestSchema = specTypeSchemas.Request.extend({
     method: z.literal(X_ECHO_METHOD),
     params: z.object({ value: z.string() })
 });
-const XEchoResultSchema = ResultSchema.extend({ echoed: z.string() });
+const XEchoResultSchema = specTypeSchemas.Result.extend({ echoed: z.string() });
 
 function customEchoServer(): Server {
     const s = new Server({ name: 's', version: '0' }, { capabilities: {} });
@@ -1000,14 +990,14 @@ verifies('protocol:custom-method:roundtrip', async ({ transport }: TestArgs) => 
 
     // A truly-unknown method still surfaces as MethodNotFound, proving the
     // custom registration is what made the previous call succeed.
-    await expect(client.request({ method: 'x-e2e/never-registered', params: {} }, ResultSchema)).rejects.toMatchObject({
-        code: ErrorCode.MethodNotFound
+    await expect(client.request({ method: 'x-e2e/never-registered', params: {} })).rejects.toMatchObject({
+        code: ProtocolErrorCode.MethodNotFound
     });
 });
 
 verifies('protocol:custom-notification:roundtrip', async ({ transport }: TestArgs) => {
     const X_EVENT_METHOD = 'x-e2e/event';
-    const XEventNotificationSchema = NotificationSchema.extend({
+    const XEventNotificationSchema = specTypeSchemas.Notification.extend({
         method: z.literal(X_EVENT_METHOD),
         params: z.object({ kind: z.string(), id: z.number() })
     });
@@ -1043,10 +1033,10 @@ verifies('protocol:meta:request-to-handler', async ({ transport }: TestArgs) => 
     const handlerExtraMeta: unknown[] = [];
     const makeServer = () => {
         const s = new Server({ name: 's', version: '0' }, { capabilities: { tools: {} } });
-        s.setRequestHandler(ListToolsRequestSchema, () => ({ tools: [] }));
-        s.setRequestHandler(CallToolRequestSchema, (req, extra) => {
+        s.setRequestHandler('tools/list', () => ({ tools: [] }));
+        s.setRequestHandler('tools/call', (req, ctx) => {
             handlerParamsMeta.push(req.params._meta);
-            handlerExtraMeta.push(extra._meta);
+            handlerExtraMeta.push(ctx.mcpReq._meta);
             return { content: [{ type: 'text', text: 'traced' }] };
         });
         return s;
@@ -1066,8 +1056,8 @@ verifies('protocol:meta:result-to-client', async ({ transport }: TestArgs) => {
     const resultMeta = { 'example.com/cost-tokens': 42, 'example.com/cache': { hit: true, region: 'eu-west-1' } };
     const makeServer = () => {
         const s = new Server({ name: 's', version: '0' }, { capabilities: { tools: {} } });
-        s.setRequestHandler(ListToolsRequestSchema, () => ({ tools: [] }));
-        s.setRequestHandler(CallToolRequestSchema, () => ({ content: [{ type: 'text', text: 'metered' }], _meta: resultMeta }));
+        s.setRequestHandler('tools/list', () => ({ tools: [] }));
+        s.setRequestHandler('tools/call', () => ({ content: [{ type: 'text', text: 'metered' }], _meta: resultMeta }));
         return s;
     };
     const client = newClient();
@@ -1158,23 +1148,23 @@ verifies('protocol:notifications:no-response', async ({ transport }: TestArgs) =
 verifies('protocol:progress:monotonic', async ({ transport }: TestArgs) => {
     const makeServer = () => {
         const s = new McpServer({ name: 's', version: '0' });
-        s.registerTool('index_files', { inputSchema: z.object({}) }, async (_a, extra) => {
-            const token = extra._meta?.progressToken;
+        s.registerTool('index_files', { inputSchema: z.object({}) }, async (_a, ctx) => {
+            const token = ctx.mcpReq._meta?.progressToken;
             if (token === undefined) throw new Error('expected a progressToken on the request');
-            await extra.sendNotification({
+            await ctx.mcpReq.notify({
                 method: 'notifications/progress',
                 params: { progressToken: token, progress: 5, message: 'indexed 5 files' }
             });
             try {
                 // A spec-compliant sender refuses (or drops) this regression to a smaller value.
-                await extra.sendNotification({
+                await ctx.mcpReq.notify({
                     method: 'notifications/progress',
                     params: { progressToken: token, progress: 3, message: 'regressed' }
                 });
             } catch {
                 /* sender-side rejection of the non-increasing value is a valid way to satisfy the spec */
             }
-            await extra.sendNotification({
+            await ctx.mcpReq.notify({
                 method: 'notifications/progress',
                 params: { progressToken: token, progress: 12, message: 'indexed 12 files' }
             });
@@ -1210,11 +1200,11 @@ verifies('protocol:progress:stops-after-completion', async ({ transport }: TestA
     let lateProgress: (() => Promise<void>) | undefined;
     const makeServer = () => {
         server = new Server({ name: 's', version: '0' }, { capabilities: { tools: { listChanged: true } } });
-        server.setRequestHandler(ListToolsRequestSchema, () => ({ tools: [] }));
-        server.setRequestHandler(CallToolRequestSchema, async (req, extra) => {
+        server.setRequestHandler('tools/list', () => ({ tools: [] }));
+        server.setRequestHandler('tools/call', async (req, ctx) => {
             const token = req.params._meta?.progressToken;
             if (token === undefined) throw new Error('expected a progressToken on the request');
-            await extra.sendNotification({
+            await ctx.mcpReq.notify({
                 method: 'notifications/progress',
                 params: { progressToken: token, progress: 1, total: 2, message: 'halfway' }
             });
@@ -1264,12 +1254,12 @@ verifies('protocol:cancel:in-flight', async ({ transport }: TestArgs) => {
         s.registerTool(
             'long_export',
             { inputSchema: z.object({}) },
-            async (_a, extra) =>
+            async (_a, ctx) =>
                 new Promise((_resolve, reject) => {
-                    handlerStarted.push(extra.requestId);
-                    extra.signal.addEventListener('abort', () => {
-                        handlerAbortReasons.push(extra.signal.reason);
-                        reject(new Error(String(extra.signal.reason)));
+                    handlerStarted.push(ctx.mcpReq.id);
+                    ctx.mcpReq.signal.addEventListener('abort', () => {
+                        handlerAbortReasons.push(ctx.mcpReq.signal.reason);
+                        reject(new Error(String(ctx.mcpReq.signal.reason)));
                     });
                 })
         );
@@ -1316,8 +1306,8 @@ verifies('protocol:progress:client-to-server', async ({ transport }: TestArgs) =
     const serverUpdates: Progress[] = [];
     const makeServer = () => {
         const s = new McpServer({ name: 's', version: '0' });
-        s.registerTool('summarize_report', { inputSchema: z.object({ text: z.string() }) }, async ({ text }, extra) => {
-            const result = await extra.sendRequest(
+        s.registerTool('summarize_report', { inputSchema: z.object({ text: z.string() }) }, async ({ text }, ctx) => {
+            const result = await ctx.mcpReq.send(
                 {
                     method: 'sampling/createMessage',
                     params: {
@@ -1325,7 +1315,7 @@ verifies('protocol:progress:client-to-server', async ({ transport }: TestArgs) =
                         maxTokens: 200
                     }
                 },
-                CreateMessageResultSchema,
+                specTypeSchemas.CreateMessageResult,
                 { onprogress: p => serverUpdates.push(p) }
             );
             if (result.content.type !== 'text') throw new Error('expected text sampling content');
@@ -1335,14 +1325,14 @@ verifies('protocol:progress:client-to-server', async ({ transport }: TestArgs) =
     };
 
     const client = new Client({ name: 'c', version: '0' }, { capabilities: { sampling: {} } });
-    client.setRequestHandler(CreateMessageRequestSchema, async (req, extra) => {
+    client.setRequestHandler('sampling/createMessage', async (req, ctx) => {
         const token = req.params._meta?.progressToken;
         if (token === undefined) throw new Error('expected a progressToken on the sampling request');
-        await extra.sendNotification({
+        await ctx.mcpReq.notify({
             method: 'notifications/progress',
             params: { progressToken: token, progress: 1, total: 2, message: 'sampling started' }
         });
-        await extra.sendNotification({
+        await ctx.mcpReq.notify({
             method: 'notifications/progress',
             params: { progressToken: token, progress: 2, total: 2, message: 'sampling finished' }
         });
@@ -1374,16 +1364,14 @@ verifies('protocol:request-handler:override-builtin', async ({ transport }: Test
     const makeServer = () => {
         const s = new Server({ name: 's', version: '0' }, { capabilities: {} });
         // Ping has a built-in handler; this should replace it without throwing.
-        s.setRequestHandler(PingRequestSchema, () => ({ _meta: { 'e2e/overridden': true } }));
+        s.setRequestHandler('ping', () => ({ _meta: { 'e2e/overridden': true } }));
         return s;
     };
 
     const client = newClient();
     await using _ = await wire(transport, makeServer, client);
 
-    expect(() =>
-        new Server({ name: 's', version: '0' }, { capabilities: {} }).setRequestHandler(PingRequestSchema, () => ({}))
-    ).not.toThrow();
+    expect(() => new Server({ name: 's', version: '0' }, { capabilities: {} }).setRequestHandler('ping', () => ({}))).not.toThrow();
 
     const result = await client.ping();
     expect(result).toEqual({ _meta: { 'e2e/overridden': true } });

--- a/test/e2e/scenarios/protocol.test.ts
+++ b/test/e2e/scenarios/protocol.test.ts
@@ -1,0 +1,1419 @@
+/**
+ * Protocol-layer tests: cancellation, errors, progress, timeouts, custom methods.
+ *
+ * Tests covering the request/response lifecycle independent of specific MCP
+ * features like tools or resources. Most test both McpServer and raw Server
+ * via the requirement's tier map.
+ */
+
+import { expect, vi } from 'vitest';
+import { z } from 'zod/v4';
+
+import { Client } from '../../../src/client/index.js';
+import { InMemoryTransport } from '../../../src/inMemory.js';
+import { Server } from '../../../src/server/index.js';
+import { McpServer } from '../../../src/server/mcp.js';
+import {
+    type CallToolRequest,
+    CallToolRequestSchema,
+    CreateMessageRequestSchema,
+    CreateMessageResultSchema,
+    ErrorCode,
+    type JSONRPCMessage,
+    type JSONRPCNotification,
+    type JSONRPCRequest,
+    type JSONRPCResponse,
+    ListRootsRequestSchema,
+    ListRootsResultSchema,
+    ListToolsRequestSchema,
+    McpError,
+    type Notification,
+    NotificationSchema,
+    PingRequestSchema,
+    type Progress,
+    PromptListChangedNotificationSchema,
+    type RequestId,
+    RequestSchema,
+    ResultSchema,
+    ToolListChangedNotificationSchema
+} from '../../../src/types.js';
+
+import { tapWire, wire } from '../helpers/index.js';
+import type { TestArgs } from '../types.js';
+import { verifies } from '../helpers/verifies.js';
+
+const newClient = () => new Client({ name: 'c', version: '0' });
+
+/** Raw {@link Server} factory whose tools/list never resolves — for timeout / connection-closed tests. */
+function neverRespondingServer(): Server {
+    const s = new Server({ name: 's', version: '0' }, { capabilities: { tools: {} } });
+    s.setRequestHandler(
+        ListToolsRequestSchema,
+        () =>
+            new Promise(() => {
+                /* never resolves */
+            })
+    );
+    return s;
+}
+
+const isRequest = (m: JSONRPCMessage): m is JSONRPCRequest => 'method' in m && 'id' in m;
+const isNotification = (m: JSONRPCMessage): m is JSONRPCNotification => 'method' in m && !('id' in m);
+const isResponse = (m: JSONRPCMessage): m is JSONRPCResponse => 'id' in m && !('method' in m);
+
+/**
+ * Tap `client.transport.send` so every outbound JSON-RPC message is recorded.
+ * Call after `wire()` so the transport is set.
+ */
+function tapOutbound(client: Client): JSONRPCMessage[] {
+    const out: JSONRPCMessage[] = [];
+    const tx = client.transport;
+    if (!tx) throw new Error('tapOutbound: client not connected');
+    const orig = tx.send.bind(tx);
+    tx.send = async (m, opts) => {
+        out.push(m);
+        return orig(m, opts);
+    };
+    return out;
+}
+
+verifies('protocol:cancel:abort-signal', async ({ transport }: TestArgs) => {
+    const stalled: Array<() => void> = [];
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool(
+            'echo',
+            { inputSchema: z.object({ text: z.string() }) },
+            async ({ text }, extra) =>
+                new Promise(resolve => {
+                    const t = setTimeout(() => resolve({ content: [{ type: 'text', text }] }), 60_000);
+                    t.unref();
+                    stalled.push(() => {
+                        clearTimeout(t);
+                        resolve({ content: [{ type: 'text', text: 'late' }] });
+                    });
+                    extra.signal.addEventListener('abort', () => {
+                        clearTimeout(t);
+                    });
+                })
+        );
+        return s;
+    };
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    const outbound: JSONRPCMessage[] = [];
+    const originalSend = client.transport!.send.bind(client.transport!);
+    client.transport!.send = async m => {
+        outbound.push(m);
+        return originalSend(m);
+    };
+
+    const controller = new AbortController();
+    const call = client.callTool({ name: 'echo', arguments: { text: 'never' } }, undefined, {
+        signal: controller.signal
+    });
+    call.catch(() => {});
+
+    await vi.waitFor(() => outbound.some(m => 'method' in m && m.method === 'tools/call'));
+    const callMsg = outbound.find(
+        (m): m is Extract<JSONRPCMessage, { method: string; id: RequestId }> => 'method' in m && m.method === 'tools/call' && 'id' in m
+    )!;
+
+    controller.abort('user requested cancellation');
+
+    await expect(call).rejects.toThrow(/user requested cancellation/);
+
+    await vi.waitFor(() => outbound.some(m => 'method' in m && m.method === 'notifications/cancelled'));
+    const cancelled = outbound.find(m => 'method' in m && m.method === 'notifications/cancelled') as {
+        id?: RequestId;
+        params?: { requestId?: RequestId; reason?: string };
+    };
+
+    expect(cancelled).not.toHaveProperty('id');
+    expect(cancelled.params?.requestId).toBe(callMsg.id);
+    expect(cancelled.params?.reason).toContain('user requested cancellation');
+});
+
+verifies('protocol:cancel:handler-abort-propagates', async ({ transport }: TestArgs) => {
+    const aborts: Array<{ requestId: RequestId; reason: unknown }> = [];
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool(
+            'cancellable',
+            { inputSchema: z.object({}) },
+            async (_a, extra) =>
+                new Promise((resolve, reject) => {
+                    extra.signal.addEventListener('abort', () => {
+                        aborts.push({ requestId: extra.requestId, reason: extra.signal.reason });
+                        reject(new Error(extra.signal.reason));
+                    });
+                })
+        );
+        return s;
+    };
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    const ac = new AbortController();
+    const call = client.callTool({ name: 'cancellable', arguments: {} }, undefined, { signal: ac.signal });
+    call.catch(() => {});
+
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    ac.abort(new Error('user cancelled'));
+
+    await expect(call).rejects.toThrow('user cancelled');
+
+    await vi.waitFor(() => expect(aborts.length).toBeGreaterThan(0));
+
+    // Server-side signal.reason carries the cancellation reason text from the
+    // notifications/cancelled the client sent (possibly wrapped).
+    expect(String(aborts[0].reason)).toContain('user cancelled');
+});
+
+verifies('protocol:cancel:initialize-not-cancellable', async (_: TestArgs) => {
+    // This test must tap outbound messages BEFORE connect() completes (to see the
+    // initialize request and any cancelled notification). wire() awaits connect, so
+    // it can't be used here. Tested on inMemory only — the behavior is in
+    // shared/protocol.ts and is transport-agnostic.
+    const [clientTx] = InMemoryTransport.createLinkedPair();
+    // No server attached: initialize will hang, giving us a window to abort.
+
+    const outbound: JSONRPCMessage[] = [];
+    const origSend = clientTx.send.bind(clientTx);
+    clientTx.send = async (m, opts) => {
+        outbound.push(m);
+        return origSend(m, opts);
+    };
+
+    const client = newClient();
+    const ac = new AbortController();
+    const connecting = client.connect(clientTx, { signal: ac.signal });
+    connecting.catch(() => {});
+
+    await vi.waitFor(() => expect(outbound.filter(isRequest).some(m => m.method === 'initialize')).toBe(true));
+    const initReq = outbound.filter(isRequest).find(m => m.method === 'initialize');
+    expect(initReq?.id).toBeDefined();
+
+    ac.abort(new Error('user aborted connect'));
+    await expect(connecting).rejects.toThrow();
+
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    const cancelledForInit = outbound
+        .filter(isNotification)
+        .filter(m => m.method === 'notifications/cancelled' && m.params?.requestId === initReq?.id);
+    expect(cancelledForInit).toEqual([]);
+
+    await client.close();
+});
+
+verifies('protocol:cancel:late-response-ignored', async ({ transport }: TestArgs) => {
+    const stalled: Array<() => void> = [];
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool(
+            'echo',
+            { inputSchema: z.object({ text: z.string() }) },
+            async ({ text }) =>
+                new Promise(resolve => {
+                    const t = setTimeout(() => resolve({ content: [{ type: 'text', text }] }), 60_000);
+                    t.unref();
+                    stalled.push(() => {
+                        clearTimeout(t);
+                        resolve({ content: [{ type: 'text', text: 'late' }] });
+                    });
+                })
+        );
+        return s;
+    };
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    const outbound: JSONRPCMessage[] = [];
+    const originalSend = client.transport!.send.bind(client.transport!);
+    client.transport!.send = async m => {
+        outbound.push(m);
+        return originalSend(m);
+    };
+
+    const errors: Error[] = [];
+    client.onerror = e => errors.push(e);
+
+    const ac = new AbortController();
+    const call = client.callTool({ name: 'echo', arguments: { text: 'late' } }, undefined, { signal: ac.signal });
+    call.catch(() => {});
+
+    await vi.waitFor(() => outbound.some(m => 'method' in m && m.method === 'tools/call'));
+    const callReq = outbound.find(
+        (m): m is Extract<JSONRPCMessage, { method: string; id: RequestId }> => 'method' in m && m.method === 'tools/call' && 'id' in m
+    )!;
+    const callId = callReq.id;
+
+    ac.abort(new Error('user cancelled'));
+
+    await vi.waitFor(() => outbound.some(m => 'method' in m && m.method === 'notifications/cancelled'));
+
+    await expect(call).rejects.toThrow('user cancelled');
+
+    const lateResponse: JSONRPCMessage = {
+        jsonrpc: '2.0',
+        id: callId,
+        result: { content: [{ type: 'text', text: 'late' }] }
+    };
+    client.transport!.onmessage?.(lateResponse);
+
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    expect(errors).toEqual([]);
+
+    await expect(client.ping()).resolves.toBeDefined();
+});
+
+verifies('protocol:cancel:unknown-id-ignored', async ({ transport }: TestArgs) => {
+    const errors: Error[] = [];
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.server.onerror = e => errors.push(e);
+        s.registerTool('echo', { inputSchema: z.object({ text: z.string() }) }, ({ text }) => ({
+            content: [{ type: 'text', text }]
+        }));
+        return s;
+    };
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    const result = await client.callTool({ name: 'echo', arguments: { text: 'hi' } });
+    expect(result.content).toEqual([{ type: 'text', text: 'hi' }]);
+
+    await expect(
+        client.notification({
+            method: 'notifications/cancelled',
+            params: { requestId: 99999, reason: 'unknown numeric id' }
+        })
+    ).resolves.toBeUndefined();
+
+    await expect(
+        client.notification({
+            method: 'notifications/cancelled',
+            params: { requestId: 'never-issued-abc', reason: 'unknown string id' }
+        })
+    ).resolves.toBeUndefined();
+
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    expect(errors).toEqual([]);
+
+    await expect(client.ping()).resolves.toBeDefined();
+});
+
+verifies('typescript:protocol:error:connection-closed', async ({ transport }: TestArgs) => {
+    const client = newClient();
+    await using _ = await wire(transport, neverRespondingServer, client);
+
+    const onclose = vi.fn();
+    client.onclose = onclose;
+
+    const inFlight = [client.listTools(), client.listTools(), client.listTools()];
+    for (const p of inFlight) p.catch(() => {});
+
+    await new Promise(resolve => setTimeout(resolve, 50));
+    expect(onclose).not.toHaveBeenCalled();
+
+    await client.close();
+
+    for (const p of inFlight) {
+        await expect(p).rejects.toBeInstanceOf(McpError);
+        await expect(p).rejects.toMatchObject({ code: ErrorCode.ConnectionClosed });
+    }
+    // onclose fires at least once (transport peers may echo a close back, so don't pin the count).
+    await vi.waitFor(() => expect(onclose).toHaveBeenCalled());
+});
+
+verifies('protocol:error:internal-error', async ({ transport }: TestArgs) => {
+    // Uses raw Server so the throw reaches the protocol layer; McpServer.registerTool
+    // catches handler exceptions and wraps as {isError:true} (covered in tools.ts).
+    const makeServer = () => {
+        const s = new Server({ name: 's', version: '0' }, { capabilities: { tools: {} } });
+        s.setRequestHandler(ListToolsRequestSchema, () => ({ tools: [] }));
+        s.setRequestHandler(CallToolRequestSchema, () => {
+            throw new Error('handler exploded');
+        });
+        return s;
+    };
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    const call = client.callTool({ name: 'any', arguments: {} });
+
+    await expect(call).rejects.toBeInstanceOf(McpError);
+    await expect(call).rejects.toMatchObject({ code: ErrorCode.InternalError });
+    await expect(call).rejects.toThrow(/handler exploded/);
+    expect(ErrorCode.InternalError).toBe(-32603);
+});
+
+verifies('protocol:error:invalid-params', async ({ transport }: TestArgs) => {
+    // Raw Server: setRequestHandler parses the inbound request against
+    // CallToolRequestSchema; missing the required `name` field should yield
+    // -32602 InvalidParams at the protocol layer (not McpServer's tool-arg validation).
+    const makeServer = () => {
+        const s = new Server({ name: 's', version: '0' }, { capabilities: { tools: {} } });
+        s.setRequestHandler(ListToolsRequestSchema, () => ({ tools: [] }));
+        s.setRequestHandler(CallToolRequestSchema, () => ({ content: [] }));
+        return s;
+    };
+    const client = newClient();
+    // strictValidation off so the malformed request reaches the server instead of being rejected by the wire sniffer.
+    await using _ = await wire(transport, makeServer, client, { strictValidation: false });
+
+    const outbound = tapOutbound(client);
+
+    // Send tools/call without the required `name` field.
+    const call = client.request({ method: 'tools/call', params: { arguments: {} } }, z.object({}).passthrough());
+
+    await expect(call).rejects.toBeInstanceOf(McpError);
+
+    // The malformed request did reach the wire (failure is server-side, not client-side validation).
+    const sent = outbound.filter(isRequest).find(m => m.method === 'tools/call');
+    expect(sent?.params).toEqual({ arguments: {} });
+
+    expect(ErrorCode.InvalidParams).toBe(-32602);
+    await expect(call).rejects.toMatchObject({ code: ErrorCode.InvalidParams });
+});
+
+verifies('protocol:error:method-not-found', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        return s;
+    };
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client, { allowCustomMethods: true });
+
+    const outbound: JSONRPCMessage[] = [];
+    const originalSend = client.transport!.send.bind(client.transport!);
+    client.transport!.send = async m => {
+        outbound.push(m);
+        return originalSend(m);
+    };
+
+    const call = client.request({ method: 'no/such/method' }, z.object({}));
+
+    await expect(call).rejects.toBeInstanceOf(McpError);
+
+    const err = await call.catch(e => e as McpError);
+    expect(err.code).toBe(ErrorCode.MethodNotFound);
+    expect(err.code).toBe(-32601);
+
+    const sent = outbound.filter(m => 'method' in m && m.method === 'no/such/method' && 'id' in m);
+    expect(sent).toHaveLength(1);
+});
+
+verifies('protocol:error:reconnect-no-stale-timers', async (_: TestArgs) => {
+    // Manages its own connection lifecycle (close + reconnect of the same Client),
+    // so it wires inMemory pairs directly instead of using wire(). Transport-agnostic
+    // behavior — lives in shared/protocol.ts.
+    const serverA = neverRespondingServer();
+    const [clientTxA, serverTxA] = InMemoryTransport.createLinkedPair();
+
+    const client = newClient();
+    const clientErrors: Error[] = [];
+    client.onerror = e => clientErrors.push(e);
+
+    await serverA.connect(serverTxA);
+    await client.connect(clientTxA);
+
+    // Park a request with a timeout long enough that we can drop the connection
+    // first: its timer is armed in Protocol._timeoutInfo and must be cleared by
+    // _onclose(), not left to fire after reconnect.
+    const sentOnA: JSONRPCMessage[] = [];
+    const origSendA = clientTxA.send.bind(clientTxA);
+    clientTxA.send = async (m, opts) => {
+        sentOnA.push(m);
+        return origSendA(m, opts);
+    };
+    const inFlight = client.listTools(undefined, { timeout: 400 });
+    inFlight.catch(() => {});
+
+    await vi.waitFor(() => expect(sentOnA.filter(isRequest).some(m => m.method === 'tools/list')).toBe(true));
+
+    // Connection drops before the 400 ms timeout fires; the in-flight request is
+    // rejected by close (how it rejects is protocol:error:connection-closed's concern).
+    await clientTxA.close();
+    await serverA.close();
+
+    // Reconnect the SAME Client instance to a fresh, healthy server. Tap the new
+    // transport before connect so any spurious message would be captured.
+    const serverB = new Server({ name: 's-b', version: '0' }, { capabilities: {} });
+    const [clientTxB, serverTxB] = InMemoryTransport.createLinkedPair();
+    const sentOnB: JSONRPCMessage[] = [];
+    const origSendB = clientTxB.send.bind(clientTxB);
+    clientTxB.send = async (m, opts) => {
+        sentOnB.push(m);
+        return origSendB(m, opts);
+    };
+    await serverB.connect(serverTxB);
+    await client.connect(clientTxB);
+
+    // Let the original 400 ms window elapse well past its deadline. A stale timer
+    // surviving _onclose() would now fire and push notifications/cancelled (for a
+    // request id server B never saw) onto the new transport.
+    await new Promise(resolve => setTimeout(resolve, 550));
+
+    expect(sentOnB.filter(isNotification).filter(m => m.method === 'notifications/cancelled')).toEqual([]);
+    expect(clientErrors).toEqual([]);
+
+    // The reconnected session is healthy.
+    await expect(client.ping()).resolves.toBeDefined();
+    expect(sentOnB.filter(isRequest).some(m => m.method === 'ping')).toBe(true);
+
+    await client.close();
+    await serverB.close();
+});
+
+verifies('protocol:progress:callback', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool('progress', { inputSchema: z.object({ steps: z.number().int().positive() }) }, async ({ steps }, extra) => {
+            const token = extra._meta?.progressToken;
+            if (token !== undefined) {
+                for (let i = 1; i <= steps; i++) {
+                    await extra.sendNotification({
+                        method: 'notifications/progress',
+                        params: {
+                            progressToken: token,
+                            progress: i,
+                            total: steps,
+                            message: `step ${i}/${steps}`
+                        }
+                    });
+                }
+            }
+            return { content: [{ type: 'text', text: `done after ${steps} steps` }] };
+        });
+        return s;
+    };
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    const updates: Progress[] = [];
+
+    await client.callTool({ name: 'progress', arguments: { steps: 2 } }, undefined, {
+        onprogress: p => updates.push(p)
+    });
+
+    expect(updates).toHaveLength(2);
+
+    expect(updates[0]).toMatchObject({ progress: 1, total: 2, message: 'step 1/2' });
+    expect(updates[1]).toMatchObject({ progress: 2, total: 2, message: 'step 2/2' });
+
+    expect(updates[0]).not.toHaveProperty('progressToken');
+});
+
+verifies('typescript:protocol:progress:token-injected', async ({ transport }: TestArgs) => {
+    const received: CallToolRequest['params'][] = [];
+    const makeServer = () => {
+        const s = new Server({ name: 's', version: '0' }, { capabilities: { tools: {} } });
+        s.setRequestHandler(ListToolsRequestSchema, () => ({ tools: [] }));
+        s.setRequestHandler(CallToolRequestSchema, async (req, extra) => {
+            received.push(req.params);
+            const token = req.params._meta?.progressToken;
+            if (token !== undefined) {
+                await extra.sendNotification({
+                    method: 'notifications/progress',
+                    params: { progressToken: token, progress: 1, total: 1 }
+                });
+            }
+            return { content: [{ type: 'text', text: 'ok' }] };
+        });
+        return s;
+    };
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    const traceKey = 'example.com/trace-id';
+    const traceId = 'trace-abc-123';
+    const progressEvents: Progress[] = [];
+
+    const result = await client.callTool({ name: 'any', arguments: {}, _meta: { [traceKey]: traceId } }, undefined, {
+        onprogress: p => progressEvents.push(p)
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(progressEvents).toEqual([expect.objectContaining({ progress: 1, total: 1 })]);
+
+    expect(received).toHaveLength(1);
+    const meta = received[0]._meta;
+    expect(meta?.progressToken).toBeDefined();
+    expect(['number', 'string']).toContain(typeof meta?.progressToken);
+    // Existing _meta fields are preserved alongside the injected token.
+    expect(meta?.[traceKey]).toBe(traceId);
+});
+
+verifies('protocol:progress:token-unique', async ({ transport }: TestArgs) => {
+    const tokens: Array<string | number> = [];
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool('probe', { inputSchema: z.object({}) }, async (_a, extra) => {
+            const token = extra._meta?.progressToken;
+            if (token !== undefined) {
+                tokens.push(token);
+                await extra.sendNotification({
+                    method: 'notifications/progress',
+                    params: { progressToken: token, progress: 1, total: 1 }
+                });
+            }
+            return { content: [] };
+        });
+        return s;
+    };
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    const a = client.callTool({ name: 'probe', arguments: {} }, undefined, { onprogress: () => {} });
+    const b = client.callTool({ name: 'probe', arguments: {} }, undefined, { onprogress: () => {} });
+
+    await Promise.all([a, b]);
+
+    expect(tokens).toHaveLength(2);
+    expect(tokens[0]).not.toBe(tokens[1]);
+});
+
+verifies('protocol:timeout:basic', async ({ transport }: TestArgs) => {
+    vi.useFakeTimers();
+    try {
+        const client = newClient();
+        await using _ = await wire(transport, neverRespondingServer, client);
+
+        const outbound = tapOutbound(client);
+
+        let outcome: { kind: 'resolved' | 'rejected'; value: unknown } | undefined;
+        const pending = client.listTools(undefined, { timeout: 100 });
+        void pending.then(
+            v => (outcome = { kind: 'resolved', value: v }),
+            (e: unknown) => (outcome = { kind: 'rejected', value: e })
+        );
+
+        await vi.advanceTimersByTimeAsync(0);
+        expect(outbound.filter(isRequest).some(m => m.method === 'tools/list')).toBe(true);
+        expect(outcome).toBeUndefined();
+
+        await vi.advanceTimersByTimeAsync(99);
+        expect(outcome).toBeUndefined();
+
+        await vi.advanceTimersByTimeAsync(2);
+        expect(outcome?.kind).toBe('rejected');
+        expect(outcome?.value).toBeInstanceOf(McpError);
+        expect(outcome?.value).toMatchObject({ code: ErrorCode.RequestTimeout });
+    } finally {
+        vi.useRealTimers();
+    }
+});
+
+verifies('protocol:timeout:max-total', async ({ transport }: TestArgs) => {
+    vi.useFakeTimers();
+    try {
+        const makeServer = () => {
+            const s = new McpServer({ name: 's', version: '0' });
+            s.registerTool(
+                'slow-progress',
+                { inputSchema: z.object({ delayMs: z.number(), steps: z.number() }) },
+                async ({ delayMs, steps }, extra) => {
+                    const token = extra._meta?.progressToken;
+                    if (token !== undefined) {
+                        for (let i = 1; i <= steps; i++) {
+                            await new Promise(resolve => setTimeout(resolve, delayMs));
+                            await extra.sendNotification({
+                                method: 'notifications/progress',
+                                params: { progressToken: token, progress: i, total: steps }
+                            });
+                        }
+                    }
+                    return { content: [] };
+                }
+            );
+            return s;
+        };
+        const client = newClient();
+        await using _ = await wire(transport, makeServer, client);
+
+        const perChunk = 500;
+        const maxTotal = 1000;
+        const delayMs = 200;
+
+        const ticks: number[] = [];
+
+        const call = client.callTool({ name: 'slow-progress', arguments: { delayMs, steps: 100 } }, undefined, {
+            timeout: perChunk,
+            resetTimeoutOnProgress: true,
+            maxTotalTimeout: maxTotal,
+            onprogress: p => ticks.push(p.progress)
+        });
+        call.catch(() => {});
+
+        for (let elapsed = 0; elapsed < maxTotal + perChunk; elapsed += delayMs) {
+            await vi.advanceTimersByTimeAsync(delayMs);
+        }
+
+        await expect(call).rejects.toBeInstanceOf(McpError);
+        const err = await call.catch(e => e as McpError);
+        expect(err.code).toBe(ErrorCode.RequestTimeout);
+
+        expect(ticks.length).toBeGreaterThanOrEqual(3);
+    } finally {
+        vi.useRealTimers();
+    }
+});
+
+verifies('protocol:timeout:reset-on-progress', async ({ transport }: TestArgs) => {
+    vi.useFakeTimers();
+    try {
+        const makeServer = () => {
+            const s = new McpServer({ name: 's', version: '0' });
+            s.registerTool(
+                'slow-progress',
+                { inputSchema: z.object({ steps: z.number(), delayMs: z.number() }) },
+                async ({ steps, delayMs }, extra) => {
+                    const token = extra._meta?.progressToken;
+                    if (token !== undefined) {
+                        for (let i = 1; i <= steps; i++) {
+                            await new Promise(resolve => setTimeout(resolve, delayMs));
+                            await extra.sendNotification({
+                                method: 'notifications/progress',
+                                params: { progressToken: token, progress: i, total: steps }
+                            });
+                        }
+                    }
+                    return { content: [{ type: 'text', text: `done after ${steps} steps` }] };
+                }
+            );
+            return s;
+        };
+        const client = newClient();
+        await using _ = await wire(transport, makeServer, client);
+
+        const timeout = 200;
+        const steps = 3;
+        const delayMs = 150;
+
+        const received: number[] = [];
+        let settled: 'resolved' | 'rejected' | undefined;
+
+        const call = client
+            .callTool({ name: 'slow-progress', arguments: { steps, delayMs } }, undefined, {
+                timeout,
+                resetTimeoutOnProgress: true,
+                onprogress: p => {
+                    received.push(p.progress);
+                }
+            })
+            .then(
+                r => ((settled = 'resolved'), r),
+                e => ((settled = 'rejected'), Promise.reject(e))
+            );
+
+        for (let i = 1; i <= steps; i++) {
+            await vi.advanceTimersByTimeAsync(delayMs);
+            await vi.waitFor(() => expect(received.length).toBeGreaterThanOrEqual(i));
+            if (i < steps) expect(settled).toBeUndefined();
+        }
+
+        const result = await call;
+
+        expect(settled).toBe('resolved');
+        expect(received).toEqual([1, 2, 3]);
+        expect(result.isError).toBeFalsy();
+        expect(result.content).toEqual([{ type: 'text', text: `done after ${steps} steps` }]);
+    } finally {
+        vi.useRealTimers();
+    }
+});
+
+verifies('protocol:timeout:sends-cancellation', async ({ transport }: TestArgs) => {
+    vi.useFakeTimers();
+    try {
+        const client = newClient();
+        await using _ = await wire(transport, neverRespondingServer, client);
+
+        const outbound = tapOutbound(client);
+
+        const pending = client.listTools(undefined, { timeout: 100 });
+        // Snapshot at rejection time so the cancellation-before-reject ordering is actually observed.
+        let sentAtRejection: JSONRPCMessage[] | undefined;
+        pending.catch(() => {
+            sentAtRejection = [...outbound];
+        });
+
+        await vi.advanceTimersByTimeAsync(100);
+
+        await expect(pending).rejects.toBeInstanceOf(McpError);
+        await expect(pending).rejects.toMatchObject({ code: ErrorCode.RequestTimeout });
+
+        expect(sentAtRejection).toBeDefined();
+        const listReq = sentAtRejection!.filter(isRequest).find(m => m.method === 'tools/list');
+        expect(listReq).toBeDefined();
+
+        const cancelled = sentAtRejection!.filter(isNotification).find(m => m.method === 'notifications/cancelled');
+        expect(cancelled, 'notifications/cancelled must be handed to transport.send() before the request promise rejects').toBeDefined();
+        expect(cancelled?.params?.requestId).toBe(listReq?.id);
+        expect(String(cancelled?.params?.reason)).toMatch(/timed? ?out/i);
+        expect(sentAtRejection!.indexOf(cancelled!)).toBeGreaterThan(sentAtRejection!.indexOf(listReq!));
+    } finally {
+        vi.useRealTimers();
+    }
+});
+
+verifies('mcpserver:onerror:reach-through', async ({ transport }: TestArgs) => {
+    const errors: Error[] = [];
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.server.onerror = e => errors.push(e);
+        return s;
+    };
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client, { strictValidation: false });
+
+    const baseA = errors.length;
+    const stray: JSONRPCMessage = { jsonrpc: '2.0', id: 99999, result: {} };
+    await client.transport?.send(stray);
+
+    await vi.waitFor(() => errors.length > baseA);
+
+    const hitA = errors.slice(baseA).find(e => /unknown message ID/i.test(e.message));
+    expect(
+        hitA,
+        `expected an "unknown message ID" onerror; got: ${errors
+            .slice(baseA)
+            .map(e => e.message)
+            .join(' | ')}`
+    ).toBeDefined();
+    expect(hitA!.message).toContain('99999');
+
+    const baseB = errors.length;
+    const badProgress = {
+        jsonrpc: '2.0',
+        method: 'notifications/progress',
+        params: { progressToken: 'onerror-reach-through', progress: 'not-a-number' }
+    } as unknown as JSONRPCMessage;
+    await client.transport?.send(badProgress);
+
+    await vi.waitFor(() => errors.length > baseB);
+
+    const hitB = errors.slice(baseB).find(e => /uncaught error in notification handler/i.test(e.message));
+    expect(
+        hitB,
+        `expected an "Uncaught error in notification handler" onerror; got: ${errors
+            .slice(baseB)
+            .map(e => e.message)
+            .join(' | ')}`
+    ).toBeDefined();
+
+    await expect(client.ping()).resolves.toBeDefined();
+});
+
+verifies('protocol:custom-method:notification', async ({ transport }: TestArgs) => {
+    const HEARTBEAT_METHOD = 'myorg/heartbeat';
+
+    const CustomNotificationSchema = NotificationSchema.extend({
+        method: z.literal(HEARTBEAT_METHOD),
+        params: z.object({ seq: z.number(), tag: z.string() })
+    });
+    type CustomNotification = z.infer<typeof CustomNotificationSchema>;
+
+    let server!: Server;
+    const makeServer = () => (server = new Server({ name: 's', version: '0' }, { capabilities: {} }));
+
+    const received: CustomNotification[] = [];
+    const clientErrors: Error[] = [];
+    const client = newClient();
+    client.onerror = e => clientErrors.push(e);
+
+    await using _ = await wire(transport, makeServer, client, { allowCustomMethods: true });
+
+    client.setNotificationHandler(CustomNotificationSchema, n => {
+        received.push(n);
+    });
+
+    await server.notification({
+        method: HEARTBEAT_METHOD,
+        params: { seq: 7, tag: 'custom', extra: 'stripped-by-zod' }
+    });
+
+    await vi.waitFor(() => expect(received).toHaveLength(1));
+    expect(received[0].method).toBe(HEARTBEAT_METHOD);
+    // Handler receives the Zod-parsed params (extra fields stripped).
+    expect(received[0].params).toEqual({ seq: 7, tag: 'custom' });
+    expect(received[0].params).not.toHaveProperty('extra');
+    expect(clientErrors).toEqual([]);
+});
+
+verifies('protocol:error:data-roundtrip', async ({ transport }: TestArgs) => {
+    // Raw Server so the McpError reaches the protocol layer's error envelope.
+    const data = { detail: 'x', nested: { n: 1 } };
+    const makeServer = () => {
+        const s = new Server({ name: 's', version: '0' }, { capabilities: { tools: {} } });
+        s.setRequestHandler(ListToolsRequestSchema, () => ({ tools: [] }));
+        s.setRequestHandler(CallToolRequestSchema, () => {
+            throw new McpError(ErrorCode.InternalError, 'boom', data);
+        });
+        return s;
+    };
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    const call = client.callTool({ name: 'any', arguments: {} });
+
+    await expect(call).rejects.toBeInstanceOf(McpError);
+    await expect(call).rejects.toThrow(/boom/);
+    await expect(call).rejects.toMatchObject({ code: ErrorCode.InternalError, data });
+});
+
+verifies('protocol:fallback-notification-handler', async ({ transport }: TestArgs) => {
+    const NEVER_REGISTERED = 'notifications/_e2e/never-registered';
+
+    // Notifications are emitted from inside the tools/call handler so they cross the real wire on every transport, including stateless hosting.
+    const makeServer = () => {
+        const s = new Server(
+            { name: 's', version: '0' },
+            { capabilities: { tools: { listChanged: true }, prompts: { listChanged: true } } }
+        );
+        s.setRequestHandler(ListToolsRequestSchema, () => ({ tools: [] }));
+        s.setRequestHandler(CallToolRequestSchema, async (_req, extra) => {
+            await extra.sendNotification({ method: NEVER_REGISTERED });
+            await extra.sendNotification({ method: 'notifications/prompts/list_changed' });
+            await extra.sendNotification({ method: 'notifications/tools/list_changed' });
+            return { content: [] };
+        });
+        return s;
+    };
+    const client = newClient();
+
+    const fallback: Notification[] = [];
+    const specific: Notification[] = [];
+
+    await using _ = await wire(transport, makeServer, client, { allowCustomMethods: true });
+
+    client.setNotificationHandler(ToolListChangedNotificationSchema, async n => {
+        specific.push(n);
+    });
+    client.setNotificationHandler(PromptListChangedNotificationSchema, async n => {
+        specific.push(n);
+    });
+
+    client.fallbackNotificationHandler = async n => {
+        fallback.push(n);
+    };
+
+    client.removeNotificationHandler('notifications/prompts/list_changed');
+
+    await client.callTool({ name: 'emit-notifications', arguments: {} });
+
+    await vi.waitFor(() =>
+        expect(
+            fallback.some(n => n.method === NEVER_REGISTERED) &&
+                fallback.some(n => n.method === 'notifications/prompts/list_changed') &&
+                specific.some(n => n.method === 'notifications/tools/list_changed')
+        ).toBe(true)
+    );
+
+    expect(fallback.filter(n => n.method === NEVER_REGISTERED)).toHaveLength(1);
+    expect(specific.filter(n => n.method === NEVER_REGISTERED)).toHaveLength(0);
+
+    expect(fallback.filter(n => n.method === 'notifications/prompts/list_changed')).toHaveLength(1);
+    expect(specific.filter(n => n.method === 'notifications/prompts/list_changed')).toHaveLength(0);
+
+    expect(specific.filter(n => n.method === 'notifications/tools/list_changed')).toHaveLength(1);
+    expect(fallback.filter(n => n.method === 'notifications/tools/list_changed')).toHaveLength(0);
+});
+
+verifies('protocol:handler:re-register-replaces', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool('list-roots', { inputSchema: z.object({}) }, async (_a, extra) => {
+            const result = await extra.sendRequest({ method: 'roots/list' }, ListRootsResultSchema);
+            return { structuredContent: { ok: true, result }, content: [] };
+        });
+        return s;
+    };
+    const client = new Client({ name: 'c', version: '0' }, { capabilities: { roots: { listChanged: true } } });
+    await using _ = await wire(transport, makeServer, client);
+
+    let firstCalls = 0;
+    let secondCalls = 0;
+
+    client.setRequestHandler(ListRootsRequestSchema, async () => {
+        firstCalls++;
+        return { roots: [{ uri: 'file:///first', name: 'first' }] };
+    });
+
+    expect(() =>
+        client.setRequestHandler(ListRootsRequestSchema, async () => {
+            secondCalls++;
+            return { roots: [{ uri: 'file:///second', name: 'second' }] };
+        })
+    ).not.toThrow();
+
+    const result = await client.callTool({ name: 'list-roots', arguments: {} });
+
+    expect(result.isError).toBeFalsy();
+    expect(result.structuredContent).toMatchObject({
+        ok: true,
+        result: { roots: [{ uri: 'file:///second', name: 'second' }] }
+    });
+
+    expect(secondCalls).toBe(1);
+    expect(firstCalls).toBe(0);
+});
+
+const X_ECHO_METHOD = 'x-e2e/echo';
+const XEchoRequestSchema = RequestSchema.extend({
+    method: z.literal(X_ECHO_METHOD),
+    params: z.object({ value: z.string() })
+});
+const XEchoResultSchema = ResultSchema.extend({ echoed: z.string() });
+
+function customEchoServer(): Server {
+    const s = new Server({ name: 's', version: '0' }, { capabilities: {} });
+    s.setRequestHandler(XEchoRequestSchema, req => ({ echoed: req.params.value }));
+    return s;
+}
+
+verifies('protocol:custom-method:request', async ({ transport }: TestArgs) => {
+    const client = newClient();
+    await using _ = await wire(transport, customEchoServer, client, { allowCustomMethods: true });
+
+    const result = await client.request({ method: X_ECHO_METHOD, params: { value: 'hi' } }, XEchoResultSchema);
+
+    expect(result).toEqual({ echoed: 'hi' });
+});
+
+verifies('protocol:custom-method:roundtrip', async ({ transport }: TestArgs) => {
+    const client = newClient();
+    const clientErrors: Error[] = [];
+    client.onerror = e => clientErrors.push(e);
+    await using _ = await wire(transport, customEchoServer, client, { allowCustomMethods: true });
+
+    // Custom method dispatches to the user handler — not -32601 MethodNotFound.
+    const result = await client.request({ method: X_ECHO_METHOD, params: { value: 'round' } }, XEchoResultSchema);
+    expect(result).toEqual({ echoed: 'round' });
+    expect(clientErrors).toEqual([]);
+
+    // A truly-unknown method still surfaces as MethodNotFound, proving the
+    // custom registration is what made the previous call succeed.
+    await expect(client.request({ method: 'x-e2e/never-registered', params: {} }, ResultSchema)).rejects.toMatchObject({
+        code: ErrorCode.MethodNotFound
+    });
+});
+
+verifies('protocol:custom-notification:roundtrip', async ({ transport }: TestArgs) => {
+    const X_EVENT_METHOD = 'x-e2e/event';
+    const XEventNotificationSchema = NotificationSchema.extend({
+        method: z.literal(X_EVENT_METHOD),
+        params: z.object({ kind: z.string(), id: z.number() })
+    });
+    type XEvent = z.infer<typeof XEventNotificationSchema>;
+
+    const received: XEvent[] = [];
+    const serverErrors: Error[] = [];
+    const makeServer = () => {
+        const s = new Server({ name: 's', version: '0' }, { capabilities: {} });
+        s.onerror = e => serverErrors.push(e);
+        s.setNotificationHandler(XEventNotificationSchema, n => {
+            received.push(n);
+        });
+        return s;
+    };
+
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client, { allowCustomMethods: true });
+
+    await client.notification({ method: X_EVENT_METHOD, params: { kind: 'k', id: 42, extra: 'stripped-by-zod' } });
+
+    await vi.waitFor(() => expect(received).toHaveLength(1));
+    expect(received[0].method).toBe(X_EVENT_METHOD);
+    // Handler receives the Zod-parsed params (extra fields stripped), not raw passthrough.
+    expect(received[0].params).toEqual({ kind: 'k', id: 42 });
+    expect(received[0].params).not.toHaveProperty('extra');
+    expect(serverErrors).toEqual([]);
+});
+
+verifies('protocol:meta:request-to-handler', async ({ transport }: TestArgs) => {
+    const requestMeta = { 'example.com/trace-id': 'trace-abc-123', 'example.com/tenant': { org: 'acme', region: 'eu-west-1' } };
+    const handlerParamsMeta: unknown[] = [];
+    const handlerExtraMeta: unknown[] = [];
+    const makeServer = () => {
+        const s = new Server({ name: 's', version: '0' }, { capabilities: { tools: {} } });
+        s.setRequestHandler(ListToolsRequestSchema, () => ({ tools: [] }));
+        s.setRequestHandler(CallToolRequestSchema, (req, extra) => {
+            handlerParamsMeta.push(req.params._meta);
+            handlerExtraMeta.push(extra._meta);
+            return { content: [{ type: 'text', text: 'traced' }] };
+        });
+        return s;
+    };
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    const result = await client.callTool({ name: 'traced_call', arguments: {}, _meta: requestMeta });
+
+    expect(result.content).toEqual([{ type: 'text', text: 'traced' }]);
+    // Exact equality against the sent object: nothing was stripped and nothing (e.g. a progressToken) was injected.
+    expect(handlerParamsMeta).toEqual([requestMeta]);
+    expect(handlerExtraMeta).toEqual([requestMeta]);
+});
+
+verifies('protocol:meta:result-to-client', async ({ transport }: TestArgs) => {
+    const resultMeta = { 'example.com/cost-tokens': 42, 'example.com/cache': { hit: true, region: 'eu-west-1' } };
+    const makeServer = () => {
+        const s = new Server({ name: 's', version: '0' }, { capabilities: { tools: {} } });
+        s.setRequestHandler(ListToolsRequestSchema, () => ({ tools: [] }));
+        s.setRequestHandler(CallToolRequestSchema, () => ({ content: [{ type: 'text', text: 'metered' }], _meta: resultMeta }));
+        return s;
+    };
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    const result = await client.callTool({ name: 'metered_call', arguments: {} });
+
+    expect(result.content).toEqual([{ type: 'text', text: 'metered' }]);
+    // The _meta the handler attached to its result reaches the requesting client unchanged.
+    expect(result._meta).toEqual(resultMeta);
+});
+
+verifies('protocol:request-id:unique', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool('echo', { inputSchema: z.object({ text: z.string() }) }, ({ text }) => ({
+            content: [{ type: 'text', text }]
+        }));
+        return s;
+    };
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    const tap = tapWire(client);
+
+    await client.ping();
+    await client.listTools();
+    await Promise.all([
+        client.callTool({ name: 'echo', arguments: { text: 'first' } }),
+        client.callTool({ name: 'echo', arguments: { text: 'second' } })
+    ]);
+    await client.ping();
+
+    const requests = tap.sent.filter(isRequest);
+    expect(requests.map(m => m.method).sort()).toEqual(['ping', 'ping', 'tools/call', 'tools/call', 'tools/list']);
+
+    const ids = requests.map(m => m.id);
+    for (const id of ids) {
+        expect(id).not.toBeNull();
+        expect(['string', 'number']).toContain(typeof id);
+    }
+    // Five requests on the session, five distinct ids — no id is ever reused.
+    expect(new Set(ids).size).toBe(5);
+});
+
+verifies('protocol:notifications:no-response', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool('echo', { inputSchema: z.object({ text: z.string() }) }, ({ text }) => ({
+            content: [{ type: 'text', text }]
+        }));
+        return s;
+    };
+    const client = new Client({ name: 'c', version: '0' }, { capabilities: { roots: { listChanged: true } } });
+    await using _ = await wire(transport, makeServer, client);
+
+    const tap = tapWire(client);
+
+    await client.sendRootsListChanged();
+    await client.notification({
+        method: 'notifications/cancelled',
+        params: { requestId: 424242, reason: 'request was never issued' }
+    });
+
+    const result = await client.callTool({ name: 'echo', arguments: { text: 'after notifications' } });
+    expect(result.content).toEqual([{ type: 'text', text: 'after notifications' }]);
+    await expect(client.ping()).resolves.toBeDefined();
+
+    // Both requests round-tripped after the notifications, so a (non-conformant) reply to either notification would have arrived by now.
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    expect(tap.sent.filter(isNotification).map(m => m.method)).toEqual(['notifications/roots/list_changed', 'notifications/cancelled']);
+    const requestIds = tap.sent.filter(isRequest).map(m => m.id);
+    expect(requestIds).toHaveLength(2);
+
+    const responses = tap.received.filter(isResponse);
+    expect(responses.map(m => m.id)).toEqual(requestIds);
+    for (const m of tap.received) {
+        if (isResponse(m)) {
+            expect(requestIds).toContain(m.id);
+        } else {
+            // Anything that is not a response to one of our requests must be an id-less notification.
+            expect(isNotification(m), `unexpected server→client message: ${JSON.stringify(m)}`).toBe(true);
+        }
+    }
+});
+
+verifies('protocol:progress:monotonic', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool('index_files', { inputSchema: z.object({}) }, async (_a, extra) => {
+            const token = extra._meta?.progressToken;
+            if (token === undefined) throw new Error('expected a progressToken on the request');
+            await extra.sendNotification({
+                method: 'notifications/progress',
+                params: { progressToken: token, progress: 5, message: 'indexed 5 files' }
+            });
+            try {
+                // A spec-compliant sender refuses (or drops) this regression to a smaller value.
+                await extra.sendNotification({
+                    method: 'notifications/progress',
+                    params: { progressToken: token, progress: 3, message: 'regressed' }
+                });
+            } catch {
+                /* sender-side rejection of the non-increasing value is a valid way to satisfy the spec */
+            }
+            await extra.sendNotification({
+                method: 'notifications/progress',
+                params: { progressToken: token, progress: 12, message: 'indexed 12 files' }
+            });
+            return { content: [{ type: 'text', text: 'indexing complete' }] };
+        });
+        return s;
+    };
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    const updates: Progress[] = [];
+    const result = await client.callTool({ name: 'index_files', arguments: {} }, undefined, { onprogress: p => updates.push(p) });
+
+    expect(result.content).toEqual([{ type: 'text', text: 'indexing complete' }]);
+
+    // Progress flows even though no total was supplied.
+    expect(updates.map(p => p.progress)).toContain(5);
+    expect(updates.map(p => p.progress)).toContain(12);
+    for (const update of updates) {
+        expect(update.total).toBeUndefined();
+    }
+    // Spec: the progress value MUST increase with each notification for the token, so the regressed value never reaches the caller.
+    for (let i = 1; i < updates.length; i++) {
+        expect(
+            updates[i].progress,
+            `progress sequence ${updates.map(p => p.progress).join(' → ')} must be strictly increasing`
+        ).toBeGreaterThan(updates[i - 1].progress);
+    }
+});
+
+verifies('protocol:progress:stops-after-completion', async ({ transport }: TestArgs) => {
+    let server!: Server;
+    let lateProgress: (() => Promise<void>) | undefined;
+    const makeServer = () => {
+        server = new Server({ name: 's', version: '0' }, { capabilities: { tools: { listChanged: true } } });
+        server.setRequestHandler(ListToolsRequestSchema, () => ({ tools: [] }));
+        server.setRequestHandler(CallToolRequestSchema, async (req, extra) => {
+            const token = req.params._meta?.progressToken;
+            if (token === undefined) throw new Error('expected a progressToken on the request');
+            await extra.sendNotification({
+                method: 'notifications/progress',
+                params: { progressToken: token, progress: 1, total: 2, message: 'halfway' }
+            });
+            // Captured so the test can attempt a post-completion progress send for the same token through the public API.
+            lateProgress = () =>
+                server.notification({
+                    method: 'notifications/progress',
+                    params: { progressToken: token, progress: 2, total: 2, message: 'late' }
+                });
+            return { content: [{ type: 'text', text: 'partial upload complete' }] };
+        });
+        return server;
+    };
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    const tap = tapWire(client);
+
+    const updates: Progress[] = [];
+    const result = await client.callTool({ name: 'upload', arguments: {} }, undefined, { onprogress: p => updates.push(p) });
+
+    expect(result.content).toEqual([{ type: 'text', text: 'partial upload complete' }]);
+    expect(updates).toEqual([{ progress: 1, total: 2, message: 'halfway' }]);
+
+    const receivedBeforeLateSend = tap.received.length;
+    if (!lateProgress) throw new Error('handler did not capture the late-progress sender');
+    await lateProgress();
+    // Sentinel on the same server→client channel: once it arrives, the late progress (had it been sent) would have arrived too.
+    await server.sendToolListChanged();
+    await vi.waitFor(() =>
+        expect(tap.received.filter(isNotification).filter(m => m.method === 'notifications/tools/list_changed')).toHaveLength(1)
+    );
+
+    // Spec: progress notifications for the token stop once the associated request has completed.
+    const lateProgressOnWire = tap.received
+        .slice(receivedBeforeLateSend)
+        .filter(isNotification)
+        .filter(m => m.method === 'notifications/progress');
+    expect(lateProgressOnWire).toEqual([]);
+});
+
+verifies('protocol:cancel:in-flight', async ({ transport }: TestArgs) => {
+    const handlerStarted: RequestId[] = [];
+    const handlerAbortReasons: unknown[] = [];
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool(
+            'long_export',
+            { inputSchema: z.object({}) },
+            async (_a, extra) =>
+                new Promise((_resolve, reject) => {
+                    handlerStarted.push(extra.requestId);
+                    extra.signal.addEventListener('abort', () => {
+                        handlerAbortReasons.push(extra.signal.reason);
+                        reject(new Error(String(extra.signal.reason)));
+                    });
+                })
+        );
+        return s;
+    };
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    const tap = tapWire(client);
+
+    const ac = new AbortController();
+    const call = client.callTool({ name: 'long_export', arguments: {} }, undefined, { signal: ac.signal });
+    call.catch(() => {});
+
+    // Cancel only once the handler is running, so the cancellation targets a request that is genuinely in flight on the server.
+    await vi.waitFor(() => expect(handlerStarted).toHaveLength(1));
+    const callRequest = tap.sent.filter(isRequest).find(m => m.method === 'tools/call');
+    if (!callRequest) throw new Error('tools/call request not captured');
+
+    ac.abort(new Error('user cancelled the export'));
+    await expect(call).rejects.toThrow('user cancelled the export');
+
+    await vi.waitFor(() =>
+        expect(
+            tap.sent
+                .filter(isNotification)
+                .filter(m => m.method === 'notifications/cancelled')
+                .map(m => m.params?.requestId)
+        ).toEqual([callRequest.id])
+    );
+
+    // The cancellation stopped the server-side handler, carrying the client's reason.
+    await vi.waitFor(() => expect(handlerAbortReasons).toHaveLength(1));
+    expect(String(handlerAbortReasons[0])).toContain('user cancelled the export');
+
+    // A later round-trip on the same channel proves a (non-conformant) response to the cancelled request would have arrived by now.
+    await expect(client.ping()).resolves.toBeDefined();
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    expect(tap.received.filter(isResponse).filter(m => m.id === callRequest.id)).toEqual([]);
+});
+
+verifies('protocol:progress:client-to-server', async ({ transport }: TestArgs) => {
+    const serverUpdates: Progress[] = [];
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool('summarize_report', { inputSchema: z.object({ text: z.string() }) }, async ({ text }, extra) => {
+            const result = await extra.sendRequest(
+                {
+                    method: 'sampling/createMessage',
+                    params: {
+                        messages: [{ role: 'user', content: { type: 'text', text: `Summarize the following report:\n${text}` } }],
+                        maxTokens: 200
+                    }
+                },
+                CreateMessageResultSchema,
+                { onprogress: p => serverUpdates.push(p) }
+            );
+            if (result.content.type !== 'text') throw new Error('expected text sampling content');
+            return { content: [{ type: 'text', text: result.content.text }] };
+        });
+        return s;
+    };
+
+    const client = new Client({ name: 'c', version: '0' }, { capabilities: { sampling: {} } });
+    client.setRequestHandler(CreateMessageRequestSchema, async (req, extra) => {
+        const token = req.params._meta?.progressToken;
+        if (token === undefined) throw new Error('expected a progressToken on the sampling request');
+        await extra.sendNotification({
+            method: 'notifications/progress',
+            params: { progressToken: token, progress: 1, total: 2, message: 'sampling started' }
+        });
+        await extra.sendNotification({
+            method: 'notifications/progress',
+            params: { progressToken: token, progress: 2, total: 2, message: 'sampling finished' }
+        });
+        return {
+            model: 'test-model',
+            role: 'assistant',
+            stopReason: 'endTurn',
+            content: { type: 'text', text: 'Quarterly revenue grew 12%.' }
+        };
+    });
+
+    await using _ = await wire(transport, makeServer, client);
+
+    const result = await client.callTool({
+        name: 'summarize_report',
+        arguments: { text: 'Revenue was up 12% quarter over quarter, driven by enterprise renewals.' }
+    });
+
+    expect(result.content).toEqual([{ type: 'text', text: 'Quarterly revenue grew 12%.' }]);
+
+    await vi.waitFor(() => expect(serverUpdates).toHaveLength(2));
+    expect(serverUpdates).toEqual([
+        { progress: 1, total: 2, message: 'sampling started' },
+        { progress: 2, total: 2, message: 'sampling finished' }
+    ]);
+});
+
+verifies('protocol:request-handler:override-builtin', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        const s = new Server({ name: 's', version: '0' }, { capabilities: {} });
+        // Ping has a built-in handler; this should replace it without throwing.
+        s.setRequestHandler(PingRequestSchema, () => ({ _meta: { 'e2e/overridden': true } }));
+        return s;
+    };
+
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    expect(() =>
+        new Server({ name: 's', version: '0' }, { capabilities: {} }).setRequestHandler(PingRequestSchema, () => ({}))
+    ).not.toThrow();
+
+    const result = await client.ping();
+    expect(result).toEqual({ _meta: { 'e2e/overridden': true } });
+});
+
+export async function mcpserverOnerrorReachThroughRaw({ transport }: TestArgs) {
+    const errors: Error[] = [];
+    const makeServer = () => {
+        const s = new Server({ name: 's', version: '0' }, { capabilities: {} });
+        s.onerror = e => errors.push(e);
+        return s;
+    };
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    const baseA = errors.length;
+    const stray: JSONRPCMessage = { jsonrpc: '2.0', id: 99999, result: {} };
+    await client.transport?.send(stray);
+
+    await vi.waitFor(() => errors.length > baseA);
+
+    const hitA = errors.slice(baseA).find(e => /unknown message ID/i.test(e.message));
+    expect(
+        hitA,
+        `expected an "unknown message ID" onerror; got: ${errors
+            .slice(baseA)
+            .map(e => e.message)
+            .join(' | ')}`
+    ).toBeDefined();
+    expect(hitA!.message).toContain('99999');
+
+    await expect(client.ping()).resolves.toBeDefined();
+}

--- a/test/e2e/scenarios/protocol.test.ts
+++ b/test/e2e/scenarios/protocol.test.ts
@@ -6,17 +6,7 @@
  * via the requirement's tier map.
  */
 
-import { expect, vi } from 'vitest';
-import { z } from 'zod/v4';
-import {
-    InMemoryTransport,
-    Server,
-    McpServer,
-    ProtocolError,
-    ProtocolErrorCode,
-    SdkErrorCode,
-    specTypeSchemas
-} from '@modelcontextprotocol/server';
+import { Client } from '@modelcontextprotocol/client';
 import type {
     CallToolRequest,
     JSONRPCMessage,
@@ -27,10 +17,22 @@ import type {
     Progress,
     RequestId
 } from '@modelcontextprotocol/server';
-import { Client } from '@modelcontextprotocol/client';
+import {
+    InMemoryTransport,
+    McpServer,
+    ProtocolError,
+    ProtocolErrorCode,
+    SdkError,
+    SdkErrorCode,
+    Server,
+    specTypeSchemas
+} from '@modelcontextprotocol/server';
+import { expect, vi } from 'vitest';
+import { z } from 'zod/v4';
+
 import { tapWire, wire } from '../helpers/index.js';
-import type { TestArgs } from '../types.js';
 import { verifies } from '../helpers/verifies.js';
+import type { TestArgs } from '../types.js';
 
 const newClient = () => new Client({ name: 'c', version: '0' });
 
@@ -92,35 +94,31 @@ verifies('protocol:cancel:abort-signal', async ({ transport }: TestArgs) => {
     const client = newClient();
     await using _ = await wire(transport, makeServer, client);
 
-    const outbound: JSONRPCMessage[] = [];
-    const originalSend = client.transport!.send.bind(client.transport!);
-    client.transport!.send = async m => {
-        outbound.push(m);
-        return originalSend(m);
-    };
+    const outbound = tapOutbound(client);
 
     const controller = new AbortController();
-    const call = client.callTool({ name: 'echo', arguments: { text: 'never' } }, undefined, {
-        signal: controller.signal
-    });
+    const call = client.callTool(
+        { name: 'echo', arguments: { text: 'never' } },
+        {
+            signal: controller.signal
+        }
+    );
     call.catch(() => {});
 
-    await vi.waitFor(() => outbound.some(m => 'method' in m && m.method === 'tools/call'));
-    const callMsg = outbound.find(
-        (m): m is Extract<JSONRPCMessage, { method: string; id: RequestId }> => 'method' in m && m.method === 'tools/call' && 'id' in m
-    )!;
+    await vi.waitFor(() => expect(outbound.some(m => 'method' in m && m.method === 'tools/call')).toBe(true));
+    const callMsg = outbound.filter(m => isRequest(m)).find(m => m.method === 'tools/call');
+    if (!callMsg) throw new Error('tools/call request not captured');
 
     controller.abort('user requested cancellation');
 
     await expect(call).rejects.toThrow(/user requested cancellation/);
 
-    await vi.waitFor(() => outbound.some(m => 'method' in m && m.method === 'notifications/cancelled'));
-    const cancelled = outbound.find(m => 'method' in m && m.method === 'notifications/cancelled') as {
-        id?: RequestId;
-        params?: { requestId?: RequestId; reason?: string };
-    };
+    await vi.waitFor(() => expect(outbound.some(m => 'method' in m && m.method === 'notifications/cancelled')).toBe(true));
+    const cancelled = outbound.find(m => 'method' in m && m.method === 'notifications/cancelled');
 
+    expect(cancelled).toBeDefined();
     expect(cancelled).not.toHaveProperty('id');
+    if (!cancelled || !('params' in cancelled)) throw new Error('notifications/cancelled message has no params');
     expect(cancelled.params?.requestId).toBe(callMsg.id);
     expect(cancelled.params?.reason).toContain('user requested cancellation');
 });
@@ -146,7 +144,7 @@ verifies('protocol:cancel:handler-abort-propagates', async ({ transport }: TestA
     await using _ = await wire(transport, makeServer, client);
 
     const ac = new AbortController();
-    const call = client.callTool({ name: 'cancellable', arguments: {} }, undefined, { signal: ac.signal });
+    const call = client.callTool({ name: 'cancellable', arguments: {} }, { signal: ac.signal });
     call.catch(() => {});
 
     await new Promise(resolve => setTimeout(resolve, 50));
@@ -157,9 +155,11 @@ verifies('protocol:cancel:handler-abort-propagates', async ({ transport }: TestA
 
     await vi.waitFor(() => expect(aborts.length).toBeGreaterThan(0));
 
+    const firstAbort = aborts[0];
+    if (!firstAbort) throw new Error('no abort recorded');
     // Server-side signal.reason carries the cancellation reason text from the
     // notifications/cancelled the client sent (possibly wrapped).
-    expect(String(aborts[0].reason)).toContain('user cancelled');
+    expect(String(firstAbort.reason)).toContain('user cancelled');
 });
 
 verifies('protocol:cancel:initialize-not-cancellable', async (_: TestArgs) => {
@@ -182,8 +182,8 @@ verifies('protocol:cancel:initialize-not-cancellable', async (_: TestArgs) => {
     const connecting = client.connect(clientTx, { signal: ac.signal });
     connecting.catch(() => {});
 
-    await vi.waitFor(() => expect(outbound.filter(isRequest).some(m => m.method === 'initialize')).toBe(true));
-    const initReq = outbound.filter(isRequest).find(m => m.method === 'initialize');
+    await vi.waitFor(() => expect(outbound.filter(m => isRequest(m)).some(m => m.method === 'initialize')).toBe(true));
+    const initReq = outbound.filter(m => isRequest(m)).find(m => m.method === 'initialize');
     expect(initReq?.id).toBeDefined();
 
     ac.abort(new Error('user aborted connect'));
@@ -192,7 +192,7 @@ verifies('protocol:cancel:initialize-not-cancellable', async (_: TestArgs) => {
     await new Promise(resolve => setTimeout(resolve, 50));
 
     const cancelledForInit = outbound
-        .filter(isNotification)
+        .filter(m => isNotification(m))
         .filter(m => m.method === 'notifications/cancelled' && m.params?.requestId === initReq?.id);
     expect(cancelledForInit).toEqual([]);
 
@@ -221,29 +221,23 @@ verifies('protocol:cancel:late-response-ignored', async ({ transport }: TestArgs
     const client = newClient();
     await using _ = await wire(transport, makeServer, client);
 
-    const outbound: JSONRPCMessage[] = [];
-    const originalSend = client.transport!.send.bind(client.transport!);
-    client.transport!.send = async m => {
-        outbound.push(m);
-        return originalSend(m);
-    };
+    const outbound = tapOutbound(client);
 
     const errors: Error[] = [];
     client.onerror = e => errors.push(e);
 
     const ac = new AbortController();
-    const call = client.callTool({ name: 'echo', arguments: { text: 'late' } }, undefined, { signal: ac.signal });
+    const call = client.callTool({ name: 'echo', arguments: { text: 'late' } }, { signal: ac.signal });
     call.catch(() => {});
 
-    await vi.waitFor(() => outbound.some(m => 'method' in m && m.method === 'tools/call'));
-    const callReq = outbound.find(
-        (m): m is Extract<JSONRPCMessage, { method: string; id: RequestId }> => 'method' in m && m.method === 'tools/call' && 'id' in m
-    )!;
+    await vi.waitFor(() => expect(outbound.some(m => 'method' in m && m.method === 'tools/call')).toBe(true));
+    const callReq = outbound.filter(m => isRequest(m)).find(m => m.method === 'tools/call');
+    if (!callReq) throw new Error('tools/call request not captured');
     const callId = callReq.id;
 
     ac.abort(new Error('user cancelled'));
 
-    await vi.waitFor(() => outbound.some(m => 'method' in m && m.method === 'notifications/cancelled'));
+    await vi.waitFor(() => expect(outbound.some(m => 'method' in m && m.method === 'notifications/cancelled')).toBe(true));
 
     await expect(call).rejects.toThrow('user cancelled');
 
@@ -252,7 +246,9 @@ verifies('protocol:cancel:late-response-ignored', async ({ transport }: TestArgs
         id: callId,
         result: { content: [{ type: 'text', text: 'late' }] }
     };
-    client.transport!.onmessage?.(lateResponse);
+    const clientTx = client.transport;
+    if (!clientTx) throw new Error('client transport not connected');
+    clientTx.onmessage?.(lateResponse);
 
     await new Promise(resolve => setTimeout(resolve, 50));
 
@@ -280,7 +276,7 @@ verifies('protocol:cancel:unknown-id-ignored', async ({ transport }: TestArgs) =
     await expect(
         client.notification({
             method: 'notifications/cancelled',
-            params: { requestId: 99999, reason: 'unknown numeric id' }
+            params: { requestId: 99_999, reason: 'unknown numeric id' }
         })
     ).resolves.toBeUndefined();
 
@@ -314,7 +310,7 @@ verifies('typescript:protocol:error:connection-closed', async ({ transport }: Te
     await client.close();
 
     for (const p of inFlight) {
-        await expect(p).rejects.toBeInstanceOf(ProtocolError);
+        await expect(p).rejects.toBeInstanceOf(SdkError);
         await expect(p).rejects.toMatchObject({ code: SdkErrorCode.ConnectionClosed });
     }
     // onclose fires at least once (transport peers may echo a close back, so don't pin the count).
@@ -340,7 +336,7 @@ verifies('protocol:error:internal-error', async ({ transport }: TestArgs) => {
     await expect(call).rejects.toBeInstanceOf(ProtocolError);
     await expect(call).rejects.toMatchObject({ code: ProtocolErrorCode.InternalError });
     await expect(call).rejects.toThrow(/handler exploded/);
-    expect(ProtocolErrorCode.InternalError).toBe(-32603);
+    expect(ProtocolErrorCode.InternalError).toBe(-32_603);
 });
 
 verifies('protocol:error:invalid-params', async ({ transport }: TestArgs) => {
@@ -365,10 +361,10 @@ verifies('protocol:error:invalid-params', async ({ transport }: TestArgs) => {
     await expect(call).rejects.toBeInstanceOf(ProtocolError);
 
     // The malformed request did reach the wire (failure is server-side, not client-side validation).
-    const sent = outbound.filter(isRequest).find(m => m.method === 'tools/call');
+    const sent = outbound.filter(m => isRequest(m)).find(m => m.method === 'tools/call');
     expect(sent?.params).toEqual({ arguments: {} });
 
-    expect(ProtocolErrorCode.InvalidParams).toBe(-32602);
+    expect(ProtocolErrorCode.InvalidParams).toBe(-32_602);
     await expect(call).rejects.toMatchObject({ code: ProtocolErrorCode.InvalidParams });
 });
 
@@ -380,20 +376,13 @@ verifies('protocol:error:method-not-found', async ({ transport }: TestArgs) => {
     const client = newClient();
     await using _ = await wire(transport, makeServer, client, { allowCustomMethods: true });
 
-    const outbound: JSONRPCMessage[] = [];
-    const originalSend = client.transport!.send.bind(client.transport!);
-    client.transport!.send = async m => {
-        outbound.push(m);
-        return originalSend(m);
-    };
+    const outbound = tapOutbound(client);
 
     const call = client.request({ method: 'no/such/method' }, z.object({}));
 
     await expect(call).rejects.toBeInstanceOf(ProtocolError);
-
-    const err = await call.catch(e => e as ProtocolError);
-    expect(err.code).toBe(ProtocolErrorCode.MethodNotFound);
-    expect(err.code).toBe(-32601);
+    await expect(call).rejects.toMatchObject({ code: ProtocolErrorCode.MethodNotFound });
+    expect(ProtocolErrorCode.MethodNotFound).toBe(-32_601);
 
     const sent = outbound.filter(m => 'method' in m && m.method === 'no/such/method' && 'id' in m);
     expect(sent).toHaveLength(1);
@@ -425,7 +414,7 @@ verifies('protocol:error:reconnect-no-stale-timers', async (_: TestArgs) => {
     const inFlight = client.listTools(undefined, { timeout: 400 });
     inFlight.catch(() => {});
 
-    await vi.waitFor(() => expect(sentOnA.filter(isRequest).some(m => m.method === 'tools/list')).toBe(true));
+    await vi.waitFor(() => expect(sentOnA.filter(m => isRequest(m)).some(m => m.method === 'tools/list')).toBe(true));
 
     // Connection drops before the 400 ms timeout fires; the in-flight request is
     // rejected by close (how it rejects is protocol:error:connection-closed's concern).
@@ -450,12 +439,12 @@ verifies('protocol:error:reconnect-no-stale-timers', async (_: TestArgs) => {
     // request id server B never saw) onto the new transport.
     await new Promise(resolve => setTimeout(resolve, 550));
 
-    expect(sentOnB.filter(isNotification).filter(m => m.method === 'notifications/cancelled')).toEqual([]);
+    expect(sentOnB.filter(m => isNotification(m)).filter(m => m.method === 'notifications/cancelled')).toEqual([]);
     expect(clientErrors).toEqual([]);
 
     // The reconnected session is healthy.
     await expect(client.ping()).resolves.toBeDefined();
-    expect(sentOnB.filter(isRequest).some(m => m.method === 'ping')).toBe(true);
+    expect(sentOnB.filter(m => isRequest(m)).some(m => m.method === 'ping')).toBe(true);
 
     await client.close();
     await serverB.close();
@@ -488,9 +477,12 @@ verifies('protocol:progress:callback', async ({ transport }: TestArgs) => {
 
     const updates: Progress[] = [];
 
-    await client.callTool({ name: 'progress', arguments: { steps: 2 } }, undefined, {
-        onprogress: p => updates.push(p)
-    });
+    await client.callTool(
+        { name: 'progress', arguments: { steps: 2 } },
+        {
+            onprogress: p => updates.push(p)
+        }
+    );
 
     expect(updates).toHaveLength(2);
 
@@ -525,15 +517,18 @@ verifies('typescript:protocol:progress:token-injected', async ({ transport }: Te
     const traceId = 'trace-abc-123';
     const progressEvents: Progress[] = [];
 
-    const result = await client.callTool({ name: 'any', arguments: {}, _meta: { [traceKey]: traceId } }, undefined, {
-        onprogress: p => progressEvents.push(p)
-    });
+    const result = await client.callTool(
+        { name: 'any', arguments: {}, _meta: { [traceKey]: traceId } },
+        {
+            onprogress: p => progressEvents.push(p)
+        }
+    );
 
     expect(result.isError).toBeFalsy();
     expect(progressEvents).toEqual([expect.objectContaining({ progress: 1, total: 1 })]);
 
     expect(received).toHaveLength(1);
-    const meta = received[0]._meta;
+    const meta = received[0]?._meta;
     expect(meta?.progressToken).toBeDefined();
     expect(['number', 'string']).toContain(typeof meta?.progressToken);
     // Existing _meta fields are preserved alongside the injected token.
@@ -560,8 +555,8 @@ verifies('protocol:progress:token-unique', async ({ transport }: TestArgs) => {
     const client = newClient();
     await using _ = await wire(transport, makeServer, client);
 
-    const a = client.callTool({ name: 'probe', arguments: {} }, undefined, { onprogress: () => {} });
-    const b = client.callTool({ name: 'probe', arguments: {} }, undefined, { onprogress: () => {} });
+    const a = client.callTool({ name: 'probe', arguments: {} }, { onprogress: () => {} });
+    const b = client.callTool({ name: 'probe', arguments: {} }, { onprogress: () => {} });
 
     await Promise.all([a, b]);
 
@@ -581,11 +576,11 @@ verifies('protocol:timeout:basic', async ({ transport }: TestArgs) => {
         const pending = client.listTools(undefined, { timeout: 100 });
         void pending.then(
             v => (outcome = { kind: 'resolved', value: v }),
-            (e: unknown) => (outcome = { kind: 'rejected', value: e })
+            (error: unknown) => (outcome = { kind: 'rejected', value: error })
         );
 
         await vi.advanceTimersByTimeAsync(0);
-        expect(outbound.filter(isRequest).some(m => m.method === 'tools/list')).toBe(true);
+        expect(outbound.filter(m => isRequest(m)).some(m => m.method === 'tools/list')).toBe(true);
         expect(outcome).toBeUndefined();
 
         await vi.advanceTimersByTimeAsync(99);
@@ -593,7 +588,7 @@ verifies('protocol:timeout:basic', async ({ transport }: TestArgs) => {
 
         await vi.advanceTimersByTimeAsync(2);
         expect(outcome?.kind).toBe('rejected');
-        expect(outcome?.value).toBeInstanceOf(ProtocolError);
+        expect(outcome?.value).toBeInstanceOf(SdkError);
         expect(outcome?.value).toMatchObject({ code: SdkErrorCode.RequestTimeout });
     } finally {
         vi.useRealTimers();
@@ -633,21 +628,23 @@ verifies('protocol:timeout:max-total', async ({ transport }: TestArgs) => {
 
         const ticks: number[] = [];
 
-        const call = client.callTool({ name: 'slow-progress', arguments: { delayMs, steps: 100 } }, undefined, {
-            timeout: perChunk,
-            resetTimeoutOnProgress: true,
-            maxTotalTimeout: maxTotal,
-            onprogress: p => ticks.push(p.progress)
-        });
+        const call = client.callTool(
+            { name: 'slow-progress', arguments: { delayMs, steps: 100 } },
+            {
+                timeout: perChunk,
+                resetTimeoutOnProgress: true,
+                maxTotalTimeout: maxTotal,
+                onprogress: p => ticks.push(p.progress)
+            }
+        );
         call.catch(() => {});
 
         for (let elapsed = 0; elapsed < maxTotal + perChunk; elapsed += delayMs) {
             await vi.advanceTimersByTimeAsync(delayMs);
         }
 
-        await expect(call).rejects.toBeInstanceOf(ProtocolError);
-        const err = await call.catch(e => e as ProtocolError);
-        expect(err.code).toBe(SdkErrorCode.RequestTimeout);
+        await expect(call).rejects.toBeInstanceOf(SdkError);
+        await expect(call).rejects.toMatchObject({ code: SdkErrorCode.RequestTimeout });
 
         expect(ticks.length).toBeGreaterThanOrEqual(3);
     } finally {
@@ -690,16 +687,19 @@ verifies('protocol:timeout:reset-on-progress', async ({ transport }: TestArgs) =
         let settled: 'resolved' | 'rejected' | undefined;
 
         const call = client
-            .callTool({ name: 'slow-progress', arguments: { steps, delayMs } }, undefined, {
-                timeout,
-                resetTimeoutOnProgress: true,
-                onprogress: p => {
-                    received.push(p.progress);
+            .callTool(
+                { name: 'slow-progress', arguments: { steps, delayMs } },
+                {
+                    timeout,
+                    resetTimeoutOnProgress: true,
+                    onprogress: p => {
+                        received.push(p.progress);
+                    }
                 }
-            })
+            )
             .then(
                 r => ((settled = 'resolved'), r),
-                e => ((settled = 'rejected'), Promise.reject(e))
+                error => ((settled = 'rejected'), Promise.reject(error))
             );
 
         for (let i = 1; i <= steps; i++) {
@@ -736,104 +736,109 @@ verifies('protocol:timeout:sends-cancellation', async ({ transport }: TestArgs) 
 
         await vi.advanceTimersByTimeAsync(100);
 
-        await expect(pending).rejects.toBeInstanceOf(ProtocolError);
+        await expect(pending).rejects.toBeInstanceOf(SdkError);
         await expect(pending).rejects.toMatchObject({ code: SdkErrorCode.RequestTimeout });
 
         expect(sentAtRejection).toBeDefined();
-        const listReq = sentAtRejection!.filter(isRequest).find(m => m.method === 'tools/list');
+        if (!sentAtRejection) throw new Error('rejection snapshot not captured');
+        const listReq = sentAtRejection.filter(m => isRequest(m)).find(m => m.method === 'tools/list');
         expect(listReq).toBeDefined();
 
-        const cancelled = sentAtRejection!.filter(isNotification).find(m => m.method === 'notifications/cancelled');
+        const cancelled = sentAtRejection.filter(m => isNotification(m)).find(m => m.method === 'notifications/cancelled');
         expect(cancelled, 'notifications/cancelled must be handed to transport.send() before the request promise rejects').toBeDefined();
-        expect(cancelled?.params?.requestId).toBe(listReq?.id);
-        expect(String(cancelled?.params?.reason)).toMatch(/timed? ?out/i);
-        expect(sentAtRejection!.indexOf(cancelled!)).toBeGreaterThan(sentAtRejection!.indexOf(listReq!));
+        if (!listReq || !cancelled) throw new Error('expected tools/list request and notifications/cancelled on the wire');
+        expect(cancelled.params?.requestId).toBe(listReq.id);
+        expect(String(cancelled.params?.reason)).toMatch(/timed? ?out/i);
+        expect(sentAtRejection.indexOf(cancelled)).toBeGreaterThan(sentAtRejection.indexOf(listReq));
     } finally {
         vi.useRealTimers();
     }
 });
 
-verifies('mcpserver:onerror:reach-through', async ({ transport }: TestArgs) => {
-    const errors: Error[] = [];
-    const makeServer = () => {
-        const s = new McpServer({ name: 's', version: '0' });
-        s.server.onerror = e => errors.push(e);
-        return s;
-    };
-    const client = newClient();
-    await using _ = await wire(transport, makeServer, client, { strictValidation: false });
+verifies(
+    'mcpserver:onerror:reach-through',
+    async ({ transport }: TestArgs) => {
+        const errors: Error[] = [];
+        const makeServer = () => {
+            const s = new McpServer({ name: 's', version: '0' });
+            s.server.onerror = e => errors.push(e);
+            return s;
+        };
+        const client = newClient();
+        await using _ = await wire(transport, makeServer, client, { strictValidation: false });
 
-    const baseA = errors.length;
-    const stray: JSONRPCMessage = { jsonrpc: '2.0', id: 99999, result: {} };
-    await client.transport?.send(stray);
+        const baseA = errors.length;
+        const stray: JSONRPCMessage = { jsonrpc: '2.0', id: 99_999, result: {} };
+        await client.transport?.send(stray);
 
-    await vi.waitFor(() => errors.length > baseA);
+        await vi.waitFor(() => errors.length > baseA);
 
-    const hitA = errors.slice(baseA).find(e => /unknown message ID/i.test(e.message));
-    expect(
-        hitA,
-        `expected an "unknown message ID" onerror; got: ${errors
-            .slice(baseA)
-            .map(e => e.message)
-            .join(' | ')}`
-    ).toBeDefined();
-    expect(hitA!.message).toContain('99999');
+        const hitA = errors.slice(baseA).find(e => /unknown message ID/i.test(e.message));
+        expect(
+            hitA,
+            `expected an "unknown message ID" onerror; got: ${errors
+                .slice(baseA)
+                .map(e => e.message)
+                .join(' | ')}`
+        ).toBeDefined();
+        expect(hitA?.message).toContain('99999');
 
-    const baseB = errors.length;
-    const badProgress = {
-        jsonrpc: '2.0',
-        method: 'notifications/progress',
-        params: { progressToken: 'onerror-reach-through', progress: 'not-a-number' }
-    } as unknown as JSONRPCMessage;
-    await client.transport?.send(badProgress);
+        const baseB = errors.length;
+        const badProgress: JSONRPCMessage = {
+            jsonrpc: '2.0',
+            method: 'notifications/progress',
+            params: { progressToken: 'onerror-reach-through', progress: 'not-a-number' }
+        };
+        await client.transport?.send(badProgress);
 
-    await vi.waitFor(() => errors.length > baseB);
+        await vi.waitFor(() => errors.length > baseB);
 
-    const hitB = errors.slice(baseB).find(e => /uncaught error in notification handler/i.test(e.message));
-    expect(
-        hitB,
-        `expected an "Uncaught error in notification handler" onerror; got: ${errors
-            .slice(baseB)
-            .map(e => e.message)
-            .join(' | ')}`
-    ).toBeDefined();
+        const hitB = errors.slice(baseB).find(e => /uncaught error in notification handler/i.test(e.message));
+        expect(
+            hitB,
+            `expected an "Uncaught error in notification handler" onerror; got: ${errors
+                .slice(baseB)
+                .map(e => e.message)
+                .join(' | ')}`
+        ).toBeDefined();
 
-    await expect(client.ping()).resolves.toBeDefined();
-});
+        await expect(client.ping()).resolves.toBeDefined();
+    },
+    { title: 'via mcpServer.server' }
+);
 
 verifies('protocol:custom-method:notification', async ({ transport }: TestArgs) => {
     const HEARTBEAT_METHOD = 'myorg/heartbeat';
+    const HeartbeatParamsSchema = z.object({ seq: z.number(), tag: z.string() });
 
-    const CustomNotificationSchema = specTypeSchemas.Notification.extend({
-        method: z.literal(HEARTBEAT_METHOD),
-        params: z.object({ seq: z.number(), tag: z.string() })
-    });
-    type CustomNotification = z.infer<typeof CustomNotificationSchema>;
+    let server: Server | undefined;
+    const makeServer = () => {
+        server = new Server({ name: 's', version: '0' }, { capabilities: {} });
+        return server;
+    };
 
-    let server!: Server;
-    const makeServer = () => (server = new Server({ name: 's', version: '0' }, { capabilities: {} }));
-
-    const received: CustomNotification[] = [];
+    const received: Array<{ method: string; params: z.infer<typeof HeartbeatParamsSchema> }> = [];
     const clientErrors: Error[] = [];
     const client = newClient();
     client.onerror = e => clientErrors.push(e);
 
     await using _ = await wire(transport, makeServer, client, { allowCustomMethods: true });
 
-    client.setNotificationHandler(CustomNotificationSchema, n => {
-        received.push(n);
+    client.setNotificationHandler(HEARTBEAT_METHOD, { params: HeartbeatParamsSchema }, (params, notification) => {
+        received.push({ method: notification.method, params });
     });
 
+    if (!server) throw new Error('server not created');
     await server.notification({
         method: HEARTBEAT_METHOD,
         params: { seq: 7, tag: 'custom', extra: 'stripped-by-zod' }
     });
 
     await vi.waitFor(() => expect(received).toHaveLength(1));
-    expect(received[0].method).toBe(HEARTBEAT_METHOD);
-    // Handler receives the Zod-parsed params (extra fields stripped).
-    expect(received[0].params).toEqual({ seq: 7, tag: 'custom' });
-    expect(received[0].params).not.toHaveProperty('extra');
+    expect(received[0]?.method).toBe(HEARTBEAT_METHOD);
+    // Handler receives the schema-parsed params (extra fields stripped).
+    expect(received[0]?.params).toEqual({ seq: 7, tag: 'custom' });
+    expect(received[0]?.params).not.toHaveProperty('extra');
     expect(clientErrors).toEqual([]);
 });
 
@@ -956,15 +961,12 @@ verifies('protocol:handler:re-register-replaces', async ({ transport }: TestArgs
 });
 
 const X_ECHO_METHOD = 'x-e2e/echo';
-const XEchoRequestSchema = specTypeSchemas.Request.extend({
-    method: z.literal(X_ECHO_METHOD),
-    params: z.object({ value: z.string() })
-});
-const XEchoResultSchema = specTypeSchemas.Result.extend({ echoed: z.string() });
+const XEchoParamsSchema = z.object({ value: z.string() });
+const XEchoResultSchema = z.object({ echoed: z.string() });
 
 function customEchoServer(): Server {
     const s = new Server({ name: 's', version: '0' }, { capabilities: {} });
-    s.setRequestHandler(XEchoRequestSchema, req => ({ echoed: req.params.value }));
+    s.setRequestHandler(X_ECHO_METHOD, { params: XEchoParamsSchema, result: XEchoResultSchema }, params => ({ echoed: params.value }));
     return s;
 }
 
@@ -990,26 +992,22 @@ verifies('protocol:custom-method:roundtrip', async ({ transport }: TestArgs) => 
 
     // A truly-unknown method still surfaces as MethodNotFound, proving the
     // custom registration is what made the previous call succeed.
-    await expect(client.request({ method: 'x-e2e/never-registered', params: {} })).rejects.toMatchObject({
+    await expect(client.request({ method: 'x-e2e/never-registered', params: {} }, specTypeSchemas.Result)).rejects.toMatchObject({
         code: ProtocolErrorCode.MethodNotFound
     });
 });
 
 verifies('protocol:custom-notification:roundtrip', async ({ transport }: TestArgs) => {
     const X_EVENT_METHOD = 'x-e2e/event';
-    const XEventNotificationSchema = specTypeSchemas.Notification.extend({
-        method: z.literal(X_EVENT_METHOD),
-        params: z.object({ kind: z.string(), id: z.number() })
-    });
-    type XEvent = z.infer<typeof XEventNotificationSchema>;
+    const XEventParamsSchema = z.object({ kind: z.string(), id: z.number() });
 
-    const received: XEvent[] = [];
+    const received: Array<{ method: string; params: z.infer<typeof XEventParamsSchema> }> = [];
     const serverErrors: Error[] = [];
     const makeServer = () => {
         const s = new Server({ name: 's', version: '0' }, { capabilities: {} });
         s.onerror = e => serverErrors.push(e);
-        s.setNotificationHandler(XEventNotificationSchema, n => {
-            received.push(n);
+        s.setNotificationHandler(X_EVENT_METHOD, { params: XEventParamsSchema }, (params, notification) => {
+            received.push({ method: notification.method, params });
         });
         return s;
     };
@@ -1020,10 +1018,10 @@ verifies('protocol:custom-notification:roundtrip', async ({ transport }: TestArg
     await client.notification({ method: X_EVENT_METHOD, params: { kind: 'k', id: 42, extra: 'stripped-by-zod' } });
 
     await vi.waitFor(() => expect(received).toHaveLength(1));
-    expect(received[0].method).toBe(X_EVENT_METHOD);
-    // Handler receives the Zod-parsed params (extra fields stripped), not raw passthrough.
-    expect(received[0].params).toEqual({ kind: 'k', id: 42 });
-    expect(received[0].params).not.toHaveProperty('extra');
+    expect(received[0]?.method).toBe(X_EVENT_METHOD);
+    // Handler receives the schema-parsed params (extra fields stripped), not raw passthrough.
+    expect(received[0]?.params).toEqual({ kind: 'k', id: 42 });
+    expect(received[0]?.params).not.toHaveProperty('extra');
     expect(serverErrors).toEqual([]);
 });
 
@@ -1091,8 +1089,8 @@ verifies('protocol:request-id:unique', async ({ transport }: TestArgs) => {
     ]);
     await client.ping();
 
-    const requests = tap.sent.filter(isRequest);
-    expect(requests.map(m => m.method).sort()).toEqual(['ping', 'ping', 'tools/call', 'tools/call', 'tools/list']);
+    const requests = tap.sent.filter(m => isRequest(m));
+    expect(requests.map(m => m.method).toSorted()).toEqual(['ping', 'ping', 'tools/call', 'tools/call', 'tools/list']);
 
     const ids = requests.map(m => m.id);
     for (const id of ids) {
@@ -1119,7 +1117,7 @@ verifies('protocol:notifications:no-response', async ({ transport }: TestArgs) =
     await client.sendRootsListChanged();
     await client.notification({
         method: 'notifications/cancelled',
-        params: { requestId: 424242, reason: 'request was never issued' }
+        params: { requestId: 424_242, reason: 'request was never issued' }
     });
 
     const result = await client.callTool({ name: 'echo', arguments: { text: 'after notifications' } });
@@ -1129,11 +1127,14 @@ verifies('protocol:notifications:no-response', async ({ transport }: TestArgs) =
     // Both requests round-tripped after the notifications, so a (non-conformant) reply to either notification would have arrived by now.
     await new Promise(resolve => setTimeout(resolve, 50));
 
-    expect(tap.sent.filter(isNotification).map(m => m.method)).toEqual(['notifications/roots/list_changed', 'notifications/cancelled']);
-    const requestIds = tap.sent.filter(isRequest).map(m => m.id);
+    expect(tap.sent.filter(m => isNotification(m)).map(m => m.method)).toEqual([
+        'notifications/roots/list_changed',
+        'notifications/cancelled'
+    ]);
+    const requestIds = tap.sent.filter(m => isRequest(m)).map(m => m.id);
     expect(requestIds).toHaveLength(2);
 
-    const responses = tap.received.filter(isResponse);
+    const responses = tap.received.filter(m => isResponse(m));
     expect(responses.map(m => m.id)).toEqual(requestIds);
     for (const m of tap.received) {
         if (isResponse(m)) {
@@ -1176,7 +1177,7 @@ verifies('protocol:progress:monotonic', async ({ transport }: TestArgs) => {
     await using _ = await wire(transport, makeServer, client);
 
     const updates: Progress[] = [];
-    const result = await client.callTool({ name: 'index_files', arguments: {} }, undefined, { onprogress: p => updates.push(p) });
+    const result = await client.callTool({ name: 'index_files', arguments: {} }, { onprogress: p => updates.push(p) });
 
     expect(result.content).toEqual([{ type: 'text', text: 'indexing complete' }]);
 
@@ -1188,20 +1189,24 @@ verifies('protocol:progress:monotonic', async ({ transport }: TestArgs) => {
     }
     // Spec: the progress value MUST increase with each notification for the token, so the regressed value never reaches the caller.
     for (let i = 1; i < updates.length; i++) {
+        const previous = updates[i - 1];
+        const current = updates[i];
+        if (!previous || !current) throw new Error('progress updates list changed during iteration');
         expect(
-            updates[i].progress,
+            current.progress,
             `progress sequence ${updates.map(p => p.progress).join(' → ')} must be strictly increasing`
-        ).toBeGreaterThan(updates[i - 1].progress);
+        ).toBeGreaterThan(previous.progress);
     }
 });
 
 verifies('protocol:progress:stops-after-completion', async ({ transport }: TestArgs) => {
-    let server!: Server;
+    let server: Server | undefined;
     let lateProgress: (() => Promise<void>) | undefined;
     const makeServer = () => {
-        server = new Server({ name: 's', version: '0' }, { capabilities: { tools: { listChanged: true } } });
-        server.setRequestHandler('tools/list', () => ({ tools: [] }));
-        server.setRequestHandler('tools/call', async (req, ctx) => {
+        const s = new Server({ name: 's', version: '0' }, { capabilities: { tools: { listChanged: true } } });
+        server = s;
+        s.setRequestHandler('tools/list', () => ({ tools: [] }));
+        s.setRequestHandler('tools/call', async (req, ctx) => {
             const token = req.params._meta?.progressToken;
             if (token === undefined) throw new Error('expected a progressToken on the request');
             await ctx.mcpReq.notify({
@@ -1210,13 +1215,13 @@ verifies('protocol:progress:stops-after-completion', async ({ transport }: TestA
             });
             // Captured so the test can attempt a post-completion progress send for the same token through the public API.
             lateProgress = () =>
-                server.notification({
+                s.notification({
                     method: 'notifications/progress',
                     params: { progressToken: token, progress: 2, total: 2, message: 'late' }
                 });
             return { content: [{ type: 'text', text: 'partial upload complete' }] };
         });
-        return server;
+        return s;
     };
     const client = newClient();
     await using _ = await wire(transport, makeServer, client);
@@ -1224,7 +1229,7 @@ verifies('protocol:progress:stops-after-completion', async ({ transport }: TestA
     const tap = tapWire(client);
 
     const updates: Progress[] = [];
-    const result = await client.callTool({ name: 'upload', arguments: {} }, undefined, { onprogress: p => updates.push(p) });
+    const result = await client.callTool({ name: 'upload', arguments: {} }, { onprogress: p => updates.push(p) });
 
     expect(result.content).toEqual([{ type: 'text', text: 'partial upload complete' }]);
     expect(updates).toEqual([{ progress: 1, total: 2, message: 'halfway' }]);
@@ -1233,15 +1238,16 @@ verifies('protocol:progress:stops-after-completion', async ({ transport }: TestA
     if (!lateProgress) throw new Error('handler did not capture the late-progress sender');
     await lateProgress();
     // Sentinel on the same server→client channel: once it arrives, the late progress (had it been sent) would have arrived too.
+    if (!server) throw new Error('server not created');
     await server.sendToolListChanged();
     await vi.waitFor(() =>
-        expect(tap.received.filter(isNotification).filter(m => m.method === 'notifications/tools/list_changed')).toHaveLength(1)
+        expect(tap.received.filter(m => isNotification(m)).filter(m => m.method === 'notifications/tools/list_changed')).toHaveLength(1)
     );
 
     // Spec: progress notifications for the token stop once the associated request has completed.
     const lateProgressOnWire = tap.received
         .slice(receivedBeforeLateSend)
-        .filter(isNotification)
+        .filter(m => isNotification(m))
         .filter(m => m.method === 'notifications/progress');
     expect(lateProgressOnWire).toEqual([]);
 });
@@ -1271,12 +1277,12 @@ verifies('protocol:cancel:in-flight', async ({ transport }: TestArgs) => {
     const tap = tapWire(client);
 
     const ac = new AbortController();
-    const call = client.callTool({ name: 'long_export', arguments: {} }, undefined, { signal: ac.signal });
+    const call = client.callTool({ name: 'long_export', arguments: {} }, { signal: ac.signal });
     call.catch(() => {});
 
     // Cancel only once the handler is running, so the cancellation targets a request that is genuinely in flight on the server.
     await vi.waitFor(() => expect(handlerStarted).toHaveLength(1));
-    const callRequest = tap.sent.filter(isRequest).find(m => m.method === 'tools/call');
+    const callRequest = tap.sent.filter(m => isRequest(m)).find(m => m.method === 'tools/call');
     if (!callRequest) throw new Error('tools/call request not captured');
 
     ac.abort(new Error('user cancelled the export'));
@@ -1285,7 +1291,7 @@ verifies('protocol:cancel:in-flight', async ({ transport }: TestArgs) => {
     await vi.waitFor(() =>
         expect(
             tap.sent
-                .filter(isNotification)
+                .filter(m => isNotification(m))
                 .filter(m => m.method === 'notifications/cancelled')
                 .map(m => m.params?.requestId)
         ).toEqual([callRequest.id])
@@ -1299,7 +1305,7 @@ verifies('protocol:cancel:in-flight', async ({ transport }: TestArgs) => {
     await expect(client.ping()).resolves.toBeDefined();
     await new Promise(resolve => setTimeout(resolve, 50));
 
-    expect(tap.received.filter(isResponse).filter(m => m.id === callRequest.id)).toEqual([]);
+    expect(tap.received.filter(m => isResponse(m)).filter(m => m.id === callRequest.id)).toEqual([]);
 });
 
 verifies('protocol:progress:client-to-server', async ({ transport }: TestArgs) => {
@@ -1377,31 +1383,35 @@ verifies('protocol:request-handler:override-builtin', async ({ transport }: Test
     expect(result).toEqual({ _meta: { 'e2e/overridden': true } });
 });
 
-export async function mcpserverOnerrorReachThroughRaw({ transport }: TestArgs) {
-    const errors: Error[] = [];
-    const makeServer = () => {
-        const s = new Server({ name: 's', version: '0' }, { capabilities: {} });
-        s.onerror = e => errors.push(e);
-        return s;
-    };
-    const client = newClient();
-    await using _ = await wire(transport, makeServer, client);
+verifies(
+    'mcpserver:onerror:reach-through',
+    async ({ transport }: TestArgs) => {
+        const errors: Error[] = [];
+        const makeServer = () => {
+            const s = new Server({ name: 's', version: '0' }, { capabilities: {} });
+            s.onerror = e => errors.push(e);
+            return s;
+        };
+        const client = newClient();
+        await using _ = await wire(transport, makeServer, client);
 
-    const baseA = errors.length;
-    const stray: JSONRPCMessage = { jsonrpc: '2.0', id: 99999, result: {} };
-    await client.transport?.send(stray);
+        const baseA = errors.length;
+        const stray: JSONRPCMessage = { jsonrpc: '2.0', id: 99_999, result: {} };
+        await client.transport?.send(stray);
 
-    await vi.waitFor(() => errors.length > baseA);
+        await vi.waitFor(() => expect(errors.length).toBeGreaterThan(baseA));
 
-    const hitA = errors.slice(baseA).find(e => /unknown message ID/i.test(e.message));
-    expect(
-        hitA,
-        `expected an "unknown message ID" onerror; got: ${errors
-            .slice(baseA)
-            .map(e => e.message)
-            .join(' | ')}`
-    ).toBeDefined();
-    expect(hitA!.message).toContain('99999');
+        const hitA = errors.slice(baseA).find(e => /unknown message ID/i.test(e.message));
+        expect(
+            hitA,
+            `expected an "unknown message ID" onerror; got: ${errors
+                .slice(baseA)
+                .map(e => e.message)
+                .join(' | ')}`
+        ).toBeDefined();
+        expect(hitA?.message).toContain('99999');
 
-    await expect(client.ping()).resolves.toBeDefined();
-}
+        await expect(client.ping()).resolves.toBeDefined();
+    },
+    { title: 'raw Server' }
+);

--- a/test/e2e/scenarios/resources.test.ts
+++ b/test/e2e/scenarios/resources.test.ts
@@ -9,22 +9,9 @@
  */
 
 import { expect, vi } from 'vitest';
-
-import { Client } from '../../../src/client/index.js';
-import { Server } from '../../../src/server/index.js';
-import { McpServer, type RegisteredResource, ResourceTemplate } from '../../../src/server/mcp.js';
-import {
-    ErrorCode,
-    ListResourcesRequestSchema,
-    ListResourceTemplatesRequestSchema,
-    McpError,
-    ReadResourceRequestSchema,
-    ResourceListChangedNotificationSchema,
-    ResourceUpdatedNotificationSchema,
-    SubscribeRequestSchema,
-    UnsubscribeRequestSchema
-} from '../../../src/types.js';
-
+import { Server, McpServer, ResourceTemplate, ProtocolError, ProtocolErrorCode } from '@modelcontextprotocol/server';
+import type { RegisteredResource } from '@modelcontextprotocol/server';
+import { Client } from '@modelcontextprotocol/client';
 import { wire } from '../helpers/index.js';
 import type { TestArgs } from '../types.js';
 import { verifies } from '../helpers/verifies.js';
@@ -119,7 +106,7 @@ verifies(
 
         const makeServer = () => {
             const s = new Server({ name: 's', version: '0' }, { capabilities: { resources: { listChanged: true } } });
-            s.setRequestHandler(ListResourcesRequestSchema, req => {
+            s.setRequestHandler('resources/list', req => {
                 cursorsReceived.push(req.params?.cursor);
                 const start = req.params?.cursor === undefined ? 0 : parseInt(req.params.cursor, 10);
                 const slice = all.slice(start, start + PAGE);
@@ -128,7 +115,7 @@ verifies(
                     nextCursor: start + PAGE < TOTAL ? String(start + PAGE) : undefined
                 };
             });
-            s.setRequestHandler(ReadResourceRequestSchema, () => ({ contents: [] }));
+            s.setRequestHandler('resources/read', () => ({ contents: [] }));
             return s;
         };
         const client = newClient();
@@ -260,7 +247,7 @@ verifies('resources:list-changed', async ({ transport }: TestArgs) => {
 
     let listChanged = 0;
     const client = newClient();
-    client.setNotificationHandler(ResourceListChangedNotificationSchema, () => {
+    client.setNotificationHandler('notifications/resources/list_changed', () => {
         listChanged++;
     });
 
@@ -365,13 +352,13 @@ verifies('resources:subscribe:updated', async ({ transport }: TestArgs) => {
     const subscriptions = new Set<string>();
     const makeServer = () => {
         server = new Server({ name: 's', version: '0' }, { capabilities: { resources: { listChanged: true, subscribe: true } } });
-        server.setRequestHandler(ListResourcesRequestSchema, () => ({
+        server.setRequestHandler('resources/list', () => ({
             resources: [{ uri: 'counter://subscribable', name: 'subscribable', mimeType: 'text/plain' }]
         }));
-        server.setRequestHandler(ReadResourceRequestSchema, () => ({
+        server.setRequestHandler('resources/read', () => ({
             contents: [{ uri: 'counter://subscribable', mimeType: 'text/plain', text: 'count' }]
         }));
-        server.setRequestHandler(SubscribeRequestSchema, req => {
+        server.setRequestHandler('resources/subscribe', req => {
             subscriptions.add(req.params.uri);
             return {};
         });
@@ -380,7 +367,7 @@ verifies('resources:subscribe:updated', async ({ transport }: TestArgs) => {
 
     const updates: string[] = [];
     const client = newClient();
-    client.setNotificationHandler(ResourceUpdatedNotificationSchema, n => {
+    client.setNotificationHandler('notifications/resources/updated', n => {
         updates.push(n.params.uri);
     });
 
@@ -399,18 +386,18 @@ verifies('resources:unsubscribe:stops-updates', async ({ transport }: TestArgs) 
     const subscriptions = new Set<string>();
     const makeServer = () => {
         server = new Server({ name: 's', version: '0' }, { capabilities: { resources: { listChanged: true, subscribe: true } } });
-        server.setRequestHandler(ListResourcesRequestSchema, () => ({
+        server.setRequestHandler('resources/list', () => ({
             resources: [
                 { uri: 'counter://target', name: 'target', mimeType: 'text/plain' },
                 { uri: 'counter://sentinel', name: 'sentinel', mimeType: 'text/plain' }
             ]
         }));
-        server.setRequestHandler(ReadResourceRequestSchema, () => ({ contents: [] }));
-        server.setRequestHandler(SubscribeRequestSchema, req => {
+        server.setRequestHandler('resources/read', () => ({ contents: [] }));
+        server.setRequestHandler('resources/subscribe', req => {
             subscriptions.add(req.params.uri);
             return {};
         });
-        server.setRequestHandler(UnsubscribeRequestSchema, req => {
+        server.setRequestHandler('resources/unsubscribe', req => {
             subscriptions.delete(req.params.uri);
             return {};
         });
@@ -419,7 +406,7 @@ verifies('resources:unsubscribe:stops-updates', async ({ transport }: TestArgs) 
 
     const updates: string[] = [];
     const client = newClient();
-    client.setNotificationHandler(ResourceUpdatedNotificationSchema, n => {
+    client.setNotificationHandler('notifications/resources/updated', n => {
         updates.push(n.params.uri);
     });
 
@@ -533,7 +520,7 @@ verifies(
 
         const makeServer = () => {
             const s = new Server({ name: 's', version: '0' }, { capabilities: { resources: { listChanged: true } } });
-            s.setRequestHandler(ListResourceTemplatesRequestSchema, req => {
+            s.setRequestHandler('resources/templates/list', req => {
                 const start = req.params?.cursor === undefined ? 0 : parseInt(req.params.cursor, 10);
                 const slice = all.slice(start, start + PAGE);
                 return {
@@ -607,7 +594,7 @@ verifies('mcpserver:resource:handle-update-remove', async ({ transport }: TestAr
 
     let listChanged = 0;
     const client = newClient();
-    client.setNotificationHandler(ResourceListChangedNotificationSchema, () => {
+    client.setNotificationHandler('notifications/resources/list_changed', () => {
         listChanged++;
     });
     await using _ = await wire(transport, makeServer, client);
@@ -640,7 +627,7 @@ verifies('mcpserver:resource:handle-update-remove', async ({ transport }: TestAr
     await vi.waitFor(() => expect(listChanged).toBeGreaterThan(beforeRemove));
     expect((await client.listResources()).resources).toHaveLength(0);
 
-    await expect(client.readResource({ uri: 'file:///probe.txt' })).rejects.toBeInstanceOf(McpError);
+    await expect(client.readResource({ uri: 'file:///probe.txt' })).rejects.toBeInstanceOf(ProtocolError);
     const gone = (await client.listResources()).resources.find(r => r.uri === 'file:///probe.txt');
     expect(gone).toBeUndefined();
 });
@@ -660,7 +647,7 @@ verifies('mcpserver:resource:read-throws-surfaced', async ({ transport }: TestAr
     await using _ = await wire(transport, makeServer, client);
 
     await expect(client.readResource({ uri: 'file:///throws' })).rejects.toMatchObject({
-        code: ErrorCode.InternalError,
+        code: ProtocolErrorCode.InternalError,
         message: expect.stringContaining('resource read failed')
     });
 
@@ -755,19 +742,19 @@ verifies('mcpserver:resource:legacy-overload', async ({ transport }: TestArgs) =
     const makeServer = () => {
         const s = new McpServer({ name: 's', version: '0' });
         // (name, uri, readCallback)
-        s.resource('plain', 'e2e://legacy/plain', uri => ({
+        s.registerResource('plain', 'e2e://legacy/plain', {}, uri => ({
             contents: [{ uri: uri.href, text: 'plain' }]
         }));
         // (name, uri, metadata, readCallback)
-        s.resource('with-meta', 'e2e://legacy/meta', { description: 'meta', mimeType: 'text/plain' }, uri => ({
+        s.registerResource('with-meta', 'e2e://legacy/meta', { description: 'meta', mimeType: 'text/plain' }, uri => ({
             contents: [{ uri: uri.href, text: 'meta' }]
         }));
         // (name, template, readCallback)
-        s.resource('tmpl', new ResourceTemplate('e2e://legacy/t/{id}', { list: undefined }), (uri, { id }) => ({
+        s.registerResource('tmpl', new ResourceTemplate('e2e://legacy/t/{id}', { list: undefined }), {}, (uri, { id }) => ({
             contents: [{ uri: uri.href, text: `t:${String(id)}` }]
         }));
         // (name, template, metadata, readCallback)
-        s.resource(
+        s.registerResource(
             'tmpl-meta',
             new ResourceTemplate('e2e://legacy/tm/{id}', { list: undefined }),
             { description: 'templated' },

--- a/test/e2e/scenarios/resources.test.ts
+++ b/test/e2e/scenarios/resources.test.ts
@@ -1,0 +1,806 @@
+/**
+ * Self-contained test bodies for the resources surface.
+ *
+ * Each export is a TestCase: it builds its own server (via a factory), builds
+ * its own client, wires them with wire(), and asserts. Function names mirror
+ * the requirement id in camelCase. Bodies that inspect server-side state
+ * declare the recorder outside the factory so every server instance closes
+ * over the same array.
+ */
+
+import { expect, vi } from 'vitest';
+
+import { Client } from '../../../src/client/index.js';
+import { Server } from '../../../src/server/index.js';
+import { McpServer, type RegisteredResource, ResourceTemplate } from '../../../src/server/mcp.js';
+import {
+    ErrorCode,
+    ListResourcesRequestSchema,
+    ListResourceTemplatesRequestSchema,
+    McpError,
+    ReadResourceRequestSchema,
+    ResourceListChangedNotificationSchema,
+    ResourceUpdatedNotificationSchema,
+    SubscribeRequestSchema,
+    UnsubscribeRequestSchema
+} from '../../../src/types.js';
+
+import { wire } from '../helpers/index.js';
+import type { TestArgs } from '../types.js';
+import { verifies } from '../helpers/verifies.js';
+
+const TINY_PNG_BASE64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=';
+const FIXTURE_LAST_MODIFIED = '2024-01-15T10:30:00.000Z';
+
+const newClient = () => new Client({ name: 'c', version: '0' });
+
+verifies('resources:list:basic', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerResource('text', 'file:///fixture.txt', { description: 'A plain-text resource.', mimeType: 'text/plain' }, () => ({
+            contents: [{ uri: 'file:///fixture.txt', mimeType: 'text/plain', text: 'hello, world' }]
+        }));
+        s.registerResource('blob', 'file:///fixture.png', { description: 'A 1×1 PNG.', mimeType: 'image/png' }, () => ({
+            contents: [{ uri: 'file:///fixture.png', mimeType: 'image/png', blob: TINY_PNG_BASE64 }]
+        }));
+        s.registerResource('annotated', 'file:///annotated.md', { description: 'Annotated.', mimeType: 'text/markdown' }, () => ({
+            contents: [{ uri: 'file:///annotated.md', mimeType: 'text/markdown', text: '# Annotated' }]
+        }));
+        return s;
+    };
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    const result = await client.listResources();
+
+    expect(result.resources).toHaveLength(3);
+    expect(result.resources.map(r => r.uri).sort()).toEqual(['file:///annotated.md', 'file:///fixture.png', 'file:///fixture.txt']);
+
+    expect(result.resources.find(r => r.uri === 'file:///fixture.txt')).toMatchObject({
+        uri: 'file:///fixture.txt',
+        name: 'text',
+        description: 'A plain-text resource.',
+        mimeType: 'text/plain'
+    });
+
+    expect(result.resources.find(r => r.uri === 'file:///fixture.png')).toMatchObject({
+        uri: 'file:///fixture.png',
+        name: 'blob',
+        description: 'A 1×1 PNG.',
+        mimeType: 'image/png'
+    });
+});
+
+verifies(
+    'resources:list:pagination',
+    async ({ transport }: TestArgs) => {
+        const TOTAL = 25;
+        const makeServer = () => {
+            const s = new McpServer({ name: 's', version: '0' });
+            for (let i = 0; i < TOTAL; i++) {
+                s.registerResource(
+                    `bulk_${String(i).padStart(2, '0')}`,
+                    `bulk://item/${String(i).padStart(2, '0')}`,
+                    { mimeType: 'text/plain' },
+                    uri => ({ contents: [{ uri: uri.href, mimeType: 'text/plain', text: '' }] })
+                );
+            }
+            return s;
+        };
+        const client = newClient();
+        await using _ = await wire(transport, makeServer, client);
+
+        const first = await client.listResources();
+        expect(first.resources.length).toBeLessThan(TOTAL);
+        expect(first.nextCursor).toBeDefined();
+
+        const seen = new Set(first.resources.map(r => r.uri));
+        let result = first;
+        let pages = 1;
+        while (result.nextCursor !== undefined) {
+            result = await client.listResources({ cursor: result.nextCursor });
+            for (const r of result.resources) seen.add(r.uri);
+            pages++;
+            expect(pages).toBeLessThan(50);
+        }
+        expect(seen.size).toBe(TOTAL);
+        expect(pages).toBeGreaterThan(1);
+    },
+    { title: 'mcpserver' }
+);
+
+verifies(
+    'resources:list:pagination',
+    async ({ transport }: TestArgs) => {
+        const TOTAL = 25;
+        const PAGE = 10;
+        const all = Array.from({ length: TOTAL }, (_, i) => `bulk://item/${String(i).padStart(2, '0')}`);
+        const cursorsReceived: Array<string | undefined> = [];
+
+        const makeServer = () => {
+            const s = new Server({ name: 's', version: '0' }, { capabilities: { resources: { listChanged: true } } });
+            s.setRequestHandler(ListResourcesRequestSchema, req => {
+                cursorsReceived.push(req.params?.cursor);
+                const start = req.params?.cursor === undefined ? 0 : parseInt(req.params.cursor, 10);
+                const slice = all.slice(start, start + PAGE);
+                return {
+                    resources: slice.map(uri => ({ uri, name: uri, mimeType: 'text/plain' })),
+                    nextCursor: start + PAGE < TOTAL ? String(start + PAGE) : undefined
+                };
+            });
+            s.setRequestHandler(ReadResourceRequestSchema, () => ({ contents: [] }));
+            return s;
+        };
+        const client = newClient();
+        await using _ = await wire(transport, makeServer, client);
+
+        const seen = new Set<string>();
+        const cursorsSent: string[] = [];
+        let pages = 0;
+        let result = await client.listResources();
+        expect(result.nextCursor).toBeDefined();
+        for (;;) {
+            for (const r of result.resources) {
+                expect(seen.has(r.uri)).toBe(false);
+                seen.add(r.uri);
+            }
+            pages++;
+            if (result.nextCursor === undefined) break;
+            cursorsSent.push(result.nextCursor);
+            result = await client.listResources({ cursor: result.nextCursor });
+            expect(pages).toBeLessThan(50);
+        }
+
+        expect(result.nextCursor).toBeUndefined();
+        expect(pages).toBe(3);
+        expect(seen.size).toBe(TOTAL);
+        for (const name of all) expect(seen.has(name)).toBe(true);
+
+        expect(cursorsReceived).toEqual([undefined, '10', '20']);
+        expect(cursorsSent).toEqual(['10', '20']);
+    },
+    { title: 'raw server' }
+);
+
+verifies('resources:read:text', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerResource('text', 'file:///fixture.txt', { mimeType: 'text/plain' }, () => ({
+            contents: [{ uri: 'file:///fixture.txt', mimeType: 'text/plain', text: 'hello, world' }]
+        }));
+        return s;
+    };
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    const result = await client.readResource({ uri: 'file:///fixture.txt' });
+    expect(result.contents).toHaveLength(1);
+
+    const [entry] = result.contents;
+    expect(entry.uri).toBe('file:///fixture.txt');
+    expect(entry.mimeType).toBe('text/plain');
+    expect('text' in entry && entry.text).toBe('hello, world');
+    expect(entry).not.toHaveProperty('blob');
+});
+
+verifies('resources:read:blob', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerResource('blob', 'file:///fixture.png', { mimeType: 'image/png' }, () => ({
+            contents: [{ uri: 'file:///fixture.png', mimeType: 'image/png', blob: TINY_PNG_BASE64 }]
+        }));
+        return s;
+    };
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    const result = await client.readResource({ uri: 'file:///fixture.png' });
+    expect(result.contents).toHaveLength(1);
+
+    const [entry] = result.contents;
+    expect(entry).toEqual({ uri: 'file:///fixture.png', mimeType: 'image/png', blob: TINY_PNG_BASE64 });
+    expect(entry).not.toHaveProperty('text');
+});
+
+verifies('resources:read:unknown-uri', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerResource('text', 'file:///exists.txt', { mimeType: 'text/plain' }, () => ({
+            contents: [{ uri: 'file:///exists.txt', mimeType: 'text/plain', text: 'ok' }]
+        }));
+        return s;
+    };
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    await expect(client.readResource({ uri: 'file:///no-such-resource' })).rejects.toMatchObject({
+        code: -32002,
+        message: expect.stringMatching(/not found|unknown/i)
+    });
+});
+
+verifies('resources:read:template-vars', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerResource(
+            'greet',
+            new ResourceTemplate('greet://hello/{name}', { list: undefined }),
+            { mimeType: 'text/plain' },
+            (uri, { name }) => ({ contents: [{ uri: uri.href, mimeType: 'text/plain', text: `Hello, ${name}!` }] })
+        );
+        s.registerResource(
+            'repo',
+            new ResourceTemplate('github://{owner}/{repo}', { list: undefined }),
+            { mimeType: 'text/plain' },
+            (uri, { owner, repo }) => ({ contents: [{ uri: uri.href, mimeType: 'text/plain', text: `${owner}/${repo}` }] })
+        );
+        return s;
+    };
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    const greet = await client.readResource({ uri: 'greet://hello/Ada' });
+    expect(greet.contents).toEqual([{ uri: 'greet://hello/Ada', mimeType: 'text/plain', text: 'Hello, Ada!' }]);
+
+    const repo = await client.readResource({ uri: 'github://modelcontextprotocol/typescript-sdk' });
+    expect(repo.contents).toEqual([
+        { uri: 'github://modelcontextprotocol/typescript-sdk', mimeType: 'text/plain', text: 'modelcontextprotocol/typescript-sdk' }
+    ]);
+});
+
+verifies('resources:list-changed', async ({ transport }: TestArgs) => {
+    let server!: McpServer;
+    const makeServer = () => {
+        server = new McpServer({ name: 's', version: '0' });
+        server.registerResource('seed', 'file:///seed.txt', { mimeType: 'text/plain' }, () => ({
+            contents: [{ uri: 'file:///seed.txt', mimeType: 'text/plain', text: 'seed' }]
+        }));
+        return server;
+    };
+
+    let listChanged = 0;
+    const client = newClient();
+    client.setNotificationHandler(ResourceListChangedNotificationSchema, () => {
+        listChanged++;
+    });
+
+    await using _ = await wire(transport, makeServer, client);
+
+    expect((await client.listResources()).resources).toHaveLength(1);
+
+    const handle = server.registerResource('dynamic', 'file:///probe.txt', { mimeType: 'text/plain' }, () => ({
+        contents: [{ uri: 'file:///probe.txt', mimeType: 'text/plain', text: 'probe' }]
+    }));
+    await vi.waitFor(() => expect(listChanged).toBeGreaterThanOrEqual(1));
+    expect((await client.listResources()).resources).toHaveLength(2);
+    const afterAdd = listChanged;
+
+    handle.remove();
+    await vi.waitFor(() => expect(listChanged).toBeGreaterThan(afterAdd));
+    expect((await client.listResources()).resources).toHaveLength(1);
+});
+
+verifies('resources:annotations', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerResource(
+            'annotated',
+            'file:///annotated.md',
+            {
+                mimeType: 'text/markdown',
+                annotations: { audience: ['user', 'assistant'], priority: 0.8, lastModified: FIXTURE_LAST_MODIFIED }
+            },
+            () => ({ contents: [{ uri: 'file:///annotated.md', mimeType: 'text/markdown', text: '# Annotated' }] })
+        );
+        s.registerResource(
+            'greet',
+            new ResourceTemplate('greet://hello/{name}', { list: undefined }),
+            {
+                mimeType: 'text/plain',
+                annotations: { audience: ['user'], priority: 0.5, lastModified: FIXTURE_LAST_MODIFIED }
+            },
+            (uri, { name }) => ({ contents: [{ uri: uri.href, mimeType: 'text/plain', text: `Hello, ${name}!` }] })
+        );
+        return s;
+    };
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    const { resources } = await client.listResources();
+    const resource = resources.find(r => r.uri === 'file:///annotated.md');
+    expect(resource).toBeDefined();
+    expect(resource!.annotations).toEqual({
+        audience: ['user', 'assistant'],
+        priority: 0.8,
+        lastModified: FIXTURE_LAST_MODIFIED
+    });
+
+    const { resourceTemplates } = await client.listResourceTemplates();
+    const template = resourceTemplates.find(t => t.name === 'greet');
+    expect(template).toBeDefined();
+    expect(template!.annotations).toEqual({ audience: ['user'], priority: 0.5, lastModified: FIXTURE_LAST_MODIFIED });
+
+    const result = await client.readResource({ uri: 'file:///annotated.md' });
+    expect(result.contents).toHaveLength(1);
+    expect(result.contents[0].uri).toBe('file:///annotated.md');
+});
+
+verifies('resources:capability:declared', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' }, { capabilities: { resources: {} } });
+        s.registerResource('echo', 'file:///echo.txt', { mimeType: 'text/plain' }, () => ({
+            contents: [{ uri: 'file:///echo.txt', mimeType: 'text/plain', text: 'echo' }]
+        }));
+        return s;
+    };
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    const caps = client.getServerCapabilities();
+    expect(caps?.resources).toBeDefined();
+    expect((await client.listResources()).resources).toHaveLength(1);
+    expect(caps?.resources?.listChanged).toBe(true);
+});
+
+verifies('resources:subscribe:capability-required', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' }, { capabilities: { resources: { listChanged: true } } });
+        s.registerResource('text', 'file:///fixture.txt', { mimeType: 'text/plain' }, () => ({
+            contents: [{ uri: 'file:///fixture.txt', mimeType: 'text/plain', text: 'hello' }]
+        }));
+        return s;
+    };
+    const client = new Client({ name: 'c', version: '0' }, { enforceStrictCapabilities: true });
+    await using _ = await wire(transport, makeServer, client);
+
+    const caps = client.getServerCapabilities();
+    expect(caps?.resources).toBeDefined();
+    expect(caps?.resources?.subscribe).toBeFalsy();
+
+    await expect(client.subscribeResource({ uri: 'file:///fixture.txt' })).rejects.toThrow(/does not support.*subscri/i);
+});
+
+verifies('resources:subscribe:updated', async ({ transport }: TestArgs) => {
+    let server!: Server;
+    const subscriptions = new Set<string>();
+    const makeServer = () => {
+        server = new Server({ name: 's', version: '0' }, { capabilities: { resources: { listChanged: true, subscribe: true } } });
+        server.setRequestHandler(ListResourcesRequestSchema, () => ({
+            resources: [{ uri: 'counter://subscribable', name: 'subscribable', mimeType: 'text/plain' }]
+        }));
+        server.setRequestHandler(ReadResourceRequestSchema, () => ({
+            contents: [{ uri: 'counter://subscribable', mimeType: 'text/plain', text: 'count' }]
+        }));
+        server.setRequestHandler(SubscribeRequestSchema, req => {
+            subscriptions.add(req.params.uri);
+            return {};
+        });
+        return server;
+    };
+
+    const updates: string[] = [];
+    const client = newClient();
+    client.setNotificationHandler(ResourceUpdatedNotificationSchema, n => {
+        updates.push(n.params.uri);
+    });
+
+    await using _ = await wire(transport, makeServer, client);
+
+    await client.subscribeResource({ uri: 'counter://subscribable' });
+    expect(subscriptions.has('counter://subscribable')).toBe(true);
+
+    await server.sendResourceUpdated({ uri: 'counter://subscribable' });
+
+    await vi.waitFor(() => expect(updates).toContain('counter://subscribable'));
+});
+
+verifies('resources:unsubscribe:stops-updates', async ({ transport }: TestArgs) => {
+    let server!: Server;
+    const subscriptions = new Set<string>();
+    const makeServer = () => {
+        server = new Server({ name: 's', version: '0' }, { capabilities: { resources: { listChanged: true, subscribe: true } } });
+        server.setRequestHandler(ListResourcesRequestSchema, () => ({
+            resources: [
+                { uri: 'counter://target', name: 'target', mimeType: 'text/plain' },
+                { uri: 'counter://sentinel', name: 'sentinel', mimeType: 'text/plain' }
+            ]
+        }));
+        server.setRequestHandler(ReadResourceRequestSchema, () => ({ contents: [] }));
+        server.setRequestHandler(SubscribeRequestSchema, req => {
+            subscriptions.add(req.params.uri);
+            return {};
+        });
+        server.setRequestHandler(UnsubscribeRequestSchema, req => {
+            subscriptions.delete(req.params.uri);
+            return {};
+        });
+        return server;
+    };
+
+    const updates: string[] = [];
+    const client = newClient();
+    client.setNotificationHandler(ResourceUpdatedNotificationSchema, n => {
+        updates.push(n.params.uri);
+    });
+
+    await using _ = await wire(transport, makeServer, client);
+
+    await client.subscribeResource({ uri: 'counter://target' });
+    await client.subscribeResource({ uri: 'counter://sentinel' });
+
+    await server.sendResourceUpdated({ uri: 'counter://target' });
+    await vi.waitFor(() => expect(updates.filter(u => u === 'counter://target').length).toBeGreaterThanOrEqual(1));
+
+    await client.unsubscribeResource({ uri: 'counter://target' });
+    expect(subscriptions.has('counter://target')).toBe(false);
+    updates.length = 0;
+
+    // A user-shaped server only emits updates for URIs that are still
+    // subscribed; the SDK provides the send method, the server author owns the
+    // subscription set. After unsubscribe, the server should not send for
+    // 'target' — so we only send for the sentinel and assert nothing for
+    // 'target' arrived while the sentinel update did.
+    for (const uri of subscriptions) await server.sendResourceUpdated({ uri });
+
+    await vi.waitFor(() => expect(updates.filter(u => u === 'counter://sentinel').length).toBeGreaterThanOrEqual(1));
+    expect(updates.filter(u => u === 'counter://target')).toHaveLength(0);
+});
+
+verifies('resources:templates:list', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerResource(
+            'greet',
+            new ResourceTemplate('greet://hello/{name}', { list: undefined }),
+            { description: 'Greets {name}.', mimeType: 'text/plain' },
+            (uri, { name }) => ({ contents: [{ uri: uri.href, mimeType: 'text/plain', text: `Hello, ${name}!` }] })
+        );
+        s.registerResource(
+            'listed',
+            new ResourceTemplate('listed://items/{id}', {
+                list: () => ({ resources: [{ uri: 'listed://items/alpha', name: 'alpha' }] })
+            }),
+            { mimeType: 'text/plain' },
+            (uri, { id }) => ({ contents: [{ uri: uri.href, mimeType: 'text/plain', text: String(id) }] })
+        );
+        return s;
+    };
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    const result = await client.listResourceTemplates();
+
+    expect(result.resourceTemplates).toHaveLength(2);
+    expect(result.resourceTemplates.map(t => t.name).sort()).toEqual(['greet', 'listed']);
+
+    expect(result.resourceTemplates.find(t => t.name === 'greet')).toMatchObject({
+        name: 'greet',
+        uriTemplate: 'greet://hello/{name}',
+        description: 'Greets {name}.',
+        mimeType: 'text/plain'
+    });
+
+    expect(result.resourceTemplates.find(t => t.name === 'listed')).toMatchObject({
+        name: 'listed',
+        uriTemplate: 'listed://items/{id}'
+    });
+});
+
+verifies(
+    'resources:templates:pagination',
+    async ({ transport }: TestArgs) => {
+        const TOTAL = 25;
+        const makeServer = () => {
+            const s = new McpServer({ name: 's', version: '0' });
+            for (let i = 0; i < TOTAL; i++) {
+                s.registerResource(
+                    `tpl_${String(i).padStart(2, '0')}`,
+                    new ResourceTemplate(`bulk-tpl://t${String(i).padStart(2, '0')}/{x}`, { list: undefined }),
+                    { mimeType: 'text/plain' },
+                    (uri, { x }) => ({ contents: [{ uri: uri.href, mimeType: 'text/plain', text: String(x) }] })
+                );
+            }
+            return s;
+        };
+        const client = newClient();
+        await using _ = await wire(transport, makeServer, client);
+
+        const first = await client.listResourceTemplates();
+        expect(first.resourceTemplates.length).toBeLessThan(TOTAL);
+        expect(first.nextCursor).toBeDefined();
+
+        const seen = new Set(first.resourceTemplates.map(t => t.uriTemplate));
+        let result = first;
+        let pages = 1;
+        while (result.nextCursor !== undefined) {
+            result = await client.listResourceTemplates({ cursor: result.nextCursor });
+            for (const t of result.resourceTemplates) seen.add(t.uriTemplate);
+            pages++;
+            expect(pages).toBeLessThan(50);
+        }
+        expect(seen.size).toBe(TOTAL);
+        expect(pages).toBeGreaterThan(1);
+    },
+    { title: 'mcpserver' }
+);
+
+verifies(
+    'resources:templates:pagination',
+    async ({ transport }: TestArgs) => {
+        const TOTAL = 25;
+        const PAGE = 10;
+        const all = Array.from({ length: TOTAL }, (_, i) => `bulk-tpl://t${String(i).padStart(2, '0')}/{x}`);
+
+        const makeServer = () => {
+            const s = new Server({ name: 's', version: '0' }, { capabilities: { resources: { listChanged: true } } });
+            s.setRequestHandler(ListResourceTemplatesRequestSchema, req => {
+                const start = req.params?.cursor === undefined ? 0 : parseInt(req.params.cursor, 10);
+                const slice = all.slice(start, start + PAGE);
+                return {
+                    resourceTemplates: slice.map(uriTemplate => ({ uriTemplate, name: uriTemplate, mimeType: 'text/plain' })),
+                    nextCursor: start + PAGE < TOTAL ? String(start + PAGE) : undefined
+                };
+            });
+            return s;
+        };
+        const client = newClient();
+        await using _ = await wire(transport, makeServer, client);
+
+        const seen = new Set<string>();
+        let pages = 0;
+        let result = await client.listResourceTemplates();
+        expect(result.nextCursor).toBeDefined();
+        for (;;) {
+            for (const t of result.resourceTemplates) {
+                expect(seen.has(t.uriTemplate)).toBe(false);
+                seen.add(t.uriTemplate);
+            }
+            pages++;
+            if (result.nextCursor === undefined) break;
+            result = await client.listResourceTemplates({ cursor: result.nextCursor });
+            expect(pages).toBeLessThan(50);
+        }
+
+        expect(result.nextCursor).toBeUndefined();
+        expect(pages).toBe(3);
+        expect(seen.size).toBe(TOTAL);
+        for (const name of all) expect(seen.has(name)).toBe(true);
+    },
+    { title: 'raw server' }
+);
+
+verifies('mcpserver:resource:duplicate-name', async ({ transport }: TestArgs) => {
+    let server!: McpServer;
+    const makeServer = () => {
+        server = new McpServer({ name: 's', version: '0' });
+        server.registerResource('text', 'file:///fixture.txt', { mimeType: 'text/plain' }, () => ({
+            contents: [{ uri: 'file:///fixture.txt', mimeType: 'text/plain', text: 'hello, world' }]
+        }));
+        return server;
+    };
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    const before = await client.listResources();
+    expect(before.resources.filter(r => r.uri === 'file:///fixture.txt')).toHaveLength(1);
+
+    expect(() => server.registerResource('text', 'file:///fixture.txt', { mimeType: 'text/plain' }, () => ({ contents: [] }))).toThrow(
+        /already registered/i
+    );
+
+    const after = await client.listResources();
+    expect(after.resources.filter(r => r.uri === 'file:///fixture.txt')).toHaveLength(1);
+
+    const result = await client.readResource({ uri: 'file:///fixture.txt' });
+    expect(result.contents).toEqual([{ uri: 'file:///fixture.txt', mimeType: 'text/plain', text: 'hello, world' }]);
+});
+
+verifies('mcpserver:resource:handle-update-remove', async ({ transport }: TestArgs) => {
+    let handle!: RegisteredResource;
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        handle = s.registerResource('probe', 'file:///probe.txt', { mimeType: 'text/plain' }, () => ({
+            contents: [{ uri: 'file:///probe.txt', mimeType: 'text/plain', text: 'v1' }]
+        }));
+        return s;
+    };
+
+    let listChanged = 0;
+    const client = newClient();
+    client.setNotificationHandler(ResourceListChangedNotificationSchema, () => {
+        listChanged++;
+    });
+    await using _ = await wire(transport, makeServer, client);
+
+    expect((await client.listResources()).resources).toHaveLength(1);
+    const before = (await client.listResources()).resources.find(r => r.uri === 'file:///probe.txt');
+    expect(before).toBeDefined();
+    expect(before!.name).toBe('probe');
+    expect((await client.readResource({ uri: 'file:///probe.txt' })).contents).toEqual([
+        { uri: 'file:///probe.txt', mimeType: 'text/plain', text: 'v1' }
+    ]);
+
+    const beforeUpdate = listChanged;
+    handle.update({
+        name: 'probe (v2)',
+        callback: () => ({ contents: [{ uri: 'file:///probe.txt', mimeType: 'text/plain', text: 'v2' }] })
+    });
+    await vi.waitFor(() => expect(listChanged).toBeGreaterThan(beforeUpdate));
+    expect((await client.listResources()).resources).toHaveLength(1);
+
+    const after = (await client.listResources()).resources.find(r => r.uri === 'file:///probe.txt');
+    expect(after).toBeDefined();
+    expect(after!.name).toBe('probe (v2)');
+    expect((await client.readResource({ uri: 'file:///probe.txt' })).contents).toEqual([
+        { uri: 'file:///probe.txt', mimeType: 'text/plain', text: 'v2' }
+    ]);
+
+    const beforeRemove = listChanged;
+    handle.remove();
+    await vi.waitFor(() => expect(listChanged).toBeGreaterThan(beforeRemove));
+    expect((await client.listResources()).resources).toHaveLength(0);
+
+    await expect(client.readResource({ uri: 'file:///probe.txt' })).rejects.toBeInstanceOf(McpError);
+    const gone = (await client.listResources()).resources.find(r => r.uri === 'file:///probe.txt');
+    expect(gone).toBeUndefined();
+});
+
+verifies('mcpserver:resource:read-throws-surfaced', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerResource('throws', 'file:///throws', { mimeType: 'text/plain' }, () => {
+            throw new Error('resource read failed');
+        });
+        s.registerResource('ok', 'file:///ok.txt', { mimeType: 'text/plain' }, () => ({
+            contents: [{ uri: 'file:///ok.txt', mimeType: 'text/plain', text: 'ok' }]
+        }));
+        return s;
+    };
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    await expect(client.readResource({ uri: 'file:///throws' })).rejects.toMatchObject({
+        code: ErrorCode.InternalError,
+        message: expect.stringContaining('resource read failed')
+    });
+
+    const ok = await client.readResource({ uri: 'file:///ok.txt' });
+    expect(ok.contents).toEqual([{ uri: 'file:///ok.txt', mimeType: 'text/plain', text: 'ok' }]);
+});
+
+verifies('mcpserver:resource:template-list-callback', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerResource('static', 'file:///static.txt', { mimeType: 'text/plain' }, () => ({
+            contents: [{ uri: 'file:///static.txt', mimeType: 'text/plain', text: 'static' }]
+        }));
+        s.registerResource(
+            'listed',
+            new ResourceTemplate('listed://items/{id}', {
+                list: () => ({
+                    resources: [
+                        { uri: 'listed://items/alpha', name: 'alpha' },
+                        { uri: 'listed://items/beta', name: 'beta' },
+                        { uri: 'listed://items/gamma', name: 'gamma' }
+                    ]
+                })
+            }),
+            { description: 'Template-level description.', mimeType: 'text/plain' },
+            (uri, { id }) => ({ contents: [{ uri: uri.href, mimeType: 'text/plain', text: String(id) }] })
+        );
+        return s;
+    };
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    const { resources } = await client.listResources();
+    expect(resources.some(r => r.uri === 'file:///static.txt')).toBe(true);
+
+    const listed = resources.filter(r => r.uri.startsWith('listed://items/'));
+    expect(listed.map(r => r.uri).sort()).toEqual(['listed://items/alpha', 'listed://items/beta', 'listed://items/gamma']);
+
+    const alpha = listed.find(r => r.uri === 'listed://items/alpha');
+    expect(alpha).toMatchObject({
+        uri: 'listed://items/alpha',
+        name: 'alpha',
+        description: 'Template-level description.',
+        mimeType: 'text/plain'
+    });
+});
+
+verifies('mcpserver:resource:metadata-override', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerResource(
+            'listed',
+            new ResourceTemplate('listed://items/{id}', {
+                list: () => ({
+                    resources: [
+                        { uri: 'listed://items/alpha', name: 'alpha' },
+                        { uri: 'listed://items/gamma', name: 'gamma', description: 'Per-resource override.', mimeType: 'application/json' }
+                    ]
+                })
+            }),
+            { description: 'Template-level.', mimeType: 'text/plain' },
+            (uri, { id }) => ({ contents: [{ uri: uri.href, mimeType: 'text/plain', text: String(id) }] })
+        );
+        return s;
+    };
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    const { resources } = await client.listResources();
+    const alpha = resources.find(r => r.uri === 'listed://items/alpha');
+    const gamma = resources.find(r => r.uri === 'listed://items/gamma');
+
+    expect(alpha).toBeDefined();
+    expect(gamma).toBeDefined();
+
+    expect(alpha).toMatchObject({
+        uri: 'listed://items/alpha',
+        name: 'alpha',
+        description: 'Template-level.',
+        mimeType: 'text/plain'
+    });
+
+    expect(gamma).toMatchObject({
+        uri: 'listed://items/gamma',
+        name: 'gamma',
+        description: 'Per-resource override.',
+        mimeType: 'application/json'
+    });
+});
+
+verifies('mcpserver:resource:legacy-overload', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        // (name, uri, readCallback)
+        s.resource('plain', 'e2e://legacy/plain', uri => ({
+            contents: [{ uri: uri.href, text: 'plain' }]
+        }));
+        // (name, uri, metadata, readCallback)
+        s.resource('with-meta', 'e2e://legacy/meta', { description: 'meta', mimeType: 'text/plain' }, uri => ({
+            contents: [{ uri: uri.href, text: 'meta' }]
+        }));
+        // (name, template, readCallback)
+        s.resource('tmpl', new ResourceTemplate('e2e://legacy/t/{id}', { list: undefined }), (uri, { id }) => ({
+            contents: [{ uri: uri.href, text: `t:${String(id)}` }]
+        }));
+        // (name, template, metadata, readCallback)
+        s.resource(
+            'tmpl-meta',
+            new ResourceTemplate('e2e://legacy/tm/{id}', { list: undefined }),
+            { description: 'templated' },
+            (uri, { id }) => ({ contents: [{ uri: uri.href, text: `tm:${String(id)}` }] })
+        );
+        return s;
+    };
+
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    const list = await client.listResources();
+    const fixed = list.resources.map(r => r.uri).sort();
+    expect(fixed).toEqual(['e2e://legacy/meta', 'e2e://legacy/plain']);
+    expect(list.resources.find(r => r.uri === 'e2e://legacy/meta')).toMatchObject({
+        description: 'meta',
+        mimeType: 'text/plain'
+    });
+
+    const templates = await client.listResourceTemplates();
+    const tmplUris = templates.resourceTemplates.map(t => t.uriTemplate).sort();
+    expect(tmplUris).toEqual(['e2e://legacy/t/{id}', 'e2e://legacy/tm/{id}']);
+    expect(templates.resourceTemplates.find(t => t.uriTemplate === 'e2e://legacy/tm/{id}')).toMatchObject({
+        description: 'templated'
+    });
+
+    expect(await client.readResource({ uri: 'e2e://legacy/plain' })).toMatchObject({
+        contents: [{ uri: 'e2e://legacy/plain', text: 'plain' }]
+    });
+    expect(await client.readResource({ uri: 'e2e://legacy/t/abc' })).toMatchObject({
+        contents: [{ text: 't:abc' }]
+    });
+    expect(await client.readResource({ uri: 'e2e://legacy/tm/xyz' })).toMatchObject({
+        contents: [{ text: 'tm:xyz' }]
+    });
+});

--- a/test/e2e/scenarios/resources.test.ts
+++ b/test/e2e/scenarios/resources.test.ts
@@ -8,13 +8,14 @@
  * over the same array.
  */
 
-import { expect, vi } from 'vitest';
-import { Server, McpServer, ResourceTemplate, ProtocolError, ProtocolErrorCode } from '@modelcontextprotocol/server';
-import type { RegisteredResource } from '@modelcontextprotocol/server';
 import { Client } from '@modelcontextprotocol/client';
+import type { RegisteredResource } from '@modelcontextprotocol/server';
+import { McpServer, ProtocolError, ProtocolErrorCode, ResourceTemplate, Server } from '@modelcontextprotocol/server';
+import { expect, vi } from 'vitest';
+
 import { wire } from '../helpers/index.js';
-import type { TestArgs } from '../types.js';
 import { verifies } from '../helpers/verifies.js';
+import type { TestArgs } from '../types.js';
 
 const TINY_PNG_BASE64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=';
 const FIXTURE_LAST_MODIFIED = '2024-01-15T10:30:00.000Z';
@@ -41,7 +42,7 @@ verifies('resources:list:basic', async ({ transport }: TestArgs) => {
     const result = await client.listResources();
 
     expect(result.resources).toHaveLength(3);
-    expect(result.resources.map(r => r.uri).sort()).toEqual(['file:///annotated.md', 'file:///fixture.png', 'file:///fixture.txt']);
+    expect(result.resources.map(r => r.uri).toSorted()).toEqual(['file:///annotated.md', 'file:///fixture.png', 'file:///fixture.txt']);
 
     expect(result.resources.find(r => r.uri === 'file:///fixture.txt')).toMatchObject({
         uri: 'file:///fixture.txt',
@@ -108,7 +109,7 @@ verifies(
             const s = new Server({ name: 's', version: '0' }, { capabilities: { resources: { listChanged: true } } });
             s.setRequestHandler('resources/list', req => {
                 cursorsReceived.push(req.params?.cursor);
-                const start = req.params?.cursor === undefined ? 0 : parseInt(req.params.cursor, 10);
+                const start = req.params?.cursor === undefined ? 0 : Number.parseInt(req.params.cursor, 10);
                 const slice = all.slice(start, start + PAGE);
                 return {
                     resources: slice.map(uri => ({ uri, name: uri, mimeType: 'text/plain' })),
@@ -164,6 +165,7 @@ verifies('resources:read:text', async ({ transport }: TestArgs) => {
     expect(result.contents).toHaveLength(1);
 
     const [entry] = result.contents;
+    if (entry === undefined) throw new Error('expected exactly one content entry');
     expect(entry.uri).toBe('file:///fixture.txt');
     expect(entry.mimeType).toBe('text/plain');
     expect('text' in entry && entry.text).toBe('hello, world');
@@ -201,7 +203,7 @@ verifies('resources:read:unknown-uri', async ({ transport }: TestArgs) => {
     await using _ = await wire(transport, makeServer, client);
 
     await expect(client.readResource({ uri: 'file:///no-such-resource' })).rejects.toMatchObject({
-        code: -32002,
+        code: -32_002,
         message: expect.stringMatching(/not found|unknown/i)
     });
 });
@@ -253,18 +255,21 @@ verifies('resources:list-changed', async ({ transport }: TestArgs) => {
 
     await using _ = await wire(transport, makeServer, client);
 
-    expect((await client.listResources()).resources).toHaveLength(1);
+    const initial = await client.listResources();
+    expect(initial.resources).toHaveLength(1);
 
     const handle = server.registerResource('dynamic', 'file:///probe.txt', { mimeType: 'text/plain' }, () => ({
         contents: [{ uri: 'file:///probe.txt', mimeType: 'text/plain', text: 'probe' }]
     }));
     await vi.waitFor(() => expect(listChanged).toBeGreaterThanOrEqual(1));
-    expect((await client.listResources()).resources).toHaveLength(2);
+    const afterAddList = await client.listResources();
+    expect(afterAddList.resources).toHaveLength(2);
     const afterAdd = listChanged;
 
     handle.remove();
     await vi.waitFor(() => expect(listChanged).toBeGreaterThan(afterAdd));
-    expect((await client.listResources()).resources).toHaveLength(1);
+    const afterRemoveList = await client.listResources();
+    expect(afterRemoveList.resources).toHaveLength(1);
 });
 
 verifies('resources:annotations', async ({ transport }: TestArgs) => {
@@ -296,7 +301,7 @@ verifies('resources:annotations', async ({ transport }: TestArgs) => {
     const { resources } = await client.listResources();
     const resource = resources.find(r => r.uri === 'file:///annotated.md');
     expect(resource).toBeDefined();
-    expect(resource!.annotations).toEqual({
+    expect(resource?.annotations).toEqual({
         audience: ['user', 'assistant'],
         priority: 0.8,
         lastModified: FIXTURE_LAST_MODIFIED
@@ -305,11 +310,11 @@ verifies('resources:annotations', async ({ transport }: TestArgs) => {
     const { resourceTemplates } = await client.listResourceTemplates();
     const template = resourceTemplates.find(t => t.name === 'greet');
     expect(template).toBeDefined();
-    expect(template!.annotations).toEqual({ audience: ['user'], priority: 0.5, lastModified: FIXTURE_LAST_MODIFIED });
+    expect(template?.annotations).toEqual({ audience: ['user'], priority: 0.5, lastModified: FIXTURE_LAST_MODIFIED });
 
     const result = await client.readResource({ uri: 'file:///annotated.md' });
     expect(result.contents).toHaveLength(1);
-    expect(result.contents[0].uri).toBe('file:///annotated.md');
+    expect(result.contents[0]?.uri).toBe('file:///annotated.md');
 });
 
 verifies('resources:capability:declared', async ({ transport }: TestArgs) => {
@@ -325,7 +330,8 @@ verifies('resources:capability:declared', async ({ transport }: TestArgs) => {
 
     const caps = client.getServerCapabilities();
     expect(caps?.resources).toBeDefined();
-    expect((await client.listResources()).resources).toHaveLength(1);
+    const list = await client.listResources();
+    expect(list.resources).toHaveLength(1);
     expect(caps?.resources?.listChanged).toBe(true);
 });
 
@@ -458,7 +464,7 @@ verifies('resources:templates:list', async ({ transport }: TestArgs) => {
     const result = await client.listResourceTemplates();
 
     expect(result.resourceTemplates).toHaveLength(2);
-    expect(result.resourceTemplates.map(t => t.name).sort()).toEqual(['greet', 'listed']);
+    expect(result.resourceTemplates.map(t => t.name).toSorted()).toEqual(['greet', 'listed']);
 
     expect(result.resourceTemplates.find(t => t.name === 'greet')).toMatchObject({
         name: 'greet',
@@ -521,7 +527,7 @@ verifies(
         const makeServer = () => {
             const s = new Server({ name: 's', version: '0' }, { capabilities: { resources: { listChanged: true } } });
             s.setRequestHandler('resources/templates/list', req => {
-                const start = req.params?.cursor === undefined ? 0 : parseInt(req.params.cursor, 10);
+                const start = req.params?.cursor === undefined ? 0 : Number.parseInt(req.params.cursor, 10);
                 const slice = all.slice(start, start + PAGE);
                 return {
                     resourceTemplates: slice.map(uriTemplate => ({ uriTemplate, name: uriTemplate, mimeType: 'text/plain' })),
@@ -599,13 +605,13 @@ verifies('mcpserver:resource:handle-update-remove', async ({ transport }: TestAr
     });
     await using _ = await wire(transport, makeServer, client);
 
-    expect((await client.listResources()).resources).toHaveLength(1);
-    const before = (await client.listResources()).resources.find(r => r.uri === 'file:///probe.txt');
+    const initialList = await client.listResources();
+    expect(initialList.resources).toHaveLength(1);
+    const before = initialList.resources.find(r => r.uri === 'file:///probe.txt');
     expect(before).toBeDefined();
-    expect(before!.name).toBe('probe');
-    expect((await client.readResource({ uri: 'file:///probe.txt' })).contents).toEqual([
-        { uri: 'file:///probe.txt', mimeType: 'text/plain', text: 'v1' }
-    ]);
+    expect(before?.name).toBe('probe');
+    const initialRead = await client.readResource({ uri: 'file:///probe.txt' });
+    expect(initialRead.contents).toEqual([{ uri: 'file:///probe.txt', mimeType: 'text/plain', text: 'v1' }]);
 
     const beforeUpdate = listChanged;
     handle.update({
@@ -613,22 +619,24 @@ verifies('mcpserver:resource:handle-update-remove', async ({ transport }: TestAr
         callback: () => ({ contents: [{ uri: 'file:///probe.txt', mimeType: 'text/plain', text: 'v2' }] })
     });
     await vi.waitFor(() => expect(listChanged).toBeGreaterThan(beforeUpdate));
-    expect((await client.listResources()).resources).toHaveLength(1);
+    const updatedList = await client.listResources();
+    expect(updatedList.resources).toHaveLength(1);
 
-    const after = (await client.listResources()).resources.find(r => r.uri === 'file:///probe.txt');
+    const after = updatedList.resources.find(r => r.uri === 'file:///probe.txt');
     expect(after).toBeDefined();
-    expect(after!.name).toBe('probe (v2)');
-    expect((await client.readResource({ uri: 'file:///probe.txt' })).contents).toEqual([
-        { uri: 'file:///probe.txt', mimeType: 'text/plain', text: 'v2' }
-    ]);
+    expect(after?.name).toBe('probe (v2)');
+    const updatedRead = await client.readResource({ uri: 'file:///probe.txt' });
+    expect(updatedRead.contents).toEqual([{ uri: 'file:///probe.txt', mimeType: 'text/plain', text: 'v2' }]);
 
     const beforeRemove = listChanged;
     handle.remove();
     await vi.waitFor(() => expect(listChanged).toBeGreaterThan(beforeRemove));
-    expect((await client.listResources()).resources).toHaveLength(0);
+    const removedList = await client.listResources();
+    expect(removedList.resources).toHaveLength(0);
 
     await expect(client.readResource({ uri: 'file:///probe.txt' })).rejects.toBeInstanceOf(ProtocolError);
-    const gone = (await client.listResources()).resources.find(r => r.uri === 'file:///probe.txt');
+    const finalList = await client.listResources();
+    const gone = finalList.resources.find(r => r.uri === 'file:///probe.txt');
     expect(gone).toBeUndefined();
 });
 
@@ -684,7 +692,7 @@ verifies('mcpserver:resource:template-list-callback', async ({ transport }: Test
     expect(resources.some(r => r.uri === 'file:///static.txt')).toBe(true);
 
     const listed = resources.filter(r => r.uri.startsWith('listed://items/'));
-    expect(listed.map(r => r.uri).sort()).toEqual(['listed://items/alpha', 'listed://items/beta', 'listed://items/gamma']);
+    expect(listed.map(r => r.uri).toSorted()).toEqual(['listed://items/alpha', 'listed://items/beta', 'listed://items/gamma']);
 
     const alpha = listed.find(r => r.uri === 'listed://items/alpha');
     expect(alpha).toMatchObject({
@@ -735,59 +743,5 @@ verifies('mcpserver:resource:metadata-override', async ({ transport }: TestArgs)
         name: 'gamma',
         description: 'Per-resource override.',
         mimeType: 'application/json'
-    });
-});
-
-verifies('mcpserver:resource:legacy-overload', async ({ transport }: TestArgs) => {
-    const makeServer = () => {
-        const s = new McpServer({ name: 's', version: '0' });
-        // (name, uri, readCallback)
-        s.registerResource('plain', 'e2e://legacy/plain', {}, uri => ({
-            contents: [{ uri: uri.href, text: 'plain' }]
-        }));
-        // (name, uri, metadata, readCallback)
-        s.registerResource('with-meta', 'e2e://legacy/meta', { description: 'meta', mimeType: 'text/plain' }, uri => ({
-            contents: [{ uri: uri.href, text: 'meta' }]
-        }));
-        // (name, template, readCallback)
-        s.registerResource('tmpl', new ResourceTemplate('e2e://legacy/t/{id}', { list: undefined }), {}, (uri, { id }) => ({
-            contents: [{ uri: uri.href, text: `t:${String(id)}` }]
-        }));
-        // (name, template, metadata, readCallback)
-        s.registerResource(
-            'tmpl-meta',
-            new ResourceTemplate('e2e://legacy/tm/{id}', { list: undefined }),
-            { description: 'templated' },
-            (uri, { id }) => ({ contents: [{ uri: uri.href, text: `tm:${String(id)}` }] })
-        );
-        return s;
-    };
-
-    const client = newClient();
-    await using _ = await wire(transport, makeServer, client);
-
-    const list = await client.listResources();
-    const fixed = list.resources.map(r => r.uri).sort();
-    expect(fixed).toEqual(['e2e://legacy/meta', 'e2e://legacy/plain']);
-    expect(list.resources.find(r => r.uri === 'e2e://legacy/meta')).toMatchObject({
-        description: 'meta',
-        mimeType: 'text/plain'
-    });
-
-    const templates = await client.listResourceTemplates();
-    const tmplUris = templates.resourceTemplates.map(t => t.uriTemplate).sort();
-    expect(tmplUris).toEqual(['e2e://legacy/t/{id}', 'e2e://legacy/tm/{id}']);
-    expect(templates.resourceTemplates.find(t => t.uriTemplate === 'e2e://legacy/tm/{id}')).toMatchObject({
-        description: 'templated'
-    });
-
-    expect(await client.readResource({ uri: 'e2e://legacy/plain' })).toMatchObject({
-        contents: [{ uri: 'e2e://legacy/plain', text: 'plain' }]
-    });
-    expect(await client.readResource({ uri: 'e2e://legacy/t/abc' })).toMatchObject({
-        contents: [{ text: 't:abc' }]
-    });
-    expect(await client.readResource({ uri: 'e2e://legacy/tm/xyz' })).toMatchObject({
-        contents: [{ text: 'tm:xyz' }]
     });
 });

--- a/test/e2e/scenarios/roots.test.ts
+++ b/test/e2e/scenarios/roots.test.ts
@@ -6,15 +6,15 @@
  * the server when roots change via `notifications/roots/list_changed`.
  */
 
-import { expect, vi } from 'vitest';
-
-import { z } from 'zod/v4';
-import { McpServer, ProtocolError, ProtocolErrorCode } from '@modelcontextprotocol/server';
-import type { ListRootsResult } from '@modelcontextprotocol/server';
 import { Client } from '@modelcontextprotocol/client';
+import type { ListRootsResult } from '@modelcontextprotocol/server';
+import { McpServer, ProtocolError, ProtocolErrorCode } from '@modelcontextprotocol/server';
+import { expect, vi } from 'vitest';
+import { z } from 'zod/v4';
+
 import { wire } from '../helpers/index.js';
-import type { TestArgs } from '../types.js';
 import { verifies } from '../helpers/verifies.js';
+import type { TestArgs } from '../types.js';
 
 verifies('roots:list:basic', async ({ transport }: TestArgs) => {
     const received: Array<{ method: string }> = [];
@@ -42,7 +42,7 @@ verifies('roots:list:basic', async ({ transport }: TestArgs) => {
     const result = await client.callTool({ name: 'list-roots', arguments: {} });
 
     expect(received).toHaveLength(1);
-    expect(received[0].method).toBe('roots/list');
+    expect(received[0]?.method).toBe('roots/list');
 
     expect(result.isError).toBeFalsy();
     expect(result.structuredContent).toMatchObject({
@@ -74,7 +74,7 @@ verifies('roots:list:empty', async ({ transport }: TestArgs) => {
 
     expect(result.isError).toBeFalsy();
     expect(results).toHaveLength(1);
-    expect(results[0].roots).toEqual([]);
+    expect(results[0]?.roots).toEqual([]);
 });
 
 verifies('roots:list:client-error', async ({ transport }: TestArgs) => {
@@ -85,8 +85,8 @@ verifies('roots:list:client-error', async ({ transport }: TestArgs) => {
             try {
                 await s.server.listRoots();
                 return { content: [{ type: 'text', text: 'unexpected success' }] };
-            } catch (e) {
-                if (e instanceof ProtocolError) failures.push(e);
+            } catch (error) {
+                if (error instanceof ProtocolError) failures.push(error);
                 return { content: [{ type: 'text', text: 'rejected' }] };
             }
         });
@@ -102,11 +102,11 @@ verifies('roots:list:client-error', async ({ transport }: TestArgs) => {
 
     const result = await client.callTool({ name: 'list-roots', arguments: {} });
 
-    // The handler observed a rejection (not a hang or a malformed result), and it was an McpError.
+    // The handler observed a rejection (not a hang or a malformed result), and it was a ProtocolError.
     expect(result.content).toEqual([{ type: 'text', text: 'rejected' }]);
     expect(failures).toHaveLength(1);
-    expect(failures[0].code).toBe(ProtocolErrorCode.InternalError);
-    expect(failures[0].message).toMatch(/roots provider crashed/);
+    expect(failures[0]?.code).toBe(ProtocolErrorCode.InternalError);
+    expect(failures[0]?.message).toMatch(/roots provider crashed/);
 });
 
 verifies('roots:list:not-supported', async ({ transport }: TestArgs) => {
@@ -117,8 +117,8 @@ verifies('roots:list:not-supported', async ({ transport }: TestArgs) => {
             try {
                 await s.server.listRoots();
                 return { content: [{ type: 'text', text: 'unexpected success' }] };
-            } catch (e) {
-                if (e instanceof ProtocolError) failures.push(e);
+            } catch (error) {
+                if (error instanceof ProtocolError) failures.push(error);
                 return { content: [{ type: 'text', text: 'rejected' }] };
             }
         });
@@ -134,15 +134,14 @@ verifies('roots:list:not-supported', async ({ transport }: TestArgs) => {
 
     expect(result.content).toEqual([{ type: 'text', text: 'rejected' }]);
     expect(failures).toHaveLength(1);
-    expect(failures[0].code).toBe(ProtocolErrorCode.MethodNotFound);
-    expect(failures[0].message).toMatch(/Method not found/);
+    expect(failures[0]?.code).toBe(ProtocolErrorCode.MethodNotFound);
+    expect(failures[0]?.message).toMatch(/Method not found/);
 });
 
 verifies('roots:list-changed', async ({ transport }: TestArgs) => {
     const refetched: ListRootsResult[] = [];
-    let server!: McpServer;
     const makeServer = () => {
-        server = new McpServer({ name: 's', version: '0' });
+        const server = new McpServer({ name: 's', version: '0' });
         server.server.setNotificationHandler('notifications/roots/list_changed', async () => {
             refetched.push(await server.server.listRoots());
         });
@@ -163,10 +162,10 @@ verifies('roots:list-changed', async ({ transport }: TestArgs) => {
     ];
     await client.sendRootsListChanged();
     await vi.waitFor(() => expect(refetched).toHaveLength(1));
-    expect(refetched[0].roots).toEqual(roots);
+    expect(refetched[0]?.roots).toEqual(roots);
 
     roots = [{ uri: 'file:///home/user/projects/b', name: 'B' }];
     await client.sendRootsListChanged();
     await vi.waitFor(() => expect(refetched).toHaveLength(2));
-    expect(refetched[1].roots).toEqual(roots);
+    expect(refetched[1]?.roots).toEqual(roots);
 });

--- a/test/e2e/scenarios/roots.test.ts
+++ b/test/e2e/scenarios/roots.test.ts
@@ -9,17 +9,9 @@
 import { expect, vi } from 'vitest';
 
 import { z } from 'zod/v4';
-
-import { Client } from '../../../src/client/index.js';
-import { McpServer } from '../../../src/server/mcp.js';
-import {
-    ErrorCode,
-    type ListRootsResult,
-    ListRootsRequestSchema,
-    McpError,
-    RootsListChangedNotificationSchema
-} from '../../../src/types.js';
-
+import { McpServer, ProtocolError, ProtocolErrorCode } from '@modelcontextprotocol/server';
+import type { ListRootsResult } from '@modelcontextprotocol/server';
+import { Client } from '@modelcontextprotocol/client';
 import { wire } from '../helpers/index.js';
 import type { TestArgs } from '../types.js';
 import { verifies } from '../helpers/verifies.js';
@@ -38,7 +30,7 @@ verifies('roots:list:basic', async ({ transport }: TestArgs) => {
     };
 
     const client = new Client({ name: 'c', version: '0' }, { capabilities: { roots: { listChanged: true } } });
-    client.setRequestHandler(ListRootsRequestSchema, async req => {
+    client.setRequestHandler('roots/list', async req => {
         received.push({ method: req.method });
         return {
             roots: [{ uri: 'file:///home/user/projects/myproject', name: 'My Project' }, { uri: 'file:///home/user/repos/backend' }]
@@ -74,7 +66,7 @@ verifies('roots:list:empty', async ({ transport }: TestArgs) => {
 
     // The client supports roots but currently has none to offer.
     const client = new Client({ name: 'c', version: '0' }, { capabilities: { roots: {} } });
-    client.setRequestHandler(ListRootsRequestSchema, async () => ({ roots: [] }));
+    client.setRequestHandler('roots/list', async () => ({ roots: [] }));
 
     await using _ = await wire(transport, makeServer, client);
 
@@ -86,7 +78,7 @@ verifies('roots:list:empty', async ({ transport }: TestArgs) => {
 });
 
 verifies('roots:list:client-error', async ({ transport }: TestArgs) => {
-    const failures: McpError[] = [];
+    const failures: ProtocolError[] = [];
     const makeServer = () => {
         const s = new McpServer({ name: 's', version: '0' });
         s.registerTool('list-roots', { inputSchema: z.object({}) }, async () => {
@@ -94,7 +86,7 @@ verifies('roots:list:client-error', async ({ transport }: TestArgs) => {
                 await s.server.listRoots();
                 return { content: [{ type: 'text', text: 'unexpected success' }] };
             } catch (e) {
-                if (e instanceof McpError) failures.push(e);
+                if (e instanceof ProtocolError) failures.push(e);
                 return { content: [{ type: 'text', text: 'rejected' }] };
             }
         });
@@ -102,8 +94,8 @@ verifies('roots:list:client-error', async ({ transport }: TestArgs) => {
     };
 
     const client = new Client({ name: 'c', version: '0' }, { capabilities: { roots: {} } });
-    client.setRequestHandler(ListRootsRequestSchema, async () => {
-        throw new McpError(ErrorCode.InternalError, 'roots provider crashed');
+    client.setRequestHandler('roots/list', async () => {
+        throw new ProtocolError(ProtocolErrorCode.InternalError, 'roots provider crashed');
     });
 
     await using _ = await wire(transport, makeServer, client);
@@ -113,12 +105,12 @@ verifies('roots:list:client-error', async ({ transport }: TestArgs) => {
     // The handler observed a rejection (not a hang or a malformed result), and it was an McpError.
     expect(result.content).toEqual([{ type: 'text', text: 'rejected' }]);
     expect(failures).toHaveLength(1);
-    expect(failures[0].code).toBe(ErrorCode.InternalError);
+    expect(failures[0].code).toBe(ProtocolErrorCode.InternalError);
     expect(failures[0].message).toMatch(/roots provider crashed/);
 });
 
 verifies('roots:list:not-supported', async ({ transport }: TestArgs) => {
-    const failures: McpError[] = [];
+    const failures: ProtocolError[] = [];
     const makeServer = () => {
         const s = new McpServer({ name: 's', version: '0' });
         s.registerTool('list-roots', { inputSchema: z.object({}) }, async () => {
@@ -126,7 +118,7 @@ verifies('roots:list:not-supported', async ({ transport }: TestArgs) => {
                 await s.server.listRoots();
                 return { content: [{ type: 'text', text: 'unexpected success' }] };
             } catch (e) {
-                if (e instanceof McpError) failures.push(e);
+                if (e instanceof ProtocolError) failures.push(e);
                 return { content: [{ type: 'text', text: 'rejected' }] };
             }
         });
@@ -142,7 +134,7 @@ verifies('roots:list:not-supported', async ({ transport }: TestArgs) => {
 
     expect(result.content).toEqual([{ type: 'text', text: 'rejected' }]);
     expect(failures).toHaveLength(1);
-    expect(failures[0].code).toBe(ErrorCode.MethodNotFound);
+    expect(failures[0].code).toBe(ProtocolErrorCode.MethodNotFound);
     expect(failures[0].message).toMatch(/Method not found/);
 });
 
@@ -151,7 +143,7 @@ verifies('roots:list-changed', async ({ transport }: TestArgs) => {
     let server!: McpServer;
     const makeServer = () => {
         server = new McpServer({ name: 's', version: '0' });
-        server.server.setNotificationHandler(RootsListChangedNotificationSchema, async () => {
+        server.server.setNotificationHandler('notifications/roots/list_changed', async () => {
             refetched.push(await server.server.listRoots());
         });
         return server;
@@ -159,7 +151,7 @@ verifies('roots:list-changed', async ({ transport }: TestArgs) => {
 
     let roots = [{ uri: 'file:///home/user/projects/a', name: 'A' }];
     const client = new Client({ name: 'c', version: '0' }, { capabilities: { roots: { listChanged: true } } });
-    client.setRequestHandler(ListRootsRequestSchema, async () => ({ roots }));
+    client.setRequestHandler('roots/list', async () => ({ roots }));
 
     await using _ = await wire(transport, makeServer, client);
 

--- a/test/e2e/scenarios/roots.test.ts
+++ b/test/e2e/scenarios/roots.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Self-contained test bodies for the roots surface.
+ *
+ * Roots are a client capability: the client exposes filesystem roots to the
+ * server. The server can request them via `roots/list`, and the client notifies
+ * the server when roots change via `notifications/roots/list_changed`.
+ */
+
+import { expect, vi } from 'vitest';
+
+import { z } from 'zod/v4';
+
+import { Client } from '../../../src/client/index.js';
+import { McpServer } from '../../../src/server/mcp.js';
+import {
+    ErrorCode,
+    type ListRootsResult,
+    ListRootsRequestSchema,
+    McpError,
+    RootsListChangedNotificationSchema
+} from '../../../src/types.js';
+
+import { wire } from '../helpers/index.js';
+import type { TestArgs } from '../types.js';
+import { verifies } from '../helpers/verifies.js';
+
+verifies('roots:list:basic', async ({ transport }: TestArgs) => {
+    const received: Array<{ method: string }> = [];
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        // Drive the server→client call via the typed Server.listRoots() helper —
+        // this is the user-facing API and exercises the capability check.
+        s.registerTool('list-roots', { inputSchema: z.object({}) }, async () => {
+            const result = await s.server.listRoots();
+            return { structuredContent: { ok: true, result }, content: [] };
+        });
+        return s;
+    };
+
+    const client = new Client({ name: 'c', version: '0' }, { capabilities: { roots: { listChanged: true } } });
+    client.setRequestHandler(ListRootsRequestSchema, async req => {
+        received.push({ method: req.method });
+        return {
+            roots: [{ uri: 'file:///home/user/projects/myproject', name: 'My Project' }, { uri: 'file:///home/user/repos/backend' }]
+        };
+    });
+
+    await using _ = await wire(transport, makeServer, client);
+
+    const result = await client.callTool({ name: 'list-roots', arguments: {} });
+
+    expect(received).toHaveLength(1);
+    expect(received[0].method).toBe('roots/list');
+
+    expect(result.isError).toBeFalsy();
+    expect(result.structuredContent).toMatchObject({
+        ok: true,
+        result: {
+            roots: [{ uri: 'file:///home/user/projects/myproject', name: 'My Project' }, { uri: 'file:///home/user/repos/backend' }]
+        }
+    });
+});
+
+verifies('roots:list:empty', async ({ transport }: TestArgs) => {
+    const results: ListRootsResult[] = [];
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool('list-roots', { inputSchema: z.object({}) }, async () => {
+            results.push(await s.server.listRoots());
+            return { content: [{ type: 'text', text: 'ok' }] };
+        });
+        return s;
+    };
+
+    // The client supports roots but currently has none to offer.
+    const client = new Client({ name: 'c', version: '0' }, { capabilities: { roots: {} } });
+    client.setRequestHandler(ListRootsRequestSchema, async () => ({ roots: [] }));
+
+    await using _ = await wire(transport, makeServer, client);
+
+    const result = await client.callTool({ name: 'list-roots', arguments: {} });
+
+    expect(result.isError).toBeFalsy();
+    expect(results).toHaveLength(1);
+    expect(results[0].roots).toEqual([]);
+});
+
+verifies('roots:list:client-error', async ({ transport }: TestArgs) => {
+    const failures: McpError[] = [];
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool('list-roots', { inputSchema: z.object({}) }, async () => {
+            try {
+                await s.server.listRoots();
+                return { content: [{ type: 'text', text: 'unexpected success' }] };
+            } catch (e) {
+                if (e instanceof McpError) failures.push(e);
+                return { content: [{ type: 'text', text: 'rejected' }] };
+            }
+        });
+        return s;
+    };
+
+    const client = new Client({ name: 'c', version: '0' }, { capabilities: { roots: {} } });
+    client.setRequestHandler(ListRootsRequestSchema, async () => {
+        throw new McpError(ErrorCode.InternalError, 'roots provider crashed');
+    });
+
+    await using _ = await wire(transport, makeServer, client);
+
+    const result = await client.callTool({ name: 'list-roots', arguments: {} });
+
+    // The handler observed a rejection (not a hang or a malformed result), and it was an McpError.
+    expect(result.content).toEqual([{ type: 'text', text: 'rejected' }]);
+    expect(failures).toHaveLength(1);
+    expect(failures[0].code).toBe(ErrorCode.InternalError);
+    expect(failures[0].message).toMatch(/roots provider crashed/);
+});
+
+verifies('roots:list:not-supported', async ({ transport }: TestArgs) => {
+    const failures: McpError[] = [];
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool('list-roots', { inputSchema: z.object({}) }, async () => {
+            try {
+                await s.server.listRoots();
+                return { content: [{ type: 'text', text: 'unexpected success' }] };
+            } catch (e) {
+                if (e instanceof McpError) failures.push(e);
+                return { content: [{ type: 'text', text: 'rejected' }] };
+            }
+        });
+        return s;
+    };
+
+    // The client deliberately declares no roots capability and registers no roots/list handler.
+    const client = new Client({ name: 'c', version: '0' });
+
+    await using _ = await wire(transport, makeServer, client);
+
+    const result = await client.callTool({ name: 'list-roots', arguments: {} });
+
+    expect(result.content).toEqual([{ type: 'text', text: 'rejected' }]);
+    expect(failures).toHaveLength(1);
+    expect(failures[0].code).toBe(ErrorCode.MethodNotFound);
+    expect(failures[0].message).toMatch(/Method not found/);
+});
+
+verifies('roots:list-changed', async ({ transport }: TestArgs) => {
+    const refetched: ListRootsResult[] = [];
+    let server!: McpServer;
+    const makeServer = () => {
+        server = new McpServer({ name: 's', version: '0' });
+        server.server.setNotificationHandler(RootsListChangedNotificationSchema, async () => {
+            refetched.push(await server.server.listRoots());
+        });
+        return server;
+    };
+
+    let roots = [{ uri: 'file:///home/user/projects/a', name: 'A' }];
+    const client = new Client({ name: 'c', version: '0' }, { capabilities: { roots: { listChanged: true } } });
+    client.setRequestHandler(ListRootsRequestSchema, async () => ({ roots }));
+
+    await using _ = await wire(transport, makeServer, client);
+
+    // Change roots, signal the server, and observe the server's re-request
+    // returning the *new* roots.
+    roots = [
+        { uri: 'file:///home/user/projects/a', name: 'A' },
+        { uri: 'file:///home/user/projects/b', name: 'B' }
+    ];
+    await client.sendRootsListChanged();
+    await vi.waitFor(() => expect(refetched).toHaveLength(1));
+    expect(refetched[0].roots).toEqual(roots);
+
+    roots = [{ uri: 'file:///home/user/projects/b', name: 'B' }];
+    await client.sendRootsListChanged();
+    await vi.waitFor(() => expect(refetched).toHaveLength(2));
+    expect(refetched[1].roots).toEqual(roots);
+});

--- a/test/e2e/scenarios/sampling.test.ts
+++ b/test/e2e/scenarios/sampling.test.ts
@@ -10,19 +10,9 @@
 
 import { expect } from 'vitest';
 import { z } from 'zod/v4';
-
-import { Client } from '../../../src/client/index.js';
-import type { ServerOptions } from '../../../src/server/index.js';
-import { McpServer } from '../../../src/server/mcp.js';
-import {
-    type CreateMessageRequest,
-    CreateMessageRequestSchema,
-    type CreateMessageResultWithTools,
-    ErrorCode,
-    McpError,
-    type SamplingMessage
-} from '../../../src/types.js';
-
+import { McpServer, ProtocolError, ProtocolErrorCode } from '@modelcontextprotocol/server';
+import type { ServerOptions, CreateMessageRequest, CreateMessageResultWithTools, SamplingMessage } from '@modelcontextprotocol/server';
+import { Client } from '@modelcontextprotocol/client';
 import { tapWire, wire } from '../helpers/index.js';
 import type { TestArgs } from '../types.js';
 import { verifies } from '../helpers/verifies.js';
@@ -75,7 +65,7 @@ function passthroughServer(options?: ServerOptions) {
 verifies('sampling:capability:declare', async ({ transport }: TestArgs) => {
     const received: CreateMessageRequest[] = [];
     const client = newClient({ sampling: {} });
-    client.setRequestHandler(CreateMessageRequestSchema, async req => {
+    client.setRequestHandler('sampling/createMessage', async req => {
         received.push(req);
         return { model: 'stub', role: 'assistant', stopReason: 'endTurn', content: { type: 'text', text: 'ok' } };
     });
@@ -89,7 +79,7 @@ verifies('sampling:capability:declare', async ({ transport }: TestArgs) => {
 verifies('sampling:create:basic', async ({ transport }: TestArgs) => {
     const received: CreateMessageRequest[] = [];
     const client = newClient();
-    client.setRequestHandler(CreateMessageRequestSchema, async req => {
+    client.setRequestHandler('sampling/createMessage', async req => {
         received.push(req);
         return { model: 'test-model', role: 'assistant', stopReason: 'endTurn', content: { type: 'text', text: 'Paris' } };
     });
@@ -114,7 +104,7 @@ verifies('sampling:create:basic', async ({ transport }: TestArgs) => {
 verifies('sampling:create:include-context', async ({ transport }: TestArgs) => {
     const received: CreateMessageRequest[] = [];
     const client = newClient();
-    client.setRequestHandler(CreateMessageRequestSchema, async req => {
+    client.setRequestHandler('sampling/createMessage', async req => {
         received.push(req);
         return { model: 'm', role: 'assistant', stopReason: 'endTurn', content: { type: 'text', text: 'ok' } };
     });
@@ -136,7 +126,7 @@ verifies('sampling:create:include-context', async ({ transport }: TestArgs) => {
 verifies('sampling:create:model-preferences', async ({ transport }: TestArgs) => {
     const received: CreateMessageRequest[] = [];
     const client = newClient();
-    client.setRequestHandler(CreateMessageRequestSchema, async req => {
+    client.setRequestHandler('sampling/createMessage', async req => {
         received.push(req);
         return { model: 'm', role: 'assistant', stopReason: 'endTurn', content: { type: 'text', text: 'ok' } };
     });
@@ -153,7 +143,7 @@ verifies('sampling:create:model-preferences', async ({ transport }: TestArgs) =>
 verifies('sampling:create:system-prompt', async ({ transport }: TestArgs) => {
     const received: CreateMessageRequest[] = [];
     const client = newClient();
-    client.setRequestHandler(CreateMessageRequestSchema, async req => {
+    client.setRequestHandler('sampling/createMessage', async req => {
         received.push(req);
         return { model: 'm', role: 'assistant', stopReason: 'endTurn', content: { type: 'text', text: 'ok' } };
     });
@@ -169,7 +159,7 @@ verifies('sampling:create:system-prompt', async ({ transport }: TestArgs) => {
 verifies('sampling:create:tools', async ({ transport }: TestArgs) => {
     const received: CreateMessageRequest[] = [];
     const client = newClient({ sampling: { tools: {} } });
-    client.setRequestHandler(CreateMessageRequestSchema, async req => {
+    client.setRequestHandler('sampling/createMessage', async req => {
         received.push(req);
         const mode = req.params.toolChoice?.mode;
         if (mode === 'auto' || mode === 'required') {
@@ -203,8 +193,8 @@ verifies('sampling:create:tools', async ({ transport }: TestArgs) => {
 
 verifies('sampling:error:user-rejected', async ({ transport }: TestArgs) => {
     const client = newClient();
-    client.setRequestHandler(CreateMessageRequestSchema, async () => {
-        throw new McpError(-1, 'User rejected sampling request');
+    client.setRequestHandler('sampling/createMessage', async () => {
+        throw new ProtocolError(-1, 'User rejected sampling request');
     });
 
     await using _ = await wire(transport, passthroughServer, client);
@@ -218,7 +208,7 @@ verifies('sampling:error:user-rejected', async ({ transport }: TestArgs) => {
 verifies('sampling:message:content-cardinality', async ({ transport }: TestArgs) => {
     const received: CreateMessageRequest[] = [];
     const client = newClient();
-    client.setRequestHandler(CreateMessageRequestSchema, async req => {
+    client.setRequestHandler('sampling/createMessage', async req => {
         received.push(req);
         return { model: 'm', role: 'assistant', stopReason: 'endTurn', content: { type: 'text', text: 'ok' } };
     });
@@ -234,7 +224,7 @@ verifies('sampling:message:content-cardinality', async ({ transport }: TestArgs)
 
     received.length = 0;
     const client2 = newClient();
-    client2.setRequestHandler(CreateMessageRequestSchema, async req => {
+    client2.setRequestHandler('sampling/createMessage', async req => {
         received.push(req);
         return { model: 'm', role: 'assistant', stopReason: 'endTurn', content: { type: 'text', text: 'ok' } };
     });
@@ -269,7 +259,7 @@ verifies('sampling:message:content-cardinality', async ({ transport }: TestArgs)
 verifies('sampling:result:no-tools-single-content', async ({ transport }: TestArgs) => {
     const client = newClient();
     // No tools/toolChoice in the request, so the client's wrapped sampling handler validates against CreateMessageResultSchema and rejects array content with -32602.
-    client.setRequestHandler(CreateMessageRequestSchema, async () => ({
+    client.setRequestHandler('sampling/createMessage', async () => ({
         model: 'm',
         role: 'assistant',
         stopReason: 'endTurn',
@@ -288,7 +278,7 @@ verifies('sampling:result:no-tools-single-content', async ({ transport }: TestAr
 
 verifies('sampling:result:with-tools-array-content', async ({ transport }: TestArgs) => {
     const client = newClient({ sampling: { tools: {} } });
-    client.setRequestHandler(CreateMessageRequestSchema, async () => {
+    client.setRequestHandler('sampling/createMessage', async () => {
         return {
             model: 'm',
             role: 'assistant',
@@ -321,7 +311,7 @@ verifies('sampling:result:with-tools-array-content', async ({ transport }: TestA
 
 verifies('sampling:tool-result:no-mixed-content', async ({ transport }: TestArgs) => {
     const client = newClient();
-    client.setRequestHandler(CreateMessageRequestSchema, async () => {
+    client.setRequestHandler('sampling/createMessage', async () => {
         return { model: 'm', role: 'assistant', stopReason: 'endTurn', content: { type: 'text', text: 'unreachable' } };
     });
 
@@ -344,14 +334,14 @@ verifies('sampling:tool-result:no-mixed-content', async ({ transport }: TestArgs
         }
     });
 
-    expect(r.structuredContent).toMatchObject({ ok: false, code: ErrorCode.InvalidParams });
+    expect(r.structuredContent).toMatchObject({ ok: false, code: ProtocolErrorCode.InvalidParams });
     expect((r.structuredContent as { message?: string }).message).toMatch(/tool.?result/i);
 });
 
 verifies('sampling:tool-use:result-balance', async ({ transport }: TestArgs) => {
     const received: CreateMessageRequest[] = [];
     const client = newClient({ sampling: { tools: {} } });
-    client.setRequestHandler(CreateMessageRequestSchema, async req => {
+    client.setRequestHandler('sampling/createMessage', async req => {
         received.push(req);
         return { model: 'm', role: 'assistant', stopReason: 'endTurn', content: { type: 'text', text: 'ok' } };
     });
@@ -395,7 +385,7 @@ verifies('sampling:tool-use:result-balance', async ({ transport }: TestArgs) => 
         }
     });
 
-    expect(missing.structuredContent).toMatchObject({ ok: false, code: ErrorCode.InvalidParams });
+    expect(missing.structuredContent).toMatchObject({ ok: false, code: ProtocolErrorCode.InvalidParams });
     expect(received).toHaveLength(1);
 
     const trailing = await client.callTool({
@@ -410,14 +400,14 @@ verifies('sampling:tool-use:result-balance', async ({ transport }: TestArgs) => 
         }
     });
 
-    expect(trailing.structuredContent).toMatchObject({ ok: false, code: ErrorCode.InvalidParams });
+    expect(trailing.structuredContent).toMatchObject({ ok: false, code: ProtocolErrorCode.InvalidParams });
     expect(received).toHaveLength(1);
 });
 
 verifies('sampling:tools:server-gated-by-capability', async ({ transport }: TestArgs) => {
     const received: CreateMessageRequest[] = [];
     const client = newClient({ sampling: {} });
-    client.setRequestHandler(CreateMessageRequestSchema, async req => {
+    client.setRequestHandler('sampling/createMessage', async req => {
         received.push(req);
         return { model: 'm', role: 'assistant', stopReason: 'endTurn', content: { type: 'text', text: 'unreachable' } };
     });
@@ -455,7 +445,7 @@ verifies('sampling:tools:server-gated-by-capability', async ({ transport }: Test
 verifies('sampling:create:image-content', async ({ transport }: TestArgs) => {
     const received: CreateMessageRequest[] = [];
     const client = newClient();
-    client.setRequestHandler(CreateMessageRequestSchema, async req => {
+    client.setRequestHandler('sampling/createMessage', async req => {
         received.push(req);
         return {
             model: 'mock-vision-1',
@@ -493,7 +483,7 @@ verifies('sampling:create:image-content', async ({ transport }: TestArgs) => {
 verifies('sampling:create:audio-content', async ({ transport }: TestArgs) => {
     const received: CreateMessageRequest[] = [];
     const client = newClient();
-    client.setRequestHandler(CreateMessageRequestSchema, async req => {
+    client.setRequestHandler('sampling/createMessage', async req => {
         received.push(req);
         return {
             model: 'mock-audio-1',
@@ -532,7 +522,7 @@ verifies('sampling:context:server-gated-by-capability', async ({ transport }: Te
     const received: CreateMessageRequest[] = [];
     // Client declares plain sampling but not the sampling.context sub-capability.
     const client = newClient({ sampling: {} });
-    client.setRequestHandler(CreateMessageRequestSchema, async req => {
+    client.setRequestHandler('sampling/createMessage', async req => {
         received.push(req);
         return { model: 'm', role: 'assistant', stopReason: 'endTurn', content: { type: 'text', text: 'ok' } };
     });

--- a/test/e2e/scenarios/sampling.test.ts
+++ b/test/e2e/scenarios/sampling.test.ts
@@ -1,0 +1,582 @@
+/**
+ * Self-contained test bodies for the sampling surface.
+ *
+ * Sampling is bidirectional: servers request LLM completions from clients by
+ * sending `sampling/createMessage`. Each test builds its own server (via
+ * factory) and client, wires them with {@link wire}, and asserts. Clients
+ * declare the `sampling` capability and register a handler via
+ * `setRequestHandler(CreateMessageRequestSchema, ...)`.
+ */
+
+import { expect } from 'vitest';
+import { z } from 'zod/v4';
+
+import { Client } from '../../../src/client/index.js';
+import type { ServerOptions } from '../../../src/server/index.js';
+import { McpServer } from '../../../src/server/mcp.js';
+import {
+    type CreateMessageRequest,
+    CreateMessageRequestSchema,
+    type CreateMessageResultWithTools,
+    ErrorCode,
+    McpError,
+    type SamplingMessage
+} from '../../../src/types.js';
+
+import { tapWire, wire } from '../helpers/index.js';
+import type { TestArgs } from '../types.js';
+import { verifies } from '../helpers/verifies.js';
+
+const newClient = (capabilities: { sampling?: object } = { sampling: {} }) => new Client({ name: 'c', version: '0' }, { capabilities });
+
+function samplingServer() {
+    const s = new McpServer({ name: 's', version: '0' });
+    s.registerTool('ask-llm', { inputSchema: z.object({ prompt: z.string() }) }, async ({ prompt }) => {
+        const result = await s.server.createMessage({
+            messages: [{ role: 'user', content: { type: 'text', text: prompt } }],
+            maxTokens: 100
+        });
+        const text = Array.isArray(result.content)
+            ? ((result.content[0] as { type: string; text?: string }).text ?? '')
+            : ((result.content as { type: string; text?: string }).text ?? '');
+        return { content: [{ type: 'text', text: `model said: ${text}` }] };
+    });
+    return s;
+}
+
+function passthroughServer(options?: ServerOptions) {
+    const s = new McpServer({ name: 's', version: '0' }, options);
+    s.registerTool(
+        'sampling-passthrough',
+        {
+            inputSchema: z.any(),
+            outputSchema: z.object({
+                ok: z.boolean(),
+                result: z.any().optional(),
+                code: z.number().optional(),
+                message: z.string().optional()
+            })
+        },
+        async args => {
+            try {
+                const result = await s.server.createMessage(args as unknown as CreateMessageRequest['params']);
+                return { structuredContent: { ok: true, result }, content: [{ type: 'text', text: JSON.stringify(result) }] };
+            } catch (e: unknown) {
+                const err = e as { code?: number; message?: string };
+                const message = err.message ?? String(e);
+                const code = err.code ?? (e instanceof Error ? undefined : (e as { error?: { code?: number } }).error?.code);
+                return { structuredContent: { ok: false, code, message }, content: [{ type: 'text', text: message }] };
+            }
+        }
+    );
+    return s;
+}
+
+verifies('sampling:capability:declare', async ({ transport }: TestArgs) => {
+    const received: CreateMessageRequest[] = [];
+    const client = newClient({ sampling: {} });
+    client.setRequestHandler(CreateMessageRequestSchema, async req => {
+        received.push(req);
+        return { model: 'stub', role: 'assistant', stopReason: 'endTurn', content: { type: 'text', text: 'ok' } };
+    });
+
+    await using _ = await wire(transport, samplingServer, client);
+
+    await client.callTool({ name: 'ask-llm', arguments: { prompt: 'hi' } });
+    expect(received).toHaveLength(1);
+});
+
+verifies('sampling:create:basic', async ({ transport }: TestArgs) => {
+    const received: CreateMessageRequest[] = [];
+    const client = newClient();
+    client.setRequestHandler(CreateMessageRequestSchema, async req => {
+        received.push(req);
+        return { model: 'test-model', role: 'assistant', stopReason: 'endTurn', content: { type: 'text', text: 'Paris' } };
+    });
+
+    await using _ = await wire(transport, passthroughServer, client);
+
+    const r = await client.callTool({
+        name: 'sampling-passthrough',
+        arguments: { messages: [{ role: 'user', content: { type: 'text', text: 'capital?' } }], maxTokens: 50 }
+    });
+
+    expect(received).toHaveLength(1);
+    expect(received[0].params.messages).toEqual([{ role: 'user', content: { type: 'text', text: 'capital?' } }]);
+    expect(received[0].params.maxTokens).toBe(50);
+
+    expect(r.structuredContent).toEqual({
+        ok: true,
+        result: { role: 'assistant', content: { type: 'text', text: 'Paris' }, model: 'test-model', stopReason: 'endTurn' }
+    });
+});
+
+verifies('sampling:create:include-context', async ({ transport }: TestArgs) => {
+    const received: CreateMessageRequest[] = [];
+    const client = newClient();
+    client.setRequestHandler(CreateMessageRequestSchema, async req => {
+        received.push(req);
+        return { model: 'm', role: 'assistant', stopReason: 'endTurn', content: { type: 'text', text: 'ok' } };
+    });
+
+    await using _ = await wire(transport, passthroughServer, client);
+
+    for (const val of ['none', 'thisServer', 'allServers'] as const) {
+        await client.callTool({ name: 'sampling-passthrough', arguments: { messages: [], maxTokens: 10, includeContext: val } });
+    }
+    await client.callTool({ name: 'sampling-passthrough', arguments: { messages: [], maxTokens: 10 } });
+
+    expect(received).toHaveLength(4);
+    expect(received[0].params.includeContext).toBe('none');
+    expect(received[1].params.includeContext).toBe('thisServer');
+    expect(received[2].params.includeContext).toBe('allServers');
+    expect(received[3].params.includeContext).toBeUndefined();
+});
+
+verifies('sampling:create:model-preferences', async ({ transport }: TestArgs) => {
+    const received: CreateMessageRequest[] = [];
+    const client = newClient();
+    client.setRequestHandler(CreateMessageRequestSchema, async req => {
+        received.push(req);
+        return { model: 'm', role: 'assistant', stopReason: 'endTurn', content: { type: 'text', text: 'ok' } };
+    });
+
+    await using _ = await wire(transport, passthroughServer, client);
+
+    const prefs = { hints: [{ name: 'sonnet' }], costPriority: 0.3, speedPriority: 0.7, intelligencePriority: 0.5 };
+    await client.callTool({ name: 'sampling-passthrough', arguments: { messages: [], maxTokens: 10, modelPreferences: prefs } });
+
+    expect(received).toHaveLength(1);
+    expect(received[0].params.modelPreferences).toEqual(prefs);
+});
+
+verifies('sampling:create:system-prompt', async ({ transport }: TestArgs) => {
+    const received: CreateMessageRequest[] = [];
+    const client = newClient();
+    client.setRequestHandler(CreateMessageRequestSchema, async req => {
+        received.push(req);
+        return { model: 'm', role: 'assistant', stopReason: 'endTurn', content: { type: 'text', text: 'ok' } };
+    });
+
+    await using _ = await wire(transport, passthroughServer, client);
+
+    await client.callTool({ name: 'sampling-passthrough', arguments: { messages: [], maxTokens: 10, systemPrompt: 'Be helpful' } });
+
+    expect(received).toHaveLength(1);
+    expect(received[0].params.systemPrompt).toBe('Be helpful');
+});
+
+verifies('sampling:create:tools', async ({ transport }: TestArgs) => {
+    const received: CreateMessageRequest[] = [];
+    const client = newClient({ sampling: { tools: {} } });
+    client.setRequestHandler(CreateMessageRequestSchema, async req => {
+        received.push(req);
+        const mode = req.params.toolChoice?.mode;
+        if (mode === 'auto' || mode === 'required') {
+            return {
+                model: 'm',
+                role: 'assistant',
+                stopReason: 'toolUse',
+                content: [{ type: 'tool_use', id: 'c1', name: 'weather', input: { city: 'SF' } }]
+            } satisfies CreateMessageResultWithTools;
+        }
+        return { model: 'm', role: 'assistant', stopReason: 'endTurn', content: { type: 'text', text: 'sunny' } };
+    });
+
+    await using _ = await wire(transport, passthroughServer, client);
+
+    const tools = [
+        { name: 'weather', description: 'Get weather', inputSchema: { type: 'object' as const, properties: { city: { type: 'string' } } } }
+    ];
+
+    for (const mode of ['auto', 'required', 'none'] as const) {
+        await client.callTool({ name: 'sampling-passthrough', arguments: { messages: [], maxTokens: 10, tools, toolChoice: { mode } } });
+    }
+
+    expect(received).toHaveLength(3);
+    for (let i = 0; i < 3; i++) {
+        expect(received[i].params.tools).toHaveLength(1);
+        expect(received[i].params.tools![0].name).toBe('weather');
+        expect(received[i].params.toolChoice?.mode).toBe(['auto', 'required', 'none'][i]);
+    }
+});
+
+verifies('sampling:error:user-rejected', async ({ transport }: TestArgs) => {
+    const client = newClient();
+    client.setRequestHandler(CreateMessageRequestSchema, async () => {
+        throw new McpError(-1, 'User rejected sampling request');
+    });
+
+    await using _ = await wire(transport, passthroughServer, client);
+
+    const r = await client.callTool({ name: 'sampling-passthrough', arguments: { messages: [], maxTokens: 10 } });
+
+    expect(r.structuredContent).toMatchObject({ ok: false, code: -1 });
+    expect((r.structuredContent as { message?: string }).message).toMatch(/User rejected sampling request/);
+});
+
+verifies('sampling:message:content-cardinality', async ({ transport }: TestArgs) => {
+    const received: CreateMessageRequest[] = [];
+    const client = newClient();
+    client.setRequestHandler(CreateMessageRequestSchema, async req => {
+        received.push(req);
+        return { model: 'm', role: 'assistant', stopReason: 'endTurn', content: { type: 'text', text: 'ok' } };
+    });
+
+    await using _ = await wire(transport, samplingServer, client);
+
+    await client.callTool({ name: 'ask-llm', arguments: { prompt: 'one' } });
+
+    expect(received).toHaveLength(1);
+    const msg = received[0].params.messages[0] as SamplingMessage;
+    expect(Array.isArray(msg.content)).toBe(false);
+    expect(msg.content).toEqual({ type: 'text', text: 'one' });
+
+    received.length = 0;
+    const client2 = newClient();
+    client2.setRequestHandler(CreateMessageRequestSchema, async req => {
+        received.push(req);
+        return { model: 'm', role: 'assistant', stopReason: 'endTurn', content: { type: 'text', text: 'ok' } };
+    });
+
+    await using _2 = await wire(transport, passthroughServer, client2);
+
+    await client2.callTool({
+        name: 'sampling-passthrough',
+        arguments: {
+            messages: [
+                {
+                    role: 'user',
+                    content: [
+                        { type: 'text', text: 'a' },
+                        { type: 'text', text: 'b' }
+                    ]
+                }
+            ],
+            maxTokens: 10
+        }
+    });
+
+    expect(received).toHaveLength(1);
+    const msg2 = received[0].params.messages[0] as SamplingMessage;
+    expect(Array.isArray(msg2.content)).toBe(true);
+    expect(msg2.content).toEqual([
+        { type: 'text', text: 'a' },
+        { type: 'text', text: 'b' }
+    ]);
+});
+
+verifies('sampling:result:no-tools-single-content', async ({ transport }: TestArgs) => {
+    const client = newClient();
+    // No tools/toolChoice in the request, so the client's wrapped sampling handler validates against CreateMessageResultSchema and rejects array content with -32602.
+    client.setRequestHandler(CreateMessageRequestSchema, async () => ({
+        model: 'm',
+        role: 'assistant',
+        stopReason: 'endTurn',
+        content: [{ type: 'text', text: 'array-content' }]
+    }));
+
+    await using _ = await wire(transport, samplingServer, client);
+
+    const r = await client.callTool({ name: 'ask-llm', arguments: { prompt: 'hi' } });
+
+    expect(r.isError).toBe(true);
+    expect(r.content).toEqual([{ type: 'text', text: expect.stringContaining('Invalid sampling result') }]);
+    // The handler's text must never reach the tool result: the client rejects before any sampling result is returned.
+    expect((r.content as [{ text: string }])[0].text).not.toContain('array-content');
+});
+
+verifies('sampling:result:with-tools-array-content', async ({ transport }: TestArgs) => {
+    const client = newClient({ sampling: { tools: {} } });
+    client.setRequestHandler(CreateMessageRequestSchema, async () => {
+        return {
+            model: 'm',
+            role: 'assistant',
+            stopReason: 'toolUse',
+            content: [
+                { type: 'text', text: 'using' },
+                { type: 'tool_use', id: 'c1', name: 'noop', input: {} }
+            ]
+        } satisfies CreateMessageResultWithTools;
+    });
+
+    await using _ = await wire(transport, passthroughServer, client);
+
+    const r = await client.callTool({
+        name: 'sampling-passthrough',
+        arguments: { messages: [], maxTokens: 10, tools: [{ name: 'noop', inputSchema: { type: 'object' as const } }] }
+    });
+
+    expect(r.structuredContent).toMatchObject({
+        ok: true,
+        result: {
+            stopReason: 'toolUse',
+            content: [
+                { type: 'text', text: 'using' },
+                { type: 'tool_use', id: 'c1', name: 'noop', input: {} }
+            ]
+        }
+    });
+});
+
+verifies('sampling:tool-result:no-mixed-content', async ({ transport }: TestArgs) => {
+    const client = newClient();
+    client.setRequestHandler(CreateMessageRequestSchema, async () => {
+        return { model: 'm', role: 'assistant', stopReason: 'endTurn', content: { type: 'text', text: 'unreachable' } };
+    });
+
+    await using _ = await wire(transport, passthroughServer, client);
+
+    const r = await client.callTool({
+        name: 'sampling-passthrough',
+        arguments: {
+            messages: [
+                { role: 'assistant', content: [{ type: 'tool_use', id: 'c1', name: 'n', input: {} }] },
+                {
+                    role: 'user',
+                    content: [
+                        { type: 'tool_result', toolUseId: 'c1', content: [] },
+                        { type: 'text', text: 'mixed' }
+                    ]
+                }
+            ],
+            maxTokens: 10
+        }
+    });
+
+    expect(r.structuredContent).toMatchObject({ ok: false, code: ErrorCode.InvalidParams });
+    expect((r.structuredContent as { message?: string }).message).toMatch(/tool.?result/i);
+});
+
+verifies('sampling:tool-use:result-balance', async ({ transport }: TestArgs) => {
+    const received: CreateMessageRequest[] = [];
+    const client = newClient({ sampling: { tools: {} } });
+    client.setRequestHandler(CreateMessageRequestSchema, async req => {
+        received.push(req);
+        return { model: 'm', role: 'assistant', stopReason: 'endTurn', content: { type: 'text', text: 'ok' } };
+    });
+
+    await using _ = await wire(transport, passthroughServer, client);
+
+    const tools = [{ name: 'weather', inputSchema: { type: 'object' as const } }];
+
+    const balanced = await client.callTool({
+        name: 'sampling-passthrough',
+        arguments: {
+            messages: [
+                { role: 'user', content: { type: 'text', text: 'hi' } },
+                { role: 'assistant', content: [{ type: 'tool_use', id: 'c1', name: 'weather', input: {} }] },
+                { role: 'user', content: [{ type: 'tool_result', toolUseId: 'c1', content: [] }] }
+            ],
+            tools,
+            maxTokens: 10
+        }
+    });
+
+    expect(balanced.structuredContent).toMatchObject({ ok: true });
+    expect(received).toHaveLength(1);
+
+    const missing = await client.callTool({
+        name: 'sampling-passthrough',
+        arguments: {
+            messages: [
+                { role: 'user', content: { type: 'text', text: 'hi' } },
+                {
+                    role: 'assistant',
+                    content: [
+                        { type: 'tool_use', id: 'a', name: 'weather', input: {} },
+                        { type: 'tool_use', id: 'b', name: 'weather', input: {} }
+                    ]
+                },
+                { role: 'user', content: [{ type: 'tool_result', toolUseId: 'a', content: [] }] }
+            ],
+            tools,
+            maxTokens: 10
+        }
+    });
+
+    expect(missing.structuredContent).toMatchObject({ ok: false, code: ErrorCode.InvalidParams });
+    expect(received).toHaveLength(1);
+
+    const trailing = await client.callTool({
+        name: 'sampling-passthrough',
+        arguments: {
+            messages: [
+                { role: 'user', content: { type: 'text', text: 'hi' } },
+                { role: 'assistant', content: [{ type: 'tool_use', id: 'c', name: 'weather', input: {} }] }
+            ],
+            tools,
+            maxTokens: 10
+        }
+    });
+
+    expect(trailing.structuredContent).toMatchObject({ ok: false, code: ErrorCode.InvalidParams });
+    expect(received).toHaveLength(1);
+});
+
+verifies('sampling:tools:server-gated-by-capability', async ({ transport }: TestArgs) => {
+    const received: CreateMessageRequest[] = [];
+    const client = newClient({ sampling: {} });
+    client.setRequestHandler(CreateMessageRequestSchema, async req => {
+        received.push(req);
+        return { model: 'm', role: 'assistant', stopReason: 'endTurn', content: { type: 'text', text: 'unreachable' } };
+    });
+
+    await using _ = await wire(transport, passthroughServer, client);
+
+    const withTools = await client.callTool({
+        name: 'sampling-passthrough',
+        arguments: { messages: [], maxTokens: 10, tools: [{ name: 'n', inputSchema: { type: 'object' as const } }] }
+    });
+
+    expect(withTools.structuredContent).toMatchObject({ ok: false });
+    expect((withTools.structuredContent as { message?: string }).message).toMatch(/sampling.*tools/i);
+    expect(received).toHaveLength(0);
+
+    const withChoice = await client.callTool({
+        name: 'sampling-passthrough',
+        arguments: { messages: [], maxTokens: 10, toolChoice: { mode: 'auto' } }
+    });
+
+    expect(withChoice.structuredContent).toMatchObject({ ok: false });
+    expect((withChoice.structuredContent as { message?: string }).message).toMatch(/sampling.*tools/i);
+    expect(received).toHaveLength(0);
+
+    const empty = await client.callTool({
+        name: 'sampling-passthrough',
+        arguments: { messages: [], maxTokens: 10, tools: [], toolChoice: { mode: 'required' } }
+    });
+
+    expect(empty.structuredContent).toMatchObject({ ok: false });
+    expect((empty.structuredContent as { message?: string }).message).toMatch(/sampling.*tools/i);
+    expect(received).toHaveLength(0);
+});
+
+verifies('sampling:create:image-content', async ({ transport }: TestArgs) => {
+    const received: CreateMessageRequest[] = [];
+    const client = newClient();
+    client.setRequestHandler(CreateMessageRequestSchema, async req => {
+        received.push(req);
+        return {
+            model: 'mock-vision-1',
+            role: 'assistant',
+            stopReason: 'endTurn',
+            content: { type: 'image', data: 'Y2F0', mimeType: 'image/png' }
+        };
+    });
+
+    await using _ = await wire(transport, passthroughServer, client);
+
+    const r = await client.callTool({
+        name: 'sampling-passthrough',
+        arguments: {
+            messages: [{ role: 'user', content: { type: 'image', data: 'aW1n', mimeType: 'image/jpeg' } }],
+            maxTokens: 100
+        }
+    });
+
+    expect(received).toHaveLength(1);
+    expect(received[0].params.messages).toEqual([{ role: 'user', content: { type: 'image', data: 'aW1n', mimeType: 'image/jpeg' } }]);
+    expect(received[0].params.maxTokens).toBe(100);
+
+    expect(r.structuredContent).toEqual({
+        ok: true,
+        result: {
+            role: 'assistant',
+            content: { type: 'image', data: 'Y2F0', mimeType: 'image/png' },
+            model: 'mock-vision-1',
+            stopReason: 'endTurn'
+        }
+    });
+});
+
+verifies('sampling:create:audio-content', async ({ transport }: TestArgs) => {
+    const received: CreateMessageRequest[] = [];
+    const client = newClient();
+    client.setRequestHandler(CreateMessageRequestSchema, async req => {
+        received.push(req);
+        return {
+            model: 'mock-audio-1',
+            role: 'assistant',
+            stopReason: 'endTurn',
+            content: { type: 'audio', data: 'aGVsbG8=', mimeType: 'audio/wav' }
+        };
+    });
+
+    await using _ = await wire(transport, passthroughServer, client);
+
+    const r = await client.callTool({
+        name: 'sampling-passthrough',
+        arguments: {
+            messages: [{ role: 'user', content: { type: 'audio', data: 'c25k', mimeType: 'audio/mpeg' } }],
+            maxTokens: 100
+        }
+    });
+
+    expect(received).toHaveLength(1);
+    expect(received[0].params.messages).toEqual([{ role: 'user', content: { type: 'audio', data: 'c25k', mimeType: 'audio/mpeg' } }]);
+    expect(received[0].params.maxTokens).toBe(100);
+
+    expect(r.structuredContent).toEqual({
+        ok: true,
+        result: {
+            role: 'assistant',
+            content: { type: 'audio', data: 'aGVsbG8=', mimeType: 'audio/wav' },
+            model: 'mock-audio-1',
+            stopReason: 'endTurn'
+        }
+    });
+});
+
+verifies('sampling:context:server-gated-by-capability', async ({ transport }: TestArgs) => {
+    const received: CreateMessageRequest[] = [];
+    // Client declares plain sampling but not the sampling.context sub-capability.
+    const client = newClient({ sampling: {} });
+    client.setRequestHandler(CreateMessageRequestSchema, async req => {
+        received.push(req);
+        return { model: 'm', role: 'assistant', stopReason: 'endTurn', content: { type: 'text', text: 'ok' } };
+    });
+
+    await using _ = await wire(transport, passthroughServer, client);
+
+    const none = await client.callTool({
+        name: 'sampling-passthrough',
+        arguments: { messages: [], maxTokens: 10, includeContext: 'none' }
+    });
+
+    expect(none.structuredContent).toMatchObject({ ok: true });
+    expect(received).toHaveLength(1);
+
+    const thisServer = await client.callTool({
+        name: 'sampling-passthrough',
+        arguments: { messages: [], maxTokens: 10, includeContext: 'thisServer' }
+    });
+
+    expect(thisServer.structuredContent).toMatchObject({ ok: false, message: expect.stringMatching(/context/i) });
+    expect(received).toHaveLength(1);
+
+    const allServers = await client.callTool({
+        name: 'sampling-passthrough',
+        arguments: { messages: [], maxTokens: 10, includeContext: 'allServers' }
+    });
+
+    expect(allServers.structuredContent).toMatchObject({ ok: false, message: expect.stringMatching(/context/i) });
+    expect(received).toHaveLength(1);
+});
+
+verifies('sampling:create:not-supported', async ({ transport }: TestArgs) => {
+    // Client declares no sampling capability at all and registers no sampling handler.
+    const client = newClient({});
+
+    await using _ = await wire(transport, () => passthroughServer({ enforceStrictCapabilities: true }), client);
+    const tap = tapWire(client);
+
+    const r = await client.callTool({
+        name: 'sampling-passthrough',
+        arguments: { messages: [{ role: 'user', content: { type: 'text', text: 'Say hello.' } }], maxTokens: 100 }
+    });
+
+    expect(r.structuredContent).toMatchObject({ ok: false, message: expect.stringMatching(/does not support sampling/i) });
+    // The refusal happens server-side: no sampling/createMessage request ever reaches the client.
+    expect(tap.received.filter(m => 'method' in m && m.method === 'sampling/createMessage')).toEqual([]);
+});

--- a/test/e2e/scenarios/sampling.test.ts
+++ b/test/e2e/scenarios/sampling.test.ts
@@ -5,19 +5,23 @@
  * sending `sampling/createMessage`. Each test builds its own server (via
  * factory) and client, wires them with {@link wire}, and asserts. Clients
  * declare the `sampling` capability and register a handler via
- * `setRequestHandler(CreateMessageRequestSchema, ...)`.
+ * `setRequestHandler('sampling/createMessage', ...)`.
  */
 
+import type { ClientCapabilities } from '@modelcontextprotocol/client';
+import { Client } from '@modelcontextprotocol/client';
+import { CreateMessageRequestParamsSchema } from '@modelcontextprotocol/core';
+import type { CreateMessageRequest, CreateMessageResultWithTools, ServerOptions } from '@modelcontextprotocol/server';
+import { McpServer, ProtocolError, ProtocolErrorCode } from '@modelcontextprotocol/server';
 import { expect } from 'vitest';
 import { z } from 'zod/v4';
-import { McpServer, ProtocolError, ProtocolErrorCode } from '@modelcontextprotocol/server';
-import type { ServerOptions, CreateMessageRequest, CreateMessageResultWithTools, SamplingMessage } from '@modelcontextprotocol/server';
-import { Client } from '@modelcontextprotocol/client';
-import { tapWire, wire } from '../helpers/index.js';
-import type { TestArgs } from '../types.js';
-import { verifies } from '../helpers/verifies.js';
 
-const newClient = (capabilities: { sampling?: object } = { sampling: {} }) => new Client({ name: 'c', version: '0' }, { capabilities });
+import { tapWire, wire } from '../helpers/index.js';
+import { verifies } from '../helpers/verifies.js';
+import type { TestArgs } from '../types.js';
+
+const newClient = (capabilities?: ClientCapabilities) =>
+    new Client({ name: 'c', version: '0' }, { capabilities: capabilities ?? { sampling: {} } });
 
 function samplingServer() {
     const s = new McpServer({ name: 's', version: '0' });
@@ -26,9 +30,8 @@ function samplingServer() {
             messages: [{ role: 'user', content: { type: 'text', text: prompt } }],
             maxTokens: 100
         });
-        const text = Array.isArray(result.content)
-            ? ((result.content[0] as { type: string; text?: string }).text ?? '')
-            : ((result.content as { type: string; text?: string }).text ?? '');
+        // Without tools in the request, createMessage returns a single content block.
+        const text = result.content.type === 'text' ? result.content.text : '';
         return { content: [{ type: 'text', text: `model said: ${text}` }] };
     });
     return s;
@@ -39,22 +42,22 @@ function passthroughServer(options?: ServerOptions) {
     s.registerTool(
         'sampling-passthrough',
         {
-            inputSchema: z.any(),
+            // The SDK's own params schema keeps the forwarded arguments fully typed without casts.
+            inputSchema: CreateMessageRequestParamsSchema,
             outputSchema: z.object({
                 ok: z.boolean(),
-                result: z.any().optional(),
+                result: z.unknown().optional(),
                 code: z.number().optional(),
                 message: z.string().optional()
             })
         },
         async args => {
             try {
-                const result = await s.server.createMessage(args as unknown as CreateMessageRequest['params']);
+                const result = await s.server.createMessage(args);
                 return { structuredContent: { ok: true, result }, content: [{ type: 'text', text: JSON.stringify(result) }] };
-            } catch (e: unknown) {
-                const err = e as { code?: number; message?: string };
-                const message = err.message ?? String(e);
-                const code = err.code ?? (e instanceof Error ? undefined : (e as { error?: { code?: number } }).error?.code);
+            } catch (error) {
+                const message = error instanceof Error ? error.message : String(error);
+                const code = error instanceof ProtocolError ? error.code : undefined;
                 return { structuredContent: { ok: false, code, message }, content: [{ type: 'text', text: message }] };
             }
         }
@@ -92,8 +95,9 @@ verifies('sampling:create:basic', async ({ transport }: TestArgs) => {
     });
 
     expect(received).toHaveLength(1);
-    expect(received[0].params.messages).toEqual([{ role: 'user', content: { type: 'text', text: 'capital?' } }]);
-    expect(received[0].params.maxTokens).toBe(50);
+    const [request] = received;
+    expect(request?.params.messages).toEqual([{ role: 'user', content: { type: 'text', text: 'capital?' } }]);
+    expect(request?.params.maxTokens).toBe(50);
 
     expect(r.structuredContent).toEqual({
         ok: true,
@@ -117,10 +121,7 @@ verifies('sampling:create:include-context', async ({ transport }: TestArgs) => {
     await client.callTool({ name: 'sampling-passthrough', arguments: { messages: [], maxTokens: 10 } });
 
     expect(received).toHaveLength(4);
-    expect(received[0].params.includeContext).toBe('none');
-    expect(received[1].params.includeContext).toBe('thisServer');
-    expect(received[2].params.includeContext).toBe('allServers');
-    expect(received[3].params.includeContext).toBeUndefined();
+    expect(received.map(r => r.params.includeContext)).toEqual(['none', 'thisServer', 'allServers', undefined]);
 });
 
 verifies('sampling:create:model-preferences', async ({ transport }: TestArgs) => {
@@ -137,7 +138,8 @@ verifies('sampling:create:model-preferences', async ({ transport }: TestArgs) =>
     await client.callTool({ name: 'sampling-passthrough', arguments: { messages: [], maxTokens: 10, modelPreferences: prefs } });
 
     expect(received).toHaveLength(1);
-    expect(received[0].params.modelPreferences).toEqual(prefs);
+    const [request] = received;
+    expect(request?.params.modelPreferences).toEqual(prefs);
 });
 
 verifies('sampling:create:system-prompt', async ({ transport }: TestArgs) => {
@@ -153,7 +155,8 @@ verifies('sampling:create:system-prompt', async ({ transport }: TestArgs) => {
     await client.callTool({ name: 'sampling-passthrough', arguments: { messages: [], maxTokens: 10, systemPrompt: 'Be helpful' } });
 
     expect(received).toHaveLength(1);
-    expect(received[0].params.systemPrompt).toBe('Be helpful');
+    const [request] = received;
+    expect(request?.params.systemPrompt).toBe('Be helpful');
 });
 
 verifies('sampling:create:tools', async ({ transport }: TestArgs) => {
@@ -184,11 +187,8 @@ verifies('sampling:create:tools', async ({ transport }: TestArgs) => {
     }
 
     expect(received).toHaveLength(3);
-    for (let i = 0; i < 3; i++) {
-        expect(received[i].params.tools).toHaveLength(1);
-        expect(received[i].params.tools![0].name).toBe('weather');
-        expect(received[i].params.toolChoice?.mode).toBe(['auto', 'required', 'none'][i]);
-    }
+    expect(received.map(r => r.params.tools?.map(t => t.name))).toEqual([['weather'], ['weather'], ['weather']]);
+    expect(received.map(r => r.params.toolChoice?.mode)).toEqual(['auto', 'required', 'none']);
 });
 
 verifies('sampling:error:user-rejected', async ({ transport }: TestArgs) => {
@@ -202,7 +202,7 @@ verifies('sampling:error:user-rejected', async ({ transport }: TestArgs) => {
     const r = await client.callTool({ name: 'sampling-passthrough', arguments: { messages: [], maxTokens: 10 } });
 
     expect(r.structuredContent).toMatchObject({ ok: false, code: -1 });
-    expect((r.structuredContent as { message?: string }).message).toMatch(/User rejected sampling request/);
+    expect(r.structuredContent?.message).toMatch(/User rejected sampling request/);
 });
 
 verifies('sampling:message:content-cardinality', async ({ transport }: TestArgs) => {
@@ -218,9 +218,9 @@ verifies('sampling:message:content-cardinality', async ({ transport }: TestArgs)
     await client.callTool({ name: 'ask-llm', arguments: { prompt: 'one' } });
 
     expect(received).toHaveLength(1);
-    const msg = received[0].params.messages[0] as SamplingMessage;
-    expect(Array.isArray(msg.content)).toBe(false);
-    expect(msg.content).toEqual({ type: 'text', text: 'one' });
+    const singleMessage = received[0]?.params.messages[0];
+    expect(Array.isArray(singleMessage?.content)).toBe(false);
+    expect(singleMessage?.content).toEqual({ type: 'text', text: 'one' });
 
     received.length = 0;
     const client2 = newClient();
@@ -229,31 +229,34 @@ verifies('sampling:message:content-cardinality', async ({ transport }: TestArgs)
         return { model: 'm', role: 'assistant', stopReason: 'endTurn', content: { type: 'text', text: 'ok' } };
     });
 
-    await using _2 = await wire(transport, passthroughServer, client2);
+    // Inner block scopes the second connection's `await using` binding.
+    {
+        await using _ = await wire(transport, passthroughServer, client2);
 
-    await client2.callTool({
-        name: 'sampling-passthrough',
-        arguments: {
-            messages: [
-                {
-                    role: 'user',
-                    content: [
-                        { type: 'text', text: 'a' },
-                        { type: 'text', text: 'b' }
-                    ]
-                }
-            ],
-            maxTokens: 10
-        }
-    });
+        await client2.callTool({
+            name: 'sampling-passthrough',
+            arguments: {
+                messages: [
+                    {
+                        role: 'user',
+                        content: [
+                            { type: 'text', text: 'a' },
+                            { type: 'text', text: 'b' }
+                        ]
+                    }
+                ],
+                maxTokens: 10
+            }
+        });
 
-    expect(received).toHaveLength(1);
-    const msg2 = received[0].params.messages[0] as SamplingMessage;
-    expect(Array.isArray(msg2.content)).toBe(true);
-    expect(msg2.content).toEqual([
-        { type: 'text', text: 'a' },
-        { type: 'text', text: 'b' }
-    ]);
+        expect(received).toHaveLength(1);
+        const arrayMessage = received[0]?.params.messages[0];
+        expect(Array.isArray(arrayMessage?.content)).toBe(true);
+        expect(arrayMessage?.content).toEqual([
+            { type: 'text', text: 'a' },
+            { type: 'text', text: 'b' }
+        ]);
+    }
 });
 
 verifies('sampling:result:no-tools-single-content', async ({ transport }: TestArgs) => {
@@ -273,7 +276,9 @@ verifies('sampling:result:no-tools-single-content', async ({ transport }: TestAr
     expect(r.isError).toBe(true);
     expect(r.content).toEqual([{ type: 'text', text: expect.stringContaining('Invalid sampling result') }]);
     // The handler's text must never reach the tool result: the client rejects before any sampling result is returned.
-    expect((r.content as [{ text: string }])[0].text).not.toContain('array-content');
+    const [block] = r.content;
+    if (block?.type !== 'text') throw new Error('expected a text content block');
+    expect(block.text).not.toContain('array-content');
 });
 
 verifies('sampling:result:with-tools-array-content', async ({ transport }: TestArgs) => {
@@ -335,7 +340,7 @@ verifies('sampling:tool-result:no-mixed-content', async ({ transport }: TestArgs
     });
 
     expect(r.structuredContent).toMatchObject({ ok: false, code: ProtocolErrorCode.InvalidParams });
-    expect((r.structuredContent as { message?: string }).message).toMatch(/tool.?result/i);
+    expect(r.structuredContent?.message).toMatch(/tool.?result/i);
 });
 
 verifies('sampling:tool-use:result-balance', async ({ transport }: TestArgs) => {
@@ -420,7 +425,7 @@ verifies('sampling:tools:server-gated-by-capability', async ({ transport }: Test
     });
 
     expect(withTools.structuredContent).toMatchObject({ ok: false });
-    expect((withTools.structuredContent as { message?: string }).message).toMatch(/sampling.*tools/i);
+    expect(withTools.structuredContent?.message).toMatch(/sampling.*tools/i);
     expect(received).toHaveLength(0);
 
     const withChoice = await client.callTool({
@@ -429,7 +434,7 @@ verifies('sampling:tools:server-gated-by-capability', async ({ transport }: Test
     });
 
     expect(withChoice.structuredContent).toMatchObject({ ok: false });
-    expect((withChoice.structuredContent as { message?: string }).message).toMatch(/sampling.*tools/i);
+    expect(withChoice.structuredContent?.message).toMatch(/sampling.*tools/i);
     expect(received).toHaveLength(0);
 
     const empty = await client.callTool({
@@ -438,7 +443,7 @@ verifies('sampling:tools:server-gated-by-capability', async ({ transport }: Test
     });
 
     expect(empty.structuredContent).toMatchObject({ ok: false });
-    expect((empty.structuredContent as { message?: string }).message).toMatch(/sampling.*tools/i);
+    expect(empty.structuredContent?.message).toMatch(/sampling.*tools/i);
     expect(received).toHaveLength(0);
 });
 
@@ -466,8 +471,9 @@ verifies('sampling:create:image-content', async ({ transport }: TestArgs) => {
     });
 
     expect(received).toHaveLength(1);
-    expect(received[0].params.messages).toEqual([{ role: 'user', content: { type: 'image', data: 'aW1n', mimeType: 'image/jpeg' } }]);
-    expect(received[0].params.maxTokens).toBe(100);
+    const [request] = received;
+    expect(request?.params.messages).toEqual([{ role: 'user', content: { type: 'image', data: 'aW1n', mimeType: 'image/jpeg' } }]);
+    expect(request?.params.maxTokens).toBe(100);
 
     expect(r.structuredContent).toEqual({
         ok: true,
@@ -504,8 +510,9 @@ verifies('sampling:create:audio-content', async ({ transport }: TestArgs) => {
     });
 
     expect(received).toHaveLength(1);
-    expect(received[0].params.messages).toEqual([{ role: 'user', content: { type: 'audio', data: 'c25k', mimeType: 'audio/mpeg' } }]);
-    expect(received[0].params.maxTokens).toBe(100);
+    const [request] = received;
+    expect(request?.params.messages).toEqual([{ role: 'user', content: { type: 'audio', data: 'c25k', mimeType: 'audio/mpeg' } }]);
+    expect(request?.params.maxTokens).toBe(100);
 
     expect(r.structuredContent).toEqual({
         ok: true,

--- a/test/e2e/scenarios/spec-2026-06-stubs.test.ts
+++ b/test/e2e/scenarios/spec-2026-06-stubs.test.ts
@@ -1,0 +1,313 @@
+/**
+ * 2026-06 spec release backlog — failing stubs.
+ *
+ * One stub per new requirement from the SEP-2260 + SEP-2575/2567 backlog (see the
+ * matching entries at the bottom of requirements.ts). Every body deliberately throws,
+ * and every requirement carries a knownFailure, so these register as expected-fail
+ * cells: the executable todo list for the next spec release.
+ *
+ * Implementing a requirement = replace its stub with a real assertion (move it to the
+ * appropriate area file), make it pass, and delete the knownFailure from the manifest.
+ * The TODO on each stub sketches the intended assertion; sub-batch labels (P0, G0,
+ * S1–S9) give the proposed implementation order — see the backlog PR description.
+ */
+
+import { verifies } from '../helpers/verifies.js';
+
+const stub = (plan: string): never => {
+    throw new Error(`stub: not yet asserted — ${plan}`);
+};
+
+// ── P0 · SEP-2260 server-request association ──
+
+verifies('protocol:assoc:nested-on-originating-stream', async () => {
+    stub(
+        'TODO(P0): during tools/call with a sampling/elicit handler, assert the server request arrives on the originating POST SSE stream, never a separate channel'
+    );
+});
+
+verifies('protocol:assoc:keepalive-during-nested', async () => {
+    stub(
+        'TODO(P0): long-running tools/call with nested elicit; assert SSE keepalive comments observed on the response stream while waiting'
+    );
+});
+
+verifies('protocol:assoc:client-rejects-unsolicited', async () => {
+    stub('TODO(P0): harness-as-server pushes sampling/createMessage with no pending outbound request; assert client responds -32602');
+});
+
+verifies('protocol:assoc:get-stream-no-requests', async () => {
+    stub('TODO(P0): open the GET SSE stream and trigger server activity; assert no roots/sampling/elicitation requests ever appear on it');
+});
+
+verifies('protocol:assoc:no-unsolicited-api', async () => {
+    stub('TODO(P0): assert the server API offers no way to send an elicit/sample/roots request outside a request handler context');
+});
+
+verifies('protocol:assoc:ping-exempt', async () => {
+    stub('TODO(P0): assert server-initiated ping is still delivered and answered outside any originating request');
+});
+
+// ── G0 · groundwork: version negotiation + the NotImplemented gate ──
+
+verifies('lifecycle:version:2026-pin-per-instance', async () => {
+    stub('TODO(G0): construct client and server pinned to ["2026-06"]; assert negotiation outside that list is refused on both sides');
+});
+
+verifies('lifecycle:version:2026-negotiable', async () => {
+    stub('TODO(G0): client and server both supporting 2026-06 agree on it; assert the agreed version is observable on both ends');
+});
+
+verifies('lifecycle:version:2026-gate-not-implemented', async () => {
+    stub(
+        'TODO(G0): negotiate 2026-06, call tools/list and tools/call; assert each fails fast with a NotImplemented error while a 2025 client on the same server works'
+    );
+});
+
+verifies('protocol:envelope:ctx-version-readable', async () => {
+    stub(
+        'TODO(G0): register a tool that echoes the protocol version from its handler context; assert it matches the negotiated/per-request version in both modes'
+    );
+});
+
+// ── S1 · server/discover + version-negotiation errors ──
+
+verifies('discover:basic', async () => {
+    stub('TODO(S1): send server/discover; assert supportedVersions, capabilities, and serverInfo in the result');
+});
+
+verifies('lifecycle:version:unsupported-error-32004', async () => {
+    stub('TODO(S1): send a request with protocolVersion "9999-01-01"; assert -32004 with the supported version list in error data');
+});
+
+verifies('lifecycle:version:unknown-method-32601', async () => {
+    stub('TODO(S1): call a nonexistent method with a valid 2026 envelope; assert -32601 and HTTP 404');
+});
+
+verifies('lifecycle:version:client-retries-from-supported', async () => {
+    stub(
+        'TODO(S1): server advertises only 2026-06; client prefers an unsupported draft; assert the client retries with a version from supported[] and never sends initialize'
+    );
+});
+
+verifies('lifecycle:version:client-retry-any-request', async () => {
+    stub('TODO(S1): tools/list at version X gets -32004 with supported [Y]; assert the client retries tools/list at Y');
+});
+
+// ── S2 · client _meta envelope stamping ──
+
+verifies('client-transport:meta:protocol-version-every-request', async () => {
+    stub('TODO(S2): tap outbound 2026 requests; assert every one carries _meta io.modelcontextprotocol/protocolVersion');
+});
+
+verifies('client-transport:meta:clientinfo-every-request', async () => {
+    stub('TODO(S2): tap outbound 2026 requests; assert clientInfo with name and version on every request');
+});
+
+verifies('client-transport:meta:capabilities-every-request', async () => {
+    stub('TODO(S2): tap outbound 2026 requests; assert clientCapabilities present (possibly {}) on every request');
+});
+
+verifies('client-transport:http:version-header-every-post', async () => {
+    stub('TODO(S2): record raw POSTs; assert MCP-Protocol-Version header on every one, equal to the _meta value');
+});
+
+verifies('client-transport:stdio:meta-envelope', async () => {
+    stub('TODO(S2): over stdio, tap outbound 2026 requests; assert the full _meta envelope is present without any header mechanism');
+});
+
+// ── S3 · server envelope acceptance + enforcement ──
+
+verifies('protocol:envelope:missing-version-rejected', async () => {
+    stub('TODO(S3): hand-craft a 2026-mode request without _meta protocolVersion; assert -32602');
+});
+
+verifies('protocol:envelope:missing-clientinfo-rejected', async () => {
+    stub('TODO(S3): hand-craft a 2026-mode request without _meta clientInfo; assert -32602');
+});
+
+verifies('hosting:http:header-meta-version-mismatch-400', async () => {
+    stub('TODO(S3): POST with header 2025-11-25 but _meta 2026-06; assert HTTP 400');
+});
+
+verifies('protocol:envelope:caps-not-inherited-across-requests', async () => {
+    stub('TODO(S3): request 1 declares sampling, request 2 declares {}; assert request 2 gets -32003 when the handler needs sampling');
+});
+
+verifies('protocol:envelope:undeclared-capability-32003', async () => {
+    stub('TODO(S3): handler needs elicitation, request _meta capabilities omit it; assert -32003 with requiredCapabilities in error data');
+});
+
+verifies('hosting:http:no-version-header-treated-legacy', async () => {
+    stub('TODO(S3): POST without MCP-Protocol-Version or _meta version; assert it is served as 2025-03-26 legacy traffic, not rejected');
+});
+
+// ── S4 · backward-compatibility probe matrix ──
+
+verifies('lifecycle:compat:dual-server-answers-initialize', async () => {
+    stub('TODO(S4): dual-stack server; legacy client sends initialize; assert InitializeResult and a working 2025 session');
+});
+
+verifies('lifecycle:compat:client-probes-discover-stdio', async () => {
+    stub('TODO(S4): dual-era client over stdio; assert its first message is server/discover with the preferred modern version in _meta');
+});
+
+verifies('lifecycle:compat:client-falls-back-to-initialize', async () => {
+    stub('TODO(S4): server answers discover with -32601; assert the client sends initialize next and completes the legacy handshake');
+});
+
+verifies('lifecycle:compat:mixed-era-one-pipe', async () => {
+    stub(
+        'TODO(S4): one stdio server receives discover (modern) then initialize (legacy) on the same pipe; assert both are answered correctly'
+    );
+});
+
+// ── S5 · sessionless + stateless HTTP ──
+
+verifies('hosting:sessionless:no-session-header', async () => {
+    stub('TODO(S5): 2026-mode POST without Mcp-Session-Id is handled; assert no Mcp-Session-Id header on any response');
+});
+
+verifies('transport:base:no-session-concept', async () => {
+    stub('TODO(S5): assert the 2026 transport surface exposes no session identifier (type-level and runtime)');
+});
+
+verifies('hosting:sessionless:get-405', async () => {
+    stub('TODO(S5): GET the MCP endpoint in 2026 mode; assert 405 and no SSE stream');
+});
+
+verifies('hosting:sessionless:no-batching', async () => {
+    stub('TODO(S5): POST a JSON-RPC batch array; assert 400');
+});
+
+verifies('hosting:sessionless:per-request-auth', async () => {
+    stub('TODO(S5): authenticated request succeeds; immediately following unauthenticated request on the same connection is rejected');
+});
+
+verifies('hosting:sessionless:no-connection-affinity', async () => {
+    stub('TODO(S5): run the same two requests over one connection and over two; assert identical results');
+});
+
+verifies('protocol:stateless:list-connection-independent', async () => {
+    stub('TODO(S5): two clients with the same auth call tools/list over separate connections; assert identical results');
+});
+
+verifies('protocol:stateless:list-no-side-effects', async () => {
+    stub('TODO(S5): tools/list, tools/call, tools/list on one connection; assert both lists identical');
+});
+
+verifies('protocol:request-id:outstanding-scope', async () => {
+    stub('TODO(S5): reuse a request id after its first request completed; assert the second request is served normally');
+});
+
+verifies('client-transport:http:accept-both-content-types', async () => {
+    stub(
+        'TODO(S5): record raw 2026 POSTs; assert Accept includes application/json and text/event-stream; serve each form and assert both parse'
+    );
+});
+
+verifies('hosting:http:notification-202', async () => {
+    stub('TODO(S5): POST a notification in 2026 mode; assert HTTP 202 with no body');
+});
+
+verifies('hosting:http:stream-notifications-relate-to-request', async () => {
+    stub('TODO(S5): tools/call with progress; assert progress notifications on the response stream carry the originating progressToken');
+});
+
+// ── S6 · removed RPCs + per-request logging ──
+
+verifies('protocol:removed:ping-32601', async () => {
+    stub('TODO(S6): send ping under a 2026 envelope; assert -32601');
+});
+
+verifies('protocol:removed:subscribe-32601', async () => {
+    stub('TODO(S6): send resources/subscribe and resources/unsubscribe under 2026; assert -32601 for both');
+});
+
+verifies('protocol:removed:setlevel-32601', async () => {
+    stub('TODO(S6): send logging/setLevel under 2026; assert -32601');
+});
+
+verifies('protocol:removed:initialize-32601-2026-only', async () => {
+    stub('TODO(S6): server configured 2026-only; send initialize; assert -32601');
+});
+
+verifies('logging:per-request:loglevel-opt-in', async () => {
+    stub('TODO(S6): handler logs during a request without _meta logLevel; assert no notifications/message on the stream');
+});
+
+verifies('logging:per-request:level-respected', async () => {
+    stub('TODO(S6): request with _meta logLevel "warning"; handler logs debug and error; assert only the error notification is delivered');
+});
+
+// ── S7 · subscriptions/listen ──
+
+verifies('subscriptions:listen-basic', async () => {
+    stub(
+        'TODO(S7): subscriptions/listen with a toolsListChanged filter; register a tool; assert the change notification arrives on the listen stream'
+    );
+});
+
+verifies('subscriptions:filter-required', async () => {
+    stub('TODO(S7): subscriptions/listen without a notifications filter; assert an error response');
+});
+
+verifies('subscriptions:opt-in-only', async () => {
+    stub('TODO(S7): listen opted into toolsListChanged only; trigger a resource update; assert it is not delivered');
+});
+
+verifies('subscriptions:ack-first-message', async () => {
+    stub('TODO(S7): open a listen stream; assert the first event is notifications/subscriptions/acknowledged');
+});
+
+verifies('subscriptions:subscription-id-on-notifications', async () => {
+    stub('TODO(S7): assert every notification delivered on the stream carries _meta subscriptionId equal to the listen request id');
+});
+
+verifies('subscriptions:cancel-stops-delivery', async () => {
+    stub('TODO(S7): cancel the listen request; trigger more changes; assert no further notifications are delivered');
+});
+
+verifies('subscriptions:server-teardown-closes', async () => {
+    stub(
+        'TODO(S7): server tears down the subscription; assert the SSE stream closes (HTTP) or notifications/cancelled is sent for the listen request (stdio)'
+    );
+});
+
+verifies('subscriptions:no-requests-on-response-streams', async () => {
+    stub('TODO(S7): inspect all response streams; assert only notifications and the final result appear, never JSON-RPC request frames');
+});
+
+verifies('subscriptions:stdio-resubscribe-after-restart', async () => {
+    stub('TODO(S7): restart the stdio server process; assert the client re-sends subscriptions/listen with the same filter');
+});
+
+verifies('subscriptions:client-routes-by-subscription-id', async () => {
+    stub('TODO(S7): two concurrent listens with different filters; assert each notification reaches only the matching handler');
+});
+
+// ── S8 · cancellation / SSE-close semantics ──
+
+verifies('protocol:cancel:sse-close-cancels', async () => {
+    stub('TODO(S8): close the SSE response stream mid-request; assert the handler abort signal fires and no further events are written');
+});
+
+verifies('protocol:cancel:stdio-notification-2026', async () => {
+    stub('TODO(S8): cancel an in-flight 2026 stdio request; assert notifications/cancelled is emitted with the request id');
+});
+
+verifies('protocol:cancel:no-messages-after-cancel-2026', async () => {
+    stub('TODO(S8): cancel a 2026 request; assert the server emits nothing further for it');
+});
+
+verifies('hosting:resume:not-honored-2026', async () => {
+    stub('TODO(S8): reconnect with Last-Event-ID in 2026 mode; assert no buffered events are replayed');
+});
+
+// ── S9 · lands with the MRTR (SEP-2322) series ──
+
+verifies('mrtr:roots-via-input-required', async () => {
+    stub(
+        'TODO(MRTR): handler asks for roots under 2026; assert the response is an InputRequiredResult containing a roots/list input request, not a pushed server request'
+    );
+});

--- a/test/e2e/scenarios/standard-schema.test.ts
+++ b/test/e2e/scenarios/standard-schema.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Self-contained test bodies for Standard Schema (standardschema.dev) support:
+ * non-Zod schema libraries (ArkType and Valibot here) passed to registerTool() /
+ * registerPrompt(), covering JSON Schema derivation for listings, argument
+ * parsing/validation before handlers run, and output-schema enforcement.
+ *
+ * Each body builds its own server (via a factory), builds its own client, and
+ * wires them with {@link wire}. Recorders live outside the factory so stateless
+ * hosting (fresh server per request) still observes them.
+ */
+
+import { Client } from '@modelcontextprotocol/client';
+import { McpServer, ProtocolError, ProtocolErrorCode } from '@modelcontextprotocol/server';
+import { toStandardJsonSchema } from '@valibot/to-json-schema';
+import { type } from 'arktype';
+import * as v from 'valibot';
+import { expect } from 'vitest';
+
+import { wire } from '../helpers/index.js';
+import { verifies } from '../helpers/verifies.js';
+import type { TestArgs } from '../types.js';
+
+/** Plain client with no extra capabilities declared. */
+const newClient = () => new Client({ name: 'c', version: '0' });
+
+verifies('standardschema:tool:arktype-input', async ({ transport }: TestArgs) => {
+    // Recorder lives outside the factory so stateless hosting (fresh server per request) shares it.
+    const handlerArgs: Array<{ sku: string; quantity: number }> = [];
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool(
+            'submit-order',
+            { description: 'Submit an order for a product.', inputSchema: type({ sku: 'string', quantity: 'number' }) },
+            ({ sku, quantity }) => {
+                handlerArgs.push({ sku, quantity });
+                return { content: [{ type: 'text', text: `ordered ${quantity} x ${sku}` }] };
+            }
+        );
+        return s;
+    };
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    const { tools } = await client.listTools();
+    const tool = tools.find(t => t.name === 'submit-order');
+    if (!tool) throw new Error('expected submit-order to be listed');
+    expect(tool.inputSchema).toMatchObject({
+        type: 'object',
+        properties: { sku: { type: 'string' }, quantity: { type: 'number' } }
+    });
+    expect([...(tool.inputSchema.required ?? [])].toSorted()).toEqual(['quantity', 'sku']);
+
+    const r = await client.callTool({ name: 'submit-order', arguments: { sku: 'SKU-1042', quantity: 3 } });
+    expect(r.isError).toBeFalsy();
+    expect(r.content).toEqual([{ type: 'text', text: 'ordered 3 x SKU-1042' }]);
+    expect(handlerArgs).toEqual([{ sku: 'SKU-1042', quantity: 3 }]);
+});
+
+verifies('standardschema:tool:valibot-input', async ({ transport }: TestArgs) => {
+    // Recorder lives outside the factory so stateless hosting (fresh server per request) shares it.
+    const handlerArgs: Array<{ sku: string; quantity: number }> = [];
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool(
+            'restock-item',
+            {
+                description: 'Restock an item.',
+                // The documented valibot path: wrap the schema with @valibot/to-json-schema so JSON Schema can be derived.
+                inputSchema: toStandardJsonSchema(v.object({ sku: v.string(), quantity: v.number() }))
+            },
+            ({ sku, quantity }) => {
+                handlerArgs.push({ sku, quantity });
+                return { content: [{ type: 'text', text: `restocked ${quantity} x ${sku}` }] };
+            }
+        );
+        return s;
+    };
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    const { tools } = await client.listTools();
+    const tool = tools.find(t => t.name === 'restock-item');
+    if (!tool) throw new Error('expected restock-item to be listed');
+    expect(tool.inputSchema).toMatchObject({
+        type: 'object',
+        properties: { sku: { type: 'string' }, quantity: { type: 'number' } }
+    });
+    expect([...(tool.inputSchema.required ?? [])].toSorted()).toEqual(['quantity', 'sku']);
+
+    const r = await client.callTool({ name: 'restock-item', arguments: { sku: 'SKU-7', quantity: 2 } });
+    expect(r.isError).toBeFalsy();
+    expect(r.content).toEqual([{ type: 'text', text: 'restocked 2 x SKU-7' }]);
+    expect(handlerArgs).toEqual([{ sku: 'SKU-7', quantity: 2 }]);
+});
+
+verifies('standardschema:tool:invalid-args-rejected', async ({ transport }: TestArgs) => {
+    // Counter lives outside the factory so stateless hosting (fresh server per request) shares it.
+    const handlerCalls = { n: 0 };
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool(
+            'set-thermostat',
+            { description: 'Set the target temperature in degrees Celsius.', inputSchema: type({ targetCelsius: 'number' }) },
+            ({ targetCelsius }) => {
+                handlerCalls.n++;
+                return { content: [{ type: 'text', text: `target set to ${targetCelsius}` }] };
+            }
+        );
+        return s;
+    };
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    // Positive control: conforming arguments reach the handler.
+    const ok = await client.callTool({ name: 'set-thermostat', arguments: { targetCelsius: 21 } });
+    expect(ok.isError).toBeFalsy();
+    expect(ok.content).toEqual([{ type: 'text', text: 'target set to 21' }]);
+    expect(handlerCalls.n).toBe(1);
+
+    // Spec: arguments failing input validation are a JSON-RPC -32602 protocol error, not a tool execution result.
+    const invalid = client.callTool({ name: 'set-thermostat', arguments: { targetCelsius: 'warm' } });
+    await expect(invalid).rejects.toBeInstanceOf(ProtocolError);
+    await expect(invalid).rejects.toMatchObject({
+        code: ProtocolErrorCode.InvalidParams,
+        message: expect.stringMatching(/input validation error/i)
+    });
+    expect(handlerCalls.n).toBe(1);
+});
+
+verifies('standardschema:tool:output-schema-validation', async ({ transport }: TestArgs) => {
+    const outputSchema = type({ healthy: 'boolean', uptimeSeconds: 'number' });
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool('get-server-status', { inputSchema: type({}), outputSchema }, () => ({
+            structuredContent: { healthy: true, uptimeSeconds: 12_345 },
+            content: [{ type: 'text', text: JSON.stringify({ healthy: true, uptimeSeconds: 12_345 }) }]
+        }));
+        s.registerTool(
+            'get-server-status-corrupt',
+            { inputSchema: type({}), outputSchema },
+            // intentionally nonconforming structuredContent (server-side output validation must reject it)
+            () => ({ structuredContent: { healthy: 'definitely', uptimeSeconds: 'a while' }, content: [] })
+        );
+        return s;
+    };
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    // Cold calls (no listTools first) so any validation observed is server-side, not the client's.
+    const ok = await client.callTool({ name: 'get-server-status', arguments: {} });
+    expect(ok.isError).toBeFalsy();
+    expect(ok.structuredContent).toEqual({ healthy: true, uptimeSeconds: 12_345 });
+
+    const corrupt = client.callTool({ name: 'get-server-status-corrupt', arguments: {} });
+    await expect(corrupt).rejects.toBeInstanceOf(ProtocolError);
+    await expect(corrupt).rejects.toMatchObject({
+        code: ProtocolErrorCode.InvalidParams,
+        message: expect.stringMatching(/output validation error/i)
+    });
+
+    // The declaration is real: tools/list advertises the outputSchema derived from the arktype type.
+    const { tools } = await client.listTools();
+    const corruptTool = tools.find(t => t.name === 'get-server-status-corrupt');
+    if (!corruptTool?.outputSchema) throw new Error('expected get-server-status-corrupt to advertise an outputSchema');
+    expect(corruptTool.outputSchema).toMatchObject({
+        type: 'object',
+        properties: { healthy: { type: 'boolean' }, uptimeSeconds: { type: 'number' } }
+    });
+});
+
+verifies('standardschema:prompt:args-schema', async ({ transport }: TestArgs) => {
+    // Recorder lives outside the factory so stateless hosting (fresh server per request) shares it.
+    const callbackArgs: Array<{ city: string }> = [];
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerPrompt(
+            'plan-itinerary',
+            { description: 'Plan a one-day itinerary for a city.', argsSchema: type({ city: 'string' }) },
+            ({ city }) => {
+                callbackArgs.push({ city });
+                return { messages: [{ role: 'user', content: { type: 'text', text: `Plan a one-day itinerary for ${city}.` } }] };
+            }
+        );
+        return s;
+    };
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    // prompts/list exposes the argument names derived from the arktype schema.
+    const { prompts } = await client.listPrompts();
+    expect(prompts).toHaveLength(1);
+    expect(prompts[0]?.name).toBe('plan-itinerary');
+    expect(prompts[0]?.arguments).toEqual([{ name: 'city', required: true }]);
+
+    const ok = await client.getPrompt({ name: 'plan-itinerary', arguments: { city: 'Lisbon' } });
+    expect(ok.messages).toEqual([{ role: 'user', content: { type: 'text', text: 'Plan a one-day itinerary for Lisbon.' } }]);
+    expect(callbackArgs).toEqual([{ city: 'Lisbon' }]);
+
+    // Arguments failing the schema are rejected before the callback runs.
+    await expect(client.getPrompt({ name: 'plan-itinerary', arguments: {} })).rejects.toMatchObject({
+        code: ProtocolErrorCode.InvalidParams,
+        message: expect.stringMatching(/invalid arguments for prompt plan-itinerary/i)
+    });
+    expect(callbackArgs).toEqual([{ city: 'Lisbon' }]);
+});

--- a/test/e2e/scenarios/stdio.test.ts
+++ b/test/e2e/scenarios/stdio.test.ts
@@ -1,0 +1,362 @@
+/**
+ * Self-contained test bodies for the real spawned-process stdio transport.
+ *
+ * Unlike other scenario areas these do not use `wire()`: every body spawns the
+ * fixture server in `fixtures/stdio-server.ts` as a real child process via
+ * {@link StdioClientTransport}, so the matrix `transport` arg is ignored and
+ * the requirements should list `transports: ['stdio']` only. Each body closes
+ * the transport in a `finally` so no child process outlives the test.
+ *
+ * Function names mirror the requirement id in camelCase.
+ */
+
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import { expect, vi } from 'vitest';
+
+import { Client } from '../../../src/client/index.js';
+import { StdioClientTransport } from '../../../src/client/stdio.js';
+import { JSONRPCMessageSchema } from '../../../src/types.js';
+
+import type { TestArgs } from '../types.js';
+import { verifies } from '../helpers/verifies.js';
+
+/** Absolute path to the runnable fixture server (executed with tsx). */
+const FIXTURE_PATH = fileURLToPath(new URL('../fixtures/stdio-server.ts', import.meta.url));
+
+/** Repo root — used as the spawn cwd so `npx`/node resolve the workspace-local `tsx`. */
+const REPO_ROOT = fileURLToPath(new URL('../../../', import.meta.url));
+
+/** Plain client with no extra capabilities declared. */
+const newClient = () => new Client({ name: 'c', version: '0' });
+
+/** True while `pid` refers to a live process (signal 0 probes existence only). */
+function processAlive(pid: number): boolean {
+    try {
+        process.kill(pid, 0);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+/** Asserts a raw wire capture is one JSON-RPC message per line (newline count == message count) and returns the lines. */
+function expectOneMessagePerLine(raw: string): string[] {
+    expect(raw.endsWith('\n')).toBe(true);
+    const lines = raw.slice(0, -1).split('\n');
+    const messages = lines.map(line => JSONRPCMessageSchema.parse(JSON.parse(line)));
+    const newlineCount = raw.split('\n').length - 1;
+    expect(messages).toHaveLength(newlineCount);
+    return lines;
+}
+
+verifies('transport:stdio:clean-shutdown', async (_args: TestArgs) => {
+    // Direct spawn (not npx) so transport.pid IS the server, with a thin wrapper
+    // logging stderr markers: the exit path is observed (stdin EOF seen, no
+    // SIGTERM delivered) instead of inferred from a wall-clock bound.
+    const wrapperScript = [
+        `process.on('SIGTERM', () => { process.stderr.write('[wrapper] sigterm received\\n'); process.exit(143); });`,
+        `process.stdin.on('end', () => { process.stderr.write('[wrapper] stdin eof\\n'); });`,
+        `await import(${JSON.stringify(pathToFileURL(FIXTURE_PATH).href)});`
+    ].join('\n');
+    const transport = new StdioClientTransport({
+        command: process.execPath,
+        args: ['--import', 'tsx', '--input-type=module', '-e', wrapperScript],
+        cwd: REPO_ROOT,
+        stderr: 'pipe'
+    });
+    const stderr = transport.stderr;
+    if (stderr === null) throw new Error('expected transport.stderr when spawned with stderr: "pipe"');
+    let captured = '';
+    stderr.on('data', (chunk: Buffer) => {
+        captured += chunk.toString();
+    });
+
+    const client = newClient();
+    let sawClose = false;
+    client.onclose = () => {
+        sawClose = true;
+    };
+
+    try {
+        await client.connect(transport);
+        const childPid = transport.pid;
+        if (childPid === null) throw new Error('expected a child pid after connect');
+        expect(processAlive(childPid)).toBe(true);
+
+        const echoed = await client.callTool({ name: 'echo', arguments: { text: 'shutting down soon' } });
+        expect(echoed.isError).toBeFalsy();
+        expect(echoed.content).toEqual([{ type: 'text', text: 'shutting down soon' }]);
+
+        // close() ends the child's stdin; a well-behaved server exits on EOF alone.
+        await client.close();
+
+        expect(sawClose).toBe(true);
+        expect(processAlive(childPid)).toBe(false);
+        await vi.waitFor(() => expect(captured).toContain('[wrapper] stdin eof'), { timeout: 2_000, interval: 25 });
+        // Exit came from the EOF path, not the SIGTERM/SIGKILL escalation ladder.
+        expect(captured).not.toContain('[wrapper] sigterm received');
+    } finally {
+        await transport.close();
+    }
+});
+
+verifies('transport:stdio:no-embedded-newlines', async (_args: TestArgs) => {
+    const payload = [
+        'first line',
+        'second line with a carriage return\r',
+        '',
+        '{"jsonrpc":"2.0","id":99,"method":"tools/call","params":{}}',
+        'last line',
+        ''
+    ].join('\n');
+
+    // Tee wrapper between client and fixture: appends each direction's raw bytes
+    // to a capture file (synchronously, before forwarding) so the serialized wire
+    // framing itself is observable, not just the content round-trip.
+    const captureDir = await mkdtemp(join(tmpdir(), 'stdio-wire-'));
+    const clientToServerPath = join(captureDir, 'client-to-server.jsonl');
+    const serverToClientPath = join(captureDir, 'server-to-client.jsonl');
+    const teeScript = [
+        `import { spawn } from 'node:child_process';`,
+        `import { appendFileSync } from 'node:fs';`,
+        `const child = spawn(process.execPath, ['--import', 'tsx', ${JSON.stringify(FIXTURE_PATH)}], { stdio: ['pipe', 'pipe', 'inherit'] });`,
+        `process.stdin.on('data', c => { appendFileSync(${JSON.stringify(clientToServerPath)}, c); child.stdin.write(c); });`,
+        `process.stdin.on('end', () => child.stdin.end());`,
+        `child.stdout.on('data', c => { appendFileSync(${JSON.stringify(serverToClientPath)}, c); process.stdout.write(c); });`,
+        `child.on('exit', code => process.exit(code === null ? 1 : code));`
+    ].join('\n');
+
+    const transport = new StdioClientTransport({
+        command: process.execPath,
+        args: ['--input-type=module', '-e', teeScript],
+        cwd: REPO_ROOT
+    });
+    const client = newClient();
+    try {
+        await client.connect(transport);
+
+        // Round-trip sanity check: the multi-line payload survives intact.
+        const echoed = await client.callTool({ name: 'echo', arguments: { text: payload } });
+        expect(echoed.isError).toBeFalsy();
+        expect(echoed.content).toEqual([{ type: 'text', text: payload }]);
+
+        const after = await client.callTool({ name: 'echo', arguments: { text: 'still framed' } });
+        expect(after.content).toEqual([{ type: 'text', text: 'still framed' }]);
+
+        // Captures are complete once the calls above resolved (bytes are written
+        // to disk before being forwarded), so read them before close().
+        const clientLines = expectOneMessagePerLine(await readFile(clientToServerPath, 'utf8'));
+        const serverLines = expectOneMessagePerLine(await readFile(serverToClientPath, 'utf8'));
+
+        // initialize, notifications/initialized, two tools/call ↔ three responses.
+        expect(clientLines).toHaveLength(4);
+        expect(serverLines).toHaveLength(3);
+
+        // The newline-riddled payload crossed each direction inside exactly one
+        // line, escaped — never split across lines.
+        const escapedPayload = JSON.stringify(payload);
+        expect(clientLines.filter(line => line.includes(escapedPayload))).toHaveLength(1);
+        expect(serverLines.filter(line => line.includes(escapedPayload))).toHaveLength(1);
+    } finally {
+        await transport.close();
+        await rm(captureDir, { recursive: true, force: true });
+    }
+});
+
+verifies('transport:stdio:shutdown-escalation', async (_args: TestArgs) => {
+    // Spawned directly (`node --import tsx`) instead of via `npx tsx`: close()
+    // signals the process the transport spawned, and behind npx the SIGTERM/
+    // SIGKILL escalation would only ever reach the npx wrapper while the real
+    // server — which ignores SIGTERM — survived as an orphan. Direct spawn makes
+    // the spawned process BE the server so the full ladder is observable.
+    const transport = new StdioClientTransport({
+        command: process.execPath,
+        args: ['--import', 'tsx', FIXTURE_PATH],
+        cwd: REPO_ROOT,
+        env: { E2E_IGNORE_SIGTERM: '1' },
+        stderr: 'pipe'
+    });
+    const stderr = transport.stderr;
+    if (stderr === null) throw new Error('expected transport.stderr when spawned with stderr: "pipe"');
+    let captured = '';
+    stderr.on('data', (chunk: Buffer) => {
+        captured += chunk.toString();
+    });
+
+    const client = newClient();
+    let childPid: number | null = null;
+    try {
+        await client.connect(transport);
+        childPid = transport.pid;
+        if (childPid === null) throw new Error('expected a child pid after connect');
+        const pid = childPid;
+        expect(processAlive(pid)).toBe(true);
+
+        const echoed = await client.callTool({ name: 'echo', arguments: { text: 'about to ignore shutdown' } });
+        expect(echoed.content).toEqual([{ type: 'text', text: 'about to ignore shutdown' }]);
+
+        // The fixture survives stdin EOF and swallows SIGTERM, so close() must
+        // walk the whole escalation ladder (two grace periods, ~4s wall clock).
+        await client.close();
+
+        // SIGTERM really was delivered and ignored — surviving rung 1 (stdin
+        // EOF) and rung 2 (SIGTERM) is proven by the marker, so the child's
+        // termination below can only have come from the SIGKILL escalation.
+        await vi.waitFor(() => expect(captured).toContain('[stdio-server] sigterm ignored'), { timeout: 1_000, interval: 25 });
+        await vi.waitFor(() => expect(processAlive(pid)).toBe(false), { timeout: 2_000, interval: 25 });
+    } finally {
+        await transport.close();
+        // Belt and braces: if an assertion threw mid-ladder the stubborn child
+        // may still be alive and must not outlive the test run.
+        if (childPid !== null && processAlive(childPid)) {
+            process.kill(childPid, 'SIGKILL');
+        }
+    }
+});
+
+verifies('transport:stdio:stderr-passthrough', async (_args: TestArgs) => {
+    const transport = new StdioClientTransport({ command: 'npx', args: ['tsx', FIXTURE_PATH], cwd: REPO_ROOT, stderr: 'pipe' });
+
+    // With stderr: 'pipe' the stream is available before start(), so listeners
+    // attached here cannot miss output written while the server boots.
+    const stderr = transport.stderr;
+    if (stderr === null) throw new Error('expected transport.stderr when spawned with stderr: "pipe"');
+    let captured = '';
+    stderr.on('data', (chunk: Buffer) => {
+        captured += chunk.toString();
+    });
+
+    const client = newClient();
+    try {
+        await client.connect(transport);
+
+        // The startup marker the server wrote to stderr is observable on
+        // transport.stderr — the transport neither swallows it nor mixes it
+        // into the stdout JSON-RPC channel.
+        await vi.waitFor(() => expect(captured).toContain('[stdio-server] ready'), { timeout: 2_000, interval: 25 });
+
+        // ...and stderr output does not disturb the JSON-RPC channel itself.
+        const echoed = await client.callTool({ name: 'echo', arguments: { text: 'hello over stdio' } });
+        expect(echoed.isError).toBeFalsy();
+        expect(echoed.content).toEqual([{ type: 'text', text: 'hello over stdio' }]);
+    } finally {
+        await transport.close();
+    }
+});
+
+verifies('lifecycle:connect:onerror-pre-handshake', async (_args: TestArgs) => {
+    // Requirement: 'Transport errors emitted after transport.start() but before
+    // client.connect() resolves are delivered to a client.onerror handler set
+    // prior to connect (Protocol wires transport.onerror before start() and
+    // before the initialize handshake).'
+    //
+    // Spawn the fixture with E2E_GARBAGE_STDOUT=1: it writes non-JSON garbage to
+    // stdout immediately (before the handshake) and exits. The garbage fails to
+    // parse, triggering transport.onerror. Assert that client.onerror fires and
+    // that connect() does not hang or falsely succeed.
+
+    const transport = new StdioClientTransport({
+        command: 'npx',
+        args: ['tsx', FIXTURE_PATH],
+        cwd: REPO_ROOT,
+        env: { E2E_GARBAGE_STDOUT: '1' }
+    });
+
+    const client = newClient();
+    const errors: Error[] = [];
+    client.onerror = (error: Error) => {
+        errors.push(error);
+    };
+
+    try {
+        // connect() should either reject (because the handshake never completes)
+        // or hang until timeout. We bound the whole test well under 10s by racing
+        // with a short timeout, ensuring we don't wait forever if the SDK
+        // incorrectly succeeds or hangs.
+        const connectPromise = client.connect(transport);
+        const timeoutPromise = new Promise((_, reject) =>
+            setTimeout(() => reject(new Error('connect timed out (expected behavior)')), 8_000)
+        );
+
+        await expect(Promise.race([connectPromise, timeoutPromise])).rejects.toThrow();
+
+        // At this point, client.onerror should have fired at least once due to
+        // the garbage JSON parse failures.
+        expect(errors.length).toBeGreaterThan(0);
+
+        // At least one error should relate to JSON parsing of the garbage lines.
+        const hasJsonError = errors.some(
+            e => e.message.includes('JSON') || e.message.includes('parse') || e.message.includes('Unexpected token')
+        );
+        expect(hasJsonError).toBe(true);
+    } finally {
+        await transport.close();
+    }
+});
+
+verifies('transport:stdio:default-env-safelist', async (_args: TestArgs) => {
+    // Requirement: 'StdioClientTransport spawned with no `env` option passes
+    // only DEFAULT_INHERITED_ENV_VARS (PATH, HOME, USER, …) to the child;
+    // arbitrary parent process.env entries (secrets) are not inherited.
+    // getDefaultEnvironment() is the public helper that produces this safelist.'
+    //
+    // Set a sentinel env var in the parent for the duration of this test, spawn
+    // the fixture WITHOUT passing env (so getDefaultEnvironment() is applied),
+    // call the env-report tool to see which variable NAMES reached the child,
+    // then assert the sentinel is NOT present while expected safelisted vars are.
+
+    const SENTINEL_KEY = 'E2E_SECRET_SENTINEL';
+    const originalValue = process.env[SENTINEL_KEY];
+    process.env[SENTINEL_KEY] = 'should-not-reach-child';
+
+    const transport = new StdioClientTransport({
+        command: 'npx',
+        args: ['tsx', FIXTURE_PATH],
+        cwd: REPO_ROOT
+        // Deliberately omit `env` option, so getDefaultEnvironment() applies.
+    });
+
+    const client = newClient();
+    try {
+        await client.connect(transport);
+
+        // Call env-report tool: returns JSON.stringify(Object.keys(process.env).sort()).
+        const result = await client.callTool({ name: 'env-report', arguments: {} });
+        expect(result.isError).toBeFalsy();
+        if (!result.content || !Array.isArray(result.content)) {
+            throw new Error('expected content array from env-report');
+        }
+        expect(result.content).toHaveLength(1);
+        const firstContent = result.content[0];
+        if (!firstContent || firstContent.type !== 'text') {
+            throw new Error('expected text content from env-report');
+        }
+        const childEnvKeys: string[] = JSON.parse(firstContent.text);
+
+        // The sentinel must NOT be present in the child.
+        expect(childEnvKeys).not.toContain(SENTINEL_KEY);
+
+        // At least one safelisted variable (from DEFAULT_INHERITED_ENV_VARS)
+        // should be present. We pick variables that are very likely to exist
+        // on any platform the test runs on.
+        const expectedKeys = process.platform === 'win32' ? ['PATH', 'SYSTEMROOT'] : ['PATH', 'HOME'];
+        for (const key of expectedKeys) {
+            // Only assert presence if the parent has it (some minimal containers might lack HOME).
+            if (process.env[key] !== undefined) {
+                expect(childEnvKeys).toContain(key);
+            }
+        }
+    } finally {
+        await transport.close();
+        // Restore original env state.
+        if (originalValue === undefined) {
+            delete process.env[SENTINEL_KEY];
+        } else {
+            process.env[SENTINEL_KEY] = originalValue;
+        }
+    }
+});

--- a/test/e2e/scenarios/stdio.test.ts
+++ b/test/e2e/scenarios/stdio.test.ts
@@ -16,11 +16,9 @@ import { join } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
 import { expect, vi } from 'vitest';
-
-import { Client } from '../../../src/client/index.js';
-import { StdioClientTransport } from '../../../src/client/stdio.js';
-import { JSONRPCMessageSchema } from '../../../src/types.js';
-
+import { StdioClientTransport } from '@modelcontextprotocol/client/stdio';
+import { Client } from '@modelcontextprotocol/client';
+import { JSONRPCMessageSchema } from '@modelcontextprotocol/core';
 import type { TestArgs } from '../types.js';
 import { verifies } from '../helpers/verifies.js';
 

--- a/test/e2e/scenarios/stdio.test.ts
+++ b/test/e2e/scenarios/stdio.test.ts
@@ -12,21 +12,22 @@
 
 import { mkdtemp, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
-import { expect, vi } from 'vitest';
-import { StdioClientTransport } from '@modelcontextprotocol/client/stdio';
 import { Client } from '@modelcontextprotocol/client';
+import { StdioClientTransport } from '@modelcontextprotocol/client/stdio';
 import { JSONRPCMessageSchema } from '@modelcontextprotocol/core';
-import type { TestArgs } from '../types.js';
+import { expect, vi } from 'vitest';
+
 import { verifies } from '../helpers/verifies.js';
+import type { TestArgs } from '../types.js';
 
 /** Absolute path to the runnable fixture server (executed with tsx). */
 const FIXTURE_PATH = fileURLToPath(new URL('../fixtures/stdio-server.ts', import.meta.url));
 
-/** Repo root — used as the spawn cwd so `npx`/node resolve the workspace-local `tsx`. */
-const REPO_ROOT = fileURLToPath(new URL('../../../', import.meta.url));
+/** E2E package root — spawn cwd so `npx`/node resolve the local `tsx` and its tsconfig paths map workspace packages to source. */
+const E2E_ROOT = fileURLToPath(new URL('../', import.meta.url));
 
 /** Plain client with no extra capabilities declared. */
 const newClient = () => new Client({ name: 'c', version: '0' });
@@ -56,14 +57,14 @@ verifies('transport:stdio:clean-shutdown', async (_args: TestArgs) => {
     // logging stderr markers: the exit path is observed (stdin EOF seen, no
     // SIGTERM delivered) instead of inferred from a wall-clock bound.
     const wrapperScript = [
-        `process.on('SIGTERM', () => { process.stderr.write('[wrapper] sigterm received\\n'); process.exit(143); });`,
-        `process.stdin.on('end', () => { process.stderr.write('[wrapper] stdin eof\\n'); });`,
+        String.raw`process.on('SIGTERM', () => { process.stderr.write('[wrapper] sigterm received\n'); process.exit(143); });`,
+        String.raw`process.stdin.on('end', () => { process.stderr.write('[wrapper] stdin eof\n'); });`,
         `await import(${JSON.stringify(pathToFileURL(FIXTURE_PATH).href)});`
     ].join('\n');
     const transport = new StdioClientTransport({
         command: process.execPath,
         args: ['--import', 'tsx', '--input-type=module', '-e', wrapperScript],
-        cwd: REPO_ROOT,
+        cwd: E2E_ROOT,
         stderr: 'pipe'
     });
     const stderr = transport.stderr;
@@ -94,7 +95,7 @@ verifies('transport:stdio:clean-shutdown', async (_args: TestArgs) => {
 
         expect(sawClose).toBe(true);
         expect(processAlive(childPid)).toBe(false);
-        await vi.waitFor(() => expect(captured).toContain('[wrapper] stdin eof'), { timeout: 2_000, interval: 25 });
+        await vi.waitFor(() => expect(captured).toContain('[wrapper] stdin eof'), { timeout: 2000, interval: 25 });
         // Exit came from the EOF path, not the SIGTERM/SIGKILL escalation ladder.
         expect(captured).not.toContain('[wrapper] sigterm received');
     } finally {
@@ -115,9 +116,9 @@ verifies('transport:stdio:no-embedded-newlines', async (_args: TestArgs) => {
     // Tee wrapper between client and fixture: appends each direction's raw bytes
     // to a capture file (synchronously, before forwarding) so the serialized wire
     // framing itself is observable, not just the content round-trip.
-    const captureDir = await mkdtemp(join(tmpdir(), 'stdio-wire-'));
-    const clientToServerPath = join(captureDir, 'client-to-server.jsonl');
-    const serverToClientPath = join(captureDir, 'server-to-client.jsonl');
+    const captureDir = await mkdtemp(path.join(tmpdir(), 'stdio-wire-'));
+    const clientToServerPath = path.join(captureDir, 'client-to-server.jsonl');
+    const serverToClientPath = path.join(captureDir, 'server-to-client.jsonl');
     const teeScript = [
         `import { spawn } from 'node:child_process';`,
         `import { appendFileSync } from 'node:fs';`,
@@ -131,7 +132,7 @@ verifies('transport:stdio:no-embedded-newlines', async (_args: TestArgs) => {
     const transport = new StdioClientTransport({
         command: process.execPath,
         args: ['--input-type=module', '-e', teeScript],
-        cwd: REPO_ROOT
+        cwd: E2E_ROOT
     });
     const client = newClient();
     try {
@@ -174,7 +175,7 @@ verifies('transport:stdio:shutdown-escalation', async (_args: TestArgs) => {
     const transport = new StdioClientTransport({
         command: process.execPath,
         args: ['--import', 'tsx', FIXTURE_PATH],
-        cwd: REPO_ROOT,
+        cwd: E2E_ROOT,
         env: { E2E_IGNORE_SIGTERM: '1' },
         stderr: 'pipe'
     });
@@ -204,8 +205,8 @@ verifies('transport:stdio:shutdown-escalation', async (_args: TestArgs) => {
         // SIGTERM really was delivered and ignored — surviving rung 1 (stdin
         // EOF) and rung 2 (SIGTERM) is proven by the marker, so the child's
         // termination below can only have come from the SIGKILL escalation.
-        await vi.waitFor(() => expect(captured).toContain('[stdio-server] sigterm ignored'), { timeout: 1_000, interval: 25 });
-        await vi.waitFor(() => expect(processAlive(pid)).toBe(false), { timeout: 2_000, interval: 25 });
+        await vi.waitFor(() => expect(captured).toContain('[stdio-server] sigterm ignored'), { timeout: 1000, interval: 25 });
+        await vi.waitFor(() => expect(processAlive(pid)).toBe(false), { timeout: 2000, interval: 25 });
     } finally {
         await transport.close();
         // Belt and braces: if an assertion threw mid-ladder the stubborn child
@@ -217,7 +218,7 @@ verifies('transport:stdio:shutdown-escalation', async (_args: TestArgs) => {
 });
 
 verifies('transport:stdio:stderr-passthrough', async (_args: TestArgs) => {
-    const transport = new StdioClientTransport({ command: 'npx', args: ['tsx', FIXTURE_PATH], cwd: REPO_ROOT, stderr: 'pipe' });
+    const transport = new StdioClientTransport({ command: 'npx', args: ['tsx', FIXTURE_PATH], cwd: E2E_ROOT, stderr: 'pipe' });
 
     // With stderr: 'pipe' the stream is available before start(), so listeners
     // attached here cannot miss output written while the server boots.
@@ -235,7 +236,7 @@ verifies('transport:stdio:stderr-passthrough', async (_args: TestArgs) => {
         // The startup marker the server wrote to stderr is observable on
         // transport.stderr — the transport neither swallows it nor mixes it
         // into the stdout JSON-RPC channel.
-        await vi.waitFor(() => expect(captured).toContain('[stdio-server] ready'), { timeout: 2_000, interval: 25 });
+        await vi.waitFor(() => expect(captured).toContain('[stdio-server] ready'), { timeout: 2000, interval: 25 });
 
         // ...and stderr output does not disturb the JSON-RPC channel itself.
         const echoed = await client.callTool({ name: 'echo', arguments: { text: 'hello over stdio' } });
@@ -252,15 +253,15 @@ verifies('lifecycle:connect:onerror-pre-handshake', async (_args: TestArgs) => {
     // prior to connect (Protocol wires transport.onerror before start() and
     // before the initialize handshake).'
     //
-    // Spawn the fixture with E2E_GARBAGE_STDOUT=1: it writes non-JSON garbage to
-    // stdout immediately (before the handshake) and exits. The garbage fails to
-    // parse, triggering transport.onerror. Assert that client.onerror fires and
-    // that connect() does not hang or falsely succeed.
+    // Spawn the fixture with E2E_GARBAGE_STDOUT=1: before the handshake it writes
+    // non-JSON noise (which v2 deliberately skips) plus a schema-invalid JSON-RPC
+    // line, which must surface through transport.onerror. Assert that
+    // client.onerror fires and that connect() does not hang or falsely succeed.
 
     const transport = new StdioClientTransport({
         command: 'npx',
         args: ['tsx', FIXTURE_PATH],
-        cwd: REPO_ROOT,
+        cwd: E2E_ROOT,
         env: { E2E_GARBAGE_STDOUT: '1' }
     });
 
@@ -277,7 +278,7 @@ verifies('lifecycle:connect:onerror-pre-handshake', async (_args: TestArgs) => {
         // incorrectly succeeds or hangs.
         const connectPromise = client.connect(transport);
         const timeoutPromise = new Promise((_, reject) =>
-            setTimeout(() => reject(new Error('connect timed out (expected behavior)')), 8_000)
+            setTimeout(() => reject(new Error('connect timed out (expected behavior)')), 8000)
         );
 
         await expect(Promise.race([connectPromise, timeoutPromise])).rejects.toThrow();
@@ -286,9 +287,14 @@ verifies('lifecycle:connect:onerror-pre-handshake', async (_args: TestArgs) => {
         // the garbage JSON parse failures.
         expect(errors.length).toBeGreaterThan(0);
 
-        // At least one error should relate to JSON parsing of the garbage lines.
+        // At least one error should be the parse/schema failure for the garbage lines.
         const hasJsonError = errors.some(
-            e => e.message.includes('JSON') || e.message.includes('parse') || e.message.includes('Unexpected token')
+            e =>
+                e.message.includes('JSON') ||
+                e.message.includes('parse') ||
+                e.message.includes('Unexpected token') ||
+                // changed in v2: schema-invalid lines surface as a validation error naming the jsonrpc field
+                e.message.includes('"jsonrpc"')
         );
         expect(hasJsonError).toBe(true);
     } finally {
@@ -314,7 +320,7 @@ verifies('transport:stdio:default-env-safelist', async (_args: TestArgs) => {
     const transport = new StdioClientTransport({
         command: 'npx',
         args: ['tsx', FIXTURE_PATH],
-        cwd: REPO_ROOT
+        cwd: E2E_ROOT
         // Deliberately omit `env` option, so getDefaultEnvironment() applies.
     });
 

--- a/test/e2e/scenarios/tasks.test.ts
+++ b/test/e2e/scenarios/tasks.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Self-contained test bodies for experimental task-augmented tool calls
+ * (`tasks:` requirements): a tool whose asynchronous work fails after the
+ * server has already returned a CreateTaskResult must store that failure in
+ * the task store with status `failed`, and a later `tasks/result` request for
+ * the task must return the stored error result.
+ */
+
+import { Client } from '@modelcontextprotocol/client';
+import { InMemoryTaskStore, isSpecType, McpServer, RELATED_TASK_META_KEY, specTypeSchemas } from '@modelcontextprotocol/server';
+import { expect, vi } from 'vitest';
+import { z } from 'zod/v4';
+
+import { tapWire, wire } from '../helpers/index.js';
+import { verifies } from '../helpers/verifies.js';
+import type { TestArgs } from '../types.js';
+
+verifies('tasks:result:failed-task-stored-result', async ({ transport }: TestArgs) => {
+    const taskStore = new InMemoryTaskStore();
+    try {
+        // The deployment work this tool kicks off always fails, so the handler's failure path runs.
+        const pushReleaseImage = async (version: string): Promise<void> => {
+            throw new Error(`Deploy of ${version} failed: image registry unreachable`);
+        };
+
+        const makeServer = () => {
+            const s = new McpServer(
+                { name: 's', version: '0' },
+                { capabilities: { tasks: { requests: { tools: { call: {} } }, taskStore } } }
+            );
+            s.experimental.tasks.registerToolTask(
+                'deploy-release',
+                {
+                    description: 'Deploys a release image to the production fleet',
+                    inputSchema: z.object({ version: z.string() })
+                },
+                {
+                    async createTask({ version }, ctx) {
+                        const task = await ctx.task.store.createTask({ ttl: 60_000, pollInterval: 50 });
+                        const work = (async () => {
+                            // Let the CreateTaskResult response go out before the work fails.
+                            await new Promise(resolve => setTimeout(resolve, 10));
+                            try {
+                                await pushReleaseImage(version);
+                                await ctx.task.store.storeTaskResult(task.taskId, 'completed', {
+                                    content: [{ type: 'text', text: `Deployed ${version}` }]
+                                });
+                            } catch (error) {
+                                const text = error instanceof Error ? error.message : String(error);
+                                await ctx.task.store.storeTaskResult(task.taskId, 'failed', {
+                                    content: [{ type: 'text', text }],
+                                    isError: true
+                                });
+                            }
+                        })();
+                        // A status notification emitted after teardown must not surface as an unhandled rejection.
+                        work.catch(() => {});
+                        return { task };
+                    },
+                    async getTask(_args, ctx) {
+                        return await ctx.task.store.getTask(ctx.task.id);
+                    },
+                    async getTaskResult(_args, ctx) {
+                        const stored = await ctx.task.store.getTaskResult(ctx.task.id);
+                        const validated = specTypeSchemas.CallToolResult['~standard'].validate(stored);
+                        if (validated.issues) {
+                            throw new Error('stored task result is not a valid CallToolResult');
+                        }
+                        return validated.value;
+                    }
+                }
+            );
+            return s;
+        };
+        const client = new Client({ name: 'c', version: '0' }, { capabilities: { tasks: {} } });
+
+        await using _ = await wire(transport, makeServer, client);
+        const tap = tapWire(client);
+
+        const createResult = await client.request({
+            method: 'tools/call',
+            params: { name: 'deploy-release', arguments: { version: '2.4.1' }, task: { ttl: 60_000 } }
+        });
+        if (!isSpecType.CreateTaskResult(createResult)) {
+            throw new Error('expected the task-augmented tools/call to return a CreateTaskResult');
+        }
+        const taskId = createResult.task.taskId;
+
+        // The failure must be recorded in the task store with terminal status 'failed', observable via tasks/get.
+        await vi.waitFor(
+            async () => {
+                const polled = await client.experimental.tasks.getTask(taskId);
+                expect(polled.status).toBe('failed');
+            },
+            { timeout: 5000 }
+        );
+
+        // A subsequent tasks/result request returns the stored error result rather than losing it.
+        const stored = await client.experimental.tasks.getTaskResult(taskId);
+        expect(stored.isError).toBe(true);
+        expect(stored.content).toEqual([{ type: 'text', text: 'Deploy of 2.4.1 failed: image registry unreachable' }]);
+        expect(stored._meta?.[RELATED_TASK_META_KEY]).toEqual({ taskId });
+
+        const tasksResultRequests = tap.sent.filter(m => 'method' in m && m.method === 'tasks/result');
+        expect(tasksResultRequests).toHaveLength(1);
+    } finally {
+        taskStore.cleanup();
+    }
+});

--- a/test/e2e/scenarios/tools.test.ts
+++ b/test/e2e/scenarios/tools.test.ts
@@ -1,0 +1,1302 @@
+/**
+ * Self-contained test bodies for the tools surface.
+ *
+ * Each export is a {@link TestCase}: it builds its own server (via a factory),
+ * builds its own client, wires them with {@link wire}, and asserts. There are
+ * no shared fixture imports; helpers local to multiple bodies live at the top
+ * of this file.
+ *
+ * `wire()` takes a *factory* because that's the production shape: per-session
+ * HTTP creates a fresh server per session, stateless per request. Bodies that
+ * inspect server-side state therefore declare the recorder *outside* the
+ * factory so every server instance closes over the same array. Bodies that
+ * need a specific instance handle (e.g. to call `.update()`) capture it via
+ * `let server!: McpServer` and rely on `requirements/tools.ts` to mark
+ * `skipOn` for stateless where the captured ref is not the one serving
+ * subsequent requests.
+ *
+ * Function names mirror the requirement id in camelCase; a `Raw` suffix marks
+ * a low-level {@link Server} variant where the behavior under test differs by
+ * tier.
+ */
+
+import { expect, vi } from 'vitest';
+import { z } from 'zod/v4';
+
+import { Client } from '../../../src/client/index.js';
+import { Server } from '../../../src/server/index.js';
+import { McpServer, type RegisteredTool } from '../../../src/server/mcp.js';
+import {
+    CallToolRequestSchema,
+    CompatibilityCallToolResultSchema,
+    type CreateMessageRequest,
+    CreateMessageRequestSchema,
+    type CreateMessageResult,
+    type ElicitRequest,
+    ElicitRequestSchema,
+    ErrorCode,
+    type JSONRPCMessage,
+    ListToolsRequestSchema,
+    LoggingMessageNotificationSchema,
+    McpError,
+    type RequestId,
+    type Tool,
+    ToolListChangedNotificationSchema,
+    UrlElicitationRequiredError
+} from '../../../src/types.js';
+import { AjvJsonSchemaValidator } from '../../../src/validation/ajv-provider.js';
+
+import { wire } from '../helpers/index.js';
+import type { TestArgs } from '../types.js';
+import { verifies } from '../helpers/verifies.js';
+
+const TINY_PNG_BASE64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=';
+const TINY_WAV_BASE64 = 'UklGRiQAAABXQVZFZm10IBAAAAABAAEAQB8AAEAfAAABAAgAZGF0YQAAAAA=';
+const TINY_BLOB_BASE64 = 'SGVsbG8sIE1DUCE=';
+
+/** Raw JSON Schema 2020-12 inputSchema used by the `Raw` schema-preservation tests. */
+const JSON_SCHEMA_2020_12_INPUT = {
+    $schema: 'https://json-schema.org/draft/2020-12/schema',
+    type: 'object' as const,
+    properties: { point: { $ref: '#/$defs/Point' } },
+    required: ['point'],
+    additionalProperties: false,
+    $defs: {
+        Point: {
+            type: 'object',
+            properties: { x: { type: 'number' }, y: { type: 'number' } },
+            required: ['x', 'y'],
+            additionalProperties: false
+        }
+    }
+};
+
+/** Plain client with no extra capabilities declared. */
+const newClient = () => new Client({ name: 'c', version: '0' });
+
+/** McpServer factory that registers `echo` — the smallest useful server. */
+function echoServer(): McpServer {
+    const s = new McpServer({ name: 's', version: '0' });
+    s.registerTool(
+        'echo',
+        { description: 'Echoes the input text back as a text content block.', inputSchema: z.object({ text: z.string() }) },
+        ({ text }) => ({ content: [{ type: 'text', text }] })
+    );
+    return s;
+}
+
+/** McpServer factory carrying the structured/output-schema fixture set. */
+function schemaServer(): McpServer {
+    const s = new McpServer({ name: 's', version: '0' });
+    s.registerTool(
+        'structured',
+        { inputSchema: z.object({ n: z.number() }), outputSchema: z.object({ doubled: z.number().int() }) },
+        ({ n }) => ({ structuredContent: { doubled: n * 2 }, content: [{ type: 'text', text: JSON.stringify({ doubled: n * 2 }) }] })
+    );
+    s.registerTool(
+        'structured-mismatch',
+        { inputSchema: z.object({}), outputSchema: z.object({ value: z.number() }) },
+        // intentionally invalid structuredContent (tests server-side validation rejects it)
+        () => ({ structuredContent: { value: 'not-a-number' }, content: [] })
+    );
+    s.registerTool('structured-missing', { inputSchema: z.object({}), outputSchema: z.object({ value: z.number() }) }, () => ({
+        content: [{ type: 'text', text: 'handler-body-no-structured' }]
+    }));
+    s.registerTool('structured-error-skip', { inputSchema: z.object({}), outputSchema: z.object({ value: z.number() }) }, () => ({
+        isError: true,
+        content: [{ type: 'text', text: 'handler-returned-isError' }]
+    }));
+    return s;
+}
+
+/** Low-level Server factory listing/calling a single hand-authored JSON-Schema-2020-12 tool. */
+function rawJsonSchemaServer(): Server {
+    const s = new Server({ name: 's', version: '0' }, { capabilities: { tools: {} } });
+    s.setRequestHandler(ListToolsRequestSchema, () => ({
+        tools: [{ name: 'json-schema', description: 'raw 2020-12 schema', inputSchema: JSON_SCHEMA_2020_12_INPUT }]
+    }));
+    s.setRequestHandler(CallToolRequestSchema, req => {
+        const { x, y } = (req.params.arguments as { point: { x: number; y: number } }).point;
+        return { content: [{ type: 'text', text: `(${x}, ${y})` }] };
+    });
+    return s;
+}
+
+/** Low-level Server factory with output-schema fixtures and NO server-side validation. */
+function rawSchemaServer(): Server {
+    const s = new Server({ name: 's', version: '0' }, { capabilities: { tools: {} } });
+    const outputSchema: Tool['outputSchema'] = { type: 'object', properties: { value: { type: 'number' } }, required: ['value'] };
+    s.setRequestHandler(ListToolsRequestSchema, () => ({
+        tools: [
+            {
+                name: 'structured',
+                inputSchema: { type: 'object', properties: { n: { type: 'number' } } },
+                outputSchema: { type: 'object', properties: { doubled: { type: 'integer' } } }
+            },
+            { name: 'structured-mismatch', inputSchema: { type: 'object' }, outputSchema },
+            { name: 'structured-missing', inputSchema: { type: 'object' }, outputSchema },
+            { name: 'structured-error-skip', inputSchema: { type: 'object' }, outputSchema }
+        ]
+    }));
+    s.setRequestHandler(CallToolRequestSchema, req => {
+        switch (req.params.name) {
+            case 'structured': {
+                const n = (req.params.arguments as { n: number }).n;
+                return { structuredContent: { doubled: n * 2 }, content: [{ type: 'text', text: JSON.stringify({ doubled: n * 2 }) }] };
+            }
+            case 'structured-mismatch':
+                // intentionally invalid structuredContent (tests client-side validation rejects it)
+                return { structuredContent: { value: 'not-a-number' }, content: [] };
+            case 'structured-missing':
+                return { content: [{ type: 'text', text: 'handler-body-no-structured' }] };
+            case 'structured-error-skip':
+                return { isError: true, content: [{ type: 'text', text: 'handler-returned-isError' }] };
+            default:
+                throw new McpError(ErrorCode.InvalidParams, `unknown tool ${req.params.name}`);
+        }
+    });
+    return s;
+}
+
+verifies('tools:call:content:text', async ({ transport }: TestArgs) => {
+    const client = newClient();
+    await using _ = await wire(transport, echoServer, client);
+
+    const r = await client.callTool({ name: 'echo', arguments: { text: 'hi' } });
+    expect(r.isError).toBeFalsy();
+    expect(r.content).toEqual([{ type: 'text', text: 'hi' }]);
+});
+
+verifies('tools:call:content:image', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool('image', { inputSchema: z.object({}) }, () => ({
+            content: [{ type: 'image', data: TINY_PNG_BASE64, mimeType: 'image/png' }]
+        }));
+        return s;
+    };
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    const r = await client.callTool({ name: 'image', arguments: {} });
+    expect(r.isError).toBeFalsy();
+    expect(r.content).toEqual([{ type: 'image', data: TINY_PNG_BASE64, mimeType: 'image/png' }]);
+});
+
+verifies('tools:call:content:audio', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool('audio', { inputSchema: z.object({}) }, () => ({
+            content: [{ type: 'audio', data: TINY_WAV_BASE64, mimeType: 'audio/wav' }]
+        }));
+        return s;
+    };
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    const r = await client.callTool({ name: 'audio', arguments: {} });
+    expect(r.isError).toBeFalsy();
+    expect(r.content).toEqual([{ type: 'audio', data: TINY_WAV_BASE64, mimeType: 'audio/wav' }]);
+});
+
+verifies('tools:call:content:embedded-resource', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool('embedded-resource', { inputSchema: z.object({ kind: z.enum(['text', 'blob']) }) }, ({ kind }) => ({
+            content: [
+                {
+                    type: 'resource',
+                    resource:
+                        kind === 'text'
+                            ? { uri: 'file:///fixture.txt', mimeType: 'text/plain', text: 'embedded fixture text' }
+                            : { uri: 'file:///fixture.bin', mimeType: 'application/octet-stream', blob: TINY_BLOB_BASE64 }
+                }
+            ]
+        }));
+        return s;
+    };
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    const text = await client.callTool({ name: 'embedded-resource', arguments: { kind: 'text' } });
+    expect(text.content).toEqual([
+        { type: 'resource', resource: { uri: 'file:///fixture.txt', mimeType: 'text/plain', text: 'embedded fixture text' } }
+    ]);
+
+    const blob = await client.callTool({ name: 'embedded-resource', arguments: { kind: 'blob' } });
+    expect(blob.content).toEqual([
+        { type: 'resource', resource: { uri: 'file:///fixture.bin', mimeType: 'application/octet-stream', blob: TINY_BLOB_BASE64 } }
+    ]);
+});
+
+verifies('tools:call:content:resource-link', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool('resource-link', { inputSchema: z.object({}) }, () => ({
+            content: [
+                {
+                    type: 'resource_link',
+                    uri: 'file:///linked.txt',
+                    name: 'linked.txt',
+                    description: 'A linked (not embedded) resource',
+                    mimeType: 'text/plain'
+                }
+            ]
+        }));
+        return s;
+    };
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    const r = await client.callTool({ name: 'resource-link', arguments: {} });
+    expect(r.content).toEqual([
+        {
+            type: 'resource_link',
+            uri: 'file:///linked.txt',
+            name: 'linked.txt',
+            description: 'A linked (not embedded) resource',
+            mimeType: 'text/plain'
+        }
+    ]);
+});
+
+verifies('tools:call:content:mixed', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool('mixed-content', { inputSchema: z.object({}) }, () => ({
+            content: [
+                { type: 'text', text: 'first' },
+                { type: 'image', mimeType: 'image/png', data: TINY_PNG_BASE64 },
+                { type: 'resource', resource: { uri: 'file:///mixed.txt', mimeType: 'text/plain', text: 'inlined' } },
+                { type: 'text', text: 'last' }
+            ]
+        }));
+        return s;
+    };
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    const r = await client.callTool({ name: 'mixed-content', arguments: {} });
+    expect(r.content).toEqual([
+        { type: 'text', text: 'first' },
+        { type: 'image', mimeType: 'image/png', data: TINY_PNG_BASE64 },
+        { type: 'resource', resource: { uri: 'file:///mixed.txt', mimeType: 'text/plain', text: 'inlined' } },
+        { type: 'text', text: 'last' }
+    ]);
+});
+
+verifies('tools:call:sampling-roundtrip', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool('ask-llm', { inputSchema: z.object({ prompt: z.string() }) }, async ({ prompt }) => {
+            const reply = await s.server.createMessage({
+                messages: [{ role: 'user', content: { type: 'text', text: prompt } }],
+                maxTokens: 100
+            });
+            if (reply.content.type !== 'text') throw new Error('expected text content');
+            return { content: [{ type: 'text', text: `model said: ${reply.content.text}` }] };
+        });
+        return s;
+    };
+
+    const received: CreateMessageRequest[] = [];
+    const client = new Client({ name: 'c', version: '0' }, { capabilities: { sampling: {} } });
+    client.setRequestHandler(CreateMessageRequestSchema, async req => {
+        received.push(req);
+        return {
+            model: 'stub-model',
+            role: 'assistant',
+            stopReason: 'endTurn',
+            content: { type: 'text', text: 'pong' }
+        } satisfies CreateMessageResult;
+    });
+
+    await using _ = await wire(transport, makeServer, client);
+
+    const r = await client.callTool({ name: 'ask-llm', arguments: { prompt: 'ping' } });
+    expect(r.isError).toBeFalsy();
+    expect(r.content).toEqual([{ type: 'text', text: 'model said: pong' }]);
+
+    expect(received).toHaveLength(1);
+    expect(received[0].params.messages).toEqual([{ role: 'user', content: { type: 'text', text: 'ping' } }]);
+    expect(received[0].params.maxTokens).toBe(100);
+});
+
+verifies('tools:call:elicitation-roundtrip', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool('ask-name', { inputSchema: z.object({}) }, async () => {
+            const ans = await s.server.elicitInput({
+                mode: 'form',
+                message: 'What is your name?',
+                requestedSchema: { type: 'object', properties: { name: { type: 'string' } }, required: ['name'] }
+            });
+            const name = ans.action === 'accept' && typeof ans.content?.name === 'string' ? ans.content.name : '<declined>';
+            return { content: [{ type: 'text', text: `Hello, ${name}` }] };
+        });
+        return s;
+    };
+
+    const received: ElicitRequest[] = [];
+    const client = new Client({ name: 'c', version: '0' }, { capabilities: { elicitation: { form: {} } } });
+    client.setRequestHandler(ElicitRequestSchema, async req => {
+        received.push(req);
+        return { action: 'accept', content: { name: 'Ada' } };
+    });
+
+    await using _ = await wire(transport, makeServer, client);
+
+    const r = await client.callTool({ name: 'ask-name', arguments: {} });
+
+    expect(received).toHaveLength(1);
+    expect(received[0].method).toBe('elicitation/create');
+    expect(received[0].params).toMatchObject({
+        mode: 'form',
+        message: 'What is your name?',
+        requestedSchema: { type: 'object', properties: { name: { type: 'string' } }, required: ['name'] }
+    });
+
+    expect(r.isError).toBeFalsy();
+    expect(r.content).toEqual([{ type: 'text', text: 'Hello, Ada' }]);
+});
+
+verifies('tools:call:logging-mid-execution', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' }, { capabilities: { logging: {} } });
+        s.registerTool('log-then-ok', { inputSchema: z.object({}) }, async (_args, extra) => {
+            await extra.sendNotification({
+                method: 'notifications/message',
+                params: { level: 'warning', logger: 'tools-test', data: 'work in progress' }
+            });
+            return { content: [{ type: 'text', text: 'logged' }] };
+        });
+        return s;
+    };
+
+    const logs: Array<{ level: string; logger?: string; data: unknown }> = [];
+    const client = newClient();
+    client.setNotificationHandler(LoggingMessageNotificationSchema, n => {
+        logs.push(n.params);
+    });
+
+    await using _ = await wire(transport, makeServer, client);
+
+    const r = await client.callTool({ name: 'log-then-ok', arguments: {} });
+
+    expect(logs).toHaveLength(1);
+    expect(logs[0]).toMatchObject({ level: 'warning', logger: 'tools-test', data: 'work in progress' });
+    expect(r.content).toEqual([{ type: 'text', text: 'logged' }]);
+});
+
+verifies('tools:call:progress', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool('progress', { inputSchema: z.object({ steps: z.number().int().positive() }) }, async ({ steps }, extra) => {
+            const token = extra._meta?.progressToken;
+            if (token !== undefined) {
+                for (let i = 1; i <= steps; i++) {
+                    await extra.sendNotification({
+                        method: 'notifications/progress',
+                        params: { progressToken: token, progress: i, total: steps, message: `step ${i}/${steps}` }
+                    });
+                }
+            }
+            return { content: [{ type: 'text', text: `done after ${steps} steps` }] };
+        });
+        return s;
+    };
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    const steps = 3;
+    const received: Array<{ progress: number; total?: number; message?: string }> = [];
+    let receivedAtResolve = -1;
+
+    const r = await client
+        .callTool({ name: 'progress', arguments: { steps } }, undefined, {
+            onprogress: p => received.push({ progress: p.progress, total: p.total, message: p.message })
+        })
+        .then(res => {
+            receivedAtResolve = received.length;
+            return res;
+        });
+
+    expect(receivedAtResolve).toBe(steps);
+    expect(received).toEqual([
+        { progress: 1, total: steps, message: 'step 1/3' },
+        { progress: 2, total: steps, message: 'step 2/3' },
+        { progress: 3, total: steps, message: 'step 3/3' }
+    ]);
+    expect(r.content).toEqual([{ type: 'text', text: `done after ${steps} steps` }]);
+});
+
+verifies('tools:call:concurrent', async ({ transport }: TestArgs) => {
+    // Both handlers park on a shared release barrier after recording that they started; a server
+    // that dispatched calls sequentially would never start the second handler before the first
+    // returns, so the started-length wait below would time out instead of passing.
+    let releaseBoth!: () => void;
+    const release = new Promise<void>(resolve => {
+        releaseBoth = resolve;
+    });
+    // Recorders live OUTSIDE the factory so every server instance (stateless makes one per request) shares them.
+    const started: string[] = [];
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool('lookup-order-status', { inputSchema: z.object({ orderId: z.string() }) }, async ({ orderId }) => {
+            started.push(orderId);
+            await release;
+            return { content: [{ type: 'text', text: `order ${orderId}: shipped` }] };
+        });
+        return s;
+    };
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    const settled: string[] = [];
+    const firstCall = client.callTool({ name: 'lookup-order-status', arguments: { orderId: 'order-1001' } }).then(r => {
+        settled.push('order-1001');
+        return r;
+    });
+    const secondCall = client.callTool({ name: 'lookup-order-status', arguments: { orderId: 'order-2002' } }).then(r => {
+        settled.push('order-2002');
+        return r;
+    });
+
+    // Both handlers are running at the same time before either is allowed to finish.
+    await vi.waitFor(() => expect(started).toHaveLength(2));
+    expect(started.slice().sort()).toEqual(['order-1001', 'order-2002']);
+    expect(settled).toEqual([]);
+
+    releaseBoth();
+    const [first, second] = await Promise.all([firstCall, secondCall]);
+
+    // Each caller receives the response correlated to its own request, not the other one's.
+    expect(first.isError).toBeFalsy();
+    expect(first.content).toEqual([{ type: 'text', text: 'order order-1001: shipped' }]);
+    expect(second.isError).toBeFalsy();
+    expect(second.content).toEqual([{ type: 'text', text: 'order order-2002: shipped' }]);
+    expect(settled.slice().sort()).toEqual(['order-1001', 'order-2002']);
+});
+
+verifies('tools:call:is-error', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool('returns-is-error', { inputSchema: z.object({ message: z.string() }) }, ({ message }) => ({
+            isError: true,
+            content: [{ type: 'text', text: message }]
+        }));
+        return s;
+    };
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    // Tap inbound wire messages so we can assert the JSON-RPC envelope shape.
+    const inbound: JSONRPCMessage[] = [];
+    const original = client.transport!.onmessage;
+    client.transport!.onmessage = (m, e) => {
+        inbound.push(m);
+        original?.(m, e);
+    };
+
+    const r = await client.callTool({ name: 'returns-is-error', arguments: { message: 'tool-level failure' } });
+
+    // API layer: callTool resolves with the error body.
+    expect(r.isError).toBe(true);
+    expect(r.content).toEqual([{ type: 'text', text: 'tool-level failure' }]);
+
+    // Wire layer: the reply for this call is a result envelope, never `error`.
+    const reply = inbound.find(m => 'id' in m && 'result' in m);
+    expect(reply).toBeDefined();
+    expect(reply).not.toHaveProperty('error');
+    expect((reply as { result: { isError?: boolean } }).result.isError).toBe(true);
+
+    client.transport!.onmessage = original;
+});
+
+verifies(
+    'tools:call:unknown-name',
+    async ({ transport }: TestArgs) => {
+        // Spec: unknown tool is a protocol error → JSON-RPC error envelope, so
+        // callTool() rejects. Known SDK gap: McpServer's catch wraps it as
+        // {isError:true} instead — this body asserts the spec-correct behavior.
+        const client = newClient();
+        await using _ = await wire(transport, echoServer, client);
+
+        const call = client.callTool({ name: 'no-such-tool', arguments: {} });
+        await expect(call).rejects.toBeInstanceOf(McpError);
+        const err = await call.catch(e => e as McpError);
+        expect(err.code).toBe(ErrorCode.InvalidParams);
+        expect(err.message).toMatch(/no-such-tool|unknown|not found/i);
+    },
+    { title: 'mcpserver' }
+);
+
+verifies(
+    'tools:call:unknown-name',
+    async ({ transport }: TestArgs) => {
+        const makeServer = () => {
+            const s = new Server({ name: 's', version: '0' }, { capabilities: { tools: {} } });
+            s.setRequestHandler(ListToolsRequestSchema, () => ({
+                tools: [{ name: 'echo', inputSchema: { type: 'object', properties: { text: { type: 'string' } } } }]
+            }));
+            s.setRequestHandler(CallToolRequestSchema, req => {
+                if (req.params.name === 'echo') {
+                    return { content: [{ type: 'text', text: String(req.params.arguments?.text ?? '') }] };
+                }
+                throw new McpError(ErrorCode.InvalidParams, `Tool ${req.params.name} not found`);
+            });
+            return s;
+        };
+        const client = newClient();
+        await using _ = await wire(transport, makeServer, client);
+
+        const ok = await client.callTool({ name: 'echo', arguments: { text: 'hi' } });
+        expect(ok.content).toEqual([{ type: 'text', text: 'hi' }]);
+
+        const call = client.callTool({ name: 'no-such-tool', arguments: {} });
+        await expect(call).rejects.toBeInstanceOf(McpError);
+        const err = await call.catch(e => e as McpError);
+        expect(err.code).toBe(ErrorCode.InvalidParams);
+    },
+    { title: 'raw server' }
+);
+
+verifies('tools:call:structured-content', async ({ transport }: TestArgs) => {
+    const client = newClient();
+    await using _ = await wire(transport, schemaServer, client);
+
+    const { tools } = await client.listTools();
+    const tool = tools.find(t => t.name === 'structured');
+    if (!tool?.outputSchema) throw new Error('outputSchema missing');
+    expect(tool.outputSchema).toMatchObject({ type: 'object', properties: { doubled: { type: 'integer' } } });
+
+    const r = await client.callTool({ name: 'structured', arguments: { n: 7 } });
+    expect(r.isError).toBeFalsy();
+    expect(r.structuredContent).toEqual({ doubled: 14 });
+    expect(r.content).toEqual([{ type: 'text', text: JSON.stringify({ doubled: 14 }) }]);
+
+    // structuredContent satisfies the *advertised* outputSchema.
+    const validate = new AjvJsonSchemaValidator().getValidator(tool.outputSchema);
+    const v = validate(r.structuredContent);
+    expect(v.valid, v.errorMessage).toBe(true);
+});
+
+verifies('tools:call:structured-content:text-mirror', async ({ transport }: TestArgs) => {
+    const client = newClient();
+    await using _ = await wire(transport, schemaServer, client);
+
+    const r = await client.callTool({ name: 'structured', arguments: { n: 21 } });
+    expect(r.structuredContent).toEqual({ doubled: 42 });
+    expect(r.content).toContainEqual({ type: 'text', text: JSON.stringify({ doubled: 42 }) });
+});
+
+verifies(['client:output-schema:validate', 'client:output-schema:missing-structured'], async ({ transport }: TestArgs) => {
+    // Client-side validation is only observable when the server does NOT
+    // pre-validate (raw Server) — McpServer would intercept first.
+    const client = newClient();
+    await using _ = await wire(transport, rawSchemaServer, client);
+
+    // Prime the validator cache.
+    const { tools } = await client.listTools();
+    for (const name of ['structured', 'structured-mismatch', 'structured-missing']) {
+        expect(tools.find(t => t.name === name)?.outputSchema).toMatchObject({ type: 'object' });
+    }
+
+    const ok = await client.callTool({ name: 'structured', arguments: { n: 3 } });
+    expect(ok.structuredContent).toEqual({ doubled: 6 });
+
+    const mismatch = client.callTool({ name: 'structured-mismatch', arguments: {} });
+    await expect(mismatch).rejects.toBeInstanceOf(McpError);
+    await expect(mismatch).rejects.toThrow(/output schema|structured content/i);
+
+    const missing = client.callTool({ name: 'structured-missing', arguments: {} });
+    await expect(missing).rejects.toBeInstanceOf(McpError);
+    await expect(missing).rejects.toThrow(/did not return structured content/i);
+});
+
+verifies('client:output-schema:skip-on-error', async ({ transport }: TestArgs) => {
+    const client = newClient();
+    await using _ = await wire(transport, schemaServer, client);
+
+    const { tools } = await client.listTools();
+    expect(tools.find(t => t.name === 'structured-error-skip')?.outputSchema).toMatchObject({
+        type: 'object',
+        properties: { value: { type: 'number' } }
+    });
+
+    const r = await client.callTool({ name: 'structured-error-skip', arguments: {} });
+    expect(r.isError).toBe(true);
+    expect(r.structuredContent).toBeUndefined();
+    expect(r.content).toEqual([{ type: 'text', text: 'handler-returned-isError' }]);
+});
+
+verifies('typescript:mcpserver:output-schema:server-validate', async ({ transport }: TestArgs) => {
+    const client = newClient();
+    await using _ = await wire(transport, schemaServer, client);
+
+    // Cold call — no listTools() — so any validation observed is server-side.
+    const r = await client.callTool({ name: 'structured-mismatch', arguments: {} });
+    expect(r.isError).toBe(true);
+    expect(r.structuredContent).toBeUndefined();
+    expect(r.content).toEqual([{ type: 'text', text: expect.stringMatching(/Output validation error.*structured-mismatch/i) }]);
+});
+
+verifies('mcpserver:output-schema:missing-structured', async ({ transport }: TestArgs) => {
+    const client = newClient();
+    await using _ = await wire(transport, schemaServer, client);
+
+    const r = await client.callTool({ name: 'structured-missing', arguments: {} });
+    expect(r.isError).toBe(true);
+    expect(r.structuredContent).toBeUndefined();
+    expect(r.content).toEqual([{ type: 'text', text: expect.stringMatching(/Output validation error/i) }]);
+    expect(r.content).not.toEqual([{ type: 'text', text: 'handler-body-no-structured' }]);
+
+    // Postcondition: the tool really did advertise an outputSchema.
+    const { tools } = await client.listTools();
+    expect(tools.find(t => t.name === 'structured-missing')?.outputSchema).toMatchObject({
+        type: 'object',
+        properties: { value: { type: 'number' } }
+    });
+});
+
+verifies('mcpserver:output-schema:skip-on-error', async ({ transport }: TestArgs) => {
+    const client = newClient();
+    await using _ = await wire(transport, schemaServer, client);
+
+    const { tools } = await client.listTools();
+    expect(tools.find(t => t.name === 'structured-error-skip')?.outputSchema).toMatchObject({
+        type: 'object',
+        properties: { value: { type: 'number' } }
+    });
+
+    const r = await client.callTool({ name: 'structured-error-skip', arguments: {} });
+    expect(r.isError).toBe(true);
+    expect(r.content).toEqual([{ type: 'text', text: 'handler-returned-isError' }]);
+    expect(r.structuredContent).toBeUndefined();
+});
+
+verifies('tools:list:basic', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool(
+            'echo',
+            { description: 'Echoes the input text back as a text content block.', inputSchema: z.object({ text: z.string() }) },
+            ({ text }) => ({ content: [{ type: 'text', text }] })
+        );
+        s.registerTool('second', { description: 'Another tool.', inputSchema: z.object({}) }, () => ({ content: [] }));
+        return s;
+    };
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    const { tools } = await client.listTools();
+    expect(tools.length).toBeGreaterThanOrEqual(2);
+    for (const t of tools) {
+        expect(typeof t.name).toBe('string');
+        expect(t.inputSchema).toMatchObject({ type: 'object' });
+    }
+    expect(tools.map(t => t.name)).toEqual(expect.arrayContaining(['echo', 'second']));
+    expect(tools.find(t => t.name === 'echo')).toMatchObject({
+        name: 'echo',
+        description: 'Echoes the input text back as a text content block.',
+        inputSchema: { type: 'object', properties: { text: { type: 'string' } } }
+    });
+});
+
+verifies('tools:list:metadata', async ({ transport }: TestArgs) => {
+    const annotated: Tool = {
+        name: 'annotated',
+        title: 'Annotated Tool',
+        description: 'Carries every optional listing field.',
+        inputSchema: { type: 'object' },
+        annotations: {
+            title: 'Annotated Tool',
+            readOnlyHint: true,
+            destructiveHint: false,
+            idempotentHint: true,
+            openWorldHint: false
+        },
+        _meta: { 'example.com/fixture': true },
+        execution: { taskSupport: 'forbidden' },
+        icons: [{ src: 'https://example.com/tool.png', mimeType: 'image/png', sizes: ['48x48'] }]
+    };
+    const makeServer = () => {
+        const s = new Server({ name: 's', version: '0' }, { capabilities: { tools: {} } });
+        s.setRequestHandler(ListToolsRequestSchema, () => ({ tools: [annotated] }));
+        s.setRequestHandler(CallToolRequestSchema, () => ({ content: [] }));
+        return s;
+    };
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    const { tools } = await client.listTools();
+    const tool = tools.find(t => t.name === 'annotated');
+    expect(tool).toBeDefined();
+    expect(tool!.title).toBe('Annotated Tool');
+    expect(tool!.annotations).toEqual(annotated.annotations);
+    expect(tool!._meta).toEqual({ 'example.com/fixture': true });
+    expect(tool!.execution).toEqual({ taskSupport: 'forbidden' });
+    expect(tool!.icons).toEqual([{ src: 'https://example.com/tool.png', mimeType: 'image/png', sizes: ['48x48'] }]);
+});
+
+verifies(
+    'tools:list:pagination',
+    async ({ transport }: TestArgs) => {
+        const TOTAL = 25;
+        const makeServer = () => {
+            const s = new McpServer({ name: 's', version: '0' });
+            for (let i = 0; i < TOTAL; i++) {
+                s.registerTool(`bulk_${String(i).padStart(2, '0')}`, { inputSchema: z.object({}) }, () => ({ content: [] }));
+            }
+            return s;
+        };
+        const client = newClient();
+        await using _ = await wire(transport, makeServer, client);
+
+        const first = await client.listTools();
+        expect(first.tools.length).toBeLessThan(TOTAL);
+        expect(first.nextCursor).toBeDefined();
+
+        const seen = new Set(first.tools.map(t => t.name));
+        let result = first;
+        let pages = 1;
+        while (result.nextCursor !== undefined) {
+            result = await client.listTools({ cursor: result.nextCursor });
+            for (const t of result.tools) seen.add(t.name);
+            pages++;
+            expect(pages).toBeLessThan(50);
+        }
+        expect(seen.size).toBe(TOTAL);
+        expect(pages).toBeGreaterThan(1);
+    },
+    { title: 'mcpserver' }
+);
+
+verifies(
+    'tools:list:pagination',
+    async ({ transport }: TestArgs) => {
+        const TOTAL = 25;
+        const PAGE = 10;
+        const all = Array.from({ length: TOTAL }, (_, i) => `bulk_${String(i).padStart(2, '0')}`);
+        // Recorder lives OUTSIDE the factory so every server instance shares it.
+        const cursorsReceived: Array<string | undefined> = [];
+
+        const makeServer = () => {
+            const s = new Server({ name: 's', version: '0' }, { capabilities: { tools: {} } });
+            s.setRequestHandler(ListToolsRequestSchema, req => {
+                cursorsReceived.push(req.params?.cursor);
+                const start = req.params?.cursor === undefined ? 0 : parseInt(req.params.cursor, 10);
+                const slice = all.slice(start, start + PAGE);
+                return {
+                    tools: slice.map(name => ({ name, inputSchema: { type: 'object' as const } })),
+                    nextCursor: start + PAGE < TOTAL ? String(start + PAGE) : undefined
+                };
+            });
+            s.setRequestHandler(CallToolRequestSchema, () => ({ content: [] }));
+            return s;
+        };
+        const client = newClient();
+        await using _ = await wire(transport, makeServer, client);
+
+        const seen = new Set<string>();
+        const cursorsSent: string[] = [];
+        let pages = 0;
+        let result = await client.listTools();
+        expect(result.nextCursor).toBeDefined();
+        for (;;) {
+            for (const t of result.tools) {
+                expect(seen.has(t.name)).toBe(false);
+                seen.add(t.name);
+            }
+            pages++;
+            if (result.nextCursor === undefined) break;
+            cursorsSent.push(result.nextCursor);
+            result = await client.listTools({ cursor: result.nextCursor });
+            expect(pages).toBeLessThan(50);
+        }
+
+        expect(pages).toBeGreaterThan(1);
+        for (const name of all) expect(seen.has(name)).toBe(true);
+
+        // SDK plumbing: the server's request handler saw the cursors verbatim.
+        expect(cursorsReceived).toHaveLength(pages);
+        expect(cursorsReceived[0]).toBeUndefined();
+        expect(cursorsReceived.slice(1)).toEqual(cursorsSent);
+    },
+    { title: 'raw server' }
+);
+
+verifies('tools:list-changed', async ({ transport }: TestArgs) => {
+    let server!: McpServer;
+    const makeServer = () => {
+        server = new McpServer({ name: 's', version: '0' });
+        server.registerTool('seed', { inputSchema: z.object({}) }, () => ({ content: [] }));
+        return server;
+    };
+
+    let listChanged = 0;
+    const client = newClient();
+    client.setNotificationHandler(ToolListChangedNotificationSchema, () => {
+        listChanged++;
+    });
+
+    await using _ = await wire(transport, makeServer, client);
+
+    expect((await client.listTools()).tools.length).toBe(1);
+
+    const handle = server.registerTool('dynamic-probe', { inputSchema: z.object({}) }, () => ({ content: [] }));
+    await vi.waitFor(() => expect(listChanged).toBeGreaterThanOrEqual(1));
+    expect((await client.listTools()).tools.length).toBe(2);
+    const afterAdd = listChanged;
+
+    handle.remove();
+    await vi.waitFor(() => expect(listChanged).toBeGreaterThan(afterAdd));
+    expect((await client.listTools()).tools.length).toBe(1);
+});
+
+verifies('tools:capability:declared', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        // Ctor declares only `tools: {}`. McpServer.registerTool must derive
+        // `listChanged: true` itself via registerCapabilities.
+        const s = new McpServer({ name: 's', version: '0' }, { capabilities: { tools: {} } });
+        s.registerTool('echo', { inputSchema: z.object({}) }, () => ({ content: [] }));
+        return s;
+    };
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    const caps = client.getServerCapabilities();
+    expect(caps?.tools).toBeDefined();
+    const { tools } = await client.listTools();
+    expect(tools.length).toBeGreaterThan(0);
+    expect(caps?.tools?.listChanged).toBe(true);
+});
+
+verifies('tools:input-schema:json-schema-2020-12', async ({ transport }: TestArgs) => {
+    const client = newClient();
+    await using _ = await wire(transport, rawJsonSchemaServer, client);
+
+    const { tools } = await client.listTools();
+    const tool = tools.find(t => t.name === 'json-schema');
+    expect(tool).toBeDefined();
+    expect(tool!.inputSchema).toMatchObject({ type: 'object' });
+
+    const r = await client.callTool({ name: 'json-schema', arguments: { point: { x: 3, y: 4 } } });
+    expect(r.isError).toBeFalsy();
+    expect(r.content).toEqual([{ type: 'text', text: '(3, 4)' }]);
+});
+
+verifies('tools:input-schema:preserve-defs', async ({ transport }: TestArgs) => {
+    const client = newClient();
+    await using _ = await wire(transport, rawJsonSchemaServer, client);
+
+    const { tools } = await client.listTools();
+    const schema = tools.find(t => t.name === 'json-schema')!.inputSchema as Record<string, unknown>;
+
+    expect(schema.$defs).toEqual(JSON_SCHEMA_2020_12_INPUT.$defs);
+    expect(schema.properties).toEqual({ point: { $ref: '#/$defs/Point' } });
+    expect(schema).not.toHaveProperty('definitions');
+});
+
+verifies('tools:input-schema:preserve-schema-dialect', async ({ transport }: TestArgs) => {
+    // Two distinct dialects must round-trip verbatim — guards against the
+    // SDK's listing path stamping a single default $schema onto every schema.
+    const makeServer = () => {
+        const s = new Server({ name: 's', version: '0' }, { capabilities: { tools: {} } });
+        s.setRequestHandler(ListToolsRequestSchema, () => ({
+            tools: [
+                { name: 'draft07', inputSchema: { $schema: 'http://json-schema.org/draft-07/schema#', type: 'object' } },
+                { name: 'v2020', inputSchema: { $schema: 'https://json-schema.org/draft/2020-12/schema', type: 'object' } }
+            ]
+        }));
+        s.setRequestHandler(CallToolRequestSchema, () => ({ content: [] }));
+        return s;
+    };
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    const { tools } = await client.listTools();
+    const draft07 = tools.find(t => t.name === 'draft07')!.inputSchema.$schema;
+    const v2020 = tools.find(t => t.name === 'v2020')!.inputSchema.$schema;
+    expect(draft07).toBe('http://json-schema.org/draft-07/schema#');
+    expect(v2020).toBe('https://json-schema.org/draft/2020-12/schema');
+    expect(draft07).not.toBe(v2020);
+});
+
+verifies('tools:input-schema:preserve-additional-properties', async ({ transport }: TestArgs) => {
+    // Three explicit values must round-trip verbatim — guards against the
+    // SDK's listing path stamping a single constant onto every schema.
+    const makeServer = () => {
+        const s = new Server({ name: 's', version: '0' }, { capabilities: { tools: {} } });
+        s.setRequestHandler(ListToolsRequestSchema, () => ({
+            tools: [
+                { name: 'strict', inputSchema: { type: 'object', additionalProperties: false } },
+                { name: 'open', inputSchema: { type: 'object', additionalProperties: true } },
+                { name: 'absent', inputSchema: { type: 'object' } }
+            ]
+        }));
+        s.setRequestHandler(CallToolRequestSchema, () => ({ content: [] }));
+        return s;
+    };
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    const { tools } = await client.listTools();
+    const get = (name: string) => tools.find(t => t.name === name)!.inputSchema as Record<string, unknown>;
+    expect(get('strict').additionalProperties).toBe(false);
+    expect(get('open').additionalProperties).toBe(true);
+    expect(get('absent')).not.toHaveProperty('additionalProperties');
+    expect(get('strict').additionalProperties).not.toBe(get('open').additionalProperties);
+});
+
+verifies('typescript:mcpserver:tool:handler-throws', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool('throws', { inputSchema: z.object({ message: z.string() }) }, ({ message }) => {
+            throw new Error(message);
+        });
+        return s;
+    };
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    const r = await client.callTool({ name: 'throws', arguments: { message: 'kaboom' } });
+    expect(r.isError).toBe(true);
+    expect(r.content).toEqual([{ type: 'text', text: 'kaboom' }]);
+});
+
+verifies('mcpserver:tool:duplicate-name', async ({ transport }: TestArgs) => {
+    let dupError: unknown;
+    const makeServer = () => {
+        const s = echoServer();
+        // Positive control: a fresh name registers fine.
+        s.registerTool('fresh', { inputSchema: z.object({}) }, () => ({ content: [] }));
+        // Duplicate throws at registration time.
+        try {
+            s.registerTool('echo', { inputSchema: z.object({}) }, () => ({ content: [] }));
+        } catch (e) {
+            dupError = e;
+        }
+        return s;
+    };
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    expect(dupError).toBeInstanceOf(Error);
+    expect(String(dupError)).toMatch(/already registered/i);
+
+    // Original survives the failed duplicate registration.
+    const tools = (await client.listTools()).tools;
+    expect(tools.filter(t => t.name === 'echo')).toHaveLength(1);
+    expect(tools.map(t => t.name)).toContain('fresh');
+    const r = await client.callTool({ name: 'echo', arguments: { text: 'still here' } });
+    expect(r.content).toEqual([{ type: 'text', text: 'still here' }]);
+});
+
+verifies('mcpserver:tool:handle-update', async ({ transport }: TestArgs) => {
+    let handle!: RegisteredTool;
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        handle = s.registerTool('echo', { description: 'v1', inputSchema: z.object({ text: z.string() }) }, ({ text }) => ({
+            content: [{ type: 'text', text }]
+        }));
+        return s;
+    };
+
+    let listChanged = 0;
+    const client = newClient();
+    client.setNotificationHandler(ToolListChangedNotificationSchema, () => {
+        listChanged++;
+    });
+    await using _ = await wire(transport, makeServer, client);
+
+    const beforeList = (await client.listTools()).tools;
+    expect(beforeList.length).toBe(1);
+    const before = beforeList.find(t => t.name === 'echo')!;
+    expect(before.description).toBe('v1');
+    expect(before.inputSchema.properties).toHaveProperty('text');
+    expect((await client.callTool({ name: 'echo', arguments: { text: 'hi' } })).content).toEqual([{ type: 'text', text: 'hi' }]);
+
+    handle.update({
+        description: 'v2 — replaced via RegisteredTool.update()',
+        paramsSchema: {},
+        callback: () => ({ content: [{ type: 'text', text: 'echo-v2-handler' }] })
+    });
+
+    await vi.waitFor(() => expect(listChanged).toBeGreaterThanOrEqual(1));
+
+    const afterList = (await client.listTools()).tools;
+    expect(afterList.length).toBe(1);
+    const after = afterList.find(t => t.name === 'echo')!;
+    expect(after.description).toBe('v2 — replaced via RegisteredTool.update()');
+    expect(after.inputSchema.properties ?? {}).not.toHaveProperty('text');
+
+    const r = await client.callTool({ name: 'echo', arguments: {} });
+    expect(r.content).toEqual([{ type: 'text', text: 'echo-v2-handler' }]);
+});
+
+verifies('mcpserver:tool:input-validation', async ({ transport }: TestArgs) => {
+    // Shared across factory calls so stateless still observes the count.
+    const handlerCalls = { n: 0 };
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool('typed', { inputSchema: z.object({ prompt: z.string() }) }, () => {
+            handlerCalls.n++;
+            return { content: [{ type: 'text', text: 'ran' }] };
+        });
+        return s;
+    };
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    const ok = await client.callTool({ name: 'typed', arguments: { prompt: 'hello' } });
+    expect(ok.isError).toBeFalsy();
+    expect(handlerCalls.n).toBe(1);
+
+    const wrongType = await client.callTool({ name: 'typed', arguments: { prompt: 123 } });
+    expect(wrongType.isError).toBe(true);
+    expect(wrongType.content).toEqual([{ type: 'text', text: expect.stringMatching(/invalid|validation/i) }]);
+    expect(handlerCalls.n).toBe(1);
+
+    const missing = await client.callTool({ name: 'typed', arguments: {} });
+    expect(missing.isError).toBe(true);
+    expect(missing.content).toEqual([{ type: 'text', text: expect.stringMatching(/invalid|validation|required/i) }]);
+    expect(handlerCalls.n).toBe(1);
+});
+
+verifies('mcpserver:tool:naming-validation', async ({ transport }: TestArgs) => {
+    const INVALID = ['has space', 'has/slash', 'has:colon', 'naïve'] as const;
+    const VALID = ['A.b-c_1', 'snake_case_ok'] as const;
+
+    const warnedFor: string[] = [];
+    const cleanFor: string[] = [];
+
+    const makeServer = () => {
+        const s = echoServer();
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        try {
+            for (const name of [...INVALID, ...VALID]) {
+                warn.mockClear();
+                s.registerTool(name, { inputSchema: z.object({}) }, () => ({ content: [] }));
+                if (warn.mock.calls.some(c => c.some(a => String(a).includes(name)))) {
+                    warnedFor.push(name);
+                } else if (warn.mock.calls.length === 0) {
+                    cleanFor.push(name);
+                }
+            }
+        } finally {
+            warn.mockRestore();
+        }
+        return s;
+    };
+
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    for (const bad of INVALID) expect(warnedFor).toContain(bad);
+    for (const good of VALID) expect(cleanFor).toContain(good);
+
+    const names = (await client.listTools()).tools.map(t => t.name);
+    for (const good of VALID) expect(names).toContain(good);
+});
+
+verifies('mcpserver:tool:url-elicitation-error', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool('needs-auth', { inputSchema: z.object({}) }, () => {
+            throw new UrlElicitationRequiredError([
+                {
+                    mode: 'url',
+                    message: 'Please sign in to continue.',
+                    elicitationId: 'fixture-url-elicit-1',
+                    url: 'https://example.com/auth?state=fixture'
+                }
+            ]);
+        });
+        return s;
+    };
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    const err = await client.callTool({ name: 'needs-auth', arguments: {} }).catch((e: unknown) => e);
+    if (!(err instanceof UrlElicitationRequiredError)) {
+        throw new Error(`expected UrlElicitationRequiredError, got ${JSON.stringify(err)}`);
+    }
+    expect(err.code).toBe(ErrorCode.UrlElicitationRequired);
+    expect(err.elicitations).toEqual([
+        {
+            mode: 'url',
+            message: 'Please sign in to continue.',
+            elicitationId: 'fixture-url-elicit-1',
+            url: 'https://example.com/auth?state=fixture'
+        }
+    ]);
+});
+
+/** Zod union/intersection/transform/preprocess/pipe schemas: discoverable in tools/list and validate+coerce before the handler. */
+verifies('typescript:mcpserver:tool:schema-variants', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool(
+            'zod-union',
+            {
+                inputSchema: z.discriminatedUnion('kind', [
+                    z.object({ kind: z.literal('a'), a: z.string() }),
+                    z.object({ kind: z.literal('b'), b: z.number() })
+                ])
+            },
+            args => ({
+                content: [{ type: 'text', text: args.kind === 'a' ? `a:${args.a}` : `b:${args.b}` }]
+            })
+        );
+        s.registerTool(
+            'zod-intersection',
+            { inputSchema: z.intersection(z.object({ left: z.string() }), z.object({ right: z.string() })) },
+            ({ left, right }) => ({ content: [{ type: 'text', text: `${left}|${right}` }] })
+        );
+        s.registerTool(
+            'zod-nested',
+            { inputSchema: z.object({ outer: z.object({ inner: z.object({ value: z.number() }) }) }) },
+            ({ outer }) => ({ content: [{ type: 'text', text: String(outer.inner.value) }] })
+        );
+        s.registerTool(
+            'zod-coerce',
+            {
+                inputSchema: z.object({
+                    n: z
+                        .preprocess(v => (typeof v === 'string' ? v.trim() : v), z.string())
+                        .transform(s => Number(s))
+                        .pipe(z.number().int().nonnegative())
+                })
+            },
+            ({ n }) => ({ content: [{ type: 'text', text: `coerced:${n}` }] })
+        );
+        return s;
+    };
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    expect((await client.callTool({ name: 'zod-union', arguments: { kind: 'a', a: 'hello' } })).content).toEqual([
+        { type: 'text', text: 'a:hello' }
+    ]);
+    expect((await client.callTool({ name: 'zod-union', arguments: { kind: 'b', b: 42 } })).content).toEqual([
+        { type: 'text', text: 'b:42' }
+    ]);
+    expect((await client.callTool({ name: 'zod-intersection', arguments: { left: 'L', right: 'R' } })).content).toEqual([
+        { type: 'text', text: 'L|R' }
+    ]);
+    expect((await client.callTool({ name: 'zod-nested', arguments: { outer: { inner: { value: 5 } } } })).content).toEqual([
+        { type: 'text', text: '5' }
+    ]);
+    expect((await client.callTool({ name: 'zod-coerce', arguments: { n: '  7  ' } })).content).toEqual([
+        { type: 'text', text: 'coerced:7' }
+    ]);
+
+    // Rejections — proves parse() actually runs for each shape.
+    expect((await client.callTool({ name: 'zod-union', arguments: { kind: 'a', a: 123 } })).isError).toBe(true);
+    expect((await client.callTool({ name: 'zod-intersection', arguments: { left: 'L' } })).isError).toBe(true);
+    expect((await client.callTool({ name: 'zod-nested', arguments: { outer: { inner: { value: 'x' } } } })).isError).toBe(true);
+    expect((await client.callTool({ name: 'zod-coerce', arguments: { n: '-3' } })).isError).toBe(true);
+});
+
+verifies('typescript:mcpserver:tool:extra', async ({ transport }: TestArgs) => {
+    // Asserts the always-present RequestHandlerExtra fields. authInfo /
+    // requestInfo need a bearer-auth host (not provided by `wire()`); see
+    // hosting tests for those. Recorder lives outside the factory so every
+    // server instance writes to the same slot.
+    const seen: Array<{ sessionId?: string; requestId: RequestId; hasSignal: boolean; hasSend: boolean }> = [];
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool('report-extra', { inputSchema: z.object({}) }, (_a, extra) => {
+            seen.push({
+                sessionId: extra.sessionId,
+                requestId: extra.requestId,
+                hasSignal: extra.signal instanceof AbortSignal,
+                hasSend: typeof extra.sendNotification === 'function' && typeof extra.sendRequest === 'function'
+            });
+            return { content: [] };
+        });
+        return s;
+    };
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    await client.callTool({ name: 'report-extra', arguments: {} });
+    await client.callTool({ name: 'report-extra', arguments: {} });
+    expect(seen).toHaveLength(2);
+
+    for (const r of seen) {
+        expect(['string', 'number']).toContain(typeof r.requestId);
+        expect(r.hasSignal).toBe(true);
+        expect(r.hasSend).toBe(true);
+        const clientSessionId = client.transport?.sessionId;
+        if (clientSessionId !== undefined) expect(r.sessionId).toBe(clientSessionId);
+    }
+    expect(seen[1].requestId).not.toBe(seen[0].requestId);
+});
+
+verifies('client:call-tool:compat-result-schema', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        const s = new Server({ name: 's', version: '0' }, { capabilities: { tools: {} } });
+        s.setRequestHandler(ListToolsRequestSchema, () => ({
+            tools: [{ name: 'legacy', inputSchema: { type: 'object' } }]
+        }));
+        // legacy 2024-10-07 result shape (tests CompatibilityCallToolResultSchema accepts it)
+        s.setRequestHandler(CallToolRequestSchema, () => ({ toolResult: 'plain string' }));
+        return s;
+    };
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    const r = await client.callTool({ name: 'legacy', arguments: {} }, CompatibilityCallToolResultSchema);
+    expect(r).toHaveProperty('toolResult', 'plain string');
+});
+
+verifies('mcpserver:tool:variadic-forms', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        // (name, cb)
+        s.tool('plain', () => ({ content: [{ type: 'text', text: 'plain' }] }));
+        // (name, description, cb)
+        s.tool('desc', 'desc tool', () => ({ content: [{ type: 'text', text: 'desc' }] }));
+        // (name, paramsSchema, cb)
+        s.tool('args', { x: z.string() }, ({ x }) => ({ content: [{ type: 'text', text: x }] }));
+        // (name, description, paramsSchema, cb)
+        s.tool('desc-args', 'with both', { y: z.number() }, ({ y }) => ({
+            content: [{ type: 'text', text: String(y) }]
+        }));
+        // (name, description, paramsSchema, annotations, cb)
+        s.tool('full', 'full overload', { v: z.string() }, { readOnlyHint: true }, ({ v }) => ({
+            content: [{ type: 'text', text: v }]
+        }));
+        return s;
+    };
+
+    const client = newClient();
+    await using _ = await wire(transport, makeServer, client);
+
+    const list = await client.listTools();
+    const names = list.tools.map(t => t.name).sort();
+    expect(names).toEqual(['args', 'desc', 'desc-args', 'full', 'plain']);
+
+    const desc = list.tools.find(t => t.name === 'desc');
+    expect(desc?.description).toBe('desc tool');
+
+    const full = list.tools.find(t => t.name === 'full');
+    expect(full?.description).toBe('full overload');
+    expect(full?.annotations).toMatchObject({ readOnlyHint: true });
+    expect(full?.inputSchema).toMatchObject({ type: 'object', properties: { v: { type: 'string' } } });
+
+    expect(await client.callTool({ name: 'plain', arguments: {} })).toMatchObject({
+        content: [{ type: 'text', text: 'plain' }]
+    });
+    expect(await client.callTool({ name: 'args', arguments: { x: 'hi' } })).toMatchObject({
+        content: [{ type: 'text', text: 'hi' }]
+    });
+    expect(await client.callTool({ name: 'desc-args', arguments: { y: 3 } })).toMatchObject({
+        content: [{ type: 'text', text: '3' }]
+    });
+    expect(await client.callTool({ name: 'full', arguments: { v: 'go' } })).toMatchObject({
+        content: [{ type: 'text', text: 'go' }]
+    });
+});

--- a/test/e2e/scenarios/tools.test.ts
+++ b/test/e2e/scenarios/tools.test.ts
@@ -20,24 +20,25 @@
  * tier.
  */
 
-import { expect, vi } from 'vitest';
-import { z } from 'zod/v4';
-import { Server, McpServer, ProtocolError, UrlElicitationRequiredError, ProtocolErrorCode } from '@modelcontextprotocol/server';
+import { Client } from '@modelcontextprotocol/client';
+import type { JsonSchemaType } from '@modelcontextprotocol/core';
+import { AjvJsonSchemaValidator } from '@modelcontextprotocol/core';
 import type {
-    RegisteredTool,
     CreateMessageRequest,
     CreateMessageResult,
     ElicitRequest,
     JSONRPCMessage,
+    RegisteredTool,
     RequestId,
     Tool
 } from '@modelcontextprotocol/server';
-import { Client } from '@modelcontextprotocol/client';
-import { AjvJsonSchemaValidator } from '@modelcontextprotocol/core';
+import { McpServer, ProtocolError, ProtocolErrorCode, Server, UrlElicitationRequiredError } from '@modelcontextprotocol/server';
+import { expect, vi } from 'vitest';
+import { z } from 'zod/v4';
 
 import { wire } from '../helpers/index.js';
-import type { TestArgs } from '../types.js';
 import { verifies } from '../helpers/verifies.js';
+import type { TestArgs } from '../types.js';
 
 const TINY_PNG_BASE64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=';
 const TINY_WAV_BASE64 = 'UklGRiQAAABXQVZFZm10IBAAAAABAAEAQB8AAEAfAAABAAgAZGF0YQAAAAA=';
@@ -62,6 +63,11 @@ const JSON_SCHEMA_2020_12_INPUT = {
 
 /** Plain client with no extra capabilities declared. */
 const newClient = () => new Client({ name: 'c', version: '0' });
+
+/** Wire-delivered schemas arrive as plain JSON objects; this runtime check narrows them to the validator's input type. */
+function isJsonSchemaObject(schema: unknown): schema is JsonSchemaType {
+    return typeof schema === 'object' && schema !== null && !Array.isArray(schema);
+}
 
 /** McpServer factory that registers `echo` — the smallest useful server. */
 function echoServer(): McpServer {
@@ -133,15 +139,19 @@ function rawSchemaServer(): Server {
                 const n = (req.params.arguments as { n: number }).n;
                 return { structuredContent: { doubled: n * 2 }, content: [{ type: 'text', text: JSON.stringify({ doubled: n * 2 }) }] };
             }
-            case 'structured-mismatch':
+            case 'structured-mismatch': {
                 // intentionally invalid structuredContent (tests client-side validation rejects it)
                 return { structuredContent: { value: 'not-a-number' }, content: [] };
-            case 'structured-missing':
+            }
+            case 'structured-missing': {
                 return { content: [{ type: 'text', text: 'handler-body-no-structured' }] };
-            case 'structured-error-skip':
+            }
+            case 'structured-error-skip': {
                 return { isError: true, content: [{ type: 'text', text: 'handler-returned-isError' }] };
-            default:
+            }
+            default: {
                 throw new ProtocolError(ProtocolErrorCode.InvalidParams, `unknown tool ${req.params.name}`);
+            }
         }
     });
     return s;
@@ -307,8 +317,10 @@ verifies('tools:call:sampling-roundtrip', async ({ transport }: TestArgs) => {
     expect(r.content).toEqual([{ type: 'text', text: 'model said: pong' }]);
 
     expect(received).toHaveLength(1);
-    expect(received[0].params.messages).toEqual([{ role: 'user', content: { type: 'text', text: 'ping' } }]);
-    expect(received[0].params.maxTokens).toBe(100);
+    const samplingRequest = received[0];
+    if (samplingRequest === undefined) throw new Error('expected a sampling request to have been received');
+    expect(samplingRequest.params.messages).toEqual([{ role: 'user', content: { type: 'text', text: 'ping' } }]);
+    expect(samplingRequest.params.maxTokens).toBe(100);
 });
 
 verifies('tools:call:elicitation-roundtrip', async ({ transport }: TestArgs) => {
@@ -338,8 +350,10 @@ verifies('tools:call:elicitation-roundtrip', async ({ transport }: TestArgs) => 
     const r = await client.callTool({ name: 'ask-name', arguments: {} });
 
     expect(received).toHaveLength(1);
-    expect(received[0].method).toBe('elicitation/create');
-    expect(received[0].params).toMatchObject({
+    const elicitRequest = received[0];
+    if (elicitRequest === undefined) throw new Error('expected an elicitation request to have been received');
+    expect(elicitRequest.method).toBe('elicitation/create');
+    expect(elicitRequest.params).toMatchObject({
         mode: 'form',
         message: 'What is your name?',
         requestedSchema: { type: 'object', properties: { name: { type: 'string' } }, required: ['name'] }
@@ -402,9 +416,10 @@ verifies('tools:call:progress', async ({ transport }: TestArgs) => {
     let receivedAtResolve = -1;
 
     const r = await client
-        .callTool({ name: 'progress', arguments: { steps } }, undefined, {
-            onprogress: p => received.push({ progress: p.progress, total: p.total, message: p.message })
-        })
+        .callTool(
+            { name: 'progress', arguments: { steps } },
+            { onprogress: p => received.push({ progress: p.progress, total: p.total, message: p.message }) }
+        )
         .then(res => {
             receivedAtResolve = received.length;
             return res;
@@ -453,7 +468,7 @@ verifies('tools:call:concurrent', async ({ transport }: TestArgs) => {
 
     // Both handlers are running at the same time before either is allowed to finish.
     await vi.waitFor(() => expect(started).toHaveLength(2));
-    expect(started.slice().sort()).toEqual(['order-1001', 'order-2002']);
+    expect(started.toSorted()).toEqual(['order-1001', 'order-2002']);
     expect(settled).toEqual([]);
 
     releaseBoth();
@@ -464,7 +479,7 @@ verifies('tools:call:concurrent', async ({ transport }: TestArgs) => {
     expect(first.content).toEqual([{ type: 'text', text: 'order order-1001: shipped' }]);
     expect(second.isError).toBeFalsy();
     expect(second.content).toEqual([{ type: 'text', text: 'order order-2002: shipped' }]);
-    expect(settled.slice().sort()).toEqual(['order-1001', 'order-2002']);
+    expect(settled.toSorted()).toEqual(['order-1001', 'order-2002']);
 });
 
 verifies('tools:call:is-error', async ({ transport }: TestArgs) => {
@@ -513,7 +528,7 @@ verifies(
 
         const call = client.callTool({ name: 'no-such-tool', arguments: {} });
         await expect(call).rejects.toBeInstanceOf(ProtocolError);
-        const err = await call.catch(e => e as ProtocolError);
+        const err = await call.catch(error => error as ProtocolError);
         expect(err.code).toBe(ProtocolErrorCode.InvalidParams);
         expect(err.message).toMatch(/no-such-tool|unknown|not found/i);
     },
@@ -544,7 +559,7 @@ verifies(
 
         const call = client.callTool({ name: 'no-such-tool', arguments: {} });
         await expect(call).rejects.toBeInstanceOf(ProtocolError);
-        const err = await call.catch(e => e as ProtocolError);
+        const err = await call.catch(error => error as ProtocolError);
         expect(err.code).toBe(ProtocolErrorCode.InvalidParams);
     },
     { title: 'raw server' }
@@ -565,6 +580,7 @@ verifies('tools:call:structured-content', async ({ transport }: TestArgs) => {
     expect(r.content).toEqual([{ type: 'text', text: JSON.stringify({ doubled: 14 }) }]);
 
     // structuredContent satisfies the *advertised* outputSchema.
+    if (!isJsonSchemaObject(tool.outputSchema)) throw new Error('advertised outputSchema is not a JSON Schema object');
     const validate = new AjvJsonSchemaValidator().getValidator(tool.outputSchema);
     const v = validate(r.structuredContent);
     expect(v.valid, v.errorMessage).toBe(true);
@@ -774,7 +790,7 @@ verifies(
             const s = new Server({ name: 's', version: '0' }, { capabilities: { tools: {} } });
             s.setRequestHandler('tools/list', req => {
                 cursorsReceived.push(req.params?.cursor);
-                const start = req.params?.cursor === undefined ? 0 : parseInt(req.params.cursor, 10);
+                const start = req.params?.cursor === undefined ? 0 : Number.parseInt(req.params.cursor, 10);
                 const slice = all.slice(start, start + PAGE);
                 return {
                     tools: slice.map(name => ({ name, inputSchema: { type: 'object' as const } })),
@@ -831,16 +847,19 @@ verifies('tools:list-changed', async ({ transport }: TestArgs) => {
 
     await using _ = await wire(transport, makeServer, client);
 
-    expect((await client.listTools()).tools.length).toBe(1);
+    const initialList = await client.listTools();
+    expect(initialList.tools.length).toBe(1);
 
     const handle = server.registerTool('dynamic-probe', { inputSchema: z.object({}) }, () => ({ content: [] }));
     await vi.waitFor(() => expect(listChanged).toBeGreaterThanOrEqual(1));
-    expect((await client.listTools()).tools.length).toBe(2);
+    const listAfterAdd = await client.listTools();
+    expect(listAfterAdd.tools.length).toBe(2);
     const afterAdd = listChanged;
 
     handle.remove();
     await vi.waitFor(() => expect(listChanged).toBeGreaterThan(afterAdd));
-    expect((await client.listTools()).tools.length).toBe(1);
+    const listAfterRemove = await client.listTools();
+    expect(listAfterRemove.tools.length).toBe(1);
 });
 
 verifies('tools:capability:declared', async ({ transport }: TestArgs) => {
@@ -963,8 +982,8 @@ verifies('mcpserver:tool:duplicate-name', async ({ transport }: TestArgs) => {
         // Duplicate throws at registration time.
         try {
             s.registerTool('echo', { inputSchema: z.object({}) }, () => ({ content: [] }));
-        } catch (e) {
-            dupError = e;
+        } catch (error) {
+            dupError = error;
         }
         return s;
     };
@@ -975,7 +994,7 @@ verifies('mcpserver:tool:duplicate-name', async ({ transport }: TestArgs) => {
     expect(String(dupError)).toMatch(/already registered/i);
 
     // Original survives the failed duplicate registration.
-    const tools = (await client.listTools()).tools;
+    const { tools } = await client.listTools();
     expect(tools.filter(t => t.name === 'echo')).toHaveLength(1);
     expect(tools.map(t => t.name)).toContain('fresh');
     const r = await client.callTool({ name: 'echo', arguments: { text: 'still here' } });
@@ -999,22 +1018,25 @@ verifies('mcpserver:tool:handle-update', async ({ transport }: TestArgs) => {
     });
     await using _ = await wire(transport, makeServer, client);
 
-    const beforeList = (await client.listTools()).tools;
+    const beforeResult = await client.listTools();
+    const beforeList = beforeResult.tools;
     expect(beforeList.length).toBe(1);
     const before = beforeList.find(t => t.name === 'echo')!;
     expect(before.description).toBe('v1');
     expect(before.inputSchema.properties).toHaveProperty('text');
-    expect((await client.callTool({ name: 'echo', arguments: { text: 'hi' } })).content).toEqual([{ type: 'text', text: 'hi' }]);
+    const beforeCall = await client.callTool({ name: 'echo', arguments: { text: 'hi' } });
+    expect(beforeCall.content).toEqual([{ type: 'text', text: 'hi' }]);
 
     handle.update({
         description: 'v2 — replaced via RegisteredTool.update()',
-        paramsSchema: {},
+        paramsSchema: z.object({}),
         callback: () => ({ content: [{ type: 'text', text: 'echo-v2-handler' }] })
     });
 
     await vi.waitFor(() => expect(listChanged).toBeGreaterThanOrEqual(1));
 
-    const afterList = (await client.listTools()).tools;
+    const afterResult = await client.listTools();
+    const afterList = afterResult.tools;
     expect(afterList.length).toBe(1);
     const after = afterList.find(t => t.name === 'echo')!;
     expect(after.description).toBe('v2 — replaced via RegisteredTool.update()');
@@ -1085,7 +1107,8 @@ verifies('mcpserver:tool:naming-validation', async ({ transport }: TestArgs) => 
     for (const bad of INVALID) expect(warnedFor).toContain(bad);
     for (const good of VALID) expect(cleanFor).toContain(good);
 
-    const names = (await client.listTools()).tools.map(t => t.name);
+    const listed = await client.listTools();
+    const names = listed.tools.map(t => t.name);
     for (const good of VALID) expect(names).toContain(good);
 });
 
@@ -1107,7 +1130,7 @@ verifies('mcpserver:tool:url-elicitation-error', async ({ transport }: TestArgs)
     const client = newClient();
     await using _ = await wire(transport, makeServer, client);
 
-    const err = await client.callTool({ name: 'needs-auth', arguments: {} }).catch((e: unknown) => e);
+    const err = await client.callTool({ name: 'needs-auth', arguments: {} }).catch((error: unknown) => error);
     if (!(err instanceof UrlElicitationRequiredError)) {
         throw new Error(`expected UrlElicitationRequiredError, got ${JSON.stringify(err)}`);
     }
@@ -1154,7 +1177,7 @@ verifies('typescript:mcpserver:tool:schema-variants', async ({ transport }: Test
                 inputSchema: z.object({
                     n: z
                         .preprocess(v => (typeof v === 'string' ? v.trim() : v), z.string())
-                        .transform(s => Number(s))
+                        .transform(Number)
                         .pipe(z.number().int().nonnegative())
                 })
             },
@@ -1165,27 +1188,26 @@ verifies('typescript:mcpserver:tool:schema-variants', async ({ transport }: Test
     const client = newClient();
     await using _ = await wire(transport, makeServer, client);
 
-    expect((await client.callTool({ name: 'zod-union', arguments: { kind: 'a', a: 'hello' } })).content).toEqual([
-        { type: 'text', text: 'a:hello' }
-    ]);
-    expect((await client.callTool({ name: 'zod-union', arguments: { kind: 'b', b: 42 } })).content).toEqual([
-        { type: 'text', text: 'b:42' }
-    ]);
-    expect((await client.callTool({ name: 'zod-intersection', arguments: { left: 'L', right: 'R' } })).content).toEqual([
-        { type: 'text', text: 'L|R' }
-    ]);
-    expect((await client.callTool({ name: 'zod-nested', arguments: { outer: { inner: { value: 5 } } } })).content).toEqual([
-        { type: 'text', text: '5' }
-    ]);
-    expect((await client.callTool({ name: 'zod-coerce', arguments: { n: '  7  ' } })).content).toEqual([
-        { type: 'text', text: 'coerced:7' }
-    ]);
+    const unionA = await client.callTool({ name: 'zod-union', arguments: { kind: 'a', a: 'hello' } });
+    expect(unionA.content).toEqual([{ type: 'text', text: 'a:hello' }]);
+    const unionB = await client.callTool({ name: 'zod-union', arguments: { kind: 'b', b: 42 } });
+    expect(unionB.content).toEqual([{ type: 'text', text: 'b:42' }]);
+    const intersection = await client.callTool({ name: 'zod-intersection', arguments: { left: 'L', right: 'R' } });
+    expect(intersection.content).toEqual([{ type: 'text', text: 'L|R' }]);
+    const nested = await client.callTool({ name: 'zod-nested', arguments: { outer: { inner: { value: 5 } } } });
+    expect(nested.content).toEqual([{ type: 'text', text: '5' }]);
+    const coerced = await client.callTool({ name: 'zod-coerce', arguments: { n: '  7  ' } });
+    expect(coerced.content).toEqual([{ type: 'text', text: 'coerced:7' }]);
 
     // Rejections — proves parse() actually runs for each shape.
-    expect((await client.callTool({ name: 'zod-union', arguments: { kind: 'a', a: 123 } })).isError).toBe(true);
-    expect((await client.callTool({ name: 'zod-intersection', arguments: { left: 'L' } })).isError).toBe(true);
-    expect((await client.callTool({ name: 'zod-nested', arguments: { outer: { inner: { value: 'x' } } } })).isError).toBe(true);
-    expect((await client.callTool({ name: 'zod-coerce', arguments: { n: '-3' } })).isError).toBe(true);
+    const unionRejected = await client.callTool({ name: 'zod-union', arguments: { kind: 'a', a: 123 } });
+    expect(unionRejected.isError).toBe(true);
+    const intersectionRejected = await client.callTool({ name: 'zod-intersection', arguments: { left: 'L' } });
+    expect(intersectionRejected.isError).toBe(true);
+    const nestedRejected = await client.callTool({ name: 'zod-nested', arguments: { outer: { inner: { value: 'x' } } } });
+    expect(nestedRejected.isError).toBe(true);
+    const coerceRejected = await client.callTool({ name: 'zod-coerce', arguments: { n: '-3' } });
+    expect(coerceRejected.isError).toBe(true);
 });
 
 verifies('typescript:mcpserver:tool:extra', async ({ transport }: TestArgs) => {
@@ -1221,75 +1243,7 @@ verifies('typescript:mcpserver:tool:extra', async ({ transport }: TestArgs) => {
         const clientSessionId = client.transport?.sessionId;
         if (clientSessionId !== undefined) expect(r.sessionId).toBe(clientSessionId);
     }
-    expect(seen[1].requestId).not.toBe(seen[0].requestId);
-});
-
-verifies('client:call-tool:compat-result-schema', async ({ transport }: TestArgs) => {
-    const makeServer = () => {
-        const s = new Server({ name: 's', version: '0' }, { capabilities: { tools: {} } });
-        s.setRequestHandler('tools/list', () => ({
-            tools: [{ name: 'legacy', inputSchema: { type: 'object' } }]
-        }));
-        // legacy 2024-10-07 result shape (tests CompatibilityCallToolResultSchema accepts it)
-        s.setRequestHandler('tools/call', () => ({ toolResult: 'plain string' }));
-        return s;
-    };
-    const client = newClient();
-    await using _ = await wire(transport, makeServer, client);
-
-    const r = await client.callTool({ name: 'legacy', arguments: {} });
-    expect(r).toHaveProperty('toolResult', 'plain string');
-});
-
-verifies('mcpserver:tool:variadic-forms', async ({ transport }: TestArgs) => {
-    const makeServer = () => {
-        const s = new McpServer({ name: 's', version: '0' });
-        // (name, cb)
-        s.registerTool('plain', {}, () => ({ content: [{ type: 'text', text: 'plain' }] }));
-        // (name, description, cb)
-        s.registerTool('desc', { description: 'desc tool' }, () => ({ content: [{ type: 'text', text: 'desc' }] }));
-        // (name, paramsSchema, cb)
-        s.registerTool('args', { inputSchema: z.object({ x: z.string() }) }, ({ x }) => ({ content: [{ type: 'text', text: x }] }));
-        // (name, description, paramsSchema, cb)
-        s.registerTool('desc-args', { description: 'with both', inputSchema: z.object({ y: z.number() }) }, ({ y }) => ({
-            content: [{ type: 'text', text: String(y) }]
-        }));
-        // (name, description, paramsSchema, annotations, cb)
-        s.registerTool(
-            'full',
-            { description: 'full overload', inputSchema: z.object({ v: z.string() }), annotations: { readOnlyHint: true } },
-            ({ v }) => ({
-                content: [{ type: 'text', text: v }]
-            })
-        );
-        return s;
-    };
-
-    const client = newClient();
-    await using _ = await wire(transport, makeServer, client);
-
-    const list = await client.listTools();
-    const names = list.tools.map(t => t.name).sort();
-    expect(names).toEqual(['args', 'desc', 'desc-args', 'full', 'plain']);
-
-    const desc = list.tools.find(t => t.name === 'desc');
-    expect(desc?.description).toBe('desc tool');
-
-    const full = list.tools.find(t => t.name === 'full');
-    expect(full?.description).toBe('full overload');
-    expect(full?.annotations).toMatchObject({ readOnlyHint: true });
-    expect(full?.inputSchema).toMatchObject({ type: 'object', properties: { v: { type: 'string' } } });
-
-    expect(await client.callTool({ name: 'plain', arguments: {} })).toMatchObject({
-        content: [{ type: 'text', text: 'plain' }]
-    });
-    expect(await client.callTool({ name: 'args', arguments: { x: 'hi' } })).toMatchObject({
-        content: [{ type: 'text', text: 'hi' }]
-    });
-    expect(await client.callTool({ name: 'desc-args', arguments: { y: 3 } })).toMatchObject({
-        content: [{ type: 'text', text: '3' }]
-    });
-    expect(await client.callTool({ name: 'full', arguments: { v: 'go' } })).toMatchObject({
-        content: [{ type: 'text', text: 'go' }]
-    });
+    const [firstCallSeen, secondCallSeen] = seen;
+    if (firstCallSeen === undefined || secondCallSeen === undefined) throw new Error('expected both calls to be recorded');
+    expect(secondCallSeen.requestId).not.toBe(firstCallSeen.requestId);
 });

--- a/test/e2e/scenarios/tools.test.ts
+++ b/test/e2e/scenarios/tools.test.ts
@@ -22,29 +22,18 @@
 
 import { expect, vi } from 'vitest';
 import { z } from 'zod/v4';
-
-import { Client } from '../../../src/client/index.js';
-import { Server } from '../../../src/server/index.js';
-import { McpServer, type RegisteredTool } from '../../../src/server/mcp.js';
-import {
-    CallToolRequestSchema,
-    CompatibilityCallToolResultSchema,
-    type CreateMessageRequest,
-    CreateMessageRequestSchema,
-    type CreateMessageResult,
-    type ElicitRequest,
-    ElicitRequestSchema,
-    ErrorCode,
-    type JSONRPCMessage,
-    ListToolsRequestSchema,
-    LoggingMessageNotificationSchema,
-    McpError,
-    type RequestId,
-    type Tool,
-    ToolListChangedNotificationSchema,
-    UrlElicitationRequiredError
-} from '../../../src/types.js';
-import { AjvJsonSchemaValidator } from '../../../src/validation/ajv-provider.js';
+import { Server, McpServer, ProtocolError, UrlElicitationRequiredError, ProtocolErrorCode } from '@modelcontextprotocol/server';
+import type {
+    RegisteredTool,
+    CreateMessageRequest,
+    CreateMessageResult,
+    ElicitRequest,
+    JSONRPCMessage,
+    RequestId,
+    Tool
+} from '@modelcontextprotocol/server';
+import { Client } from '@modelcontextprotocol/client';
+import { AjvJsonSchemaValidator } from '@modelcontextprotocol/core';
 
 import { wire } from '../helpers/index.js';
 import type { TestArgs } from '../types.js';
@@ -112,10 +101,10 @@ function schemaServer(): McpServer {
 /** Low-level Server factory listing/calling a single hand-authored JSON-Schema-2020-12 tool. */
 function rawJsonSchemaServer(): Server {
     const s = new Server({ name: 's', version: '0' }, { capabilities: { tools: {} } });
-    s.setRequestHandler(ListToolsRequestSchema, () => ({
+    s.setRequestHandler('tools/list', () => ({
         tools: [{ name: 'json-schema', description: 'raw 2020-12 schema', inputSchema: JSON_SCHEMA_2020_12_INPUT }]
     }));
-    s.setRequestHandler(CallToolRequestSchema, req => {
+    s.setRequestHandler('tools/call', req => {
         const { x, y } = (req.params.arguments as { point: { x: number; y: number } }).point;
         return { content: [{ type: 'text', text: `(${x}, ${y})` }] };
     });
@@ -126,7 +115,7 @@ function rawJsonSchemaServer(): Server {
 function rawSchemaServer(): Server {
     const s = new Server({ name: 's', version: '0' }, { capabilities: { tools: {} } });
     const outputSchema: Tool['outputSchema'] = { type: 'object', properties: { value: { type: 'number' } }, required: ['value'] };
-    s.setRequestHandler(ListToolsRequestSchema, () => ({
+    s.setRequestHandler('tools/list', () => ({
         tools: [
             {
                 name: 'structured',
@@ -138,7 +127,7 @@ function rawSchemaServer(): Server {
             { name: 'structured-error-skip', inputSchema: { type: 'object' }, outputSchema }
         ]
     }));
-    s.setRequestHandler(CallToolRequestSchema, req => {
+    s.setRequestHandler('tools/call', req => {
         switch (req.params.name) {
             case 'structured': {
                 const n = (req.params.arguments as { n: number }).n;
@@ -152,7 +141,7 @@ function rawSchemaServer(): Server {
             case 'structured-error-skip':
                 return { isError: true, content: [{ type: 'text', text: 'handler-returned-isError' }] };
             default:
-                throw new McpError(ErrorCode.InvalidParams, `unknown tool ${req.params.name}`);
+                throw new ProtocolError(ProtocolErrorCode.InvalidParams, `unknown tool ${req.params.name}`);
         }
     });
     return s;
@@ -301,7 +290,7 @@ verifies('tools:call:sampling-roundtrip', async ({ transport }: TestArgs) => {
 
     const received: CreateMessageRequest[] = [];
     const client = new Client({ name: 'c', version: '0' }, { capabilities: { sampling: {} } });
-    client.setRequestHandler(CreateMessageRequestSchema, async req => {
+    client.setRequestHandler('sampling/createMessage', async req => {
         received.push(req);
         return {
             model: 'stub-model',
@@ -339,7 +328,7 @@ verifies('tools:call:elicitation-roundtrip', async ({ transport }: TestArgs) => 
 
     const received: ElicitRequest[] = [];
     const client = new Client({ name: 'c', version: '0' }, { capabilities: { elicitation: { form: {} } } });
-    client.setRequestHandler(ElicitRequestSchema, async req => {
+    client.setRequestHandler('elicitation/create', async req => {
         received.push(req);
         return { action: 'accept', content: { name: 'Ada' } };
     });
@@ -363,8 +352,8 @@ verifies('tools:call:elicitation-roundtrip', async ({ transport }: TestArgs) => 
 verifies('tools:call:logging-mid-execution', async ({ transport }: TestArgs) => {
     const makeServer = () => {
         const s = new McpServer({ name: 's', version: '0' }, { capabilities: { logging: {} } });
-        s.registerTool('log-then-ok', { inputSchema: z.object({}) }, async (_args, extra) => {
-            await extra.sendNotification({
+        s.registerTool('log-then-ok', { inputSchema: z.object({}) }, async (_args, ctx) => {
+            await ctx.mcpReq.notify({
                 method: 'notifications/message',
                 params: { level: 'warning', logger: 'tools-test', data: 'work in progress' }
             });
@@ -375,7 +364,7 @@ verifies('tools:call:logging-mid-execution', async ({ transport }: TestArgs) => 
 
     const logs: Array<{ level: string; logger?: string; data: unknown }> = [];
     const client = newClient();
-    client.setNotificationHandler(LoggingMessageNotificationSchema, n => {
+    client.setNotificationHandler('notifications/message', n => {
         logs.push(n.params);
     });
 
@@ -391,11 +380,11 @@ verifies('tools:call:logging-mid-execution', async ({ transport }: TestArgs) => 
 verifies('tools:call:progress', async ({ transport }: TestArgs) => {
     const makeServer = () => {
         const s = new McpServer({ name: 's', version: '0' });
-        s.registerTool('progress', { inputSchema: z.object({ steps: z.number().int().positive() }) }, async ({ steps }, extra) => {
-            const token = extra._meta?.progressToken;
+        s.registerTool('progress', { inputSchema: z.object({ steps: z.number().int().positive() }) }, async ({ steps }, ctx) => {
+            const token = ctx.mcpReq._meta?.progressToken;
             if (token !== undefined) {
                 for (let i = 1; i <= steps; i++) {
-                    await extra.sendNotification({
+                    await ctx.mcpReq.notify({
                         method: 'notifications/progress',
                         params: { progressToken: token, progress: i, total: steps, message: `step ${i}/${steps}` }
                     });
@@ -523,9 +512,9 @@ verifies(
         await using _ = await wire(transport, echoServer, client);
 
         const call = client.callTool({ name: 'no-such-tool', arguments: {} });
-        await expect(call).rejects.toBeInstanceOf(McpError);
-        const err = await call.catch(e => e as McpError);
-        expect(err.code).toBe(ErrorCode.InvalidParams);
+        await expect(call).rejects.toBeInstanceOf(ProtocolError);
+        const err = await call.catch(e => e as ProtocolError);
+        expect(err.code).toBe(ProtocolErrorCode.InvalidParams);
         expect(err.message).toMatch(/no-such-tool|unknown|not found/i);
     },
     { title: 'mcpserver' }
@@ -536,14 +525,14 @@ verifies(
     async ({ transport }: TestArgs) => {
         const makeServer = () => {
             const s = new Server({ name: 's', version: '0' }, { capabilities: { tools: {} } });
-            s.setRequestHandler(ListToolsRequestSchema, () => ({
+            s.setRequestHandler('tools/list', () => ({
                 tools: [{ name: 'echo', inputSchema: { type: 'object', properties: { text: { type: 'string' } } } }]
             }));
-            s.setRequestHandler(CallToolRequestSchema, req => {
+            s.setRequestHandler('tools/call', req => {
                 if (req.params.name === 'echo') {
                     return { content: [{ type: 'text', text: String(req.params.arguments?.text ?? '') }] };
                 }
-                throw new McpError(ErrorCode.InvalidParams, `Tool ${req.params.name} not found`);
+                throw new ProtocolError(ProtocolErrorCode.InvalidParams, `Tool ${req.params.name} not found`);
             });
             return s;
         };
@@ -554,9 +543,9 @@ verifies(
         expect(ok.content).toEqual([{ type: 'text', text: 'hi' }]);
 
         const call = client.callTool({ name: 'no-such-tool', arguments: {} });
-        await expect(call).rejects.toBeInstanceOf(McpError);
-        const err = await call.catch(e => e as McpError);
-        expect(err.code).toBe(ErrorCode.InvalidParams);
+        await expect(call).rejects.toBeInstanceOf(ProtocolError);
+        const err = await call.catch(e => e as ProtocolError);
+        expect(err.code).toBe(ProtocolErrorCode.InvalidParams);
     },
     { title: 'raw server' }
 );
@@ -606,11 +595,11 @@ verifies(['client:output-schema:validate', 'client:output-schema:missing-structu
     expect(ok.structuredContent).toEqual({ doubled: 6 });
 
     const mismatch = client.callTool({ name: 'structured-mismatch', arguments: {} });
-    await expect(mismatch).rejects.toBeInstanceOf(McpError);
+    await expect(mismatch).rejects.toBeInstanceOf(ProtocolError);
     await expect(mismatch).rejects.toThrow(/output schema|structured content/i);
 
     const missing = client.callTool({ name: 'structured-missing', arguments: {} });
-    await expect(missing).rejects.toBeInstanceOf(McpError);
+    await expect(missing).rejects.toBeInstanceOf(ProtocolError);
     await expect(missing).rejects.toThrow(/did not return structured content/i);
 });
 
@@ -722,8 +711,8 @@ verifies('tools:list:metadata', async ({ transport }: TestArgs) => {
     };
     const makeServer = () => {
         const s = new Server({ name: 's', version: '0' }, { capabilities: { tools: {} } });
-        s.setRequestHandler(ListToolsRequestSchema, () => ({ tools: [annotated] }));
-        s.setRequestHandler(CallToolRequestSchema, () => ({ content: [] }));
+        s.setRequestHandler('tools/list', () => ({ tools: [annotated] }));
+        s.setRequestHandler('tools/call', () => ({ content: [] }));
         return s;
     };
     const client = newClient();
@@ -783,7 +772,7 @@ verifies(
 
         const makeServer = () => {
             const s = new Server({ name: 's', version: '0' }, { capabilities: { tools: {} } });
-            s.setRequestHandler(ListToolsRequestSchema, req => {
+            s.setRequestHandler('tools/list', req => {
                 cursorsReceived.push(req.params?.cursor);
                 const start = req.params?.cursor === undefined ? 0 : parseInt(req.params.cursor, 10);
                 const slice = all.slice(start, start + PAGE);
@@ -792,7 +781,7 @@ verifies(
                     nextCursor: start + PAGE < TOTAL ? String(start + PAGE) : undefined
                 };
             });
-            s.setRequestHandler(CallToolRequestSchema, () => ({ content: [] }));
+            s.setRequestHandler('tools/call', () => ({ content: [] }));
             return s;
         };
         const client = newClient();
@@ -836,7 +825,7 @@ verifies('tools:list-changed', async ({ transport }: TestArgs) => {
 
     let listChanged = 0;
     const client = newClient();
-    client.setNotificationHandler(ToolListChangedNotificationSchema, () => {
+    client.setNotificationHandler('notifications/tools/list_changed', () => {
         listChanged++;
     });
 
@@ -903,13 +892,13 @@ verifies('tools:input-schema:preserve-schema-dialect', async ({ transport }: Tes
     // SDK's listing path stamping a single default $schema onto every schema.
     const makeServer = () => {
         const s = new Server({ name: 's', version: '0' }, { capabilities: { tools: {} } });
-        s.setRequestHandler(ListToolsRequestSchema, () => ({
+        s.setRequestHandler('tools/list', () => ({
             tools: [
                 { name: 'draft07', inputSchema: { $schema: 'http://json-schema.org/draft-07/schema#', type: 'object' } },
                 { name: 'v2020', inputSchema: { $schema: 'https://json-schema.org/draft/2020-12/schema', type: 'object' } }
             ]
         }));
-        s.setRequestHandler(CallToolRequestSchema, () => ({ content: [] }));
+        s.setRequestHandler('tools/call', () => ({ content: [] }));
         return s;
     };
     const client = newClient();
@@ -928,14 +917,14 @@ verifies('tools:input-schema:preserve-additional-properties', async ({ transport
     // SDK's listing path stamping a single constant onto every schema.
     const makeServer = () => {
         const s = new Server({ name: 's', version: '0' }, { capabilities: { tools: {} } });
-        s.setRequestHandler(ListToolsRequestSchema, () => ({
+        s.setRequestHandler('tools/list', () => ({
             tools: [
                 { name: 'strict', inputSchema: { type: 'object', additionalProperties: false } },
                 { name: 'open', inputSchema: { type: 'object', additionalProperties: true } },
                 { name: 'absent', inputSchema: { type: 'object' } }
             ]
         }));
-        s.setRequestHandler(CallToolRequestSchema, () => ({ content: [] }));
+        s.setRequestHandler('tools/call', () => ({ content: [] }));
         return s;
     };
     const client = newClient();
@@ -1005,7 +994,7 @@ verifies('mcpserver:tool:handle-update', async ({ transport }: TestArgs) => {
 
     let listChanged = 0;
     const client = newClient();
-    client.setNotificationHandler(ToolListChangedNotificationSchema, () => {
+    client.setNotificationHandler('notifications/tools/list_changed', () => {
         listChanged++;
     });
     await using _ = await wire(transport, makeServer, client);
@@ -1122,7 +1111,7 @@ verifies('mcpserver:tool:url-elicitation-error', async ({ transport }: TestArgs)
     if (!(err instanceof UrlElicitationRequiredError)) {
         throw new Error(`expected UrlElicitationRequiredError, got ${JSON.stringify(err)}`);
     }
-    expect(err.code).toBe(ErrorCode.UrlElicitationRequired);
+    expect(err.code).toBe(ProtocolErrorCode.UrlElicitationRequired);
     expect(err.elicitations).toEqual([
         {
             mode: 'url',
@@ -1207,12 +1196,12 @@ verifies('typescript:mcpserver:tool:extra', async ({ transport }: TestArgs) => {
     const seen: Array<{ sessionId?: string; requestId: RequestId; hasSignal: boolean; hasSend: boolean }> = [];
     const makeServer = () => {
         const s = new McpServer({ name: 's', version: '0' });
-        s.registerTool('report-extra', { inputSchema: z.object({}) }, (_a, extra) => {
+        s.registerTool('report-extra', { inputSchema: z.object({}) }, (_a, ctx) => {
             seen.push({
-                sessionId: extra.sessionId,
-                requestId: extra.requestId,
-                hasSignal: extra.signal instanceof AbortSignal,
-                hasSend: typeof extra.sendNotification === 'function' && typeof extra.sendRequest === 'function'
+                sessionId: ctx.sessionId,
+                requestId: ctx.mcpReq.id,
+                hasSignal: ctx.mcpReq.signal instanceof AbortSignal,
+                hasSend: typeof ctx.mcpReq.notify === 'function' && typeof ctx.mcpReq.send === 'function'
             });
             return { content: [] };
         });
@@ -1238,17 +1227,17 @@ verifies('typescript:mcpserver:tool:extra', async ({ transport }: TestArgs) => {
 verifies('client:call-tool:compat-result-schema', async ({ transport }: TestArgs) => {
     const makeServer = () => {
         const s = new Server({ name: 's', version: '0' }, { capabilities: { tools: {} } });
-        s.setRequestHandler(ListToolsRequestSchema, () => ({
+        s.setRequestHandler('tools/list', () => ({
             tools: [{ name: 'legacy', inputSchema: { type: 'object' } }]
         }));
         // legacy 2024-10-07 result shape (tests CompatibilityCallToolResultSchema accepts it)
-        s.setRequestHandler(CallToolRequestSchema, () => ({ toolResult: 'plain string' }));
+        s.setRequestHandler('tools/call', () => ({ toolResult: 'plain string' }));
         return s;
     };
     const client = newClient();
     await using _ = await wire(transport, makeServer, client);
 
-    const r = await client.callTool({ name: 'legacy', arguments: {} }, CompatibilityCallToolResultSchema);
+    const r = await client.callTool({ name: 'legacy', arguments: {} });
     expect(r).toHaveProperty('toolResult', 'plain string');
 });
 
@@ -1256,19 +1245,23 @@ verifies('mcpserver:tool:variadic-forms', async ({ transport }: TestArgs) => {
     const makeServer = () => {
         const s = new McpServer({ name: 's', version: '0' });
         // (name, cb)
-        s.tool('plain', () => ({ content: [{ type: 'text', text: 'plain' }] }));
+        s.registerTool('plain', {}, () => ({ content: [{ type: 'text', text: 'plain' }] }));
         // (name, description, cb)
-        s.tool('desc', 'desc tool', () => ({ content: [{ type: 'text', text: 'desc' }] }));
+        s.registerTool('desc', { description: 'desc tool' }, () => ({ content: [{ type: 'text', text: 'desc' }] }));
         // (name, paramsSchema, cb)
-        s.tool('args', { x: z.string() }, ({ x }) => ({ content: [{ type: 'text', text: x }] }));
+        s.registerTool('args', { inputSchema: z.object({ x: z.string() }) }, ({ x }) => ({ content: [{ type: 'text', text: x }] }));
         // (name, description, paramsSchema, cb)
-        s.tool('desc-args', 'with both', { y: z.number() }, ({ y }) => ({
+        s.registerTool('desc-args', { description: 'with both', inputSchema: z.object({ y: z.number() }) }, ({ y }) => ({
             content: [{ type: 'text', text: String(y) }]
         }));
         // (name, description, paramsSchema, annotations, cb)
-        s.tool('full', 'full overload', { v: z.string() }, { readOnlyHint: true }, ({ v }) => ({
-            content: [{ type: 'text', text: v }]
-        }));
+        s.registerTool(
+            'full',
+            { description: 'full overload', inputSchema: z.object({ v: z.string() }), annotations: { readOnlyHint: true } },
+            ({ v }) => ({
+                content: [{ type: 'text', text: v }]
+            })
+        );
         return s;
     };
 

--- a/test/e2e/scenarios/transport-http.test.ts
+++ b/test/e2e/scenarios/transport-http.test.ts
@@ -18,20 +18,21 @@
 
 import { randomUUID } from 'node:crypto';
 
+import { Client, StreamableHTTPClientTransport } from '@modelcontextprotocol/client';
+import { JSONRPCRequestSchema } from '@modelcontextprotocol/core';
+import {
+    LATEST_PROTOCOL_VERSION,
+    McpServer,
+    SUPPORTED_PROTOCOL_VERSIONS,
+    WebStandardStreamableHTTPServerTransport
+} from '@modelcontextprotocol/server';
 import { expect, vi } from 'vitest';
 import { z } from 'zod/v4';
-import {
-    McpServer,
-    WebStandardStreamableHTTPServerTransport,
-    LATEST_PROTOCOL_VERSION,
-    SUPPORTED_PROTOCOL_VERSIONS
-} from '@modelcontextprotocol/server';
-import { JSONRPCRequestSchema } from '@modelcontextprotocol/core';
-import type { JSONRPCRequest } from '@modelcontextprotocol/server';
-import { Client, StreamableHTTPClientTransport } from '@modelcontextprotocol/client';
-import { hostPerSession, type HttpHandler } from '../helpers/index.js';
-import type { TestArgs } from '../types.js';
+
+import type { HttpHandler } from '../helpers/index.js';
+import { hostPerSession } from '../helpers/index.js';
 import { verifies } from '../helpers/verifies.js';
+import type { TestArgs } from '../types.js';
 
 const newClient = () => new Client({ name: 'c', version: '0' });
 
@@ -43,13 +44,21 @@ function echoServer(): McpServer {
     return s;
 }
 
-const OLDER_VERSION = SUPPORTED_PROTOCOL_VERSIONS.find(v => v !== LATEST_PROTOCOL_VERSION)!;
+const OLDER_VERSION = SUPPORTED_PROTOCOL_VERSIONS.find(v => v !== LATEST_PROTOCOL_VERSION);
 
 interface RecordedRequest {
     method: string;
     url: string;
     headers: Record<string, string>;
     body?: string;
+}
+
+function headersToRecord(headers: Headers): Record<string, string> {
+    const record: Record<string, string> = {};
+    for (const [key, value] of headers.entries()) {
+        record[key.toLowerCase()] = value;
+    }
+    return record;
 }
 
 function recordingFetch(
@@ -59,14 +68,16 @@ function recordingFetch(
     return async (url, init) => {
         const u = typeof url === 'string' ? url : url.toString();
         const req = new Request(u, init);
-        const headers: Record<string, string> = {};
-        req.headers.forEach((v, k) => {
-            headers[k.toLowerCase()] = v;
-        });
         const body = init?.body ? String(init.body) : undefined;
-        records.push({ method: req.method, url: u, headers, body });
+        records.push({ method: req.method, url: u, headers: headersToRecord(req.headers), body });
         return baseHandler(req);
     };
+}
+
+/** Narrows away `undefined` for values the surrounding test has already proven exist (replaces non-null assertions). */
+function defined<T>(value: T | undefined, label: string): T {
+    if (value === undefined) throw new Error(`expected ${label} to be defined`);
+    return value;
 }
 
 verifies('client-transport:http:session-stored', async (_args: TestArgs) => {
@@ -87,12 +98,13 @@ verifies('client-transport:http:session-stored', async (_args: TestArgs) => {
 
         const initReq = records.find(r => r.body?.includes('"method":"initialize"'));
         expect(initReq).toBeDefined();
-        expect(initReq!.headers['mcp-session-id']).toBeUndefined();
+        const initRequest = defined(initReq, 'recorded initialize request');
+        expect(initRequest.headers['mcp-session-id']).toBeUndefined();
 
         await client.ping();
         await client.listTools();
 
-        const initIdx = records.indexOf(initReq!);
+        const initIdx = records.indexOf(initRequest);
         const subsequent = records.slice(initIdx + 1);
         expect(subsequent.length).toBeGreaterThan(0);
         for (const req of subsequent) {
@@ -130,29 +142,21 @@ verifies('typescript:client-transport:http:protocol-version-stored', async (_arg
 
 verifies('client-transport:http:protocol-version-header', async (_args: TestArgs) => {
     const records: RecordedRequest[] = [];
-    let claimedVersion = LATEST_PROTOCOL_VERSION;
 
+    expect(OLDER_VERSION).toBeDefined();
+    expect(OLDER_VERSION).not.toBe(LATEST_PROTOCOL_VERSION);
+    const olderVersion = defined(OLDER_VERSION, 'older supported protocol version');
+
+    // The server only supports an older spec version, so initialize negotiates the connection down to it
     const handle = hostPerSession(() => {
-        const s = echoServer();
-        const origHandlers = (
-            s.server as unknown as { _requestHandlers: Map<string, (req: JSONRPCRequest, extra: unknown) => Promise<unknown>> }
-        )._requestHandlers;
-        const initHandler = origHandlers.get('initialize');
-        if (initHandler) {
-            origHandlers.set('initialize', async (req: JSONRPCRequest, extra: unknown) => {
-                const result = (await initHandler(req, extra)) as { protocolVersion: string };
-                return { ...result, protocolVersion: claimedVersion };
-            });
-        }
+        const s = new McpServer({ name: 's', version: '0' }, { supportedProtocolVersions: [olderVersion] });
+        s.registerTool('echo', { description: 'Echo tool', inputSchema: z.object({ text: z.string() }) }, ({ text }) => ({
+            content: [{ type: 'text', text }]
+        }));
         return s;
     });
 
     try {
-        expect(OLDER_VERSION).toBeDefined();
-        expect(OLDER_VERSION).not.toBe(LATEST_PROTOCOL_VERSION);
-
-        claimedVersion = OLDER_VERSION;
-
         const url = new URL('http://in-process/mcp');
         const transport = new StreamableHTTPClientTransport(url, {
             fetch: recordingFetch(records, handle.handleRequest)
@@ -168,13 +172,14 @@ verifies('client-transport:http:protocol-version-header', async (_args: TestArgs
 
         const initIdx = records.findIndex(r => r.body?.includes('"method":"initialize"'));
         expect(initIdx).toBeGreaterThanOrEqual(0);
-        expect(records[initIdx].headers['mcp-protocol-version']).toBeUndefined();
+        const initReq = defined(records[initIdx], 'recorded initialize request');
+        expect(initReq.headers['mcp-protocol-version']).toBeUndefined();
 
         const afterInit = records.slice(initIdx + 1);
         expect(afterInit.length).toBeGreaterThanOrEqual(2);
 
         for (const req of afterInit) {
-            expect(req.headers['mcp-protocol-version']).toBe(OLDER_VERSION);
+            expect(req.headers['mcp-protocol-version']).toBe(olderVersion);
         }
 
         await client.close();
@@ -362,10 +367,7 @@ verifies('client-transport:http:404-surfaces', async (_args: TestArgs) => {
                 const req = new Request(u, init);
                 const sid = req.headers.get('mcp-session-id');
                 if (sid && sid === sessionIdToBreak) {
-                    return new Response(JSON.stringify({ error: 'Session not found' }), {
-                        status: 404,
-                        headers: { 'Content-Type': 'application/json' }
-                    });
+                    return Response.json({ error: 'Session not found' }, { status: 404 });
                 }
                 return handle.handleRequest(req);
             }
@@ -477,12 +479,12 @@ verifies('client-transport:http:no-reconnect-after-close', async (_args: TestArg
         await vi.waitFor(() => expect(getControllers.length).toBe(1));
 
         // Prove the reconnect machinery is live in this setup: an errored GET stream is reconnected after the delay
-        getControllers[0].error(new Error('connection reset'));
+        defined(getControllers[0], 'first GET stream controller').error(new Error('connection reset'));
         await vi.waitFor(() => expect(records.filter(r => r.method === 'GET').length).toBe(2));
         await vi.waitFor(() => expect(getControllers.length).toBe(2));
 
         // Error the second stream so a reconnection is pending, then close before its 200ms delay elapses
-        getControllers[1].error(new Error('connection reset'));
+        defined(getControllers[1], 'second GET stream controller').error(new Error('connection reset'));
         await vi.waitFor(() => expect(transportErrors.filter(e => e.message.includes('SSE stream disconnected')).length).toBe(2), {
             interval: 10
         });
@@ -505,12 +507,10 @@ verifies('client-transport:http:concurrent-streams', async (_args: TestArgs) => 
     const started: string[] = [];
     const gates = new Map<string, { promise: Promise<void>; release: () => void }>();
     for (const text of ['first', 'second', 'third']) {
-        let release!: () => void;
-        const promise = new Promise<void>(resolve => {
-            release = resolve;
-        });
-        gates.set(text, { promise, release });
+        const { promise, resolve } = Promise.withResolvers<void>();
+        gates.set(text, { promise, release: resolve });
     }
+    const releaseGate = (text: string) => defined(gates.get(text), `gate for ${text}`).release();
 
     const handle = hostPerSession(() => {
         const s = new McpServer({ name: 's', version: '0' });
@@ -532,23 +532,24 @@ verifies('client-transport:http:concurrent-streams', async (_args: TestArgs) => 
 
         await client.connect(transport);
 
-        const calls = [
-            client.callTool({ name: 'echo', arguments: { text: 'first' } }),
-            client.callTool({ name: 'echo', arguments: { text: 'second' } }),
-            client.callTool({ name: 'echo', arguments: { text: 'third' } })
-        ];
+        const firstCall = client.callTool({ name: 'echo', arguments: { text: 'first' } });
+        const secondCall = client.callTool({ name: 'echo', arguments: { text: 'second' } });
+        const thirdCall = client.callTool({ name: 'echo', arguments: { text: 'third' } });
 
-        await vi.waitFor(() => expect([...started].sort()).toEqual(['first', 'second', 'third']));
+        await vi.waitFor(() => expect(started.toSorted()).toEqual(['first', 'second', 'third']));
 
         // Release responses in reverse order: each promise must still receive its own call's text
-        gates.get('third')!.release();
-        expect((await calls[2]).content).toEqual([{ type: 'text', text: 'third' }]);
+        releaseGate('third');
+        const thirdResult = await thirdCall;
+        expect(thirdResult.content).toEqual([{ type: 'text', text: 'third' }]);
 
-        gates.get('second')!.release();
-        expect((await calls[1]).content).toEqual([{ type: 'text', text: 'second' }]);
+        releaseGate('second');
+        const secondResult = await secondCall;
+        expect(secondResult.content).toEqual([{ type: 'text', text: 'second' }]);
 
-        gates.get('first')!.release();
-        expect((await calls[0]).content).toEqual([{ type: 'text', text: 'first' }]);
+        releaseGate('first');
+        const firstResult = await firstCall;
+        expect(firstResult.content).toEqual([{ type: 'text', text: 'first' }]);
 
         await client.close();
         await transport.close();
@@ -571,12 +572,8 @@ verifies('client-transport:http:no-reconnect-after-response', async (_args: Test
         const transport = new StreamableHTTPClientTransport(url, {
             fetch: async (u, init) => {
                 const req = new Request(u, init);
-                const headers: Record<string, string> = {};
-                req.headers.forEach((v, k) => {
-                    headers[k.toLowerCase()] = v;
-                });
                 const body = init?.body ? String(init.body) : undefined;
-                records.push({ method: req.method, url: u.toString(), headers, body });
+                records.push({ method: req.method, url: u.toString(), headers: headersToRecord(req.headers), body });
 
                 if (req.method === 'GET') {
                     // Refuse the standalone GET so any further GET could only be a reconnection of the POST stream
@@ -613,9 +610,10 @@ verifies('client-transport:http:no-reconnect-after-response', async (_args: Test
 
         await vi.waitFor(() => expect(records.filter(r => r.method === 'GET').length).toBe(1));
 
-        const result = await client.callTool({ name: 'echo', arguments: { text: 'delivered' } }, undefined, {
-            onresumptiontoken: token => void tokens.push(token)
-        });
+        const result = await client.callTool(
+            { name: 'echo', arguments: { text: 'delivered' } },
+            { onresumptiontoken: token => void tokens.push(token) }
+        );
 
         expect(result.content).toEqual([{ type: 'text', text: 'delivered' }]);
         expect(tokens).toContain(PRIMING_EVENT_ID);
@@ -693,14 +691,15 @@ verifies('client-transport:http:reconnect-retry-value', async (_args: TestArgs) 
 
             await client.connect(transport);
 
-            const call = client.callTool({ name: 'echo', arguments: { text: 'after retry' } }, undefined, {
-                onresumptiontoken: token => void tokens.push(token)
-            });
+            const call = client.callTool(
+                { name: 'echo', arguments: { text: 'after retry' } },
+                { onresumptiontoken: token => void tokens.push(token) }
+            );
 
             await vi.waitFor(() => expect(tokens).toContain('retry-evt-1'));
 
             const disconnectedAt = Date.now();
-            postController!.error(new Error('connection reset'));
+            defined(postController, 'POST SSE stream controller').error(new Error('connection reset'));
 
             await vi.advanceTimersByTimeAsync(RETRY_MS);
             // Bounded waitFor keeps total advanced time under the 1000ms default delay, so only a retry-honoring reconnect can arrive
@@ -709,7 +708,10 @@ verifies('client-transport:http:reconnect-retry-value', async (_args: TestArgs) 
                 interval: 10
             });
 
-            const reconnect = getRecords.find(g => g.lastEventId === 'retry-evt-1')!;
+            const reconnect = defined(
+                getRecords.find(g => g.lastEventId === 'retry-evt-1'),
+                'reconnection GET carrying the retry event id'
+            );
             expect(reconnect.at - disconnectedAt).toBeGreaterThanOrEqual(RETRY_MS);
 
             const result = await call;
@@ -747,7 +749,7 @@ verifies('client-transport:http:reconnect-retry-value', async (_args: TestArgs) 
                 },
                 reconnectionOptions: {
                     initialReconnectionDelay: 100,
-                    maxReconnectionDelay: 10000,
+                    maxReconnectionDelay: 10_000,
                     reconnectionDelayGrowFactor: 2,
                     maxRetries: 2
                 }
@@ -760,19 +762,21 @@ verifies('client-transport:http:reconnect-retry-value', async (_args: TestArgs) 
             await vi.waitFor(() => expect(firstGetController).toBeDefined());
 
             const disconnectedAt = Date.now();
-            firstGetController!.error(new Error('connection reset'));
+            defined(firstGetController, 'first GET stream controller').error(new Error('connection reset'));
 
             await vi.waitFor(() => expect(getRecords).toHaveLength(2));
-            expect(getRecords[1].at - disconnectedAt).toBeGreaterThanOrEqual(100);
+            const secondGet = defined(getRecords[1], 'second GET record');
+            expect(secondGet.at - disconnectedAt).toBeGreaterThanOrEqual(100);
 
             await vi.waitFor(() => expect(getRecords).toHaveLength(3));
-            expect(getRecords[2].at - getRecords[1].at).toBeGreaterThanOrEqual(200);
+            const thirdGet = defined(getRecords[2], 'third GET record');
+            expect(thirdGet.at - secondGet.at).toBeGreaterThanOrEqual(200);
 
             await vi.waitFor(() =>
                 expect(transportErrors.some(e => e.message.includes('Maximum reconnection attempts (2) exceeded'))).toBe(true)
             );
 
-            await vi.advanceTimersByTimeAsync(30000);
+            await vi.advanceTimersByTimeAsync(30_000);
             expect(getRecords).toHaveLength(3);
 
             await client.close();
@@ -798,14 +802,10 @@ verifies('client-transport:http:reconnect-get', async (_args: TestArgs) => {
         const transport = new StreamableHTTPClientTransport(url, {
             fetch: async (u, init) => {
                 const req = new Request(u, init);
-                const headers: Record<string, string> = {};
-                req.headers.forEach((v, k) => {
-                    headers[k.toLowerCase()] = v;
-                });
                 records.push({
                     method: req.method,
                     url: u.toString(),
-                    headers,
+                    headers: headersToRecord(req.headers),
                     body: init?.body ? String(init.body) : undefined
                 });
 
@@ -842,16 +842,19 @@ verifies('client-transport:http:reconnect-get', async (_args: TestArgs) => {
 
         await client.connect(transport);
 
-        await vi.waitFor(() => records.filter(r => r.method === 'GET').length >= 1);
+        await vi.waitFor(() => expect(records.filter(r => r.method === 'GET').length).toBeGreaterThanOrEqual(1));
 
-        const firstGet = records.find(r => r.method === 'GET');
-        expect(firstGet!.headers['last-event-id']).toBeUndefined();
+        const firstGet = defined(
+            records.find(r => r.method === 'GET'),
+            'first GET request'
+        );
+        expect(firstGet.headers['last-event-id']).toBeUndefined();
 
         await vi.advanceTimersByTimeAsync(100);
 
-        await vi.waitFor(() => records.filter(r => r.method === 'GET').length >= 2);
+        await vi.waitFor(() => expect(records.filter(r => r.method === 'GET').length).toBeGreaterThanOrEqual(2));
 
-        const secondGet = records.filter(r => r.method === 'GET')[1];
+        const secondGet = defined(records.filter(r => r.method === 'GET')[1], 'second GET request');
         expect(secondGet.headers['last-event-id']).toBe(FIRST_EVENT_ID);
 
         await client.close();
@@ -880,10 +883,7 @@ verifies('client-transport:http:reconnect-post-priming', async (_args: TestArgs)
         const transport = new StreamableHTTPClientTransport(url, {
             fetch: async (u, init) => {
                 const req = new Request(u, init);
-                const headers: Record<string, string> = {};
-                req.headers.forEach((v, k) => {
-                    headers[k.toLowerCase()] = v;
-                });
+                const headers = headersToRecord(req.headers);
                 const body = init?.body ? String(init.body) : undefined;
                 records.push({ method: req.method, url: u.toString(), headers, body });
 
@@ -953,18 +953,21 @@ verifies('client-transport:http:reconnect-post-priming', async (_args: TestArgs)
         );
 
         await vi.waitFor(() => expect(unprimedController).toBeDefined());
-        unprimedController!.error(new Error('connection reset before priming'));
+        defined(unprimedController, 'un-primed POST stream controller').error(new Error('connection reset before priming'));
         await vi.waitFor(() => expect(transportErrors.some(e => e.message.includes('SSE stream disconnected'))).toBe(true));
 
         // POST stream errored after the priming event: must reconnect with Last-Event-ID set to the priming id
-        const primedCall = client.callTool({ name: 'echo', arguments: { text: 'with priming' } }, undefined, {
-            onresumptiontoken: token => {
-                primedTokens.push(token);
+        const primedCall = client.callTool(
+            { name: 'echo', arguments: { text: 'with priming' } },
+            {
+                onresumptiontoken: token => {
+                    primedTokens.push(token);
+                }
             }
-        });
+        );
 
         await vi.waitFor(() => expect(primedTokens).toContain(PRIMING_EVENT_ID));
-        primedController!.error(new Error('connection reset after priming'));
+        defined(primedController, 'primed POST stream controller').error(new Error('connection reset after priming'));
 
         await vi.waitFor(() =>
             expect(records.filter(r => r.method === 'GET' && r.headers['last-event-id'] === PRIMING_EVENT_ID).length).toBe(1)
@@ -1019,12 +1022,15 @@ verifies('client-transport:http:resume-stream-api', async (_args: TestArgs) => {
         expect(sessionId).toBeDefined();
 
         const tokens: string[] = [];
-        await client.callTool({ name: 'progress', arguments: { steps: 3 } }, undefined, {
-            onprogress: () => {},
-            onresumptiontoken: id => {
-                if (id) tokens.push(id);
+        await client.callTool(
+            { name: 'progress', arguments: { steps: 3 } },
+            {
+                onprogress: () => {},
+                onresumptiontoken: id => {
+                    if (id) tokens.push(id);
+                }
             }
-        });
+        );
 
         if (tokens.length === 0) {
             await client.close();
@@ -1032,7 +1038,7 @@ verifies('client-transport:http:resume-stream-api', async (_args: TestArgs) => {
             return;
         }
 
-        const resumeFrom = tokens[0];
+        const resumeFrom = defined(tokens[0], 'first resumption token');
         const replayed: string[] = [];
 
         const beforeResume = records.length;
@@ -1042,8 +1048,9 @@ verifies('client-transport:http:resume-stream-api', async (_args: TestArgs) => {
 
         const resumeReq = records.slice(beforeResume).find(r => r.method === 'GET');
         expect(resumeReq).toBeDefined();
-        expect(resumeReq!.headers['last-event-id']).toBe(resumeFrom);
-        expect(resumeReq!.headers['mcp-session-id']).toBe(sessionId);
+        const resumeRequest = defined(resumeReq, 'resume GET request');
+        expect(resumeRequest.headers['last-event-id']).toBe(resumeFrom);
+        expect(resumeRequest.headers['mcp-session-id']).toBe(sessionId);
 
         await client.close();
         await transport.close();
@@ -1146,8 +1153,8 @@ verifies('client-transport:http:session-404-reinitialize', async (_args: TestArg
 
         const initReqs = records.filter(r => r.body?.includes('"method":"initialize"'));
         expect(initReqs.length).toBe(2);
-        expect(initReqs[0].headers['mcp-session-id']).toBeUndefined();
-        expect(initReqs[1].headers['mcp-session-id']).toBeUndefined();
+        expect(defined(initReqs[0], 'first initialize request').headers['mcp-session-id']).toBeUndefined();
+        expect(defined(initReqs[1], 'second initialize request').headers['mcp-session-id']).toBeUndefined();
 
         await client.close();
         await transport.close();

--- a/test/e2e/scenarios/transport-http.test.ts
+++ b/test/e2e/scenarios/transport-http.test.ts
@@ -1,0 +1,1155 @@
+/**
+ * Self-contained test bodies for the StreamableHTTPClientTransport surface.
+ *
+ * Each export is a {@link TestCase}: builds its own StreamableHTTPClientTransport
+ * directly with a counting/intercepting custom fetch, connects it to a Client,
+ * and asserts on exactly what the transport sent/did (headers, session id
+ * propagation, reconnection attempts, terminateSession, resumption tokens).
+ *
+ * Pattern: recorder OUTSIDE factories so every server instance shares the same
+ * storage; build transport with custom fetch pointing at hostPerSession();
+ * close transports/clients in finally so vitest exits cleanly.
+ *
+ * These tests construct StreamableHTTPClientTransport directly (rather than via wire()) because the
+ * transport itself is the subject: a recording fetch in front of the in-process host captures the HTTP
+ * traffic the SDK generates, and assertions are made on that recorded traffic — same host fidelity as
+ * wire(), with the transport options explicit because they are what is under test.
+ */
+
+import { randomUUID } from 'node:crypto';
+
+import { expect, vi } from 'vitest';
+import { z } from 'zod/v4';
+
+import { Client } from '../../../src/client/index.js';
+import { StreamableHTTPClientTransport } from '../../../src/client/streamableHttp.js';
+import { McpServer } from '../../../src/server/mcp.js';
+import { WebStandardStreamableHTTPServerTransport } from '../../../src/server/webStandardStreamableHttp.js';
+import { type JSONRPCRequest, JSONRPCRequestSchema, LATEST_PROTOCOL_VERSION, SUPPORTED_PROTOCOL_VERSIONS } from '../../../src/types.js';
+
+import { hostPerSession, type HttpHandler } from '../helpers/index.js';
+import type { TestArgs } from '../types.js';
+import { verifies } from '../helpers/verifies.js';
+
+const newClient = () => new Client({ name: 'c', version: '0' });
+
+function echoServer(): McpServer {
+    const s = new McpServer({ name: 's', version: '0' });
+    s.registerTool('echo', { description: 'Echo tool', inputSchema: z.object({ text: z.string() }) }, ({ text }) => ({
+        content: [{ type: 'text', text }]
+    }));
+    return s;
+}
+
+const OLDER_VERSION = SUPPORTED_PROTOCOL_VERSIONS.find(v => v !== LATEST_PROTOCOL_VERSION)!;
+
+interface RecordedRequest {
+    method: string;
+    url: string;
+    headers: Record<string, string>;
+    body?: string;
+}
+
+function recordingFetch(
+    records: RecordedRequest[],
+    baseHandler: HttpHandler
+): (url: URL | string, init?: RequestInit) => Promise<Response> {
+    return async (url, init) => {
+        const u = typeof url === 'string' ? url : url.toString();
+        const req = new Request(u, init);
+        const headers: Record<string, string> = {};
+        req.headers.forEach((v, k) => {
+            headers[k.toLowerCase()] = v;
+        });
+        const body = init?.body ? String(init.body) : undefined;
+        records.push({ method: req.method, url: u, headers, body });
+        return baseHandler(req);
+    };
+}
+
+verifies('client-transport:http:session-stored', async (_args: TestArgs) => {
+    const records: RecordedRequest[] = [];
+    const handle = hostPerSession(() => echoServer());
+
+    try {
+        const url = new URL('http://in-process/mcp');
+        const transport = new StreamableHTTPClientTransport(url, {
+            fetch: recordingFetch(records, handle.handleRequest)
+        });
+
+        const client = newClient();
+        await client.connect(transport);
+
+        const sessionId = transport.sessionId;
+        expect(sessionId).toBeDefined();
+
+        const initReq = records.find(r => r.body?.includes('"method":"initialize"'));
+        expect(initReq).toBeDefined();
+        expect(initReq!.headers['mcp-session-id']).toBeUndefined();
+
+        await client.ping();
+        await client.listTools();
+
+        const initIdx = records.indexOf(initReq!);
+        const subsequent = records.slice(initIdx + 1);
+        expect(subsequent.length).toBeGreaterThan(0);
+        for (const req of subsequent) {
+            expect(req.headers['mcp-session-id']).toBe(sessionId);
+        }
+
+        await client.close();
+        await transport.close();
+    } finally {
+        await handle.close();
+    }
+});
+
+verifies('typescript:client-transport:http:protocol-version-stored', async (_args: TestArgs) => {
+    const records: RecordedRequest[] = [];
+    const handle = hostPerSession(() => echoServer());
+
+    try {
+        const url = new URL('http://in-process/mcp');
+        const transport = new StreamableHTTPClientTransport(url, {
+            fetch: recordingFetch(records, handle.handleRequest)
+        });
+        const client = newClient();
+
+        await client.connect(transport);
+
+        expect(transport.protocolVersion).toBe(LATEST_PROTOCOL_VERSION);
+
+        await client.close();
+        await transport.close();
+    } finally {
+        await handle.close();
+    }
+});
+
+verifies('client-transport:http:protocol-version-header', async (_args: TestArgs) => {
+    const records: RecordedRequest[] = [];
+    let claimedVersion = LATEST_PROTOCOL_VERSION;
+
+    const handle = hostPerSession(() => {
+        const s = echoServer();
+        const origHandlers = (
+            s.server as unknown as { _requestHandlers: Map<string, (req: JSONRPCRequest, extra: unknown) => Promise<unknown>> }
+        )._requestHandlers;
+        const initHandler = origHandlers.get('initialize');
+        if (initHandler) {
+            origHandlers.set('initialize', async (req: JSONRPCRequest, extra: unknown) => {
+                const result = (await initHandler(req, extra)) as { protocolVersion: string };
+                return { ...result, protocolVersion: claimedVersion };
+            });
+        }
+        return s;
+    });
+
+    try {
+        expect(OLDER_VERSION).toBeDefined();
+        expect(OLDER_VERSION).not.toBe(LATEST_PROTOCOL_VERSION);
+
+        claimedVersion = OLDER_VERSION;
+
+        const url = new URL('http://in-process/mcp');
+        const transport = new StreamableHTTPClientTransport(url, {
+            fetch: recordingFetch(records, handle.handleRequest)
+        });
+        const client = newClient();
+
+        await client.connect(transport);
+
+        await vi.waitFor(() => expect(records.some(r => r.method === 'GET')).toBe(true));
+
+        await client.listTools();
+        await client.ping();
+
+        const initIdx = records.findIndex(r => r.body?.includes('"method":"initialize"'));
+        expect(initIdx).toBeGreaterThanOrEqual(0);
+        expect(records[initIdx].headers['mcp-protocol-version']).toBeUndefined();
+
+        const afterInit = records.slice(initIdx + 1);
+        expect(afterInit.length).toBeGreaterThanOrEqual(2);
+
+        for (const req of afterInit) {
+            expect(req.headers['mcp-protocol-version']).toBe(OLDER_VERSION);
+        }
+
+        await client.close();
+        await transport.close();
+    } finally {
+        await handle.close();
+    }
+});
+
+verifies('client-transport:http:accept-header-get', async (_args: TestArgs) => {
+    const records: RecordedRequest[] = [];
+    const handle = hostPerSession(() => echoServer());
+
+    try {
+        const url = new URL('http://in-process/mcp');
+        const transport = new StreamableHTTPClientTransport(url, {
+            fetch: recordingFetch(records, handle.handleRequest)
+        });
+        const client = newClient();
+
+        await client.connect(transport);
+
+        await vi.waitFor(() => expect(records.some(r => r.method === 'GET')).toBe(true));
+
+        const getReqs = records.filter(r => r.method === 'GET');
+        expect(getReqs.length).toBeGreaterThan(0);
+
+        for (const req of getReqs) {
+            expect(req.headers.accept).toContain('text/event-stream');
+        }
+
+        await client.close();
+        await transport.close();
+    } finally {
+        await handle.close();
+    }
+});
+
+verifies('client-transport:http:accept-header-post', async (_args: TestArgs) => {
+    const records: RecordedRequest[] = [];
+    const handle = hostPerSession(() => echoServer());
+
+    try {
+        const url = new URL('http://in-process/mcp');
+        const transport = new StreamableHTTPClientTransport(url, {
+            fetch: recordingFetch(records, handle.handleRequest)
+        });
+        const client = newClient();
+
+        await client.connect(transport);
+
+        const postReqs = records.filter(r => r.method === 'POST');
+        expect(postReqs.length).toBeGreaterThan(0);
+
+        for (const req of postReqs) {
+            expect(req.headers.accept).toContain('application/json');
+            expect(req.headers.accept).toContain('text/event-stream');
+        }
+
+        await client.close();
+        await transport.close();
+    } finally {
+        await handle.close();
+    }
+});
+
+verifies('client-transport:http:custom-headers', async (_args: TestArgs) => {
+    const records: RecordedRequest[] = [];
+    const handle = hostPerSession(() => echoServer());
+
+    try {
+        const url = new URL('http://in-process/mcp');
+        const customHeaders = {
+            'X-Custom-Header': 'custom-value',
+            'X-Another': 'another-value'
+        };
+
+        const transport = new StreamableHTTPClientTransport(url, {
+            fetch: recordingFetch(records, handle.handleRequest),
+            requestInit: { headers: customHeaders }
+        });
+        const client = newClient();
+
+        await client.connect(transport);
+
+        await client.ping();
+
+        expect(records.length).toBeGreaterThan(0);
+        for (const req of records) {
+            expect(req.headers['x-custom-header']).toBe('custom-value');
+            expect(req.headers['x-another']).toBe('another-value');
+        }
+
+        await client.close();
+        await transport.close();
+    } finally {
+        await handle.close();
+    }
+});
+
+verifies('typescript:client-transport:http:custom-fetch', async (_args: TestArgs) => {
+    const customFetchCalls: string[] = [];
+    const records: RecordedRequest[] = [];
+    const handle = hostPerSession(() => echoServer());
+
+    const customFetch = (url: URL | string, init?: RequestInit) => {
+        customFetchCalls.push(typeof url === 'string' ? url : url.toString());
+        return recordingFetch(records, handle.handleRequest)(url, init);
+    };
+
+    const globalFetchSpy = vi.spyOn(globalThis, 'fetch');
+
+    try {
+        const url = new URL('http://in-process/mcp');
+        const transport = new StreamableHTTPClientTransport(url, { fetch: customFetch });
+        const client = newClient();
+
+        await client.connect(transport);
+        await client.callTool({ name: 'echo', arguments: { text: 'hi' } });
+
+        expect(customFetchCalls.length).toBeGreaterThan(0);
+        expect(globalFetchSpy).not.toHaveBeenCalled();
+
+        await client.close();
+        await transport.close();
+    } finally {
+        globalFetchSpy.mockRestore();
+        await handle.close();
+    }
+});
+
+verifies('client-transport:http:json-response-parsed', async (_args: TestArgs) => {
+    const callResponseContentTypes: Array<string | null> = [];
+    const sessions = new Map<string, WebStandardStreamableHTTPServerTransport>();
+    // hostPerSession() defaults to SSE responses, so host inline with enableJsonResponse to exercise the application/json parse path
+    const handleRequest: HttpHandler = async req => {
+        const sid = req.headers.get('mcp-session-id') ?? undefined;
+        const existing = sid ? sessions.get(sid) : undefined;
+        if (existing) return existing.handleRequest(req);
+
+        const tx = new WebStandardStreamableHTTPServerTransport({
+            sessionIdGenerator: randomUUID,
+            enableJsonResponse: true,
+            onsessioninitialized: id => void sessions.set(id, tx)
+        });
+        await echoServer().connect(tx);
+        return tx.handleRequest(req);
+    };
+
+    try {
+        const url = new URL('http://in-process/mcp');
+        const transport = new StreamableHTTPClientTransport(url, {
+            fetch: async (u, init) => {
+                const response = await handleRequest(new Request(u, init));
+                if (init?.body && String(init.body).includes('"tools/call"')) {
+                    callResponseContentTypes.push(response.headers.get('content-type'));
+                }
+                return response;
+            }
+        });
+        const client = newClient();
+
+        await client.connect(transport);
+
+        const result = await client.callTool({ name: 'echo', arguments: { text: 'test' } });
+
+        expect(callResponseContentTypes).toEqual(['application/json']);
+        expect(result.content).toEqual([{ type: 'text', text: 'test' }]);
+
+        await client.close();
+        await transport.close();
+    } finally {
+        for (const tx of sessions.values()) await tx.close();
+    }
+});
+
+verifies('client-transport:http:404-surfaces', async (_args: TestArgs) => {
+    const handle = hostPerSession(() => echoServer());
+    let sessionIdToBreak: string | undefined;
+
+    try {
+        const url = new URL('http://in-process/mcp');
+        const transport = new StreamableHTTPClientTransport(url, {
+            fetch: async (u, init) => {
+                const req = new Request(u, init);
+                const sid = req.headers.get('mcp-session-id');
+                if (sid && sid === sessionIdToBreak) {
+                    return new Response(JSON.stringify({ error: 'Session not found' }), {
+                        status: 404,
+                        headers: { 'Content-Type': 'application/json' }
+                    });
+                }
+                return handle.handleRequest(req);
+            }
+        });
+        const client = newClient();
+
+        await client.connect(transport);
+        sessionIdToBreak = transport.sessionId;
+
+        const call = client.ping();
+        await expect(call).rejects.toThrow();
+
+        await transport.close();
+    } finally {
+        await handle.close();
+    }
+});
+
+verifies('client-transport:http:terminate-405-ok', async (_args: TestArgs) => {
+    const handle = hostPerSession(() => echoServer());
+
+    try {
+        const url = new URL('http://in-process/mcp');
+        const transport = new StreamableHTTPClientTransport(url, {
+            fetch: async (u, init) => {
+                const req = new Request(u, init);
+                if (req.method === 'DELETE') {
+                    return new Response(null, { status: 405 });
+                }
+                return handle.handleRequest(req);
+            }
+        });
+        const client = newClient();
+
+        await client.connect(transport);
+
+        await transport.terminateSession();
+
+        await client.close();
+        await transport.close();
+    } finally {
+        await handle.close();
+    }
+});
+
+verifies('client-transport:http:sse-405-tolerated', async (_args: TestArgs) => {
+    const handle = hostPerSession(() => echoServer());
+
+    try {
+        const url = new URL('http://in-process/mcp');
+        const transport = new StreamableHTTPClientTransport(url, {
+            fetch: async (u, init) => {
+                const req = new Request(u, init);
+                if (req.method === 'GET') {
+                    return new Response(null, { status: 405 });
+                }
+                return handle.handleRequest(req);
+            }
+        });
+        const client = newClient();
+
+        await client.connect(transport);
+
+        await client.ping();
+
+        await client.close();
+        await transport.close();
+    } finally {
+        await handle.close();
+    }
+});
+
+verifies('client-transport:http:no-reconnect-after-close', async (_args: TestArgs) => {
+    const records: RecordedRequest[] = [];
+    const transportErrors: Error[] = [];
+    const getControllers: Array<ReadableStreamDefaultController<Uint8Array>> = [];
+    const handle = hostPerSession(() => echoServer());
+
+    try {
+        vi.useFakeTimers();
+
+        const url = new URL('http://in-process/mcp');
+        const transport = new StreamableHTTPClientTransport(url, {
+            fetch: recordingFetch(records, async req => {
+                if (req.method === 'GET') {
+                    return new Response(
+                        new ReadableStream<Uint8Array>({
+                            start(controller) {
+                                getControllers.push(controller);
+                            }
+                        }),
+                        { status: 200, headers: { 'Content-Type': 'text/event-stream' } }
+                    );
+                }
+                return handle.handleRequest(req);
+            }),
+            reconnectionOptions: {
+                initialReconnectionDelay: 200,
+                maxReconnectionDelay: 200,
+                reconnectionDelayGrowFactor: 1,
+                maxRetries: 10
+            }
+        });
+        transport.onerror = error => void transportErrors.push(error);
+        const client = newClient();
+
+        await client.connect(transport);
+
+        await vi.waitFor(() => expect(getControllers.length).toBe(1));
+
+        // Prove the reconnect machinery is live in this setup: an errored GET stream is reconnected after the delay
+        getControllers[0].error(new Error('connection reset'));
+        await vi.waitFor(() => expect(records.filter(r => r.method === 'GET').length).toBe(2));
+        await vi.waitFor(() => expect(getControllers.length).toBe(2));
+
+        // Error the second stream so a reconnection is pending, then close before its 200ms delay elapses
+        getControllers[1].error(new Error('connection reset'));
+        await vi.waitFor(() => expect(transportErrors.filter(e => e.message.includes('SSE stream disconnected')).length).toBe(2), {
+            interval: 10
+        });
+
+        await client.close();
+        await transport.close();
+
+        const requestsAtClose = records.length;
+        await vi.advanceTimersByTimeAsync(5000);
+
+        expect(records.filter(r => r.method === 'GET').length).toBe(2);
+        expect(records.length).toBe(requestsAtClose);
+    } finally {
+        vi.useRealTimers();
+        await handle.close();
+    }
+});
+
+verifies('client-transport:http:concurrent-streams', async (_args: TestArgs) => {
+    const started: string[] = [];
+    const gates = new Map<string, { promise: Promise<void>; release: () => void }>();
+    for (const text of ['first', 'second', 'third']) {
+        let release!: () => void;
+        const promise = new Promise<void>(resolve => {
+            release = resolve;
+        });
+        gates.set(text, { promise, release });
+    }
+
+    const handle = hostPerSession(() => {
+        const s = new McpServer({ name: 's', version: '0' });
+        // Gate each call so all three POST SSE streams stay open until the test releases them
+        s.registerTool('echo', { description: 'Echo tool', inputSchema: z.object({ text: z.string() }) }, async ({ text }) => {
+            started.push(text);
+            await gates.get(text)?.promise;
+            return { content: [{ type: 'text', text }] };
+        });
+        return s;
+    });
+
+    try {
+        const url = new URL('http://in-process/mcp');
+        const transport = new StreamableHTTPClientTransport(url, {
+            fetch: (u, init) => handle.handleRequest(new Request(u, init))
+        });
+        const client = newClient();
+
+        await client.connect(transport);
+
+        const calls = [
+            client.callTool({ name: 'echo', arguments: { text: 'first' } }),
+            client.callTool({ name: 'echo', arguments: { text: 'second' } }),
+            client.callTool({ name: 'echo', arguments: { text: 'third' } })
+        ];
+
+        await vi.waitFor(() => expect([...started].sort()).toEqual(['first', 'second', 'third']));
+
+        // Release responses in reverse order: each promise must still receive its own call's text
+        gates.get('third')!.release();
+        expect((await calls[2]).content).toEqual([{ type: 'text', text: 'third' }]);
+
+        gates.get('second')!.release();
+        expect((await calls[1]).content).toEqual([{ type: 'text', text: 'second' }]);
+
+        gates.get('first')!.release();
+        expect((await calls[0]).content).toEqual([{ type: 'text', text: 'first' }]);
+
+        await client.close();
+        await transport.close();
+    } finally {
+        await handle.close();
+    }
+});
+
+verifies('client-transport:http:no-reconnect-after-response', async (_args: TestArgs) => {
+    const records: RecordedRequest[] = [];
+    const tokens: string[] = [];
+    const PRIMING_EVENT_ID = 'call-stream-event-1';
+    const encoder = new TextEncoder();
+    const handle = hostPerSession(() => echoServer());
+
+    try {
+        vi.useFakeTimers();
+
+        const url = new URL('http://in-process/mcp');
+        const transport = new StreamableHTTPClientTransport(url, {
+            fetch: async (u, init) => {
+                const req = new Request(u, init);
+                const headers: Record<string, string> = {};
+                req.headers.forEach((v, k) => {
+                    headers[k.toLowerCase()] = v;
+                });
+                const body = init?.body ? String(init.body) : undefined;
+                records.push({ method: req.method, url: u.toString(), headers, body });
+
+                if (req.method === 'GET') {
+                    // Refuse the standalone GET so any further GET could only be a reconnection of the POST stream
+                    return new Response(null, { status: 405 });
+                }
+
+                if (req.method === 'POST' && body?.includes('"tools/call"')) {
+                    const requestId = JSONRPCRequestSchema.parse(JSON.parse(body)).id;
+                    const response = JSON.stringify({
+                        jsonrpc: '2.0',
+                        id: requestId,
+                        result: { content: [{ type: 'text', text: 'delivered' }] }
+                    });
+                    // Priming event makes the stream resumable; the response then completes the request before the stream closes
+                    return new Response(
+                        new ReadableStream<Uint8Array>({
+                            start(controller) {
+                                controller.enqueue(encoder.encode(`id: ${PRIMING_EVENT_ID}\ndata: \n\n`));
+                                controller.enqueue(encoder.encode(`id: call-stream-event-2\ndata: ${response}\n\n`));
+                                controller.close();
+                            }
+                        }),
+                        { status: 200, headers: { 'Content-Type': 'text/event-stream' } }
+                    );
+                }
+
+                return handle.handleRequest(req);
+            },
+            reconnectionOptions: { initialReconnectionDelay: 10, maxReconnectionDelay: 10, reconnectionDelayGrowFactor: 1, maxRetries: 5 }
+        });
+        const client = newClient();
+
+        await client.connect(transport);
+
+        await vi.waitFor(() => expect(records.filter(r => r.method === 'GET').length).toBe(1));
+
+        const result = await client.callTool({ name: 'echo', arguments: { text: 'delivered' } }, undefined, {
+            onresumptiontoken: token => void tokens.push(token)
+        });
+
+        expect(result.content).toEqual([{ type: 'text', text: 'delivered' }]);
+        expect(tokens).toContain(PRIMING_EVENT_ID);
+
+        await vi.advanceTimersByTimeAsync(1000);
+
+        const gets = records.filter(r => r.method === 'GET');
+        expect(gets).toHaveLength(1);
+        expect(gets.filter(r => r.headers['last-event-id'] !== undefined)).toHaveLength(0);
+
+        await client.close();
+        await transport.close();
+    } finally {
+        vi.useRealTimers();
+        await handle.close();
+    }
+});
+
+verifies('client-transport:http:reconnect-retry-value', async (_args: TestArgs) => {
+    const RETRY_MS = 100;
+    const encoder = new TextEncoder();
+    const handle = hostPerSession(() => echoServer());
+    const url = new URL('http://in-process/mcp');
+
+    try {
+        vi.useFakeTimers();
+
+        // SSE retry: value overrides the default reconnection delay (1000ms with default options)
+        {
+            const getRecords: Array<{ at: number; lastEventId: string | undefined }> = [];
+            const tokens: string[] = [];
+            let callRequestId: string | number | undefined;
+            let postController: ReadableStreamDefaultController<Uint8Array> | undefined;
+
+            const transport = new StreamableHTTPClientTransport(url, {
+                fetch: async (u, init) => {
+                    const req = new Request(u, init);
+                    const body = init?.body ? String(init.body) : undefined;
+
+                    if (req.method === 'GET') {
+                        const lastEventId = req.headers.get('last-event-id') ?? undefined;
+                        getRecords.push({ at: Date.now(), lastEventId });
+                        if (lastEventId === undefined) {
+                            // Refuse the standalone GET so the only resumable GET is the POST-stream reconnection
+                            return new Response(null, { status: 405 });
+                        }
+                        const replayed = JSON.stringify({
+                            jsonrpc: '2.0',
+                            id: callRequestId,
+                            result: { content: [{ type: 'text', text: 'after retry' }] }
+                        });
+                        return new Response(`id: retry-evt-2\ndata: ${replayed}\n\n`, {
+                            status: 200,
+                            headers: { 'Content-Type': 'text/event-stream' }
+                        });
+                    }
+
+                    if (req.method === 'POST' && body?.includes('"tools/call"')) {
+                        callRequestId = JSONRPCRequestSchema.parse(JSON.parse(body)).id;
+                        return new Response(
+                            new ReadableStream<Uint8Array>({
+                                start(controller) {
+                                    postController = controller;
+                                    controller.enqueue(encoder.encode(`retry: ${RETRY_MS}\nid: retry-evt-1\ndata: \n\n`));
+                                }
+                            }),
+                            { status: 200, headers: { 'Content-Type': 'text/event-stream' } }
+                        );
+                    }
+
+                    return handle.handleRequest(req);
+                }
+            });
+            const client = newClient();
+
+            await client.connect(transport);
+
+            const call = client.callTool({ name: 'echo', arguments: { text: 'after retry' } }, undefined, {
+                onresumptiontoken: token => void tokens.push(token)
+            });
+
+            await vi.waitFor(() => expect(tokens).toContain('retry-evt-1'));
+
+            const disconnectedAt = Date.now();
+            postController!.error(new Error('connection reset'));
+
+            await vi.advanceTimersByTimeAsync(RETRY_MS);
+            // Bounded waitFor keeps total advanced time under the 1000ms default delay, so only a retry-honoring reconnect can arrive
+            await vi.waitFor(() => expect(getRecords.filter(g => g.lastEventId === 'retry-evt-1')).toHaveLength(1), {
+                timeout: 500,
+                interval: 10
+            });
+
+            const reconnect = getRecords.find(g => g.lastEventId === 'retry-evt-1')!;
+            expect(reconnect.at - disconnectedAt).toBeGreaterThanOrEqual(RETRY_MS);
+
+            const result = await call;
+            expect(result.content).toEqual([{ type: 'text', text: 'after retry' }]);
+
+            await client.close();
+            await transport.close();
+        }
+
+        // Without a retry: field, reconnection backs off exponentially and stops at maxRetries
+        {
+            const getRecords: Array<{ at: number }> = [];
+            const transportErrors: Error[] = [];
+            let firstGetController: ReadableStreamDefaultController<Uint8Array> | undefined;
+
+            const transport = new StreamableHTTPClientTransport(url, {
+                fetch: async (u, init) => {
+                    const req = new Request(u, init);
+                    if (req.method === 'GET') {
+                        getRecords.push({ at: Date.now() });
+                        if (getRecords.length === 1) {
+                            return new Response(
+                                new ReadableStream<Uint8Array>({
+                                    start(controller) {
+                                        firstGetController = controller;
+                                    }
+                                }),
+                                { status: 200, headers: { 'Content-Type': 'text/event-stream' } }
+                            );
+                        }
+                        // Fail every reconnection attempt so the next one is scheduled with a grown delay
+                        return new Response(null, { status: 500 });
+                    }
+                    return handle.handleRequest(req);
+                },
+                reconnectionOptions: {
+                    initialReconnectionDelay: 100,
+                    maxReconnectionDelay: 10000,
+                    reconnectionDelayGrowFactor: 2,
+                    maxRetries: 2
+                }
+            });
+            transport.onerror = error => void transportErrors.push(error);
+            const client = newClient();
+
+            await client.connect(transport);
+
+            await vi.waitFor(() => expect(firstGetController).toBeDefined());
+
+            const disconnectedAt = Date.now();
+            firstGetController!.error(new Error('connection reset'));
+
+            await vi.waitFor(() => expect(getRecords).toHaveLength(2));
+            expect(getRecords[1].at - disconnectedAt).toBeGreaterThanOrEqual(100);
+
+            await vi.waitFor(() => expect(getRecords).toHaveLength(3));
+            expect(getRecords[2].at - getRecords[1].at).toBeGreaterThanOrEqual(200);
+
+            await vi.waitFor(() =>
+                expect(transportErrors.some(e => e.message.includes('Maximum reconnection attempts (2) exceeded'))).toBe(true)
+            );
+
+            await vi.advanceTimersByTimeAsync(30000);
+            expect(getRecords).toHaveLength(3);
+
+            await client.close();
+            await transport.close();
+        }
+    } finally {
+        vi.useRealTimers();
+        await handle.close();
+    }
+});
+
+verifies('client-transport:http:reconnect-get', async (_args: TestArgs) => {
+    const records: RecordedRequest[] = [];
+    let getStreamCounter = 0;
+    const FIRST_EVENT_ID = 'event-id-1';
+
+    const handle = hostPerSession(() => echoServer());
+
+    try {
+        vi.useFakeTimers();
+
+        const url = new URL('http://in-process/mcp');
+        const transport = new StreamableHTTPClientTransport(url, {
+            fetch: async (u, init) => {
+                const req = new Request(u, init);
+                const headers: Record<string, string> = {};
+                req.headers.forEach((v, k) => {
+                    headers[k.toLowerCase()] = v;
+                });
+                records.push({
+                    method: req.method,
+                    url: u.toString(),
+                    headers,
+                    body: init?.body ? String(init.body) : undefined
+                });
+
+                if (req.method === 'GET') {
+                    getStreamCounter++;
+                    if (getStreamCounter === 1) {
+                        const encoder = new TextEncoder();
+                        const stream = new ReadableStream({
+                            start(controller) {
+                                controller.enqueue(encoder.encode(`id: ${FIRST_EVENT_ID}\ndata: {}\n\n`));
+                                setTimeout(() => {
+                                    controller.error(new Error('simulated disconnect'));
+                                }, 10);
+                            }
+                        });
+                        return new Response(stream, {
+                            status: 200,
+                            headers: { 'Content-Type': 'text/event-stream' }
+                        });
+                    }
+                }
+
+                return handle.handleRequest(req);
+            },
+            reconnectionOptions: {
+                initialReconnectionDelay: 50,
+                maxReconnectionDelay: 50,
+                reconnectionDelayGrowFactor: 1,
+                maxRetries: 2
+            }
+        });
+
+        const client = newClient();
+
+        await client.connect(transport);
+
+        await vi.waitFor(() => records.filter(r => r.method === 'GET').length >= 1);
+
+        const firstGet = records.find(r => r.method === 'GET');
+        expect(firstGet!.headers['last-event-id']).toBeUndefined();
+
+        await vi.advanceTimersByTimeAsync(100);
+
+        await vi.waitFor(() => records.filter(r => r.method === 'GET').length >= 2);
+
+        const secondGet = records.filter(r => r.method === 'GET')[1];
+        expect(secondGet.headers['last-event-id']).toBe(FIRST_EVENT_ID);
+
+        await client.close();
+        await transport.close();
+    } finally {
+        vi.useRealTimers();
+        await handle.close();
+    }
+});
+
+verifies('client-transport:http:reconnect-post-priming', async (_args: TestArgs) => {
+    const records: RecordedRequest[] = [];
+    const transportErrors: Error[] = [];
+    const primedTokens: string[] = [];
+    const PRIMING_EVENT_ID = 'post-stream-event-1';
+    const REPLAY_EVENT_ID = 'post-stream-event-2';
+    let unprimedController: ReadableStreamDefaultController<Uint8Array> | undefined;
+    let primedController: ReadableStreamDefaultController<Uint8Array> | undefined;
+    let primedRequestId: string | number | undefined;
+    const encoder = new TextEncoder();
+
+    const handle = hostPerSession(() => echoServer());
+
+    try {
+        const url = new URL('http://in-process/mcp');
+        const transport = new StreamableHTTPClientTransport(url, {
+            fetch: async (u, init) => {
+                const req = new Request(u, init);
+                const headers: Record<string, string> = {};
+                req.headers.forEach((v, k) => {
+                    headers[k.toLowerCase()] = v;
+                });
+                const body = init?.body ? String(init.body) : undefined;
+                records.push({ method: req.method, url: u.toString(), headers, body });
+
+                if (req.method === 'GET') {
+                    if (headers['last-event-id'] === PRIMING_EVENT_ID && primedRequestId !== undefined) {
+                        const replayed = JSON.stringify({
+                            jsonrpc: '2.0',
+                            id: primedRequestId,
+                            result: { content: [{ type: 'text', text: 'with priming' }] }
+                        });
+                        return new Response(`id: ${REPLAY_EVENT_ID}\ndata: ${replayed}\n\n`, {
+                            status: 200,
+                            headers: { 'Content-Type': 'text/event-stream' }
+                        });
+                    }
+                    // Refuse the optional standalone GET stream so any GET carrying Last-Event-ID is a POST-stream reconnection
+                    return new Response(null, { status: 405 });
+                }
+
+                if (req.method === 'POST' && body?.includes('"tools/call"')) {
+                    if (body.includes('without priming')) {
+                        return new Response(
+                            new ReadableStream<Uint8Array>({
+                                start(controller) {
+                                    unprimedController = controller;
+                                }
+                            }),
+                            { status: 200, headers: { 'Content-Type': 'text/event-stream' } }
+                        );
+                    }
+                    primedRequestId = JSONRPCRequestSchema.parse(JSON.parse(body)).id;
+                    return new Response(
+                        new ReadableStream<Uint8Array>({
+                            start(controller) {
+                                primedController = controller;
+                                controller.enqueue(encoder.encode(`id: ${PRIMING_EVENT_ID}\ndata: \n\n`));
+                            }
+                        }),
+                        { status: 200, headers: { 'Content-Type': 'text/event-stream' } }
+                    );
+                }
+
+                return handle.handleRequest(req);
+            },
+            reconnectionOptions: {
+                initialReconnectionDelay: 25,
+                maxReconnectionDelay: 25,
+                reconnectionDelayGrowFactor: 1,
+                maxRetries: 2
+            }
+        });
+
+        transport.onerror = error => {
+            transportErrors.push(error);
+        };
+
+        const client = newClient();
+        await client.connect(transport);
+
+        await vi.waitFor(() => expect(records.filter(r => r.method === 'GET').length).toBe(1));
+
+        // POST stream errored before any priming event: must not be reconnected
+        const unprimedCall = client.callTool({ name: 'echo', arguments: { text: 'without priming' } });
+        const unprimedOutcome = unprimedCall.then(
+            () => 'resolved',
+            () => 'rejected'
+        );
+
+        await vi.waitFor(() => expect(unprimedController).toBeDefined());
+        unprimedController!.error(new Error('connection reset before priming'));
+        await vi.waitFor(() => expect(transportErrors.some(e => e.message.includes('SSE stream disconnected'))).toBe(true));
+
+        // POST stream errored after the priming event: must reconnect with Last-Event-ID set to the priming id
+        const primedCall = client.callTool({ name: 'echo', arguments: { text: 'with priming' } }, undefined, {
+            onresumptiontoken: token => {
+                primedTokens.push(token);
+            }
+        });
+
+        await vi.waitFor(() => expect(primedTokens).toContain(PRIMING_EVENT_ID));
+        primedController!.error(new Error('connection reset after priming'));
+
+        await vi.waitFor(() =>
+            expect(records.filter(r => r.method === 'GET' && r.headers['last-event-id'] === PRIMING_EVENT_ID).length).toBe(1)
+        );
+
+        const primedResult = await primedCall;
+        expect(primedResult.content).toEqual([{ type: 'text', text: 'with priming' }]);
+
+        // An un-primed reconnection would have surfaced earlier as a second GET without Last-Event-ID
+        expect(records.filter(r => r.method === 'GET' && r.headers['last-event-id'] === undefined).length).toBe(1);
+        expect(records.filter(r => r.method === 'GET').length).toBe(2);
+
+        await client.close();
+        await transport.close();
+
+        expect(await unprimedOutcome).toBe('rejected');
+    } finally {
+        await handle.close();
+    }
+});
+
+verifies('client-transport:http:resume-stream-api', async (_args: TestArgs) => {
+    const records: RecordedRequest[] = [];
+
+    const handle = hostPerSession(() => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool('progress', { inputSchema: z.object({ steps: z.number().int().positive() }) }, async ({ steps }, extra) => {
+            const token = extra._meta?.progressToken;
+            if (token !== undefined) {
+                for (let i = 1; i <= steps; i++) {
+                    await extra.sendNotification({
+                        method: 'notifications/progress',
+                        params: { progressToken: token, progress: i, total: steps }
+                    });
+                }
+            }
+            return { content: [{ type: 'text', text: `done after ${steps}` }] };
+        });
+        return s;
+    });
+
+    try {
+        const url = new URL('http://in-process/mcp');
+        const transport = new StreamableHTTPClientTransport(url, {
+            fetch: recordingFetch(records, handle.handleRequest)
+        });
+
+        const client = newClient();
+        await client.connect(transport);
+
+        const sessionId = transport.sessionId;
+        expect(sessionId).toBeDefined();
+
+        const tokens: string[] = [];
+        await client.callTool({ name: 'progress', arguments: { steps: 3 } }, undefined, {
+            onprogress: () => {},
+            onresumptiontoken: id => {
+                if (id) tokens.push(id);
+            }
+        });
+
+        if (tokens.length === 0) {
+            await client.close();
+            await transport.close();
+            return;
+        }
+
+        const resumeFrom = tokens[0];
+        const replayed: string[] = [];
+
+        const beforeResume = records.length;
+        await transport.resumeStream(resumeFrom, {
+            onresumptiontoken: id => replayed.push(id)
+        });
+
+        const resumeReq = records.slice(beforeResume).find(r => r.method === 'GET');
+        expect(resumeReq).toBeDefined();
+        expect(resumeReq!.headers['last-event-id']).toBe(resumeFrom);
+        expect(resumeReq!.headers['mcp-session-id']).toBe(sessionId);
+
+        await client.close();
+        await transport.close();
+    } finally {
+        await handle.close();
+    }
+});
+
+verifies('client-transport:http:body-stream-error-preserved', async (_args: TestArgs) => {
+    const originalError = new TypeError('Custom SSE stream TypeError xyz123');
+    const handle = hostPerSession(() => echoServer());
+    const errors: Error[] = [];
+
+    try {
+        const url = new URL('http://in-process/mcp');
+        const transport = new StreamableHTTPClientTransport(url, {
+            fetch: async (u, init) => {
+                const req = new Request(u, init);
+                if (req.method === 'GET') {
+                    const encoder = new TextEncoder();
+                    const stream = new ReadableStream({
+                        async start(controller) {
+                            controller.enqueue(encoder.encode('data: {}\n\n'));
+                            await new Promise(resolve => setTimeout(resolve, 10));
+                            controller.error(originalError);
+                        }
+                    });
+                    return new Response(stream, {
+                        status: 200,
+                        headers: { 'Content-Type': 'text/event-stream' }
+                    });
+                }
+                return handle.handleRequest(req);
+            }
+        });
+
+        transport.onerror = (error: Error) => {
+            errors.push(error);
+        };
+
+        const client = newClient();
+        await client.connect(transport);
+
+        await vi.waitFor(() => expect(errors.length).toBeGreaterThan(0), { timeout: 2000 });
+
+        const capturedError = errors[0];
+
+        const checkPreserved = (err: unknown, depth = 0): boolean => {
+            if (depth > 5 || !err) return false;
+            if (err === originalError) return true;
+            if (err && typeof err === 'object' && 'cause' in err) return checkPreserved(err.cause, depth + 1);
+            return false;
+        };
+
+        const isPreserved = checkPreserved(capturedError);
+        expect(isPreserved).toBe(true);
+
+        await transport.close();
+    } finally {
+        await handle.close();
+    }
+});
+
+verifies('client-transport:http:session-404-reinitialize', async (_args: TestArgs) => {
+    const records: RecordedRequest[] = [];
+    const handle = hostPerSession(() => echoServer());
+    let sessionIdToBreak: string | undefined;
+    let shouldBreak = false;
+
+    try {
+        const url = new URL('http://in-process/mcp');
+        const transport = new StreamableHTTPClientTransport(url, {
+            fetch: recordingFetch(records, async req => {
+                const sid = req.headers.get('mcp-session-id');
+                if (shouldBreak && sid && sid === sessionIdToBreak) {
+                    shouldBreak = false;
+                    return new Response(null, { status: 404 });
+                }
+                return handle.handleRequest(req);
+            })
+        });
+        const client = newClient();
+
+        await client.connect(transport);
+        const firstSessionId = transport.sessionId;
+        expect(firstSessionId).toBeDefined();
+
+        const firstCall = await client.callTool({ name: 'echo', arguments: { text: 'first' } });
+        expect(firstCall.content).toEqual([{ type: 'text', text: 'first' }]);
+
+        sessionIdToBreak = firstSessionId;
+        shouldBreak = true;
+
+        const secondCall = await client.callTool({ name: 'echo', arguments: { text: 'second' } });
+        expect(secondCall.content).toEqual([{ type: 'text', text: 'second' }]);
+
+        const secondSessionId = transport.sessionId;
+        expect(secondSessionId).toBeDefined();
+        expect(secondSessionId).not.toBe(firstSessionId);
+
+        const initReqs = records.filter(r => r.body?.includes('"method":"initialize"'));
+        expect(initReqs.length).toBe(2);
+        expect(initReqs[0].headers['mcp-session-id']).toBeUndefined();
+        expect(initReqs[1].headers['mcp-session-id']).toBeUndefined();
+
+        await client.close();
+        await transport.close();
+    } finally {
+        await handle.close();
+    }
+});

--- a/test/e2e/scenarios/transport-http.test.ts
+++ b/test/e2e/scenarios/transport-http.test.ts
@@ -20,13 +20,15 @@ import { randomUUID } from 'node:crypto';
 
 import { expect, vi } from 'vitest';
 import { z } from 'zod/v4';
-
-import { Client } from '../../../src/client/index.js';
-import { StreamableHTTPClientTransport } from '../../../src/client/streamableHttp.js';
-import { McpServer } from '../../../src/server/mcp.js';
-import { WebStandardStreamableHTTPServerTransport } from '../../../src/server/webStandardStreamableHttp.js';
-import { type JSONRPCRequest, JSONRPCRequestSchema, LATEST_PROTOCOL_VERSION, SUPPORTED_PROTOCOL_VERSIONS } from '../../../src/types.js';
-
+import {
+    McpServer,
+    WebStandardStreamableHTTPServerTransport,
+    LATEST_PROTOCOL_VERSION,
+    SUPPORTED_PROTOCOL_VERSIONS
+} from '@modelcontextprotocol/server';
+import { JSONRPCRequestSchema } from '@modelcontextprotocol/core';
+import type { JSONRPCRequest } from '@modelcontextprotocol/server';
+import { Client, StreamableHTTPClientTransport } from '@modelcontextprotocol/client';
 import { hostPerSession, type HttpHandler } from '../helpers/index.js';
 import type { TestArgs } from '../types.js';
 import { verifies } from '../helpers/verifies.js';
@@ -989,11 +991,11 @@ verifies('client-transport:http:resume-stream-api', async (_args: TestArgs) => {
 
     const handle = hostPerSession(() => {
         const s = new McpServer({ name: 's', version: '0' });
-        s.registerTool('progress', { inputSchema: z.object({ steps: z.number().int().positive() }) }, async ({ steps }, extra) => {
-            const token = extra._meta?.progressToken;
+        s.registerTool('progress', { inputSchema: z.object({ steps: z.number().int().positive() }) }, async ({ steps }, ctx) => {
+            const token = ctx.mcpReq._meta?.progressToken;
             if (token !== undefined) {
                 for (let i = 1; i <= steps; i++) {
-                    await extra.sendNotification({
+                    await ctx.mcpReq.notify({
                         method: 'notifications/progress',
                         params: { progressToken: token, progress: i, total: steps }
                     });

--- a/test/e2e/scenarios/transport-http.test.ts
+++ b/test/e2e/scenarios/transport-http.test.ts
@@ -1162,3 +1162,107 @@ verifies('client-transport:http:session-404-reinitialize', async (_args: TestArg
         await handle.close();
     }
 });
+
+verifies('client-transport:http:reconnection-scheduler', async (_args: TestArgs) => {
+    const records: RecordedRequest[] = [];
+    const schedulerCalls: Array<{ delay: number; attemptCount: number }> = [];
+    const pendingReconnects: Array<() => void> = [];
+    const notifications: unknown[] = [];
+    const encoder = new TextEncoder();
+    let firstGetController: ReadableStreamDefaultController<Uint8Array> | undefined;
+    const handle = hostPerSession(() => echoServer());
+
+    try {
+        vi.useFakeTimers();
+
+        const url = new URL('http://in-process/mcp');
+        const transport = new StreamableHTTPClientTransport(url, {
+            fetch: recordingFetch(records, async req => {
+                if (req.method === 'GET') {
+                    const getCount = records.filter(r => r.method === 'GET').length;
+                    if (getCount === 1) {
+                        return new Response(
+                            new ReadableStream<Uint8Array>({
+                                start(controller) {
+                                    firstGetController = controller;
+                                }
+                            }),
+                            { status: 200, headers: { 'Content-Type': 'text/event-stream' } }
+                        );
+                    }
+                    if (getCount === 2) {
+                        // Fail the first scheduler-driven reconnect so the next schedule carries an incremented attemptCount
+                        return new Response(null, { status: 500 });
+                    }
+                    const notification = JSON.stringify({
+                        jsonrpc: '2.0',
+                        method: 'notifications/message',
+                        params: { level: 'info', logger: 'scheduler', data: 'after reconnect' }
+                    });
+                    // Left open so the re-established stream does not itself end and trigger yet another reconnection
+                    return new Response(
+                        new ReadableStream<Uint8Array>({
+                            start(controller) {
+                                controller.enqueue(encoder.encode(`id: scheduler-evt-1\ndata: ${notification}\n\n`));
+                            }
+                        }),
+                        { status: 200, headers: { 'Content-Type': 'text/event-stream' } }
+                    );
+                }
+                return handle.handleRequest(req);
+            }),
+            reconnectionOptions: {
+                initialReconnectionDelay: 50,
+                maxReconnectionDelay: 1000,
+                reconnectionDelayGrowFactor: 2,
+                maxRetries: 5
+            },
+            reconnectionScheduler: (reconnect, delay, attemptCount) => {
+                schedulerCalls.push({ delay, attemptCount });
+                pendingReconnects.push(reconnect);
+            }
+        });
+        const client = newClient();
+        client.setNotificationHandler('notifications/message', n => {
+            notifications.push(n.params);
+        });
+
+        await client.connect(transport);
+
+        await vi.waitFor(() => expect(firstGetController).toBeDefined());
+        expect(records.filter(r => r.method === 'GET')).toHaveLength(1);
+        expect(schedulerCalls).toEqual([]);
+
+        defined(firstGetController, 'first GET stream controller').error(new Error('connection reset'));
+
+        // The dropped stream invokes the scheduler with the configured initial delay and attemptCount 0
+        await vi.waitFor(() => expect(schedulerCalls).toHaveLength(1));
+        expect(schedulerCalls).toEqual([{ delay: 50, attemptCount: 0 }]);
+
+        // Default backoff timer is replaced: no reconnection GET fires from elapsed time, only from the scheduler's reconnect callback
+        await vi.advanceTimersByTimeAsync(5000);
+        expect(records.filter(r => r.method === 'GET')).toHaveLength(1);
+
+        defined(pendingReconnects[0], 'first scheduled reconnect callback')();
+
+        // The 500'd reconnect attempt is rescheduled through the scheduler with attemptCount 1 and the grown delay
+        await vi.waitFor(() => expect(schedulerCalls).toHaveLength(2));
+        expect(schedulerCalls).toEqual([
+            { delay: 50, attemptCount: 0 },
+            { delay: 100, attemptCount: 1 }
+        ]);
+        expect(records.filter(r => r.method === 'GET')).toHaveLength(2);
+
+        defined(pendingReconnects[1], 'second scheduled reconnect callback')();
+
+        await vi.waitFor(() => expect(records.filter(r => r.method === 'GET')).toHaveLength(3));
+        // The re-established stream is live end-to-end: a notification served on it reaches the client
+        await vi.waitFor(() => expect(notifications).toEqual([{ level: 'info', logger: 'scheduler', data: 'after reconnect' }]));
+
+        await client.close();
+        await transport.close();
+    } finally {
+        vi.useRealTimers();
+        await handle.close();
+    }
+});

--- a/test/e2e/scenarios/transport-http.test.ts
+++ b/test/e2e/scenarios/transport-http.test.ts
@@ -507,8 +507,12 @@ verifies('client-transport:http:concurrent-streams', async (_args: TestArgs) => 
     const started: string[] = [];
     const gates = new Map<string, { promise: Promise<void>; release: () => void }>();
     for (const text of ['first', 'second', 'third']) {
-        const { promise, resolve } = Promise.withResolvers<void>();
-        gates.set(text, { promise, release: resolve });
+        // Promise.withResolvers needs Node 22+; build the gate manually so the suite runs on Node 20.
+        let release: () => void = () => {};
+        const promise = new Promise<void>(resolve => {
+            release = resolve;
+        });
+        gates.set(text, { promise, release });
     }
     const releaseGate = (text: string) => defined(gates.get(text), `gate for ${text}`).release();
 

--- a/test/e2e/scenarios/validation.test.ts
+++ b/test/e2e/scenarios/validation.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Self-contained test bodies for the pluggable JSON Schema validation surface.
+ *
+ * The SDK validates tool `structuredContent` on the client against the tool's
+ * advertised `outputSchema`, using the provider passed as
+ * `ClientOptions.jsonSchemaValidator` (Ajv by default). These bodies prove the
+ * provider is genuinely pluggable: the Cloudflare-Workers-compatible provider
+ * yields the same accept/reject outcomes as the default, and a custom provider
+ * is actually invoked for schema compilation and validation.
+ *
+ * The server side is a low-level {@link Server} that does NOT pre-validate its
+ * own output — that is what makes the client-side validation observable.
+ */
+
+import { expect } from 'vitest';
+
+import { Client } from '../../../src/client/index.js';
+import { Server } from '../../../src/server/index.js';
+import { CallToolRequestSchema, ErrorCode, ListToolsRequestSchema, McpError, type Tool } from '../../../src/types.js';
+import { AjvJsonSchemaValidator } from '../../../src/validation/ajv-provider.js';
+import { CfWorkerJsonSchemaValidator } from '../../../src/validation/cfworker-provider.js';
+import type { JsonSchemaType, JsonSchemaValidator, jsonSchemaValidator } from '../../../src/validation/types.js';
+
+import { wire } from '../helpers/index.js';
+import type { TestArgs, Transport } from '../types.js';
+import { verifies } from '../helpers/verifies.js';
+
+const FORECAST_OUTPUT_SCHEMA: Tool['outputSchema'] = {
+    type: 'object',
+    properties: { celsius: { type: 'integer' }, summary: { type: 'string' } },
+    required: ['celsius', 'summary'],
+    additionalProperties: false
+};
+
+/**
+ * Low-level Server exposing two forecast tools that share an outputSchema:
+ * `forecast` returns conforming structured content, `forecast-corrupted`
+ * returns a non-conforming payload (string where an integer is required).
+ * No server-side validation happens here, so the client's validator decides.
+ */
+function forecastServer(): Server {
+    const s = new Server({ name: 's', version: '0' }, { capabilities: { tools: {} } });
+    s.setRequestHandler(ListToolsRequestSchema, () => ({
+        tools: [
+            {
+                name: 'forecast',
+                description: 'Current temperature forecast.',
+                inputSchema: { type: 'object' },
+                outputSchema: FORECAST_OUTPUT_SCHEMA
+            },
+            {
+                name: 'forecast-corrupted',
+                description: 'Forecast whose payload violates its own output schema.',
+                inputSchema: { type: 'object' },
+                outputSchema: FORECAST_OUTPUT_SCHEMA
+            }
+        ]
+    }));
+    s.setRequestHandler(CallToolRequestSchema, req => {
+        if (req.params.name === 'forecast') {
+            const structuredContent = { celsius: 21, summary: 'mild and sunny' };
+            return { structuredContent, content: [{ type: 'text', text: JSON.stringify(structuredContent) }] };
+        }
+        const corrupted = { celsius: 'mild', summary: 42 };
+        return { structuredContent: corrupted, content: [{ type: 'text', text: JSON.stringify(corrupted) }] };
+    });
+    return s;
+}
+
+/**
+ * Wire a fresh client (built by `makeClient`) to a fresh forecast server, then
+ * exercise the accept and reject paths once each. Returns what the provider
+ * decided so callers can compare providers against each other.
+ */
+async function runForecastOutcomes(transport: Transport, makeClient: () => Client) {
+    const client = makeClient();
+    await using _ = await wire(transport, forecastServer, client);
+
+    // listTools() primes the client's output-schema validator cache — this is
+    // where the configured provider compiles the schema.
+    const { tools } = await client.listTools();
+    expect(tools.map(t => t.name).sort()).toEqual(['forecast', 'forecast-corrupted']);
+
+    const accepted = await client.callTool({ name: 'forecast', arguments: {} });
+
+    let rejection: McpError | undefined;
+    try {
+        await client.callTool({ name: 'forecast-corrupted', arguments: {} });
+    } catch (e) {
+        if (!(e instanceof McpError)) throw e;
+        rejection = e;
+    }
+
+    return { acceptedStructuredContent: accepted.structuredContent, rejection };
+}
+
+verifies('validation:cfworker-provider', async ({ transport }: TestArgs) => {
+    const ajv = await runForecastOutcomes(transport, () => new Client({ name: 'c', version: '0' }));
+    const cfworker = await runForecastOutcomes(
+        transport,
+        () => new Client({ name: 'c', version: '0' }, { jsonSchemaValidator: new CfWorkerJsonSchemaValidator() })
+    );
+
+    // Both providers accept the conforming payload and hand back the same data.
+    expect(ajv.acceptedStructuredContent).toEqual({ celsius: 21, summary: 'mild and sunny' });
+    expect(cfworker.acceptedStructuredContent).toEqual(ajv.acceptedStructuredContent);
+
+    // Both providers reject the non-conforming payload the same way: an
+    // McpError with the same code, pointing at the output-schema mismatch.
+    expect(ajv.rejection).toBeInstanceOf(McpError);
+    expect(cfworker.rejection).toBeInstanceOf(McpError);
+    expect(ajv.rejection?.code).toBe(ErrorCode.InvalidParams);
+    expect(cfworker.rejection?.code).toBe(ajv.rejection?.code);
+    expect(ajv.rejection?.message).toMatch(/output schema|structured content/i);
+    expect(cfworker.rejection?.message).toMatch(/output schema|structured content/i);
+});
+
+/**
+ * Provider that records every schema it compiles and every value it is asked
+ * to validate, delegating verdicts to the default Ajv provider.
+ */
+class RecordingValidatorProvider implements jsonSchemaValidator {
+    readonly compiledSchemas: JsonSchemaType[] = [];
+    readonly validatedValues: unknown[] = [];
+    private readonly delegate = new AjvJsonSchemaValidator();
+
+    getValidator<T>(schema: JsonSchemaType): JsonSchemaValidator<T> {
+        this.compiledSchemas.push(schema);
+        const inner = this.delegate.getValidator<T>(schema);
+        return input => {
+            this.validatedValues.push(input);
+            return inner(input);
+        };
+    }
+}
+
+verifies('validation:pluggable-provider', async ({ transport }: TestArgs) => {
+    const recorder = new RecordingValidatorProvider();
+    const client = new Client({ name: 'c', version: '0' }, { jsonSchemaValidator: recorder });
+    await using _ = await wire(transport, forecastServer, client);
+
+    await client.listTools();
+
+    // The custom provider compiled the advertised outputSchema (once per tool
+    // that declares one — both forecast tools share the same schema).
+    expect(recorder.compiledSchemas).toEqual([FORECAST_OUTPUT_SCHEMA, FORECAST_OUTPUT_SCHEMA]);
+
+    // The custom provider's validator is the one consulted on tools/call, and
+    // its (delegated) verdict is what the caller sees.
+    const result = await client.callTool({ name: 'forecast', arguments: {} });
+    expect(result.structuredContent).toEqual({ celsius: 21, summary: 'mild and sunny' });
+    expect(recorder.validatedValues).toEqual([{ celsius: 21, summary: 'mild and sunny' }]);
+
+    await expect(client.callTool({ name: 'forecast-corrupted', arguments: {} })).rejects.toBeInstanceOf(McpError);
+    expect(recorder.validatedValues).toEqual([
+        { celsius: 21, summary: 'mild and sunny' },
+        { celsius: 'mild', summary: 42 }
+    ]);
+});

--- a/test/e2e/scenarios/validation.test.ts
+++ b/test/e2e/scenarios/validation.test.ts
@@ -12,17 +12,17 @@
  * own output — that is what makes the client-side validation observable.
  */
 
-import { expect } from 'vitest';
-import { Server, ProtocolError, ProtocolErrorCode } from '@modelcontextprotocol/server';
-import type { Tool } from '@modelcontextprotocol/server';
 import { Client } from '@modelcontextprotocol/client';
+import type { JsonSchemaType, JsonSchemaValidator, jsonSchemaValidator } from '@modelcontextprotocol/core';
 import { AjvJsonSchemaValidator } from '@modelcontextprotocol/core';
 import { CfWorkerJsonSchemaValidator } from '@modelcontextprotocol/core/validators/cfWorker';
-import type { JsonSchemaType, JsonSchemaValidator, jsonSchemaValidator } from '@modelcontextprotocol/core';
+import type { Tool } from '@modelcontextprotocol/server';
+import { ProtocolError, ProtocolErrorCode, Server } from '@modelcontextprotocol/server';
+import { expect } from 'vitest';
 
 import { wire } from '../helpers/index.js';
-import type { TestArgs, Transport } from '../types.js';
 import { verifies } from '../helpers/verifies.js';
+import type { TestArgs, Transport } from '../types.js';
 
 const FORECAST_OUTPUT_SCHEMA: Tool['outputSchema'] = {
     type: 'object',
@@ -78,16 +78,16 @@ async function runForecastOutcomes(transport: Transport, makeClient: () => Clien
     // listTools() primes the client's output-schema validator cache — this is
     // where the configured provider compiles the schema.
     const { tools } = await client.listTools();
-    expect(tools.map(t => t.name).sort()).toEqual(['forecast', 'forecast-corrupted']);
+    expect(tools.map(t => t.name).toSorted()).toEqual(['forecast', 'forecast-corrupted']);
 
     const accepted = await client.callTool({ name: 'forecast', arguments: {} });
 
     let rejection: ProtocolError | undefined;
     try {
         await client.callTool({ name: 'forecast-corrupted', arguments: {} });
-    } catch (e) {
-        if (!(e instanceof ProtocolError)) throw e;
-        rejection = e;
+    } catch (error) {
+        if (!(error instanceof ProtocolError)) throw error;
+        rejection = error;
     }
 
     return { acceptedStructuredContent: accepted.structuredContent, rejection };

--- a/test/e2e/scenarios/validation.test.ts
+++ b/test/e2e/scenarios/validation.test.ts
@@ -13,13 +13,12 @@
  */
 
 import { expect } from 'vitest';
-
-import { Client } from '../../../src/client/index.js';
-import { Server } from '../../../src/server/index.js';
-import { CallToolRequestSchema, ErrorCode, ListToolsRequestSchema, McpError, type Tool } from '../../../src/types.js';
-import { AjvJsonSchemaValidator } from '../../../src/validation/ajv-provider.js';
-import { CfWorkerJsonSchemaValidator } from '../../../src/validation/cfworker-provider.js';
-import type { JsonSchemaType, JsonSchemaValidator, jsonSchemaValidator } from '../../../src/validation/types.js';
+import { Server, ProtocolError, ProtocolErrorCode } from '@modelcontextprotocol/server';
+import type { Tool } from '@modelcontextprotocol/server';
+import { Client } from '@modelcontextprotocol/client';
+import { AjvJsonSchemaValidator } from '@modelcontextprotocol/core';
+import { CfWorkerJsonSchemaValidator } from '@modelcontextprotocol/core/validators/cfWorker';
+import type { JsonSchemaType, JsonSchemaValidator, jsonSchemaValidator } from '@modelcontextprotocol/core';
 
 import { wire } from '../helpers/index.js';
 import type { TestArgs, Transport } from '../types.js';
@@ -40,7 +39,7 @@ const FORECAST_OUTPUT_SCHEMA: Tool['outputSchema'] = {
  */
 function forecastServer(): Server {
     const s = new Server({ name: 's', version: '0' }, { capabilities: { tools: {} } });
-    s.setRequestHandler(ListToolsRequestSchema, () => ({
+    s.setRequestHandler('tools/list', () => ({
         tools: [
             {
                 name: 'forecast',
@@ -56,7 +55,7 @@ function forecastServer(): Server {
             }
         ]
     }));
-    s.setRequestHandler(CallToolRequestSchema, req => {
+    s.setRequestHandler('tools/call', req => {
         if (req.params.name === 'forecast') {
             const structuredContent = { celsius: 21, summary: 'mild and sunny' };
             return { structuredContent, content: [{ type: 'text', text: JSON.stringify(structuredContent) }] };
@@ -83,11 +82,11 @@ async function runForecastOutcomes(transport: Transport, makeClient: () => Clien
 
     const accepted = await client.callTool({ name: 'forecast', arguments: {} });
 
-    let rejection: McpError | undefined;
+    let rejection: ProtocolError | undefined;
     try {
         await client.callTool({ name: 'forecast-corrupted', arguments: {} });
     } catch (e) {
-        if (!(e instanceof McpError)) throw e;
+        if (!(e instanceof ProtocolError)) throw e;
         rejection = e;
     }
 
@@ -107,9 +106,9 @@ verifies('validation:cfworker-provider', async ({ transport }: TestArgs) => {
 
     // Both providers reject the non-conforming payload the same way: an
     // McpError with the same code, pointing at the output-schema mismatch.
-    expect(ajv.rejection).toBeInstanceOf(McpError);
-    expect(cfworker.rejection).toBeInstanceOf(McpError);
-    expect(ajv.rejection?.code).toBe(ErrorCode.InvalidParams);
+    expect(ajv.rejection).toBeInstanceOf(ProtocolError);
+    expect(cfworker.rejection).toBeInstanceOf(ProtocolError);
+    expect(ajv.rejection?.code).toBe(ProtocolErrorCode.InvalidParams);
     expect(cfworker.rejection?.code).toBe(ajv.rejection?.code);
     expect(ajv.rejection?.message).toMatch(/output schema|structured content/i);
     expect(cfworker.rejection?.message).toMatch(/output schema|structured content/i);
@@ -151,7 +150,7 @@ verifies('validation:pluggable-provider', async ({ transport }: TestArgs) => {
     expect(result.structuredContent).toEqual({ celsius: 21, summary: 'mild and sunny' });
     expect(recorder.validatedValues).toEqual([{ celsius: 21, summary: 'mild and sunny' }]);
 
-    await expect(client.callTool({ name: 'forecast-corrupted', arguments: {} })).rejects.toBeInstanceOf(McpError);
+    await expect(client.callTool({ name: 'forecast-corrupted', arguments: {} })).rejects.toBeInstanceOf(ProtocolError);
     expect(recorder.validatedValues).toEqual([
         { celsius: 21, summary: 'mild and sunny' },
         { celsius: 'mild', summary: 42 }

--- a/test/e2e/scenarios/validation.test.ts
+++ b/test/e2e/scenarios/validation.test.ts
@@ -13,12 +13,21 @@
  */
 
 import { Client } from '@modelcontextprotocol/client';
-import type { JsonSchemaType, JsonSchemaValidator, jsonSchemaValidator } from '@modelcontextprotocol/core';
+import type { JsonSchemaType, JsonSchemaValidator, jsonSchemaValidator, StandardSchemaWithJSON } from '@modelcontextprotocol/core';
 import { AjvJsonSchemaValidator } from '@modelcontextprotocol/core';
 import { CfWorkerJsonSchemaValidator } from '@modelcontextprotocol/core/validators/cfWorker';
 import type { Tool } from '@modelcontextprotocol/server';
-import { ProtocolError, ProtocolErrorCode, Server } from '@modelcontextprotocol/server';
+import {
+    fromJsonSchema,
+    isSpecType,
+    McpServer,
+    ProtocolError,
+    ProtocolErrorCode,
+    Server,
+    specTypeSchemas
+} from '@modelcontextprotocol/server';
 import { expect } from 'vitest';
+import { z } from 'zod/v4';
 
 import { wire } from '../helpers/index.js';
 import { verifies } from '../helpers/verifies.js';
@@ -155,4 +164,157 @@ verifies('validation:pluggable-provider', async ({ transport }: TestArgs) => {
         { celsius: 21, summary: 'mild and sunny' },
         { celsius: 'mild', summary: 42 }
     ]);
+});
+
+/** Raw JSON Schema registered via fromJsonSchema(); the `greet` tool both advertises it and validates arguments against it. */
+const GREET_INPUT_SCHEMA: JsonSchemaType = {
+    type: 'object',
+    properties: { name: { type: 'string' } },
+    required: ['name'],
+    additionalProperties: false
+};
+
+/**
+ * McpServer factory-of-factories for the fromJsonSchema tests: registers a single
+ * `greet` tool with the given (already wrapped) inputSchema and pushes every
+ * handler invocation's arguments into `handlerArgs` so tests can prove whether
+ * the handler ran. The recorder lives outside the factory because per-session /
+ * stateless hosting builds a fresh server per session or request.
+ */
+function greetServerFactory(inputSchema: StandardSchemaWithJSON<{ name: string }>, handlerArgs: unknown[]): () => McpServer {
+    return () => {
+        const s = new McpServer({ name: 's', version: '0' });
+        s.registerTool('greet', { description: 'Greets the caller by name.', inputSchema }, ({ name }) => {
+            handlerArgs.push({ name });
+            return { content: [{ type: 'text', text: `Hello, ${name}!` }] };
+        });
+        return s;
+    };
+}
+
+verifies('validators:from-json-schema:tool-roundtrip', async ({ transport }: TestArgs) => {
+    const handlerArgs: unknown[] = [];
+    const client = new Client({ name: 'c', version: '0' });
+    await using _ = await wire(transport, greetServerFactory(fromJsonSchema<{ name: string }>(GREET_INPUT_SCHEMA), handlerArgs), client);
+
+    // tools/list advertises the wrapped raw JSON Schema as-is.
+    const { tools } = await client.listTools();
+    expect(tools.map(t => t.name)).toEqual(['greet']);
+    expect(tools[0]?.inputSchema).toEqual(GREET_INPUT_SCHEMA);
+
+    // Conforming arguments reach the handler end to end and the call resolves with its result.
+    const result = await client.callTool({ name: 'greet', arguments: { name: 'Ada' } });
+    expect(result.isError).toBeUndefined();
+    expect(result.content).toEqual([{ type: 'text', text: 'Hello, Ada!' }]);
+    expect(handlerArgs).toEqual([{ name: 'Ada' }]);
+});
+
+verifies('validators:from-json-schema:invalid-args-rejected', async ({ transport }: TestArgs) => {
+    const handlerArgs: unknown[] = [];
+    const client = new Client({ name: 'c', version: '0' });
+    await using _ = await wire(transport, greetServerFactory(fromJsonSchema<{ name: string }>(GREET_INPUT_SCHEMA), handlerArgs), client);
+
+    // Arguments violating the wrapped JSON Schema (`name` must be a string) are rejected with JSON-RPC -32602.
+    const rejected = client.callTool({ name: 'greet', arguments: { name: 42 } });
+    await expect(rejected).rejects.toBeInstanceOf(ProtocolError);
+    await expect(rejected).rejects.toMatchObject({ code: ProtocolErrorCode.InvalidParams });
+
+    // The handler was never invoked for the rejected call.
+    expect(handlerArgs).toEqual([]);
+});
+
+/**
+ * jsonSchemaValidator for the override test: delegates verdicts to Ajv but
+ * records every compile/validate call and additionally vetoes the
+ * schema-conforming arguments `{ name: 'vetoed' }`, so its decisions are
+ * observably different from the runtime default validator's.
+ */
+class VetoingRecordingValidator implements jsonSchemaValidator {
+    readonly compiledSchemas: JsonSchemaType[] = [];
+    readonly validatedInputs: unknown[] = [];
+    private readonly delegate = new AjvJsonSchemaValidator();
+
+    getValidator<T>(schema: JsonSchemaType): JsonSchemaValidator<T> {
+        this.compiledSchemas.push(schema);
+        const inner = this.delegate.getValidator<T>(schema);
+        return input => {
+            this.validatedInputs.push(input);
+            // Veto a value the JSON Schema accepts so the call outcome provably reflects this validator, not the default.
+            if (z.object({ name: z.literal('vetoed') }).safeParse(input).success) {
+                return { valid: false, data: undefined, errorMessage: 'vetoed name rejected by the custom validator override' };
+            }
+            return inner(input);
+        };
+    }
+}
+
+verifies('validators:custom-validator:override', async ({ transport }: TestArgs) => {
+    const recorder = new VetoingRecordingValidator();
+    const handlerArgs: unknown[] = [];
+    const client = new Client({ name: 'c', version: '0' });
+    await using _ = await wire(
+        transport,
+        greetServerFactory(fromJsonSchema<{ name: string }>(GREET_INPUT_SCHEMA, recorder), handlerArgs),
+        client
+    );
+
+    // The supplied validator (not the runtime default) compiled the registered schema.
+    expect(recorder.compiledSchemas).toEqual([GREET_INPUT_SCHEMA]);
+
+    // The supplied validator is consulted on tools/call and its accept verdict lets the handler run.
+    const accepted = await client.callTool({ name: 'greet', arguments: { name: 'Ada' } });
+    expect(accepted.content).toEqual([{ type: 'text', text: 'Hello, Ada!' }]);
+    expect(recorder.validatedInputs).toEqual([{ name: 'Ada' }]);
+
+    // 'vetoed' conforms to the JSON Schema (the default validator would run the handler), so only the supplied validator can gate it.
+    const vetoOutcome = await client.callTool({ name: 'greet', arguments: { name: 'vetoed' } }).catch((error: unknown) => error);
+    const vetoText = vetoOutcome instanceof Error ? vetoOutcome.message : JSON.stringify(vetoOutcome);
+    expect(vetoText).toContain('vetoed name rejected by the custom validator override');
+    expect(recorder.validatedInputs).toEqual([{ name: 'Ada' }, { name: 'vetoed' }]);
+    expect(handlerArgs).toEqual([{ name: 'Ada' }]);
+});
+
+/** McpServer factory exposing a single `ping-tool` returning a fixed text block — fixture for the spec-type guard tests. */
+function pingToolServer(): McpServer {
+    const s = new McpServer({ name: 's', version: '0' });
+    s.registerTool('ping-tool', { inputSchema: z.object({}) }, () => ({ content: [{ type: 'text', text: 'pong' }] }));
+    return s;
+}
+
+verifies('guards:spec-type:call-tool-result', async ({ transport }: TestArgs) => {
+    const client = new Client({ name: 'c', version: '0' });
+    await using _ = await wire(transport, pingToolServer, client);
+
+    // Hold the live result as `unknown` so the guard is what narrows it for the caller.
+    const result: unknown = await client.callTool({ name: 'ping-tool', arguments: {} });
+
+    expect(isSpecType.CallToolResult(result)).toBe(true);
+    if (isSpecType.CallToolResult(result)) {
+        // Narrowed without casts: the guarded value exposes the spec-typed content array.
+        expect(result.content).toEqual([{ type: 'text', text: 'pong' }]);
+    }
+
+    // Structurally non-conforming values are rejected ({} is avoided here: content has a default, so the input-type guard accepts it).
+    expect(isSpecType.CallToolResult({ content: 'nope' })).toBe(false);
+    expect(isSpecType.CallToolResult(42)).toBe(false);
+});
+
+verifies('guards:spec-type-schemas:sync-validate', async ({ transport }: TestArgs) => {
+    const client = new Client({ name: 'c', version: '0' });
+    await using _ = await wire(transport, pingToolServer, client);
+
+    const result = await client.callTool({ name: 'ping-tool', arguments: {} });
+
+    // Synchronous Standard Schema: validate() hands back the result object directly, never a Promise.
+    const accepted = specTypeSchemas.CallToolResult['~standard'].validate(result);
+    expect(accepted).not.toBeInstanceOf(Promise);
+    expect(accepted.issues).toBeUndefined();
+    if (accepted.issues === undefined) {
+        expect(accepted.value.content).toEqual([{ type: 'text', text: 'pong' }]);
+    }
+
+    const rejected = specTypeSchemas.CallToolResult['~standard'].validate({ content: 'nope' });
+    expect(rejected).not.toBeInstanceOf(Promise);
+    expect(rejected.issues).toBeDefined();
+    expect(rejected.issues?.length).toBeGreaterThan(0);
 });

--- a/test/e2e/tsconfig.json
+++ b/test/e2e/tsconfig.json
@@ -17,6 +17,8 @@
             "@modelcontextprotocol/server/stdio": ["./node_modules/@modelcontextprotocol/server/src/stdio.ts"],
             "@modelcontextprotocol/server/_shims": ["./node_modules/@modelcontextprotocol/server/src/shimsNode.ts"],
             "@modelcontextprotocol/express": ["./node_modules/@modelcontextprotocol/express/src/index.ts"],
+            "@modelcontextprotocol/fastify": ["./node_modules/@modelcontextprotocol/fastify/src/index.ts"],
+            "@modelcontextprotocol/hono": ["./node_modules/@modelcontextprotocol/hono/src/index.ts"],
             "@modelcontextprotocol/node": ["./node_modules/@modelcontextprotocol/node/src/index.ts"],
             "@modelcontextprotocol/vitest-config": ["./node_modules/@modelcontextprotocol/vitest-config/tsconfig.json"],
             "@modelcontextprotocol/test-helpers": ["./node_modules/@modelcontextprotocol/test-helpers/src/index.ts"]

--- a/test/e2e/tsconfig.json
+++ b/test/e2e/tsconfig.json
@@ -1,0 +1,25 @@
+{
+    "extends": "@modelcontextprotocol/tsconfig",
+    "include": ["./"],
+    "exclude": ["node_modules", "dist"],
+    "compilerOptions": {
+        "paths": {
+            "*": ["./*"],
+            "@modelcontextprotocol/core": ["./node_modules/@modelcontextprotocol/core/src/index.ts"],
+            "@modelcontextprotocol/core/public": ["./node_modules/@modelcontextprotocol/core/src/exports/public/index.ts"],
+            "@modelcontextprotocol/core/validators/cfWorker": [
+                "./node_modules/@modelcontextprotocol/core/src/validators/cfWorkerProvider.ts"
+            ],
+            "@modelcontextprotocol/client": ["./node_modules/@modelcontextprotocol/client/src/index.ts"],
+            "@modelcontextprotocol/client/stdio": ["./node_modules/@modelcontextprotocol/client/src/stdio.ts"],
+            "@modelcontextprotocol/client/_shims": ["./node_modules/@modelcontextprotocol/client/src/shimsNode.ts"],
+            "@modelcontextprotocol/server": ["./node_modules/@modelcontextprotocol/server/src/index.ts"],
+            "@modelcontextprotocol/server/stdio": ["./node_modules/@modelcontextprotocol/server/src/stdio.ts"],
+            "@modelcontextprotocol/server/_shims": ["./node_modules/@modelcontextprotocol/server/src/shimsNode.ts"],
+            "@modelcontextprotocol/express": ["./node_modules/@modelcontextprotocol/express/src/index.ts"],
+            "@modelcontextprotocol/node": ["./node_modules/@modelcontextprotocol/node/src/index.ts"],
+            "@modelcontextprotocol/vitest-config": ["./node_modules/@modelcontextprotocol/vitest-config/tsconfig.json"],
+            "@modelcontextprotocol/test-helpers": ["./node_modules/@modelcontextprotocol/test-helpers/src/index.ts"]
+        }
+    }
+}

--- a/test/e2e/types.ts
+++ b/test/e2e/types.ts
@@ -1,0 +1,43 @@
+/**
+ * Shared types for the e2e suite.
+ */
+
+export const ALL_TRANSPORTS = ['inMemory', 'stdio', 'streamableHttp', 'streamableHttpStateless'] as const;
+export type Transport = (typeof ALL_TRANSPORTS)[number];
+
+export const ALL_SPEC_VERSIONS = ['2025-11-25'] as const;
+export type SpecVersion = (typeof ALL_SPEC_VERSIONS)[number];
+
+/**
+ * Arguments every test body receives. Expand with new matrix axes here so
+ * test signatures don't churn — bodies destructure only what they use.
+ */
+export interface TestArgs {
+    transport: Transport;
+    protocolVersion: SpecVersion;
+}
+
+export interface KnownFailure {
+    test?: string;
+    transport?: Transport;
+    specVersion?: SpecVersion;
+    note: string;
+}
+
+export interface Requirement {
+    source: string;
+    behavior: string;
+    transports?: readonly Transport[];
+    /** Free-form rationale for how the entry is set up (e.g. why certain transports are excluded). */
+    note?: string;
+
+    /** First / last spec versions a requirement applies to; changed behaviors are sibling entries linked via `supersedes`. */
+    addedInSpecVersion?: SpecVersion;
+    removedInSpecVersion?: SpecVersion;
+    /** Requirement id this entry replaces (for behaviors changed by a spec release). */
+
+    supersedes?: string;
+    knownFailures?: readonly KnownFailure[];
+
+    deferred?: string;
+}

--- a/test/e2e/vitest.config.js
+++ b/test/e2e/vitest.config.js
@@ -1,4 +1,5 @@
 import { defineConfig, mergeConfig } from 'vitest/config';
+
 import baseConfig from '../../common/vitest-config/vitest.config.js';
 
 export default mergeConfig(

--- a/test/e2e/vitest.config.js
+++ b/test/e2e/vitest.config.js
@@ -1,0 +1,14 @@
+import { defineConfig, mergeConfig } from 'vitest/config';
+import baseConfig from '../../common/vitest-config/vitest.config.js';
+
+export default mergeConfig(
+    baseConfig,
+    defineConfig({
+        test: {
+            // The e2e suite keeps its test files at the package root (coverage.test.ts,
+            // scenarios/*.test.ts, helpers/*.test.ts) rather than under test/.
+            include: ['**/*.test.ts'],
+            exclude: ['**/node_modules/**', '**/dist/**']
+        }
+    })
+);


### PR DESCRIPTION
Adds the first two chunks of the 2026-06 (draft) spec release to the e2e suite as **63 new requirements with deliberately-failing stub tests**: SEP-2260 (server-request association) and the stateless/sessionless cluster (SEP-2575 + SEP-2567). No SDK code changes. Each requirement is marked as a `knownFailure`, so the matrix stays at **0 unexpected failures** — the new cells are an executable, ordered todo list for the next spec release.

Stacked on the v2 e2e suite port (`fweinberger/e2e-v2`); the diff here is only `requirements.ts` + one stub scenario file.

## Motivation and Context

The next spec release is large (stateless/sessionless core, MRTR, tasks-as-extension, plus a dozen smaller SEPs). Implementing it SEP-by-SEP would mean a handful of huge, hard-to-review PRs. This PR proposes the alternative: break each SEP into requirement-level assertions in `requirements.ts`, land them up front as failing stubs, and implement them gradually — one small, individually-testable behavior at a time, in a declared order.

The development loop per requirement: replace its stub with a real assertion → watch it fail → make the smallest SDK change that turns it green without breaking the existing 916 passing cells → delete the knownFailure → small PR named for the requirement(s). The suite is the ledger: "what's left" is the expected-fail count.

**How we avoid one giant stateless PR — the NotImplemented gate.** The first implementation sub-batch (G0) makes only this true: a client and server can *agree* on the 2026 version, and once they have, every operation on that negotiated path fails fast with a NotImplemented error. 2025 clients on the same server are completely unaffected (dual-stack: both doors stay open). Every subsequent sub-batch then replaces one NotImplemented throw with real behavior and turns its requirements green — so each piece of 2026 work has a precise, pre-existing integration point, every PR stays small, and at every moment the SDK is honest about what it supports.

Proposed implementation order (each row = one or a few small PRs):

| # | Sub-batch | Reqs | What turns green | API decisions forced |
|---|---|---|---|---|
| P0 | SEP-2260 association (current spec — can start immediately, in parallel) | 6 | server→client requests ride the originating request's stream; client rejects unsolicited | — |
| G0 | Groundwork: version pinning, 2026 negotiable, NotImplemented gate | 4 | 2026 negotiable; gated paths fail fast; handlers can read the operative version | server version-mode option |
| S1 | `server/discover` + version errors | 5 | discover; -32004 + `supported[]`; client retry/downgrade | discover client API; version selection |
| S2 | Client `_meta` envelope stamping | 5 | every outbound 2026 request self-describes | — |
| S3 | Server envelope acceptance + enforcement | 6 | missing/mismatched envelope rejected; per-request capabilities | — |
| S4 | Backward-compat probe matrix | 4 | discover→initialize fallback; mixed-era traffic on one pipe | — |
| S5 | Sessionless + stateless HTTP | 12 | no session header; GET 405; no batching; per-request auth; list invariance | 2026 hosting entry point |
| S6 | Removed RPCs + per-request logging | 6 | ping/subscribe/setLevel/initialize → -32601 under 2026; logLevel opt-in | logging surface |
| S7 | `subscriptions/listen` | 10 | the replacement notification channel | listen client/server API |
| S8 | Cancellation / SSE-close semantics | 4 | close==cancel; stdio cancellation | — |
| S9 | Roots via MRTR | 1 | lands with the MRTR (SEP-2322) series | — |

After S8 the stateless cluster is complete and the gate is gone. MRTR (SEP-2322), extensions (SEP-2133), and tasks (SEP-2663) follow as their own requirement sets using the same pattern — MRTR staged progressively (tool calls without elicitation → MRTR-native elicitation → await-form emulated over MRTR).

Notes on mechanics:
- Behaviors carry their `[SEP-XXXX]` and the acceptance-criteria row reference (R-…), so each entry traces back to the spec clause it asserts.
- Stubs register on a single representative transport for now; transports broaden (and `addedInSpecVersion` version-gating is added) as each sub-batch is implemented.
- Picking up work: choose the lowest-numbered sub-batch with red cells, pick a requirement, replace its stub, implement, drop the knownFailure.

## How Has This Been Tested?

Full e2e suite on this branch: **32 files, 916 passed + 131 expected-fail (1047 cells), 0 unexpected failures**, ~20s. The 63 new cells are all expected-fail stubs (68 → 131). Typecheck, eslint, and prettier clean.

## Breaking Changes

None — test-only. No SDK code or published package is touched.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context

- Requirement wording is derived from the per-SEP acceptance-criteria breakdown of the 2025-11-25 → draft spec diff (the same source that will drive the MRTR/extensions/tasks requirement sets).
- `[DRAFT]` on purpose: this PR is the proposal for *how* the release gets implemented as much as it is the first slice of it. Feedback wanted on (a) the requirement granularity, (b) the sub-batch order, and (c) the NotImplemented-gate approach to keeping the stateless cluster incremental.
