### PR TITLE
fix(test-conformance): stop leaking the conformance server and hanging on stale ports

### DIFF
--- a/.changeset/fix-conformance-server-leak.md
+++ b/.changeset/fix-conformance-server-leak.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/test-conformance': patch
+---
+
+Fix the server conformance script leaking the test server process: the cleanup trap killed the npx wrapper while the actual server kept listening on port 3000, making later runs silently test stale code or hang forever in the readiness loop. The script now spawns the server directly with `node --import tsx`, refuses to start while the port is taken, and bounds each readiness probe; both test servers report `EADDRINUSE` with an actionable message, and the plain `test:conformance:client` script works again (`--suite core`, required since conformance 0.2.0-alpha.1).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1131,6 +1131,9 @@ importers:
       express:
         specifier: catalog:runtimeServerOnly
         version: 5.2.1
+      tsx:
+        specifier: catalog:devTools
+        version: 4.21.0
       zod:
         specifier: catalog:runtimeShared
         version: 4.3.6

--- a/test/conformance/README.md
+++ b/test/conformance/README.md
@@ -60,6 +60,8 @@ npx @modelcontextprotocol/conformance server \
   --scenario server-initialize
 ```
 
+Note: `pnpm run test:conformance:server` always starts (and tests) its own server, and refuses to run while anything is still listening on its port. Stop the manually started server first, or keep using the direct `--url` invocation above against it.
+
 ## Files
 
 - `src/everythingClient.ts` - Client that handles all client conformance scenarios

--- a/test/conformance/package.json
+++ b/test/conformance/package.json
@@ -28,13 +28,13 @@
         "start": "npm run server",
         "server": "tsx watch --clear-screen=false scripts/cli.ts server",
         "client": "tsx scripts/cli.ts client",
-        "test:conformance:client": "conformance client --command 'npx tsx ./src/everythingClient.ts' --expected-failures ./expected-failures.yaml",
-        "test:conformance:client:all": "conformance client --command 'npx tsx ./src/everythingClient.ts' --suite all --expected-failures ./expected-failures.yaml",
-        "test:conformance:client:run": "npx tsx ./src/everythingClient.ts",
+        "test:conformance:client": "conformance client --command 'node --import tsx ./src/everythingClient.ts' --suite core --expected-failures ./expected-failures.yaml",
+        "test:conformance:client:all": "conformance client --command 'node --import tsx ./src/everythingClient.ts' --suite all --expected-failures ./expected-failures.yaml",
+        "test:conformance:client:run": "node --import tsx ./src/everythingClient.ts",
         "test:conformance:server": "scripts/run-server-conformance.sh --expected-failures ./expected-failures.yaml",
         "test:conformance:server:draft": "scripts/run-server-conformance.sh --suite draft --expected-failures ./expected-failures.yaml",
         "test:conformance:server:all": "scripts/run-server-conformance.sh --suite all --expected-failures ./expected-failures.yaml",
-        "test:conformance:server:run": "npx tsx ./src/everythingServer.ts",
+        "test:conformance:server:run": "node --import tsx ./src/everythingServer.ts",
         "test:conformance:all": "pnpm run test:conformance:client:all && pnpm run test:conformance:server:all"
     },
     "devDependencies": {
@@ -50,6 +50,7 @@
         "@modelcontextprotocol/test-helpers": "workspace:^",
         "cors": "catalog:runtimeServerOnly",
         "express": "catalog:runtimeServerOnly",
+        "tsx": "catalog:devTools",
         "zod": "catalog:runtimeShared"
     }
 }

--- a/test/conformance/scripts/run-server-conformance.sh
+++ b/test/conformance/scripts/run-server-conformance.sh
@@ -11,9 +11,21 @@ SERVER_URL="http://localhost:${PORT}/mcp"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR/.."
 
-# Start the server in the background
+# Refuse to start if something is already listening on the port. The readiness
+# check below cannot tell our server apart from a stale one, so a leftover
+# listener would mean silently running conformance against old code — or
+# hanging forever if the listener never responds.
+if (: > "/dev/tcp/localhost/${PORT}") 2>/dev/null; then
+    echo "Error: port ${PORT} is already in use."
+    echo "Stop the stale process first (lsof -ti:${PORT} -sTCP:LISTEN | xargs kill) or set PORT to a free port."
+    exit 1
+fi
+
+# Start the server in the background. Use `node --import tsx` rather than
+# `npx tsx` so SERVER_PID is the server process itself — killing an npx/tsx
+# wrapper leaves the actual server running and squatting the port.
 echo "Starting conformance test server on port ${PORT}..."
-npx tsx ./src/everythingServer.ts &
+node --import tsx ./src/everythingServer.ts &
 SERVER_PID=$!
 
 # Function to cleanup on exit
@@ -24,11 +36,16 @@ cleanup() {
 }
 trap cleanup EXIT
 
-# Wait for server to be ready
+# Wait for server to be ready. --max-time keeps a hung listener from wedging
+# the loop forever, and a dead server process fails fast instead of retrying.
 echo "Waiting for server to be ready..."
 MAX_RETRIES=30
 RETRY_COUNT=0
-while ! curl -s "${SERVER_URL}" > /dev/null 2>&1; do
+while ! curl -s --max-time 2 "${SERVER_URL}" > /dev/null 2>&1; do
+    if ! kill -0 $SERVER_PID 2>/dev/null; then
+        echo "Server process exited unexpectedly"
+        exit 1
+    fi
     RETRY_COUNT=$((RETRY_COUNT + 1))
     if [ $RETRY_COUNT -ge $MAX_RETRIES ]; then
         echo "Server failed to start after ${MAX_RETRIES} attempts"

--- a/test/conformance/src/authTestServer.ts
+++ b/test/conformance/src/authTestServer.ts
@@ -412,11 +412,18 @@ async function startServer() {
     });
 
     // Start server
-    app.listen(PORT, () => {
+    const httpServer = app.listen(PORT, () => {
         console.log(`MCP Auth Test Server running at http://localhost:${PORT}/mcp`);
         console.log(`  - PRM endpoint: http://localhost:${PORT}/.well-known/oauth-protected-resource`);
         console.log(`  - Auth server: ${AUTH_SERVER_URL}`);
         console.log(`  - Introspection: ${asMetadata.introspection_endpoint}`);
