### PR TITLE
Fix URI template matching for multi-variable simple expressions

### DIFF
--- a/.changeset/fix-uri-template-multi-variable-match.md
+++ b/.changeset/fix-uri-template-multi-variable-match.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/core': patch
+---
+
+Fix `UriTemplate.match()` for simple expressions with multiple variables, such as `/users/{userId,format}`.

--- a/packages/core/src/shared/uriTemplate.ts
+++ b/packages/core/src/shared/uriTemplate.ts
@@ -227,6 +227,12 @@ export class UriTemplate {
 
         switch (part.operator) {
             case '': {
+                if (part.names.length > 1) {
+                    return part.names.map((name, index) => ({
+                        pattern: `${index === 0 ? '' : ','}([^/,]+)`,
+                        name
+                    }));
+                }
                 pattern = part.exploded ? '([^/,]+(?:,[^/,]+)*)' : '([^/,]+)';
                 break;
             }

--- a/packages/core/test/shared/uriTemplate.test.ts
+++ b/packages/core/test/shared/uriTemplate.test.ts
@@ -98,6 +98,12 @@ describe('UriTemplate', () => {
             expect(match).toEqual({ username: 'fred', postId: '123' });
         });
 
+        it('should match multiple variables in a simple expression', () => {
+            const template = new UriTemplate('/users/{userId,format}');
+            const match = template.match('/users/42,json');
+            expect(match).toEqual({ userId: '42', format: 'json' });
+        });
+
         it('should return null for non-matching URIs', () => {
             const template = new UriTemplate('/users/{username}');
             const match = template.match('/posts/123');


### PR DESCRIPTION
## Summary

Fixes `UriTemplate.match()` for simple expressions that contain multiple variables, such as `/users/{userId,format}`.

Previously the matcher generated one capture group for the whole expression and used a pattern that rejected commas, so `/users/42,json` returned `null`. This now generates one capture group per variable with literal comma separators.

Fixes #2166.

## Testing

- `pnpm --filter @modelcontextprotocol/core test -- packages/core/test/shared/uriTemplate.test.ts`
- `pnpm --filter @modelcontextprotocol/core lint`
- pre-push hook: typecheck, build, lint
