### PR TITLE
chore(client): normalize trailing slashes in discovery paths

### DIFF
--- a/packages/client/src/client/auth.ts
+++ b/packages/client/src/client/auth.ts
@@ -1035,10 +1035,9 @@ function buildWellKnownPath(
     pathname: string = '',
     options: { prependPathname?: boolean } = {}
 ): string {
-    // Strip trailing slash from pathname to avoid double slashes
-    if (pathname.endsWith('/')) {
-        pathname = pathname.slice(0, -1);
-    }
+    // Strip trailing slashes from pathname to avoid malformed discovery paths like
+    // "/foo//.well-known/oauth-authorization-server".
+    pathname = pathname.replace(/\/+$/, '');
 
     return options.prependPathname ? `${pathname}/.well-known/${wellKnownPrefix}` : `/.well-known/${wellKnownPrefix}${pathname}`;
 }
@@ -1173,11 +1172,8 @@ export function buildDiscoveryUrls(authorizationServerUrl: string | URL): { url:
         return urlsToTry;
     }
 
-    // Strip trailing slash from pathname to avoid double slashes
-    let pathname = url.pathname;
-    if (pathname.endsWith('/')) {
-        pathname = pathname.slice(0, -1);
-    }
+    // Strip trailing slashes from pathname to avoid malformed discovery paths.
+    let pathname = url.pathname.replace(/\/+$/, '');
 
     urlsToTry.push(
         // 1. OAuth metadata at the given URL

--- a/packages/client/test/client/auth.test.ts
+++ b/packages/client/test/client/auth.test.ts
@@ -265,6 +265,21 @@ describe('OAuth Authorization', () => {
             expect(url.toString()).toBe('https://resource.example.com/.well-known/oauth-protected-resource/path/name');
         });
 
+        it('normalizes duplicate trailing slashes in path before metadata discovery', async () => {
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                status: 200,
+                json: async () => validMetadata
+            });
+
+            const metadata = await discoverOAuthProtectedResourceMetadata('https://resource.example.com/path/name//');
+            expect(metadata).toEqual(validMetadata);
+            const calls = mockFetch.mock.calls;
+            expect(calls.length).toBe(1);
+            const [url] = calls[0]!;
+            expect(url.toString()).toBe('https://resource.example.com/.well-known/oauth-protected-resource/path/name');
+        });
+
         it('preserves query parameters in path-aware discovery', async () => {
             mockFetch.mockResolvedValueOnce({
                 ok: true,
@@ -850,6 +865,17 @@ describe('OAuth Authorization', () => {
                     url: 'https://auth.example.com/tenant1/.well-known/openid-configuration',
                     type: 'oidc'
                 }
+            ]);
+        });
+
+        it('normalizes trailing slashes in server URLs before discovery', () => {
+            const urls = buildDiscoveryUrls('https://auth.example.com/tenant1//');
+
+            expect(urls).toHaveLength(3);
+            expect(urls.map(u => u.url.toString())).toEqual([
+                'https://auth.example.com/.well-known/oauth-authorization-server/tenant1',
+                'https://auth.example.com/.well-known/openid-configuration/tenant1',
+                'https://auth.example.com/tenant1/.well-known/openid-configuration'
             ]);
         });
 


### PR DESCRIPTION
## Summary
- Normalize discovery pathname handling to remove duplicate trailing slashes before building OAuth metadata URLs.
- Update tests for duplicate trailing slash handling in discovery URL generation and path-based metadata lookup.

## Validation
- npx pnpm@10.26.1 --filter @modelcontextprotocol/client test test/client/auth.test.ts