### PR TITLE
fix(server): handle empty declared lists

### DIFF
--- a/packages/server/src/server/mcp.ts
+++ b/packages/server/src/server/mcp.ts
@@ -70,6 +70,15 @@ export class McpServer {
 
     constructor(serverInfo: Implementation, options?: ServerOptions) {
         this.server = new Server(serverInfo, options);
+        if (options?.capabilities?.tools) {
+            this.setToolRequestHandlers();
+        }
+        if (options?.capabilities?.resources) {
+            this.setResourceRequestHandlers();
+        }
+        if (options?.capabilities?.prompts) {
+            this.setPromptRequestHandlers();
+        }
     }
 
     /**

--- a/test/integration/test/server/mcp.test.ts
+++ b/test/integration/test/server/mcp.test.ts
@@ -1257,6 +1257,71 @@ describe('Zod v4', () => {
             mcpServer.registerTool('tool2', {}, () => ({ content: [] }));
         });
 
+        test('should list no tools when the tools capability is declared without registrations', async () => {
+            const mcpServer = new McpServer(
+                {
+                    name: 'test server',
+                    version: '1.0'
+                },
+                { capabilities: { tools: {} } }
+            );
+            const client = new Client({
+                name: 'test client',
+                version: '1.0'
+            });
+
+            const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+            await Promise.all([client.connect(clientTransport), mcpServer.server.connect(serverTransport)]);
+
+            const result = await client.request({ method: 'tools/list' });
+
+            expect(result.tools).toEqual([]);
+        });
+
+        test('should list no prompts when the prompts capability is declared without registrations', async () => {
+            const mcpServer = new McpServer(
+                {
+                    name: 'test server',
+                    version: '1.0'
+                },
+                { capabilities: { prompts: {} } }
+            );
+            const client = new Client({
+                name: 'test client',
+                version: '1.0'
+            });
+
+            const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+            await Promise.all([client.connect(clientTransport), mcpServer.server.connect(serverTransport)]);
+
+            const result = await client.request({ method: 'prompts/list' });
+
+            expect(result.prompts).toEqual([]);
+        });
+
+        test('should list no resources when the resources capability is declared without registrations', async () => {
+            const mcpServer = new McpServer(
+                {
+                    name: 'test server',
+                    version: '1.0'
+                },
+                { capabilities: { resources: {} } }
+            );
+            const client = new Client({
+                name: 'test client',
+                version: '1.0'
+            });
+
+            const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+            await Promise.all([client.connect(clientTransport), mcpServer.server.connect(serverTransport)]);
+
+            const resources = await client.request({ method: 'resources/list' });
+            const templates = await client.request({ method: 'resources/templates/list' });
+
+            expect(resources.resources).toEqual([]);
+            expect(templates.resourceTemplates).toEqual([]);
+        });
+
         /***
          * Test: Tool with Output Schema and Structured Content
          */


### PR DESCRIPTION
﻿## Summary
- install high-level list handlers when `McpServer` is constructed with tools, prompts, or resources capabilities already declared
- return empty `tools/list`, `prompts/list`, `resources/list`, and `resources/templates/list` results when no items are registered yet
- add integration coverage for the declared-but-empty capability cases

Covers the U-7 item in #2202.

## Test plan
- pnpm --filter @modelcontextprotocol/test-integration exec vitest run test/server/mcp.test.ts -t "capability is declared without registrations"
- pnpm --filter @modelcontextprotocol/server typecheck
- pnpm --filter @modelcontextprotocol/server lint
- pnpm --filter @modelcontextprotocol/test-integration lint
- pnpm --filter @modelcontextprotocol/server build
- pnpm --filter @modelcontextprotocol/examples-server-quickstart typecheck
- git push pre-push hook: typecheck:all, build:all, lint:all
