### PR TITLE
fix(client): avoid redundant fallback on root-like discovery paths

### DIFF
--- a/packages/client/src/client/auth.ts
+++ b/packages/client/src/client/auth.ts
@@ -1035,9 +1035,7 @@ function buildWellKnownPath(
     pathname: string = '',
     options: { prependPathname?: boolean } = {}
 ): string {
-    // Strip trailing slashes from pathname to avoid malformed discovery paths like
-    // "/foo//.well-known/oauth-authorization-server".
-    pathname = pathname.replace(/\/+$/, '');
+    pathname = normalizeDiscoveryPath(pathname);
 
     return options.prependPathname ? `${pathname}/.well-known/${wellKnownPrefix}` : `/.well-known/${wellKnownPrefix}${pathname}`;
 }
@@ -1057,8 +1055,13 @@ async function tryMetadataDiscovery(url: URL, protocolVersion: string, fetchFn: 
  */
 function shouldAttemptFallback(response: Response | undefined, pathname: string): boolean {
     if (!response) return true; // CORS error — always try fallback
-    if (pathname === '/') return false; // Already at root
+    if (pathname === '') return false; // Already at root
     return (response.status >= 400 && response.status < 500) || response.status === 502;
+}
+
+function normalizeDiscoveryPath(pathname: string): string {
+    const normalizedPathname = pathname.replace(/\/+$/, '');
+    return normalizedPathname === '/' ? '' : normalizedPathname;
 }
 
 /**
@@ -1072,6 +1075,7 @@ async function discoverMetadataWithFallback(
 ): Promise<Response | undefined> {
     const issuer = new URL(serverUrl);
     const protocolVersion = opts?.protocolVersion ?? LATEST_PROTOCOL_VERSION;
+    const normalizedPathname = normalizeDiscoveryPath(issuer.pathname);
 
     let url: URL;
     if (opts?.metadataUrl) {
@@ -1086,7 +1090,7 @@ async function discoverMetadataWithFallback(
     let response = await tryMetadataDiscovery(url, protocolVersion, fetchFn);
 
     // If path-aware discovery fails (4xx or 502 Bad Gateway) and we're not already at root, try fallback to root discovery
-    if (!opts?.metadataUrl && shouldAttemptFallback(response, issuer.pathname)) {
+    if (!opts?.metadataUrl && shouldAttemptFallback(response, normalizedPathname)) {
         const rootUrl = new URL(`/.well-known/${wellKnownType}`, issuer);
         response = await tryMetadataDiscovery(rootUrl, protocolVersion, fetchFn);
     }
@@ -1150,7 +1154,8 @@ export async function discoverOAuthMetadata(
  */
 export function buildDiscoveryUrls(authorizationServerUrl: string | URL): { url: URL; type: 'oauth' | 'oidc' }[] {
     const url = typeof authorizationServerUrl === 'string' ? new URL(authorizationServerUrl) : authorizationServerUrl;
-    const hasPath = url.pathname !== '/';
+    const normalizedPathname = normalizeDiscoveryPath(url.pathname);
+    const hasPath = normalizedPathname !== '';
     const urlsToTry: { url: URL; type: 'oauth' | 'oidc' }[] = [];
 
     if (!hasPath) {
@@ -1173,7 +1178,7 @@ export function buildDiscoveryUrls(authorizationServerUrl: string | URL): { url:
     }
 
     // Strip trailing slashes from pathname to avoid malformed discovery paths.
-    let pathname = url.pathname.replace(/\/+$/, '');
+    const pathname = normalizedPathname;
 
     urlsToTry.push(
         // 1. OAuth metadata at the given URL

--- a/packages/client/src/client/auth.ts
+++ b/packages/client/src/client/auth.ts
@@ -1035,10 +1035,9 @@ function buildWellKnownPath(
     pathname: string = '',
     options: { prependPathname?: boolean } = {}
 ): string {
-    // Strip trailing slash from pathname to avoid double slashes
-    if (pathname.endsWith('/')) {
-        pathname = pathname.slice(0, -1);
-    }
+    // Strip trailing slashes from pathname to avoid malformed discovery paths like
+    // "/foo//.well-known/oauth-authorization-server".
+    pathname = pathname.replace(/\/+$/, '');
 
     return options.prependPathname ? `${pathname}/.well-known/${wellKnownPrefix}` : `/.well-known/${wellKnownPrefix}${pathname}`;
 }
@@ -1173,11 +1172,8 @@ export function buildDiscoveryUrls(authorizationServerUrl: string | URL): { url:
         return urlsToTry;
     }
 
-    // Strip trailing slash from pathname to avoid double slashes
-    let pathname = url.pathname;
-    if (pathname.endsWith('/')) {
-        pathname = pathname.slice(0, -1);
-    }
+    // Strip trailing slashes from pathname to avoid malformed discovery paths.
+    let pathname = url.pathname.replace(/\/+$/, '');
 
     urlsToTry.push(
         // 1. OAuth metadata at the given URL

--- a/packages/client/test/client/auth.test.ts
+++ b/packages/client/test/client/auth.test.ts
@@ -422,6 +422,24 @@ describe('OAuth Authorization', () => {
             expect(url.toString()).toBe('https://resource.example.com/.well-known/oauth-protected-resource');
         });
 
+        it('does not fallback for URLs that normalize to root with extra slashes', async () => {
+            // First call returns 404
+            mockFetch.mockResolvedValueOnce({
+                ok: false,
+                status: 404
+            });
+
+            await expect(discoverOAuthProtectedResourceMetadata('https://resource.example.com//')).rejects.toThrow(
+                'Resource server does not implement OAuth 2.0 Protected Resource Metadata.'
+            );
+
+            const calls = mockFetch.mock.calls;
+            expect(calls.length).toBe(1);
+
+            const [url] = calls[0]!;
+            expect(url.toString()).toBe('https://resource.example.com/.well-known/oauth-protected-resource');
+        });
+
         it('falls back when path-aware discovery encounters CORS error (browser)', async () => {
             withBrowserLikeEnvironment();
             // First call (path-aware) fails with TypeError (CORS)
@@ -876,6 +894,16 @@ describe('OAuth Authorization', () => {
                 'https://auth.example.com/.well-known/oauth-authorization-server/tenant1',
                 'https://auth.example.com/.well-known/openid-configuration/tenant1',
                 'https://auth.example.com/tenant1/.well-known/openid-configuration'
+            ]);
+        });
+
+        it('treats double-slashed paths as root', () => {
+            const urls = buildDiscoveryUrls('https://auth.example.com//');
+
+            expect(urls).toHaveLength(2);
+            expect(urls.map(u => u.url.toString())).toEqual([
+                'https://auth.example.com/.well-known/oauth-authorization-server',
+                'https://auth.example.com/.well-known/openid-configuration'
             ]);
         });
 

--- a/packages/client/test/client/auth.test.ts
+++ b/packages/client/test/client/auth.test.ts
@@ -265,6 +265,21 @@ describe('OAuth Authorization', () => {
             expect(url.toString()).toBe('https://resource.example.com/.well-known/oauth-protected-resource/path/name');
         });
 
+        it('normalizes duplicate trailing slashes in path before metadata discovery', async () => {
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                status: 200,
+                json: async () => validMetadata
+            });
+
+            const metadata = await discoverOAuthProtectedResourceMetadata('https://resource.example.com/path/name//');
+            expect(metadata).toEqual(validMetadata);
+            const calls = mockFetch.mock.calls;
+            expect(calls.length).toBe(1);
+            const [url] = calls[0]!;
+            expect(url.toString()).toBe('https://resource.example.com/.well-known/oauth-protected-resource/path/name');
+        });
+
         it('preserves query parameters in path-aware discovery', async () => {
             mockFetch.mockResolvedValueOnce({
                 ok: true,
@@ -850,6 +865,17 @@ describe('OAuth Authorization', () => {
                     url: 'https://auth.example.com/tenant1/.well-known/openid-configuration',
                     type: 'oidc'
                 }
+            ]);
+        });
+
+        it('normalizes trailing slashes in server URLs before discovery', () => {
+            const urls = buildDiscoveryUrls('https://auth.example.com/tenant1//');
+
+            expect(urls).toHaveLength(3);
+            expect(urls.map(u => u.url.toString())).toEqual([
+                'https://auth.example.com/.well-known/oauth-authorization-server/tenant1',
+                'https://auth.example.com/.well-known/openid-configuration/tenant1',
+                'https://auth.example.com/tenant1/.well-known/openid-configuration'
             ]);
         });
 


### PR DESCRIPTION
## Summary
- Normalize OAuth discovery path strings consistently so discovery helpers treat paths that only contain trailing slashes as root.
- Skip unnecessary root fallback for discovery when the normalized path is root.
- Added regression tests in `auth.test.ts` for:
  - `discoverOAuthProtectedResourceMetadata('https://resource.example.com//')` uses a single root discovery call.
  - `buildDiscoveryUrls('https://auth.example.com//')` returns root-style URLs only.

## Validation

- `corepack pnpm --dir modelcontextprotocol-typescript-sdk --filter @modelcontextprotocol/client exec vitest run test/client/auth.test.ts`
- `corepack pnpm --dir modelcontextprotocol-typescript-sdk --filter @modelcontextprotocol/client exec vitest run test/client/sse.test.ts`
- `corepack pnpm --dir modelcontextprotocol-typescript-sdk --filter @modelcontextprotocol/client exec vitest run test/client/authExtensions.test.ts`