### PR TITLE
test(conformance): pin the conformance suite to 0.2.0-alpha.2 and reconcile the expected-failures baseline

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1099,8 +1099,8 @@ importers:
         specifier: workspace:^
         version: link:../../packages/client
       '@modelcontextprotocol/conformance':
-        specifier: 0.2.0-alpha.1
-        version: 0.2.0-alpha.1(@cfworker/json-schema@4.1.1)
+        specifier: 0.2.0-alpha.2
+        version: 0.2.0-alpha.2(@cfworker/json-schema@4.1.1)
       '@modelcontextprotocol/core':
         specifier: workspace:^
         version: link:../../packages/core
@@ -2108,8 +2108,8 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
-  '@modelcontextprotocol/conformance@0.2.0-alpha.1':
-    resolution: {integrity: sha512-w5YpjJ7uNXGIWs2r+gMwowNgREykYvDlrFS1Ckl47lVbkZJn2CAytmuV/zCrsCuZkeE7djK1tJkuZ0oa72BhGA==}
+  '@modelcontextprotocol/conformance@0.2.0-alpha.2':
+    resolution: {integrity: sha512-/8bde9d0mfsvgd9IwQgNIl1AS9uNOp/+ZG+2nNRWXtPs6xrz/cNp4ObBMmGY9kP8dkDaF3bvjtC/2Hj8TStMRg==}
     hasBin: true
 
   '@modelcontextprotocol/sdk@1.29.0':
@@ -5998,7 +5998,7 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@modelcontextprotocol/conformance@0.2.0-alpha.1(@cfworker/json-schema@4.1.1)':
+  '@modelcontextprotocol/conformance@0.2.0-alpha.2(@cfworker/json-schema@4.1.1)':
     dependencies:
       '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
       '@octokit/rest': 22.0.1

--- a/test/conformance/expected-failures.yaml
+++ b/test/conformance/expected-failures.yaml
@@ -1,10 +1,21 @@
 # Conformance scenarios not yet implemented in the v2 TypeScript SDK.
 # CI exits 0 if only these fail, exits 1 on unexpected failures or stale entries.
 #
-# Baseline established against @modelcontextprotocol/conformance 0.2.0-alpha.1,
-# which adds the draft-spec scenario suite (SEP-2575, SEP-2322, SEP-2243, SEP-2549,
-# SEP-2468, ...) plus new checks on existing scenarios (SEP-837 application_type
-# during DCR).
+# Baseline established against the published @modelcontextprotocol/conformance
+# release pinned in package.json (0.2.0-alpha.2). Relative to 0.2.0-alpha.1,
+# that release re-scoped the SEP-837 application_type check to draft-version
+# runs only, so the dated-version auth scenarios that failed only on that
+# check were removed from this baseline. Newer conformance releases are
+# adopted by deliberately bumping the package.json pin and reconciling this
+# file in the same change. (The auth/iss-* scenarios are not present in
+# 0.2.0-alpha.2; the runner reports them as unknown/failed, covered by their
+# entries below until a release ships them.)
+#
+# NOTE: the draft error-code assignments exercised by the SEP-2243 server
+# scenarios (-32001 HeaderMismatch) and their neighbours (-32602, -32004) are
+# still under discussion upstream (pending conformance #336). Those cells are
+# treated as parameterized, not settled: the entries below record today's
+# referee behavior and are re-derived when a #336-containing referee is pinned.
 #
 # Entries are grouped by SEP. As each SEP/milestone is implemented in the SDK the
 # corresponding scenarios start passing and MUST be removed from this list (the
@@ -34,26 +45,15 @@ client:
     # SEP-2352 (authorization server migration): client does not re-register when
     # PRM authorization_servers changes.
     - auth/authorization-server-migration
-    # SEP-2207 (offline_access scope) scenario, currently failing only on the new
-    # SEP-837 application_type check (see the SEP-837 group below).
+    # SEP-837 (application_type during DCR): the check only fires on draft-version
+    # runs; this draft scenario is the one place the client still hits it.
     - auth/offline-access-not-supported
 
     # --- Pre-existing scenarios that fail on checks added after conformance 0.1.15 ---
