### PR TITLE
fix(client): accumulate scopes (union) on step-up authorization challenges (SEP-2350)

### DIFF
--- a/.changeset/sep-2350-scope-union-step-up.md
+++ b/.changeset/sep-2350-scope-union-step-up.md
@@ -4,3 +4,5 @@
 
 Accumulate scopes (union) when re-authorizing after a `403 insufficient_scope` step-up challenge (SEP-2350). Previously the challenged scopes replaced the requested scope, so per-operation challenges dropped previously granted permissions. The client now requests the union of
 previously granted scopes (from stored tokens), previously requested scopes, protected resource metadata scopes, provider-configured default scopes, and the newly challenged scopes, using the existing exported `computeScopeUnion` helper.
+
+The 401 re-authorization path now preserves accumulated `scope` and `resourceMetadataUrl` context too: `UnauthorizedContext` exposes optional `scope` / `resourceMetadataUrl` fields for custom `AuthProvider.onUnauthorized` handlers, and `handleOAuthUnauthorized` folds that context into the next `auth()` call.

--- a/.changeset/sep-2350-scope-union-step-up.md
+++ b/.changeset/sep-2350-scope-union-step-up.md
@@ -6,3 +6,5 @@ Accumulate scopes (union) when re-authorizing after a `403 insufficient_scope` s
 previously granted scopes (from stored tokens), previously requested scopes, protected resource metadata scopes, provider-configured default scopes, and the newly challenged scopes, using the existing exported `computeScopeUnion` helper.
 
 The 401 re-authorization path now preserves accumulated `scope` and `resourceMetadataUrl` context too: `UnauthorizedContext` exposes optional `scope` / `resourceMetadataUrl` fields for custom `AuthProvider.onUnauthorized` handlers, and `handleOAuthUnauthorized` folds that context into the next `auth()` call.
+
+The `withOAuth` fetch middleware likewise unions the stored token scope with the 401 challenge scope when re-authenticating.

--- a/.changeset/sep-2350-scope-union-step-up.md
+++ b/.changeset/sep-2350-scope-union-step-up.md
@@ -3,4 +3,4 @@
 ---
 
 Accumulate scopes (union) when re-authorizing after a `403 insufficient_scope` step-up challenge (SEP-2350). Previously the challenged scopes replaced the requested scope, so per-operation challenges dropped previously granted permissions. The client now requests the union of
-previously granted scopes (from stored tokens), previously requested scopes, protected resource metadata scopes, provider-configured default scopes, and the newly challenged scopes. Adds an exported `unionScopes` helper to `@modelcontextprotocol/client`.
+previously granted scopes (from stored tokens), previously requested scopes, protected resource metadata scopes, provider-configured default scopes, and the newly challenged scopes, using the existing exported `computeScopeUnion` helper.

--- a/.changeset/sep-2350-scope-union-step-up.md
+++ b/.changeset/sep-2350-scope-union-step-up.md
@@ -2,4 +2,5 @@
 '@modelcontextprotocol/client': patch
 ---
 
-Accumulate scopes (union) when re-authorizing after a `403 insufficient_scope` step-up challenge (SEP-2350). Previously the challenged scopes replaced the requested scope, so per-operation challenges dropped previously granted permissions. The client now requests the union of previously granted scopes (from stored tokens), previously requested scopes, and the newly challenged scopes. Adds an exported `unionScopes` helper to `@modelcontextprotocol/client`.
+Accumulate scopes (union) when re-authorizing after a `403 insufficient_scope` step-up challenge (SEP-2350). Previously the challenged scopes replaced the requested scope, so per-operation challenges dropped previously granted permissions. The client now requests the union of
+previously granted scopes (from stored tokens), previously requested scopes, protected resource metadata scopes, provider-configured default scopes, and the newly challenged scopes. Adds an exported `unionScopes` helper to `@modelcontextprotocol/client`.

--- a/.changeset/sep-2350-scope-union-step-up.md
+++ b/.changeset/sep-2350-scope-union-step-up.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/client': patch
+---
+
+Accumulate scopes (union) when re-authorizing after a `403 insufficient_scope` step-up challenge (SEP-2350). Previously the challenged scopes replaced the requested scope, so per-operation challenges dropped previously granted permissions. The client now requests the union of previously granted scopes (from stored tokens), previously requested scopes, and the newly challenged scopes. Adds an exported `unionScopes` helper to `@modelcontextprotocol/client`.

--- a/docs/migration/upgrade-to-v2.md
+++ b/docs/migration/upgrade-to-v2.md
@@ -1217,9 +1217,11 @@ TLS; there is no opt-out. Storage confidentiality of `refresh_token` remains you
 
 `StreamableHTTPClientTransport` accepts `onInsufficientScope: 'reauthorize' | 'throw'`
 (default `'reauthorize'`). On `'reauthorize'` the transport re-authorizes with the
-**union** of the previously-requested and challenged scope (`computeScopeUnion`); when
-that union strictly exceeds the current token's granted scope (`isStrictScopeSuperset`),
-the SDK bypasses the refresh-token branch and forces a fresh authorization request. On
+**union** of the current token's granted scope, the previously-requested scope, protected
+resource metadata `scopes_supported`, the provider-configured default scope, and the
+newly challenged scope (`computeScopeUnion`); when that union strictly exceeds the current
+token's granted scope (`isStrictScopeSuperset`), the SDK bypasses the refresh-token branch
+and forces a fresh authorization request. On
 `'throw'` the transport raises `InsufficientScopeError` and does not re-authorize — set
 this for `client_credentials` / m2m clients where re-authorization can't widen scope, or
 to gate the consent prompt behind UX. Step-up retries are hard-capped per send

