### PR TITLE
fix(server): return -32602 for nonexistent resources (SEP-2164)

### DIFF
--- a/.changeset/sep-2164-resource-not-found-invalid-params.md
+++ b/.changeset/sep-2164-resource-not-found-invalid-params.md
@@ -7,4 +7,6 @@
 Resource not found now returns `-32602` (Invalid params) per SEP-2164; `-32002` (`ProtocolErrorCode.ResourceNotFound`) is deprecated. The error includes the requested URI in `data.uri` so clients can still distinguish not-found from other invalid-params errors. Clients SHOULD
 continue to accept legacy `-32002` from older servers.
 
+This supersedes the earlier 2.0.0-alpha.1 / #1389 resource error-code change that moved unknown resource reads to `-32002`.
+
 `NodeStreamableHTTPServerTransport` now forwards server-configured supported protocol versions to the underlying web-standard transport, so custom version lists passed to `McpServer` are also honored by HTTP header validation.

--- a/.changeset/sep-2164-resource-not-found-invalid-params.md
+++ b/.changeset/sep-2164-resource-not-found-invalid-params.md
@@ -1,6 +1,10 @@
 ---
 '@modelcontextprotocol/server': patch
 '@modelcontextprotocol/core': patch
+'@modelcontextprotocol/node': patch
 ---
 
-Resource not found now returns `-32602` (Invalid params) per SEP-2164; `-32002` (`ProtocolErrorCode.ResourceNotFound`) is deprecated. The error includes the requested URI in `data.uri` so clients can still distinguish not-found from other invalid-params errors. Clients SHOULD continue to accept legacy `-32002` from older servers.
+Resource not found now returns `-32602` (Invalid params) per SEP-2164; `-32002` (`ProtocolErrorCode.ResourceNotFound`) is deprecated. The error includes the requested URI in `data.uri` so clients can still distinguish not-found from other invalid-params errors. Clients SHOULD
+continue to accept legacy `-32002` from older servers.
+
+`NodeStreamableHTTPServerTransport` now forwards server-configured supported protocol versions to the underlying web-standard transport, so custom version lists passed to `McpServer` are also honored by HTTP header validation.

--- a/.changeset/sep-2164-resource-not-found-invalid-params.md
+++ b/.changeset/sep-2164-resource-not-found-invalid-params.md
@@ -1,6 +1,6 @@
 ---
 '@modelcontextprotocol/server': patch
-'@modelcontextprotocol/core': patch
+'@modelcontextprotocol/core-internal': patch
 '@modelcontextprotocol/node': patch
 ---
 

--- a/.changeset/sep-2164-resource-not-found-invalid-params.md
+++ b/.changeset/sep-2164-resource-not-found-invalid-params.md
@@ -1,12 +1,5 @@
 ---
 '@modelcontextprotocol/server': patch
-'@modelcontextprotocol/core-internal': patch
-'@modelcontextprotocol/node': patch
 ---
 
-Resource not found now returns `-32602` (Invalid params) per SEP-2164; `-32002` (`ProtocolErrorCode.ResourceNotFound`) is deprecated. The error includes the requested URI in `data.uri` so clients can still distinguish not-found from other invalid-params errors. Clients SHOULD
-continue to accept legacy `-32002` from older servers.
-
-This supersedes the earlier 2.0.0-alpha.1 / #1389 resource error-code change that moved unknown resource reads to `-32002`.
-
-`NodeStreamableHTTPServerTransport` now forwards server-configured supported protocol versions to the underlying web-standard transport, so custom version lists passed to `McpServer` are also honored by HTTP header validation.
+Return a generic `-32602` Invalid params error when `resources/read` receives a syntactically invalid URI. The error data includes `{ uri, reason: 'invalid_uri' }`, so clients do not confuse malformed URIs with the exact `{ uri }` discriminator used for resource-not-found.

--- a/.changeset/sep-2164-resource-not-found-invalid-params.md
+++ b/.changeset/sep-2164-resource-not-found-invalid-params.md
@@ -1,0 +1,6 @@
+---
+'@modelcontextprotocol/server': patch
+'@modelcontextprotocol/core': patch
+---
+
+Resource not found now returns `-32602` (Invalid params) per SEP-2164; `-32002` (`ProtocolErrorCode.ResourceNotFound`) is deprecated. The error includes the requested URI in `data.uri` so clients can still distinguish not-found from other invalid-params errors. Clients SHOULD continue to accept legacy `-32002` from older servers.