-    # SEP-837: client MUST send application_type during Dynamic Client Registration.
-    # Single new check; everything else in these scenarios passes.
-    - auth/metadata-default
-    - auth/metadata-var1
-    - auth/metadata-var2
-    - auth/metadata-var3
-    - auth/scope-from-www-authenticate
-    - auth/scope-from-scopes-supported
-    - auth/scope-omitted-when-undefined
+    # SEP-2350 (scope step-up): WARNING-only — client does not compute the union of
+    # previously requested and newly challenged scopes on re-authorization; the
+    # expected-failures evaluator counts WARNINGs as failures.
     - auth/scope-step-up
-    - auth/scope-retry-limit
-    - auth/token-endpoint-auth-basic
-    - auth/token-endpoint-auth-post
-    - auth/token-endpoint-auth-none
-    - auth/2025-03-26-oauth-metadata-backcompat
     # SEP-990 (enterprise-managed authorization extension): no fixture handler /
     # client support for the token-exchange + JWT bearer flow.
     - auth/enterprise-managed-authorization
@@ -81,6 +81,7 @@ server:
     - caching
     # SEP-2243 (HTTP header standardization): -32001 HeaderMismatch handling and
     # case-insensitive/whitespace-trimmed header validation not implemented.
+    # (Error-code cells parameterized pending conformance #336 — see header note.)
     - http-header-validation
     - http-custom-header-server-validation
     # WARNING-only entries: these scenarios emit no FAILURE checks, only SHOULD-level

--- a/test/conformance/package.json
+++ b/test/conformance/package.json
@@ -38,7 +38,7 @@
         "test:conformance:all": "pnpm run test:conformance:client:all && pnpm run test:conformance:server:all"
     },
     "devDependencies": {
-        "@modelcontextprotocol/conformance": "0.2.0-alpha.1",
+        "@modelcontextprotocol/conformance": "0.2.0-alpha.2",
         "@modelcontextprotocol/client": "workspace:^",
         "@modelcontextprotocol/server": "workspace:^",
         "@modelcontextprotocol/core": "workspace:^",


### PR DESCRIPTION
Bumps the pinned `@modelcontextprotocol/conformance` release from 0.2.0-alpha.1 to 0.2.0-alpha.2 and reconciles `expected-failures.yaml` against it: **45 → 33 entries**, zero stale.

## Motivation and Context
The conformance baseline was established against 0.2.0-alpha.1. Since then, the conformance suite re-scoped the SEP-837 `application_type` check to draft-version runs only (shipped in 0.2.0-alpha.2), so twelve dated-version client auth scenarios that failed **only** on that check now pass — those twelve entries existed purely as artifacts of the stale referee and are removed. Keeping the baseline honest matters because the runner fails CI on stale entries, making `expected-failures.yaml` the per-PR burn-down ledger for draft-spec work.

Referee policy made explicit in the yaml header: the referee is always a published conformance release; newer releases are adopted by deliberately bumping the pin and reconciling the baseline in the same change.

## How Has This Been Tested?
All three CI conformance legs run green against 0.2.0-alpha.2 with zero stale entries:
- `test:conformance:client:all` (16 expected client failures)
- `test:conformance:server` (42/42 green)
- `test:conformance:server:draft` (17 expected server failures)

Notes from the reconcile, verified by running both referees:
- The root cause of the twelve now-passing entries was confirmed in the conformance source (`createAuthServer` SEP-837 check now draft-scoped).
- `auth/scope-step-up` stays red for a new reason (SEP-2350 scope-union WARNING) — entry kept, comment updated.
- The `auth/iss-*` scenarios are not present in 0.2.0-alpha.2 (reported unknown → failed); their baseline entries cover them until a release ships them.
- The draft error-ladder cells disputed in modelcontextprotocol/conformance#336 (−32001/−32602/−32004) remain listed pending that PR.

## Breaking Changes
None. Test/CI configuration only; no runtime or API changes.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
First of a series: subsequent PRs lean on this baseline as their conformance burn-down referee. No changeset (test-only, per repo convention).
