### PR TITLE
test(e2e): spec-version lifecycle infrastructure for the 2026-07-28 release

### DIFF
--- a/test/e2e/CLAUDE.md
+++ b/test/e2e/CLAUDE.md
@@ -55,7 +55,8 @@ transports: STATEFUL_TRANSPORTS, // or an explicit list
 note: 'stateless hosting has no server→client back-channel'
 ```
 
-`addedInSpecVersion` / `removedInSpecVersion` bound the spec versions a requirement applies to; a behavior changed by a spec release gets a sibling entry linked via `supersedes`.
+`addedInSpecVersion` / `removedInSpecVersion` bound the spec versions a requirement applies to. A behavior changed by a spec release gets a sibling entry: the new entry lists every retired id it replaces in `supersedes` (an array, requires `addedInSpecVersion`), and each retired
+entry points back via `supersededBy` (requires `removedInSpecVersion`). A coverage gate enforces that the links resolve and are exactly symmetric.
 
 ## Running
 

--- a/test/e2e/coverage.test.ts
+++ b/test/e2e/coverage.test.ts
@@ -88,10 +88,25 @@ test('every transport-restricted requirement explains why in note', () => {
     expect(missing).toEqual([]);
 });
 
-test('every supersedes reference points at an existing requirement id', () => {
+test('supersedes/supersededBy links are symmetric and resolve', () => {
+    const bad: string[] = [];
     for (const [id, req] of Object.entries(REQUIREMENTS)) {
-        if (req.supersedes !== undefined) {
-            expect(REQUIREMENTS[req.supersedes], `${id} supersedes unknown id '${req.supersedes}'`).toBeDefined();
+        for (const oldId of req.supersedes ?? []) {
+            const old = REQUIREMENTS[oldId];
+            if (!old) bad.push(`${id}: supersedes unknown id '${oldId}'`);
+            else if (old.supersededBy !== id)
+                bad.push(`${id}: supersedes '${oldId}', but that entry's supersededBy is '${old.supersededBy}'`);
         }
+        if (req.supersededBy !== undefined) {
+            const successor = REQUIREMENTS[req.supersededBy];
+            if (!successor) bad.push(`${id}: supersededBy unknown id '${req.supersededBy}'`);
+            else if (!successor.supersedes?.includes(id))
+                bad.push(`${id}: supersededBy '${req.supersededBy}', but that entry's supersedes array does not include '${id}'`);
+            if (req.removedInSpecVersion === undefined)
+                bad.push(`${id}: has supersededBy but no removedInSpecVersion (only a retired entry can be superseded)`);
+        }
+        if (req.supersedes !== undefined && req.addedInSpecVersion === undefined)
+            bad.push(`${id}: has supersedes but no addedInSpecVersion (a superseding entry is by definition new)`);
     }
+    expect(bad).toEqual([]);
 });

--- a/test/e2e/types.ts
+++ b/test/e2e/types.ts
@@ -39,12 +39,21 @@ export interface Requirement {
     /** Free-form rationale for how the entry is set up (e.g. why certain transports are excluded). */
     note?: string;
 
-    /** First / last spec versions a requirement applies to; changed behaviors are sibling entries linked via `supersedes`. */
+    /** First / last spec versions a requirement applies to; changed behaviors are sibling entries linked via `supersedes`/`supersededBy`. */
     addedInSpecVersion?: SpecVersion;
     removedInSpecVersion?: SpecVersion;
-    /** Requirement id this entry replaces (for behaviors changed by a spec release). */
-
-    supersedes?: string;
+    /**
+     * Requirement ids this (new) entry replaces. The structural link from a superseding entry to the
+     * retired entries it covers: each listed id's `supersededBy` points back at this entry. Semantic
+     * context about how/why the behavior changed belongs in `note`, not here.
+     */
+    supersedes?: readonly string[];
+    /**
+     * Requirement id of the entry that replaces this (retired) one. The structural link from a retired
+     * entry to its successor: that entry's `supersedes` array includes this id. Semantic context about
+     * how/why the behavior changed belongs in `note`, not here.
+     */
+    supersededBy?: string;
     knownFailures?: readonly KnownFailure[];
 
     deferred?: string;

--- a/test/e2e/types.ts
+++ b/test/e2e/types.ts
@@ -5,8 +5,16 @@
 export const ALL_TRANSPORTS = ['inMemory', 'stdio', 'streamableHttp', 'streamableHttpStateless', 'sse'] as const;
 export type Transport = (typeof ALL_TRANSPORTS)[number];
 
-export const ALL_SPEC_VERSIONS = ['2025-11-25'] as const;
-export type SpecVersion = (typeof ALL_SPEC_VERSIONS)[number];
+/**
+ * Every spec version the manifest may reference — used for typing
+ * `addedInSpecVersion` / `removedInSpecVersion` bounds and knownFailure
+ * scoping. Includes versions that are not yet part of the active matrix.
+ */
+export const KNOWN_SPEC_VERSIONS = ['2025-11-25', '2026-07-28'] as const;
+export type SpecVersion = (typeof KNOWN_SPEC_VERSIONS)[number];
+
+/** The spec versions cells are registered for (the active matrix axis). */
+export const ALL_SPEC_VERSIONS = ['2025-11-25'] as const satisfies readonly SpecVersion[];
 
 /**
  * Arguments every test body receives. Expand with new matrix axes here so


### PR DESCRIPTION
> 🗺️ **[2026-07-28 Spec Implementation — milestone tracker](https://gist.github.com/felixweinberger/722c541d7ed89069598ffb6ce64992e0)** · This PR: **M0: e2e manifest infrastructure (version label, supersession links, symmetry gate)**
Adds the manifest infrastructure the 2026-07-28 spec release needs: the version label, and structural supersession links with a symmetry gate. **No requirement entries are annotated or added here** — each implementation PR carries its own manifest changes (retirements + successors + tests) together with the code that makes them true.

## Motivation and Context

The upcoming spec release (stateless/sessionless/MRTR — SEP-2575/2567/2322) retires some 2025 behaviors and replaces others. Recording those changes requires two pieces of manifest infrastructure:

1. **`KNOWN_SPEC_VERSIONS`** — version labels that `addedInSpecVersion`/`removedInSpecVersion` bounds and knownFailure scoping may reference. `ALL_SPEC_VERSIONS` (the active matrix axis) is unchanged: only `2025-11-25` registers cells.
2. **Structural supersession links** — when a release replaces a behavior, the retired entry records its successor (`supersededBy`) and the new entry lists what it replaces (`supersedes: readonly string[]`). A coverage gate enforces referential integrity and exact symmetry, plus two consistency rules: `supersededBy` requires `removedInSpecVersion`, and `supersedes` requires `addedInSpecVersion`.

The actual annotations land incrementally: each implementation PR marks the entries it retires and adds the successors it implements, in the same diff as the code — so every manifest change is reviewed alongside the behavior change that justifies it.

## How Has This Been Tested?

Full e2e matrix unchanged: 1,231 cells = 1,139 passed + 92 expected-fail, 0 unexpected failures. The new symmetry gate passes (vacuously, until entries populate the fields). Typecheck and lint clean.

## Breaking Changes

None. Test-infrastructure only; no SDK code touched.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed
