### PR TITLE
fix(auth): send OAuth resource parameter when Protected Resource Metadata is absent (v1.x)

### DIFF
--- a/.changeset/oauth-resource-fallback-no-prm.md
+++ b/.changeset/oauth-resource-fallback-no-prm.md
@@ -1,0 +1,6 @@
+---
+'@modelcontextprotocol/sdk': patch
+---
+
+Always send the OAuth `resource` parameter, falling back to the canonical server URI when Protected Resource Metadata (RFC 9728) is absent. Previously `selectResourceURL` returned `undefined` whenever PRM discovery failed, omitting `resource` from `/authorize` and `/token`
+requests. The MCP authorization spec requires clients to send this parameter "regardless of whether authorization servers support it".

--- a/src/client/auth.ts
+++ b/src/client/auth.ts
@@ -471,7 +471,7 @@ async function authInternal(
                     fetchFn
                 );
             } catch {
-                // RFC 9728 not available — selectResourceURL will handle undefined
+                // RFC 9728 not available — selectResourceURL falls back to the canonical server URI
             }
         }
 
@@ -641,9 +641,11 @@ export async function selectResourceURL(
         return await provider.validateResourceURL(defaultResource, resourceMetadata?.resource);
     }
 
-    // Only include resource parameter when Protected Resource Metadata is present
+    // Fall back to the canonical server URI when Protected Resource Metadata is absent.
+    // The MCP spec requires clients to send the `resource` parameter "regardless of whether
+    // authorization servers support it", using the canonical server URI (RFC 8707).
     if (!resourceMetadata) {
-        return undefined;
+        return defaultResource;
     }
 
     // Validate that the metadata's resource is compatible with our request

--- a/test/client/auth.test.ts
+++ b/test/client/auth.test.ts
@@ -2562,7 +2562,7 @@ describe('OAuth Authorization', () => {
             expect(authUrl.searchParams.get('resource')).toBe('https://api.example.com/');
         });
 
-        it('excludes resource parameter when Protected Resource Metadata is not present', async () => {
+        it('falls back to the canonical server URI when Protected Resource Metadata is not present', async () => {
             // Mock metadata discovery where protected resource metadata is not available (404)
             // but authorization server metadata is available
             mockFetch.mockImplementation(url => {
@@ -2600,14 +2600,14 @@ describe('OAuth Authorization', () => {
             (mockProvider.saveCodeVerifier as Mock).mockResolvedValue(undefined);
             (mockProvider.redirectToAuthorization as Mock).mockResolvedValue(undefined);
 
-            // Call auth - should not include resource parameter
+            // Call auth - should still include resource parameter (canonical server URI)
             const result = await auth(mockProvider, {
                 serverUrl: 'https://api.example.com/mcp-server'
             });
 
             expect(result).toBe('REDIRECT');
 
-            // Verify the authorization URL does NOT include the resource parameter
+            // Verify the authorization URL includes the resource parameter
             expect(mockProvider.redirectToAuthorization).toHaveBeenCalledWith(
                 expect.objectContaining({
                     searchParams: expect.any(URLSearchParams)
@@ -2616,11 +2616,12 @@ describe('OAuth Authorization', () => {
 
             const redirectCall = (mockProvider.redirectToAuthorization as Mock).mock.calls[0];
             const authUrl: URL = redirectCall[0];
-            // Resource parameter should not be present when PRM is not available
-            expect(authUrl.searchParams.has('resource')).toBe(false);
+            // Resource parameter must fall back to the canonical server URI when PRM is not available.
+            // The MCP spec requires clients to send `resource` regardless of authorization server support.
+            expect(authUrl.searchParams.get('resource')).toBe('https://api.example.com/mcp-server');
         });
 
-        it('excludes resource parameter in token exchange when Protected Resource Metadata is not present', async () => {
+        it('falls back to the canonical server URI in token exchange when Protected Resource Metadata is not present', async () => {
             // Mock metadata discovery - no protected resource metadata, but auth server metadata available
             mockFetch.mockImplementation(url => {
                 const urlString = url.toString();
@@ -2679,12 +2680,12 @@ describe('OAuth Authorization', () => {
             expect(tokenCall).toBeDefined();
 
             const body = tokenCall![1].body as URLSearchParams;
-            // Resource parameter should not be present when PRM is not available
-            expect(body.has('resource')).toBe(false);
+            // Resource parameter must fall back to the canonical server URI when PRM is not available
+            expect(body.get('resource')).toBe('https://api.example.com/mcp-server');
             expect(body.get('code')).toBe('auth-code-123');
         });
 
-        it('excludes resource parameter in token refresh when Protected Resource Metadata is not present', async () => {
+        it('falls back to the canonical server URI in token refresh when Protected Resource Metadata is not present', async () => {
             // Mock metadata discovery - no protected resource metadata, but auth server metadata available
             mockFetch.mockImplementation(url => {
                 const urlString = url.toString();
@@ -2744,8 +2745,8 @@ describe('OAuth Authorization', () => {
             expect(tokenCall).toBeDefined();
 
             const body = tokenCall![1].body as URLSearchParams;
-            // Resource parameter should not be present when PRM is not available
-            expect(body.has('resource')).toBe(false);
+            // Resource parameter must fall back to the canonical server URI when PRM is not available
+            expect(body.get('resource')).toBe('https://api.example.com/mcp-server');
             expect(body.get('grant_type')).toBe('refresh_token');
             expect(body.get('refresh_token')).toBe('refresh123');
         });


### PR DESCRIPTION
> **Note:** This targets the `v1.x` release branch. The equivalent fix for `main` (monorepo) is in #2253.

## Summary

The MCP authorization specification requires clients to **always** send the RFC 8707 `resource` parameter on authorization and token requests, derived from the canonical server URI — independently of Protected Resource Metadata (RFC 9728) discovery.

From the [Resource Parameter Implementation](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization#resource-parameter-implementation) section:

> The `resource` parameter:
> 1. **MUST** be included in both authorization requests and token requests.
> 2. **MUST** identify the MCP server that the client intends to use the token with.
> 3. **MUST** use the canonical URI of the MCP server as defined in RFC 8707 Section 2.

And explicitly:

> MCP clients **MUST** send this parameter regardless of whether authorization servers support it.

The spec also defines the canonical server URI as derived from the **server URL**, which merely "aligns with the `resource` parameter in RFC 9728" — it is not sourced from Protected Resource Metadata.

This requirement is present in both the current released revision ([2025-06-18](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization#resource-parameter-implementation)) and the [draft](https://modelcontextprotocol.io/specification/draft/basic/authorization#resource-parameter-implementation) revision.

## Problem

`selectResourceURL` returned `undefined` whenever Protected Resource Metadata discovery failed (e.g. the server does not serve `/.well-known/oauth-protected-resource`). That dropped the `resource` parameter entirely from `/authorize` and `/token` requests, even though the canonical server URI had already been computed. Authorization servers that require the `resource` parameter then reject the request.

## Change

Fall back to the canonical server URI (`resourceUrlFromServerUrl(serverUrl)`) when Protected Resource Metadata is absent, instead of returning `undefined`:

```ts
if (!resourceMetadata) {
    return defaultResource;
}
```

When Protected Resource Metadata **is** present, behavior is unchanged: the metadata's `resource` is validated against the canonical URI and preferred.

## Tests

Updated the three existing tests that asserted the resource parameter was omitted when PRM is absent (authorize redirect, token exchange, token refresh) to assert it falls back to the canonical server URI. All client auth tests pass; typecheck is clean.
