### PR TITLE
[draft tally] v2-2026-07-28 integration branch vs main

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -2,7 +2,7 @@ name: Conformance Tests
 
 on:
     push:
-        branches: [main]
+        branches: [main, v2-2026-07-28]
     pull_request:
     workflow_dispatch:
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,8 @@ on:
     push:
         branches:
             - main
+            - v2-2026-07-28
+            - v2-2026-07-28
     pull_request:
     workflow_dispatch:
 


### PR DESCRIPTION
**Standing draft — running tally of the `v2-2026-07-28` integration branch vs `main`. Not for merging in this form.**

Work toward the 2026-07-28 (draft) revision accumulates on `v2-2026-07-28` via reviewed chunk PRs (e.g. #2281, #2285). This draft exists to:

- show the live combined diff vs `main` (size + surface at a glance),
- run CI on the **merge ref**, so drift between the branch and `main` (conflicts, or changes on `main` that break the combined state) surfaces here immediately rather than at the end.

When the branch is complete it gets merged to `main` either wholesale or re-sliced into reviewable PRs — decided then. History note: this PR briefly existed as a CI carrier for an earlier wholesale push of the branch; the branch was reset and now grows chunk-by-chunk.
