### PR TITLE
fix(client): let auth headers override request init

### DIFF
--- a/packages/client/src/client/sse.ts
+++ b/packages/client/src/client/sse.ts
@@ -120,8 +120,8 @@ export class SSEClientTransport implements Transport {
         const extraHeaders = normalizeHeaders(this._requestInit?.headers);
 
         return new Headers({
-            ...headers,
-            ...extraHeaders
+            ...extraHeaders,
+            ...headers
         });
     }
 

--- a/packages/client/src/client/streamableHttp.ts
+++ b/packages/client/src/client/streamableHttp.ts
@@ -226,8 +226,8 @@ export class StreamableHTTPClientTransport implements Transport {
         const extraHeaders = normalizeHeaders(this._requestInit?.headers);
 
         return new Headers({
-            ...headers,
-            ...extraHeaders
+            ...extraHeaders,
+            ...headers
         });
     }
 

--- a/packages/client/test/client/sse.test.ts
+++ b/packages/client/test/client/sse.test.ts
@@ -658,6 +658,37 @@ describe('SSEClientTransport', () => {
             expect(lastServerRequest.headers['x-custom-header']).toBe('custom-value');
         });
 
+        it('uses auth provider Authorization over requestInit Authorization', async () => {
+            mockAuthProvider.tokens.mockResolvedValue({
+                access_token: 'fresh-token',
+                token_type: 'Bearer'
+            });
+
+            transport = new SSEClientTransport(resourceBaseUrl, {
+                authProvider: mockAuthProvider,
+                requestInit: {
+                    headers: {
+                        Authorization: 'Bearer stale-token',
+                        'X-Custom-Header': 'custom-value'
+                    }
+                }
+            });
+
+            await transport.start();
+
+            const message: JSONRPCMessage = {
+                jsonrpc: '2.0',
+                id: '1',
+                method: 'test',
+                params: {}
+            };
+
+            await transport.send(message);
+
+            expect(lastServerRequest.headers.authorization).toBe('Bearer fresh-token');
+            expect(lastServerRequest.headers['x-custom-header']).toBe('custom-value');
+        });
+
         it('refreshes expired token during SSE connection', async () => {
             // Mock tokens() to return expired token until saveTokens is called
             let currentTokens: OAuthTokens = {

--- a/packages/client/test/client/streamableHttp.test.ts
+++ b/packages/client/test/client/streamableHttp.test.ts
@@ -2,7 +2,7 @@ import type { JSONRPCMessage, JSONRPCRequest } from '@modelcontextprotocol/core'
 import { OAuthError, OAuthErrorCode, SdkErrorCode, SdkHttpError } from '@modelcontextprotocol/core';
 import type { Mock, Mocked } from 'vitest';
 
-import type { OAuthClientProvider } from '../../src/client/auth.js';
+import type { AuthProvider, OAuthClientProvider } from '../../src/client/auth.js';
 import { UnauthorizedError } from '../../src/client/auth.js';
 import type { ReconnectionScheduler, StartSSEOptions, StreamableHTTPReconnectionOptions } from '../../src/client/streamableHttp.js';
 import { StreamableHTTPClientTransport } from '../../src/client/streamableHttp.js';
@@ -627,6 +627,34 @@ describe('StreamableHTTPClientTransport', () => {
         await transport['_startOrAuthSse']({});
         expect((actualReqInit.headers as Headers).get('authorization')).toBe('Bearer test-token');
         expect((actualReqInit.headers as Headers).get('x-custom-header')).toBe('CustomValue');
+    });
+
+    it('uses auth provider Authorization over requestInit Authorization', async () => {
+        const authProvider: AuthProvider = {
+            token: vi.fn(async () => 'fresh-token')
+        };
+
+        transport = new StreamableHTTPClientTransport(new URL('http://localhost:1234/mcp'), {
+            authProvider,
+            requestInit: {
+                headers: {
+                    Authorization: 'Bearer stale-token',
+                    'X-Custom-Header': 'CustomValue'
+                }
+            }
+        });
+
+        let actualReqInit: RequestInit = {};
+        (globalThis.fetch as Mock).mockImplementation(async (_url, reqInit) => {
+            actualReqInit = reqInit;
+            return new Response(null, { status: 202 });
+        });
+
+        await transport.send({ jsonrpc: '2.0', method: 'test', params: {} } as JSONRPCMessage);
+
+        const headers = actualReqInit.headers as Headers;
+        expect(headers.get('authorization')).toBe('Bearer fresh-token');
+        expect(headers.get('x-custom-header')).toBe('CustomValue');
     });
 
     it('should append custom Accept header to required types on POST requests', async () => {


### PR DESCRIPTION
## Summary

Fixes #2208.

When an auth provider has a token, the SDK should send that derived Authorization header instead of a stale Authorization value from requestInit.headers. This keeps the fallback-auth path working after OAuth has produced a token.

This changes the merge order in both client transports:

- StreamableHTTPClientTransport
- SSEClientTransport

Other custom requestInit headers are still preserved.

## Tests

- pnpm --filter @modelcontextprotocol/client exec vitest run test/client/streamableHttp.test.ts
- pnpm --filter @modelcontextprotocol/client exec vitest run test/client/sse.test.ts
- pnpm --filter @modelcontextprotocol/client typecheck
- pnpm --filter @modelcontextprotocol/client lint
- pnpm --filter @modelcontextprotocol/client build
