### PR TITLE
ci: run CI and conformance on the v1.x-2026-07-28 integration branch

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -2,9 +2,9 @@ name: Conformance Tests
 
 on:
     push:
-        branches: [v1.x]
+        branches: [v1.x, v1.x-2026-07-28]
     pull_request:
-        branches: [v1.x]
+        branches: [v1.x, v1.x-2026-07-28]
     workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,7 @@ on:
     push:
         branches:
             - v1.x
+            - v1.x-2026-07-28
     pull_request:
     workflow_dispatch:
     release:


### PR DESCRIPTION
Extends workflow triggers so the `v1.x-2026-07-28` integration branch gets the same CI coverage as `v1.x`.

## Motivation and Context
`v1.x-2026-07-28` is a long-lived integration branch for developing 2026-07-28 spec support against the v1.x line. Development PRs target this branch; the accumulated work will return to `v1.x` as a single reviewable PR. Without this change, `main.yml` would not run on pushes to the branch and `conformance.yml` would not run on PRs targeting it.

## How Has This Been Tested?
CI on this PR exercises the change directly: `pull_request` workflows run from the merge ref, so conformance triggering on this PR confirms the new branch filter works.

## Breaking Changes
None.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
CI-trigger-only change; lives on the integration branch and will be dropped/ignored when the branch merges back to `v1.x` (the `v1.x` copies of these files keep their current triggers there).