### PR TITLE
docs(faq): fix incorrect file references in the Web Crypto answer

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -40,14 +40,14 @@ Once your project is using a single, compatible `zod` version, the `TS2589` erro
 
 ### How do I enable Web Crypto (`globalThis.crypto`) for client authentication in older Node.js versions?
 
-The SDK’s OAuth client authentication helpers (for example, those in `packages/client/src/client/auth-extensions.ts` that use `jose`) rely on the Web Crypto API exposed as `globalThis.crypto`. This is especially important for **client credentials** and **JWT-based**
+The SDK’s OAuth client authentication helpers (for example, those in `packages/client/src/client/authExtensions.ts` that use `jose`) rely on the Web Crypto API exposed as `globalThis.crypto`. This is especially important for **client credentials** and **JWT-based**
 authentication flows used by MCP clients.
 
 - **Node.js v19.0.0 and later**: `globalThis.crypto` is available by default.
 - **Node.js v18.x**: `globalThis.crypto` may not be defined by default. In this repository we polyfill it for tests (see `packages/client/vitest.setup.js`), and you should do the same in your app if it is missing – or alternatively, run Node with `--experimental-global-webcrypto`
   as per your Node version documentation. (See https://nodejs.org/dist/latest-v18.x/docs/api/globals.html#crypto )
 
-If you run clients on Node.js versions where `globalThis.crypto` is missing, you can polyfill it using the built-in `node:crypto` module, similar to the SDK's own `vitest.setup.ts`:
+If you run clients on Node.js versions where `globalThis.crypto` is missing, you can polyfill it using the built-in `node:crypto` module, similar to the SDK's own `packages/client/vitest.setup.js`:
 
 ```typescript
 import { webcrypto } from 'node:crypto';


### PR DESCRIPTION
## What

Fixes two incorrect file references in the FAQ answer
**"How do I enable Web Crypto (`globalThis.crypto`) for client authentication in older Node.js versions?"** (`docs/faq.md`).

- The answer pointed at `packages/client/src/client/auth-extensions.ts`, which
  does not exist. The actual file is
  `packages/client/src/client/authExtensions.ts` (camelCase, no hyphen) — it's
  the one that imports `jose` and implements `private_key_jwt` /
  `client_credentials`, matching the surrounding prose.
- The answer also referred to "the SDK's own `vitest.setup.ts`", but there is no
  `.ts` setup file. The polyfill it describes lives at
  `packages/client/vitest.setup.js` — which this same answer already links
  correctly two lines earlier. The reference now matches.

## Why

Both paths were dead links: a reader trying to open the cited source hits a
file that isn't there, which defeats the point of citing it. This corrects them
to the real files.

## Scope

Docs-only. Two lines in `docs/faq.md` (`+2 / -2`). No package, runtime, public
API, or behavior change; no new dependencies; no changeset needed (top-level
docs change, no published package affected — consistent with other recent
`docs(...)` PRs).

## Verification

- Confirmed `packages/client/src/client/authExtensions.ts` and
  `packages/client/vitest.setup.js` exist on `main`, and the old hyphenated /
  `.ts` paths do not.
- `pnpm sync:snippets --check` passes (the edited lines are prose, not
  `source=`-backed code fences).
