### PR TITLE
fix(client): let auth headers override request headers

### DIFF
--- a/.changeset/fresh-buses-auth.md
+++ b/.changeset/fresh-buses-auth.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/client': patch
+---
+
+Let auth provider headers override requestInit headers in client transports.

--- a/packages/client/src/client/sse.ts
+++ b/packages/client/src/client/sse.ts
@@ -120,8 +120,8 @@ export class SSEClientTransport implements Transport {
         const extraHeaders = normalizeHeaders(this._requestInit?.headers);
 
         return new Headers({
-            ...headers,
-            ...extraHeaders
+            ...extraHeaders,
+            ...headers
         });
     }
 

--- a/packages/client/src/client/streamableHttp.ts
+++ b/packages/client/src/client/streamableHttp.ts
@@ -226,8 +226,8 @@ export class StreamableHTTPClientTransport implements Transport {
         const extraHeaders = normalizeHeaders(this._requestInit?.headers);
 
         return new Headers({
-            ...headers,
-            ...extraHeaders
+            ...extraHeaders,
+            ...headers
         });
     }
 

--- a/packages/client/test/client/sse.test.ts
+++ b/packages/client/test/client/sse.test.ts
@@ -344,6 +344,44 @@ describe('SSEClientTransport', () => {
             }
         });
 
+        it('lets auth provider headers override custom Authorization headers', async () => {
+            const authProvider: AuthProvider = {
+                token: async () => 'fresh-token'
+            };
+
+            transport = new SSEClientTransport(resourceBaseUrl, {
+                authProvider,
+                requestInit: {
+                    headers: {
+                        Authorization: 'Bearer stale-token',
+                        'X-Custom-Header': 'custom-value'
+                    }
+                }
+            });
+
+            await transport.start();
+
+            const originalFetch = globalThis.fetch;
+            try {
+                globalThis.fetch = vi.fn().mockResolvedValue({ ok: true });
+
+                const message: JSONRPCMessage = {
+                    jsonrpc: '2.0',
+                    id: '1',
+                    method: 'test',
+                    params: {}
+                };
+
+                await transport.send(message);
+
+                const calledHeaders = (globalThis.fetch as Mock).mock.calls[0]![1].headers;
+                expect(calledHeaders.get('Authorization')).toBe('Bearer fresh-token');
+                expect(calledHeaders.get('X-Custom-Header')).toBe('custom-value');
+            } finally {
+                globalThis.fetch = originalFetch;
+            }
+        });
+
         it('passes custom headers to fetch requests (Headers class)', async () => {
             const customHeaders = new Headers({
                 Authorization: 'Bearer test-token',

--- a/packages/client/test/client/streamableHttp.test.ts
+++ b/packages/client/test/client/streamableHttp.test.ts
@@ -2,7 +2,7 @@ import type { JSONRPCMessage, JSONRPCRequest } from '@modelcontextprotocol/core'
 import { OAuthError, OAuthErrorCode, SdkErrorCode, SdkHttpError } from '@modelcontextprotocol/core';
 import type { Mock, Mocked } from 'vitest';
 
-import type { OAuthClientProvider } from '../../src/client/auth.js';
+import type { AuthProvider, OAuthClientProvider } from '../../src/client/auth.js';
 import { UnauthorizedError } from '../../src/client/auth.js';
 import type { ReconnectionScheduler, StartSSEOptions, StreamableHTTPReconnectionOptions } from '../../src/client/streamableHttp.js';
 import { StreamableHTTPClientTransport } from '../../src/client/streamableHttp.js';
@@ -571,6 +571,36 @@ describe('StreamableHTTPClientTransport', () => {
         expect((actualReqInit.headers as Headers).get('x-custom-header')).toBe('SecondCustomValue');
 
         expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('should let auth provider headers override custom Authorization headers', async () => {
+        const authProvider: AuthProvider = {
+            token: async () => 'fresh-token'
+        };
+
+        transport = new StreamableHTTPClientTransport(new URL('http://localhost:1234/mcp'), {
+            authProvider,
+            requestInit: {
+                headers: {
+                    Authorization: 'Bearer stale-token',
+                    'X-Custom-Header': 'CustomValue'
+                }
+            }
+        });
+
+        let actualReqInit: RequestInit = {};
+
+        (globalThis.fetch as Mock).mockImplementation(async (_url, reqInit) => {
+            actualReqInit = reqInit;
+            return new Response(null, { status: 200, headers: { 'content-type': 'text/event-stream' } });
+        });
+
+        await transport.start();
+
+        await transport['_startOrAuthSse']({});
+
+        expect((actualReqInit.headers as Headers).get('authorization')).toBe('Bearer fresh-token');
+        expect((actualReqInit.headers as Headers).get('x-custom-header')).toBe('CustomValue');
     });
 
     it('should always send specified custom headers (Headers class)', async () => {


### PR DESCRIPTION
## Summary

`requestInit.headers.Authorization` currently wins over the transport's auth-provider token in both HTTP client transports. That makes fallback auth awkward: a stale configured Authorization header keeps overriding the fresh OAuth or bearer token even after the transport has one.

This changes the common header merge order so user request headers are still included, but derived auth/session/protocol headers win when the transport has them.

Fixes #2208.

## Tests

```bash
pnpm --filter @modelcontextprotocol/client test -- test/client/streamableHttp.test.ts test/client/sse.test.ts
pnpm --filter @modelcontextprotocol/client typecheck
pnpm --filter @modelcontextprotocol/client exec eslint src/client/streamableHttp.ts src/client/sse.ts
pnpm exec prettier --check .changeset/fresh-buses-auth.md packages/client/src/client/streamableHttp.ts packages/client/src/client/sse.ts packages/client/test/client/streamableHttp.test.ts packages/client/test/client/sse.test.ts
git diff --check
```

The repository pre-push hook also ran successfully:

```bash
pnpm sync:snippets --check && pnpm -r lint
pnpm -r build
pnpm -r typecheck
```