+    });
+    httpServer.on('error', (error: NodeJS.ErrnoException) => {
+        if (error.code !== 'EADDRINUSE') {
+            throw error;
+        }
+        console.error(`Port ${PORT} is already in use — is a stale auth test server still running?`);
+        process.exit(1);
     });
 }
 

--- a/test/conformance/src/everythingServer.ts
+++ b/test/conformance/src/everythingServer.ts
@@ -1020,7 +1020,14 @@ app.delete('/mcp', async (req: Request, res: Response) => {
 
 // Start server
 const PORT = process.env.PORT || 3000;
-app.listen(PORT, () => {
+const httpServer = app.listen(PORT, () => {
     console.log(`MCP Conformance Test Server running on http://localhost:${PORT}`);
     console.log(`  - MCP endpoint: http://localhost:${PORT}/mcp`);
+});
+httpServer.on('error', (error: NodeJS.ErrnoException) => {
+    if (error.code !== 'EADDRINUSE') {
+        throw error;
+    }
+    console.error(`Port ${PORT} is already in use — is a stale conformance server still running?`);
+    process.exit(1);
 });


### PR DESCRIPTION
Running conformance locally could take \"forever\" or silently test stale code. Root cause: every `pnpm test:conformance:server` run leaks the test server, which then poisons later runs.

## Motivation and Context

`run-server-conformance.sh` starts the server with `npx tsx ./src/everythingServer.ts &` and kills `$SERVER_PID` on exit — but that PID is the npx wrapper. The actual node server survives every run and keeps listening on port 3000. That single leak produces three failure modes:

1. **Silent stale-server testing**: on the next run the fresh server dies on an unhandled `EADDRINUSE` (no `error` handler on `app.listen`), the readiness `curl` happily gets a response from the leaked server, and conformance runs against old code. CI hits this too: `test:conformance:server` and `test:conformance:server:draft` run back-to-back in one job, so the draft pass was exercising the leaked server from the previous step (the Actions runner logs `Terminate orphan process` after the job).
2. **Infinite hang**: the readiness loop is `while ! curl -s ...` with `MAX_RETRIES=30` — but no `--max-time`. Once a leaked listener stops responding (or any half-open socket holds the port), curl blocks forever and the retry cap never engages. The run sits at \"Waiting for server to be ready...\" indefinitely.
3. **Tens-of-minutes runs**: against a wedged-but-accepting listener the runner has no per-scenario timeout, so each scenario burns the SDK's 60s request timeout sequentially — ~30 min for the active suite.

Separately, the plain `test:conformance:client` script has been broken since the 0.2.0-alpha.1 pin (#2227): the CLI now requires `--scenario` or `--suite` in client mode, so the script exits immediately with a usage error. CI never noticed because it only runs `:client:all`.

## What changed

- `scripts/run-server-conformance.sh`:
  - refuse to start if anything already listens on the port (with the `lsof`/`PORT` remedy in the message) — removes the silent-stale-testing mode
  - spawn via `node --import tsx` so `$SERVER_PID` is the server process itself and the cleanup `kill` actually stops it — removes the leak
  - `curl --max-time 2` in the readiness loop, plus a fail-fast if the server process died — removes the unbounded hang
- `package.json`: `node --import tsx` for all spawned commands; declare `tsx` explicitly (it was resolving via root hoisting); add `--suite core` to `test:conformance:client` (`core` matches the CLI's previous no-flag default, `active`)
- `everythingServer.ts` / `authTestServer.ts`: handle the listen `error` event — `EADDRINUSE` now prints a one-line \"stale server still running?\" hint instead of an uncaught stack trace
- `README.md`: document the new refuse-to-start behavior for the manual-debugging flow

## How Has This Been Tested?

All on Linux, current main:

- Reproduced each failure mode before the fix: leaked listener present after a green run (`lsof -i:3000 -sTCP:LISTEN`); second run \"passing\" against the stale server; readiness loop stuck >75s against an accepting-but-silent listener (`nc -lk`).
- After the fix: back-to-back server runs green (42 passed) with the port free immediately after each; a squatted port fails in milliseconds with the clear message; double-start prints the EADDRINUSE hint; `test:conformance:client` runs the core suite green; `:client:all` and `:server:draft` unchanged; lint and typecheck clean.

## Breaking Changes

None for CI. Two local behavior changes: `test:conformance:server` now refuses to start while the port is taken (previously it silently tested whatever was listening), and the spawn commands require Node ≥ 20.6 for `--import` (engines says ≥ 20; `test/e2e` already uses `node --import tsx`).

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

A deeper fix would be binding an ephemeral port (`PORT=0`) and passing the discovered URL to the runner, eliminating the fixed-port collision class entirely — left as a follow-up since it changes the documented debugging workflow. The missing per-scenario timeout in the runner itself is a conformance-repo issue, not addressable from this repo.