### PR TITLE
feat(client,core): RFC 9207 iss parameter validation on authorization responses (SEP-2468)

### DIFF
--- a/.changeset/sep-2468-iss-validation.md
+++ b/.changeset/sep-2468-iss-validation.md
@@ -6,5 +6,8 @@
 Add RFC 9207 `iss` parameter validation for authorization responses (SEP-2468). `OAuthMetadataSchema` and `OpenIdProviderMetadataSchema` now recognize `authorization_response_iss_parameter_supported`. The client exports a new `validateAuthorizationResponseIssuer()` helper,
 `auth()` accepts an optional `iss`, and `StreamableHTTPClientTransport.finishAuth()` / `SSEClientTransport.finishAuth()` accept an optional `{ iss }` second argument. The `iss` option is tri-state: a string is validated by exact comparison against the issuer recorded in the
 authorization server metadata before the authorization code is sent to any token endpoint (mismatch rejects the response without processing any other response parameters); `null` asserts the caller inspected the authorization response and it carried no `iss`, enabling the RFC
-9207 fail-closed rejection when the AS advertises `authorization_response_iss_parameter_supported: true`; `undefined` (omitted) skips validation, so existing `finishAuth(code)` callers that never see the authorization response are unaffected. All additions are
-backwards-compatible.
+9207 fail-closed rejection when the AS advertises `authorization_response_iss_parameter_supported: true`; `undefined` (omitted) skips RFC 9207 response validation, so existing `finishAuth(code)` callers that never see the authorization response are unaffected.
+
+Discovery also now validates authorization-server metadata issuer values per RFC 8414 Section 3.3. Metadata discovered for a PRM-provided or cached authorization server URL is rejected when its `issuer` does not match that URL, and the public
+`discoverAuthorizationServerMetadata()` helper throws on mismatches or invalid issuer identifiers. For legacy servers without protected resource metadata, metadata is still discovered at the MCP server origin; when that metadata names a distinct issuer, the SDK now treats the
+metadata `issuer` as the authorization server URL for persisted discovery state and fallback endpoint construction.

--- a/.changeset/sep-2468-iss-validation.md
+++ b/.changeset/sep-2468-iss-validation.md
@@ -8,6 +8,7 @@ Add RFC 9207 `iss` parameter validation for authorization responses (SEP-2468). 
 authorization server metadata before the authorization code is sent to any token endpoint (mismatch rejects the response without processing any other response parameters); `null` asserts the caller inspected the authorization response and it carried no `iss`, enabling the RFC
 9207 fail-closed rejection when the AS advertises `authorization_response_iss_parameter_supported: true`; `undefined` (omitted) skips RFC 9207 response validation, so existing `finishAuth(code)` callers that never see the authorization response are unaffected.
 
-Discovery also now validates authorization-server metadata issuer values per RFC 8414 Section 3.3. Metadata discovered for a PRM-provided or cached authorization server URL is rejected when its `issuer` does not match that URL, and the public
-`discoverAuthorizationServerMetadata()` helper throws on mismatches or invalid issuer identifiers. For legacy servers without protected resource metadata, metadata is still discovered at the MCP server origin; when that metadata names a distinct issuer, the SDK now treats the
-metadata `issuer` as the authorization server URL for persisted discovery state and fallback endpoint construction.
+Discovery also now validates authorization-server metadata issuer values per RFC 8414 Section 3.3. Metadata discovered for a PRM-provided authorization server URL is rejected when its `issuer` does not match that URL, and the public
+`discoverAuthorizationServerMetadata()` helper throws on mismatches or invalid issuer identifiers. Cached discovery state is also validated; stale legacy no-PRM fallback state that saved the MCP server origin before learning a distinct metadata issuer is ignored and refreshed.
+For legacy servers without protected resource metadata, metadata is still discovered at the MCP server origin; when that metadata names a distinct issuer, the SDK now treats the metadata `issuer` as the authorization server URL for persisted discovery state and fallback endpoint
+construction.

--- a/.changeset/sep-2468-iss-validation.md
+++ b/.changeset/sep-2468-iss-validation.md
@@ -1,0 +1,6 @@
+---
+'@modelcontextprotocol/core': patch
+'@modelcontextprotocol/client': minor
+---
+
+Add RFC 9207 `iss` parameter validation for authorization responses (SEP-2468). `OAuthMetadataSchema` and `OpenIdProviderMetadataSchema` now recognize `authorization_response_iss_parameter_supported`. The client exports a new `validateAuthorizationResponseIssuer()` helper, `auth()` accepts an optional `iss`, and `StreamableHTTPClientTransport.finishAuth()` / `SSEClientTransport.finishAuth()` accept an optional `{ iss }` second argument. When provided, the `iss` from the authorization response is validated against the issuer recorded in the authorization server metadata before the authorization code is sent to any token endpoint; on mismatch the response is rejected without processing any other response parameters. All additions are backwards-compatible.

--- a/.changeset/sep-2468-iss-validation.md
+++ b/.changeset/sep-2468-iss-validation.md
@@ -1,9 +1,8 @@
 ---
-'@modelcontextprotocol/core': patch
 '@modelcontextprotocol/client': minor
 ---
 
-Add RFC 9207 `iss` parameter validation for authorization responses (SEP-2468). `OAuthMetadataSchema` and `OpenIdProviderMetadataSchema` now recognize `authorization_response_iss_parameter_supported`. The client exports a new `validateAuthorizationResponseIssuer()` helper,
+Add RFC 9207 `iss` parameter validation for authorization responses (SEP-2468). The client exports a new `validateAuthorizationResponseIssuer()` helper,
 `auth()` accepts an optional `iss`, and `StreamableHTTPClientTransport.finishAuth()` / `SSEClientTransport.finishAuth()` accept an optional `{ iss }` second argument. The `iss` option is tri-state: a string is validated by exact comparison against the issuer recorded in the
 authorization server metadata before the authorization code is sent to any token endpoint (mismatch rejects the response without processing any other response parameters); `null` asserts the caller inspected the authorization response and it carried no `iss`, enabling the RFC
 9207 fail-closed rejection when the AS advertises `authorization_response_iss_parameter_supported: true`; `undefined` (omitted) skips RFC 9207 response validation, so existing `finishAuth(code)` callers that never see the authorization response are unaffected.

--- a/.changeset/sep-2468-iss-validation.md
+++ b/.changeset/sep-2468-iss-validation.md
@@ -3,4 +3,8 @@
 '@modelcontextprotocol/client': minor
 ---
 
-Add RFC 9207 `iss` parameter validation for authorization responses (SEP-2468). `OAuthMetadataSchema` and `OpenIdProviderMetadataSchema` now recognize `authorization_response_iss_parameter_supported`. The client exports a new `validateAuthorizationResponseIssuer()` helper, `auth()` accepts an optional `iss`, and `StreamableHTTPClientTransport.finishAuth()` / `SSEClientTransport.finishAuth()` accept an optional `{ iss }` second argument. When provided, the `iss` from the authorization response is validated against the issuer recorded in the authorization server metadata before the authorization code is sent to any token endpoint; on mismatch the response is rejected without processing any other response parameters. All additions are backwards-compatible.
+Add RFC 9207 `iss` parameter validation for authorization responses (SEP-2468). `OAuthMetadataSchema` and `OpenIdProviderMetadataSchema` now recognize `authorization_response_iss_parameter_supported`. The client exports a new `validateAuthorizationResponseIssuer()` helper,
+`auth()` accepts an optional `iss`, and `StreamableHTTPClientTransport.finishAuth()` / `SSEClientTransport.finishAuth()` accept an optional `{ iss }` second argument. The `iss` option is tri-state: a string is validated by exact comparison against the issuer recorded in the
+authorization server metadata before the authorization code is sent to any token endpoint (mismatch rejects the response without processing any other response parameters); `null` asserts the caller inspected the authorization response and it carried no `iss`, enabling the RFC
+9207 fail-closed rejection when the AS advertises `authorization_response_iss_parameter_supported: true`; `undefined` (omitted) skips validation, so existing `finishAuth(code)` callers that never see the authorization response are unaffected. All additions are
+backwards-compatible.

--- a/.changeset/sep-2468-iss-validation.md
+++ b/.changeset/sep-2468-iss-validation.md
@@ -2,8 +2,7 @@
 '@modelcontextprotocol/client': minor
 ---
 
-Add RFC 9207 `iss` parameter validation for authorization responses (SEP-2468). The client exports a new `validateAuthorizationResponseIssuer()` helper,
-`auth()` accepts an optional `iss`, and `StreamableHTTPClientTransport.finishAuth()` / `SSEClientTransport.finishAuth()` accept an optional `{ iss }` second argument. The `iss` option is tri-state: a string is validated by exact comparison against the issuer recorded in the
+Refine RFC 9207 `iss` parameter validation for authorization responses (SEP-2468). `validateAuthorizationResponseIssuer()` gains a two-argument `(metadata, iss)` overload, and `auth()`'s `iss` option plus `StreamableHTTPClientTransport.finishAuth()` / `SSEClientTransport.finishAuth()` second arguments now use tri-state `string | null | undefined` semantics, with `finishAuth()` also accepting an `{ iss }` options object. The `iss` option is tri-state: a string is validated by exact comparison against the issuer recorded in the
 authorization server metadata before the authorization code is sent to any token endpoint (mismatch rejects the response without processing any other response parameters); `null` asserts the caller inspected the authorization response and it carried no `iss`, enabling the RFC
 9207 fail-closed rejection when the AS advertises `authorization_response_iss_parameter_supported: true`; `undefined` (omitted) skips RFC 9207 response validation, so existing `finishAuth(code)` callers that never see the authorization response are unaffected.
 

--- a/.changeset/sep-2468-iss-validation.md
+++ b/.changeset/sep-2468-iss-validation.md
@@ -8,7 +8,7 @@ Add RFC 9207 `iss` parameter validation for authorization responses (SEP-2468). 
 authorization server metadata before the authorization code is sent to any token endpoint (mismatch rejects the response without processing any other response parameters); `null` asserts the caller inspected the authorization response and it carried no `iss`, enabling the RFC
 9207 fail-closed rejection when the AS advertises `authorization_response_iss_parameter_supported: true`; `undefined` (omitted) skips RFC 9207 response validation, so existing `finishAuth(code)` callers that never see the authorization response are unaffected.
 
-Discovery also now validates authorization-server metadata issuer values per RFC 8414 Section 3.3. Metadata discovered for a PRM-provided authorization server URL is rejected when its `issuer` does not match that URL, and the public
-`discoverAuthorizationServerMetadata()` helper throws on mismatches or invalid issuer identifiers. Cached discovery state is also validated; stale legacy no-PRM fallback state that saved the MCP server origin before learning a distinct metadata issuer is ignored and refreshed.
-For legacy servers without protected resource metadata, metadata is still discovered at the MCP server origin; when that metadata names a distinct issuer, the SDK now treats the metadata `issuer` as the authorization server URL for persisted discovery state and fallback endpoint
-construction.
+Discovery also now validates authorization-server metadata issuer values per RFC 8414 Section 3.3. Metadata discovered for a PRM-provided authorization server URL is rejected when its `issuer` does not match that URL, and the public `discoverAuthorizationServerMetadata()` helper
+throws on mismatches or invalid issuer identifiers unless called with `{ validateIssuer: false }` for intentional alias discovery. Cached discovery state is also validated; stale legacy no-PRM fallback state that saved the MCP server origin before learning a distinct metadata
+issuer is ignored and refreshed. For legacy servers without protected resource metadata, metadata is still discovered at the MCP server origin; when that metadata names a distinct issuer, the SDK now treats the metadata `issuer` as the authorization server URL for persisted
+discovery state and fallback endpoint construction.

--- a/.changeset/sep-2468-iss-validation.md
+++ b/.changeset/sep-2468-iss-validation.md
@@ -11,3 +11,5 @@ Discovery also now validates authorization-server metadata issuer values per RFC
 throws on mismatches or invalid issuer identifiers unless called with `{ validateIssuer: false }` for intentional alias discovery. Cached discovery state is also validated; stale legacy no-PRM fallback state that saved the MCP server origin before learning a distinct metadata
 issuer is ignored and refreshed. For legacy servers without protected resource metadata, metadata is still discovered at the MCP server origin; when that metadata names a distinct issuer, the SDK now treats the metadata `issuer` as the authorization server URL for persisted
 discovery state and fallback endpoint construction.
+
+Cross-App Access IdP discovery (`discoverAndRequestJwtAuthGrant()` / `CrossAppAccessProvider`) intentionally skips the RFC 8414 issuer-echo check, so configured IdP alias URLs whose metadata names a canonical issuer keep working.

