### PR TITLE
fix(core): reset request timeout on progress without an onprogress handler

### DIFF
--- a/.changeset/fix-reset-timeout-without-onprogress.md
+++ b/.changeset/fix-reset-timeout-without-onprogress.md
@@ -1,0 +1,6 @@
+---
+'@modelcontextprotocol/client': patch
+'@modelcontextprotocol/server': patch
+---
+
+Fix `resetTimeoutOnProgress` so it works without an `onprogress` handler. Requests that opt into timeout resets now advertise a progress token, reset their timeout when progress arrives, and no longer report progress for the known in-flight request as an unknown-token error.

--- a/packages/core-internal/src/shared/protocol.ts
+++ b/packages/core-internal/src/shared/protocol.ts
@@ -1164,13 +1164,13 @@ export abstract class Protocol<ContextT extends BaseContext> {
         const messageId = Number(progressToken);
 
         const handler = this._progressHandlers.get(messageId);
-        if (!handler) {
+        const responseHandler = this._responseHandlers.get(messageId);
+        const timeoutInfo = this._timeoutInfo.get(messageId);
+
+        if (!handler && !responseHandler) {
             this._onerror(new Error(`Received a progress notification for an unknown token: ${JSON.stringify(notification)}`));
             return;
         }
-
-        const responseHandler = this._responseHandlers.get(messageId);
-        const timeoutInfo = this._timeoutInfo.get(messageId);
 
         if (timeoutInfo && responseHandler && timeoutInfo.resetTimeoutOnProgress) {
             try {
@@ -1185,7 +1185,7 @@ export abstract class Protocol<ContextT extends BaseContext> {
             }
         }
 
-        handler(params);
+        handler?.(params);
     }
 
     /**
@@ -1427,6 +1427,8 @@ export abstract class Protocol<ContextT extends BaseContext> {
 
             if (options?.onprogress) {
                 this._progressHandlers.set(messageId, options.onprogress);
+            }
+            if (options?.onprogress || options?.resetTimeoutOnProgress) {
                 jsonrpcRequest.params = {
                     ...request.params,
                     _meta: {

--- a/packages/core-internal/test/shared/protocol.test.ts
+++ b/packages/core-internal/test/shared/protocol.test.ts
@@ -444,6 +444,55 @@ describe('protocol tests', () => {
             await expect(requestPromise).resolves.toEqual({ result: 'success' });
         });
 
+        test('should reset timeout without an onprogress handler', async () => {
+            await protocol.connect(transport);
+            const request = { method: 'example', params: {} };
+            const mockSchema: ZodType<{ result: string }> = z.object({
+                result: z.string()
+            });
+            const onErrorMock = vi.fn();
+            protocol.onerror = onErrorMock;
+
+            const requestPromise = protocol.request(request, mockSchema, {
+                timeout: 1000,
+                resetTimeoutOnProgress: true
+            });
+
+            expect(sendSpy).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    params: {
+                        _meta: {
+                            progressToken: 0
+                        }
+                    }
+                }),
+                expect.any(Object)
+            );
+
+            vi.advanceTimersByTime(800);
+            transport.onmessage?.({
+                jsonrpc: '2.0',
+                method: 'notifications/progress',
+                params: {
+                    progressToken: 0,
+                    progress: 50,
+                    total: 100
+                }
+            });
+            await Promise.resolve();
+
+            expect(onErrorMock).not.toHaveBeenCalled();
+
+            vi.advanceTimersByTime(800);
+            transport.onmessage?.({
+                jsonrpc: '2.0',
+                id: 0,
+                result: { result: 'success' }
+            });
+            await Promise.resolve();
+            await expect(requestPromise).resolves.toEqual({ result: 'success' });
+        });
+
         test('should respect maxTotalTimeout', async () => {
             await protocol.connect(transport);
             const request = { method: 'example', params: {} };


### PR DESCRIPTION
## What

`resetTimeoutOnProgress: true` is documented to keep a long-running request alive as progress notifications arrive. In practice it only worked when an `onprogress` callback was also passed on the same `request()` call.

Without `onprogress`, the request did not advertise `_meta.progressToken`, and `_onprogress` treated any manually delivered progress as an unknown token before the timeout-reset code could run. (#2076)

## Fix

- Advertise `_meta.progressToken` when either `onprogress` or `resetTimeoutOnProgress` is enabled.
- Treat a progress token as known when it belongs to either a registered progress handler or an in-flight request.
- Reset the timeout for the in-flight request even when no progress callback is registered.
- Invoke the progress callback only when one exists.

This preserves the existing task-progress path, where a progress handler may remain after the response handler is gone, and still reports genuinely unknown tokens.

## Test plan

- Added a public `Protocol.request()` regression covering `resetTimeoutOnProgress: true` without `onprogress`.
- The regression asserts that the outbound request advertises a progress token, progress extends the timer beyond its original deadline, the request resolves successfully, and no spurious unknown-token error is emitted.
- `pnpm exec vitest run test/shared/protocol.test.ts`: 40 passed.
- `pnpm --filter @modelcontextprotocol/core-internal test`: 1,434 passed.
- `pnpm --filter @modelcontextprotocol/core-internal check`: passed.
- Pre-push repository hooks: build, typecheck, and lint passed across the workspace.

## Scope

This PR targets `main` (SDK v2). The stable `v1.x` branch requires a separate backport PR if maintainers want the same fix there.

Fixes #2076
