### PR TITLE
docs: fix vitest setup filename in FAQ

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -47,7 +47,7 @@ authentication flows used by MCP clients.
 - **Node.js v18.x**: `globalThis.crypto` may not be defined by default. In this repository we polyfill it for tests (see `packages/client/vitest.setup.js`), and you should do the same in your app if it is missing – or alternatively, run Node with `--experimental-global-webcrypto`
   as per your Node version documentation. (See https://nodejs.org/dist/latest-v18.x/docs/api/globals.html#crypto )
 
-If you run clients on Node.js versions where `globalThis.crypto` is missing, you can polyfill it using the built-in `node:crypto` module, similar to the SDK's own `vitest.setup.ts`:
+If you run clients on Node.js versions where `globalThis.crypto` is missing, you can polyfill it using the built-in `node:crypto` module, similar to the SDK's own `vitest.setup.js`:
 
 ```typescript
 import { webcrypto } from 'node:crypto';


### PR DESCRIPTION
The Web Crypto FAQ entry refers to the client package's vitest setup file as `vitest.setup.ts`, but the actual file is `packages/client/vitest.setup.js` (correctly referenced two paragraphs earlier). This fixes the second reference to match.

## Motivation and Context
Small docs consistency fix — readers following the FAQ pointer would look for a file that doesn't exist.

## How Has This Been Tested?
Docs-only change; verified `packages/client/vitest.setup.js` is the file that exists in the repo.

## Breaking Changes
None.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
None.