### PR TITLE
fix(tasks): preserve empty pagination cursors

### DIFF
--- a/packages/client/src/experimental/tasks/client.ts
+++ b/packages/client/src/experimental/tasks/client.ts
@@ -210,7 +210,7 @@ export class ExperimentalClientTasks {
      * @experimental
      */
     async listTasks(cursor?: string, options?: RequestOptions): Promise<ListTasksResult> {
-        return this._module.listTasks(cursor ? { cursor } : undefined, options);
+        return this._module.listTasks(cursor === undefined ? undefined : { cursor }, options);
     }
 
     /**

--- a/packages/core/src/experimental/tasks/stores/inMemory.ts
+++ b/packages/core/src/experimental/tasks/stores/inMemory.ts
@@ -197,7 +197,7 @@ export class InMemoryTaskStore implements TaskStore {
             .map(([taskId]) => taskId);
 
         let startIndex = 0;
-        if (cursor) {
+        if (cursor !== undefined) {
             const cursorIndex = filteredTaskIds.indexOf(cursor);
             if (cursorIndex === -1) {
                 // Invalid cursor - throw error

--- a/packages/core/test/experimental/inMemory.test.ts
+++ b/packages/core/test/experimental/inMemory.test.ts
@@ -628,6 +628,15 @@ describe('InMemoryTaskStore', () => {
             await expect(store.listTasks('non-existent-cursor')).rejects.toThrow('Invalid cursor: non-existent-cursor');
         });
 
+        it('should not treat an empty string cursor as an omitted cursor', async () => {
+            await store.createTask({}, 1, {
+                method: 'tools/call',
+                params: {}
+            });
+
+            await expect(store.listTasks('')).rejects.toThrow('Invalid cursor: ');
+        });
+
         it('should continue from cursor correctly', async () => {
             // Create 5 tasks
             for (let i = 1; i <= 5; i++) {

--- a/packages/server/src/experimental/tasks/server.ts
+++ b/packages/server/src/experimental/tasks/server.ts
@@ -281,7 +281,7 @@ export class ExperimentalServerTasks {
      * @experimental
      */
     async listTasks(cursor?: string, options?: RequestOptions): Promise<ListTasksResult> {
-        return this._module.listTasks(cursor ? { cursor } : undefined, options);
+        return this._module.listTasks(cursor === undefined ? undefined : { cursor }, options);
     }
 
     /**

--- a/test/integration/test/experimental/tasks/taskListing.test.ts
+++ b/test/integration/test/experimental/tasks/taskListing.test.ts
@@ -96,6 +96,20 @@ describe('Task Listing with Pagination', () => {
         });
     });
 
+    it('should not treat an empty string cursor as an omitted cursor', async () => {
+        await taskStore.createTask({}, 1, {
+            method: 'tools/call',
+            params: { name: 'test-tool' }
+        });
+
+        await expect(client.experimental.tasks.listTasks('')).rejects.toSatisfy((error: ProtocolError) => {
+            expect(error).toBeInstanceOf(ProtocolError);
+            expect(error.code).toBe(ProtocolErrorCode.InvalidParams);
+            expect(error.message).toContain('Invalid cursor');
+            return true;
+        });
+    });
+
     it('should ensure tasks accessible via tasks/get are also accessible via tasks/list', async () => {
         // Create a task
         const task = await taskStore.createTask({}, 1, {


### PR DESCRIPTION
﻿## Summary
- preserve empty-string cursors in experimental task list helpers instead of treating them as omitted
- make the in-memory task store validate empty cursors as provided values
- add unit and integration coverage for the empty-cursor path

Part of #2202 (U-8).

## To verify
- `pnpm --filter @modelcontextprotocol/core test -- test/experimental/inMemory.test.ts`
- `pnpm --filter @modelcontextprotocol/test-integration test -- test/experimental/tasks/taskListing.test.ts`
- `pnpm --filter @modelcontextprotocol/core lint`
- `pnpm --filter @modelcontextprotocol/client lint`
- `pnpm --filter @modelcontextprotocol/server lint`
- `pnpm --filter @modelcontextprotocol/test-integration lint`
- `pnpm --filter @modelcontextprotocol/core typecheck`
- `pnpm --filter @modelcontextprotocol/client typecheck`
- `pnpm --filter @modelcontextprotocol/server typecheck`
- `git diff --check`