--- a/packages/middleware/node/test/streamableHttp.test.ts
+++ b/packages/middleware/node/test/streamableHttp.test.ts
@@ -40,6 +40,7 @@ async function getFreePort() {
 interface TestServerConfig {
     sessionIdGenerator: (() => string) | undefined;
     enableJsonResponse?: boolean;
+    supportedProtocolVersions?: string[];
     customRequestHandler?: (req: IncomingMessage, res: ServerResponse, parsedBody?: unknown) => Promise<void>;
     eventStore?: EventStore;
     onsessioninitialized?: ((sessionId: string) => void | Promise<void>) | undefined;
@@ -159,7 +160,13 @@ describe('Zod v4', () => {
         baseUrl: URL;
     }> {
         config ??= { sessionIdGenerator: () => randomUUID() };
-        const mcpServer = new McpServer({ name: 'test-server', version: '1.0.0' }, { capabilities: { logging: {} } });
+        const mcpServer = new McpServer(
+            { name: 'test-server', version: '1.0.0' },
+            {
+                capabilities: { logging: {} },
+                ...(config.supportedProtocolVersions ? { supportedProtocolVersions: config.supportedProtocolVersions } : {})
+            }
+        );
 
         mcpServer.registerTool(
             'greet',
@@ -999,6 +1006,50 @@ describe('Zod v4', () => {
 
                 // Request should still succeed
                 expect(response.status).toBe(200);
+            });
+
+            it('should accept protocol versions configured on the connected server', async () => {
+                const customVersion = '2026-07-28';
+                const {
+                    server: customServer,
+                    transport: customTransport,
+                    baseUrl: customBaseUrl
+                } = await createTestServer({
+                    sessionIdGenerator: () => randomUUID(),
+                    supportedProtocolVersions: [customVersion, '2025-11-25']
+                });
+
+                try {
+                    const initResponse = await sendPostRequest(customBaseUrl, {
+                        jsonrpc: '2.0',
+                        method: 'initialize',
+                        params: {
+                            clientInfo: { name: 'test-client', version: '1.0' },
+                            protocolVersion: customVersion,
+                            capabilities: {}
+                        },
+                        id: 'init-custom-version'
+                    } as JSONRPCMessage);
+
+                    expect(initResponse.status).toBe(200);
+                    const customSessionId = initResponse.headers.get('mcp-session-id');
+                    expect(customSessionId).toBeDefined();
+
+                    const response = await fetch(customBaseUrl, {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json',
+                            Accept: 'application/json, text/event-stream',
+                            'mcp-session-id': customSessionId!,
+                            'mcp-protocol-version': customVersion
+                        },
+                        body: JSON.stringify(TEST_MESSAGES.toolsList)
+                    });
+
+                    expect(response.status).toBe(200);
+                } finally {
+                    await stopTestServer({ server: customServer, transport: customTransport });
+                }
             });
 
             it('should reject unsupported protocol version on GET requests', async () => {

--- a/packages/server/src/server/mcp.ts
+++ b/packages/server/src/server/mcp.ts
@@ -481,7 +481,8 @@ export class McpServer {
                 uri = new URL(request.params.uri);
             } catch {
                 throw new ProtocolError(ProtocolErrorCode.InvalidParams, `Resource URI ${request.params.uri} is invalid`, {
-                    uri: request.params.uri
+                    uri: request.params.uri,
+                    reason: 'invalid_uri'
                 });
             }
 

--- a/packages/server/src/server/mcp.ts
+++ b/packages/server/src/server/mcp.ts
@@ -476,7 +476,14 @@ export class McpServer {
         });
 
         this.server.setRequestHandler('resources/read', async (request, ctx) => {
-            const uri = new URL(request.params.uri);
+            let uri: URL;
+            try {
+                uri = new URL(request.params.uri);
+            } catch {
+                throw new ProtocolError(ProtocolErrorCode.InvalidParams, `Resource URI ${request.params.uri} is invalid`, {
+                    uri: request.params.uri
+                });
+            }
 
             // First check for exact resource match
             const resource = this._registeredResources[uri.toString()];

--- a/test/conformance/src/everythingServer.ts
+++ b/test/conformance/src/everythingServer.ts
@@ -88,6 +88,7 @@ const TEST_IMAGE_BASE64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQ
 
 // Sample base64 encoded minimal WAV file for testing
 const TEST_AUDIO_BASE64 = 'UklGRiYAAABXQVZFZm10IBAAAAABAAEAQB8AAAB9AAACABAAZGF0YQIAAAA=';
+const DRAFT_PROTOCOL_VERSION = '2026-07-28';
 
 // ===== MULTI-ROUND-TRIP requestState INTEGRITY (SEP-2322) =====
 //
@@ -116,6 +117,7 @@ function createMcpServer() {
             version: '1.0.0'
         },
         {
+            supportedProtocolVersions: [...new Set([DRAFT_PROTOCOL_VERSION, ...SUPPORTED_PROTOCOL_VERSIONS])],
             capabilities: {
                 tools: {
                     listChanged: true

--- a/test/conformance/src/everythingServer.ts
+++ b/test/conformance/src/everythingServer.ts
@@ -34,7 +34,8 @@ import {
     McpServer,
     ProtocolError,
     ProtocolErrorCode,
-    ResourceTemplate
+    ResourceTemplate,
+    SUPPORTED_PROTOCOL_VERSIONS
 } from '@modelcontextprotocol/server';
 import cors from 'cors';
 import type { Request, Response } from 'express';

--- a/test/integration/test/server/mcp.test.ts
+++ b/test/integration/test/server/mcp.test.ts
@@ -2780,6 +2780,43 @@ describe('Zod v4', () => {
             });
         });
 
+        test('should return invalid params for syntactically invalid resource URIs', async () => {
+            const mcpServer = new McpServer({
+                name: 'test server',
+                version: '1.0'
+            });
+            const client = new Client({
+                name: 'test client',
+                version: '1.0'
+            });
+            const requestedUri = 'not a valid URI';
+            mcpServer.registerResource('test', 'test://resource', {}, async () => ({
+                contents: [
+                    {
+                        uri: 'test://resource',
+                        text: 'Test content'
+                    }
+                ]
+            }));
+
+            const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+            await Promise.all([client.connect(clientTransport), mcpServer.server.connect(serverTransport)]);
+
+            await expect(
+                client.request({
+                    method: 'resources/read',
+                    params: {
+                        uri: requestedUri
+                    }
+                })
+            ).rejects.toMatchObject({
+                code: ProtocolErrorCode.InvalidParams,
+                message: expect.stringContaining('invalid'),
+                data: { uri: requestedUri }
+            });
+        });
+
         /***
          * Test: ProtocolError for Disabled Resource
          */

--- a/test/integration/test/server/mcp.test.ts
+++ b/test/integration/test/server/mcp.test.ts
@@ -2813,7 +2813,7 @@ describe('Zod v4', () => {
             ).rejects.toMatchObject({
                 code: ProtocolErrorCode.InvalidParams,
                 message: expect.stringContaining('invalid'),
-                data: { uri: requestedUri }
+                data: { uri: requestedUri, reason: 'invalid_uri' }
             });
         });
 

--- a/test/integration/test/server/mcp.test.ts
+++ b/test/integration/test/server/mcp.test.ts
@@ -2743,6 +2743,43 @@ describe('Zod v4', () => {
             });
         });
 
+        test('should echo the exact requested URI for nonexistent resources', async () => {
+            const mcpServer = new McpServer({
+                name: 'test server',
+                version: '1.0'
+            });
+            const client = new Client({
+                name: 'test client',
+                version: '1.0'
+            });
+            const requestedUri = 'HTTP://example.com:80/docs/../missing file.txt';
+            mcpServer.registerResource('test', 'test://resource', {}, async () => ({
+                contents: [
+                    {
+                        uri: 'test://resource',
+                        text: 'Test content'
+                    }
+                ]
+            }));
+
+            const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+            await Promise.all([client.connect(clientTransport), mcpServer.server.connect(serverTransport)]);
+
+            await expect(
+                client.request({
+                    method: 'resources/read',
+                    params: {
+                        uri: requestedUri
+                    }
+                })
+            ).rejects.toMatchObject({
+                code: ProtocolErrorCode.InvalidParams,
+                message: expect.stringContaining('not found'),
+                data: { uri: requestedUri }
+            });
+        });
+
         /***
          * Test: ProtocolError for Disabled Resource
          */


### PR DESCRIPTION
## Summary

Implements SEP-2164: reads of nonexistent resources now fail with JSON-RPC **`-32602` (Invalid params)** instead of the MCP-specific **`-32002`** (`ProtocolErrorCode.ResourceNotFound`). The requested URI is carried in the error's `data.uri` so clients can still distinguish not-found from other invalid-params failures.

### Spec citation

The draft spec ([`server/resources.mdx`](https://modelcontextprotocol.io/specification/draft/server/resources#error-handling), ~L395-398) says:

> Servers **MUST** return standard JSON-RPC errors for common failure cases:
> - Resource not found: `-32602` (Invalid params)
> - Internal errors: `-32603` (Internal error)
>
> Clients **SHOULD** also accept the legacy error code `-32002` for resource-not-found errors. Servers **MUST NOT** return an empty `contents` array for a nonexistent resource.

Note the history: the 2025-11-25 revision said servers **SHOULD** return `-32002`; the draft (SEP-2164) flips this to **MUST** return `-32602`, keeping `-32002` only as a legacy code clients should tolerate.

### This reverses a recent deliberate change

#1389 (shipped in `2.0.0-alpha.1`) intentionally moved unknown-resource reads from `-32602` → `-32002` and introduced `ProtocolErrorCode.ResourceNotFound`, matching the then-current SHOULD-strength spec text. SEP-2164 has since standardized the opposite direction, so this PR flips it back:

- `McpServer`'s `resources/read` handler throws `ProtocolErrorCode.InvalidParams` with `data: { uri }`.
- `ProtocolErrorCode.ResourceNotFound` is marked `@deprecated` but **remains exported** — clients may still need to match it from older servers, per the spec's "SHOULD also accept legacy `-32002`" language.
- Client side needs no change: it has no code-specific handling of `-32002`.

### Open design question for maintainers

Implemented as an **unconditional flip** — should this instead be gated on the negotiated protocol version (runtime still defaults to 2025-11-25, where `-32002` was SHOULD-strength)? Unconditional seems defensible since the draft tells clients to accept both, but flagging for a direction call. (The 2026-07-28 reference types from #2252 already define only `INVALID_PARAMS` for this case.)

Draft until that's resolved.

### Changes

- `packages/server/src/server/mcp.ts`: `resources/read` not-found path throws `InvalidParams` with `data: { uri }`
- `packages/core/src/types/enums.ts`: `ResourceNotFound` deprecated with JSDoc pointing at `InvalidParams` per SEP-2164
- `test/integration/test/server/mcp.test.ts`: unknown-resource test now asserts `-32602` + `data.uri`
- `test/e2e/scenarios/resources.test.ts` + `test/e2e/requirements.ts`: `resources:read:unknown-uri` updated to `-32602` with a manifest note on the SEP-2164 SHOULD→MUST history
- Changeset (patch, `@modelcontextprotocol/server` + `@modelcontextprotocol/core`)

### Validation

- `pnpm build:all`, `pnpm typecheck:all`, `pnpm lint:all`: pass
- Core: 463/463, server: 72/72, client: 367/367, integration: 320/320, server-legacy 162/162, middleware all green
- E2E: 1141 passed, 91 expected-fail; sole failure was the known pre-existing flake `protocol:timeout:max-total [sse]` (unrelated, fails only under full-suite parallel load)
- One server-legacy timing flake (`bearerAuth` "expired 0 seconds ago") failed once under the full run, passes 3/3 in isolation — unrelated

Downstream impact: cloudflare/agents MCPAgent servers will emit -32602 for unknown resources after upgrading; grep confirms no agents code branches on -32002, so no downstream changes needed.

Closes #2194