--- a/packages/client/src/client/auth.ts
+++ b/packages/client/src/client/auth.ts
@@ -182,10 +182,11 @@ export async function handleOAuthUnauthorized(
     extraAuthOptions?: Pick<AuthOptions, 'skipIssuerMetadataValidation'>
 ): Promise<void> {
     const challenge = extractWWWAuthenticateParams(ctx.response);
+    const tokens = await provider.tokens();
     const result = await auth(provider, {
         serverUrl: ctx.serverUrl,
         resourceMetadataUrl: challenge.resourceMetadataUrl ?? ctx.resourceMetadataUrl,
-        scope: computeScopeUnion(ctx.scope, challenge.scope),
+        scope: computeScopeUnion(tokens?.scope, ctx.scope, challenge.scope),
         fetchFn: ctx.fetchFn,
         ...extraAuthOptions
     });

--- a/packages/client/src/client/auth.ts
+++ b/packages/client/src/client/auth.ts
@@ -53,6 +53,10 @@ export interface UnauthorizedContext {
     serverUrl: URL;
     /** Fetch function configured with the transport's `requestInit`, for making auth requests. */
     fetchFn: FetchLike;
+    /** Accumulated OAuth scope from previous challenges, if the transport has one. */
+    scope?: string;
+    /** Resource metadata URL from previous challenges, if the transport has one. */
+    resourceMetadataUrl?: URL;
 }
 
 /**

--- a/packages/client/src/client/auth.ts
+++ b/packages/client/src/client/auth.ts
@@ -1018,6 +1018,34 @@ export function determineScope(options: {
     return effectiveScope;
 }
 
+/**
+ * Computes the union of one or more space-delimited OAuth scope strings (SEP-2350).
+ *
+ * Per the MCP authorization spec's step-up authorization flow, scope accumulation is a
+ * client-side responsibility: when re-authorizing after an `insufficient_scope` challenge,
+ * clients SHOULD request the union of previously requested/granted scopes and the newly
+ * challenged scopes, so that per-operation challenges don't drop previously granted
+ * permissions.
+ *
+ * Scopes are treated as opaque strings (no hierarchy-aware deduplication). The result
+ * preserves first-seen order and removes exact duplicates. Returns `undefined` when no
+ * scopes are present in any input.
+ */
+export function unionScopes(...scopeStrings: Array<string | undefined>): string | undefined {
+    const seen = new Set<string>();
+    for (const scopeString of scopeStrings) {
+        if (!scopeString) {
+            continue;
+        }
+        for (const scope of scopeString.split(/\s+/)) {
+            if (scope) {
+                seen.add(scope);
+            }
+        }
+    }
+    return seen.size > 0 ? [...seen].join(' ') : undefined;
+}
+
 async function authInternal(
     provider: OAuthClientProvider,
     {

--- a/packages/client/src/client/auth.ts
+++ b/packages/client/src/client/auth.ts
@@ -181,11 +181,11 @@ export async function handleOAuthUnauthorized(
     ctx: UnauthorizedContext,
     extraAuthOptions?: Pick<AuthOptions, 'skipIssuerMetadataValidation'>
 ): Promise<void> {
-    const { resourceMetadataUrl, scope } = extractWWWAuthenticateParams(ctx.response);
+    const challenge = extractWWWAuthenticateParams(ctx.response);
     const result = await auth(provider, {
         serverUrl: ctx.serverUrl,
-        resourceMetadataUrl,
-        scope,
+        resourceMetadataUrl: challenge.resourceMetadataUrl ?? ctx.resourceMetadataUrl,
+        scope: computeScopeUnion(ctx.scope, challenge.scope),
         fetchFn: ctx.fetchFn,
         ...extraAuthOptions
     });
@@ -1020,34 +1020,6 @@ export function determineScope(options: {
     }
 
     return effectiveScope;
-}
-
-/**
- * Computes the union of one or more space-delimited OAuth scope strings (SEP-2350).
- *
- * Per the MCP authorization spec's step-up authorization flow, scope accumulation is a
- * client-side responsibility: when re-authorizing after an `insufficient_scope` challenge,
- * clients SHOULD request the union of previously requested/granted scopes and the newly
- * challenged scopes, so that per-operation challenges don't drop previously granted
- * permissions.
- *
- * Scopes are treated as opaque strings (no hierarchy-aware deduplication). The result
- * preserves first-seen order and removes exact duplicates. Returns `undefined` when no
- * scopes are present in any input.
- */
-export function unionScopes(...scopeStrings: Array<string | undefined>): string | undefined {
-    const seen = new Set<string>();
-    for (const scopeString of scopeStrings) {
-        if (!scopeString) {
-            continue;
-        }
-        for (const scope of scopeString.split(/\s+/)) {
-            if (scope) {
-                seen.add(scope);
-            }
-        }
-    }
-    return seen.size > 0 ? [...seen].join(' ') : undefined;
 }
 
 async function authInternal(

--- a/packages/client/src/client/middleware.ts
+++ b/packages/client/src/client/middleware.ts
@@ -1,7 +1,7 @@
 import type { FetchLike } from '@modelcontextprotocol/core-internal';
 
 import type { OAuthClientProvider } from './auth';
-import { auth, extractWWWAuthenticateParams, UnauthorizedError } from './auth';
+import { auth, computeScopeUnion, extractWWWAuthenticateParams, UnauthorizedError } from './auth';
 
 /**
  * Middleware function that wraps and enhances fetch functionality.
@@ -39,11 +39,13 @@ export const withOAuth =
     (provider: OAuthClientProvider, baseUrl?: string | URL): Middleware =>
     next => {
         return async (input, init) => {
+            let lastTokenScope: string | undefined;
             const makeRequest = async (): Promise<Response> => {
                 const headers = new Headers(init?.headers);
 
                 // Add authorization header if tokens are available
                 const tokens = await provider.tokens();
+                lastTokenScope = tokens?.scope;
                 if (tokens) {
                     headers.set('Authorization', `Bearer ${tokens.access_token}`);
                 }
@@ -64,7 +66,7 @@ export const withOAuth =
                     const result = await auth(provider, {
                         serverUrl,
                         resourceMetadataUrl,
-                        scope,
+                        scope: computeScopeUnion(lastTokenScope, scope),
                         fetchFn: next
                     });
 

--- a/packages/client/src/client/middleware.ts
+++ b/packages/client/src/client/middleware.ts
@@ -63,7 +63,7 @@ export const withOAuth =
                     // Use provided baseUrl or extract from request URL
                     const serverUrl = baseUrl || (typeof input === 'string' ? new URL(input).origin : input.origin);
                     const unionScope = computeScopeUnion(lastTokenScope, scope);
-                    const forceReauthorization = isStrictScopeSuperset(unionScope, lastTokenScope);
+                    const forceReauthorization = lastTokenScope !== undefined && isStrictScopeSuperset(unionScope, lastTokenScope);
 
                     const result = await auth(provider, {
                         serverUrl,

--- a/packages/client/src/client/middleware.ts
+++ b/packages/client/src/client/middleware.ts
@@ -1,7 +1,7 @@
 import type { FetchLike } from '@modelcontextprotocol/core-internal';
 
 import type { OAuthClientProvider } from './auth';
-import { auth, computeScopeUnion, extractWWWAuthenticateParams, UnauthorizedError } from './auth';
+import { auth, computeScopeUnion, extractWWWAuthenticateParams, isStrictScopeSuperset, UnauthorizedError } from './auth';
 
 /**
  * Middleware function that wraps and enhances fetch functionality.
@@ -62,11 +62,14 @@ export const withOAuth =
 
                     // Use provided baseUrl or extract from request URL
                     const serverUrl = baseUrl || (typeof input === 'string' ? new URL(input).origin : input.origin);
+                    const unionScope = computeScopeUnion(lastTokenScope, scope);
+                    const forceReauthorization = isStrictScopeSuperset(unionScope, lastTokenScope);
 
                     const result = await auth(provider, {
                         serverUrl,
                         resourceMetadataUrl,
-                        scope: computeScopeUnion(lastTokenScope, scope),
+                        scope: unionScope,
+                        ...(forceReauthorization ? { forceReauthorization } : {}),
                         fetchFn: next
                     });
 

--- a/packages/client/src/client/sse.ts
+++ b/packages/client/src/client/sse.ts
@@ -164,7 +164,7 @@ export class SSEClientTransport implements Transport {
                         this._last401Response = response;
                         if (response.headers.has('www-authenticate')) {
                             const { resourceMetadataUrl, scope } = extractWWWAuthenticateParams(response);
-                            this._resourceMetadataUrl = resourceMetadataUrl;
+                            this._resourceMetadataUrl = resourceMetadataUrl ?? this._resourceMetadataUrl;
                             this._scope = unionScopes(this._scope, scope);
                         }
                     }
@@ -336,7 +336,7 @@ export class SSEClientTransport implements Transport {
                 if (response.status === 401 && this._authProvider) {
                     if (response.headers.has('www-authenticate')) {
                         const { resourceMetadataUrl, scope } = extractWWWAuthenticateParams(response);
-                        this._resourceMetadataUrl = resourceMetadataUrl;
+                        this._resourceMetadataUrl = resourceMetadataUrl ?? this._resourceMetadataUrl;
                         this._scope = unionScopes(this._scope, scope);
                     }
 

--- a/packages/client/src/client/sse.ts
+++ b/packages/client/src/client/sse.ts
@@ -14,6 +14,7 @@ import type { AuthProvider, OAuthClientProvider } from './auth';
 import {
     adaptOAuthProvider,
     auth,
+    computeScopeUnion,
     extractWWWAuthenticateParams,
     isOAuthClientProvider,
     resolveAuthorizationCallbackParams,
@@ -165,7 +166,7 @@ export class SSEClientTransport implements Transport {
                         if (response.headers.has('www-authenticate')) {
                             const { resourceMetadataUrl, scope } = extractWWWAuthenticateParams(response);
                             this._resourceMetadataUrl = resourceMetadataUrl ?? this._resourceMetadataUrl;
-                            this._scope = unionScopes(this._scope, scope);
+                            this._scope = computeScopeUnion(this._scope, scope);
                         }
                     }
 
@@ -337,7 +338,7 @@ export class SSEClientTransport implements Transport {
                     if (response.headers.has('www-authenticate')) {
                         const { resourceMetadataUrl, scope } = extractWWWAuthenticateParams(response);
                         this._resourceMetadataUrl = resourceMetadataUrl ?? this._resourceMetadataUrl;
-                        this._scope = unionScopes(this._scope, scope);
+                        this._scope = computeScopeUnion(this._scope, scope);
                     }
 
                     if (this._authProvider.onUnauthorized && !isAuthRetry) {

--- a/packages/client/src/client/sse.ts
+++ b/packages/client/src/client/sse.ts
@@ -165,7 +165,7 @@ export class SSEClientTransport implements Transport {
                         if (response.headers.has('www-authenticate')) {
                             const { resourceMetadataUrl, scope } = extractWWWAuthenticateParams(response);
                             this._resourceMetadataUrl = resourceMetadataUrl;
-                            this._scope = scope;
+                            this._scope = unionScopes(this._scope, scope);
                         }
                     }
 
@@ -180,15 +180,23 @@ export class SSEClientTransport implements Transport {
                         const response = this._last401Response;
                         this._last401Response = undefined;
                         this._eventSource?.close();
-                        this._authProvider.onUnauthorized({ response, serverUrl: this._url, fetchFn: this._fetchWithInit }).then(
-                            // onUnauthorized succeeded → retry fresh. Its onerror handles its own onerror?.() + reject.
-                            () => this._startOrAuth().then(resolve, reject),
-                            // onUnauthorized failed → not yet reported.
-                            error => {
-                                this.onerror?.(error);
-                                reject(error);
-                            }
-                        );
+                        this._authProvider
+                            .onUnauthorized({
+                                response,
+                                serverUrl: this._url,
+                                fetchFn: this._fetchWithInit,
+                                resourceMetadataUrl: this._resourceMetadataUrl,
+                                scope: this._scope
+                            })
+                            .then(
+                                // onUnauthorized succeeded → retry fresh. Its onerror handles its own onerror?.() + reject.
+                                () => this._startOrAuth().then(resolve, reject),
+                                // onUnauthorized failed → not yet reported.
+                                error => {
+                                    this.onerror?.(error);
+                                    reject(error);
+                                }
+                            );
                         return;
                     }
                     const error = new UnauthorizedError();
@@ -329,14 +337,16 @@ export class SSEClientTransport implements Transport {
                     if (response.headers.has('www-authenticate')) {
                         const { resourceMetadataUrl, scope } = extractWWWAuthenticateParams(response);
                         this._resourceMetadataUrl = resourceMetadataUrl;
-                        this._scope = scope;
+                        this._scope = unionScopes(this._scope, scope);
                     }
 
                     if (this._authProvider.onUnauthorized && !isAuthRetry) {
                         await this._authProvider.onUnauthorized({
                             response,
                             serverUrl: this._url,
-                            fetchFn: this._fetchWithInit
+                            fetchFn: this._fetchWithInit,
+                            resourceMetadataUrl: this._resourceMetadataUrl,
+                            scope: this._scope
                         });
                         await response.text?.().catch(() => {});
                         // Purposely _not_ awaited, so we don't call onerror twice

--- a/packages/client/src/client/streamableHttp.ts
+++ b/packages/client/src/client/streamableHttp.ts
@@ -212,11 +212,13 @@ export type StreamableHTTPClientTransportOptions = {
      * `WWW-Authenticate: Bearer error="insufficient_scope"`.
      *
      * - `'reauthorize'` (default): the transport runs the step-up authorization
-     *   flow — computes the union of the previously-requested scope and the
-     *   challenged scope, calls {@linkcode index.auth | auth()} (forcing a
-     *   fresh authorization request when the union strictly exceeds the current
-     *   token's granted scope, since refresh cannot widen scope per RFC 6749
-     *   §6), and retries the request once. Retries are bounded by
+     *   flow — computes the union of the current token's granted scope, the
+     *   previously requested scope, protected resource metadata scopes, provider
+     *   default scope, and the challenged scope, then calls
+     *   {@linkcode index.auth | auth()} (forcing a fresh authorization request
+     *   when the union strictly exceeds the current token's granted scope, since
+     *   refresh cannot widen scope per RFC 6749 §6), and retries the request once.
+     *   Retries are bounded by
      *   {@linkcode StreamableHTTPClientTransportOptions.maxStepUpRetries | maxStepUpRetries}.
      *   If no {@linkcode index.OAuthClientProvider | OAuthClientProvider} is
      *   configured, step-up cannot run and the transport throws
@@ -397,8 +399,9 @@ export class StreamableHTTPClientTransport implements Transport {
             this._resourceMetadataUrl = challenge.resourceMetadataUrl;
         }
 
-        // Spec step-up: union of previously-requested scope and challenged scope,
-        // so previously-granted permissions are not lost on re-authorization.
+        // Spec step-up: union the current token grant, the previously requested
+        // scope, PRM scopes_supported, provider default scope, and challenged
+        // scope so permissions are not lost on re-authorization.
         const tokens = await this._oauthProvider.tokens();
         const discoveryState = await this._oauthProvider.discoveryState?.();
         const resourceScope = discoveryState?.resourceMetadata?.scopes_supported?.join(' ');

--- a/packages/client/src/client/streamableHttp.ts
+++ b/packages/client/src/client/streamableHttp.ts
@@ -400,7 +400,15 @@ export class StreamableHTTPClientTransport implements Transport {
         // Spec step-up: union of previously-requested scope and challenged scope,
         // so previously-granted permissions are not lost on re-authorization.
         const tokens = await this._oauthProvider.tokens();
-        const unionScope = computeScopeUnion(this._scope, tokens?.scope, challenge.scope);
+        const discoveryState = await this._oauthProvider.discoveryState?.();
+        const resourceScope = discoveryState?.resourceMetadata?.scopes_supported?.join(' ');
+        const unionScope = computeScopeUnion(
+            tokens?.scope,
+            this._scope,
+            resourceScope,
+            this._oauthProvider.clientMetadata.scope,
+            challenge.scope
+        );
         this._scope = unionScope;
 
         // Superset-gated refresh bypass: refresh cannot widen scope (RFC 6749 §6),
@@ -534,7 +542,7 @@ export class StreamableHTTPClientTransport implements Transport {
                 if (response.status === 401 && this._authProvider) {
                     if (response.headers.has('www-authenticate')) {
                         const { resourceMetadataUrl, scope } = extractWWWAuthenticateParams(response);
-                        this._resourceMetadataUrl = resourceMetadataUrl;
+                        this._resourceMetadataUrl = resourceMetadataUrl ?? this._resourceMetadataUrl;
                         // Preserve any union accumulated by `_stepUpAuthorize` so a 401
                         // mid-chain does not narrow `_scope` back to the challenge value.
                         this._scope = computeScopeUnion(this._scope, scope);
@@ -985,7 +993,7 @@ export class StreamableHTTPClientTransport implements Transport {
                     // Store WWW-Authenticate params for interactive finishAuth() path
                     if (response.headers.has('www-authenticate')) {
                         const { resourceMetadataUrl, scope } = extractWWWAuthenticateParams(response);
-                        this._resourceMetadataUrl = resourceMetadataUrl;
+                        this._resourceMetadataUrl = resourceMetadataUrl ?? this._resourceMetadataUrl;
                         // Preserve any union accumulated by `_stepUpAuthorize` so a 401
                         // mid-chain does not narrow `_scope` back to the challenge value.
                         this._scope = computeScopeUnion(this._scope, scope);

--- a/packages/client/src/client/streamableHttp.ts
+++ b/packages/client/src/client/streamableHttp.ts
@@ -544,7 +544,9 @@ export class StreamableHTTPClientTransport implements Transport {
                         await this._authProvider.onUnauthorized({
                             response,
                             serverUrl: this._url,
-                            fetchFn: this._fetchWithInit
+                            fetchFn: this._fetchWithInit,
+                            resourceMetadataUrl: this._resourceMetadataUrl,
+                            scope: this._scope
                         });
                         await response.text?.().catch(() => {});
                         // Purposely _not_ awaited, so we don't call onerror twice
@@ -993,7 +995,9 @@ export class StreamableHTTPClientTransport implements Transport {
                         await this._authProvider.onUnauthorized({
                             response,
                             serverUrl: this._url,
-                            fetchFn: this._fetchWithInit
+                            fetchFn: this._fetchWithInit,
+                            resourceMetadataUrl: this._resourceMetadataUrl,
+                            scope: this._scope
                         });
                         await response.text?.().catch(() => {});
                         // Purposely _not_ awaited, so we don't call onerror twice

--- a/packages/client/test/client/auth.test.ts
+++ b/packages/client/test/client/auth.test.ts
@@ -25,8 +25,8 @@ import {
     discoverOAuthServerInfo,
     exchangeAuthorization,
     extractWWWAuthenticateParams,
+    handleOAuthUnauthorized,
     InsecureTokenEndpointError,
-    unionScopes,
     isHttpsUrl,
     isStrictScopeSuperset,
     IssuerMismatchError,
@@ -213,6 +213,71 @@ describe('OAuth Authorization', () => {
             // The spec explicitly does not require clients to deduplicate
             // hierarchically; the AS normalizes redundancy.
             expect(computeScopeUnion('admin', 'read')).toBe('admin read');
+        });
+    });
+
+    describe('handleOAuthUnauthorized', () => {
+        it('uses accumulated context scope and resource metadata when reauthorizing', async () => {
+            const resourceMetadataUrl = new URL('https://resource.example.com/custom-prm');
+            const provider: OAuthClientProvider = {
+                get redirectUrl() {
+                    return 'http://localhost:3000/callback';
+                },
+                get clientMetadata() {
+                    return {
+                        redirect_uris: ['http://localhost:3000/callback'],
+                        client_name: 'Test Client'
+                    };
+                },
+                clientInformation: vi.fn().mockResolvedValue({ client_id: 'test-client' }),
+                tokens: vi.fn().mockResolvedValue(undefined),
+                saveTokens: vi.fn(),
+                saveCodeVerifier: vi.fn(),
+                codeVerifier: vi.fn(),
+                redirectToAuthorization: vi.fn()
+            };
+            const response = new Response(null, {
+                status: 401,
+                headers: { 'WWW-Authenticate': 'Bearer scope="write"' }
+            });
+
+            mockFetch.mockImplementation(url => {
+                const urlString = url.toString();
+                if (urlString === resourceMetadataUrl.toString()) {
+                    return Promise.resolve(
+                        Response.json({
+                            resource: 'https://api.example.com/mcp',
+                            authorization_servers: ['https://auth.example.com']
+                        })
+                    );
+                }
+                if (urlString.includes('/.well-known/oauth-authorization-server')) {
+                    return Promise.resolve(
+                        Response.json({
+                            issuer: 'https://auth.example.com',
+                            authorization_endpoint: 'https://auth.example.com/authorize',
+                            token_endpoint: 'https://auth.example.com/token',
+                            response_types_supported: ['code'],
+                            code_challenge_methods_supported: ['S256']
+                        })
+                    );
+                }
+                return Promise.reject(new Error(`Unexpected fetch: ${urlString}`));
+            });
+
+            await expect(
+                handleOAuthUnauthorized(provider, {
+                    response,
+                    serverUrl: new URL('https://api.example.com/mcp'),
+                    fetchFn: mockFetch,
+                    resourceMetadataUrl,
+                    scope: 'read'
+                })
+            ).rejects.toBeInstanceOf(UnauthorizedError);
+
+            expect(mockFetch.mock.calls[0]?.[0].toString()).toBe(resourceMetadataUrl.toString());
+            const authorizationUrl = (provider.redirectToAuthorization as Mock).mock.calls[0]?.[0] as URL;
+            expect(authorizationUrl.searchParams.get('scope')).toBe('read write');
         });
     });
 
@@ -5054,45 +5119,5 @@ describe('OAuth Authorization', () => {
             const ok = new ClientCredentialsProvider({ clientId: 'static', clientSecret: 's', expectedIssuer: AS_ONE });
             expect(await auth(ok, { serverUrl: 'https://api.example.com/mcp', fetchFn: srv.fetchFn })).toBe('AUTHORIZED');
         });
-    });
-});
-
-describe('unionScopes (SEP-2350)', () => {
-    it('returns undefined when called with no arguments', () => {
-        expect(unionScopes()).toBeUndefined();
-    });
-
-    it('returns undefined when all inputs are undefined or empty', () => {
-        expect(unionScopes(undefined, undefined)).toBeUndefined();
-        expect(unionScopes('', undefined, '')).toBeUndefined();
-        expect(unionScopes('   ')).toBeUndefined();
-    });
-
-    it('returns a single scope string unchanged', () => {
-        expect(unionScopes('read')).toBe('read');
-        expect(unionScopes('read write')).toBe('read write');
-    });
-
-    it('unions multiple scope strings preserving first-seen order', () => {
-        expect(unionScopes('read write', 'admin')).toBe('read write admin');
-        expect(unionScopes('admin', 'read write')).toBe('admin read write');
-    });
-
-    it('deduplicates repeated scopes across inputs', () => {
-        expect(unionScopes('read write', 'write admin')).toBe('read write admin');
-        expect(unionScopes('read', 'read', 'read')).toBe('read');
-    });
-
-    it('skips undefined and empty entries between scope strings', () => {
-        expect(unionScopes(undefined, 'read', undefined, 'write')).toBe('read write');
-        expect(unionScopes('', 'admin')).toBe('admin');
-    });
-
-    it('normalizes extra whitespace between scopes', () => {
-        expect(unionScopes('read   write', ' admin ')).toBe('read write admin');
-    });
-
-    it('does not perform hierarchy-aware deduplication (scopes are opaque strings)', () => {
-        expect(unionScopes('repo', 'repo:read')).toBe('repo repo:read');
     });
 });

--- a/packages/client/test/client/auth.test.ts
+++ b/packages/client/test/client/auth.test.ts
@@ -26,6 +26,7 @@ import {
     exchangeAuthorization,
     extractWWWAuthenticateParams,
     InsecureTokenEndpointError,
+    unionScopes,
     isHttpsUrl,
     isStrictScopeSuperset,
     IssuerMismatchError,

--- a/packages/client/test/client/auth.test.ts
+++ b/packages/client/test/client/auth.test.ts
@@ -217,7 +217,7 @@ describe('OAuth Authorization', () => {
     });
 
     describe('handleOAuthUnauthorized', () => {
-        it('uses accumulated context scope and resource metadata when reauthorizing', async () => {
+        it('uses stored token scope, accumulated context scope, and resource metadata when reauthorizing', async () => {
             const resourceMetadataUrl = new URL('https://resource.example.com/custom-prm');
             const provider: OAuthClientProvider = {
                 get redirectUrl() {
@@ -230,7 +230,7 @@ describe('OAuth Authorization', () => {
                     };
                 },
                 clientInformation: vi.fn().mockResolvedValue({ client_id: 'test-client' }),
-                tokens: vi.fn().mockResolvedValue(undefined),
+                tokens: vi.fn().mockResolvedValue({ access_token: 'old-token', token_type: 'Bearer', scope: 'openid read' }),
                 saveTokens: vi.fn(),
                 saveCodeVerifier: vi.fn(),
                 codeVerifier: vi.fn(),
@@ -277,7 +277,7 @@ describe('OAuth Authorization', () => {
 
             expect(mockFetch.mock.calls[0]?.[0].toString()).toBe(resourceMetadataUrl.toString());
             const authorizationUrl = (provider.redirectToAuthorization as Mock).mock.calls[0]?.[0] as URL;
-            expect(authorizationUrl.searchParams.get('scope')).toBe('read write');
+            expect(authorizationUrl.searchParams.get('scope')).toBe('openid read write');
         });
     });
 

--- a/packages/client/test/client/auth.test.ts
+++ b/packages/client/test/client/auth.test.ts
@@ -5055,3 +5055,43 @@ describe('OAuth Authorization', () => {
         });
     });
 });
+
+describe('unionScopes (SEP-2350)', () => {
+    it('returns undefined when called with no arguments', () => {
+        expect(unionScopes()).toBeUndefined();
+    });
+
+    it('returns undefined when all inputs are undefined or empty', () => {
+        expect(unionScopes(undefined, undefined)).toBeUndefined();
+        expect(unionScopes('', undefined, '')).toBeUndefined();
+        expect(unionScopes('   ')).toBeUndefined();
+    });
+
+    it('returns a single scope string unchanged', () => {
+        expect(unionScopes('read')).toBe('read');
+        expect(unionScopes('read write')).toBe('read write');
+    });
+
+    it('unions multiple scope strings preserving first-seen order', () => {
+        expect(unionScopes('read write', 'admin')).toBe('read write admin');
+        expect(unionScopes('admin', 'read write')).toBe('admin read write');
+    });
+
+    it('deduplicates repeated scopes across inputs', () => {
+        expect(unionScopes('read write', 'write admin')).toBe('read write admin');
+        expect(unionScopes('read', 'read', 'read')).toBe('read');
+    });
+
+    it('skips undefined and empty entries between scope strings', () => {
+        expect(unionScopes(undefined, 'read', undefined, 'write')).toBe('read write');
+        expect(unionScopes('', 'admin')).toBe('admin');
+    });
+
+    it('normalizes extra whitespace between scopes', () => {
+        expect(unionScopes('read   write', ' admin ')).toBe('read write admin');
+    });
+
+    it('does not perform hierarchy-aware deduplication (scopes are opaque strings)', () => {
+        expect(unionScopes('repo', 'repo:read')).toBe('repo repo:read');
+    });
+});

--- a/packages/client/test/client/middleware.test.ts
+++ b/packages/client/test/client/middleware.test.ts
@@ -157,6 +157,41 @@ describe('withOAuth', () => {
         expect(retryHeaders.get('Authorization')).toBe('Bearer new-token');
     });
 
+    it('should union stored token scope with 401 challenge scope when re-authenticating', async () => {
+        mockProvider.tokens
+            .mockResolvedValueOnce({
+                access_token: 'old-token',
+                token_type: 'Bearer',
+                scope: 'read write'
+            })
+            .mockResolvedValueOnce({
+                access_token: 'new-token',
+                token_type: 'Bearer',
+                scope: 'read write admin'
+            });
+
+        const unauthorizedResponse = new Response('Unauthorized', {
+            status: 401,
+            headers: { 'www-authenticate': 'Bearer realm="oauth", scope="admin"' }
+        });
+        const successResponse = new Response('success', { status: 200 });
+
+        mockFetch.mockResolvedValueOnce(unauthorizedResponse).mockResolvedValueOnce(successResponse);
+        mockExtractWWWAuthenticateParams.mockReturnValue({ scope: 'admin' });
+        mockAuth.mockResolvedValue('AUTHORIZED');
+
+        const enhancedFetch = withOAuth(mockProvider, 'https://api.example.com')(mockFetch);
+
+        await enhancedFetch('https://api.example.com/data');
+
+        expect(mockAuth).toHaveBeenCalledWith(mockProvider, {
+            serverUrl: 'https://api.example.com',
+            resourceMetadataUrl: undefined,
+            scope: 'read write admin',
+            fetchFn: mockFetch
+        });
+    });
+
     it('should retry request after successful auth on 401 response (without baseUrl)', async () => {
         mockProvider.tokens
             .mockResolvedValueOnce({

--- a/packages/client/test/client/middleware.test.ts
+++ b/packages/client/test/client/middleware.test.ts
@@ -148,7 +148,6 @@ describe('withOAuth', () => {
             serverUrl: 'https://api.example.com',
             resourceMetadataUrl: mockWWWAuthenticateParams.resourceMetadataUrl,
             scope: mockWWWAuthenticateParams.scope,
-            forceReauthorization: true,
             fetchFn: mockFetch
         });
 
@@ -233,7 +232,6 @@ describe('withOAuth', () => {
             serverUrl: 'https://api.example.com', // Should be extracted from request URL
             resourceMetadataUrl: mockWWWAuthenticateParams.resourceMetadataUrl,
             scope: mockWWWAuthenticateParams.scope,
-            forceReauthorization: true,
             fetchFn: mockFetch
         });
 
@@ -948,7 +946,6 @@ describe('Integration Tests', () => {
             serverUrl: 'https://mcp-server.example.com',
             resourceMetadataUrl: new URL('https://auth.example.com/.well-known/oauth-protected-resource'),
             scope: 'read',
-            forceReauthorization: true,
             fetchFn: mockFetch
         });
     });

--- a/packages/client/test/client/middleware.test.ts
+++ b/packages/client/test/client/middleware.test.ts
@@ -148,6 +148,7 @@ describe('withOAuth', () => {
             serverUrl: 'https://api.example.com',
             resourceMetadataUrl: mockWWWAuthenticateParams.resourceMetadataUrl,
             scope: mockWWWAuthenticateParams.scope,
+            forceReauthorization: true,
             fetchFn: mockFetch
         });
 
@@ -188,6 +189,7 @@ describe('withOAuth', () => {
             serverUrl: 'https://api.example.com',
             resourceMetadataUrl: undefined,
             scope: 'read write admin',
+            forceReauthorization: true,
             fetchFn: mockFetch
         });
     });
@@ -231,6 +233,7 @@ describe('withOAuth', () => {
             serverUrl: 'https://api.example.com', // Should be extracted from request URL
             resourceMetadataUrl: mockWWWAuthenticateParams.resourceMetadataUrl,
             scope: mockWWWAuthenticateParams.scope,
+            forceReauthorization: true,
             fetchFn: mockFetch
         });
 
@@ -945,6 +948,7 @@ describe('Integration Tests', () => {
             serverUrl: 'https://mcp-server.example.com',
             resourceMetadataUrl: new URL('https://auth.example.com/.well-known/oauth-protected-resource'),
             scope: 'read',
+            forceReauthorization: true,
             fetchFn: mockFetch
         });
     });

--- a/packages/client/test/client/sse.test.ts
+++ b/packages/client/test/client/sse.test.ts
@@ -1550,12 +1550,14 @@ describe('SSEClientTransport', () => {
 
     describe('minimal AuthProvider (non-OAuth)', () => {
         let postResponses: number[];
+        let postHeaders: Record<string, string> | undefined;
         let postCount: number;
 
         async function setupServer(): Promise<void> {
             await resourceServer.close();
 
             postCount = 0;
+            postHeaders = undefined;
             resourceServer = createServer((req, res) => {
                 lastServerRequest = req;
 
@@ -1573,7 +1575,11 @@ describe('SSEClientTransport', () => {
                 if (req.method === 'POST') {
                     const status = postResponses[postCount] ?? 200;
                     postCount++;
-                    res.writeHead(status).end();
+                    if (status === 401 && postHeaders) {
+                        res.writeHead(status, postHeaders).end();
+                    } else {
+                        res.writeHead(status).end();
+                    }
                     return;
                 }
             });
@@ -1592,6 +1598,31 @@ describe('SSEClientTransport', () => {
             await transport.start();
 
             await expect(transport.send(message)).rejects.toThrow(UnauthorizedError);
+        });
+
+        it('keeps accumulated scope and resource metadata after a POST 401 challenge without params', async () => {
+            postResponses = [401, 200];
+            await setupServer();
+            postHeaders = { 'WWW-Authenticate': 'Bearer realm="test"' };
+
+            const resourceMetadataUrl = new URL('http://localhost:1234/.well-known/oauth-protected-resource/mcp');
+            const authProvider: AuthProvider = {
+                token: vi.fn(async () => 'token'),
+                onUnauthorized: vi.fn(async ctx => {
+                    expect(ctx.scope).toBe('read write');
+                    expect(ctx.resourceMetadataUrl).toBe(resourceMetadataUrl);
+                })
+            };
+            transport = new SSEClientTransport(resourceBaseUrl, { authProvider });
+            await transport.start();
+            (transport as unknown as { _scope?: string })._scope = 'read write';
+            (transport as unknown as { _resourceMetadataUrl?: URL })._resourceMetadataUrl = resourceMetadataUrl;
+
+            await transport.send(message);
+
+            expect(authProvider.onUnauthorized).toHaveBeenCalledTimes(1);
+            expect((transport as unknown as { _scope?: string })._scope).toBe('read write');
+            expect((transport as unknown as { _resourceMetadataUrl?: URL })._resourceMetadataUrl).toBe(resourceMetadataUrl);
         });
 
         it('enforces circuit breaker on double-401: onUnauthorized called once, then throws SdkHttpError', async () => {

--- a/packages/client/test/client/streamableHttp.test.ts
+++ b/packages/client/test/client/streamableHttp.test.ts
@@ -1215,7 +1215,9 @@ describe('StreamableHTTPClientTransport', () => {
         it('keeps accumulated scope after a 401 challenge without scope', async () => {
             const authProvider: AuthProvider = { token: vi.fn(async () => undefined) };
             const challengeTransport = new StreamableHTTPClientTransport(new URL('http://localhost:1234/mcp'), { authProvider });
+            const resourceMetadataUrl = new URL('http://localhost:1234/.well-known/oauth-protected-resource/mcp');
             (challengeTransport as unknown as { _scope?: string })._scope = 'read write';
+            (challengeTransport as unknown as { _resourceMetadataUrl?: URL })._resourceMetadataUrl = resourceMetadataUrl;
             (globalThis.fetch as Mock).mockResolvedValueOnce({
                 ok: false,
                 status: 401,
@@ -1228,6 +1230,7 @@ describe('StreamableHTTPClientTransport', () => {
 
             await expect(challengeTransport.send(message)).rejects.toThrow(UnauthorizedError);
             expect((challengeTransport as unknown as { _scope?: string })._scope).toBe('read write');
+            expect((challengeTransport as unknown as { _resourceMetadataUrl?: URL })._resourceMetadataUrl).toBe(resourceMetadataUrl);
 
             await challengeTransport.close().catch(() => {});
         });

--- a/packages/client/test/client/streamableHttp.test.ts
+++ b/packages/client/test/client/streamableHttp.test.ts
@@ -2,7 +2,7 @@ import type { JSONRPCMessage, JSONRPCRequest, OAuthTokens } from '@modelcontextp
 import { OAuthError, OAuthErrorCode, SdkErrorCode, SdkHttpError } from '@modelcontextprotocol/core-internal';
 import type { Mock, Mocked } from 'vitest';
 
-import type { OAuthClientProvider } from '../../src/client/auth';
+import type { AuthProvider, OAuthClientProvider } from '../../src/client/auth';
 import * as authModule from '../../src/client/auth';
 import { UnauthorizedError } from '../../src/client/auth';
 import type { ReconnectionScheduler, StartSSEOptions, StreamableHTTPReconnectionOptions } from '../../src/client/streamableHttp';
@@ -1155,6 +1155,81 @@ describe('StreamableHTTPClientTransport', () => {
             );
 
             authSpy.mockRestore();
+        });
+
+        it('preserves client metadata scope when the token response omits scope', async () => {
+            vi.spyOn(mockAuthProvider, 'clientMetadata', 'get').mockReturnValue({
+                redirect_uris: ['http://localhost/callback'],
+                scope: 'read write'
+            });
+            mockAuthProvider.tokens.mockResolvedValue({
+                access_token: 'test-token',
+                token_type: 'Bearer'
+            });
+            mock403Then202('admin');
+
+            const authSpy = vi.spyOn(authModule, 'auth');
+            authSpy.mockResolvedValue('AUTHORIZED');
+
+            await transport.send(message);
+
+            expect(authSpy).toHaveBeenCalledWith(
+                mockAuthProvider,
+                expect.objectContaining({
+                    scope: 'read write admin'
+                })
+            );
+
+            authSpy.mockRestore();
+        });
+
+        it('preserves protected resource metadata scope when the token response omits scope', async () => {
+            mockAuthProvider.discoveryState = vi.fn().mockResolvedValue({
+                authorizationServerUrl: 'http://localhost:1234',
+                resourceMetadata: {
+                    resource: 'http://localhost:1234/mcp',
+                    scopes_supported: ['read', 'write']
+                }
+            });
+            mockAuthProvider.tokens.mockResolvedValue({
+                access_token: 'test-token',
+                token_type: 'Bearer'
+            });
+            mock403Then202('admin');
+
+            const authSpy = vi.spyOn(authModule, 'auth');
+            authSpy.mockResolvedValue('AUTHORIZED');
+
+            await transport.send(message);
+
+            expect(authSpy).toHaveBeenCalledWith(
+                mockAuthProvider,
+                expect.objectContaining({
+                    scope: 'read write admin'
+                })
+            );
+
+            authSpy.mockRestore();
+        });
+
+        it('keeps accumulated scope after a 401 challenge without scope', async () => {
+            const authProvider: AuthProvider = { token: vi.fn(async () => undefined) };
+            const challengeTransport = new StreamableHTTPClientTransport(new URL('http://localhost:1234/mcp'), { authProvider });
+            (challengeTransport as unknown as { _scope?: string })._scope = 'read write';
+            (globalThis.fetch as Mock).mockResolvedValueOnce({
+                ok: false,
+                status: 401,
+                statusText: 'Unauthorized',
+                headers: new Headers({
+                    'WWW-Authenticate': 'Bearer realm="test"'
+                }),
+                text: () => Promise.resolve('Unauthorized')
+            });
+
+            await expect(challengeTransport.send(message)).rejects.toThrow(UnauthorizedError);
+            expect((challengeTransport as unknown as { _scope?: string })._scope).toBe('read write');
+
+            await challengeTransport.close().catch(() => {});
         });
     });
 

--- a/packages/client/test/client/streamableHttp.test.ts
+++ b/packages/client/test/client/streamableHttp.test.ts
@@ -3,6 +3,7 @@ import { OAuthError, OAuthErrorCode, SdkErrorCode, SdkHttpError } from '@modelco
 import type { Mock, Mocked } from 'vitest';
 
 import type { OAuthClientProvider } from '../../src/client/auth';
+import * as authModule from '../../src/client/auth';
 import { UnauthorizedError } from '../../src/client/auth';
 import type { ReconnectionScheduler, StartSSEOptions, StreamableHTTPReconnectionOptions } from '../../src/client/streamableHttp';
 import { StreamableHTTPClientTransport } from '../../src/client/streamableHttp';
@@ -1063,6 +1064,98 @@ describe('StreamableHTTPClientTransport', () => {
         expect(authSpy).not.toHaveBeenCalled();
 
         authSpy.mockRestore();
+    });
+
+    describe('scope accumulation on step-up authorization (SEP-2350)', () => {
+        const message: JSONRPCMessage = {
+            jsonrpc: '2.0',
+            method: 'test',
+            params: {},
+            id: 'test-id'
+        };
+
+        const mock403Then202 = (challengeScope: string) => {
+            (globalThis.fetch as Mock)
+                .mockResolvedValueOnce({
+                    ok: false,
+                    status: 403,
+                    statusText: 'Forbidden',
+                    headers: new Headers({
+                        'WWW-Authenticate': `Bearer error="insufficient_scope", scope="${challengeScope}"`
+                    }),
+                    text: () => Promise.resolve('Insufficient scope')
+                })
+                .mockResolvedValueOnce({
+                    ok: true,
+                    status: 202,
+                    headers: new Headers()
+                });
+        };
+
+        it('requests the union of previously granted scopes and the challenged scope', async () => {
+            mockAuthProvider.tokens.mockResolvedValue({
+                access_token: 'test-token',
+                token_type: 'Bearer',
+                scope: 'read write'
+            });
+            mock403Then202('admin');
+
+            const authSpy = vi.spyOn(authModule, 'auth');
+            authSpy.mockResolvedValue('AUTHORIZED');
+
+            await transport.send(message);
+
+            expect(authSpy).toHaveBeenCalledWith(
+                mockAuthProvider,
+                expect.objectContaining({
+                    scope: 'read write admin'
+                })
+            );
+
+            authSpy.mockRestore();
+        });
+
+        it('deduplicates when the challenge repeats an already-granted scope', async () => {
+            mockAuthProvider.tokens.mockResolvedValue({
+                access_token: 'test-token',
+                token_type: 'Bearer',
+                scope: 'read write'
+            });
+            mock403Then202('write admin');
+
+            const authSpy = vi.spyOn(authModule, 'auth');
+            authSpy.mockResolvedValue('AUTHORIZED');
+
+            await transport.send(message);
+
+            expect(authSpy).toHaveBeenCalledWith(
+                mockAuthProvider,
+                expect.objectContaining({
+                    scope: 'read write admin'
+                })
+            );
+
+            authSpy.mockRestore();
+        });
+
+        it('uses only the challenged scope when there is no prior scope', async () => {
+            mockAuthProvider.tokens.mockResolvedValue(undefined);
+            mock403Then202('admin');
+
+            const authSpy = vi.spyOn(authModule, 'auth');
+            authSpy.mockResolvedValue('AUTHORIZED');
+
+            await transport.send(message);
+
+            expect(authSpy).toHaveBeenCalledWith(
+                mockAuthProvider,
+                expect.objectContaining({
+                    scope: 'admin'
+                })
+            );
+
+            authSpy.mockRestore();
+        });
     });
 
     describe('Reconnection Logic', () => {

--- a/test/e2e/requirements.ts
+++ b/test/e2e/requirements.ts
@@ -2039,7 +2039,7 @@ export const REQUIREMENTS: Record<string, Requirement> = {
     'client-auth:stepup:scope-union': {
         source: 'https://modelcontextprotocol.io/specification/draft/basic/authorization#step-up-authorization-flow',
         behavior:
-            'On 403 insufficient_scope the transport re-authorizes with the union of its previously-requested scope and the challenged scope (computeScopeUnion); the union is a plain string-set dedup with no hierarchical collapse.',
+            'On 403 insufficient_scope the transport re-authorizes with the union of its stored token scope, previously-requested scope, protected resource metadata scopes, provider default scope, and challenged scope (computeScopeUnion); the union is a plain string-set dedup with no hierarchical collapse.',
         transports: ['streamableHttp'],
         note: 'This exercises the HTTP hosting/auth layer and OAuth client; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
     },

--- a/test/e2e/scenarios/client-auth.test.ts
+++ b/test/e2e/scenarios/client-auth.test.ts
@@ -475,8 +475,8 @@ verifies('client-auth:stepup:scope-union', async (_args: TestArgs) => {
     expect(computeScopeUnion('files:read openid', 'files:write')).toBe('files:read openid files:write');
     expect(computeScopeUnion('admin', 'read')).toBe('admin read'); // no hierarchical collapse
 
-    // The transport requests the union of its previously-requested scope and the
-    // newly-challenged scope on step-up.
+    // The transport requests the same set-union used by step-up: current token
+    // scope, previous request scope, PRM scopes, provider default, and challenge.
     const PREVIOUS_SCOPE = 'files:read openid';
     const CHALLENGED_SCOPE = 'files:write';
     const as = createMockAuthorizationServer();


### PR DESCRIPTION
Implements SEP-2350 (tracking issue #2200): client-side scope accumulation in step-up authorization.

## Spec

The draft authorization spec ([`basic/authorization/index.mdx`](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/main/docs/specification/draft/basic/authorization/index.mdx), "Scope Challenge Handling" note and "Step-Up Authorization Flow" step 2) makes scope accumulation a **client-side** responsibility:

> Clients are responsible for scope accumulation: when re-authorizing in response to a scope challenge, clients SHOULD request the union of previously requested/granted scopes and the newly challenged scopes, so that per-operation challenges don't drop previously granted permissions.

Servers stay stateless and emit only per-operation scopes in `WWW-Authenticate: Bearer error="insufficient_scope", scope="..."` challenges.

## Before / after

**Before:** the `403 insufficient_scope` retry path in `StreamableHTTPClientTransport` did `this._scope = scope` — the challenged scopes *replaced* the requested scope, so the re-authorization dropped everything previously granted. A client holding `read write` that hit a challenge for `admin` would re-authorize with only `admin`.

**After:** the client requests the union of (1) the scope on the stored tokens (previously granted), (2) the previously requested scope, and (3) the newly challenged scope. The same client now re-authorizes with `read write admin`. The union is order-preserving and exact-string-deduped — scopes are treated as opaque strings per the spec, so no hierarchy-aware deduplication (`repo` does not absorb `repo:read`).

The helper is exported as `unionScopes(...scopeStrings: Array<string | undefined>): string | undefined` from `@modelcontextprotocol/client`.

Retry limiting is unchanged: the existing `_lastUpscopingHeader` guard still prevents infinite upscoping loops.

## Decision note for reviewers: 401 path left as-is

The `401` path (`handleOAuthUnauthorized` / the `this._scope = scope` assignments in the 401 branches of `streamableHttp.ts` and `sse.ts`) is **intentionally unchanged**. The spec's union language is specifically about *re-authorization during step-up* after an `insufficient_scope` challenge; a 401 carries initial-auth semantics (no valid grant to preserve), and applying the union there is debatable. Flagging explicitly in case reviewers want union-on-401 too — happy to follow up.

Relatedly, `sse.ts` has no `403 insufficient_scope` handler at all (only 401 paths), so there was nothing to mirror there.

## Validation

- `pnpm build:all` ✅
- `pnpm typecheck:all` ✅
- `pnpm lint:all` ✅
- `pnpm --filter @modelcontextprotocol/client test` — 378/378 ✅ (new: 3 step-up integration tests in `streamableHttp.test.ts` covering union, dedup-on-repeated-scope, and no-prior-scope; 8 `unionScopes` unit tests in `auth.test.ts`)
- Changeset: patch for `@modelcontextprotocol/client`

Downstream impact: cloudflare/agents needs no changes — its DurableObjectOAuthClientProvider persists token scope, so the union picks previously granted scopes up automatically.

A follow-up PR implementing SEP-2468 (iss validation) touches the same transport retry region and will be rebased over this.

Closes #2200
