### PR TITLE
fix(server,client): non-SEP draft spec conformance (eager list handlers, pagination docs, path-sanitization note)

### DIFF
--- a/.changeset/draft-spec-non-sep-conformance.md
+++ b/.changeset/draft-spec-non-sep-conformance.md
@@ -1,0 +1,9 @@
+---
+'@modelcontextprotocol/server': patch
+'@modelcontextprotocol/client': patch
+---
+
+Non-SEP draft spec conformance fixes
+
+- `McpServer` now eagerly installs list/read/call handlers for every primitive capability (`tools`, `resources`, `prompts`) declared in `ServerOptions.capabilities`. Per the draft spec, a server that declares a capability MUST respond to its list method (potentially with an empty result) instead of returning "Method not found". Previously, handlers were only installed lazily on first registration, so a server constructed with e.g. `capabilities: { tools: {} }` and zero registered tools answered `tools/list` with `-32601`. Low-level `Server` users remain responsible for registering handlers for declared capabilities (documented on `ServerOptions.capabilities`).
+- Fixed pagination doc examples on `Client.listTools`/`listPrompts`/`listResources` to loop `while (cursor !== undefined)` instead of `while (cursor)` — per the draft spec, clients MUST NOT treat an empty-string cursor as the end of results.

--- a/docs/server.md
+++ b/docs/server.md
@@ -252,6 +252,9 @@ server.registerResource(
 );
 ```
 
+> [!IMPORTANT]
+> **Security note:** If a resource is backed by the filesystem (for example, a `file://` server or a template whose variables map onto file paths), the spec requires sanitizing any user-influenced path before use. Resolve the requested path and verify it stays within the intended root directory, rejecting traversal sequences such as `..` (including encoded forms) and symlinks that escape the root. Never pass template variables or client-supplied URIs to filesystem APIs unchecked.
+
 ## Prompts
 
 Prompts are reusable templates that help structure interactions with models (see [Prompts](https://modelcontextprotocol.io/docs/learn/server-concepts#prompts) in the MCP overview). Use a prompt when you want to offer a canned interaction pattern that users invoke explicitly; use a [tool](#tools) when the LLM should decide when to call it.

--- a/packages/client/src/client/client.examples.ts
+++ b/packages/client/src/client/client.examples.ts
@@ -143,11 +143,12 @@ async function Client_listTools_pagination(client: Client) {
     //#region Client_listTools_pagination
     const allTools: Tool[] = [];
     let cursor: string | undefined;
+    // Note: an empty-string cursor is valid and does not signal the end of results.
     do {
         const { tools, nextCursor } = await client.listTools({ cursor });
         allTools.push(...tools);
         cursor = nextCursor;
-    } while (cursor);
+    } while (cursor !== undefined);
     console.log(
         'Available tools:',
         allTools.map(t => t.name)
@@ -162,11 +163,12 @@ async function Client_listPrompts_pagination(client: Client) {
     //#region Client_listPrompts_pagination
     const allPrompts: Prompt[] = [];
     let cursor: string | undefined;
+    // Note: an empty-string cursor is valid and does not signal the end of results.
     do {
         const { prompts, nextCursor } = await client.listPrompts({ cursor });
         allPrompts.push(...prompts);
         cursor = nextCursor;
-    } while (cursor);
+    } while (cursor !== undefined);
     console.log(
         'Available prompts:',
         allPrompts.map(p => p.name)
@@ -181,11 +183,12 @@ async function Client_listResources_pagination(client: Client) {
     //#region Client_listResources_pagination
     const allResources: Resource[] = [];
     let cursor: string | undefined;
+    // Note: an empty-string cursor is valid and does not signal the end of results.
     do {
         const { resources, nextCursor } = await client.listResources({ cursor });
         allResources.push(...resources);
         cursor = nextCursor;
-    } while (cursor);
+    } while (cursor !== undefined);
     console.log(
         'Available resources:',
         allResources.map(r => r.name)

--- a/packages/client/src/client/client.ts
+++ b/packages/client/src/client/client.ts
@@ -657,11 +657,12 @@ export class Client extends Protocol<ClientContext> {
      * ```ts source="./client.examples.ts#Client_listPrompts_pagination"
      * const allPrompts: Prompt[] = [];
      * let cursor: string | undefined;
+     * // Note: an empty-string cursor is valid and does not signal the end of results.
      * do {
      *     const { prompts, nextCursor } = await client.listPrompts({ cursor });
      *     allPrompts.push(...prompts);
      *     cursor = nextCursor;
-     * } while (cursor);
+     * } while (cursor !== undefined);
      * console.log(
      *     'Available prompts:',
      *     allPrompts.map(p => p.name)
@@ -687,11 +688,12 @@ export class Client extends Protocol<ClientContext> {
      * ```ts source="./client.examples.ts#Client_listResources_pagination"
      * const allResources: Resource[] = [];
      * let cursor: string | undefined;
+     * // Note: an empty-string cursor is valid and does not signal the end of results.
      * do {
      *     const { resources, nextCursor } = await client.listResources({ cursor });
      *     allResources.push(...resources);
      *     cursor = nextCursor;
-     * } while (cursor);
+     * } while (cursor !== undefined);
      * console.log(
      *     'Available resources:',
      *     allResources.map(r => r.name)
@@ -850,11 +852,12 @@ export class Client extends Protocol<ClientContext> {
      * ```ts source="./client.examples.ts#Client_listTools_pagination"
      * const allTools: Tool[] = [];
      * let cursor: string | undefined;
+     * // Note: an empty-string cursor is valid and does not signal the end of results.
      * do {
      *     const { tools, nextCursor } = await client.listTools({ cursor });
      *     allTools.push(...tools);
      *     cursor = nextCursor;
-     * } while (cursor);
+     * } while (cursor !== undefined);
      * console.log(
      *     'Available tools:',
      *     allTools.map(t => t.name)

--- a/packages/server/src/server/mcp.ts
+++ b/packages/server/src/server/mcp.ts
@@ -70,6 +70,21 @@ export class McpServer {
 
     constructor(serverInfo: Implementation, options?: ServerOptions) {
         this.server = new Server(serverInfo, options);
+
+        // Per the MCP spec, a server that declares a primitive capability MUST respond to its
+        // list method (potentially with an empty result) rather than "Method not found" — even
+        // if nothing has been registered yet. Handlers are normally installed lazily on first
+        // registration, so eagerly install them here for any capability declared up front.
+        // (Users of the low-level `Server` class remain responsible for their own handlers.)
+        if (options?.capabilities?.tools) {
+            this.setToolRequestHandlers();
+        }
+        if (options?.capabilities?.resources) {
+            this.setResourceRequestHandlers();
+        }
+        if (options?.capabilities?.prompts) {
+            this.setPromptRequestHandlers();
+        }
     }
 
     /**
@@ -111,6 +126,9 @@ export class McpServer {
             }
         });
 
+        // Note: tools are listed in registration (insertion) order, which keeps the ordering
+        // deterministic across requests when the underlying tool set has not changed, as
+        // recommended by the spec.
         this.server.setRequestHandler(
             'tools/list',
             (): ListToolsResult => ({

--- a/packages/server/src/server/server.ts
+++ b/packages/server/src/server/server.ts
@@ -54,6 +54,13 @@ import { DefaultJsonSchemaValidator } from '@modelcontextprotocol/server/_shims'
 export type ServerOptions = ProtocolOptions & {
     /**
      * Capabilities to advertise as being supported by this server.
+     *
+     * Note: per the MCP spec, a server that declares a capability MUST respond to that
+     * capability's requests (e.g. `tools/list` for `tools`) — potentially with an empty
+     * result — rather than with a "Method not found" error. {@linkcode server/mcp.McpServer | McpServer}
+     * handles this automatically for capabilities declared here; when using the low-level
+     * {@linkcode Server} directly, you are responsible for registering a request handler for
+     * every capability you declare.
      */
     capabilities?: ServerCapabilities;
 

--- a/test/integration/test/server/declaredCapabilities.test.ts
+++ b/test/integration/test/server/declaredCapabilities.test.ts
@@ -1,0 +1,152 @@
+import { Client } from '@modelcontextprotocol/client';
+import { InMemoryTransport, ProtocolErrorCode } from '@modelcontextprotocol/core';
+import { McpServer } from '@modelcontextprotocol/server';
+import { describe, expect, test } from 'vitest';
+import * as z from 'zod/v4';
+
+async function connect(mcpServer: McpServer): Promise<Client> {
+    const client = new Client({ name: 'test client', version: '1.0' });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await Promise.all([client.connect(clientTransport), mcpServer.connect(serverTransport)]);
+    return client;
+}
+
+describe('declared capabilities answer list methods (draft spec)', () => {
+    /***
+     * Test: a server that declares a primitive capability MUST respond to its list method
+     * (with an empty result) even if nothing has been registered yet, rather than
+     * returning "Method not found".
+     */
+    test('declared-but-empty tools/resources/prompts capabilities answer list methods with empty arrays', async () => {
+        const mcpServer = new McpServer(
+            { name: 'test server', version: '1.0' },
+            { capabilities: { tools: {}, resources: {}, prompts: {} } }
+        );
+
+        const client = await connect(mcpServer);
+
+        await expect(client.listTools()).resolves.toEqual({ tools: [] });
+        await expect(client.listResources()).resolves.toEqual({ resources: [] });
+        await expect(client.listResourceTemplates()).resolves.toEqual({ resourceTemplates: [] });
+        await expect(client.listPrompts()).resolves.toEqual({ prompts: [] });
+    });
+
+    /***
+     * Test: calling an unknown tool on a declared-but-empty tools capability returns
+     * an "Invalid params" error, not "Method not found".
+     */
+    test('tools/call for an unknown tool returns InvalidParams when tools capability is declared', async () => {
+        const mcpServer = new McpServer({ name: 'test server', version: '1.0' }, { capabilities: { tools: {} } });
+
+        const client = await connect(mcpServer);
+
+        await expect(client.callTool({ name: 'nonexistent' })).rejects.toMatchObject({
+            code: ProtocolErrorCode.InvalidParams
+        });
+    });
+
+    /***
+     * Test: capabilities that were NOT declared (and have no registrations) still return
+     * "Method not found" on the wire. Raw requests are used because the Client's
+     * convenience list methods short-circuit locally when the server does not advertise
+     * the corresponding capability.
+     */
+    test('undeclared capabilities still return MethodNotFound', async () => {
+        const mcpServer = new McpServer({ name: 'test server', version: '1.0' }, { capabilities: { tools: {} } });
+
+        const client = await connect(mcpServer);
+
+        await expect(client.listTools()).resolves.toEqual({ tools: [] });
+        await expect(client.request({ method: 'resources/list' })).rejects.toMatchObject({
+            code: ProtocolErrorCode.MethodNotFound
+        });
+        await expect(client.request({ method: 'prompts/list' })).rejects.toMatchObject({
+            code: ProtocolErrorCode.MethodNotFound
+        });
+    });
+
+    /***
+     * Test: a server constructed without declared capabilities behaves as before —
+     * list handlers are installed lazily on first registration.
+     */
+    test('no declared capabilities and no registrations returns MethodNotFound for all list methods', async () => {
+        const mcpServer = new McpServer({ name: 'test server', version: '1.0' });
+
+        const client = await connect(mcpServer);
+
+        await expect(client.request({ method: 'tools/list' })).rejects.toMatchObject({
+            code: ProtocolErrorCode.MethodNotFound
+        });
+        await expect(client.request({ method: 'resources/list' })).rejects.toMatchObject({
+            code: ProtocolErrorCode.MethodNotFound
+        });
+        await expect(client.request({ method: 'prompts/list' })).rejects.toMatchObject({
+            code: ProtocolErrorCode.MethodNotFound
+        });
+    });
+
+    /***
+     * Test: registering primitives after declaring the capability up front continues to work
+     * (the eagerly installed handlers list later registrations).
+     */
+    test('registrations made after construction are listed by the eagerly installed handlers', async () => {
+        const mcpServer = new McpServer({ name: 'test server', version: '1.0' }, { capabilities: { tools: {} } });
+
+        mcpServer.registerTool('greet', { description: 'Greets' }, () => ({
+            content: [{ type: 'text', text: 'hi' }]
+        }));
+
+        const client = await connect(mcpServer);
+
+        const result = await client.listTools();
+        expect(result.tools.map(t => t.name)).toEqual(['greet']);
+    });
+});
+
+describe('deterministic tools/list ordering (draft spec)', () => {
+    /***
+     * Test: tools/list SHOULD return tools in a deterministic order when the underlying
+     * tool set has not changed. The SDK lists tools in registration (insertion) order.
+     */
+    test('tools/list returns an identical order across repeated requests', async () => {
+        const mcpServer = new McpServer({ name: 'test server', version: '1.0' });
+
+        const names = ['zeta', 'alpha', 'mid', 'omega', 'beta'];
+        for (const name of names) {
+            mcpServer.registerTool(name, { inputSchema: z.object({ value: z.string() }) }, ({ value }) => ({
+                content: [{ type: 'text', text: `${name}:${value}` }]
+            }));
+        }
+
+        const client = await connect(mcpServer);
+
+        const first = await client.listTools();
+        const second = await client.listTools();
+
+        expect(first.tools.map(t => t.name)).toEqual(names);
+        expect(second.tools.map(t => t.name)).toEqual(names);
+    });
+
+    test('tools/list ordering stays stable across disable/enable toggles', async () => {
+        const mcpServer = new McpServer({ name: 'test server', version: '1.0' });
+
+        const names = ['zeta', 'alpha', 'mid', 'omega', 'beta'];
+        const registered = names.map(name =>
+            mcpServer.registerTool(name, {}, () => ({
+                content: [{ type: 'text', text: name }]
+            }))
+        );
+
+        const client = await connect(mcpServer);
+
+        // Disable a tool in the middle: relative order of the remaining tools is unchanged.
+        registered[2].disable();
+        const whileDisabled = await client.listTools();
+        expect(whileDisabled.tools.map(t => t.name)).toEqual(['zeta', 'alpha', 'omega', 'beta']);
+
+        // Re-enable it: the original insertion order is restored, not appended at the end.
+        registered[2].enable();
+        const afterReenable = await client.listTools();
+        expect(afterReenable.tools.map(t => t.name)).toEqual(names);
+    });
+});


### PR DESCRIPTION
Implements the non-SEP changes from the 2025-11-25 → draft spec diff tracked in #2202. Per-item breakdown:

### (a) Deterministic `tools/list` ordering — already compliant, tests added

> Servers **SHOULD** return tools in a deterministic order (i.e., the same ordering across requests when the underlying set of tools has not changed). — [draft `server/tools.mdx`](https://modelcontextprotocol.io/specification/draft/server/tools)

`McpServer` lists tools via `Object.entries(this._registeredTools)`, which is stable insertion order — no code change needed. Added regression tests (identical order across repeated `tools/list` calls, and stability across `disable()`/`enable()` toggles, including that re-enabling restores insertion position rather than appending) plus a short comment on the list handler documenting the guarantee.

### (b) List responses when capability declared — **the only behavioral change**

> Servers that declare the `tools` capability **MUST** respond to `tools/list` requests with the set of tools currently available to the requesting client. This set **MAY** be empty… — [draft `server/tools.mdx`](https://modelcontextprotocol.io/specification/draft/server/tools) (equivalent language for resources/prompts)

Previously, `McpServer` installed list/call handlers lazily on first `registerTool`/`registerResource`/`registerPrompt`, so a server constructed with `capabilities: { tools: {} }` and zero registrations answered `tools/list` with `-32601` (Method not found). The constructor now eagerly installs handlers for every primitive capability declared in `ServerOptions.capabilities`:

- `tools` → `tools/list` returns `[]`; `tools/call` for an unknown tool returns `-32602`
- `resources` → `resources/list` / `resources/templates/list` return `[]`; `resources/read` returns resource-not-found
- `prompts` → `prompts/list` returns `[]`; `prompts/get` returns `-32602`

Undeclared capabilities with no registrations still return `-32601`, and lazy installation on first registration is unchanged for servers that don't declare capabilities up front. Low-level `Server` users remain responsible for their own handlers — documented on `ServerOptions.capabilities`.

Happy to split this item into its own PR if you'd prefer to keep behavioral and docs-only changes separate.

### (c) Empty-string cursor — doc examples fixed

> Don't make any determination based on cursor value other than whether a non-null value was provided (e.g. an empty string is a valid cursor and thus **MUST NOT** be treated as the end of results) — [draft `server/utilities/pagination.mdx`](https://modelcontextprotocol.io/specification/draft/server/utilities/pagination)

The SDK has no runtime pagination loop, but the pagination examples in `client.examples.ts` (and the JSDoc on `listTools`/`listPrompts`/`listResources` generated from them via `sync:snippets`) used `} while (cursor);`, which stops on an empty-string cursor. Fixed to `while (cursor !== undefined)` and re-ran `pnpm sync:snippets`.

### (d) Resource path sanitization — docs only

> Servers **MUST** sanitize file paths to prevent directory traversal attacks when serving `file://` resources — [draft `server/resources.mdx`](https://modelcontextprotocol.io/specification/draft/server/resources) (Security Considerations)

The SDK serves no files itself; added a security note to the Resources section of `docs/server.md` about sanitizing user-influenced paths (traversal sequences, encoded forms, symlink escapes).

### (e) Completion value caps — already compliant, already tested

> `values`: Array of suggestions (max 100) … `hasMore`: Additional results flag — [draft `server/utilities/completion.mdx`](https://modelcontextprotocol.io/specification/draft/server/utilities/completion)

`createCompletionResult` in `mcp.ts` already slices to 100 and sets `hasMore`/`total`, and `test/e2e/scenarios/completion.test.ts` (requirement `completion:result-shape`, 150-item fixture) already asserts the 100-cap, `total`, and `hasMore: true`. No change needed.

### Notes

- **Potential rebase:** (b) touches `packages/server/src/server/mcp.ts` near regions #2249 (SEP-2106) also modifies; edits here are deliberately minimal and self-contained, but this PR may need a trivial rebase after #2249 merges (or vice versa).
- **Downstream impact:** cloudflare/agents is unaffected by (b) since `MCPAgent` always registers primitives before connect, BUT agents has the same empty-string-cursor consumer bug in `packages/agents/src/mcp/client-connection.ts` (~L562-617, `while (result.nextCursor)`) — an agents-side fix issue should be filed.

### Validation

- `pnpm build:all`, `pnpm typecheck:all`, `pnpm lint:all` (includes `sync:snippets --check`): pass
- Package tests: core 463/463, client 367/367, server 72/72
- Integration suite: 327/327 (includes 7 new tests in `test/integration/test/server/declaredCapabilities.test.ts`)
- Changeset: patch for `@modelcontextprotocol/server` and `@modelcontextprotocol/client`

Closes #2202
