### PR TITLE
fix(server): sort listed tools by name

### DIFF
--- a/packages/server/src/server/mcp.ts
+++ b/packages/server/src/server/mcp.ts
@@ -116,6 +116,8 @@ export class McpServer {
             (): ListToolsResult => ({
                 tools: Object.entries(this._registeredTools)
                     .filter(([, tool]) => tool.enabled)
+                    // eslint-disable-next-line unicorn/no-array-sort -- Object.entries() already gives us a fresh array.
+                    .sort(([left], [right]) => left.localeCompare(right))
                     .map(([name, tool]): Tool => {
                         const toolDefinition: Tool = {
                             name,

--- a/test/integration/test/server/mcp.test.ts
+++ b/test/integration/test/server/mcp.test.ts
@@ -1257,6 +1257,28 @@ describe('Zod v4', () => {
             mcpServer.registerTool('tool2', {}, () => ({ content: [] }));
         });
 
+        test('should list registered tools in deterministic name order', async () => {
+            const mcpServer = new McpServer({
+                name: 'test server',
+                version: '1.0'
+            });
+            const client = new Client({
+                name: 'test client',
+                version: '1.0'
+            });
+
+            mcpServer.registerTool('zeta', {}, () => ({ content: [] }));
+            mcpServer.registerTool('alpha', {}, () => ({ content: [] }));
+            mcpServer.registerTool('middle', {}, () => ({ content: [] }));
+
+            const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+            await Promise.all([client.connect(clientTransport), mcpServer.server.connect(serverTransport)]);
+
+            const result = await client.request({ method: 'tools/list' });
+
+            expect(result.tools.map(tool => tool.name)).toEqual(['alpha', 'middle', 'zeta']);
+        });
+
         /***
          * Test: Tool with Output Schema and Structured Content
          */


### PR DESCRIPTION
﻿## Summary
- return `tools/list` entries in tool-name order from `McpServer`
- add an integration regression test that registers tools out of order and verifies the listed order

Covers the U-6 item in #2202.

## Test plan
- pnpm --filter @modelcontextprotocol/test-integration exec vitest run test/server/mcp.test.ts -t "deterministic name order"
- pnpm --filter @modelcontextprotocol/server typecheck
- pnpm --filter @modelcontextprotocol/server lint
- pnpm --filter @modelcontextprotocol/test-integration lint
- pnpm --filter @modelcontextprotocol/server build
- pnpm --filter @modelcontextprotocol/examples-server-quickstart typecheck
- git push pre-push hook: typecheck:all, build:all, lint:all
