### PR TITLE
fix(client): let auth headers override request init

### DIFF
--- a/.changeset/fix-client-auth-header-precedence.md
+++ b/.changeset/fix-client-auth-header-precedence.md
@@ -1,0 +1,5 @@
+---
+"@modelcontextprotocol/client": patch
+---
+
+Let transport auth headers override configured request headers.

--- a/packages/client/src/client/sse.ts
+++ b/packages/client/src/client/sse.ts
@@ -120,8 +120,8 @@ export class SSEClientTransport implements Transport {
         const extraHeaders = normalizeHeaders(this._requestInit?.headers);
 
         return new Headers({
-            ...headers,
-            ...extraHeaders
+            ...extraHeaders,
+            ...headers
         });
     }
 

--- a/packages/client/src/client/streamableHttp.ts
+++ b/packages/client/src/client/streamableHttp.ts
@@ -226,8 +226,8 @@ export class StreamableHTTPClientTransport implements Transport {
         const extraHeaders = normalizeHeaders(this._requestInit?.headers);
 
         return new Headers({
-            ...headers,
-            ...extraHeaders
+            ...extraHeaders,
+            ...headers
         });
     }
 

--- a/packages/client/test/client/sse.test.ts
+++ b/packages/client/test/client/sse.test.ts
@@ -658,6 +658,28 @@ describe('SSEClientTransport', () => {
             expect(lastServerRequest.headers['x-custom-header']).toBe('custom-value');
         });
 
+        it('lets OAuth tokens override configured Authorization headers', async () => {
+            mockAuthProvider.tokens.mockResolvedValue({
+                access_token: 'fresh-token',
+                token_type: 'Bearer'
+            });
+
+            transport = new SSEClientTransport(resourceBaseUrl, {
+                authProvider: mockAuthProvider,
+                requestInit: {
+                    headers: {
+                        Authorization: 'Bearer stale-token',
+                        'X-Custom-Header': 'custom-value'
+                    }
+                }
+            });
+
+            await transport.start();
+
+            expect(lastServerRequest.headers.authorization).toBe('Bearer fresh-token');
+            expect(lastServerRequest.headers['x-custom-header']).toBe('custom-value');
+        });
+
         it('refreshes expired token during SSE connection', async () => {
             // Mock tokens() to return expired token until saveTokens is called
             let currentTokens: OAuthTokens = {

--- a/packages/client/test/client/tokenProvider.test.ts
+++ b/packages/client/test/client/tokenProvider.test.ts
@@ -34,6 +34,28 @@ describe('StreamableHTTPClientTransport with AuthProvider', () => {
         expect(init.headers.get('Authorization')).toBe('Bearer my-bearer-token');
     });
 
+    it('should let AuthProvider.token() override configured Authorization headers', async () => {
+        const authProvider: AuthProvider = { token: vi.fn(async () => 'fresh-token') };
+        transport = new StreamableHTTPClientTransport(new URL('http://localhost:1234/mcp'), {
+            authProvider,
+            requestInit: {
+                headers: {
+                    Authorization: 'Bearer stale-token',
+                    'X-Custom-Header': 'custom-value'
+                }
+            }
+        });
+        vi.spyOn(globalThis, 'fetch');
+
+        (globalThis.fetch as Mock).mockResolvedValueOnce({ ok: true, status: 202, headers: new Headers() });
+
+        await transport.send(message);
+
+        const [, init] = (globalThis.fetch as Mock).mock.calls[0]!;
+        expect(init.headers.get('Authorization')).toBe('Bearer fresh-token');
+        expect(init.headers.get('X-Custom-Header')).toBe('custom-value');
+    });
+
     it('should not set Authorization header when token() returns undefined', async () => {
         const authProvider: AuthProvider = { token: vi.fn(async () => undefined) };
         transport = new StreamableHTTPClientTransport(new URL('http://localhost:1234/mcp'), { authProvider });


### PR DESCRIPTION
﻿## Summary
- merge configured request headers before transport-derived auth headers in Streamable HTTP and SSE clients
- keep custom non-auth headers intact while allowing fresh OAuth/API tokens to replace stale configured Authorization values
- add regression coverage for both client transports

Fixes #2208.

## To verify
- `pnpm --filter @modelcontextprotocol/client test -- test/client/tokenProvider.test.ts test/client/sse.test.ts`
- `pnpm --filter @modelcontextprotocol/client typecheck`
- `pnpm --filter @modelcontextprotocol/client lint`
- `pnpm changeset status`
- `git diff --check`

The pre-push hook also ran the full workspace `build:all`, `typecheck:all`, and `lint:all` successfully. The existing `ajv` / `fast-uri` missing-export warnings appeared during build, but did not fail the build.
