### PR TITLE
test(conformance): bump the conformance pin to 0.2.0-alpha.3

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1099,8 +1099,8 @@ importers:
         specifier: workspace:^
         version: link:../../packages/client
       '@modelcontextprotocol/conformance':
-        specifier: 0.2.0-alpha.2
-        version: 0.2.0-alpha.2(@cfworker/json-schema@4.1.1)
+        specifier: 0.2.0-alpha.3
+        version: 0.2.0-alpha.3(@cfworker/json-schema@4.1.1)
       '@modelcontextprotocol/core':
         specifier: workspace:^
         version: link:../../packages/core
@@ -2111,8 +2111,8 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
-  '@modelcontextprotocol/conformance@0.2.0-alpha.2':
-    resolution: {integrity: sha512-/8bde9d0mfsvgd9IwQgNIl1AS9uNOp/+ZG+2nNRWXtPs6xrz/cNp4ObBMmGY9kP8dkDaF3bvjtC/2Hj8TStMRg==}
+  '@modelcontextprotocol/conformance@0.2.0-alpha.3':
+    resolution: {integrity: sha512-YjdEKaKWswkJtRl0G3RmZCfljkAct3je834sqGHgasGeU2eUp7sb+6sJL0uNEaAY3XXWYumN/mjr6aPZbnbJMA==}
     hasBin: true
 
   '@modelcontextprotocol/sdk@1.29.0':
@@ -6001,7 +6001,7 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@modelcontextprotocol/conformance@0.2.0-alpha.2(@cfworker/json-schema@4.1.1)':
+  '@modelcontextprotocol/conformance@0.2.0-alpha.3(@cfworker/json-schema@4.1.1)':
     dependencies:
       '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
       '@octokit/rest': 22.0.1

--- a/test/conformance/expected-failures.yaml
+++ b/test/conformance/expected-failures.yaml
@@ -2,14 +2,13 @@
 # CI exits 0 if only these fail, exits 1 on unexpected failures or stale entries.
 #
 # Baseline established against the published @modelcontextprotocol/conformance
-# release pinned in package.json (0.2.0-alpha.2). Relative to 0.2.0-alpha.1,
-# that release re-scoped the SEP-837 application_type check to draft-version
-# runs only, so the dated-version auth scenarios that failed only on that
-# check were removed from this baseline. Newer conformance releases are
-# adopted by deliberately bumping the package.json pin and reconciling this
-# file in the same change. (The auth/iss-* scenarios are not present in
-# 0.2.0-alpha.2; the runner reports them as unknown/failed, covered by their
-# entries below until a release ships them.)
+# release pinned in package.json (0.2.0-alpha.3). Newer conformance releases
+# are adopted by deliberately bumping the package.json pin and reconciling
+# this file in the same change. 0.2.0-alpha.3 fixes the draft wire version
+# (2026-07-28). Several auth scenarios in this baseline (auth/iss-*,
+# auth/authorization-server-migration, auth/enterprise-managed-authorization)
+# are still not shipped in the published release — the runner reports them
+# unknown/failed; their entries below cover them either way.
 #
 # NOTE: the draft error-code assignments exercised by the SEP-2243 server
 # scenarios (-32001 HeaderMismatch) and their neighbours (-32602, -32004) are

--- a/test/conformance/package.json
+++ b/test/conformance/package.json
@@ -38,7 +38,7 @@
         "test:conformance:all": "pnpm run test:conformance:client:all && pnpm run test:conformance:server:all"
     },
     "devDependencies": {
-        "@modelcontextprotocol/conformance": "0.2.0-alpha.2",
+        "@modelcontextprotocol/conformance": "0.2.0-alpha.3",
         "@modelcontextprotocol/client": "workspace:^",
         "@modelcontextprotocol/server": "workspace:^",
         "@modelcontextprotocol/core": "workspace:^",


### PR DESCRIPTION
Bumps the pinned `@modelcontextprotocol/conformance` release from 0.2.0-alpha.2 to 0.2.0-alpha.3.

## Motivation and Context
0.2.0-alpha.3 fixes the draft wire version used by the draft-spec suite (now 2026-07-28), so draft scenarios exercise the correct revision string. Adopted per the documented referee policy: deliberate pin bump + baseline reconcile in the same change.

## How Has This Been Tested?
All three CI legs green against 0.2.0-alpha.3 with **zero stale entries and zero baseline changes** (the 33-entry baseline holds verbatim). Header note updated: several auth scenarios in the baseline (`auth/iss-*`, `auth/authorization-server-migration`, `auth/enterprise-managed-authorization`) are still not shipped in the published release — the runner reports them unknown/failed and their entries cover them either way.

## Breaking Changes
None. Test/CI configuration only.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