--- a/docs/clients/machine-auth.md
+++ b/docs/clients/machine-auth.md
@@ -86,6 +86,7 @@ const transport = new StreamableHTTPClientTransport(new URL('https://api.example
 ```
 
 The SDK discovers the MCP server's authorization server and resource URL (RFC 9728) before it calls `assertion`, then hands them in on `ctx` together with the negotiated `scope` and the transport's `fetchFn`. Pass them through so the IdP issues a grant bound to the right audience and resource.
+For the enterprise IdP leg, `discoverAndRequestJwtAuthGrant()` intentionally accepts configured IdP alias URLs whose metadata names a canonical issuer; it skips the RFC 8414 issuer-echo check before using the discovered token endpoint.
 
 ## Drop to the token-exchange utilities
 

--- a/docs/clients/oauth.md
+++ b/docs/clients/oauth.md
@@ -1,6 +1,7 @@
 ---
 shape: how-to
 ---
+
 # Authenticate a user with OAuth
 
 Protecting a server you run → [Require authorization](../serving/authorization.md). Signing a user in from a client → this page. No user present → [Authenticate without a user](./machine-auth.md).
@@ -117,7 +118,7 @@ await client.connect(new StreamableHTTPClientTransport(url, { authProvider: prov
 `finishAuth(params)` extracts `code`, validates the RFC 9207 `iss` parameter, exchanges the code at the authorization server discovery resolved before the redirect, and saves the tokens through your provider. The second `connect()` finds those tokens and completes without another redirect.
 
 ::: tip
-`finishAuth` also takes a positional form, `finishAuth(code, iss)`. Pass the `URLSearchParams` instead: the SDK reads both values from it, and a positional call that drops `iss` is rejected when the authorization server advertises RFC 9207 support.
+`finishAuth` also takes a positional form, `finishAuth(code, iss)`. Pass the `URLSearchParams` when you have the callback URL: the SDK reads both `code` and `iss` from it, and a missing `iss` is treated as an inspected absence. A positional `finishAuth(code)` call omits callback parameters entirely and skips RFC 9207 authorization-response validation for backwards compatibility.
 :::
 
 ## Handle issuer mismatch

--- a/docs/migration/upgrade-to-v2.md
+++ b/docs/migration/upgrade-to-v2.md
@@ -64,8 +64,8 @@ The codemod ([`@modelcontextprotocol/codemod`](https://github.com/modelcontextpr
 mechanically applies every rename whose mapping is fixed. The mappings are the
 **source of truth** — they live in the codemod package and are not reproduced here:
 
-| Mapping                                                                                   | Source file                                                                                                       |
-| ----------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| Mapping                                                                                   | Source file                                                                                                                                                                  |
+| ----------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `@modelcontextprotocol/sdk/...` import paths → v2 packages                                | [`mappings/importMap.ts`](https://github.com/modelcontextprotocol/typescript-sdk/blob/main/packages/codemod/src/migrations/v1-to-v2/mappings/importMap.ts)                   |
 | Symbol renames (`McpError` → `ProtocolError`, `JSONRPCError` → `JSONRPCErrorResponse`, …) | [`mappings/symbolMap.ts`](https://github.com/modelcontextprotocol/typescript-sdk/blob/main/packages/codemod/src/migrations/v1-to-v2/mappings/symbolMap.ts)                   |
 | `setRequestHandler(Schema, …)` → `setRequestHandler('method/string', …)`                  | [`mappings/schemaToMethodMap.ts`](https://github.com/modelcontextprotocol/typescript-sdk/blob/main/packages/codemod/src/migrations/v1-to-v2/mappings/schemaToMethodMap.ts)   |
@@ -1150,8 +1150,9 @@ with or without a pin) the connect-time 401 currently surfaces wrapped as
 #### `auth()` options are now `AuthOptions`
 
 The inline options object on `auth()` is now the named `AuthOptions` type. New fields:
-`iss?: string` (the form-urldecoded `iss` from the authorization callback — pass it
-alongside `authorizationCode` for RFC 9207 validation), `skipIssuerMetadataValidation?:
+`iss?: string | null` (the form-urldecoded `iss` from the authorization callback — pass it
+alongside `authorizationCode` for RFC 9207 validation, or pass `null` when the callback was
+inspected and had no `iss`), `skipIssuerMetadataValidation?:
 boolean` (security-weakening opt-out of the RFC 8414 §3.3 issuer-echo check), and
 `forceReauthorization?: boolean` (skip the refresh-token branch — set by the transport's
 step-up path; hosts driving step-up themselves set it under the same condition).
@@ -1160,9 +1161,11 @@ step-up path; hosts driving step-up themselves set it under the same condition).
 
 `transport.finishAuth()` and `auth()` now validate `iss` from the authorization callback
 against the issuer recorded from validated AS metadata. A mismatched `iss` throws
-`IssuerMismatchError` before the code is exchanged regardless of advertised support; a
-**missing** `iss` throws only when the AS advertised
-`authorization_response_iss_parameter_supported: true`.
+`IssuerMismatchError` before the code is exchanged regardless of advertised support. An
+inspected missing `iss` (`URLSearchParams` without `iss`, or `iss: null`) throws only when
+the AS advertised `authorization_response_iss_parameter_supported: true`; omitting `iss`
+entirely preserves legacy `finishAuth(code)` / `auth({ authorizationCode })` behavior and
+skips RFC 9207 authorization-response validation.
 
 Pass the callback URL's `URLSearchParams` so the SDK can read `iss` alongside `code`.
 The SDK does **not** validate `state`; compare it yourself before calling `finishAuth`:

--- a/examples/oauth/simpleOAuthClient.ts
+++ b/examples/oauth/simpleOAuthClient.ts
@@ -90,6 +90,7 @@ class InteractiveOAuthClient {
                 console.log(`📥 Received callback: ${req.url}`);
                 const parsedUrl = new URL(req.url || '', 'http://localhost');
                 const code = parsedUrl.searchParams.get('code');
+                const iss = parsedUrl.searchParams.get('iss');
                 const error = parsedUrl.searchParams.get('error');
 
                 if (code) {

--- a/examples/oauth/simpleOAuthClient.ts
+++ b/examples/oauth/simpleOAuthClient.ts
@@ -90,7 +90,6 @@ class InteractiveOAuthClient {
                 console.log(`📥 Received callback: ${req.url}`);
                 const parsedUrl = new URL(req.url || '', 'http://localhost');
                 const code = parsedUrl.searchParams.get('code');
-                const iss = parsedUrl.searchParams.get('iss');
                 const error = parsedUrl.searchParams.get('error');
 
                 if (code) {

--- a/packages/client/src/client/auth.ts
+++ b/packages/client/src/client/auth.ts
@@ -954,6 +954,27 @@ export interface AuthOptions {
     forceReauthorization?: boolean;
 }
 
+function normalizeDiscoveredIssuerIdentifier(issuer: string | URL): string {
+    const normalized = new URL(issuer).toString();
+
+    return normalized.endsWith('/') ? normalized.slice(0, -1) : normalized;
+}
+
+function validateAuthorizationServerMetadataIssuer(metadata: { issuer: string } | undefined, authorizationServerUrl: string | URL): void {
+    if (!metadata) {
+        return;
+    }
+
+    const expectedIssuer = normalizeDiscoveredIssuerIdentifier(authorizationServerUrl);
+    const actualIssuer = normalizeDiscoveredIssuerIdentifier(metadata.issuer);
+
+    if (actualIssuer !== expectedIssuer) {
+        throw new Error(
+            `Authorization server metadata issuer does not match the expected issuer: expected ${expectedIssuer}, got ${metadata.issuer} (RFC 8414 Section 3.3)`
+        );
+    }
+}
+
 /**
  * Orchestrates the full auth flow with a server.
  *
@@ -1097,6 +1118,7 @@ async function authInternal(
         });
         authorizationServerUrl = serverInfo.authorizationServerUrl;
         metadata = serverInfo.authorizationServerMetadata;
+        validateAuthorizationServerMetadataIssuer(metadata, authorizationServerUrl);
         resourceMetadata = serverInfo.resourceMetadata;
 
         // Captured now, persisted only after the SEP-2352 callback-leg gate below — so a

--- a/packages/client/src/client/auth.ts
+++ b/packages/client/src/client/auth.ts
@@ -2075,8 +2075,11 @@ export async function discoverOAuthServerInfo(
         resourceMetadataUrl?: URL;
         fetchFn?: FetchLike;
         /**
-         * Forwarded to {@linkcode discoverAuthorizationServerMetadata} as
-         * `skipIssuerValidation`. **Security-weakening** — see {@linkcode AuthOptions.skipIssuerMetadataValidation}.
+         * When the authorization server URL comes from protected resource metadata, disables
+         * the RFC 8414 Section 3.3 issuer check by forwarding `validateIssuer: false` to
+         * {@linkcode discoverAuthorizationServerMetadata}. For the legacy no-PRM fallback,
+         * issuer validation is already disabled regardless of this flag.
+         * **Security-weakening** — see {@linkcode AuthOptions.skipIssuerMetadataValidation}.
          */
         skipIssuerMetadataValidation?: boolean;
     }

--- a/packages/client/src/client/auth.ts
+++ b/packages/client/src/client/auth.ts
@@ -522,7 +522,7 @@ function isIssParameterSupported(metadata: AuthorizationServerMetadata | undefin
     return metadata?.authorization_response_iss_parameter_supported === true;
 }
 
-type AuthorizationResponseIssuerValidation = {
+export type AuthorizationResponseIssuerValidation = {
     /** The form-urldecoded `iss` query parameter from the authorization callback, or `undefined` if absent. */
     iss: string | null | undefined;
     /** The `issuer` value from the authorization server's validated metadata document. */
@@ -531,7 +531,7 @@ type AuthorizationResponseIssuerValidation = {
     issParameterSupported: boolean;
 };
 
-type AuthorizationResponseIssuerMetadata = {
+export type AuthorizationResponseIssuerMetadata = {
     issuer: string;
     authorization_response_iss_parameter_supported?: boolean;
 };
@@ -551,13 +551,18 @@ export function validateAuthorizationResponseIssuer(
     argsOrMetadata: AuthorizationResponseIssuerValidation | AuthorizationResponseIssuerMetadata | undefined,
     explicitIss?: string | null
 ): void {
-    const { iss, expectedIssuer, issParameterSupported } = isAuthorizationResponseIssuerValidation(argsOrMetadata)
-        ? argsOrMetadata
-        : {
-              iss: explicitIss,
-              expectedIssuer: argsOrMetadata?.issuer,
-              issParameterSupported: argsOrMetadata?.authorization_response_iss_parameter_supported === true
-          };
+    const useArgsObject = arguments.length < 2 && isAuthorizationResponseIssuerValidation(argsOrMetadata);
+    const { iss, expectedIssuer, issParameterSupported } = (() => {
+        if (useArgsObject) {
+            return argsOrMetadata as AuthorizationResponseIssuerValidation;
+        }
+        const metadata = argsOrMetadata as AuthorizationResponseIssuerMetadata | undefined;
+        return {
+            iss: explicitIss,
+            expectedIssuer: metadata?.issuer,
+            issParameterSupported: metadata?.authorization_response_iss_parameter_supported === true
+        };
+    })();
 
     if (iss === undefined) {
         // Legacy callers did not provide authorization-response parameters at all.
@@ -994,18 +999,23 @@ function normalizeDiscoveredIssuerIdentifier(issuer: string | URL, label: string
     return normalized.endsWith('/') ? normalized.slice(0, -1) : normalized;
 }
 
+function rawIssuerIdentifier(issuer: string | URL): string {
+    return typeof issuer === 'string' ? issuer : issuer.href;
+}
+
+function metadataIssuerMatches(expectedIssuer: string, actualIssuer: string): boolean {
+    return actualIssuer === expectedIssuer || (expectedIssuer.endsWith('/') && actualIssuer === expectedIssuer.slice(0, -1));
+}
+
 function validateAuthorizationServerMetadataIssuer(metadata: { issuer: string } | undefined, authorizationServerUrl: string | URL): void {
     if (!metadata) {
         return;
     }
 
-    const expectedIssuer = normalizeDiscoveredIssuerIdentifier(authorizationServerUrl, 'Authorization server URL');
-    const actualIssuer = normalizeDiscoveredIssuerIdentifier(metadata.issuer, 'Authorization server metadata issuer');
+    const expectedIssuer = rawIssuerIdentifier(authorizationServerUrl);
 
-    if (actualIssuer !== expectedIssuer) {
-        throw new Error(
-            `Authorization server metadata issuer does not match the expected issuer: expected ${expectedIssuer}, got ${metadata.issuer} (RFC 8414 Section 3.3)`
-        );
+    if (!metadataIssuerMatches(expectedIssuer, metadata.issuer)) {
+        throw new IssuerMismatchError('metadata', expectedIssuer, metadata.issuer);
     }
 }
 
@@ -1162,6 +1172,7 @@ async function authInternal(
     let authorizationServerUrl: string | URL | undefined;
     let metadata: AuthorizationServerMetadata | undefined;
     let freshDiscoveryState: OAuthDiscoveryState | undefined;
+    let cachedStateWasStaleLegacyFallback = false;
 
     // If resourceMetadataUrl is not provided, try to load it from cached state
     // This handles browser redirects where the URL was saved before navigation
@@ -1195,6 +1206,7 @@ async function authInternal(
 
                     await provider.invalidateCredentials?.('discovery');
                     useCachedDiscoveryState = false;
+                    cachedStateWasStaleLegacyFallback = true;
                 }
             }
         }
@@ -1312,7 +1324,12 @@ async function authInternal(
     // the (legacy) warn-and-proceed behavior.
     if (authorizationCode !== undefined) {
         let recordedIssuer = cachedState?.authorizationServerMetadata?.issuer ?? cachedState?.authorizationServerUrl;
-        if (cachedState?.authorizationServerMetadata && cachedState.authorizationServerUrl && !skipIssuerMetadataValidation) {
+        if (
+            cachedState?.authorizationServerMetadata &&
+            cachedState.authorizationServerUrl &&
+            !skipIssuerMetadataValidation &&
+            !cachedStateWasStaleLegacyFallback
+        ) {
             try {
                 validateAuthorizationServerMetadataIssuer(cachedState.authorizationServerMetadata, cachedState.authorizationServerUrl);
             } catch {
@@ -1432,6 +1449,7 @@ async function authInternal(
 
         const tokens = await fetchToken(provider, authorizationServerUrl, {
             metadata,
+            issuer,
             resource,
             authorizationCode,
             iss,
@@ -2421,6 +2439,7 @@ export async function fetchToken(
     authorizationServerUrl: string | URL,
     {
         metadata,
+        issuer,
         resource,
         authorizationCode,
         iss,
@@ -2428,6 +2447,11 @@ export async function fetchToken(
         fetchFn
     }: {
         metadata?: AuthorizationServerMetadata;
+        /**
+         * Canonical issuer key for provider persistence callbacks. Defaults to
+         * `metadata.issuer` when available, otherwise `authorizationServerUrl`.
+         */
+        issuer?: string;
         resource?: URL;
         /** Authorization code for the default `authorization_code` grant flow */
         authorizationCode?: string;
@@ -2471,7 +2495,7 @@ export async function fetchToken(
         tokenRequestParams = prepareAuthorizationCodeRequest(authorizationCode, codeVerifier, provider.redirectUrl);
     }
 
-    const clientInformation = await provider.clientInformation({ issuer: metadata?.issuer ?? String(authorizationServerUrl) });
+    const clientInformation = await provider.clientInformation({ issuer: issuer ?? metadata?.issuer ?? String(authorizationServerUrl) });
 
     return executeTokenRequest(authorizationServerUrl, {
         metadata,

--- a/packages/client/src/client/auth.ts
+++ b/packages/client/src/client/auth.ts
@@ -980,20 +980,46 @@ function validateAuthorizationServerMetadataIssuer(metadata: { issuer: string } 
     }
 }
 
-function isStaleLegacyFallbackDiscoveryState(
-    cachedState: OAuthDiscoveryState,
-    metadata: { issuer: string } | undefined,
-    serverUrl: string | URL
-): boolean {
-    if (!metadata || cachedState.resourceMetadata?.authorization_servers?.length) {
+function isLegacyFallbackDiscoveryState(cachedState: OAuthDiscoveryState, serverUrl: string | URL): boolean {
+    if (cachedState.resourceMetadata?.authorization_servers?.length) {
         return false;
     }
 
     try {
         const cachedIssuer = normalizeDiscoveredIssuerIdentifier(cachedState.authorizationServerUrl, 'Cached authorization server URL');
         const legacyFallbackIssuer = normalizeDiscoveredIssuerIdentifier(new URL('/', serverUrl), 'MCP server URL');
+        return cachedIssuer === legacyFallbackIssuer;
+    } catch {
+        return false;
+    }
+}
+
+function hasMalformedAuthorizationServerMetadataIssuer(metadata: { issuer: string } | undefined): boolean {
+    if (!metadata) {
+        return false;
+    }
+
+    try {
+        normalizeDiscoveredIssuerIdentifier(metadata.issuer, 'Authorization server metadata issuer');
+        return false;
+    } catch {
+        return true;
+    }
+}
+
+function isStaleLegacyFallbackDiscoveryState(
+    cachedState: OAuthDiscoveryState,
+    metadata: { issuer: string } | undefined,
+    serverUrl: string | URL
+): boolean {
+    if (!metadata || !isLegacyFallbackDiscoveryState(cachedState, serverUrl)) {
+        return false;
+    }
+
+    try {
+        const cachedIssuer = normalizeDiscoveredIssuerIdentifier(cachedState.authorizationServerUrl, 'Cached authorization server URL');
         const metadataIssuer = normalizeDiscoveredIssuerIdentifier(metadata.issuer, 'Authorization server metadata issuer');
-        return cachedIssuer === legacyFallbackIssuer && metadataIssuer !== cachedIssuer;
+        return metadataIssuer !== cachedIssuer;
     } catch {
         return false;
     }
@@ -1108,8 +1134,9 @@ async function authInternal(
                 skipIssuerValidation: skipIssuerMetadataValidation
             }));
 
-            await provider.invalidateCredentials?.('discovery');
-            useCachedDiscoveryState = false;
+                await provider.invalidateCredentials?.('discovery');
+                useCachedDiscoveryState = false;
+            }
         }
     }
 

--- a/packages/client/src/client/auth.ts
+++ b/packages/client/src/client/auth.ts
@@ -1898,7 +1898,10 @@ export async function discoverAuthorizationServerMetadata(
  * @param options - Configuration options
  * @param options.fetchFn - Optional fetch function for making HTTP requests, defaults to global fetch
  * @param options.protocolVersion - MCP protocol version to use, defaults to {@linkcode LATEST_PROTOCOL_VERSION}
+ * @param options.validateIssuer - Whether to validate metadata's issuer against the discovery URL, defaults to true
  * @returns Promise resolving to authorization server metadata, or undefined if discovery fails
+ * @throws {Error} If discovered metadata has an invalid issuer or the issuer does not match
+ *                 the discovery URL while issuer validation is enabled
  */
 export async function discoverAuthorizationServerMetadata(
     authorizationServerUrl: string | URL,

--- a/packages/client/src/client/auth.ts
+++ b/packages/client/src/client/auth.ts
@@ -980,6 +980,25 @@ function validateAuthorizationServerMetadataIssuer(metadata: { issuer: string } 
     }
 }
 
+function isStaleLegacyFallbackDiscoveryState(
+    cachedState: OAuthDiscoveryState,
+    metadata: { issuer: string } | undefined,
+    serverUrl: string | URL
+): boolean {
+    if (!metadata || cachedState.resourceMetadata?.authorization_servers?.length) {
+        return false;
+    }
+
+    try {
+        const cachedIssuer = normalizeDiscoveredIssuerIdentifier(cachedState.authorizationServerUrl, 'Cached authorization server URL');
+        const legacyFallbackIssuer = normalizeDiscoveredIssuerIdentifier(new URL('/', serverUrl), 'MCP server URL');
+        const metadataIssuer = normalizeDiscoveredIssuerIdentifier(metadata.issuer, 'Authorization server metadata issuer');
+        return cachedIssuer === legacyFallbackIssuer && metadataIssuer !== cachedIssuer;
+    } catch {
+        return false;
+    }
+}
+
 /**
  * Orchestrates the full auth flow with a server.
  *
@@ -1065,7 +1084,7 @@ async function authInternal(
     const cachedState = await provider.discoveryState?.();
 
     let resourceMetadata: OAuthProtectedResourceMetadata | undefined;
-    let authorizationServerUrl: string | URL;
+    let authorizationServerUrl: string | URL | undefined;
     let metadata: AuthorizationServerMetadata | undefined;
     let freshDiscoveryState: OAuthDiscoveryState | undefined;
 
@@ -1076,7 +1095,9 @@ async function authInternal(
         effectiveResourceMetadataUrl = new URL(cachedState.resourceMetadataUrl);
     }
 
+    let useCachedDiscoveryState = false;
     if (cachedState?.authorizationServerUrl) {
+        useCachedDiscoveryState = true;
         // Restore discovery state from cache
         authorizationServerUrl = cachedState.authorizationServerUrl;
         resourceMetadata = cachedState.resourceMetadata;
@@ -1087,6 +1108,12 @@ async function authInternal(
                 skipIssuerValidation: skipIssuerMetadataValidation
             }));
 
+            await provider.invalidateCredentials?.('discovery');
+            useCachedDiscoveryState = false;
+        }
+    }
+
+    if (useCachedDiscoveryState && cachedState?.authorizationServerUrl) {
         // If resource metadata wasn't cached, try to fetch it for selectResourceURL
         if (!resourceMetadata) {
             try {
@@ -1114,7 +1141,9 @@ async function authInternal(
                 authorizationServerMetadata: metadata
             });
         }
-    } else {
+    }
+
+    if (!useCachedDiscoveryState) {
         // Full discovery via RFC 9728
         const serverInfo = await discoverOAuthServerInfo(serverUrl, {
             resourceMetadataUrl: effectiveResourceMetadataUrl,

--- a/packages/client/src/client/auth.ts
+++ b/packages/client/src/client/auth.ts
@@ -492,27 +492,6 @@ export class UnauthorizedError extends Error {
 }
 
 /**
- * Validates the `iss` parameter from an authorization response against the
- * issuer recorded from the authorization server's validated metadata, per
- * RFC 9207 §2.4 and the MCP specification's four-row decision table.
- *
- * | `issParameterSupported` | `iss`   | Action                                           |
- * | ----------------------- | ------- | ------------------------------------------------ |
- * | `true`                  | present | compare; throw {@linkcode IssuerMismatchError} on mismatch |
- * | `true`                  | absent  | throw {@linkcode IssuerMismatchError}            |
- * | `false`                 | present | compare; throw {@linkcode IssuerMismatchError} on mismatch |
- * | `false`                 | absent  | proceed (no-op)                                  |
- *
- * Comparison is **simple string equality** (RFC 3986 §6.2.1). Scheme/host case
- * folding, default-port elision, trailing-slash, and percent-encoding
- * normalization are explicitly **not** applied — any difference is a mismatch.
- *
- * When `expectedIssuer` is `undefined` (no validated metadata document exists),
- * the check has no authentic baseline and degenerates to a no-op.
- *
- * @throws {IssuerMismatchError} with `kind: 'authorization_response'`
- */
-/**
  * Reads RFC 9207's `authorization_response_iss_parameter_supported` from
  * authorization-server metadata. Only a literal `true` counts as advertised;
  * absent, `false`, or a non-boolean wire value (coerced to `undefined` by the
@@ -523,7 +502,11 @@ function isIssParameterSupported(metadata: AuthorizationServerMetadata | undefin
 }
 
 export type AuthorizationResponseIssuerValidation = {
-    /** The form-urldecoded `iss` query parameter from the authorization callback, or `undefined` if absent. */
+    /**
+     * The form-urldecoded `iss` query parameter from the authorization callback; `null` when
+     * the callback was inspected and carried no `iss`; `undefined` only when the caller never
+     * received callback parameters, which skips RFC 9207 validation.
+     */
     iss: string | null | undefined;
     /** The `issuer` value from the authorization server's validated metadata document. */
     expectedIssuer: string | undefined;
@@ -542,6 +525,23 @@ function isAuthorizationResponseIssuerValidation(
     return value !== undefined && 'expectedIssuer' in value;
 }
 
+/**
+ * Validates the `iss` parameter from an authorization response against the
+ * issuer recorded from the authorization server's validated metadata, per
+ * RFC 9207 Section 2.4 and the MCP specification's decision table.
+ *
+ * - A string `iss` is compared with simple string equality; any mismatch throws.
+ * - `null` means the callback was inspected and no `iss` was present; it throws only
+ *   when metadata advertised `authorization_response_iss_parameter_supported: true`.
+ * - `undefined` means legacy callers did not provide callback parameters at all, so
+ *   validation is skipped.
+ * - A present `iss` with no recorded `expectedIssuer` throws fail-closed.
+ *
+ * Scheme/host case folding, default-port elision, trailing-slash, and percent-encoding
+ * normalization are explicitly **not** applied — any difference is a mismatch.
+ *
+ * @throws {IssuerMismatchError} with `kind: 'authorization_response'`
+ */
 export function validateAuthorizationResponseIssuer(args: AuthorizationResponseIssuerValidation): void;
 export function validateAuthorizationResponseIssuer(
     metadata: AuthorizationResponseIssuerMetadata | undefined,

--- a/packages/client/src/client/auth.ts
+++ b/packages/client/src/client/auth.ts
@@ -522,31 +522,62 @@ function isIssParameterSupported(metadata: AuthorizationServerMetadata | undefin
     return metadata?.authorization_response_iss_parameter_supported === true;
 }
 
-export function validateAuthorizationResponseIssuer({
-    iss,
-    expectedIssuer,
-    issParameterSupported
-}: {
+type AuthorizationResponseIssuerValidation = {
     /** The form-urldecoded `iss` query parameter from the authorization callback, or `undefined` if absent. */
-    iss: string | undefined;
+    iss: string | null | undefined;
     /** The `issuer` value from the authorization server's validated metadata document. */
     expectedIssuer: string | undefined;
     /** Whether the metadata advertised `authorization_response_iss_parameter_supported: true`. */
     issParameterSupported: boolean;
-}): void {
-    if (expectedIssuer === undefined) {
-        // No validated metadata document → no recorded issuer → no comparison (table row 4).
+};
+
+type AuthorizationResponseIssuerMetadata = {
+    issuer: string;
+    authorization_response_iss_parameter_supported?: boolean;
+};
+
+function isAuthorizationResponseIssuerValidation(
+    value: AuthorizationResponseIssuerValidation | AuthorizationResponseIssuerMetadata | undefined
+): value is AuthorizationResponseIssuerValidation {
+    return value !== undefined && 'expectedIssuer' in value;
+}
+
+export function validateAuthorizationResponseIssuer(args: AuthorizationResponseIssuerValidation): void;
+export function validateAuthorizationResponseIssuer(
+    metadata: AuthorizationResponseIssuerMetadata | undefined,
+    iss: string | null | undefined
+): void;
+export function validateAuthorizationResponseIssuer(
+    argsOrMetadata: AuthorizationResponseIssuerValidation | AuthorizationResponseIssuerMetadata | undefined,
+    explicitIss?: string | null
+): void {
+    const { iss, expectedIssuer, issParameterSupported } = isAuthorizationResponseIssuerValidation(argsOrMetadata)
+        ? argsOrMetadata
+        : {
+              iss: explicitIss,
+              expectedIssuer: argsOrMetadata?.issuer,
+              issParameterSupported: argsOrMetadata?.authorization_response_iss_parameter_supported === true
+          };
+
+    if (iss === undefined) {
+        // Legacy callers did not provide authorization-response parameters at all.
         return;
     }
-    if (iss === undefined) {
+
+    if (iss === null) {
         if (issParameterSupported) {
-            // Row 2: AS advertised that it always sends `iss`; absence is a stripped-parameter attack indicator.
+            // AS advertised that it always sends `iss`; explicit absence is a stripped-parameter attack indicator.
             throw new IssuerMismatchError('authorization_response', expectedIssuer, undefined);
         }
-        // Row 4: not advertised, not present → proceed.
+        // Not advertised and explicitly absent: validation is not possible; proceed.
         return;
     }
-    // Rows 1 & 3: present → compare with simple string comparison only.
+
+    if (expectedIssuer === undefined) {
+        throw new IssuerMismatchError('authorization_response', undefined, iss);
+    }
+
+    // Present → compare with simple string comparison only.
     if (iss !== expectedIssuer) {
         throw new IssuerMismatchError('authorization_response', expectedIssuer, iss);
     }
@@ -626,15 +657,15 @@ export function isStrictScopeSuperset(union: string | undefined, current: string
  */
 export async function resolveAuthorizationCallbackParams(
     codeOrParams: string | URLSearchParams,
-    iss: string | undefined,
+    iss: string | null | { iss?: string | null } | undefined,
     provider: OAuthClientProvider,
     serverUrl: string | URL,
     opts?: { fetchFn?: FetchLike; resourceMetadataUrl?: URL }
-): Promise<{ authorizationCode: string; iss: string | undefined }> {
+): Promise<{ authorizationCode: string; iss: string | null | undefined }> {
     if (typeof codeOrParams === 'string') {
-        return { authorizationCode: codeOrParams, iss };
+        return { authorizationCode: codeOrParams, iss: typeof iss === 'object' && iss !== null ? iss.iss : iss };
     }
-    const issParam = codeOrParams.get('iss') ?? undefined;
+    const issParam = codeOrParams.has('iss') ? codeOrParams.get('iss') : null;
     const code = codeOrParams.get('code');
     if (code) {
         return { authorizationCode: code, iss: issParam };
@@ -911,14 +942,12 @@ export interface AuthOptions {
      */
     authorizationCode?: string;
     /**
-     * The form-urldecoded `iss` query parameter from the authorization callback,
-     * if present. Passed through to RFC 9207 §2.4 issuer validation alongside
-     * `authorizationCode`. Validated against the recorded issuer per RFC 9207
-     * §2.4 before the code is redeemed — see
-     * {@linkcode validateAuthorizationResponseIssuer} and the migration guide's
-     * *Authorization-server mix-up defense* section.
+     * The form-urldecoded `iss` query parameter from the authorization callback.
+     * Pass a string when the response contained `iss`, `null` when the callback
+     * was inspected and `iss` was absent, and leave it `undefined` only for
+     * legacy callers that did not receive callback parameters.
      */
-    iss?: string;
+    iss?: string | null;
     /** Scope to request; computed by Scope Selection Strategy when omitted. */
     scope?: string;
     /** Explicit `resource_metadata` URL from a `WWW-Authenticate` challenge. */
@@ -1023,6 +1052,26 @@ function isStaleLegacyFallbackDiscoveryState(
     } catch {
         return false;
     }
+}
+
+/**
+ * Options for {@linkcode discoverAuthorizationServerMetadata}.
+ */
+export interface DiscoverAuthorizationServerMetadataOptions {
+    /** Optional fetch function for making HTTP requests, defaults to global fetch. */
+    fetchFn?: FetchLike;
+    /** MCP protocol version sent during metadata discovery. */
+    protocolVersion?: string;
+    /**
+     * Whether to validate discovered metadata's issuer against the discovery URL.
+     * Defaults to true. Set to false only when discovery intentionally starts from
+     * an alias URL whose metadata may name a canonical issuer.
+     */
+    validateIssuer?: boolean;
+    /**
+     * @deprecated Use `validateIssuer: false` instead.
+     */
+    skipIssuerValidation?: boolean;
 }
 
 /**
@@ -1131,11 +1180,22 @@ async function authInternal(
             cachedState.authorizationServerMetadata ??
             (await discoverAuthorizationServerMetadata(authorizationServerUrl, {
                 fetchFn,
-                skipIssuerValidation: skipIssuerMetadataValidation
+                validateIssuer: false
             }));
+        if (!skipIssuerMetadataValidation) {
+            try {
+                validateAuthorizationServerMetadataIssuer(metadata, authorizationServerUrl);
+            } catch (error) {
+                const canUseMalformedLegacyFallbackState =
+                    isLegacyFallbackDiscoveryState(cachedState, serverUrl) && hasMalformedAuthorizationServerMetadataIssuer(metadata);
+                if (!canUseMalformedLegacyFallbackState) {
+                    if (!isStaleLegacyFallbackDiscoveryState(cachedState, metadata, serverUrl)) {
+                        throw error;
+                    }
 
-                await provider.invalidateCredentials?.('discovery');
-                useCachedDiscoveryState = false;
+                    await provider.invalidateCredentials?.('discovery');
+                    useCachedDiscoveryState = false;
+                }
             }
         }
     }
@@ -1179,27 +1239,29 @@ async function authInternal(
         });
         authorizationServerUrl = serverInfo.authorizationServerUrl;
         metadata = serverInfo.authorizationServerMetadata;
-        try {
-            validateAuthorizationServerMetadataIssuer(metadata, authorizationServerUrl);
-        } catch (error) {
-            if (serverInfo.resourceMetadata?.authorization_servers?.length) {
-                throw error;
-            }
-            if (!metadata) {
-                throw error;
-            }
-
-            let legacyIssuerIsMalformed = false;
+        if (!skipIssuerMetadataValidation) {
             try {
-                normalizeDiscoveredIssuerIdentifier(metadata.issuer, 'Authorization server metadata issuer');
-            } catch {
-                // Legacy no-PRM discovery intentionally disables issuer validation. Keep the
-                // fallback MCP origin when legacy metadata has an unparseable issuer value.
-                legacyIssuerIsMalformed = true;
-            }
+                validateAuthorizationServerMetadataIssuer(metadata, authorizationServerUrl);
+            } catch (error) {
+                if (serverInfo.resourceMetadata?.authorization_servers?.length) {
+                    throw error;
+                }
+                if (!metadata) {
+                    throw error;
+                }
 
-            if (!legacyIssuerIsMalformed) {
-                throw error;
+                let legacyIssuerIsMalformed = false;
+                try {
+                    normalizeDiscoveredIssuerIdentifier(metadata.issuer, 'Authorization server metadata issuer');
+                } catch {
+                    // Legacy no-PRM discovery intentionally disables issuer validation. Keep the
+                    // fallback MCP origin when legacy metadata has an unparseable issuer value.
+                    legacyIssuerIsMalformed = true;
+                }
+
+                if (!legacyIssuerIsMalformed) {
+                    throw error;
+                }
             }
         }
         resourceMetadata = serverInfo.resourceMetadata;
@@ -1218,10 +1280,21 @@ async function authInternal(
         };
     }
 
+    if (authorizationServerUrl === undefined) {
+        throw new Error('OAuth authorization server discovery did not resolve an authorization server');
+    }
+
     // SEP-2352: the canonical authorization-server identity for this flow. `metadata.issuer`
     // is RFC 8414 §3.3-validated to equal the discovery URL; when no metadata document was
     // found (legacy fallback) the discovery URL itself is the only identifier available.
-    const issuer = metadata?.issuer ?? String(authorizationServerUrl);
+    let issuer = metadata?.issuer ?? String(authorizationServerUrl);
+    if (metadata && !skipIssuerMetadataValidation) {
+        try {
+            validateAuthorizationServerMetadataIssuer(metadata, authorizationServerUrl);
+        } catch {
+            issuer = String(authorizationServerUrl);
+        }
+    }
     const infoCtx: OAuthClientInformationContext = { issuer };
 
     // Deprecated write-only hook, kept for providers (e.g. Cross-App Access) that read it
@@ -1238,7 +1311,14 @@ async function authInternal(
     // multi-AS provider here. Providers that do not implement saveDiscoveryState at all keep
     // the (legacy) warn-and-proceed behavior.
     if (authorizationCode !== undefined) {
-        const recordedIssuer = cachedState?.authorizationServerMetadata?.issuer ?? cachedState?.authorizationServerUrl;
+        let recordedIssuer = cachedState?.authorizationServerMetadata?.issuer ?? cachedState?.authorizationServerUrl;
+        if (cachedState?.authorizationServerMetadata && cachedState.authorizationServerUrl && !skipIssuerMetadataValidation) {
+            try {
+                validateAuthorizationServerMetadataIssuer(cachedState.authorizationServerMetadata, cachedState.authorizationServerUrl);
+            } catch {
+                recordedIssuer = cachedState.authorizationServerUrl;
+            }
+        }
         if (recordedIssuer === undefined) {
             if (provider.saveDiscoveryState !== undefined) {
                 throw new AuthorizationServerMismatchError(
@@ -1849,13 +1929,13 @@ export function buildDiscoveryUrls(authorizationServerUrl: string | URL): { url:
  * The returned metadata's `issuer` is validated against `authorizationServerUrl`
  * per RFC 8414 §3.3 (and OIDC Discovery §4.3): if they differ the metadata is
  * **rejected** with {@linkcode IssuerMismatchError} and not returned. Set
- * `skipIssuerValidation: true` to suppress this check — **security-weakening**,
- * intended only for known-misconfigured authorization servers.
+ * `validateIssuer: false` to suppress this check — **security-weakening**,
+ * intended only for intentional alias discovery.
  *
  * @param options - Configuration options
  * @param options.fetchFn - Optional fetch function for making HTTP requests, defaults to global fetch
  * @param options.protocolVersion - MCP protocol version to use, defaults to {@linkcode LATEST_PROTOCOL_VERSION}
- * @param options.skipIssuerValidation - Skip the RFC 8414 §3.3 `issuer` echo check. **Security-weakening.**
+ * @param options.validateIssuer - Validate the RFC 8414 §3.3 `issuer` echo check, defaults to true.
  * @returns Promise resolving to authorization server metadata, or undefined if discovery fails
  * @throws {IssuerMismatchError} when the metadata's `issuer` does not match `authorizationServerUrl`
  */
@@ -1864,13 +1944,11 @@ export async function discoverAuthorizationServerMetadata(
     {
         fetchFn = fetch,
         protocolVersion = LATEST_PROTOCOL_VERSION,
-        skipIssuerValidation = false
-    }: {
-        fetchFn?: FetchLike;
-        protocolVersion?: string;
-        skipIssuerValidation?: boolean;
-    } = {}
+        validateIssuer,
+        skipIssuerValidation
+    }: DiscoverAuthorizationServerMetadataOptions = {}
 ): Promise<AuthorizationServerMetadata | undefined> {
+    const shouldValidateIssuer = validateIssuer ?? !skipIssuerValidation;
     const headers = {
         'MCP-Protocol-Version': protocolVersion,
         Accept: 'application/json'
@@ -1907,7 +1985,7 @@ export async function discoverAuthorizationServerMetadata(
                 ? OAuthMetadataSchema.parse(await response.json())
                 : OpenIdProviderDiscoveryMetadataSchema.parse(await response.json());
 
-        if (!skipIssuerValidation) {
+        if (shouldValidateIssuer) {
             // RFC 8414 §3.3 / OIDC Discovery §4.3: the `issuer` value in the document MUST be
             // identical to the issuer identifier used to construct the well-known URL. Compare
             // against the raw input string — callers pass the exact issuer string the AS published.
@@ -1928,35 +2006,6 @@ export async function discoverAuthorizationServerMetadata(
     }
 
     return undefined;
-}
-
-/**
- * Discovers authorization server metadata with support for
- * {@link https://datatracker.ietf.org/doc/html/rfc8414 | RFC 8414} OAuth 2.0
- * Authorization Server Metadata and
- * {@link https://openid.net/specs/openid-connect-discovery-1_0.html | OpenID Connect Discovery 1.0}
- * specifications.
- *
- * This function implements a fallback strategy for authorization server discovery:
- * 1. Attempts RFC 8414 OAuth metadata discovery first
- * 2. If OAuth discovery fails, falls back to OpenID Connect Discovery
- *
- * @param authorizationServerUrl - The authorization server URL obtained from the MCP Server's
- *                                 protected resource metadata, or the MCP server's URL if the
- *                                 metadata was not found.
- * @param options - Configuration options
- * @param options.fetchFn - Optional fetch function for making HTTP requests, defaults to global fetch
- * @param options.protocolVersion - MCP protocol version to use, defaults to {@linkcode LATEST_PROTOCOL_VERSION}
- * @param options.validateIssuer - Whether to validate metadata's issuer against the discovery URL, defaults to true
- * @returns Promise resolving to authorization server metadata, or undefined if discovery fails
- * @throws {Error} If discovered metadata has an invalid issuer or the issuer does not match
- *                 the discovery URL while issuer validation is enabled
- */
-export async function discoverAuthorizationServerMetadata(
-    authorizationServerUrl: string | URL,
-    options: DiscoverAuthorizationServerMetadataOptions = {}
-): Promise<AuthorizationServerMetadata | undefined> {
-    return discoverAuthorizationServerMetadataInternal(authorizationServerUrl, options);
 }
 
 /**
@@ -2046,8 +2095,24 @@ export async function discoverOAuthServerInfo(
 
     const authorizationServerMetadata = await discoverAuthorizationServerMetadata(authorizationServerUrl, {
         fetchFn: opts?.fetchFn,
-        skipIssuerValidation: opts?.skipIssuerMetadataValidation
+        validateIssuer: !opts?.skipIssuerMetadataValidation && authorizationServerUrlFromResourceMetadata
     });
+
+    if (!authorizationServerUrlFromResourceMetadata && authorizationServerMetadata) {
+        try {
+            const fallbackIssuer = normalizeDiscoveredIssuerIdentifier(authorizationServerUrl, 'Authorization server URL');
+            const metadataIssuer = normalizeDiscoveredIssuerIdentifier(
+                authorizationServerMetadata.issuer,
+                'Authorization server metadata issuer'
+            );
+            if (metadataIssuer !== fallbackIssuer) {
+                authorizationServerUrl = authorizationServerMetadata.issuer;
+            }
+        } catch {
+            // Legacy no-PRM discovery intentionally disables issuer validation. Keep the
+            // fallback MCP origin when legacy metadata has an unparseable issuer value.
+        }
+    }
 
     return {
         authorizationServerUrl,
@@ -2250,7 +2315,7 @@ export async function exchangeAuthorization(
          * Validated per RFC 9207 §2.4 against `metadata.issuer` before the code is
          * redeemed; see {@linkcode validateAuthorizationResponseIssuer}.
          */
-        iss?: string;
+        iss?: string | null;
         codeVerifier: string;
         redirectUri: string | URL;
         resource?: URL;
@@ -2371,7 +2436,7 @@ export async function fetchToken(
          * Validated per RFC 9207 §2.4 when `authorizationCode` is present;
          * see {@linkcode validateAuthorizationResponseIssuer}.
          */
-        iss?: string;
+        iss?: string | null;
         /** Optional scope parameter from auth() options */
         scope?: string;
         fetchFn?: FetchLike;

--- a/packages/client/src/client/auth.ts
+++ b/packages/client/src/client/auth.ts
@@ -1152,7 +1152,29 @@ async function authInternal(
         });
         authorizationServerUrl = serverInfo.authorizationServerUrl;
         metadata = serverInfo.authorizationServerMetadata;
-        validateAuthorizationServerMetadataIssuer(metadata, authorizationServerUrl);
+        try {
+            validateAuthorizationServerMetadataIssuer(metadata, authorizationServerUrl);
+        } catch (error) {
+            if (serverInfo.resourceMetadata?.authorization_servers?.length) {
+                throw error;
+            }
+            if (!metadata) {
+                throw error;
+            }
+
+            let legacyIssuerIsMalformed = false;
+            try {
+                normalizeDiscoveredIssuerIdentifier(metadata.issuer, 'Authorization server metadata issuer');
+            } catch {
+                // Legacy no-PRM discovery intentionally disables issuer validation. Keep the
+                // fallback MCP origin when legacy metadata has an unparseable issuer value.
+                legacyIssuerIsMalformed = true;
+            }
+
+            if (!legacyIssuerIsMalformed) {
+                throw error;
+            }
+        }
         resourceMetadata = serverInfo.resourceMetadata;
 
         // Captured now, persisted only after the SEP-2352 callback-leg gate below — so a

--- a/packages/client/src/client/auth.ts
+++ b/packages/client/src/client/auth.ts
@@ -1848,6 +1848,32 @@ export async function discoverAuthorizationServerMetadata(
 }
 
 /**
+ * Discovers authorization server metadata with support for
+ * {@link https://datatracker.ietf.org/doc/html/rfc8414 | RFC 8414} OAuth 2.0
+ * Authorization Server Metadata and
+ * {@link https://openid.net/specs/openid-connect-discovery-1_0.html | OpenID Connect Discovery 1.0}
+ * specifications.
+ *
+ * This function implements a fallback strategy for authorization server discovery:
+ * 1. Attempts RFC 8414 OAuth metadata discovery first
+ * 2. If OAuth discovery fails, falls back to OpenID Connect Discovery
+ *
+ * @param authorizationServerUrl - The authorization server URL obtained from the MCP Server's
+ *                                 protected resource metadata, or the MCP server's URL if the
+ *                                 metadata was not found.
+ * @param options - Configuration options
+ * @param options.fetchFn - Optional fetch function for making HTTP requests, defaults to global fetch
+ * @param options.protocolVersion - MCP protocol version to use, defaults to {@linkcode LATEST_PROTOCOL_VERSION}
+ * @returns Promise resolving to authorization server metadata, or undefined if discovery fails
+ */
+export async function discoverAuthorizationServerMetadata(
+    authorizationServerUrl: string | URL,
+    options: DiscoverAuthorizationServerMetadataOptions = {}
+): Promise<AuthorizationServerMetadata | undefined> {
+    return discoverAuthorizationServerMetadataInternal(authorizationServerUrl, options);
+}
+
+/**
  * Result of {@linkcode discoverOAuthServerInfo}.
  */
 export interface OAuthServerInfo {
@@ -1904,6 +1930,7 @@ export async function discoverOAuthServerInfo(
 ): Promise<OAuthServerInfo> {
     let resourceMetadata: OAuthProtectedResourceMetadata | undefined;
     let authorizationServerUrl: string | undefined;
+    let authorizationServerUrlFromResourceMetadata = false;
 
     try {
         resourceMetadata = await discoverOAuthProtectedResourceMetadata(
@@ -1913,6 +1940,7 @@ export async function discoverOAuthServerInfo(
         );
         if (resourceMetadata.authorization_servers && resourceMetadata.authorization_servers.length > 0) {
             authorizationServerUrl = resourceMetadata.authorization_servers[0];
+            authorizationServerUrlFromResourceMetadata = true;
         }
     } catch (error) {
         // Network failures (DNS, connection refused) surface as TypeError from fetch. Those are

--- a/packages/client/src/client/auth.ts
+++ b/packages/client/src/client/auth.ts
@@ -954,8 +954,13 @@ export interface AuthOptions {
     forceReauthorization?: boolean;
 }
 
-function normalizeDiscoveredIssuerIdentifier(issuer: string | URL): string {
-    const normalized = new URL(issuer).toString();
+function normalizeDiscoveredIssuerIdentifier(issuer: string | URL, label: string): string {
+    let normalized: string;
+    try {
+        normalized = new URL(issuer).toString();
+    } catch {
+        throw new Error(`${label} is not a valid issuer identifier: got ${String(issuer)} (RFC 8414 Section 3.3)`);
+    }
 
     return normalized.endsWith('/') ? normalized.slice(0, -1) : normalized;
 }
@@ -965,8 +970,8 @@ function validateAuthorizationServerMetadataIssuer(metadata: { issuer: string } 
         return;
     }
 
-    const expectedIssuer = normalizeDiscoveredIssuerIdentifier(authorizationServerUrl);
-    const actualIssuer = normalizeDiscoveredIssuerIdentifier(metadata.issuer);
+    const expectedIssuer = normalizeDiscoveredIssuerIdentifier(authorizationServerUrl, 'Authorization server URL');
+    const actualIssuer = normalizeDiscoveredIssuerIdentifier(metadata.issuer, 'Authorization server metadata issuer');
 
     if (actualIssuer !== expectedIssuer) {
         throw new Error(

--- a/packages/client/src/client/authErrors.ts
+++ b/packages/client/src/client/authErrors.ts
@@ -53,9 +53,29 @@ export class IssuerMismatchError extends OAuthClientFlowError {
     readonly received: string | undefined;
 
     constructor(kind: 'metadata' | 'authorization_response', expected: string | undefined, received: string | undefined) {
-        const where = kind === 'metadata' ? 'authorization server metadata (RFC 8414 §3.3)' : 'authorization response (RFC 9207)';
         // JSON-stringify embedded values so attacker-supplied control characters cannot forge log lines.
-        super(`Issuer mismatch in ${where}: expected ${JSON.stringify(expected)}, received ${JSON.stringify(received)}`);
+        let message: string;
+        if (kind === 'authorization_response') {
+            if (received === undefined) {
+                message =
+                    'Authorization server metadata advertises authorization_response_iss_parameter_supported, ' +
+                    'but the authorization response did not include an iss parameter (RFC 9207)';
+            } else if (expected === undefined) {
+                message =
+                    'Authorization response included an iss parameter, but no authorization server metadata was recorded ' +
+                    'to validate it against (RFC 9207)';
+            } else {
+                message =
+                    'Authorization response iss parameter does not match the expected issuer: ' +
+                    `expected ${JSON.stringify(expected)}, got ${JSON.stringify(received)} (RFC 9207). ` +
+                    'The authorization response must not be processed.';
+            }
+        } else {
+            message = `Issuer mismatch in authorization server metadata (RFC 8414 §3.3): expected ${JSON.stringify(
+                expected
+            )}, received ${JSON.stringify(received)}`;
+        }
+        super(message);
         this.kind = kind;
         this.expected = expected;
         this.received = received;

--- a/packages/client/src/client/crossAppAccess.ts
+++ b/packages/client/src/client/crossAppAccess.ts
@@ -205,8 +205,8 @@ export async function requestJwtAuthorizationGrant(options: RequestJwtAuthGrantO
 export async function discoverAndRequestJwtAuthGrant(options: DiscoverAndRequestJwtAuthGrantOptions): Promise<JwtAuthGrantResult> {
     const { idpUrl, fetchFn = fetch, ...restOptions } = options;
 
-    // Discover IdP's authorization server metadata
-    const metadata = await discoverAuthorizationServerMetadata(String(idpUrl), { fetchFn });
+    // Enterprise IdP URLs are caller-configured and may be aliases for a canonical issuer.
+    const metadata = await discoverAuthorizationServerMetadata(String(idpUrl), { fetchFn, validateIssuer: false });
 
     if (!metadata?.token_endpoint) {
         throw new Error(`Failed to discover token endpoint for IdP: ${idpUrl}`);

--- a/packages/client/src/client/sse.ts
+++ b/packages/client/src/client/sse.ts
@@ -269,8 +269,8 @@ export class SSEClientTransport implements Transport {
      * @param iss - The form-urldecoded `iss` query parameter from the same callback URL, if
      *   present. Validated per RFC 9207 against the recorded issuer before the code is redeemed.
      */
-    async finishAuth(authorizationCode: string, iss?: string): Promise<void>;
-    async finishAuth(codeOrParams: string | URLSearchParams, iss?: string): Promise<void> {
+    async finishAuth(authorizationCode: string, iss?: string | null | { iss?: string | null }): Promise<void>;
+    async finishAuth(codeOrParams: string | URLSearchParams, iss?: string | null | { iss?: string | null }): Promise<void> {
         if (!this._oauthProvider) {
             throw new UnauthorizedError('finishAuth requires an OAuthClientProvider');
         }

--- a/packages/client/src/client/sse.ts
+++ b/packages/client/src/client/sse.ts
@@ -269,7 +269,7 @@ export class SSEClientTransport implements Transport {
      * @param iss - The form-urldecoded `iss` query parameter from the same callback URL, if
      *   present. Pass `null` to assert that the callback was inspected and carried no `iss`;
      *   when the authorization server advertises `authorization_response_iss_parameter_supported:
-     *   true`, that observed absence is rejected with {@linkcode IssuerMismatchError}. Omit this
+     *   true`, that observed absence is rejected with `IssuerMismatchError`. Omit this
      *   argument, or pass `undefined`, only when the caller does not have the full callback
      *   parameters; that preserves the legacy `finishAuth(code)` behavior and skips RFC 9207
      *   authorization-response validation. Non-null values are validated against the recorded

--- a/packages/client/src/client/sse.ts
+++ b/packages/client/src/client/sse.ts
@@ -267,7 +267,13 @@ export class SSEClientTransport implements Transport {
     /**
      * @param authorizationCode - The `code` query parameter from the authorization callback URL.
      * @param iss - The form-urldecoded `iss` query parameter from the same callback URL, if
-     *   present. Validated per RFC 9207 against the recorded issuer before the code is redeemed.
+     *   present. Pass `null` to assert that the callback was inspected and carried no `iss`;
+     *   when the authorization server advertises `authorization_response_iss_parameter_supported:
+     *   true`, that observed absence is rejected with {@linkcode IssuerMismatchError}. Omit this
+     *   argument, or pass `undefined`, only when the caller does not have the full callback
+     *   parameters; that preserves the legacy `finishAuth(code)` behavior and skips RFC 9207
+     *   authorization-response validation. Non-null values are validated against the recorded
+     *   issuer before the code is redeemed.
      */
     async finishAuth(authorizationCode: string, iss?: string | null | { iss?: string | null }): Promise<void>;
     async finishAuth(codeOrParams: string | URLSearchParams, iss?: string | null | { iss?: string | null }): Promise<void> {

--- a/packages/client/src/client/streamableHttp.ts
+++ b/packages/client/src/client/streamableHttp.ts
@@ -851,8 +851,8 @@ export class StreamableHTTPClientTransport implements Transport {
      *   When the authorization server advertises `authorization_response_iss_parameter_supported: true`,
      *   omitting this causes the exchange to be **rejected** with {@linkcode IssuerMismatchError}.
      */
-    async finishAuth(authorizationCode: string, iss?: string): Promise<void>;
-    async finishAuth(codeOrParams: string | URLSearchParams, iss?: string): Promise<void> {
+    async finishAuth(authorizationCode: string, iss?: string | null | { iss?: string | null }): Promise<void>;
+    async finishAuth(codeOrParams: string | URLSearchParams, iss?: string | null | { iss?: string | null }): Promise<void> {
         if (!this._oauthProvider) {
             throw new UnauthorizedError('finishAuth requires an OAuthClientProvider');
         }

--- a/packages/client/src/client/streamableHttp.ts
+++ b/packages/client/src/client/streamableHttp.ts
@@ -847,9 +847,13 @@ export class StreamableHTTPClientTransport implements Transport {
     /**
      * @param authorizationCode - The `code` query parameter from the authorization callback URL.
      * @param iss - The form-urldecoded `iss` query parameter from the same callback URL, if
-     *   present. Validated per RFC 9207 against the recorded issuer before the code is redeemed.
-     *   When the authorization server advertises `authorization_response_iss_parameter_supported: true`,
-     *   omitting this causes the exchange to be **rejected** with {@linkcode IssuerMismatchError}.
+     *   present. Pass `null` to assert that the callback was inspected and carried no `iss`;
+     *   when the authorization server advertises `authorization_response_iss_parameter_supported:
+     *   true`, that observed absence is rejected with {@linkcode IssuerMismatchError}. Omit this
+     *   argument, or pass `undefined`, only when the caller does not have the full callback
+     *   parameters; that preserves the legacy `finishAuth(code)` behavior and skips RFC 9207
+     *   authorization-response validation. Non-null values are validated against the recorded
+     *   issuer before the code is redeemed.
      */
     async finishAuth(authorizationCode: string, iss?: string | null | { iss?: string | null }): Promise<void>;
     async finishAuth(codeOrParams: string | URLSearchParams, iss?: string | null | { iss?: string | null }): Promise<void> {

--- a/packages/client/src/client/streamableHttp.ts
+++ b/packages/client/src/client/streamableHttp.ts
@@ -849,7 +849,7 @@ export class StreamableHTTPClientTransport implements Transport {
      * @param iss - The form-urldecoded `iss` query parameter from the same callback URL, if
      *   present. Pass `null` to assert that the callback was inspected and carried no `iss`;
      *   when the authorization server advertises `authorization_response_iss_parameter_supported:
-     *   true`, that observed absence is rejected with {@linkcode IssuerMismatchError}. Omit this
+     *   true`, that observed absence is rejected with `IssuerMismatchError`. Omit this
      *   argument, or pass `undefined`, only when the caller does not have the full callback
      *   parameters; that preserves the legacy `finishAuth(code)` behavior and skips RFC 9207
      *   authorization-response validation. Non-null values are validated against the recorded

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -9,6 +9,8 @@
 export type {
     AddClientAuthentication,
     AuthOptions,
+    AuthorizationResponseIssuerMetadata,
+    AuthorizationResponseIssuerValidation,
     AuthProvider,
     AuthResult,
     ClientAuthMethod,

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -12,6 +12,7 @@ export type {
     AuthProvider,
     AuthResult,
     ClientAuthMethod,
+    DiscoverAuthorizationServerMetadataOptions,
     OAuthClientInformationContext,
     OAuthClientProvider,
     OAuthDiscoveryState,

--- a/packages/client/test/client/auth.test.ts
+++ b/packages/client/test/client/auth.test.ts
@@ -3004,6 +3004,84 @@ describe('OAuth Authorization', () => {
             expect(authUrl.origin + authUrl.pathname).toBe('https://auth.example.com/oauth/authorize');
         });
 
+        it('keeps the fallback MCP origin when legacy no-PRM auth metadata has an invalid issuer', async () => {
+            const saveDiscoveryState = vi.fn();
+            const saveAuthorizationServerUrl = vi.fn();
+            const provider: OAuthClientProvider = {
+                ...mockProvider,
+                clientInformation: vi.fn().mockResolvedValue(undefined),
+                tokens: vi.fn().mockResolvedValue(undefined),
+                saveClientInformation: vi.fn(),
+                saveCodeVerifier: vi.fn(),
+                redirectToAuthorization: vi.fn(),
+                saveDiscoveryState,
+                saveAuthorizationServerUrl
+            };
+
+            mockFetch.mockImplementation(url => {
+                const urlString = url.toString();
+
+                if (urlString.includes('/.well-known/oauth-protected-resource')) {
+                    return Promise.resolve({
+                        ok: false,
+                        status: 404
+                    });
+                }
+
+                if (urlString === 'https://resource.example.com/.well-known/oauth-authorization-server') {
+                    return Promise.resolve({
+                        ok: true,
+                        status: 200,
+                        json: async () => ({
+                            issuer: 'auth.example.com',
+                            authorization_endpoint: 'https://auth.example.com/oauth/authorize',
+                            token_endpoint: 'https://auth.example.com/oauth/token',
+                            registration_endpoint: 'https://auth.example.com/oauth/register',
+                            response_types_supported: ['code'],
+                            code_challenge_methods_supported: ['S256']
+                        })
+                    });
+                }
+
+                if (urlString === 'https://auth.example.com/oauth/register') {
+                    return Promise.resolve({
+                        ok: true,
+                        status: 200,
+                        json: async () => ({
+                            client_id: 'test-client-id',
+                            client_secret: 'test-client-secret',
+                            client_id_issued_at: 1_612_137_600,
+                            client_secret_expires_at: 1_612_224_000,
+                            redirect_uris: ['http://localhost:3000/callback'],
+                            client_name: 'Test Client'
+                        })
+                    });
+                }
+
+                return Promise.reject(new Error(`Unexpected fetch call: ${urlString}`));
+            });
+
+            const result = await auth(provider, {
+                serverUrl: 'https://resource.example.com'
+            });
+
+            expect(result).toBe('REDIRECT');
+            expect(saveDiscoveryState).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    authorizationServerUrl: 'https://resource.example.com/',
+                    resourceMetadata: undefined,
+                    authorizationServerMetadata: expect.objectContaining({
+                        issuer: 'auth.example.com'
+                    })
+                })
+            );
+            expect(saveAuthorizationServerUrl).toHaveBeenCalledWith('https://resource.example.com/');
+
+            const redirectCall = (provider.redirectToAuthorization as Mock).mock.calls[0]!;
+            const authUrl: URL = redirectCall[0];
+            expect(authUrl.origin + authUrl.pathname).toBe('https://auth.example.com/oauth/authorize');
+        });
+
         it('uses base URL (with root path) as authorization server when protected-resource-metadata discovery fails', async () => {
             // Setup: First call to protected resource metadata fails (404)
             // When no authorization_servers are found in protected resource metadata,

--- a/packages/client/test/client/auth.test.ts
+++ b/packages/client/test/client/auth.test.ts
@@ -1416,6 +1416,43 @@ describe('OAuth Authorization', () => {
             expect(result.authorizationServerMetadata).toBeDefined();
         });
 
+        it('uses legacy fallback metadata issuer when it differs from the MCP origin', async () => {
+            const legacyAuthMetadata = {
+                ...validAuthMetadata,
+                issuer: 'https://auth.example.com/oauth',
+                authorization_endpoint: 'https://auth.example.com/oauth/authorize',
+                token_endpoint: 'https://auth.example.com/oauth/token'
+            };
+
+            mockFetch.mockImplementation(url => {
+                const urlString = url.toString();
+
+                if (urlString.includes('/.well-known/oauth-protected-resource')) {
+                    return Promise.resolve({
+                        ok: false,
+                        status: 404
+                    });
+                }
+
+                if (urlString.includes('/.well-known/oauth-authorization-server')) {
+                    return Promise.resolve({
+                        ok: true,
+                        status: 200,
+                        json: async () => legacyAuthMetadata
+                    });
+                }
+
+                return Promise.reject(new Error(`Unexpected fetch: ${urlString}`));
+            });
+
+            const result = await discoverOAuthServerInfo('https://resource.example.com');
+
+            expect(result.authorizationServerUrl).toBe('https://auth.example.com/oauth');
+            expect(result.resourceMetadata).toBeUndefined();
+            expect(result.authorizationServerMetadata).toEqual(legacyAuthMetadata);
+            expect(mockFetch.mock.calls[1]![0].toString()).toBe('https://resource.example.com/.well-known/oauth-authorization-server');
+        });
+
         it('forwards resourceMetadataUrl override to protected resource metadata discovery', async () => {
             const overrideUrl = new URL('https://custom.example.com/.well-known/oauth-protected-resource');
 
@@ -2777,6 +2814,84 @@ describe('OAuth Authorization', () => {
 
             // Second call should be to oauth metadata at the root path
             expect(mockFetch.mock.calls[1]![0].toString()).toBe('https://resource.example.com/.well-known/oauth-authorization-server');
+        });
+
+        it('saves the metadata issuer as the AS URL for legacy no-PRM fallback', async () => {
+            const saveDiscoveryState = vi.fn();
+            const saveAuthorizationServerUrl = vi.fn();
+            const provider: OAuthClientProvider = {
+                ...mockProvider,
+                clientInformation: vi.fn().mockResolvedValue(undefined),
+                tokens: vi.fn().mockResolvedValue(undefined),
+                saveClientInformation: vi.fn(),
+                saveCodeVerifier: vi.fn(),
+                redirectToAuthorization: vi.fn(),
+                saveDiscoveryState,
+                saveAuthorizationServerUrl
+            };
+
+            mockFetch.mockImplementation(url => {
+                const urlString = url.toString();
+
+                if (urlString.includes('/.well-known/oauth-protected-resource')) {
+                    return Promise.resolve({
+                        ok: false,
+                        status: 404
+                    });
+                }
+
+                if (urlString === 'https://resource.example.com/.well-known/oauth-authorization-server') {
+                    return Promise.resolve({
+                        ok: true,
+                        status: 200,
+                        json: async () => ({
+                            issuer: 'https://auth.example.com/oauth',
+                            authorization_endpoint: 'https://auth.example.com/oauth/authorize',
+                            token_endpoint: 'https://auth.example.com/oauth/token',
+                            registration_endpoint: 'https://auth.example.com/oauth/register',
+                            response_types_supported: ['code'],
+                            code_challenge_methods_supported: ['S256']
+                        })
+                    });
+                }
+
+                if (urlString === 'https://auth.example.com/oauth/register') {
+                    return Promise.resolve({
+                        ok: true,
+                        status: 200,
+                        json: async () => ({
+                            client_id: 'test-client-id',
+                            client_secret: 'test-client-secret',
+                            client_id_issued_at: 1_612_137_600,
+                            client_secret_expires_at: 1_612_224_000,
+                            redirect_uris: ['http://localhost:3000/callback'],
+                            client_name: 'Test Client'
+                        })
+                    });
+                }
+
+                return Promise.reject(new Error(`Unexpected fetch call: ${urlString}`));
+            });
+
+            const result = await auth(provider, {
+                serverUrl: 'https://resource.example.com'
+            });
+
+            expect(result).toBe('REDIRECT');
+            expect(saveDiscoveryState).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    authorizationServerUrl: 'https://auth.example.com/oauth',
+                    resourceMetadata: undefined,
+                    authorizationServerMetadata: expect.objectContaining({
+                        issuer: 'https://auth.example.com/oauth'
+                    })
+                })
+            );
+            expect(saveAuthorizationServerUrl).toHaveBeenCalledWith('https://auth.example.com/oauth');
+
+            const redirectCall = (provider.redirectToAuthorization as Mock).mock.calls[0]!;
+            const authUrl: URL = redirectCall[0];
+            expect(authUrl.origin + authUrl.pathname).toBe('https://auth.example.com/oauth/authorize');
         });
 
         it('uses base URL (with root path) as authorization server when protected-resource-metadata discovery fails', async () => {

--- a/packages/client/test/client/auth.test.ts
+++ b/packages/client/test/client/auth.test.ts
@@ -5060,11 +5060,22 @@ describe('SEP-2468: RFC 9207 authorization response iss validation', () => {
     const issuer = 'https://auth.example.com';
 
     describe('validateAuthorizationResponseIssuer', () => {
-        // RFC 9207 Section 2.4, row 1: advertised but absent -> reject
-        it('rejects when the AS advertises iss support but the response lacks iss', () => {
+        // RFC 9207 Section 2.4, row 1: advertised but absent -> reject. The caller signals
+        // "I inspected the authorization response and it had no iss" by passing null.
+        it('rejects when the AS advertises iss support but the inspected response lacks iss (null)', () => {
+            expect(() =>
+                validateAuthorizationResponseIssuer({ issuer, authorization_response_iss_parameter_supported: true }, null)
+            ).toThrow(/did not include an iss parameter/);
+        });
+
+        // undefined means the caller never had access to the authorization response
+        // parameters, so the SDK cannot fail closed on the caller's behalf.
+        it('skips validation entirely when the caller provides no response parameters (undefined)', () => {
             expect(() =>
                 validateAuthorizationResponseIssuer({ issuer, authorization_response_iss_parameter_supported: true }, undefined)
-            ).toThrow(/did not include an iss parameter/);
+            ).not.toThrow();
+            expect(() => validateAuthorizationResponseIssuer({ issuer }, undefined)).not.toThrow();
+            expect(() => validateAuthorizationResponseIssuer(undefined, undefined)).not.toThrow();
         });
 
         // RFC 9207 Section 2.4, row 2: present (advertised) -> exact match required
@@ -5100,15 +5111,15 @@ describe('SEP-2468: RFC 9207 authorization response iss validation', () => {
         });
 
         // RFC 9207 Section 2.4, row 3: neither advertised nor present -> proceed
-        it('proceeds when iss support is not advertised and no iss is present', () => {
-            expect(() => validateAuthorizationResponseIssuer({ issuer }, undefined)).not.toThrow();
+        it('proceeds when iss support is not advertised and the inspected response has no iss', () => {
+            expect(() => validateAuthorizationResponseIssuer({ issuer }, null)).not.toThrow();
             expect(() =>
-                validateAuthorizationResponseIssuer({ issuer, authorization_response_iss_parameter_supported: false }, undefined)
+                validateAuthorizationResponseIssuer({ issuer, authorization_response_iss_parameter_supported: false }, null)
             ).not.toThrow();
         });
 
-        it('proceeds when no metadata is recorded and no iss is present', () => {
-            expect(() => validateAuthorizationResponseIssuer(undefined, undefined)).not.toThrow();
+        it('proceeds when no metadata is recorded and the inspected response has no iss', () => {
+            expect(() => validateAuthorizationResponseIssuer(undefined, null)).not.toThrow();
         });
 
         it('rejects when an iss is present but no metadata was recorded to validate against', () => {
@@ -5212,17 +5223,32 @@ describe('SEP-2468: RFC 9207 authorization response iss validation', () => {
             expect(provider.saveTokens).not.toHaveBeenCalled();
         });
 
-        it('rejects when the AS advertises iss support but no iss is provided', async () => {
+        it('rejects when the AS advertises iss support and the caller reports a response without iss (null)', async () => {
             const provider = createMockProvider();
 
             await expect(
                 auth(provider, {
                     serverUrl: 'https://resource.example.com',
-                    authorizationCode: 'code123'
+                    authorizationCode: 'code123',
+                    iss: null
                 })
             ).rejects.toThrow(/did not include an iss parameter/);
 
             expect(tokenEndpointCalls()).toHaveLength(0);
+        });
+
+        it('proceeds when iss is omitted entirely, even when the AS advertises support', async () => {
+            // Callers that never had access to the authorization response (legacy
+            // finishAuth(code) plumbing) must not be failed closed on their behalf.
+            const provider = createMockProvider();
+
+            const result = await auth(provider, {
+                serverUrl: 'https://resource.example.com',
+                authorizationCode: 'code123'
+            });
+
+            expect(result).toBe('AUTHORIZED');
+            expect(tokenEndpointCalls()).toHaveLength(1);
         });
 
         it('proceeds without an iss when the AS does not advertise support', async () => {

--- a/packages/client/test/client/auth.test.ts
+++ b/packages/client/test/client/auth.test.ts
@@ -5055,3 +5055,223 @@ describe('OAuth Authorization', () => {
         });
     });
 });
+
+describe('SEP-2468: RFC 9207 authorization response iss validation', () => {
+    const issuer = 'https://auth.example.com';
+
+    describe('validateAuthorizationResponseIssuer', () => {
+        // RFC 9207 Section 2.4, row 1: advertised but absent -> reject
+        it('rejects when the AS advertises iss support but the response lacks iss', () => {
+            expect(() =>
+                validateAuthorizationResponseIssuer({ issuer, authorization_response_iss_parameter_supported: true }, undefined)
+            ).toThrow(/did not include an iss parameter/);
+        });
+
+        // RFC 9207 Section 2.4, row 2: present (advertised) -> exact match required
+        it('accepts an exactly matching iss when support is advertised', () => {
+            expect(() =>
+                validateAuthorizationResponseIssuer({ issuer, authorization_response_iss_parameter_supported: true }, issuer)
+            ).not.toThrow();
+        });
+
+        // RFC 9207 Section 2.4, row 2: present even without advertisement -> still compared
+        it('accepts an exactly matching iss even when support is not advertised', () => {
+            expect(() => validateAuthorizationResponseIssuer({ issuer }, issuer)).not.toThrow();
+        });
+
+        it('rejects a mismatched iss regardless of advertisement', () => {
+            expect(() => validateAuthorizationResponseIssuer({ issuer }, 'https://attacker.example.com')).toThrow(
+                /does not match the expected issuer/
+            );
+            expect(() =>
+                validateAuthorizationResponseIssuer(
+                    { issuer, authorization_response_iss_parameter_supported: true },
+                    'https://attacker.example.com'
+                )
+            ).toThrow(/does not match the expected issuer/);
+        });
+
+        it('uses exact string comparison with no normalization', () => {
+            // Trailing slash and case differences are equivalent URLs but MUST be rejected
+            expect(() => validateAuthorizationResponseIssuer({ issuer }, `${issuer}/`)).toThrow(/does not match the expected issuer/);
+            expect(() => validateAuthorizationResponseIssuer({ issuer }, 'https://AUTH.example.com')).toThrow(
+                /does not match the expected issuer/
+            );
+        });
+
+        // RFC 9207 Section 2.4, row 3: neither advertised nor present -> proceed
+        it('proceeds when iss support is not advertised and no iss is present', () => {
+            expect(() => validateAuthorizationResponseIssuer({ issuer }, undefined)).not.toThrow();
+            expect(() =>
+                validateAuthorizationResponseIssuer({ issuer, authorization_response_iss_parameter_supported: false }, undefined)
+            ).not.toThrow();
+        });
+
+        it('proceeds when no metadata is recorded and no iss is present', () => {
+            expect(() => validateAuthorizationResponseIssuer(undefined, undefined)).not.toThrow();
+        });
+
+        it('rejects when an iss is present but no metadata was recorded to validate against', () => {
+            expect(() => validateAuthorizationResponseIssuer(undefined, issuer)).toThrow(/no authorization server metadata was recorded/);
+        });
+    });
+
+    describe('auth() with an authorization code', () => {
+        const resourceMetadata = {
+            resource: 'https://resource.example.com',
+            authorization_servers: [issuer]
+        };
+
+        const authServerMetadata: AuthorizationServerMetadata = {
+            issuer,
+            authorization_endpoint: `${issuer}/authorize`,
+            token_endpoint: `${issuer}/token`,
+            response_types_supported: ['code'],
+            code_challenge_methods_supported: ['S256'],
+            authorization_response_iss_parameter_supported: true
+        };
+
+        function createMockProvider(metadata: AuthorizationServerMetadata = authServerMetadata): OAuthClientProvider {
+            return {
+                get redirectUrl() {
+                    return 'http://localhost:3000/callback';
+                },
+                get clientMetadata() {
+                    return {
+                        redirect_uris: ['http://localhost:3000/callback'],
+                        client_name: 'Test Client'
+                    };
+                },
+                clientInformation: vi.fn().mockResolvedValue({
+                    client_id: 'test-client-id',
+                    client_secret: 'test-client-secret'
+                }),
+                tokens: vi.fn().mockResolvedValue(undefined),
+                saveTokens: vi.fn(),
+                redirectToAuthorization: vi.fn(),
+                saveCodeVerifier: vi.fn(),
+                codeVerifier: vi.fn().mockResolvedValue('test-verifier'),
+                // Discovery state recorded before the redirect, including the validated issuer
+                discoveryState: vi.fn().mockResolvedValue({
+                    authorizationServerUrl: issuer,
+                    resourceMetadata,
+                    authorizationServerMetadata: metadata
+                })
+            };
+        }
+
+        beforeEach(() => {
+            mockFetch.mockReset();
+            mockFetch.mockImplementation(url => {
+                const urlString = url.toString();
+                if (urlString.includes('/token')) {
+                    return Promise.resolve({
+                        ok: true,
+                        status: 200,
+                        json: async () => ({
+                            access_token: 'access123',
+                            token_type: 'Bearer',
+                            expires_in: 3600
+                        })
+                    });
+                }
+                return Promise.reject(new Error(`Unexpected fetch: ${urlString}`));
+            });
+        });
+
+        function tokenEndpointCalls(): unknown[][] {
+            return mockFetch.mock.calls.filter(call => call[0].toString().includes('/token'));
+        }
+
+        it('exchanges the code when the response iss matches the recorded issuer', async () => {
+            const provider = createMockProvider();
+
+            const result = await auth(provider, {
+                serverUrl: 'https://resource.example.com',
+                authorizationCode: 'code123',
+                iss: issuer
+            });
+
+            expect(result).toBe('AUTHORIZED');
+            expect(tokenEndpointCalls()).toHaveLength(1);
+            expect(provider.saveTokens).toHaveBeenCalled();
+        });
+
+        it('rejects a mismatched iss before the code reaches any token endpoint', async () => {
+            const provider = createMockProvider();
+
+            await expect(
+                auth(provider, {
+                    serverUrl: 'https://resource.example.com',
+                    authorizationCode: 'code123',
+                    iss: 'https://attacker.example.com'
+                })
+            ).rejects.toThrow(/does not match the expected issuer/);
+
+            expect(tokenEndpointCalls()).toHaveLength(0);
+            expect(provider.saveTokens).not.toHaveBeenCalled();
+        });
+
+        it('rejects when the AS advertises iss support but no iss is provided', async () => {
+            const provider = createMockProvider();
+
+            await expect(
+                auth(provider, {
+                    serverUrl: 'https://resource.example.com',
+                    authorizationCode: 'code123'
+                })
+            ).rejects.toThrow(/did not include an iss parameter/);
+
+            expect(tokenEndpointCalls()).toHaveLength(0);
+        });
+
+        it('proceeds without an iss when the AS does not advertise support', async () => {
+            const provider = createMockProvider({
+                ...authServerMetadata,
+                authorization_response_iss_parameter_supported: undefined
+            });
+
+            const result = await auth(provider, {
+                serverUrl: 'https://resource.example.com',
+                authorizationCode: 'code123'
+            });
+
+            expect(result).toBe('AUTHORIZED');
+            expect(tokenEndpointCalls()).toHaveLength(1);
+        });
+
+        it('does not surface error content from a mismatched-issuer error response', async () => {
+            // RFC 9207: on issuer mismatch the client MUST NOT process the rest of the
+            // authorization response — including error/error_description parameters.
+            // Simulate a forged callback carrying both a mismatched iss and attacker-
+            // controlled error content alongside the code.
+            const forgedAuthorizationResponse = {
+                code: 'code123',
+                iss: 'https://attacker.example.com',
+                error: 'access_denied',
+                error_description: 'ATTACKER CONTROLLED MESSAGE'
+            };
+
+            const provider = createMockProvider();
+
+            const error = await auth(provider, {
+                serverUrl: 'https://resource.example.com',
+                authorizationCode: forgedAuthorizationResponse.code,
+                iss: forgedAuthorizationResponse.iss
+            }).then(
+                () => {
+                    throw new Error('expected auth() to reject');
+                },
+                (e: unknown) => e as Error
+            );
+
+            // Rejected for the issuer mismatch, without echoing the forged error params
+            expect(error.message).toMatch(/does not match the expected issuer/);
+            expect(error.message).not.toContain(forgedAuthorizationResponse.error_description);
+            expect(error.message).not.toContain('access_denied');
+
+            // And the code was never sent to a token endpoint
+            expect(tokenEndpointCalls()).toHaveLength(0);
+        });
+    });
+});

--- a/packages/client/test/client/auth.test.ts
+++ b/packages/client/test/client/auth.test.ts
@@ -977,6 +977,14 @@ describe('OAuth Authorization', () => {
             code_challenge_methods_supported: ['S256']
         };
 
+        const validOpenIdTenantMetadata = {
+            ...validOpenIdMetadata,
+            issuer: 'https://auth.example.com/tenant1',
+            authorization_endpoint: 'https://auth.example.com/tenant1/authorize',
+            token_endpoint: 'https://auth.example.com/tenant1/token',
+            jwks_uri: 'https://auth.example.com/tenant1/jwks'
+        };
+
         it('tries URLs in order and returns first successful metadata', async () => {
             const tenantOidcMetadata = { ...validOpenIdMetadata, issuer: 'https://auth.example.com/tenant1' };
             // First OAuth URL (path before well-known) fails with 404
@@ -5218,6 +5226,24 @@ describe('SEP-2468: RFC 9207 authorization response iss validation', () => {
                     iss: 'https://attacker.example.com'
                 })
             ).rejects.toThrow(/does not match the expected issuer/);
+
+            expect(tokenEndpointCalls()).toHaveLength(0);
+            expect(provider.saveTokens).not.toHaveBeenCalled();
+        });
+
+        it('rejects cached AS metadata with a mismatched issuer before code exchange', async () => {
+            const provider = createMockProvider({
+                ...authServerMetadata,
+                issuer: 'https://attacker.example.com'
+            });
+
+            await expect(
+                auth(provider, {
+                    serverUrl: 'https://resource.example.com',
+                    authorizationCode: 'code123',
+                    iss: 'https://attacker.example.com'
+                })
+            ).rejects.toThrow(/Authorization server metadata issuer does not match the expected issuer/);
 
             expect(tokenEndpointCalls()).toHaveLength(0);
             expect(provider.saveTokens).not.toHaveBeenCalled();

--- a/packages/client/test/client/auth.test.ts
+++ b/packages/client/test/client/auth.test.ts
@@ -1453,6 +1453,42 @@ describe('OAuth Authorization', () => {
             expect(mockFetch.mock.calls[1]![0].toString()).toBe('https://resource.example.com/.well-known/oauth-authorization-server');
         });
 
+        it('keeps the legacy fallback MCP origin when unvalidated metadata has an invalid issuer', async () => {
+            const legacyAuthMetadata = {
+                ...validAuthMetadata,
+                issuer: 'auth.example.com',
+                authorization_endpoint: 'https://resource.example.com/authorize',
+                token_endpoint: 'https://resource.example.com/token'
+            };
+
+            mockFetch.mockImplementation(url => {
+                const urlString = url.toString();
+
+                if (urlString.includes('/.well-known/oauth-protected-resource')) {
+                    return Promise.resolve({
+                        ok: false,
+                        status: 404
+                    });
+                }
+
+                if (urlString.includes('/.well-known/oauth-authorization-server')) {
+                    return Promise.resolve({
+                        ok: true,
+                        status: 200,
+                        json: async () => legacyAuthMetadata
+                    });
+                }
+
+                return Promise.reject(new Error(`Unexpected fetch: ${urlString}`));
+            });
+
+            const result = await discoverOAuthServerInfo('https://resource.example.com');
+
+            expect(result.authorizationServerUrl).toBe('https://resource.example.com/');
+            expect(result.resourceMetadata).toBeUndefined();
+            expect(result.authorizationServerMetadata).toEqual(legacyAuthMetadata);
+        });
+
         it('forwards resourceMetadataUrl override to protected resource metadata discovery', async () => {
             const overrideUrl = new URL('https://custom.example.com/.well-known/oauth-protected-resource');
 

--- a/packages/client/test/client/auth.test.ts
+++ b/packages/client/test/client/auth.test.ts
@@ -5552,6 +5552,35 @@ describe('SEP-2468: RFC 9207 authorization response iss validation', () => {
             expect(provider.saveTokens).not.toHaveBeenCalled();
         });
 
+        it('uses cached legacy no-PRM fallback metadata with an invalid issuer during code exchange', async () => {
+            const legacyAuthMetadata: AuthorizationServerMetadata = {
+                ...authServerMetadata,
+                issuer: 'auth.example.com',
+                authorization_endpoint: 'https://auth.example.com/oauth/authorize',
+                token_endpoint: 'https://auth.example.com/oauth/token'
+            };
+            const invalidateCredentials = vi.fn();
+            const provider: OAuthClientProvider = {
+                ...createMockProvider(legacyAuthMetadata),
+                discoveryState: vi.fn().mockResolvedValue({
+                    authorizationServerUrl: 'https://resource.example.com/',
+                    authorizationServerMetadata: legacyAuthMetadata
+                }),
+                invalidateCredentials
+            };
+
+            const result = await auth(provider, {
+                serverUrl: 'https://resource.example.com',
+                authorizationCode: 'code123'
+            });
+
+            expect(result).toBe('AUTHORIZED');
+            expect(invalidateCredentials).not.toHaveBeenCalled();
+            expect(tokenEndpointCalls()).toHaveLength(1);
+            expect(tokenEndpointCalls()[0]?.[0]?.toString()).toBe(legacyAuthMetadata.token_endpoint);
+            expect(provider.saveTokens).toHaveBeenCalled();
+        });
+
         it('rejects when the AS advertises iss support and the caller reports a response without iss (null)', async () => {
             const provider = createMockProvider();
 

--- a/packages/client/test/client/auth.test.ts
+++ b/packages/client/test/client/auth.test.ts
@@ -5439,6 +5439,17 @@ describe('SEP-2468: RFC 9207 authorization response iss validation', () => {
         it('rejects when an iss is present but no metadata was recorded to validate against', () => {
             expect(() => validateAuthorizationResponseIssuer(undefined, issuer)).toThrow(/no authorization server metadata was recorded/);
         });
+
+        it('uses the metadata overload when loose metadata includes an expectedIssuer extension key', () => {
+            const metadata = {
+                issuer,
+                authorization_response_iss_parameter_supported: true,
+                expectedIssuer: 'https://extension.example.com'
+            };
+
+            expect(() => validateAuthorizationResponseIssuer(metadata, 'https://attacker.example.com')).toThrow(IssuerMismatchError);
+            expect(() => validateAuthorizationResponseIssuer(metadata, null)).toThrow(/did not include an iss parameter/);
+        });
     });
 
     describe('auth() with an authorization code', () => {
@@ -5549,7 +5560,7 @@ describe('SEP-2468: RFC 9207 authorization response iss validation', () => {
                     authorizationCode: 'code123',
                     iss: 'https://attacker.example.com'
                 })
-            ).rejects.toThrow(/Authorization server metadata issuer does not match the expected issuer/);
+            ).rejects.toMatchObject({ name: 'IssuerMismatchError', kind: 'metadata' });
 
             expect(tokenEndpointCalls()).toHaveLength(0);
             expect(provider.saveTokens).not.toHaveBeenCalled();
@@ -5563,8 +5574,17 @@ describe('SEP-2468: RFC 9207 authorization response iss validation', () => {
                 token_endpoint: 'https://auth.example.com/oauth/token'
             };
             const invalidateCredentials = vi.fn();
+            const clientInformation = vi.fn(async (ctx?: { issuer?: string }) =>
+                ctx?.issuer === 'https://resource.example.com/'
+                    ? {
+                          client_id: 'test-client-id',
+                          client_secret: 'test-client-secret'
+                      }
+                    : undefined
+            );
             const provider: OAuthClientProvider = {
                 ...createMockProvider(legacyAuthMetadata),
+                clientInformation,
                 discoveryState: vi.fn().mockResolvedValue({
                     authorizationServerUrl: 'https://resource.example.com/',
                     authorizationServerMetadata: legacyAuthMetadata
@@ -5581,6 +5601,7 @@ describe('SEP-2468: RFC 9207 authorization response iss validation', () => {
             expect(invalidateCredentials).not.toHaveBeenCalled();
             expect(tokenEndpointCalls()).toHaveLength(1);
             expect(tokenEndpointCalls()[0]?.[0]?.toString()).toBe(legacyAuthMetadata.token_endpoint);
+            expect(clientInformation).not.toHaveBeenCalledWith({ issuer: legacyAuthMetadata.issuer });
             expect(provider.saveTokens).toHaveBeenCalled();
         });
 

--- a/packages/client/test/client/auth.test.ts
+++ b/packages/client/test/client/auth.test.ts
@@ -1690,6 +1690,80 @@ describe('OAuth Authorization', () => {
             );
         });
 
+        it('rediscovers stale legacy fallback state whose cached URL differs from the metadata issuer', async () => {
+            const legacyAuthMetadata = {
+                ...validAuthMetadata,
+                issuer: 'https://idp.example.com/oauth',
+                authorization_endpoint: 'https://idp.example.com/oauth/authorize',
+                token_endpoint: 'https://idp.example.com/oauth/token'
+            };
+            const invalidateCredentials = vi.fn();
+            const saveDiscoveryState = vi.fn();
+            const provider = createMockProvider({
+                discoveryState: vi.fn().mockResolvedValue({
+                    authorizationServerUrl: 'https://resource.example.com/',
+                    authorizationServerMetadata: legacyAuthMetadata
+                }),
+                invalidateCredentials,
+                saveDiscoveryState,
+                tokens: vi.fn().mockResolvedValue({
+                    access_token: 'valid-token',
+                    refresh_token: 'refresh-token',
+                    token_type: 'bearer'
+                })
+            });
+
+            mockFetch.mockImplementation(url => {
+                const urlString = url.toString();
+
+                if (urlString.includes('/.well-known/oauth-protected-resource')) {
+                    return Promise.resolve({
+                        ok: false,
+                        status: 404,
+                        text: async () => ''
+                    });
+                }
+
+                if (urlString === 'https://resource.example.com/.well-known/oauth-authorization-server') {
+                    return Promise.resolve({
+                        ok: true,
+                        status: 200,
+                        json: async () => legacyAuthMetadata
+                    });
+                }
+
+                if (urlString === legacyAuthMetadata.token_endpoint) {
+                    return Promise.resolve({
+                        ok: true,
+                        status: 200,
+                        json: async () => ({
+                            access_token: 'new-token',
+                            token_type: 'bearer',
+                            expires_in: 3600,
+                            refresh_token: 'new-refresh-token'
+                        })
+                    });
+                }
+
+                return Promise.reject(new Error(`Unexpected fetch: ${urlString}`));
+            });
+
+            const result = await auth(provider, { serverUrl: 'https://resource.example.com' });
+
+            expect(result).toBe('AUTHORIZED');
+            expect(invalidateCredentials).toHaveBeenCalledWith('discovery');
+            expect(saveDiscoveryState).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    authorizationServerUrl: legacyAuthMetadata.issuer,
+                    resourceMetadata: undefined,
+                    authorizationServerMetadata: legacyAuthMetadata
+                })
+            );
+
+            const tokenCall = mockFetch.mock.calls.find(call => call[0].toString() === legacyAuthMetadata.token_endpoint);
+            expect(tokenCall).toBeDefined();
+        });
+
         it('uses resourceMetadataUrl from cached discovery state for PRM discovery', async () => {
             const cachedPrmUrl = 'https://custom.example.com/.well-known/oauth-protected-resource';
             const provider = createMockProvider({

--- a/packages/client/test/client/auth.test.ts
+++ b/packages/client/test/client/auth.test.ts
@@ -1247,7 +1247,7 @@ describe('OAuth Authorization', () => {
         it.each([
             { label: 'row 1: supported + present + match → proceed', supported: true, iss: expectedIssuer, throws: false },
             { label: 'row 1: supported + present + mismatch → reject', supported: true, iss: 'https://attacker.example', throws: true },
-            { label: 'row 2: supported + absent → reject', supported: true, iss: undefined, throws: true },
+            { label: 'row 2: supported + inspected absent → reject', supported: true, iss: null, throws: true },
             { label: 'row 3: not advertised + present + match → proceed', supported: false, iss: expectedIssuer, throws: false },
             {
                 label: 'row 3: not advertised + present + mismatch → reject',
@@ -1255,7 +1255,7 @@ describe('OAuth Authorization', () => {
                 iss: 'https://attacker.example',
                 throws: true
             },
-            { label: 'row 4: not advertised + absent → proceed', supported: false, iss: undefined, throws: false }
+            { label: 'row 4: not advertised + inspected absent → proceed', supported: false, iss: null, throws: false }
         ])('$label', ({ supported, iss, throws }) => {
             const run = () => validateAuthorizationResponseIssuer({ iss, expectedIssuer, issParameterSupported: supported });
             if (throws) {
@@ -1284,13 +1284,16 @@ describe('OAuth Authorization', () => {
             );
         });
 
-        it('no-ops when there is no recorded issuer (no validated metadata)', () => {
-            expect(() =>
-                validateAuthorizationResponseIssuer({ iss: 'https://anything', expectedIssuer: undefined, issParameterSupported: true })
-            ).not.toThrow();
+        it('skips when no authorization-response parameters were supplied', () => {
             expect(() =>
                 validateAuthorizationResponseIssuer({ iss: undefined, expectedIssuer: undefined, issParameterSupported: true })
             ).not.toThrow();
+        });
+
+        it('rejects a present iss when there is no recorded issuer (no validated metadata)', () => {
+            expect(() =>
+                validateAuthorizationResponseIssuer({ iss: 'https://anything', expectedIssuer: undefined, issParameterSupported: true })
+            ).toThrow(IssuerMismatchError);
         });
 
         it('IssuerMismatchError JSON-encodes received value (log-injection guard)', () => {

--- a/packages/client/test/client/auth.test.ts
+++ b/packages/client/test/client/auth.test.ts
@@ -977,14 +977,6 @@ describe('OAuth Authorization', () => {
             code_challenge_methods_supported: ['S256']
         };
 
-        const validOpenIdTenantMetadata = {
-            ...validOpenIdMetadata,
-            issuer: 'https://auth.example.com/tenant1',
-            authorization_endpoint: 'https://auth.example.com/tenant1/authorize',
-            token_endpoint: 'https://auth.example.com/tenant1/token',
-            jwks_uri: 'https://auth.example.com/tenant1/jwks'
-        };
-
         it('tries URLs in order and returns first successful metadata', async () => {
             const tenantOidcMetadata = { ...validOpenIdMetadata, issuer: 'https://auth.example.com/tenant1' };
             // First OAuth URL (path before well-known) fails with 404

--- a/packages/client/test/client/crossAppAccess.test.ts
+++ b/packages/client/test/client/crossAppAccess.test.ts
@@ -304,6 +304,44 @@ describe('crossAppAccess', () => {
             expect(String(mockFetch.mock.calls[1]![0])).toBe('https://idp.example.com/token');
         });
 
+        it('allows IdP discovery aliases whose metadata names a canonical issuer', async () => {
+            const mockFetch = vi.fn<FetchLike>();
+
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({
+                    issuer: 'https://login.microsoftonline.com/tenant-guid/v2.0',
+                    authorization_endpoint: 'https://login.microsoftonline.com/tenant-guid/oauth2/v2.0/authorize',
+                    token_endpoint: 'https://login.microsoftonline.com/tenant-guid/oauth2/v2.0/token',
+                    jwks_uri: 'https://login.microsoftonline.com/tenant-guid/discovery/v2.0/keys',
+                    response_types_supported: ['code'],
+                    grant_types_supported: ['urn:ietf:params:oauth:grant-type:token-exchange']
+                })
+            } as Response);
+
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({
+                    issued_token_type: 'urn:ietf:params:oauth:token-type:id-jag',
+                    access_token: 'jag-token',
+                    token_type: 'N_A'
+                })
+            } as Response);
+
+            const result = await discoverAndRequestJwtAuthGrant({
+                idpUrl: 'https://login.example-corp.com',
+                audience: 'https://auth.chat.example/',
+                resource: 'https://mcp.chat.example/',
+                idToken: 'id-token',
+                clientId: 'client',
+                fetchFn: mockFetch
+            });
+
+            expect(result.jwtAuthGrant).toBe('jag-token');
+            expect(String(mockFetch.mock.calls[0]![0])).toBe('https://login.example-corp.com/.well-known/oauth-authorization-server');
+            expect(String(mockFetch.mock.calls[1]![0])).toBe('https://login.microsoftonline.com/tenant-guid/oauth2/v2.0/token');
+        });
+
         it('throws error when token endpoint is not discovered', async () => {
             const mockFetch = vi.fn<FetchLike>().mockResolvedValue({
                 ok: true,

--- a/packages/client/test/client/sse.test.ts
+++ b/packages/client/test/client/sse.test.ts
@@ -1253,7 +1253,8 @@ describe('SSEClientTransport', () => {
                             token_endpoint: `http://127.0.0.1:${(authServer.address() as AddressInfo).port}/token`,
                             registration_endpoint: `http://127.0.0.1:${(authServer.address() as AddressInfo).port}/register`,
                             response_types_supported: ['code'],
-                            code_challenge_methods_supported: ['S256']
+                            code_challenge_methods_supported: ['S256'],
+                            authorization_response_iss_parameter_supported: true
                         })
                     );
                     return;
@@ -1545,6 +1546,26 @@ describe('SSEClientTransport', () => {
 
             // Global fetch should never have been called
             expect(globalFetchSpy).not.toHaveBeenCalled();
+        });
+
+        it('rejects a mismatched finishAuth iss before token exchange', async () => {
+            const authProviderWithCode = createMockAuthProvider({
+                clientRegistered: true,
+                authorizationCode: 'test-auth-code'
+            });
+
+            transport = new SSEClientTransport(resourceBaseUrl, {
+                authProvider: authProviderWithCode,
+                fetch: customFetch
+            });
+
+            await expect(transport.finishAuth('test-auth-code', { iss: 'https://attacker.example.com' })).rejects.toThrow(
+                /does not match the expected issuer/
+            );
+
+            const tokenCalls = customFetch.mock.calls.filter(([url]) => url.toString().includes('/token'));
+            expect(tokenCalls).toHaveLength(0);
+            expect(authProviderWithCode.saveTokens).not.toHaveBeenCalled();
         });
     });
 

--- a/packages/client/test/client/sse.test.ts
+++ b/packages/client/test/client/sse.test.ts
@@ -42,6 +42,7 @@ describe('SSEClientTransport', () => {
 
         authServer = createServer((req, res) => {
             if (req.url === '/.well-known/oauth-authorization-server') {
+                const issuer = authBaseUrl.origin;
                 res.writeHead(200, {
                     'Content-Type': 'application/json'
                 });

--- a/packages/client/test/client/streamableHttp.test.ts
+++ b/packages/client/test/client/streamableHttp.test.ts
@@ -2202,6 +2202,101 @@ describe('StreamableHTTPClientTransport', () => {
         });
     });
 
+    describe('finishAuth iss validation (SEP-2468 / RFC 9207)', () => {
+        const issuer = 'http://localhost:1234';
+
+        function createOAuthFetchMock(): Mock {
+            return (
+                vi
+                    .fn()
+                    // Protected resource metadata discovery
+                    .mockResolvedValueOnce({
+                        ok: true,
+                        status: 200,
+                        json: async () => ({
+                            authorization_servers: [issuer],
+                            resource: 'http://localhost:1234/mcp'
+                        })
+                    })
+                    // OAuth metadata discovery — advertises RFC 9207 iss support
+                    .mockResolvedValueOnce({
+                        ok: true,
+                        status: 200,
+                        json: async () => ({
+                            issuer,
+                            authorization_endpoint: 'http://localhost:1234/authorize',
+                            token_endpoint: 'http://localhost:1234/token',
+                            response_types_supported: ['code'],
+                            code_challenge_methods_supported: ['S256'],
+                            authorization_response_iss_parameter_supported: true
+                        })
+                    })
+                    // Code exchange
+                    .mockResolvedValueOnce({
+                        ok: true,
+                        status: 200,
+                        json: async () => ({
+                            access_token: 'new-access-token',
+                            refresh_token: 'new-refresh-token',
+                            token_type: 'Bearer',
+                            expires_in: 3600
+                        })
+                    })
+            );
+        }
+
+        it('plumbs a matching iss through to validation and completes the exchange', async () => {
+            const customFetch = createOAuthFetchMock();
+            transport = new StreamableHTTPClientTransport(new URL('http://localhost:1234/mcp'), {
+                authProvider: mockAuthProvider,
+                fetch: customFetch
+            });
+
+            await transport.finishAuth('test-auth-code', { iss: issuer });
+
+            // The code reached the token endpoint and tokens were saved
+            const tokenCalls = customFetch.mock.calls.filter(
+                ([url, options]) => url.toString().includes('/token') && options?.method === 'POST'
+            );
+            expect(tokenCalls).toHaveLength(1);
+            expect(mockAuthProvider.saveTokens).toHaveBeenCalledWith({
+                access_token: 'new-access-token',
+                token_type: 'Bearer',
+                expires_in: 3600,
+                refresh_token: 'new-refresh-token'
+            });
+        });
+
+        it('rejects a mismatched iss before the code reaches the token endpoint', async () => {
+            const customFetch = createOAuthFetchMock();
+            transport = new StreamableHTTPClientTransport(new URL('http://localhost:1234/mcp'), {
+                authProvider: mockAuthProvider,
+                fetch: customFetch
+            });
+
+            await expect(transport.finishAuth('test-auth-code', { iss: 'https://attacker.example.com' })).rejects.toThrow(
+                /does not match the expected issuer/
+            );
+
+            const tokenCalls = customFetch.mock.calls.filter(([url]) => url.toString().includes('/token'));
+            expect(tokenCalls).toHaveLength(0);
+            expect(mockAuthProvider.saveTokens).not.toHaveBeenCalled();
+        });
+
+        it('rejects when the AS advertises iss support but finishAuth receives no iss', async () => {
+            const customFetch = createOAuthFetchMock();
+            transport = new StreamableHTTPClientTransport(new URL('http://localhost:1234/mcp'), {
+                authProvider: mockAuthProvider,
+                fetch: customFetch
+            });
+
+            await expect(transport.finishAuth('test-auth-code')).rejects.toThrow(/did not include an iss parameter/);
+
+            const tokenCalls = customFetch.mock.calls.filter(([url]) => url.toString().includes('/token'));
+            expect(tokenCalls).toHaveLength(0);
+        });
+    });
+
     describe('SSE retry field handling', () => {
         beforeEach(() => {
             vi.useFakeTimers();

--- a/packages/client/test/client/streamableHttp.test.ts
+++ b/packages/client/test/client/streamableHttp.test.ts
@@ -2283,17 +2283,35 @@ describe('StreamableHTTPClientTransport', () => {
             expect(mockAuthProvider.saveTokens).not.toHaveBeenCalled();
         });
 
-        it('rejects when the AS advertises iss support but finishAuth receives no iss', async () => {
+        it('rejects when the AS advertises iss support and the caller reports a response without iss (iss: null)', async () => {
             const customFetch = createOAuthFetchMock();
             transport = new StreamableHTTPClientTransport(new URL('http://localhost:1234/mcp'), {
                 authProvider: mockAuthProvider,
                 fetch: customFetch
             });
 
-            await expect(transport.finishAuth('test-auth-code')).rejects.toThrow(/did not include an iss parameter/);
+            await expect(transport.finishAuth('test-auth-code', { iss: null })).rejects.toThrow(/did not include an iss parameter/);
 
             const tokenCalls = customFetch.mock.calls.filter(([url]) => url.toString().includes('/token'));
             expect(tokenCalls).toHaveLength(0);
+        });
+
+        it('completes the exchange when finishAuth receives no iss at all, even though the AS advertises support', async () => {
+            // Legacy finishAuth(code) callers cannot see the authorization response;
+            // the SDK must not fail closed on their behalf.
+            const customFetch = createOAuthFetchMock();
+            transport = new StreamableHTTPClientTransport(new URL('http://localhost:1234/mcp'), {
+                authProvider: mockAuthProvider,
+                fetch: customFetch
+            });
+
+            await transport.finishAuth('test-auth-code');
+
+            const tokenCalls = customFetch.mock.calls.filter(
+                ([url, options]) => url.toString().includes('/token') && options?.method === 'POST'
+            );
+            expect(tokenCalls).toHaveLength(1);
+            expect(mockAuthProvider.saveTokens).toHaveBeenCalled();
         });
     });
 

--- a/packages/client/test/client/streamableHttp.test.ts
+++ b/packages/client/test/client/streamableHttp.test.ts
@@ -2259,12 +2259,16 @@ describe('StreamableHTTPClientTransport', () => {
                 ([url, options]) => url.toString().includes('/token') && options?.method === 'POST'
             );
             expect(tokenCalls).toHaveLength(1);
-            expect(mockAuthProvider.saveTokens).toHaveBeenCalledWith({
-                access_token: 'new-access-token',
-                token_type: 'Bearer',
-                expires_in: 3600,
-                refresh_token: 'new-refresh-token'
-            });
+            expect(mockAuthProvider.saveTokens).toHaveBeenCalledWith(
+                {
+                    access_token: 'new-access-token',
+                    token_type: 'Bearer',
+                    expires_in: 3600,
+                    refresh_token: 'new-refresh-token',
+                    issuer
+                },
+                { issuer }
+            );
         });
 
         it('rejects a mismatched iss before the code reaches the token endpoint', async () => {

--- a/test/conformance/src/helpers/conformanceOAuthProvider.ts
+++ b/test/conformance/src/helpers/conformanceOAuthProvider.ts
@@ -15,7 +15,7 @@ export class ConformanceOAuthProvider implements OAuthClientProvider {
     private _tokens?: OAuthTokens;
     private _codeVerifier?: string;
     private _authCode?: string;
-    private _iss?: string;
+    private _iss?: string | null;
     private _discoveryState?: OAuthDiscoveryState;
 
     constructor(
@@ -79,7 +79,7 @@ export class ConformanceOAuthProvider implements OAuthClientProvider {
                 const redirectUrl = new URL(location);
                 const code = redirectUrl.searchParams.get('code');
                 // RFC 9207: capture `iss` alongside `code` for validation before token exchange.
-                this._iss = redirectUrl.searchParams.get('iss') ?? undefined;
+                this._iss = redirectUrl.searchParams.has('iss') ? redirectUrl.searchParams.get('iss') : null;
                 if (code) {
                     this._authCode = code;
                     return;
@@ -102,8 +102,8 @@ export class ConformanceOAuthProvider implements OAuthClientProvider {
         throw new Error('No authorization code');
     }
 
-    /** The `iss` parameter captured from the authorization callback (RFC 9207), or `undefined` if absent. */
-    getIss(): string | undefined {
+    /** The `iss` parameter captured from the authorization callback (RFC 9207), or `null` if the callback omitted it. */
+    getIss(): string | null | undefined {
         return this._iss;
     }
 

--- a/test/e2e/requirements.ts
+++ b/test/e2e/requirements.ts
@@ -2239,6 +2239,14 @@ export const REQUIREMENTS: Record<string, Requirement> = {
         transports: ['streamableHttp'],
         note: 'This exercises the HTTP hosting/auth layer and OAuth client; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
     },
+    'client-auth:iss:positional-omitted-skips': {
+        addedInSpecVersion: '2026-07-28',
+        source: 'sdk',
+        behavior:
+            'For legacy callers that invoke finishAuth(code) without the full callback parameters, omitted iss remains an explicit compatibility opt-out from RFC 9207 authorization-response validation.',
+        transports: ['streamableHttp'],
+        note: 'This exercises the HTTP hosting/auth layer and OAuth client; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
     'client-auth:iss:unadvertised-proceed': {
         addedInSpecVersion: '2026-07-28',
         source: 'https://modelcontextprotocol.io/specification/draft/basic/authorization#authorization-response-issuer-validation',

--- a/test/e2e/scenarios/client-auth.test.ts
+++ b/test/e2e/scenarios/client-auth.test.ts
@@ -813,7 +813,7 @@ verifies('client-auth:iss:positional-omitted-skips', async (_args: TestArgs) => 
 verifies('client-auth:iss:unadvertised-proceed', async (_args: TestArgs) => {
     // Row 4: not advertised + iss absent → the exchange proceeds. Also covers row 3 (not advertised
     // + iss present → still compared) by additionally asserting the same scenario rejects a wrong iss.
-    const proceed = await runFinishAuthScenario({}, undefined);
+    const proceed = await runFinishAuthScenario({}, new URLSearchParams({ code: 'granted-code' }));
     expect(proceed.thrown).toBeUndefined();
     expect(proceed.tokenCalls).toHaveLength(1);
 

--- a/test/e2e/scenarios/client-auth.test.ts
+++ b/test/e2e/scenarios/client-auth.test.ts
@@ -740,12 +740,15 @@ verifies('client-auth:as-metadata-discovery:issuer-validation', async (_args: Te
 
 /**
  * Runs the redirect leg of the OAuth flow against a mock AS configured with `asMetadata`, then
- * calls `transport.finishAuth(...)`. When `callback` is a string (or undefined) it is passed as
- * `finishAuth('granted-code', iss)`; when it is a `URLSearchParams` it is passed verbatim to the
- * overload. Returns the thrown error (or undefined on success) and the recorded token-endpoint
+ * calls `transport.finishAuth(...)`. When `callback` is a string, null, or undefined it is passed
+ * as `finishAuth('granted-code', iss)`; when it is a `URLSearchParams` it is passed verbatim to
+ * the overload. Returns the thrown error (or undefined on success) and the recorded token-endpoint
  * calls so the caller can assert whether the code went on the wire.
  */
-async function runFinishAuthScenario(asMetadata: Partial<AuthorizationServerMetadata>, callback: string | undefined | URLSearchParams) {
+async function runFinishAuthScenario(
+    asMetadata: Partial<AuthorizationServerMetadata>,
+    callback: string | null | undefined | URLSearchParams
+) {
     const as = createMockAuthorizationServer({ asMetadata, tokenResponses: [{ access_token: 'iss-flow-token', token_type: 'Bearer' }] });
     const provider = new RecordingOAuthClientProvider();
     const mcpHost = createAuthenticatedHost('iss-flow-token');
@@ -792,10 +795,19 @@ verifies('client-auth:iss:mismatch-reject', async (_args: TestArgs) => {
 });
 
 verifies('client-auth:iss:supported-missing-reject', async (_args: TestArgs) => {
-    const { thrown, tokenCalls } = await runFinishAuthScenario({ authorization_response_iss_parameter_supported: true }, undefined);
+    const { thrown, tokenCalls } = await runFinishAuthScenario(
+        { authorization_response_iss_parameter_supported: true },
+        new URLSearchParams({ code: 'granted-code' })
+    );
     expect(thrown).toBeInstanceOf(IssuerMismatchError);
     expect((thrown as IssuerMismatchError).received).toBeUndefined();
     expect(tokenCalls).toHaveLength(0);
+});
+
+verifies('client-auth:iss:positional-omitted-skips', async (_args: TestArgs) => {
+    const { thrown, tokenCalls } = await runFinishAuthScenario({ authorization_response_iss_parameter_supported: true }, undefined);
+    expect(thrown).toBeUndefined();
+    expect(tokenCalls).toHaveLength(1);
 });
 
 verifies('client-auth:iss:unadvertised-proceed', async (_args: TestArgs) => {


### PR DESCRIPTION
## What

Implements RFC 9207 (OAuth 2.0 Authorization Server Issuer Identification) `iss` parameter validation for authorization responses, per the draft MCP spec (`basic/authorization`, "Authorization Response Validation").

Before redirecting the user, the client records the `issuer` from validated authorization server metadata alongside the PKCE verifier/state. Before sending an authorization code to any token endpoint, callers that provide authorization-response parameters can apply RFC 9207 Section 2.4 validation.

Decision table implemented by `validateAuthorizationResponseIssuer()`:

| AS metadata advertises `authorization_response_iss_parameter_supported: true` | Response `iss` | Outcome |
| --- | --- | --- |
| yes | absent (caller passed `iss: null`) | Reject |
| yes or no | present | Exact string compare against recorded issuer (no normalization); mismatch rejects |
| no | absent | Proceed |
| - | on rejection | The client MUST NOT act on `error`/`error_description` from that response either |

One extra fail-closed row: if an `iss` is received but no AS metadata was ever recorded, we reject because there is nothing trustworthy to compare against.

## The `iss` option is tri-state (`string | null | undefined`)

The SDK never sees the authorization response itself; the caller does. So the strict advertised-but-missing rejection is gated behind an explicit caller signal:

- `string` - the `iss` from the authorization response; validated by exact comparison.
- `null` - the caller asserts it inspected the authorization response and it contained no `iss`. This enables the RFC 9207 fail-closed rejection when the AS advertises `authorization_response_iss_parameter_supported: true`.
- `undefined` (omitted) - the caller did not have access to the response parameters, matching existing `finishAuth(code)` callers. Validation is skipped because the SDK cannot distinguish "the response had no iss" from "the caller did not plumb it."

This keeps existing callers compiling and behaving identically while giving hosts that have the callback URL enough API surface to enforce RFC 9207.

## API additions

- `@modelcontextprotocol/core`: `OAuthMetadataSchema` and `OpenIdProviderMetadataSchema` recognize `authorization_response_iss_parameter_supported`.
- `@modelcontextprotocol/client`:
  - New export `validateAuthorizationResponseIssuer(metadata, iss)`.
  - `auth(provider, { ..., iss? })` validates `iss` before `fetchToken` when `authorizationCode` is present and `iss` is provided (`string` or `null`).
  - `StreamableHTTPClientTransport.finishAuth(authorizationCode, options?: { iss?: string | null })` and `SSEClientTransport.finishAuth(...)` plumb the optional value through to `auth()`.

## Metadata provenance

Validation strength depends on where the recorded issuer comes from. With a provider that implements `discoveryState`/`saveDiscoveryState`, the recorded issuer is the one from the provider's validated AS metadata captured before the redirect, which is the intended RFC 9207 anchor. Without cached discovery state, `authInternal` re-discovers metadata at code-exchange time, so the comparison anchor is the freshly-discovered issuer rather than the one recorded pre-redirect. That still ensures the `iss` must match the AS the client is about to use, but recording via `discoveryState` is stronger.

## Land order / conformance note

This branch is rebased on `origin/main` and is not stacked. Because current conformance includes SEP-837 checks, the full client conformance baseline on this branch still depends on #2266 landing first; the observed local failure is `DCR application_type specified`, not an `iss` regression. Recommended order: #2265 -> #2266 -> #2271 -> this PR.

The `auth/iss-*` conformance scenarios remain in the expected-failures baseline because the conformance `everythingClient` does not yet plumb the redirect's `iss` through `finishAuth`.

## Validation

After rebasing on current `origin/main`:

- `pnpm --filter @modelcontextprotocol/client test -- auth.test.ts streamableHttp.test.ts sse.test.ts tokenProvider.test.ts` - 388 passed
- `pnpm --filter @modelcontextprotocol/core test` - 477 passed
- `pnpm run typecheck:all` - clean
- `pnpm run lint:all` - clean
- `pnpm run build:all` - clean, with the existing AJV/fast-uri missing-export warnings
- `pnpm --filter @modelcontextprotocol/test-conformance exec conformance client --command 'node --import tsx ./src/everythingClient.ts' --scenario auth/metadata-default --expected-failures ./expected-failures.yaml --verbose` - fails only on SEP-837 `application_type` omission, fixed by #2266

## Downstream impact

cloudflare/agents calls `transport.finishAuth(code)` in `packages/agents/src/mcp/client-connection.ts`, so it keeps compiling and behaving identically through the `undefined` path. Agents will not get RFC 9207 protection until it extracts `iss` from the OAuth callback URL in `packages/agents/src/mcp/client.ts` and forwards it through `completeAuthorization()` / `finishAuth()`.

Closes #2197
