### PR TITLE
fix: continue auth discovery after invalid JSON

### DIFF
--- a/.changeset/steady-auth-fallback.md
+++ b/.changeset/steady-auth-fallback.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/client': patch
+---
+
+Continue authorization server discovery when a candidate metadata endpoint returns non-JSON content.

--- a/packages/client/src/client/auth.ts
+++ b/packages/client/src/client/auth.ts
@@ -1262,10 +1262,15 @@ export async function discoverAuthorizationServerMetadata(
             );
         }
 
+        let metadata: unknown;
+        try {
+            metadata = await response.json();
+        } catch {
+            continue;
+        }
+
         // Parse and validate based on type
-        return type === 'oauth'
-            ? OAuthMetadataSchema.parse(await response.json())
-            : OpenIdProviderDiscoveryMetadataSchema.parse(await response.json());
+        return type === 'oauth' ? OAuthMetadataSchema.parse(metadata) : OpenIdProviderDiscoveryMetadataSchema.parse(metadata);
     }
 
     return undefined;

--- a/packages/client/test/client/auth.test.ts
+++ b/packages/client/test/client/auth.test.ts
@@ -907,6 +907,30 @@ describe('OAuth Authorization', () => {
             expect(calls[1]![0].toString()).toBe('https://auth.example.com/.well-known/openid-configuration/tenant1');
         });
 
+        it('continues when an endpoint returns non-JSON metadata', async () => {
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                status: 200,
+                json: async () => {
+                    throw new SyntaxError('Unexpected token < in JSON');
+                }
+            });
+
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                status: 200,
+                json: async () => validOpenIdMetadata
+            });
+
+            const metadata = await discoverAuthorizationServerMetadata('https://auth.example.com/tenant1');
+
+            expect(metadata).toEqual(validOpenIdMetadata);
+            const calls = mockFetch.mock.calls;
+            expect(calls.length).toBe(2);
+            expect(calls[0]![0].toString()).toBe('https://auth.example.com/.well-known/oauth-authorization-server/tenant1');
+            expect(calls[1]![0].toString()).toBe('https://auth.example.com/.well-known/openid-configuration/tenant1');
+        });
+
         it('continues on 4xx errors', async () => {
             mockFetch.mockResolvedValueOnce({
                 ok: false,


### PR DESCRIPTION
﻿## Summary

When the OAuth authorization-server metadata endpoint responds with `200 OK` but the body is not JSON, discovery currently stops on the JSON parse error. That prevents the client from trying the next well-known URL, including the OIDC metadata fallback.

This treats an unreadable discovery body the same way as an unavailable discovery endpoint and continues to the next candidate URL. Schema validation errors still surface once a JSON document is actually parsed.

Fixes #2126.

## Tested

- `pnpm --filter @modelcontextprotocol/client test -- test/client/auth.test.ts`
- `pnpm --filter @modelcontextprotocol/client typecheck`
- `pnpm --filter @modelcontextprotocol/client lint`
- `pnpm --filter @modelcontextprotocol/client build`
- `git diff --check`

The repository pre-push hook also ran `pnpm -r build`, `pnpm -r typecheck`, and `pnpm lint:all` successfully.
