### PR TITLE
feat(core): the 2026-07-28 era codec; registry and schema CI oracles

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -17,6 +17,10 @@ pnpm-lock.yaml
 # (fetch:spec-examples) or hand-built and frozen - byte-faithful artifacts.
 packages/core/test/corpus/fixtures/
 
+# Schema twins: raw upstream schema.json bytes (fetch:schema-twins), locked to
+# manifest.json by sha256 in schemaTwinConformance - reformatting breaks the lock.
+packages/core/test/corpus/schema-twins/
+
 # Batch test cloned repos and results
 packages/codemod/batch-test/repos
 packages/codemod/batch-test/results

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
         "mcp"
     ],
     "scripts": {
+        "fetch:schema-twins": "tsx scripts/fetch-schema-twins.ts",
         "fetch:spec-examples": "tsx scripts/fetch-spec-examples.ts",
         "fetch:spec-types": "tsx scripts/fetch-spec-types.ts",
         "sync:snippets": "tsx scripts/sync-snippets.ts",

--- a/packages/core/src/shared/protocol.ts
+++ b/packages/core/src/shared/protocol.ts
@@ -1164,7 +1164,16 @@ export abstract class Protocol<ContextT extends BaseContext> {
                 //   lift, then today's schema validation decides.
                 // Either way a non-complete body can never be masked into a
                 // hollow success by a tolerant result schema.
-                const decoded = codec.decodeResult(request.method, response.result);
+                // Guarded: this callback runs synchronously inside
+                // `_onresponse`, so a throw out of the decode hop would
+                // otherwise propagate into the transport's onmessage instead
+                // of failing this request.
+                let decoded: ReturnType<WireCodec['decodeResult']>;
+                try {
+                    decoded = codec.decodeResult(request.method, response.result);
+                } catch (error) {
+                    return reject(error instanceof Error ? error : new Error(String(error)));
+                }
                 if (decoded.kind === 'invalid') {
                     return reject(decoded.error);
                 }

--- a/packages/core/src/shared/protocol.ts
+++ b/packages/core/src/shared/protocol.ts
@@ -1154,55 +1154,17 @@ export abstract class Protocol<ContextT extends BaseContext> {
                     return reject(response);
                 }
 
-                // Raw-first result discrimination (protocol revision
-                // 2026-07-28): inspect `resultType` BEFORE any schema
-                // validation, so a non-complete result can never be masked
-                // into a hollow success by a tolerant result schema (e.g.
-                // defaults filling in absent members).
-                let result = response.result;
-                if (isPlainObject(result) && result['resultType'] !== undefined) {
-                    const rawResultType = result['resultType'];
-                    if (typeof rawResultType !== 'string') {
-                        // Defense in depth, not a reachable rejection today:
-                        // the wire schema types `resultType` as a string, so
-                        // message classification rejects a non-string carrier
-                        // before it can reach this funnel (the request then
-                        // hangs until timeout — the pre-existing failure mode
-                        // for malformed responses). The arm stays so the
-                        // raw-first check is self-contained if classification
-                        // ever loosens.
-                        return reject(
-                            new SdkError(SdkErrorCode.InvalidResult, `Invalid result for ${request.method}: non-string resultType`, {
-                                resultType: rawResultType
-                            })
-                        );
-                    }
-                    if (rawResultType !== 'complete') {
-                        // Surface the discriminated kind; no retry. This arm
-                        // is replaced by full multi-round-trip handling when
-                        // the client driver lands.
-                        return reject(
-                            new SdkError(
-                                SdkErrorCode.UnsupportedResultType,
-                                `Unsupported result type '${rawResultType}' for ${request.method}`,
-                                { resultType: rawResultType, method: request.method }
-                            )
-                        );
-                    }
-                    // 'complete': the SDK consumes the wire discriminator;
-                    // strip it before validation so consumers receive the
-                    // public result shape.
-                    const rest = { ...result };
-                    delete rest['resultType'];
-                    result = rest as Result;
-                }
-
-                // Codec decode hop (the structural V-1 home): the era codec
-                // applies its raw-first posture before schema validation.
-                // NOTE (staging): the funnel block above predates the codec
-                // split and still runs first; it is removed when the
-                // 2026-era codec lands and the codecs own the postures.
-                const decoded = codec.decodeResult(request.method, result);
+                // Codec decode hop — the structural V-1 home. The era codec
+                // owns the raw-first resultType postures (Q1-SD3):
+                // - 2026 era: REQUIRED discriminator; absent → typed error
+                //   naming the spec violation; input_required → driver seam;
+                //   unknown kind → invalid, no retry; complete → wire-exact
+                //   parse then lift.
+                // - 2025 era: resultType is foreign vocabulary → strip-on-
+                //   lift, then today's schema validation decides.
+                // Either way a non-complete body can never be masked into a
+                // hollow success by a tolerant result schema.
+                const decoded = codec.decodeResult(request.method, response.result);
                 if (decoded.kind === 'invalid') {
                     return reject(decoded.error);
                 }
@@ -1217,7 +1179,7 @@ export abstract class Protocol<ContextT extends BaseContext> {
                         })
                     );
                 }
-                result = decoded.result;
+                const result = decoded.result;
 
                 validateStandardSchema(resultSchema, result).then(parseResult => {
                     if (parseResult.success) {

--- a/packages/core/src/types/README.md
+++ b/packages/core/src/types/README.md
@@ -17,5 +17,10 @@ They are reference-only test oracles: the comparison suites in `packages/core/te
 3. **The bot proposes; it never auto-merges.** Automated refreshes always go through a pull request that a maintainer reviews and merges. No automation pushes anchor changes directly to `main` or merges its own PRs. A refresh PR that breaks the comparison suites is the desired
    signal — it is fixed in that PR, not bypassed.
 
-4. **Generated twins update atomically with their anchor.** If artifacts derived from an anchor (for example vendored JSON schemas or generated validators) are ever checked into this repository, any refresh that changes the anchor must regenerate those artifacts in the same
-   commit. The anchor and its derived twins must never be out of sync at any commit on `main`. This clause becomes operative the day such generated artifacts are first vendored.
+4. **Generated twins update atomically with their anchor.** If artifacts derived from an anchor (for example vendored JSON schemas or generated validators) are checked into this repository, any refresh that changes the anchor must regenerate those artifacts in the same commit.
+   The anchor and its derived twins must never be out of sync at any commit on `main`.
+
+    **This clause is OPERATIVE.** The vendored twins are the per-revision `schema.json` copies under `packages/core/test/corpus/schema-twins/` (`<revision>.schema.json` + `manifest.json` recording the source commit and content hashes). They are TEST-ONLY oracles consumed by the
+    schema-twin conformance lock (`test/wire/schemaTwinConformance.test.ts`) — never bundled, never imported by runtime code, and the JSON Schema engines stay optional peer dependencies. A refresh of `spec.types.<revision>.ts` must copy the matching upstream
+    `schema/<dir>/schema.json` (same spec commit) over the twin and update `manifest.json` in the same commit; the spec example corpus manifest (`test/corpus/fixtures/<revision>/manifest.json`) records its own source commit and follows the same atomicity rule when the examples
+    are re-vendored. The conformance lock failing after an anchor-only refresh is the desired loud signal of a missed twin update.

--- a/packages/core/src/wire/codec.ts
+++ b/packages/core/src/wire/codec.ts
@@ -55,6 +55,7 @@ import type {
     ResultTypeMap
 } from '../types/types.js';
 import { rev2025Codec } from './rev2025-11-25/codec.js';
+import { rev2026Codec } from './rev2026-07-28/codec.js';
 
 /** Wire eras with distinct vocabulary. */
 export type WireEra = '2025-11-25' | '2026-07-28';
@@ -166,13 +167,9 @@ export interface WireCodec {
  * 2026-era codec; `undefined`/unknown → legacy (the DV-13 default posture —
  * hand-constructed instances and unclassified traffic are legacy-era).
  *
- * NOTE (staging): the 2026-era codec lands with Q1 increment-2 step 5; until
- * then every version resolves to the 2025-era codec and behavior is
- * byte-identical to the pre-split SDK.
  */
 export function codecForVersion(version: string | undefined): WireCodec {
-    void version;
-    return rev2025Codec;
+    return version === MODERN_WIRE_REVISION ? rev2026Codec : rev2025Codec;
 }
 
 /**
@@ -203,4 +200,4 @@ export function isSpecNotificationMethod(method: string): boolean {
     return ALL_CODECS.some(codec => codec.hasNotificationMethod(method));
 }
 
-const ALL_CODECS: readonly WireCodec[] = [rev2025Codec];
+const ALL_CODECS: readonly WireCodec[] = [rev2025Codec, rev2026Codec];

--- a/packages/core/src/wire/codec.ts
+++ b/packages/core/src/wire/codec.ts
@@ -182,7 +182,7 @@ export function codecForVersion(version: string | undefined): WireCodec {
  */
 export function classifiedWireEra(classification: MessageClassification): WireEra {
     if (classification.revision !== undefined) return codecForVersion(classification.revision).era;
-    return classification.era === 'modern' ? MODERN_WIRE_REVISION : rev2025Codec.era;
+    return classification.era === 'modern' ? rev2026Codec.era : rev2025Codec.era;
 }
 
 /**

--- a/packages/core/src/wire/rev2025-11-25/wireTypes.ts
+++ b/packages/core/src/wire/rev2025-11-25/wireTypes.ts
@@ -1,0 +1,163 @@
+/**
+ * 2025-era WIRE-VIEW types: the anchor-exact 2025-11-25 shapes for the names
+ * whose NEUTRAL public types deliberately follow the 2026-07-28 typing.
+ *
+ * This module is the visible home of the shared-tier ADJUDICATIONS that the
+ * old `@ts-expect-error` affordances used to suppress (Q1 increment 2): each
+ * override below names a field where the 2025 anchor and the neutral model
+ * disagree, states which side the neutral model follows, and is pinned both
+ * ways by the per-revision parity suite (spec.types.2025-11-25.test.ts
+ * compares THESE types against the frozen anchor exactly — zero affordances).
+ *
+ * RUNTIME NOTE (Q10-L2): the 2025-era runtime schemas are BEHAVIOR-FROZEN
+ * and deliberately stay tolerant-wider than these wire views where the
+ * neutral typing is wider (e.g. `experimental` values accept any JSONObject
+ * at parse). These types pin the WIRE-LEVEL shape contract against the
+ * anchor; they do not narrow runtime acceptance.
+ *
+ * Adjudication ledger (neutral follows 2026 unless stated):
+ * - `Tool.inputSchema`/`outputSchema` property values: 2025 wire `object`;
+ *   neutral follows 2026 (`JSONValue`-capable open schema objects).
+ * - capability blobs (`experimental`, `sampling`, `elicitation`, `tasks`,
+ *   `logging`, `completions`): 2025 wire `object`; neutral `JSONObject`.
+ * - `extensions` capability key: 2026-only; absent from the 2025 wire view.
+ * - `CreateMessageRequestParams.metadata`: 2025 wire `object`; neutral
+ *   `JSONObject`.
+ * - `PromptArgument.title` / `PromptReference.title`: present on the 2025
+ *   wire (BaseMetadata); the neutral schemas do not declare it and the
+ *   strip-mode parse drops it (PRE-EXISTING runtime gap, recorded in the
+ *   project baseline-bug log — do not silently change parse behavior here).
+ */
+import type {
+    CallToolRequest,
+    CancelTaskRequest,
+    ClientCapabilities,
+    CompleteRequest,
+    CreateMessageRequest,
+    CreateMessageRequestParams,
+    ElicitRequest,
+    GetPromptRequest,
+    GetTaskPayloadRequest,
+    GetTaskRequest,
+    InitializeRequest,
+    InitializeRequestParams,
+    InitializeResult,
+    ListPromptsRequest,
+    ListResourcesRequest,
+    ListResourceTemplatesRequest,
+    ListRootsRequest,
+    ListTasksRequest,
+    ListToolsRequest,
+    ListToolsResult,
+    PingRequest,
+    PromptArgument,
+    PromptReference,
+    ReadResourceRequest,
+    ServerCapabilities,
+    SetLevelRequest,
+    SubscribeRequest,
+    Tool,
+    UnsubscribeRequest
+} from '../../types/types.js';
+
+/** The 2025 anchor types blob values as bare `object`. */
+type ObjectMap = { [key: string]: object };
+
+/**
+ * Omit that survives loose (index-signature) source types: the plain `Omit`
+ * collapses named keys into the index signature (`Pick<T, string>`), which
+ * silently weakens the pins. Key-remapping preserves both.
+ */
+type OmitKnown<T, K extends PropertyKey> = { [P in keyof T as P extends K ? never : P]: T[P] };
+
+/** 2025 wire shape of tool input/output schemas (property values are `object`). */
+export type Wire2025ToolIOSchema = {
+    $schema?: string;
+    type: 'object';
+    properties?: ObjectMap;
+    required?: string[];
+};
+
+export type Wire2025Tool = OmitKnown<Tool, 'inputSchema' | 'outputSchema'> & {
+    inputSchema: Wire2025ToolIOSchema;
+    outputSchema?: Wire2025ToolIOSchema;
+};
+
+export type Wire2025ListToolsResult = OmitKnown<ListToolsResult, 'tools'> & { tools: Wire2025Tool[] };
+
+export type Wire2025ClientCapabilities = OmitKnown<
+    ClientCapabilities,
+    'extensions' | 'experimental' | 'sampling' | 'elicitation' | 'tasks'
+> & {
+    experimental?: ObjectMap;
+    sampling?: { context?: object; tools?: object };
+    elicitation?: { form?: object; url?: object };
+    tasks?: {
+        list?: object;
+        cancel?: object;
+        requests?: { sampling?: { createMessage?: object }; elicitation?: { create?: object } };
+    };
+};
+
+export type Wire2025ServerCapabilities = OmitKnown<
+    ServerCapabilities,
+    'extensions' | 'experimental' | 'logging' | 'completions' | 'tasks'
+> & {
+    experimental?: ObjectMap;
+    logging?: object;
+    completions?: object;
+    tasks?: {
+        list?: object;
+        cancel?: object;
+        requests?: { tools?: { call?: object } };
+    };
+};
+
+export type Wire2025InitializeRequestParams = OmitKnown<InitializeRequestParams, 'capabilities'> & {
+    capabilities: Wire2025ClientCapabilities;
+};
+
+export type Wire2025InitializeRequest = OmitKnown<InitializeRequest, 'params'> & { params: Wire2025InitializeRequestParams };
+
+export type Wire2025InitializeResult = OmitKnown<InitializeResult, 'capabilities'> & { capabilities: Wire2025ServerCapabilities };
+
+export type Wire2025CreateMessageRequestParams = OmitKnown<CreateMessageRequestParams, 'metadata' | 'tools'> & {
+    metadata?: object;
+    tools?: Wire2025Tool[];
+};
+
+export type Wire2025CreateMessageRequest = OmitKnown<CreateMessageRequest, 'params'> & { params: Wire2025CreateMessageRequestParams };
+
+/** 2025 wire: `title` is a declared BaseMetadata member (the neutral schemas do not model it — see ledger above). */
+export type Wire2025PromptArgument = PromptArgument & { title?: string };
+export type Wire2025PromptReference = PromptReference & { title?: string };
+
+/** The 2025 wire role unions with the adjudicated members substituted. */
+export type Wire2025ClientRequestView =
+    | PingRequest
+    | Wire2025InitializeRequest
+    | CompleteRequest
+    | SetLevelRequest
+    | GetPromptRequest
+    | ListPromptsRequest
+    | ListResourcesRequest
+    | ListResourceTemplatesRequest
+    | ReadResourceRequest
+    | SubscribeRequest
+    | UnsubscribeRequest
+    | CallToolRequest
+    | ListToolsRequest
+    | GetTaskRequest
+    | GetTaskPayloadRequest
+    | ListTasksRequest
+    | CancelTaskRequest;
+
+export type Wire2025ServerRequestView =
+    | PingRequest
+    | Wire2025CreateMessageRequest
+    | ElicitRequest
+    | ListRootsRequest
+    | GetTaskRequest
+    | GetTaskPayloadRequest
+    | ListTasksRequest
+    | CancelTaskRequest;

--- a/packages/core/src/wire/rev2026-07-28/codec.ts
+++ b/packages/core/src/wire/rev2026-07-28/codec.ts
@@ -26,6 +26,8 @@
  * The ttlMs/cacheScope stamping content (M3.2) lands in `encodeResult` —
  * this seam is its final home.
  */
+import type * as z from 'zod/v4';
+
 import { SdkError, SdkErrorCode } from '../../errors/sdkErrors.js';
 import type { Result } from '../../types/types.js';
 import type { DecodedResult, LiftedWireMaterial, WireCodec } from '../codec.js';
@@ -36,7 +38,6 @@ import {
     hasNotificationMethod2026,
     hasRequestMethod2026
 } from './registry.js';
-import type { ResultSchema } from './schemas.js';
 import {
     CallToolResultSchema,
     CompleteResultSchema,
@@ -94,9 +95,9 @@ export const rev2026Codec: WireCodec = {
     hasRequestMethod: hasRequestMethod2026,
     hasNotificationMethod: hasNotificationMethod2026,
 
-    requestSchema: method => getRequestSchema2026(method),
-    resultSchema: method => getResultSchema2026(method),
-    notificationSchema: method => getNotificationSchema2026(method),
+    requestSchema: getRequestSchema2026,
+    resultSchema: getResultSchema2026,
+    notificationSchema: getNotificationSchema2026,
 
     decodeResult(method: string, raw: unknown): DecodedResult {
         if (!isPlainObject(raw)) {
@@ -193,14 +194,14 @@ export const rev2026Codec: WireCodec = {
 };
 
 /** Wire-true result wrappers consulted by decode step 2, keyed by method. */
-const WIRE_RESULT_SCHEMAS: Record<string, typeof ResultSchema> = {
-    'tools/call': CallToolResultSchema as unknown as typeof ResultSchema,
-    'tools/list': ListToolsResultSchema as unknown as typeof ResultSchema,
-    'prompts/get': GetPromptResultSchema as unknown as typeof ResultSchema,
-    'prompts/list': ListPromptsResultSchema as unknown as typeof ResultSchema,
-    'resources/list': ListResourcesResultSchema as unknown as typeof ResultSchema,
-    'resources/templates/list': ListResourceTemplatesResultSchema as unknown as typeof ResultSchema,
-    'resources/read': ReadResourceResultSchema as unknown as typeof ResultSchema,
-    'completion/complete': CompleteResultSchema as unknown as typeof ResultSchema,
-    'server/discover': DiscoverResultSchema as unknown as typeof ResultSchema
+const WIRE_RESULT_SCHEMAS: Record<string, z.ZodType> = {
+    'tools/call': CallToolResultSchema,
+    'tools/list': ListToolsResultSchema,
+    'prompts/get': GetPromptResultSchema,
+    'prompts/list': ListPromptsResultSchema,
+    'resources/list': ListResourcesResultSchema,
+    'resources/templates/list': ListResourceTemplatesResultSchema,
+    'resources/read': ReadResourceResultSchema,
+    'completion/complete': CompleteResultSchema,
+    'server/discover': DiscoverResultSchema
 };

--- a/packages/core/src/wire/rev2026-07-28/codec.ts
+++ b/packages/core/src/wire/rev2026-07-28/codec.ts
@@ -1,0 +1,206 @@
+/**
+ * The 2026-era wire codec (protocol revision 2026-07-28).
+ *
+ * Decode = raw-first `resultType` discrimination (the structural V-1 home:
+ * the RAW value is inspected BEFORE any schema validation, so a non-complete
+ * result can never be masked into a hollow success by a tolerant schema),
+ * then wire-exact parse, then lift (drop the wire member). Encode = the
+ * stamp seam: `resultType: 'complete'` is stamped on outbound results, and
+ * the known deleted-field set is strictly enforced (Q1-SD3 iii) — the 2026
+ * wire types have no slot for `execution.taskSupport` or
+ * `capabilities.tasks`, so the encode mapping deletes them; era-blind
+ * handlers stay era-invisible while deleted vocabulary cannot cross eras
+ * through the parse-free outbound path.
+ *
+ * Q1-SD3 postures implemented here:
+ * (i)  absent `resultType` from a 2026-classified peer → typed error NAMING
+ *      the violation. The spec's absent⇒complete bridge is scoped to
+ *      EARLIER-revision servers (spec.types.2026-07-28.ts Result.resultType:
+ *      "Servers implementing this protocol version MUST include this field")
+ *      and is deliberately NOT extended to modern traffic.
+ * (ii) `input_required` → the driver-seam payload (the multi-round-trip
+ *      driver, M4.1/#13, consumes it; until then the protocol layer surfaces
+ *      the discriminated kind as a typed local error, no retry).
+ * (iii) unrecognized kinds → invalid, no retry (DQ5).
+ *
+ * The ttlMs/cacheScope stamping content (M3.2) lands in `encodeResult` —
+ * this seam is its final home.
+ */
+import { SdkError, SdkErrorCode } from '../../errors/sdkErrors.js';
+import type { Result } from '../../types/types.js';
+import type { DecodedResult, LiftedWireMaterial, NarrowResultKey, WireCodec } from '../codec.js';
+import {
+    getNotificationSchema2026,
+    getRequestSchema2026,
+    getResultSchema2026,
+    hasNotificationMethod2026,
+    hasRequestMethod2026,
+    narrowResultSchemas2026
+} from './registry.js';
+import type { ResultSchema } from './schemas.js';
+import {
+    CallToolResultSchema,
+    CompleteResultSchema,
+    DiscoverResultSchema,
+    GetPromptResultSchema,
+    ListPromptsResultSchema,
+    ListResourcesResultSchema,
+    ListResourceTemplatesResultSchema,
+    ListToolsResultSchema,
+    ReadResourceResultSchema,
+    RequestMetaEnvelopeSchema
+} from './schemas.js';
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+    return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+/** Strip the known deleted-field set from an outbound result (Q1-SD3 iii). */
+function enforceDeletedFields(method: string, result: Result): Result {
+    let next: Record<string, unknown> = result as Record<string, unknown>;
+    let copied = false;
+    const copy = () => {
+        if (!copied) {
+            next = { ...next };
+            copied = true;
+        }
+        return next;
+    };
+
+    // tools arrays: execution (the taskSupport carrier) is deleted vocabulary.
+    const tools = (result as { tools?: unknown }).tools;
+    if (method === 'tools/list' && Array.isArray(tools) && tools.some(tool => isPlainObject(tool) && 'execution' in tool)) {
+        copy().tools = tools.map(tool => {
+            if (!isPlainObject(tool) || !('execution' in tool)) return tool;
+            const rest = { ...tool };
+            delete rest['execution'];
+            return rest;
+        });
+    }
+
+    // capability objects: the `tasks` capability is deleted vocabulary.
+    const capabilities = (result as { capabilities?: unknown }).capabilities;
+    if (isPlainObject(capabilities) && 'tasks' in capabilities) {
+        const rest = { ...capabilities };
+        delete rest['tasks'];
+        copy().capabilities = rest;
+    }
+
+    return next as Result;
+}
+
+export const rev2026Codec: WireCodec = {
+    era: '2026-07-28',
+
+    hasRequestMethod: hasRequestMethod2026,
+    hasNotificationMethod: hasNotificationMethod2026,
+
+    requestSchema: method => getRequestSchema2026(method),
+    resultSchema: method => getResultSchema2026(method),
+    notificationSchema: method => getNotificationSchema2026(method),
+
+    narrowResultSchema: (key: NarrowResultKey) => narrowResultSchemas2026[key],
+
+    decodeResult(method: string, raw: unknown): DecodedResult {
+        if (!isPlainObject(raw)) {
+            return {
+                kind: 'invalid',
+                error: new SdkError(SdkErrorCode.InvalidResult, `Invalid result for ${method}: not an object`, { method })
+            };
+        }
+
+        // Step 1 — RAW discrimination, before any schema (V-1).
+        const rawResultType = raw['resultType'];
+        if (rawResultType === undefined) {
+            // Q1-SD3 (i): hard error naming the violation.
+            return {
+                kind: 'invalid',
+                error: new SdkError(
+                    SdkErrorCode.InvalidResult,
+                    `Invalid result for ${method}: missing required resultType — servers implementing protocol revision 2026-07-28 ` +
+                        `MUST include it (the absent-means-complete bridge applies only to earlier-revision servers)`,
+                    { method, violation: 'missing-resultType' }
+                )
+            };
+        }
+        if (typeof rawResultType !== 'string') {
+            return {
+                kind: 'invalid',
+                error: new SdkError(SdkErrorCode.InvalidResult, `Invalid result for ${method}: non-string resultType`, {
+                    method,
+                    resultType: rawResultType
+                })
+            };
+        }
+        if (rawResultType === 'input_required') {
+            // The driver seam (#13 consumes this payload).
+            const inputRequests = raw['inputRequests'];
+            return {
+                kind: 'input_required',
+                inputRequests: isPlainObject(inputRequests) ? inputRequests : {},
+                ...(typeof raw['requestState'] === 'string' && { requestState: raw['requestState'] })
+            };
+        }
+        if (rawResultType !== 'complete') {
+            // Unrecognized kind ⇒ invalid, no retry (DQ5).
+            return {
+                kind: 'invalid',
+                error: new SdkError(SdkErrorCode.UnsupportedResultType, `Unsupported result type '${rawResultType}' for ${method}`, {
+                    resultType: rawResultType,
+                    method
+                })
+            };
+        }
+
+        // Step 2 — wire-exact parse (registry methods), with resultType present.
+        const wireSchema = WIRE_RESULT_SCHEMAS[method];
+        if (wireSchema !== undefined) {
+            const parsed = wireSchema.safeParse(raw);
+            if (!parsed.success) {
+                return {
+                    kind: 'invalid',
+                    error: new SdkError(SdkErrorCode.InvalidResult, `Invalid result for ${method}: ${parsed.error}`, { method })
+                };
+            }
+        }
+
+        // Step 3 — lift: the wire discriminator is consumed.
+        const lifted = { ...raw };
+        delete lifted['resultType'];
+        return { kind: 'complete', result: lifted as Result };
+    },
+
+    encodeResult(method: string, result: Result): Result {
+        // The stamp seam: outbound results carry the required discriminator.
+        // (Handler-authored resultType for methods whose vocabulary exceeds
+        // 'complete' is MRTR scope — #13 extends this seam.)
+        return { ...enforceDeletedFields(method, result), resultType: 'complete' } as Result;
+    },
+
+    checkInboundEnvelope(material: LiftedWireMaterial): string | undefined {
+        if (material.envelope === undefined) {
+            return (
+                'Request is missing the required _meta envelope for protocol revision 2026-07-28 ' +
+                '(io.modelcontextprotocol/protocolVersion, io.modelcontextprotocol/clientInfo, io.modelcontextprotocol/clientCapabilities)'
+            );
+        }
+        const parsed = RequestMetaEnvelopeSchema.safeParse(material.envelope);
+        if (!parsed.success) {
+            return `Invalid _meta envelope for protocol revision 2026-07-28: ${parsed.error.issues.map(issue => issue.message).join('; ')}`;
+        }
+        return undefined;
+    }
+};
+
+/** Wire-true result wrappers consulted by decode step 2, keyed by method. */
+const WIRE_RESULT_SCHEMAS: Record<string, typeof ResultSchema> = {
+    'tools/call': CallToolResultSchema as unknown as typeof ResultSchema,
+    'tools/list': ListToolsResultSchema as unknown as typeof ResultSchema,
+    'prompts/get': GetPromptResultSchema as unknown as typeof ResultSchema,
+    'prompts/list': ListPromptsResultSchema as unknown as typeof ResultSchema,
+    'resources/list': ListResourcesResultSchema as unknown as typeof ResultSchema,
+    'resources/templates/list': ListResourceTemplatesResultSchema as unknown as typeof ResultSchema,
+    'resources/read': ReadResourceResultSchema as unknown as typeof ResultSchema,
+    'completion/complete': CompleteResultSchema as unknown as typeof ResultSchema,
+    'server/discover': DiscoverResultSchema as unknown as typeof ResultSchema
+};

--- a/packages/core/src/wire/rev2026-07-28/codec.ts
+++ b/packages/core/src/wire/rev2026-07-28/codec.ts
@@ -28,14 +28,13 @@
  */
 import { SdkError, SdkErrorCode } from '../../errors/sdkErrors.js';
 import type { Result } from '../../types/types.js';
-import type { DecodedResult, LiftedWireMaterial, NarrowResultKey, WireCodec } from '../codec.js';
+import type { DecodedResult, LiftedWireMaterial, WireCodec } from '../codec.js';
 import {
     getNotificationSchema2026,
     getRequestSchema2026,
     getResultSchema2026,
     hasNotificationMethod2026,
-    hasRequestMethod2026,
-    narrowResultSchemas2026
+    hasRequestMethod2026
 } from './registry.js';
 import type { ResultSchema } from './schemas.js';
 import {
@@ -98,8 +97,6 @@ export const rev2026Codec: WireCodec = {
     requestSchema: method => getRequestSchema2026(method),
     resultSchema: method => getResultSchema2026(method),
     notificationSchema: method => getNotificationSchema2026(method),
-
-    narrowResultSchema: (key: NarrowResultKey) => narrowResultSchemas2026[key],
 
     decodeResult(method: string, raw: unknown): DecodedResult {
         if (!isPlainObject(raw)) {

--- a/packages/core/src/wire/rev2026-07-28/codec.ts
+++ b/packages/core/src/wire/rev2026-07-28/codec.ts
@@ -153,7 +153,10 @@ export const rev2026Codec: WireCodec = {
         }
 
         // Step 2 — wire-exact parse (registry methods), with resultType present.
-        const wireSchema = WIRE_RESULT_SCHEMAS[method];
+        // Own-key lookup: `method` is peer-influenced on related-request
+        // paths, and a prototype-chain hit (e.g. 'constructor') must not
+        // masquerade as a schema and throw out of the decode hop.
+        const wireSchema = Object.hasOwn(WIRE_RESULT_SCHEMAS, method) ? WIRE_RESULT_SCHEMAS[method] : undefined;
         if (wireSchema !== undefined) {
             const parsed = wireSchema.safeParse(raw);
             if (!parsed.success) {

--- a/packages/core/src/wire/rev2026-07-28/registry.ts
+++ b/packages/core/src/wire/rev2026-07-28/registry.ts
@@ -25,26 +25,58 @@
  */
 import type * as z from 'zod/v4';
 
+import type { NotificationMethod, NotificationTypeMap, RequestMethod, RequestTypeMap, ResultTypeMap } from '../../types/types.js';
+import type { Rev2026NotificationMethod, Rev2026RequestMethod } from './schemas.js';
 import { dispatchRequestSchemas, dispatchResultSchemas, notificationSchemas2026 } from './schemas.js';
 
-export function hasRequestMethod2026(method: string): boolean {
+/** The 2026-era request-method set (registry membership = the deletion story). */
+export function hasRequestMethod2026(method: string): method is Rev2026RequestMethod {
     return Object.prototype.hasOwnProperty.call(dispatchRequestSchemas, method);
 }
 
-export function hasNotificationMethod2026(method: string): boolean {
+/** The 2026-era notification-method set. */
+export function hasNotificationMethod2026(method: string): method is Rev2026NotificationMethod {
     return Object.prototype.hasOwnProperty.call(notificationSchemas2026, method);
 }
 
+/** Result-map membership (same key set as the request map on this era). */
+function hasResultMethod2026(method: string): method is Rev2026RequestMethod {
+    return Object.prototype.hasOwnProperty.call(dispatchResultSchemas, method);
+}
+
+/**
+ * Gets the dispatch (post-lift) Zod schema for a given request method.
+ * Returns `undefined` for methods this era's registry does not define.
+ * The typed overload mirrors `WireCodec.requestSchema` so call sites with a
+ * statically known method need no type assertion.
+ */
+export function getRequestSchema2026<M extends RequestMethod>(method: M): z.ZodType<RequestTypeMap[M]> | undefined;
+export function getRequestSchema2026(method: string): z.ZodType | undefined;
 export function getRequestSchema2026(method: string): z.ZodType | undefined {
-    return dispatchRequestSchemas[method];
+    return hasRequestMethod2026(method) ? dispatchRequestSchemas[method] : undefined;
 }
 
+/**
+ * Gets the dispatch (post-lift) Zod schema for validating results of a given
+ * request method. Returns `undefined` for methods this era's registry does
+ * not define.
+ * @see getRequestSchema2026 for the typed-overload contract.
+ */
+export function getResultSchema2026<M extends RequestMethod>(method: M): z.ZodType<ResultTypeMap[M]> | undefined;
+export function getResultSchema2026(method: string): z.ZodType | undefined;
 export function getResultSchema2026(method: string): z.ZodType | undefined {
-    return dispatchResultSchemas[method];
+    return hasResultMethod2026(method) ? dispatchResultSchemas[method] : undefined;
 }
 
+/**
+ * Gets the Zod schema for a given notification method.
+ * Returns `undefined` for methods this era's registry does not define.
+ * @see getRequestSchema2026 for the typed-overload contract.
+ */
+export function getNotificationSchema2026<M extends NotificationMethod>(method: M): z.ZodType<NotificationTypeMap[M]> | undefined;
+export function getNotificationSchema2026(method: string): z.ZodType | undefined;
 export function getNotificationSchema2026(method: string): z.ZodType | undefined {
-    return notificationSchemas2026[method];
+    return hasNotificationMethod2026(method) ? notificationSchemas2026[method] : undefined;
 }
 
 /** Registry method lists (for the spec-method universe and the CI registry-diff oracle). */

--- a/packages/core/src/wire/rev2026-07-28/registry.ts
+++ b/packages/core/src/wire/rev2026-07-28/registry.ts
@@ -50,12 +50,3 @@ export function getNotificationSchema2026(method: string): z.ZodType | undefined
 /** Registry method lists (for the spec-method universe and the CI registry-diff oracle). */
 export const rev2026RequestMethods: readonly string[] = Object.keys(dispatchRequestSchemas);
 export const rev2026NotificationMethods: readonly string[] = Object.keys(notificationSchemas2026);
-
-/** Narrow high-level result schemas for this era (see `codec.ts`
- * `NarrowResultKey`). Deliberately EMPTY: the only narrow surface is the
- * sampling pair, and sampling is not a wire request on this era (demoted to
- * in-band `InputRequest` payloads), so `server.createMessage` fails with the
- * typed era error before schema resolution. `tools/call` validates its
- * registry entry directly — with the result maps aligned to the typed maps
- * there is no narrower tools/call surface on any era. */
-export const narrowResultSchemas2026: Record<string, z.ZodType> = {};

--- a/packages/core/src/wire/rev2026-07-28/registry.ts
+++ b/packages/core/src/wire/rev2026-07-28/registry.ts
@@ -1,0 +1,61 @@
+/**
+ * The 2026-era method registries (protocol revision 2026-07-28).
+ *
+ * Registry membership IS the deletion story: there are NO entries for
+ * `initialize`, `notifications/initialized`, `ping`, `logging/setLevel`,
+ * `resources/subscribe`, `resources/unsubscribe`,
+ * `notifications/roots/list_changed`, the task family, or the server→client
+ * wire-request channel — so an era-mismatched method falls to −32601 by
+ * absence inbound and a typed local error outbound, with no table to forget.
+ *
+ * HAND-REGISTRY SEED DECISIONS (pinned by the CI registry-diff oracle, which
+ * fails LOUD if this list and the anchor diff ever disagree):
+ * - `sampling/createMessage`, `elicitation/create`, `roots/list`: the anchor
+ *   still carries their method literals on bare interfaces, but 2026 DEMOTES
+ *   them from wire requests to in-band `InputRequest` payloads — the entire
+ *   server→client JSON-RPC request channel is deleted (`ServerRequest` has
+ *   no 2026 export). A generator walking method literals would re-admit them
+ *   (the ATK-D flavor-b trap); this hand registry excludes them by
+ *   construction. Their in-band role lands with the MRTR driver (#13).
+ * - `subscriptions/listen` + `notifications/subscriptions/acknowledged`
+ *   (SEP-1865): 2026-only vocabulary whose SHELLS land with the
+ *   subscriptions feature (#14). Until then they are absent here — inbound
+ *   listen gets −32601 (capability not yet served), which is protocol-legal
+ *   for a server that does not implement subscriptions.
+ */
+import type * as z from 'zod/v4';
+
+import { dispatchRequestSchemas, dispatchResultSchemas, notificationSchemas2026 } from './schemas.js';
+
+export function hasRequestMethod2026(method: string): boolean {
+    return Object.prototype.hasOwnProperty.call(dispatchRequestSchemas, method);
+}
+
+export function hasNotificationMethod2026(method: string): boolean {
+    return Object.prototype.hasOwnProperty.call(notificationSchemas2026, method);
+}
+
+export function getRequestSchema2026(method: string): z.ZodType | undefined {
+    return dispatchRequestSchemas[method];
+}
+
+export function getResultSchema2026(method: string): z.ZodType | undefined {
+    return dispatchResultSchemas[method];
+}
+
+export function getNotificationSchema2026(method: string): z.ZodType | undefined {
+    return notificationSchemas2026[method];
+}
+
+/** Registry method lists (for the spec-method universe and the CI registry-diff oracle). */
+export const rev2026RequestMethods: readonly string[] = Object.keys(dispatchRequestSchemas);
+export const rev2026NotificationMethods: readonly string[] = Object.keys(notificationSchemas2026);
+
+/** Narrow high-level result schemas for this era (see `codec.ts`
+ * `NarrowResultKey`). Deliberately EMPTY: the only narrow surface is the
+ * sampling pair, and sampling is not a wire request on this era (demoted to
+ * in-band `InputRequest` payloads), so `server.createMessage` fails with the
+ * typed era error before schema resolution. `tools/call` validates its
+ * registry entry directly — with the result maps aligned to the typed maps
+ * there is no narrower tools/call surface on any era. */
+export const narrowResultSchemas2026: Record<string, z.ZodType> = {};

--- a/packages/core/src/wire/rev2026-07-28/schemas.ts
+++ b/packages/core/src/wire/rev2026-07-28/schemas.ts
@@ -22,37 +22,38 @@ import {
 } from '../../types/constants.js';
 import {
     AnnotationsSchema,
+    AudioContentSchema,
     BaseMetadataSchema,
     BlobResourceContentsSchema,
     CancelledNotificationSchema,
     ClientCapabilitiesSchema,
-    CompleteRequestParamsSchema,
     ContentBlockSchema,
     CursorSchema,
     ElicitationCompleteNotificationSchema,
-    GetPromptRequestParamsSchema,
     IconsSchema,
+    ImageContentSchema,
     ImplementationSchema,
-    JSONValueSchema,
     LoggingLevelSchema,
     LoggingMessageNotificationSchema,
     ProgressNotificationSchema,
     ProgressTokenSchema,
     PromptListChangedNotificationSchema,
     PromptMessageSchema,
+    PromptReferenceSchema,
     PromptSchema,
     ResourceContentsSchema,
     ResourceListChangedNotificationSchema,
-    ResourceRequestParamsSchema,
     ResourceSchema,
+    ResourceTemplateReferenceSchema,
     ResourceTemplateSchema,
     ResourceUpdatedNotificationSchema,
     RoleSchema,
-    SamplingMessageContentBlockSchema,
     ServerCapabilitiesSchema,
+    TextContentSchema,
     TextResourceContentsSchema,
     ToolAnnotationsSchema,
-    ToolListChangedNotificationSchema
+    ToolListChangedNotificationSchema,
+    ToolUseContentSchema
 } from '../../types/schemas.js';
 
 /* Per-request `_meta` envelope */
@@ -114,24 +115,39 @@ export const ToolSchema = z.object({
     ...BaseMetadataSchema.shape,
     ...IconsSchema.shape,
     description: z.string().optional(),
-    inputSchema: z
-        .object({
-            type: z.literal('object'),
-            properties: z.record(z.string(), JSONValueSchema).optional(),
-            required: z.array(z.string()).optional()
-        })
-        .catchall(z.unknown()),
+    // Anchor-exact: { $schema?: string; type: 'object'; [key: string]: unknown }
+    inputSchema: z.looseObject({
+        $schema: z.string().optional(),
+        type: z.literal('object')
+    }),
+    // Anchor-exact: { $schema?: string; [key: string]: unknown }
     outputSchema: z
-        .object({
-            type: z.literal('object'),
-            properties: z.record(z.string(), JSONValueSchema).optional(),
-            required: z.array(z.string()).optional()
+        .looseObject({
+            $schema: z.string().optional()
         })
-        .catchall(z.unknown())
         .optional(),
     annotations: ToolAnnotationsSchema.optional(),
     _meta: z.record(z.string(), z.unknown()).optional()
 });
+
+/** 2026-era ToolResultContent (anchor-exact: `structuredContent?: unknown`). */
+export const ToolResultContentSchema = z.object({
+    type: z.literal('tool_result'),
+    toolUseId: z.string(),
+    content: z.array(ContentBlockSchema),
+    structuredContent: z.unknown().optional(),
+    isError: z.boolean().optional(),
+    _meta: z.record(z.string(), z.unknown()).optional()
+});
+
+/** 2026-era sampling content union (composes the forked tool-result shape). */
+export const SamplingMessageContentBlockSchema = z.union([
+    TextContentSchema,
+    ImageContentSchema,
+    AudioContentSchema,
+    ToolUseContentSchema,
+    ToolResultContentSchema
+]);
 
 /** 2026-era SamplingMessage (anchor-exact: single block or array). */
 export const SamplingMessageSchema = z.object({
@@ -169,18 +185,26 @@ function wireResult<T extends z.core.$ZodLooseShape>(shape: T) {
 
 export const ResultSchema = wireResult({});
 
+export const PaginatedResultSchema = wireResult({
+    nextCursor: CursorSchema.optional()
+});
+
 export const CallToolResultSchema = wireResult({
     content: z.array(ContentBlockSchema),
-    structuredContent: z.record(z.string(), z.unknown()).optional(),
+    structuredContent: z.unknown().optional(),
     isError: z.boolean().optional()
 });
 
 export const ListToolsResultSchema = wireResult({
+    ttlMs: z.number().min(0),
+    cacheScope: z.enum(['public', 'private']),
     tools: z.array(ToolSchema),
     nextCursor: CursorSchema.optional()
 });
 
 export const ListPromptsResultSchema = wireResult({
+    ttlMs: z.number().min(0),
+    cacheScope: z.enum(['public', 'private']),
     prompts: z.array(PromptSchema),
     nextCursor: CursorSchema.optional()
 });
@@ -191,16 +215,22 @@ export const GetPromptResultSchema = wireResult({
 });
 
 export const ListResourcesResultSchema = wireResult({
+    ttlMs: z.number().min(0),
+    cacheScope: z.enum(['public', 'private']),
     resources: z.array(ResourceSchema),
     nextCursor: CursorSchema.optional()
 });
 
 export const ListResourceTemplatesResultSchema = wireResult({
+    ttlMs: z.number().min(0),
+    cacheScope: z.enum(['public', 'private']),
     resourceTemplates: z.array(ResourceTemplateSchema),
     nextCursor: CursorSchema.optional()
 });
 
 export const ReadResourceResultSchema = wireResult({
+    ttlMs: z.number().min(0),
+    cacheScope: z.enum(['public', 'private']),
     contents: z.array(z.union([TextResourceContentsSchema, BlobResourceContentsSchema]))
 });
 
@@ -246,15 +276,14 @@ const DispatchRequestMetaSchema = z.looseObject({
     progressToken: ProgressTokenSchema.optional()
 });
 
-function wireRequest<T extends z.core.$ZodLooseShape>(method: string, paramsShape: T, paramsOptional = false) {
-    const params = z.object({ _meta: RequestMetaEnvelopeSchema, ...paramsShape });
+function wireRequest<M extends string, T extends z.core.$ZodLooseShape>(method: M, paramsShape: T) {
     return z.object({
         method: z.literal(method),
-        params: paramsOptional ? params.optional() : params
+        params: z.object({ _meta: RequestMetaEnvelopeSchema, ...paramsShape })
     });
 }
 
-function dispatchRequest<T extends z.core.$ZodLooseShape>(method: string, paramsShape: T) {
+function dispatchRequest<M extends string, T extends z.core.$ZodLooseShape>(method: M, paramsShape: T) {
     return z.object({
         method: z.literal(method),
         params: z.object({ _meta: DispatchRequestMetaSchema.optional(), ...paramsShape }).optional()
@@ -277,18 +306,13 @@ export const GetPromptRequestSchema = wireRequest('prompts/get', {
 export const ListResourcesRequestSchema = wireRequest('resources/list', paginatedParamsShape);
 export const ListResourceTemplatesRequestSchema = wireRequest('resources/templates/list', paginatedParamsShape);
 export const ReadResourceRequestSchema = wireRequest('resources/read', { uri: z.string() });
-export const CompleteRequestSchema = wireRequest('completion/complete', {
-    ref: z.union([
-        z.object({ type: z.literal('ref/prompt'), name: z.string() }).loose(),
-        z.object({ type: z.literal('ref/resource'), uri: z.string() }).loose()
-    ]),
-    argument: z.object({ name: z.string(), value: z.string() }).loose(),
-    context: z
-        .object({ arguments: z.record(z.string(), z.string()).optional() })
-        .loose()
-        .optional()
-});
-export const DiscoverRequestSchema = wireRequest('server/discover', {}, true);
+const completeParamsShape = {
+    ref: z.union([PromptReferenceSchema, ResourceTemplateReferenceSchema]),
+    argument: z.object({ name: z.string(), value: z.string() }),
+    context: z.object({ arguments: z.record(z.string(), z.string()).optional() }).optional()
+};
+export const CompleteRequestSchema = wireRequest('completion/complete', completeParamsShape);
+export const DiscoverRequestSchema = wireRequest('server/discover', {});
 
 /** Dispatch (post-lift) request schemas, keyed by method — registry-internal. */
 export const dispatchRequestSchemas: Record<string, z.ZodType> = {
@@ -302,17 +326,7 @@ export const dispatchRequestSchemas: Record<string, z.ZodType> = {
     'resources/list': dispatchRequest('resources/list', paginatedParamsShape) as unknown as z.ZodType,
     'resources/templates/list': dispatchRequest('resources/templates/list', paginatedParamsShape) as unknown as z.ZodType,
     'resources/read': dispatchRequest('resources/read', { uri: z.string() }) as unknown as z.ZodType,
-    'completion/complete': dispatchRequest('completion/complete', {
-        ref: z.union([
-            z.object({ type: z.literal('ref/prompt'), name: z.string() }).loose(),
-            z.object({ type: z.literal('ref/resource'), uri: z.string() }).loose()
-        ]),
-        argument: z.object({ name: z.string(), value: z.string() }).loose(),
-        context: z
-            .object({ arguments: z.record(z.string(), z.string()).optional() })
-            .loose()
-            .optional()
-    }) as unknown as z.ZodType,
+    'completion/complete': dispatchRequest('completion/complete', completeParamsShape) as unknown as z.ZodType,
     'server/discover': dispatchRequest('server/discover', {}) as unknown as z.ZodType
 };
 
@@ -325,21 +339,40 @@ function liftedResult<T extends z.core.$ZodLooseShape>(shape: T) {
 export const dispatchResultSchemas: Record<string, z.ZodType> = {
     'tools/call': liftedResult({
         content: z.array(ContentBlockSchema),
-        structuredContent: z.record(z.string(), z.unknown()).optional(),
+        structuredContent: z.unknown().optional(),
         isError: z.boolean().optional()
     }) as unknown as z.ZodType,
-    'tools/list': liftedResult({ tools: z.array(ToolSchema), nextCursor: CursorSchema.optional() }) as unknown as z.ZodType,
+    'tools/list': liftedResult({
+        ttlMs: z.number().min(0),
+        cacheScope: z.enum(['public', 'private']),
+        tools: z.array(ToolSchema),
+        nextCursor: CursorSchema.optional()
+    }) as unknown as z.ZodType,
     'prompts/get': liftedResult({
         description: z.string().optional(),
         messages: z.array(PromptMessageSchema)
     }) as unknown as z.ZodType,
-    'prompts/list': liftedResult({ prompts: z.array(PromptSchema), nextCursor: CursorSchema.optional() }) as unknown as z.ZodType,
-    'resources/list': liftedResult({ resources: z.array(ResourceSchema), nextCursor: CursorSchema.optional() }) as unknown as z.ZodType,
+    'prompts/list': liftedResult({
+        ttlMs: z.number().min(0),
+        cacheScope: z.enum(['public', 'private']),
+        prompts: z.array(PromptSchema),
+        nextCursor: CursorSchema.optional()
+    }) as unknown as z.ZodType,
+    'resources/list': liftedResult({
+        ttlMs: z.number().min(0),
+        cacheScope: z.enum(['public', 'private']),
+        resources: z.array(ResourceSchema),
+        nextCursor: CursorSchema.optional()
+    }) as unknown as z.ZodType,
     'resources/templates/list': liftedResult({
+        ttlMs: z.number().min(0),
+        cacheScope: z.enum(['public', 'private']),
         resourceTemplates: z.array(ResourceTemplateSchema),
         nextCursor: CursorSchema.optional()
     }) as unknown as z.ZodType,
     'resources/read': liftedResult({
+        ttlMs: z.number().min(0),
+        cacheScope: z.enum(['public', 'private']),
         contents: z.array(z.union([TextResourceContentsSchema, BlobResourceContentsSchema]))
     }) as unknown as z.ZodType,
     'completion/complete': liftedResult({
@@ -407,6 +440,3 @@ export const DiscoverResultResponseSchema = wireResultResponse(DiscoverResultSch
 // explicit for tooling (these shared payloads serve both eras unchanged).
 void AnnotationsSchema;
 void ResourceContentsSchema;
-void CompleteRequestParamsSchema;
-void GetPromptRequestParamsSchema;
-void ResourceRequestParamsSchema;

--- a/packages/core/src/wire/rev2026-07-28/schemas.ts
+++ b/packages/core/src/wire/rev2026-07-28/schemas.ts
@@ -56,6 +56,27 @@ import {
     ToolUseContentSchema
 } from '../../types/schemas.js';
 
+/* 2026-era capability forks (defined ahead of the envelope, which composes
+ * the client fork). The shared shapes minus the deleted `tasks` key: `tasks`
+ * is 2025-only vocabulary with no slot on this revision, consistent with the
+ * encode-side deletion (Q1-SD3 iii).
+ *
+ * The client fork lists its members EXPLICITLY (composing the shared member
+ * schemas by reference) rather than using `.omit()`: the envelope schema
+ * below reaches the bundled package declarations, and an `.omit()` inference
+ * is a mapped type whose printed member order is unstable across dts-rollup
+ * builds (api-report flap). The explicit list doubles as the fork's deletion
+ * statement — a member added to the shared shape must be re-adjudicated here. */
+const sharedClientCapabilityShape = ClientCapabilitiesSchema.shape;
+export const ClientCapabilities2026Schema = z.object({
+    experimental: sharedClientCapabilityShape.experimental,
+    sampling: sharedClientCapabilityShape.sampling,
+    elicitation: sharedClientCapabilityShape.elicitation,
+    roots: sharedClientCapabilityShape.roots,
+    extensions: sharedClientCapabilityShape.extensions
+});
+export const ServerCapabilities2026Schema = ServerCapabilitiesSchema.omit({ tasks: true });
+
 /* Per-request `_meta` envelope */
 /**
  * The per-request `_meta` envelope carried by every request under protocol revision
@@ -85,9 +106,11 @@ export const RequestMetaEnvelopeSchema = z.looseObject({
     /**
      * The client's capabilities for this specific request. An empty object means the
      * client supports no optional capabilities. Servers must not infer capabilities
-     * from prior requests.
+     * from prior requests. Validated with the 2026 fork: `tasks` has no slot on
+     * this revision (deleted vocabulary), matching the server-side fork wired
+     * into `DiscoverResultSchema`.
      */
-    [CLIENT_CAPABILITIES_META_KEY]: ClientCapabilitiesSchema,
+    [CLIENT_CAPABILITIES_META_KEY]: ClientCapabilities2026Schema,
     /**
      * The desired log level for this request. When absent, the server must not send
      * `notifications/message` notifications for the request.
@@ -156,10 +179,6 @@ export const SamplingMessageSchema = z.object({
     _meta: z.record(z.string(), z.unknown()).optional()
 });
 
-/** 2026-era capabilities: the shared shapes minus the deleted `tasks` key. */
-export const ClientCapabilities2026Schema = ClientCapabilitiesSchema.omit({ tasks: true });
-export const ServerCapabilities2026Schema = ServerCapabilitiesSchema.omit({ tasks: true });
-
 /* ------------------------------------------------------------------------ *
  * Result side. `resultType` is REQUIRED at parse (spec.types.2026-07-28
  * Result.resultType: "Servers implementing this protocol version MUST
@@ -196,14 +215,14 @@ export const CallToolResultSchema = wireResult({
 });
 
 export const ListToolsResultSchema = wireResult({
-    ttlMs: z.number().min(0),
+    ttlMs: z.number().int().min(0),
     cacheScope: z.enum(['public', 'private']),
     tools: z.array(ToolSchema),
     nextCursor: CursorSchema.optional()
 });
 
 export const ListPromptsResultSchema = wireResult({
-    ttlMs: z.number().min(0),
+    ttlMs: z.number().int().min(0),
     cacheScope: z.enum(['public', 'private']),
     prompts: z.array(PromptSchema),
     nextCursor: CursorSchema.optional()
@@ -215,21 +234,21 @@ export const GetPromptResultSchema = wireResult({
 });
 
 export const ListResourcesResultSchema = wireResult({
-    ttlMs: z.number().min(0),
+    ttlMs: z.number().int().min(0),
     cacheScope: z.enum(['public', 'private']),
     resources: z.array(ResourceSchema),
     nextCursor: CursorSchema.optional()
 });
 
 export const ListResourceTemplatesResultSchema = wireResult({
-    ttlMs: z.number().min(0),
+    ttlMs: z.number().int().min(0),
     cacheScope: z.enum(['public', 'private']),
     resourceTemplates: z.array(ResourceTemplateSchema),
     nextCursor: CursorSchema.optional()
 });
 
 export const ReadResourceResultSchema = wireResult({
-    ttlMs: z.number().min(0),
+    ttlMs: z.number().int().min(0),
     cacheScope: z.enum(['public', 'private']),
     contents: z.array(z.union([TextResourceContentsSchema, BlobResourceContentsSchema]))
 });
@@ -246,12 +265,12 @@ export const CompleteResultSchema = wireResult({
 
 /** CacheableResult (SEP-2549): ttlMs and cacheScope REQUIRED per the anchor. */
 export const CacheableResultSchema = wireResult({
-    ttlMs: z.number().min(0),
+    ttlMs: z.number().int().min(0),
     cacheScope: z.enum(['public', 'private'])
 });
 
 export const DiscoverResultSchema = wireResult({
-    ttlMs: z.number().min(0),
+    ttlMs: z.number().int().min(0),
     cacheScope: z.enum(['public', 'private']),
     supportedVersions: z.array(z.string()),
     capabilities: ServerCapabilities2026Schema,
@@ -343,7 +362,7 @@ export const dispatchResultSchemas: Record<string, z.ZodType> = {
         isError: z.boolean().optional()
     }) as unknown as z.ZodType,
     'tools/list': liftedResult({
-        ttlMs: z.number().min(0),
+        ttlMs: z.number().int().min(0),
         cacheScope: z.enum(['public', 'private']),
         tools: z.array(ToolSchema),
         nextCursor: CursorSchema.optional()
@@ -353,25 +372,25 @@ export const dispatchResultSchemas: Record<string, z.ZodType> = {
         messages: z.array(PromptMessageSchema)
     }) as unknown as z.ZodType,
     'prompts/list': liftedResult({
-        ttlMs: z.number().min(0),
+        ttlMs: z.number().int().min(0),
         cacheScope: z.enum(['public', 'private']),
         prompts: z.array(PromptSchema),
         nextCursor: CursorSchema.optional()
     }) as unknown as z.ZodType,
     'resources/list': liftedResult({
-        ttlMs: z.number().min(0),
+        ttlMs: z.number().int().min(0),
         cacheScope: z.enum(['public', 'private']),
         resources: z.array(ResourceSchema),
         nextCursor: CursorSchema.optional()
     }) as unknown as z.ZodType,
     'resources/templates/list': liftedResult({
-        ttlMs: z.number().min(0),
+        ttlMs: z.number().int().min(0),
         cacheScope: z.enum(['public', 'private']),
         resourceTemplates: z.array(ResourceTemplateSchema),
         nextCursor: CursorSchema.optional()
     }) as unknown as z.ZodType,
     'resources/read': liftedResult({
-        ttlMs: z.number().min(0),
+        ttlMs: z.number().int().min(0),
         cacheScope: z.enum(['public', 'private']),
         contents: z.array(z.union([TextResourceContentsSchema, BlobResourceContentsSchema]))
     }) as unknown as z.ZodType,
@@ -385,7 +404,7 @@ export const dispatchResultSchemas: Record<string, z.ZodType> = {
             .loose()
     }) as unknown as z.ZodType,
     'server/discover': liftedResult({
-        ttlMs: z.number().min(0),
+        ttlMs: z.number().int().min(0),
         cacheScope: z.enum(['public', 'private']),
         supportedVersions: z.array(z.string()),
         capabilities: ServerCapabilities2026Schema,

--- a/packages/core/src/wire/rev2026-07-28/schemas.ts
+++ b/packages/core/src/wire/rev2026-07-28/schemas.ts
@@ -20,7 +20,40 @@ import {
     LOG_LEVEL_META_KEY,
     PROTOCOL_VERSION_META_KEY
 } from '../../types/constants.js';
-import { ClientCapabilitiesSchema, ImplementationSchema, LoggingLevelSchema, ProgressTokenSchema } from '../../types/schemas.js';
+import {
+    AnnotationsSchema,
+    BaseMetadataSchema,
+    BlobResourceContentsSchema,
+    CancelledNotificationSchema,
+    ClientCapabilitiesSchema,
+    CompleteRequestParamsSchema,
+    ContentBlockSchema,
+    CursorSchema,
+    ElicitationCompleteNotificationSchema,
+    GetPromptRequestParamsSchema,
+    IconsSchema,
+    ImplementationSchema,
+    JSONValueSchema,
+    LoggingLevelSchema,
+    LoggingMessageNotificationSchema,
+    ProgressNotificationSchema,
+    ProgressTokenSchema,
+    PromptListChangedNotificationSchema,
+    PromptMessageSchema,
+    PromptSchema,
+    ResourceContentsSchema,
+    ResourceListChangedNotificationSchema,
+    ResourceRequestParamsSchema,
+    ResourceSchema,
+    ResourceTemplateSchema,
+    ResourceUpdatedNotificationSchema,
+    RoleSchema,
+    SamplingMessageContentBlockSchema,
+    ServerCapabilitiesSchema,
+    TextResourceContentsSchema,
+    ToolAnnotationsSchema,
+    ToolListChangedNotificationSchema
+} from '../../types/schemas.js';
 
 /* Per-request `_meta` envelope */
 /**
@@ -63,3 +96,317 @@ export const RequestMetaEnvelopeSchema = z.looseObject({
      */
     [LOG_LEVEL_META_KEY]: LoggingLevelSchema.optional()
 });
+
+/* ------------------------------------------------------------------------ *
+ * Forked payload vocabulary (shared-tier admission rule, ATK-B section 1):
+ * `Tool` and `SamplingMessage` are bidirectionally incomparable between the
+ * 2025-11-25 and 2026-07-28 anchors, so they FORK per wire module instead of
+ * sitting in the shared tier. The forks below are 2026-anchor-exact:
+ * - Tool (2026) has NO `execution` member (ToolExecution and its
+ *   `taskSupport` carrier are deleted vocabulary) — a 2026 peer's tool that
+ *   carries one is stripped on parse, and the encode side strips it from
+ *   outbound tools (Q1-SD3 iii).
+ * - SamplingMessage (2026) is composed against the 2026 anchor shape.
+ * ------------------------------------------------------------------------ */
+
+/** 2026-era Tool: anchor-exact — no `execution` (deleted vocabulary). */
+export const ToolSchema = z.object({
+    ...BaseMetadataSchema.shape,
+    ...IconsSchema.shape,
+    description: z.string().optional(),
+    inputSchema: z
+        .object({
+            type: z.literal('object'),
+            properties: z.record(z.string(), JSONValueSchema).optional(),
+            required: z.array(z.string()).optional()
+        })
+        .catchall(z.unknown()),
+    outputSchema: z
+        .object({
+            type: z.literal('object'),
+            properties: z.record(z.string(), JSONValueSchema).optional(),
+            required: z.array(z.string()).optional()
+        })
+        .catchall(z.unknown())
+        .optional(),
+    annotations: ToolAnnotationsSchema.optional(),
+    _meta: z.record(z.string(), z.unknown()).optional()
+});
+
+/** 2026-era SamplingMessage (anchor-exact: single block or array). */
+export const SamplingMessageSchema = z.object({
+    role: RoleSchema,
+    content: z.union([SamplingMessageContentBlockSchema, z.array(SamplingMessageContentBlockSchema)]),
+    _meta: z.record(z.string(), z.unknown()).optional()
+});
+
+/** 2026-era capabilities: the shared shapes minus the deleted `tasks` key. */
+export const ClientCapabilities2026Schema = ClientCapabilitiesSchema.omit({ tasks: true });
+export const ServerCapabilities2026Schema = ServerCapabilitiesSchema.omit({ tasks: true });
+
+/* ------------------------------------------------------------------------ *
+ * Result side. `resultType` is REQUIRED at parse (spec.types.2026-07-28
+ * Result.resultType: "Servers implementing this protocol version MUST
+ * include this field"); requiredness is bare because no 2025-era traffic
+ * touches this module. These are the WIRE-TRUE artifacts — the corpus and
+ * the parity suite parse them; `decodeResult` parses with them and then
+ * LIFTS (drops resultType) to the neutral shape.
+ * ------------------------------------------------------------------------ */
+
+/** Open union per the anchor: 'complete' | 'input_required' | string. */
+export const ResultTypeSchema = z.string();
+
+const wireMeta = z.record(z.string(), z.unknown()).optional();
+
+function wireResult<T extends z.core.$ZodLooseShape>(shape: T) {
+    return z.looseObject({
+        _meta: wireMeta,
+        /** REQUIRED on this revision (see module header). */
+        resultType: ResultTypeSchema,
+        ...shape
+    });
+}
+
+export const ResultSchema = wireResult({});
+
+export const CallToolResultSchema = wireResult({
+    content: z.array(ContentBlockSchema),
+    structuredContent: z.record(z.string(), z.unknown()).optional(),
+    isError: z.boolean().optional()
+});
+
+export const ListToolsResultSchema = wireResult({
+    tools: z.array(ToolSchema),
+    nextCursor: CursorSchema.optional()
+});
+
+export const ListPromptsResultSchema = wireResult({
+    prompts: z.array(PromptSchema),
+    nextCursor: CursorSchema.optional()
+});
+
+export const GetPromptResultSchema = wireResult({
+    description: z.string().optional(),
+    messages: z.array(PromptMessageSchema)
+});
+
+export const ListResourcesResultSchema = wireResult({
+    resources: z.array(ResourceSchema),
+    nextCursor: CursorSchema.optional()
+});
+
+export const ListResourceTemplatesResultSchema = wireResult({
+    resourceTemplates: z.array(ResourceTemplateSchema),
+    nextCursor: CursorSchema.optional()
+});
+
+export const ReadResourceResultSchema = wireResult({
+    contents: z.array(z.union([TextResourceContentsSchema, BlobResourceContentsSchema]))
+});
+
+export const CompleteResultSchema = wireResult({
+    completion: z
+        .object({
+            values: z.array(z.string()).max(100),
+            total: z.number().int().optional(),
+            hasMore: z.boolean().optional()
+        })
+        .loose()
+});
+
+/** CacheableResult (SEP-2549): ttlMs and cacheScope REQUIRED per the anchor. */
+export const CacheableResultSchema = wireResult({
+    ttlMs: z.number().min(0),
+    cacheScope: z.enum(['public', 'private'])
+});
+
+export const DiscoverResultSchema = wireResult({
+    ttlMs: z.number().min(0),
+    cacheScope: z.enum(['public', 'private']),
+    supportedVersions: z.array(z.string()),
+    capabilities: ServerCapabilities2026Schema,
+    serverInfo: ImplementationSchema,
+    instructions: z.string().optional()
+});
+
+/* ------------------------------------------------------------------------ *
+ * Request side. Two views per method:
+ * - WIRE-TRUE (`<Name>RequestSchema`): params `_meta` carries the REQUIRED
+ *   envelope (anchor RequestParams._meta is required). The corpus and parity
+ *   suite consume these.
+ * - DISPATCH (post-lift, internal to the registry): the protocol layer's
+ *   universal lift has already extracted the envelope, so dispatch parses a
+ *   2025-like shape with optional `_meta` (progressToken/extension keys
+ *   only) and NO 2025-only members (`task` is undeclared and strips —
+ *   payload-level deletion is physical on this leg).
+ * ------------------------------------------------------------------------ */
+
+/** Post-lift request `_meta` (progressToken + extension keys; loose). */
+const DispatchRequestMetaSchema = z.looseObject({
+    progressToken: ProgressTokenSchema.optional()
+});
+
+function wireRequest<T extends z.core.$ZodLooseShape>(method: string, paramsShape: T, paramsOptional = false) {
+    const params = z.object({ _meta: RequestMetaEnvelopeSchema, ...paramsShape });
+    return z.object({
+        method: z.literal(method),
+        params: paramsOptional ? params.optional() : params
+    });
+}
+
+function dispatchRequest<T extends z.core.$ZodLooseShape>(method: string, paramsShape: T) {
+    return z.object({
+        method: z.literal(method),
+        params: z.object({ _meta: DispatchRequestMetaSchema.optional(), ...paramsShape }).optional()
+    });
+}
+
+const callToolParamsShape = {
+    name: z.string(),
+    arguments: z.record(z.string(), z.unknown()).optional()
+};
+const paginatedParamsShape = { cursor: CursorSchema.optional() };
+
+export const CallToolRequestSchema = wireRequest('tools/call', callToolParamsShape);
+export const ListToolsRequestSchema = wireRequest('tools/list', paginatedParamsShape);
+export const ListPromptsRequestSchema = wireRequest('prompts/list', paginatedParamsShape);
+export const GetPromptRequestSchema = wireRequest('prompts/get', {
+    name: z.string(),
+    arguments: z.record(z.string(), z.string()).optional()
+});
+export const ListResourcesRequestSchema = wireRequest('resources/list', paginatedParamsShape);
+export const ListResourceTemplatesRequestSchema = wireRequest('resources/templates/list', paginatedParamsShape);
+export const ReadResourceRequestSchema = wireRequest('resources/read', { uri: z.string() });
+export const CompleteRequestSchema = wireRequest('completion/complete', {
+    ref: z.union([
+        z.object({ type: z.literal('ref/prompt'), name: z.string() }).loose(),
+        z.object({ type: z.literal('ref/resource'), uri: z.string() }).loose()
+    ]),
+    argument: z.object({ name: z.string(), value: z.string() }).loose(),
+    context: z
+        .object({ arguments: z.record(z.string(), z.string()).optional() })
+        .loose()
+        .optional()
+});
+export const DiscoverRequestSchema = wireRequest('server/discover', {}, true);
+
+/** Dispatch (post-lift) request schemas, keyed by method — registry-internal. */
+export const dispatchRequestSchemas: Record<string, z.ZodType> = {
+    'tools/call': dispatchRequest('tools/call', callToolParamsShape) as unknown as z.ZodType,
+    'tools/list': dispatchRequest('tools/list', paginatedParamsShape) as unknown as z.ZodType,
+    'prompts/get': dispatchRequest('prompts/get', {
+        name: z.string(),
+        arguments: z.record(z.string(), z.string()).optional()
+    }) as unknown as z.ZodType,
+    'prompts/list': dispatchRequest('prompts/list', paginatedParamsShape) as unknown as z.ZodType,
+    'resources/list': dispatchRequest('resources/list', paginatedParamsShape) as unknown as z.ZodType,
+    'resources/templates/list': dispatchRequest('resources/templates/list', paginatedParamsShape) as unknown as z.ZodType,
+    'resources/read': dispatchRequest('resources/read', { uri: z.string() }) as unknown as z.ZodType,
+    'completion/complete': dispatchRequest('completion/complete', {
+        ref: z.union([
+            z.object({ type: z.literal('ref/prompt'), name: z.string() }).loose(),
+            z.object({ type: z.literal('ref/resource'), uri: z.string() }).loose()
+        ]),
+        argument: z.object({ name: z.string(), value: z.string() }).loose(),
+        context: z
+            .object({ arguments: z.record(z.string(), z.string()).optional() })
+            .loose()
+            .optional()
+    }) as unknown as z.ZodType,
+    'server/discover': dispatchRequest('server/discover', {}) as unknown as z.ZodType
+};
+
+/** Dispatch (post-lift) result schemas, keyed by method — what the funnel
+ * validates AFTER `decodeResult` consumed `resultType`. */
+function liftedResult<T extends z.core.$ZodLooseShape>(shape: T) {
+    return z.looseObject({ _meta: wireMeta, ...shape });
+}
+
+export const dispatchResultSchemas: Record<string, z.ZodType> = {
+    'tools/call': liftedResult({
+        content: z.array(ContentBlockSchema),
+        structuredContent: z.record(z.string(), z.unknown()).optional(),
+        isError: z.boolean().optional()
+    }) as unknown as z.ZodType,
+    'tools/list': liftedResult({ tools: z.array(ToolSchema), nextCursor: CursorSchema.optional() }) as unknown as z.ZodType,
+    'prompts/get': liftedResult({
+        description: z.string().optional(),
+        messages: z.array(PromptMessageSchema)
+    }) as unknown as z.ZodType,
+    'prompts/list': liftedResult({ prompts: z.array(PromptSchema), nextCursor: CursorSchema.optional() }) as unknown as z.ZodType,
+    'resources/list': liftedResult({ resources: z.array(ResourceSchema), nextCursor: CursorSchema.optional() }) as unknown as z.ZodType,
+    'resources/templates/list': liftedResult({
+        resourceTemplates: z.array(ResourceTemplateSchema),
+        nextCursor: CursorSchema.optional()
+    }) as unknown as z.ZodType,
+    'resources/read': liftedResult({
+        contents: z.array(z.union([TextResourceContentsSchema, BlobResourceContentsSchema]))
+    }) as unknown as z.ZodType,
+    'completion/complete': liftedResult({
+        completion: z
+            .object({
+                values: z.array(z.string()).max(100),
+                total: z.number().int().optional(),
+                hasMore: z.boolean().optional()
+            })
+            .loose()
+    }) as unknown as z.ZodType,
+    'server/discover': liftedResult({
+        ttlMs: z.number().min(0),
+        cacheScope: z.enum(['public', 'private']),
+        supportedVersions: z.array(z.string()),
+        capabilities: ServerCapabilities2026Schema,
+        serverInfo: ImplementationSchema,
+        instructions: z.string().optional()
+    }) as unknown as z.ZodType
+};
+
+/* ------------------------------------------------------------------------ *
+ * Notifications. The 2026 notification set: cancelled, progress, message,
+ * resources/updated, resources/list_changed, tools/list_changed,
+ * prompts/list_changed, elicitation/complete. Deleted: initialized,
+ * roots/list_changed, tasks/status. The shapes are revision-identical to the
+ * shared schemas, which are composed by reference. (The 2026-only
+ * subscriptions/acknowledged notification is #14 scope — see registry.ts.)
+ * ------------------------------------------------------------------------ */
+export const notificationSchemas2026: Record<string, z.ZodType> = {
+    'notifications/cancelled': CancelledNotificationSchema as unknown as z.ZodType,
+    'notifications/progress': ProgressNotificationSchema as unknown as z.ZodType,
+    'notifications/message': LoggingMessageNotificationSchema as unknown as z.ZodType,
+    'notifications/resources/updated': ResourceUpdatedNotificationSchema as unknown as z.ZodType,
+    'notifications/resources/list_changed': ResourceListChangedNotificationSchema as unknown as z.ZodType,
+    'notifications/tools/list_changed': ToolListChangedNotificationSchema as unknown as z.ZodType,
+    'notifications/prompts/list_changed': PromptListChangedNotificationSchema as unknown as z.ZodType,
+    'notifications/elicitation/complete': ElicitationCompleteNotificationSchema as unknown as z.ZodType
+};
+
+/* ------------------------------------------------------------------------ *
+ * Response envelopes (wire-true; parity/corpus artifacts).
+ * ------------------------------------------------------------------------ */
+const wireResultResponse = <T extends z.ZodType>(result: T) =>
+    z
+        .object({
+            jsonrpc: z.literal('2.0'),
+            id: z.union([z.string(), z.number().int()]),
+            result
+        })
+        .strict();
+
+export const JSONRPCResultResponseSchema = wireResultResponse(ResultSchema);
+export const CallToolResultResponseSchema = wireResultResponse(CallToolResultSchema);
+export const ListToolsResultResponseSchema = wireResultResponse(ListToolsResultSchema);
+export const ListPromptsResultResponseSchema = wireResultResponse(ListPromptsResultSchema);
+export const GetPromptResultResponseSchema = wireResultResponse(GetPromptResultSchema);
+export const ListResourcesResultResponseSchema = wireResultResponse(ListResourcesResultSchema);
+export const ListResourceTemplatesResultResponseSchema = wireResultResponse(ListResourceTemplatesResultSchema);
+export const ReadResourceResultResponseSchema = wireResultResponse(ReadResourceResultSchema);
+export const CompleteResultResponseSchema = wireResultResponse(CompleteResultSchema);
+export const DiscoverResultResponseSchema = wireResultResponse(DiscoverResultSchema);
+
+// Referenced by reference to keep the compose-by-reference relationships
+// explicit for tooling (these shared payloads serve both eras unchanged).
+void AnnotationsSchema;
+void ResourceContentsSchema;
+void CompleteRequestParamsSchema;
+void GetPromptRequestParamsSchema;
+void ResourceRequestParamsSchema;

--- a/packages/core/src/wire/rev2026-07-28/schemas.ts
+++ b/packages/core/src/wire/rev2026-07-28/schemas.ts
@@ -333,20 +333,38 @@ const completeParamsShape = {
 export const CompleteRequestSchema = wireRequest('completion/complete', completeParamsShape);
 export const DiscoverRequestSchema = wireRequest('server/discover', {});
 
+/**
+ * The 2026-era request-method set — the hand-registry seed (see registry.ts
+ * for the seed decisions). The dispatch maps below are mapped types over this
+ * union, so a missing entry, an extra entry, or an entry pointing at another
+ * method's schema is a compile error; the CI registry-diff oracle pins the
+ * same set against the anchor at runtime.
+ */
+export type Rev2026RequestMethod =
+    | 'tools/call'
+    | 'tools/list'
+    | 'prompts/get'
+    | 'prompts/list'
+    | 'resources/list'
+    | 'resources/templates/list'
+    | 'resources/read'
+    | 'completion/complete'
+    | 'server/discover';
+
 /** Dispatch (post-lift) request schemas, keyed by method — registry-internal. */
-export const dispatchRequestSchemas: Record<string, z.ZodType> = {
-    'tools/call': dispatchRequest('tools/call', callToolParamsShape) as unknown as z.ZodType,
-    'tools/list': dispatchRequest('tools/list', paginatedParamsShape) as unknown as z.ZodType,
+export const dispatchRequestSchemas: { readonly [M in Rev2026RequestMethod]: z.ZodType<{ method: M }> } = {
+    'tools/call': dispatchRequest('tools/call', callToolParamsShape),
+    'tools/list': dispatchRequest('tools/list', paginatedParamsShape),
     'prompts/get': dispatchRequest('prompts/get', {
         name: z.string(),
         arguments: z.record(z.string(), z.string()).optional()
-    }) as unknown as z.ZodType,
-    'prompts/list': dispatchRequest('prompts/list', paginatedParamsShape) as unknown as z.ZodType,
-    'resources/list': dispatchRequest('resources/list', paginatedParamsShape) as unknown as z.ZodType,
-    'resources/templates/list': dispatchRequest('resources/templates/list', paginatedParamsShape) as unknown as z.ZodType,
-    'resources/read': dispatchRequest('resources/read', { uri: z.string() }) as unknown as z.ZodType,
-    'completion/complete': dispatchRequest('completion/complete', completeParamsShape) as unknown as z.ZodType,
-    'server/discover': dispatchRequest('server/discover', {}) as unknown as z.ZodType
+    }),
+    'prompts/list': dispatchRequest('prompts/list', paginatedParamsShape),
+    'resources/list': dispatchRequest('resources/list', paginatedParamsShape),
+    'resources/templates/list': dispatchRequest('resources/templates/list', paginatedParamsShape),
+    'resources/read': dispatchRequest('resources/read', { uri: z.string() }),
+    'completion/complete': dispatchRequest('completion/complete', completeParamsShape),
+    'server/discover': dispatchRequest('server/discover', {})
 };
 
 /** Dispatch (post-lift) result schemas, keyed by method — what the funnel
@@ -355,45 +373,45 @@ function liftedResult<T extends z.core.$ZodLooseShape>(shape: T) {
     return z.looseObject({ _meta: wireMeta, ...shape });
 }
 
-export const dispatchResultSchemas: Record<string, z.ZodType> = {
+export const dispatchResultSchemas: { readonly [M in Rev2026RequestMethod]: z.ZodType } = {
     'tools/call': liftedResult({
         content: z.array(ContentBlockSchema),
         structuredContent: z.unknown().optional(),
         isError: z.boolean().optional()
-    }) as unknown as z.ZodType,
+    }),
     'tools/list': liftedResult({
         ttlMs: z.number().int().min(0),
         cacheScope: z.enum(['public', 'private']),
         tools: z.array(ToolSchema),
         nextCursor: CursorSchema.optional()
-    }) as unknown as z.ZodType,
+    }),
     'prompts/get': liftedResult({
         description: z.string().optional(),
         messages: z.array(PromptMessageSchema)
-    }) as unknown as z.ZodType,
+    }),
     'prompts/list': liftedResult({
         ttlMs: z.number().int().min(0),
         cacheScope: z.enum(['public', 'private']),
         prompts: z.array(PromptSchema),
         nextCursor: CursorSchema.optional()
-    }) as unknown as z.ZodType,
+    }),
     'resources/list': liftedResult({
         ttlMs: z.number().int().min(0),
         cacheScope: z.enum(['public', 'private']),
         resources: z.array(ResourceSchema),
         nextCursor: CursorSchema.optional()
-    }) as unknown as z.ZodType,
+    }),
     'resources/templates/list': liftedResult({
         ttlMs: z.number().int().min(0),
         cacheScope: z.enum(['public', 'private']),
         resourceTemplates: z.array(ResourceTemplateSchema),
         nextCursor: CursorSchema.optional()
-    }) as unknown as z.ZodType,
+    }),
     'resources/read': liftedResult({
         ttlMs: z.number().int().min(0),
         cacheScope: z.enum(['public', 'private']),
         contents: z.array(z.union([TextResourceContentsSchema, BlobResourceContentsSchema]))
-    }) as unknown as z.ZodType,
+    }),
     'completion/complete': liftedResult({
         completion: z
             .object({
@@ -402,7 +420,7 @@ export const dispatchResultSchemas: Record<string, z.ZodType> = {
                 hasMore: z.boolean().optional()
             })
             .loose()
-    }) as unknown as z.ZodType,
+    }),
     'server/discover': liftedResult({
         ttlMs: z.number().int().min(0),
         cacheScope: z.enum(['public', 'private']),
@@ -410,7 +428,7 @@ export const dispatchResultSchemas: Record<string, z.ZodType> = {
         capabilities: ServerCapabilities2026Schema,
         serverInfo: ImplementationSchema,
         instructions: z.string().optional()
-    }) as unknown as z.ZodType
+    })
 };
 
 /* ------------------------------------------------------------------------ *
@@ -421,15 +439,26 @@ export const dispatchResultSchemas: Record<string, z.ZodType> = {
  * shared schemas, which are composed by reference. (The 2026-only
  * subscriptions/acknowledged notification is #14 scope — see registry.ts.)
  * ------------------------------------------------------------------------ */
-export const notificationSchemas2026: Record<string, z.ZodType> = {
-    'notifications/cancelled': CancelledNotificationSchema as unknown as z.ZodType,
-    'notifications/progress': ProgressNotificationSchema as unknown as z.ZodType,
-    'notifications/message': LoggingMessageNotificationSchema as unknown as z.ZodType,
-    'notifications/resources/updated': ResourceUpdatedNotificationSchema as unknown as z.ZodType,
-    'notifications/resources/list_changed': ResourceListChangedNotificationSchema as unknown as z.ZodType,
-    'notifications/tools/list_changed': ToolListChangedNotificationSchema as unknown as z.ZodType,
-    'notifications/prompts/list_changed': PromptListChangedNotificationSchema as unknown as z.ZodType,
-    'notifications/elicitation/complete': ElicitationCompleteNotificationSchema as unknown as z.ZodType
+/** The 2026-era notification-method set (the hand-registry seed; see the deletion list above). */
+export type Rev2026NotificationMethod =
+    | 'notifications/cancelled'
+    | 'notifications/progress'
+    | 'notifications/message'
+    | 'notifications/resources/updated'
+    | 'notifications/resources/list_changed'
+    | 'notifications/tools/list_changed'
+    | 'notifications/prompts/list_changed'
+    | 'notifications/elicitation/complete';
+
+export const notificationSchemas2026: { readonly [M in Rev2026NotificationMethod]: z.ZodType<{ method: M }> } = {
+    'notifications/cancelled': CancelledNotificationSchema,
+    'notifications/progress': ProgressNotificationSchema,
+    'notifications/message': LoggingMessageNotificationSchema,
+    'notifications/resources/updated': ResourceUpdatedNotificationSchema,
+    'notifications/resources/list_changed': ResourceListChangedNotificationSchema,
+    'notifications/tools/list_changed': ToolListChangedNotificationSchema,
+    'notifications/prompts/list_changed': PromptListChangedNotificationSchema,
+    'notifications/elicitation/complete': ElicitationCompleteNotificationSchema
 };
 
 /* ------------------------------------------------------------------------ *

--- a/packages/core/test/corpus/schema-twins/2025-11-25.schema.json
+++ b/packages/core/test/corpus/schema-twins/2025-11-25.schema.json
@@ -1,0 +1,3633 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$defs": {
+        "Annotations": {
+            "description": "Optional annotations for the client. The client can use annotations to inform how objects are used or displayed",
+            "properties": {
+                "audience": {
+                    "description": "Describes who the intended audience of this object or data is.\n\nIt can include multiple entries to indicate content useful for multiple audiences (e.g., `[\"user\", \"assistant\"]`).",
+                    "items": {
+                        "$ref": "#/$defs/Role"
+                    },
+                    "type": "array"
+                },
+                "lastModified": {
+                    "description": "The moment the resource was last modified, as an ISO 8601 formatted string.\n\nShould be an ISO 8601 formatted string (e.g., \"2025-01-12T15:00:58Z\").\n\nExamples: last activity timestamp in an open file, timestamp when the resource\nwas attached, etc.",
+                    "type": "string"
+                },
+                "priority": {
+                    "description": "Describes how important this data is for operating the server.\n\nA value of 1 means \"most important,\" and indicates that the data is\neffectively required, while 0 means \"least important,\" and indicates that\nthe data is entirely optional.",
+                    "maximum": 1,
+                    "minimum": 0,
+                    "type": "number"
+                }
+            },
+            "type": "object"
+        },
+        "AudioContent": {
+            "description": "Audio provided to or from an LLM.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object"
+                },
+                "annotations": {
+                    "$ref": "#/$defs/Annotations",
+                    "description": "Optional annotations for the client."
+                },
+                "data": {
+                    "description": "The base64-encoded audio data.",
+                    "format": "byte",
+                    "type": "string"
+                },
+                "mimeType": {
+                    "description": "The MIME type of the audio. Different providers may support different audio types.",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "audio",
+                    "type": "string"
+                }
+            },
+            "required": ["data", "mimeType", "type"],
+            "type": "object"
+        },
+        "BaseMetadata": {
+            "description": "Base interface for metadata with name (identifier) and title (display name) properties.",
+            "properties": {
+                "name": {
+                    "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for Tool,\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+                    "type": "string"
+                }
+            },
+            "required": ["name"],
+            "type": "object"
+        },
+        "BlobResourceContents": {
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object"
+                },
+                "blob": {
+                    "description": "A base64-encoded string representing the binary data of the item.",
+                    "format": "byte",
+                    "type": "string"
+                },
+                "mimeType": {
+                    "description": "The MIME type of this resource, if known.",
+                    "type": "string"
+                },
+                "uri": {
+                    "description": "The URI of this resource.",
+                    "format": "uri",
+                    "type": "string"
+                }
+            },
+            "required": ["blob", "uri"],
+            "type": "object"
+        },
+        "BooleanSchema": {
+            "properties": {
+                "default": {
+                    "type": "boolean"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "type": {
+                    "const": "boolean",
+                    "type": "string"
+                }
+            },
+            "required": ["type"],
+            "type": "object"
+        },
+        "CallToolRequest": {
+            "description": "Used by the client to invoke a tool provided by the server.",
+            "properties": {
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "tools/call",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/CallToolRequestParams"
+                }
+            },
+            "required": ["id", "jsonrpc", "method", "params"],
+            "type": "object"
+        },
+        "CallToolRequestParams": {
+            "description": "Parameters for a `tools/call` request.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "properties": {
+                        "progressToken": {
+                            "$ref": "#/$defs/ProgressToken",
+                            "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
+                        }
+                    },
+                    "type": "object"
+                },
+                "arguments": {
+                    "additionalProperties": {},
+                    "description": "Arguments to use for the tool call.",
+                    "type": "object"
+                },
+                "name": {
+                    "description": "The name of the tool.",
+                    "type": "string"
+                },
+                "task": {
+                    "$ref": "#/$defs/TaskMetadata",
+                    "description": "If specified, the caller is requesting task-augmented execution for this request.\nThe request will return a CreateTaskResult immediately, and the actual result can be\nretrieved later via tasks/result.\n\nTask augmentation is subject to capability negotiation - receivers MUST declare support\nfor task augmentation of specific request types in their capabilities."
+                }
+            },
+            "required": ["name"],
+            "type": "object"
+        },
+        "CallToolResult": {
+            "description": "The server's response to a tool call.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object"
+                },
+                "content": {
+                    "description": "A list of content objects that represent the unstructured result of the tool call.",
+                    "items": {
+                        "$ref": "#/$defs/ContentBlock"
+                    },
+                    "type": "array"
+                },
+                "isError": {
+                    "description": "Whether the tool call ended in an error.\n\nIf not set, this is assumed to be false (the call was successful).\n\nAny errors that originate from the tool SHOULD be reported inside the result\nobject, with `isError` set to true, _not_ as an MCP protocol-level error\nresponse. Otherwise, the LLM would not be able to see that an error occurred\nand self-correct.\n\nHowever, any errors in _finding_ the tool, an error indicating that the\nserver does not support tool calls, or any other exceptional conditions,\nshould be reported as an MCP error response.",
+                    "type": "boolean"
+                },
+                "structuredContent": {
+                    "additionalProperties": {},
+                    "description": "An optional JSON object that represents the structured result of the tool call.",
+                    "type": "object"
+                }
+            },
+            "required": ["content"],
+            "type": "object"
+        },
+        "CancelTaskRequest": {
+            "description": "A request to cancel a task.",
+            "properties": {
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "tasks/cancel",
+                    "type": "string"
+                },
+                "params": {
+                    "properties": {
+                        "taskId": {
+                            "description": "The task identifier to cancel.",
+                            "type": "string"
+                        }
+                    },
+                    "required": ["taskId"],
+                    "type": "object"
+                }
+            },
+            "required": ["id", "jsonrpc", "method", "params"],
+            "type": "object"
+        },
+        "CancelTaskResult": {
+            "allOf": [
+                {
+                    "$ref": "#/$defs/Result"
+                },
+                {
+                    "$ref": "#/$defs/Task"
+                }
+            ],
+            "description": "The response to a tasks/cancel request."
+        },
+        "CancelledNotification": {
+            "description": "This notification can be sent by either side to indicate that it is cancelling a previously-issued request.\n\nThe request SHOULD still be in-flight, but due to communication latency, it is always possible that this notification MAY arrive after the request has already finished.\n\nThis notification indicates that the result will be unused, so any associated processing SHOULD cease.\n\nA client MUST NOT attempt to cancel its `initialize` request.\n\nFor task cancellation, use the `tasks/cancel` request instead of this notification.",
+            "properties": {
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "notifications/cancelled",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/CancelledNotificationParams"
+                }
+            },
+            "required": ["jsonrpc", "method", "params"],
+            "type": "object"
+        },
+        "CancelledNotificationParams": {
+            "description": "Parameters for a `notifications/cancelled` notification.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object"
+                },
+                "reason": {
+                    "description": "An optional string describing the reason for the cancellation. This MAY be logged or presented to the user.",
+                    "type": "string"
+                },
+                "requestId": {
+                    "$ref": "#/$defs/RequestId",
+                    "description": "The ID of the request to cancel.\n\nThis MUST correspond to the ID of a request previously issued in the same direction.\nThis MUST be provided for cancelling non-task requests.\nThis MUST NOT be used for cancelling tasks (use the `tasks/cancel` request instead)."
+                }
+            },
+            "type": "object"
+        },
+        "ClientCapabilities": {
+            "description": "Capabilities a client may support. Known capabilities are defined here, in this schema, but this is not a closed set: any client can define its own, additional capabilities.",
+            "properties": {
+                "elicitation": {
+                    "description": "Present if the client supports elicitation from the server.",
+                    "properties": {
+                        "form": {
+                            "additionalProperties": true,
+                            "properties": {},
+                            "type": "object"
+                        },
+                        "url": {
+                            "additionalProperties": true,
+                            "properties": {},
+                            "type": "object"
+                        }
+                    },
+                    "type": "object"
+                },
+                "experimental": {
+                    "additionalProperties": {
+                        "additionalProperties": true,
+                        "properties": {},
+                        "type": "object"
+                    },
+                    "description": "Experimental, non-standard capabilities that the client supports.",
+                    "type": "object"
+                },
+                "roots": {
+                    "description": "Present if the client supports listing roots.",
+                    "properties": {
+                        "listChanged": {
+                            "description": "Whether the client supports notifications for changes to the roots list.",
+                            "type": "boolean"
+                        }
+                    },
+                    "type": "object"
+                },
+                "sampling": {
+                    "description": "Present if the client supports sampling from an LLM.",
+                    "properties": {
+                        "context": {
+                            "additionalProperties": true,
+                            "description": "Whether the client supports context inclusion via includeContext parameter.\nIf not declared, servers SHOULD only use `includeContext: \"none\"` (or omit it).",
+                            "properties": {},
+                            "type": "object"
+                        },
+                        "tools": {
+                            "additionalProperties": true,
+                            "description": "Whether the client supports tool use via tools and toolChoice parameters.",
+                            "properties": {},
+                            "type": "object"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tasks": {
+                    "description": "Present if the client supports task-augmented requests.",
+                    "properties": {
+                        "cancel": {
+                            "additionalProperties": true,
+                            "description": "Whether this client supports tasks/cancel.",
+                            "properties": {},
+                            "type": "object"
+                        },
+                        "list": {
+                            "additionalProperties": true,
+                            "description": "Whether this client supports tasks/list.",
+                            "properties": {},
+                            "type": "object"
+                        },
+                        "requests": {
+                            "description": "Specifies which request types can be augmented with tasks.",
+                            "properties": {
+                                "elicitation": {
+                                    "description": "Task support for elicitation-related requests.",
+                                    "properties": {
+                                        "create": {
+                                            "additionalProperties": true,
+                                            "description": "Whether the client supports task-augmented elicitation/create requests.",
+                                            "properties": {},
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                },
+                                "sampling": {
+                                    "description": "Task support for sampling-related requests.",
+                                    "properties": {
+                                        "createMessage": {
+                                            "additionalProperties": true,
+                                            "description": "Whether the client supports task-augmented sampling/createMessage requests.",
+                                            "properties": {},
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "ClientNotification": {
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/CancelledNotification"
+                },
+                {
+                    "$ref": "#/$defs/InitializedNotification"
+                },
+                {
+                    "$ref": "#/$defs/ProgressNotification"
+                },
+                {
+                    "$ref": "#/$defs/TaskStatusNotification"
+                },
+                {
+                    "$ref": "#/$defs/RootsListChangedNotification"
+                }
+            ]
+        },
+        "ClientRequest": {
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/InitializeRequest"
+                },
+                {
+                    "$ref": "#/$defs/PingRequest"
+                },
+                {
+                    "$ref": "#/$defs/ListResourcesRequest"
+                },
+                {
+                    "$ref": "#/$defs/ListResourceTemplatesRequest"
+                },
+                {
+                    "$ref": "#/$defs/ReadResourceRequest"
+                },
+                {
+                    "$ref": "#/$defs/SubscribeRequest"
+                },
+                {
+                    "$ref": "#/$defs/UnsubscribeRequest"
+                },
+                {
+                    "$ref": "#/$defs/ListPromptsRequest"
+                },
+                {
+                    "$ref": "#/$defs/GetPromptRequest"
+                },
+                {
+                    "$ref": "#/$defs/ListToolsRequest"
+                },
+                {
+                    "$ref": "#/$defs/CallToolRequest"
+                },
+                {
+                    "$ref": "#/$defs/GetTaskRequest"
+                },
+                {
+                    "$ref": "#/$defs/GetTaskPayloadRequest"
+                },
+                {
+                    "$ref": "#/$defs/CancelTaskRequest"
+                },
+                {
+                    "$ref": "#/$defs/ListTasksRequest"
+                },
+                {
+                    "$ref": "#/$defs/SetLevelRequest"
+                },
+                {
+                    "$ref": "#/$defs/CompleteRequest"
+                }
+            ]
+        },
+        "ClientResult": {
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/Result"
+                },
+                {
+                    "$ref": "#/$defs/GetTaskResult",
+                    "description": "The response to a tasks/get request."
+                },
+                {
+                    "$ref": "#/$defs/GetTaskPayloadResult"
+                },
+                {
+                    "$ref": "#/$defs/CancelTaskResult",
+                    "description": "The response to a tasks/cancel request."
+                },
+                {
+                    "$ref": "#/$defs/ListTasksResult"
+                },
+                {
+                    "$ref": "#/$defs/CreateMessageResult"
+                },
+                {
+                    "$ref": "#/$defs/ListRootsResult"
+                },
+                {
+                    "$ref": "#/$defs/ElicitResult"
+                }
+            ]
+        },
+        "CompleteRequest": {
+            "description": "A request from the client to the server, to ask for completion options.",
+            "properties": {
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "completion/complete",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/CompleteRequestParams"
+                }
+            },
+            "required": ["id", "jsonrpc", "method", "params"],
+            "type": "object"
+        },
+        "CompleteRequestParams": {
+            "description": "Parameters for a `completion/complete` request.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "properties": {
+                        "progressToken": {
+                            "$ref": "#/$defs/ProgressToken",
+                            "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
+                        }
+                    },
+                    "type": "object"
+                },
+                "argument": {
+                    "description": "The argument's information",
+                    "properties": {
+                        "name": {
+                            "description": "The name of the argument",
+                            "type": "string"
+                        },
+                        "value": {
+                            "description": "The value of the argument to use for completion matching.",
+                            "type": "string"
+                        }
+                    },
+                    "required": ["name", "value"],
+                    "type": "object"
+                },
+                "context": {
+                    "description": "Additional, optional context for completions",
+                    "properties": {
+                        "arguments": {
+                            "additionalProperties": {
+                                "type": "string"
+                            },
+                            "description": "Previously-resolved variables in a URI template or prompt.",
+                            "type": "object"
+                        }
+                    },
+                    "type": "object"
+                },
+                "ref": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/PromptReference"
+                        },
+                        {
+                            "$ref": "#/$defs/ResourceTemplateReference"
+                        }
+                    ]
+                }
+            },
+            "required": ["argument", "ref"],
+            "type": "object"
+        },
+        "CompleteResult": {
+            "description": "The server's response to a completion/complete request",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object"
+                },
+                "completion": {
+                    "properties": {
+                        "hasMore": {
+                            "description": "Indicates whether there are additional completion options beyond those provided in the current response, even if the exact total is unknown.",
+                            "type": "boolean"
+                        },
+                        "total": {
+                            "description": "The total number of completion options available. This can exceed the number of values actually sent in the response.",
+                            "type": "integer"
+                        },
+                        "values": {
+                            "description": "An array of completion values. Must not exceed 100 items.",
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": ["values"],
+                    "type": "object"
+                }
+            },
+            "required": ["completion"],
+            "type": "object"
+        },
+        "ContentBlock": {
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/TextContent"
+                },
+                {
+                    "$ref": "#/$defs/ImageContent"
+                },
+                {
+                    "$ref": "#/$defs/AudioContent"
+                },
+                {
+                    "$ref": "#/$defs/ResourceLink"
+                },
+                {
+                    "$ref": "#/$defs/EmbeddedResource"
+                }
+            ]
+        },
+        "CreateMessageRequest": {
+            "description": "A request from the server to sample an LLM via the client. The client has full discretion over which model to select. The client should also inform the user before beginning sampling, to allow them to inspect the request (human in the loop) and decide whether to approve it.",
+            "properties": {
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "sampling/createMessage",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/CreateMessageRequestParams"
+                }
+            },
+            "required": ["id", "jsonrpc", "method", "params"],
+            "type": "object"
+        },
+        "CreateMessageRequestParams": {
+            "description": "Parameters for a `sampling/createMessage` request.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "properties": {
+                        "progressToken": {
+                            "$ref": "#/$defs/ProgressToken",
+                            "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
+                        }
+                    },
+                    "type": "object"
+                },
+                "includeContext": {
+                    "description": "A request to include context from one or more MCP servers (including the caller), to be attached to the prompt.\nThe client MAY ignore this request.\n\nDefault is \"none\". Values \"thisServer\" and \"allServers\" are soft-deprecated. Servers SHOULD only use these values if the client\ndeclares ClientCapabilities.sampling.context. These values may be removed in future spec releases.",
+                    "enum": ["allServers", "none", "thisServer"],
+                    "type": "string"
+                },
+                "maxTokens": {
+                    "description": "The requested maximum number of tokens to sample (to prevent runaway completions).\n\nThe client MAY choose to sample fewer tokens than the requested maximum.",
+                    "type": "integer"
+                },
+                "messages": {
+                    "items": {
+                        "$ref": "#/$defs/SamplingMessage"
+                    },
+                    "type": "array"
+                },
+                "metadata": {
+                    "additionalProperties": true,
+                    "description": "Optional metadata to pass through to the LLM provider. The format of this metadata is provider-specific.",
+                    "properties": {},
+                    "type": "object"
+                },
+                "modelPreferences": {
+                    "$ref": "#/$defs/ModelPreferences",
+                    "description": "The server's preferences for which model to select. The client MAY ignore these preferences."
+                },
+                "stopSequences": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "systemPrompt": {
+                    "description": "An optional system prompt the server wants to use for sampling. The client MAY modify or omit this prompt.",
+                    "type": "string"
+                },
+                "task": {
+                    "$ref": "#/$defs/TaskMetadata",
+                    "description": "If specified, the caller is requesting task-augmented execution for this request.\nThe request will return a CreateTaskResult immediately, and the actual result can be\nretrieved later via tasks/result.\n\nTask augmentation is subject to capability negotiation - receivers MUST declare support\nfor task augmentation of specific request types in their capabilities."
+                },
+                "temperature": {
+                    "type": "number"
+                },
+                "toolChoice": {
+                    "$ref": "#/$defs/ToolChoice",
+                    "description": "Controls how the model uses tools.\nThe client MUST return an error if this field is provided but ClientCapabilities.sampling.tools is not declared.\nDefault is `{ mode: \"auto\" }`."
+                },
+                "tools": {
+                    "description": "Tools that the model may use during generation.\nThe client MUST return an error if this field is provided but ClientCapabilities.sampling.tools is not declared.",
+                    "items": {
+                        "$ref": "#/$defs/Tool"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": ["maxTokens", "messages"],
+            "type": "object"
+        },
+        "CreateMessageResult": {
+            "description": "The client's response to a sampling/createMessage request from the server.\nThe client should inform the user before returning the sampled message, to allow them\nto inspect the response (human in the loop) and decide whether to allow the server to see it.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object"
+                },
+                "content": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/TextContent"
+                        },
+                        {
+                            "$ref": "#/$defs/ImageContent"
+                        },
+                        {
+                            "$ref": "#/$defs/AudioContent"
+                        },
+                        {
+                            "$ref": "#/$defs/ToolUseContent"
+                        },
+                        {
+                            "$ref": "#/$defs/ToolResultContent"
+                        },
+                        {
+                            "items": {
+                                "$ref": "#/$defs/SamplingMessageContentBlock"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "model": {
+                    "description": "The name of the model that generated the message.",
+                    "type": "string"
+                },
+                "role": {
+                    "$ref": "#/$defs/Role"
+                },
+                "stopReason": {
+                    "description": "The reason why sampling stopped, if known.\n\nStandard values:\n- \"endTurn\": Natural end of the assistant's turn\n- \"stopSequence\": A stop sequence was encountered\n- \"maxTokens\": Maximum token limit was reached\n- \"toolUse\": The model wants to use one or more tools\n\nThis field is an open string to allow for provider-specific stop reasons.",
+                    "type": "string"
+                }
+            },
+            "required": ["content", "model", "role"],
+            "type": "object"
+        },
+        "CreateTaskResult": {
+            "description": "A response to a task-augmented request.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object"
+                },
+                "task": {
+                    "$ref": "#/$defs/Task"
+                }
+            },
+            "required": ["task"],
+            "type": "object"
+        },
+        "Cursor": {
+            "description": "An opaque token used to represent a cursor for pagination.",
+            "type": "string"
+        },
+        "ElicitRequest": {
+            "description": "A request from the server to elicit additional information from the user via the client.",
+            "properties": {
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "elicitation/create",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/ElicitRequestParams"
+                }
+            },
+            "required": ["id", "jsonrpc", "method", "params"],
+            "type": "object"
+        },
+        "ElicitRequestFormParams": {
+            "description": "The parameters for a request to elicit non-sensitive information from the user via a form in the client.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "properties": {
+                        "progressToken": {
+                            "$ref": "#/$defs/ProgressToken",
+                            "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
+                        }
+                    },
+                    "type": "object"
+                },
+                "message": {
+                    "description": "The message to present to the user describing what information is being requested.",
+                    "type": "string"
+                },
+                "mode": {
+                    "const": "form",
+                    "description": "The elicitation mode.",
+                    "type": "string"
+                },
+                "requestedSchema": {
+                    "description": "A restricted subset of JSON Schema.\nOnly top-level properties are allowed, without nesting.",
+                    "properties": {
+                        "$schema": {
+                            "type": "string"
+                        },
+                        "properties": {
+                            "additionalProperties": {
+                                "$ref": "#/$defs/PrimitiveSchemaDefinition"
+                            },
+                            "type": "object"
+                        },
+                        "required": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "type": {
+                            "const": "object",
+                            "type": "string"
+                        }
+                    },
+                    "required": ["properties", "type"],
+                    "type": "object"
+                },
+                "task": {
+                    "$ref": "#/$defs/TaskMetadata",
+                    "description": "If specified, the caller is requesting task-augmented execution for this request.\nThe request will return a CreateTaskResult immediately, and the actual result can be\nretrieved later via tasks/result.\n\nTask augmentation is subject to capability negotiation - receivers MUST declare support\nfor task augmentation of specific request types in their capabilities."
+                }
+            },
+            "required": ["message", "requestedSchema"],
+            "type": "object"
+        },
+        "ElicitRequestParams": {
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/ElicitRequestURLParams"
+                },
+                {
+                    "$ref": "#/$defs/ElicitRequestFormParams"
+                }
+            ],
+            "description": "The parameters for a request to elicit additional information from the user via the client."
+        },
+        "ElicitRequestURLParams": {
+            "description": "The parameters for a request to elicit information from the user via a URL in the client.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "properties": {
+                        "progressToken": {
+                            "$ref": "#/$defs/ProgressToken",
+                            "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
+                        }
+                    },
+                    "type": "object"
+                },
+                "elicitationId": {
+                    "description": "The ID of the elicitation, which must be unique within the context of the server.\nThe client MUST treat this ID as an opaque value.",
+                    "type": "string"
+                },
+                "message": {
+                    "description": "The message to present to the user explaining why the interaction is needed.",
+                    "type": "string"
+                },
+                "mode": {
+                    "const": "url",
+                    "description": "The elicitation mode.",
+                    "type": "string"
+                },
+                "task": {
+                    "$ref": "#/$defs/TaskMetadata",
+                    "description": "If specified, the caller is requesting task-augmented execution for this request.\nThe request will return a CreateTaskResult immediately, and the actual result can be\nretrieved later via tasks/result.\n\nTask augmentation is subject to capability negotiation - receivers MUST declare support\nfor task augmentation of specific request types in their capabilities."
+                },
+                "url": {
+                    "description": "The URL that the user should navigate to.",
+                    "format": "uri",
+                    "type": "string"
+                }
+            },
+            "required": ["elicitationId", "message", "mode", "url"],
+            "type": "object"
+        },
+        "ElicitResult": {
+            "description": "The client's response to an elicitation request.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object"
+                },
+                "action": {
+                    "description": "The user action in response to the elicitation.\n- \"accept\": User submitted the form/confirmed the action\n- \"decline\": User explicitly decline the action\n- \"cancel\": User dismissed without making an explicit choice",
+                    "enum": ["accept", "cancel", "decline"],
+                    "type": "string"
+                },
+                "content": {
+                    "additionalProperties": {
+                        "anyOf": [
+                            {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            },
+                            {
+                                "type": ["string", "integer", "boolean"]
+                            }
+                        ]
+                    },
+                    "description": "The submitted form data, only present when action is \"accept\" and mode was \"form\".\nContains values matching the requested schema.\nOmitted for out-of-band mode responses.",
+                    "type": "object"
+                }
+            },
+            "required": ["action"],
+            "type": "object"
+        },
+        "ElicitationCompleteNotification": {
+            "description": "An optional notification from the server to the client, informing it of a completion of a out-of-band elicitation request.",
+            "properties": {
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "notifications/elicitation/complete",
+                    "type": "string"
+                },
+                "params": {
+                    "properties": {
+                        "elicitationId": {
+                            "description": "The ID of the elicitation that completed.",
+                            "type": "string"
+                        }
+                    },
+                    "required": ["elicitationId"],
+                    "type": "object"
+                }
+            },
+            "required": ["jsonrpc", "method", "params"],
+            "type": "object"
+        },
+        "EmbeddedResource": {
+            "description": "The contents of a resource, embedded into a prompt or tool call result.\n\nIt is up to the client how best to render embedded resources for the benefit\nof the LLM and/or the user.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object"
+                },
+                "annotations": {
+                    "$ref": "#/$defs/Annotations",
+                    "description": "Optional annotations for the client."
+                },
+                "resource": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/TextResourceContents"
+                        },
+                        {
+                            "$ref": "#/$defs/BlobResourceContents"
+                        }
+                    ]
+                },
+                "type": {
+                    "const": "resource",
+                    "type": "string"
+                }
+            },
+            "required": ["resource", "type"],
+            "type": "object"
+        },
+        "EmptyResult": {
+            "$ref": "#/$defs/Result"
+        },
+        "EnumSchema": {
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/UntitledSingleSelectEnumSchema"
+                },
+                {
+                    "$ref": "#/$defs/TitledSingleSelectEnumSchema"
+                },
+                {
+                    "$ref": "#/$defs/UntitledMultiSelectEnumSchema"
+                },
+                {
+                    "$ref": "#/$defs/TitledMultiSelectEnumSchema"
+                },
+                {
+                    "$ref": "#/$defs/LegacyTitledEnumSchema"
+                }
+            ]
+        },
+        "Error": {
+            "properties": {
+                "code": {
+                    "description": "The error type that occurred.",
+                    "type": "integer"
+                },
+                "data": {
+                    "description": "Additional information about the error. The value of this member is defined by the sender (e.g. detailed error information, nested errors etc.)."
+                },
+                "message": {
+                    "description": "A short description of the error. The message SHOULD be limited to a concise single sentence.",
+                    "type": "string"
+                }
+            },
+            "required": ["code", "message"],
+            "type": "object"
+        },
+        "GetPromptRequest": {
+            "description": "Used by the client to get a prompt provided by the server.",
+            "properties": {
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "prompts/get",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/GetPromptRequestParams"
+                }
+            },
+            "required": ["id", "jsonrpc", "method", "params"],
+            "type": "object"
+        },
+        "GetPromptRequestParams": {
+            "description": "Parameters for a `prompts/get` request.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "properties": {
+                        "progressToken": {
+                            "$ref": "#/$defs/ProgressToken",
+                            "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
+                        }
+                    },
+                    "type": "object"
+                },
+                "arguments": {
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "description": "Arguments to use for templating the prompt.",
+                    "type": "object"
+                },
+                "name": {
+                    "description": "The name of the prompt or prompt template.",
+                    "type": "string"
+                }
+            },
+            "required": ["name"],
+            "type": "object"
+        },
+        "GetPromptResult": {
+            "description": "The server's response to a prompts/get request from the client.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object"
+                },
+                "description": {
+                    "description": "An optional description for the prompt.",
+                    "type": "string"
+                },
+                "messages": {
+                    "items": {
+                        "$ref": "#/$defs/PromptMessage"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": ["messages"],
+            "type": "object"
+        },
+        "GetTaskPayloadRequest": {
+            "description": "A request to retrieve the result of a completed task.",
+            "properties": {
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "tasks/result",
+                    "type": "string"
+                },
+                "params": {
+                    "properties": {
+                        "taskId": {
+                            "description": "The task identifier to retrieve results for.",
+                            "type": "string"
+                        }
+                    },
+                    "required": ["taskId"],
+                    "type": "object"
+                }
+            },
+            "required": ["id", "jsonrpc", "method", "params"],
+            "type": "object"
+        },
+        "GetTaskPayloadResult": {
+            "additionalProperties": {},
+            "description": "The response to a tasks/result request.\nThe structure matches the result type of the original request.\nFor example, a tools/call task would return the CallToolResult structure.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "GetTaskRequest": {
+            "description": "A request to retrieve the state of a task.",
+            "properties": {
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "tasks/get",
+                    "type": "string"
+                },
+                "params": {
+                    "properties": {
+                        "taskId": {
+                            "description": "The task identifier to query.",
+                            "type": "string"
+                        }
+                    },
+                    "required": ["taskId"],
+                    "type": "object"
+                }
+            },
+            "required": ["id", "jsonrpc", "method", "params"],
+            "type": "object"
+        },
+        "GetTaskResult": {
+            "allOf": [
+                {
+                    "$ref": "#/$defs/Result"
+                },
+                {
+                    "$ref": "#/$defs/Task"
+                }
+            ],
+            "description": "The response to a tasks/get request."
+        },
+        "Icon": {
+            "description": "An optionally-sized icon that can be displayed in a user interface.",
+            "properties": {
+                "mimeType": {
+                    "description": "Optional MIME type override if the source MIME type is missing or generic.\nFor example: `\"image/png\"`, `\"image/jpeg\"`, or `\"image/svg+xml\"`.",
+                    "type": "string"
+                },
+                "sizes": {
+                    "description": "Optional array of strings that specify sizes at which the icon can be used.\nEach string should be in WxH format (e.g., `\"48x48\"`, `\"96x96\"`) or `\"any\"` for scalable formats like SVG.\n\nIf not provided, the client should assume that the icon can be used at any size.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "src": {
+                    "description": "A standard URI pointing to an icon resource. May be an HTTP/HTTPS URL or a\n`data:` URI with Base64-encoded image data.\n\nConsumers SHOULD takes steps to ensure URLs serving icons are from the\nsame domain as the client/server or a trusted domain.\n\nConsumers SHOULD take appropriate precautions when consuming SVGs as they can contain\nexecutable JavaScript.",
+                    "format": "uri",
+                    "type": "string"
+                },
+                "theme": {
+                    "description": "Optional specifier for the theme this icon is designed for. `light` indicates\nthe icon is designed to be used with a light background, and `dark` indicates\nthe icon is designed to be used with a dark background.\n\nIf not provided, the client should assume the icon can be used with any theme.",
+                    "enum": ["dark", "light"],
+                    "type": "string"
+                }
+            },
+            "required": ["src"],
+            "type": "object"
+        },
+        "Icons": {
+            "description": "Base interface to add `icons` property.",
+            "properties": {
+                "icons": {
+                    "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
+                    "items": {
+                        "$ref": "#/$defs/Icon"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "ImageContent": {
+            "description": "An image provided to or from an LLM.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object"
+                },
+                "annotations": {
+                    "$ref": "#/$defs/Annotations",
+                    "description": "Optional annotations for the client."
+                },
+                "data": {
+                    "description": "The base64-encoded image data.",
+                    "format": "byte",
+                    "type": "string"
+                },
+                "mimeType": {
+                    "description": "The MIME type of the image. Different providers may support different image types.",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "image",
+                    "type": "string"
+                }
+            },
+            "required": ["data", "mimeType", "type"],
+            "type": "object"
+        },
+        "Implementation": {
+            "description": "Describes the MCP implementation.",
+            "properties": {
+                "description": {
+                    "description": "An optional human-readable description of what this implementation does.\n\nThis can be used by clients or servers to provide context about their purpose\nand capabilities. For example, a server might describe the types of resources\nor tools it provides, while a client might describe its intended use case.",
+                    "type": "string"
+                },
+                "icons": {
+                    "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
+                    "items": {
+                        "$ref": "#/$defs/Icon"
+                    },
+                    "type": "array"
+                },
+                "name": {
+                    "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for Tool,\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+                    "type": "string"
+                },
+                "version": {
+                    "type": "string"
+                },
+                "websiteUrl": {
+                    "description": "An optional URL of the website for this implementation.",
+                    "format": "uri",
+                    "type": "string"
+                }
+            },
+            "required": ["name", "version"],
+            "type": "object"
+        },
+        "InitializeRequest": {
+            "description": "This request is sent from the client to the server when it first connects, asking it to begin initialization.",
+            "properties": {
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "initialize",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/InitializeRequestParams"
+                }
+            },
+            "required": ["id", "jsonrpc", "method", "params"],
+            "type": "object"
+        },
+        "InitializeRequestParams": {
+            "description": "Parameters for an `initialize` request.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "properties": {
+                        "progressToken": {
+                            "$ref": "#/$defs/ProgressToken",
+                            "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
+                        }
+                    },
+                    "type": "object"
+                },
+                "capabilities": {
+                    "$ref": "#/$defs/ClientCapabilities"
+                },
+                "clientInfo": {
+                    "$ref": "#/$defs/Implementation"
+                },
+                "protocolVersion": {
+                    "description": "The latest version of the Model Context Protocol that the client supports. The client MAY decide to support older versions as well.",
+                    "type": "string"
+                }
+            },
+            "required": ["capabilities", "clientInfo", "protocolVersion"],
+            "type": "object"
+        },
+        "InitializeResult": {
+            "description": "After receiving an initialize request from the client, the server sends this response.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object"
+                },
+                "capabilities": {
+                    "$ref": "#/$defs/ServerCapabilities"
+                },
+                "instructions": {
+                    "description": "Instructions describing how to use the server and its features.\n\nThis can be used by clients to improve the LLM's understanding of available tools, resources, etc. It can be thought of like a \"hint\" to the model. For example, this information MAY be added to the system prompt.",
+                    "type": "string"
+                },
+                "protocolVersion": {
+                    "description": "The version of the Model Context Protocol that the server wants to use. This may not match the version that the client requested. If the client cannot support this version, it MUST disconnect.",
+                    "type": "string"
+                },
+                "serverInfo": {
+                    "$ref": "#/$defs/Implementation"
+                }
+            },
+            "required": ["capabilities", "protocolVersion", "serverInfo"],
+            "type": "object"
+        },
+        "InitializedNotification": {
+            "description": "This notification is sent from the client to the server after initialization has finished.",
+            "properties": {
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "notifications/initialized",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/NotificationParams"
+                }
+            },
+            "required": ["jsonrpc", "method"],
+            "type": "object"
+        },
+        "JSONRPCErrorResponse": {
+            "description": "A response to a request that indicates an error occurred.",
+            "properties": {
+                "error": {
+                    "$ref": "#/$defs/Error"
+                },
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                }
+            },
+            "required": ["error", "jsonrpc"],
+            "type": "object"
+        },
+        "JSONRPCMessage": {
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/JSONRPCRequest"
+                },
+                {
+                    "$ref": "#/$defs/JSONRPCNotification"
+                },
+                {
+                    "$ref": "#/$defs/JSONRPCResultResponse"
+                },
+                {
+                    "$ref": "#/$defs/JSONRPCErrorResponse"
+                }
+            ],
+            "description": "Refers to any valid JSON-RPC object that can be decoded off the wire, or encoded to be sent."
+        },
+        "JSONRPCNotification": {
+            "description": "A notification which does not expect a response.",
+            "properties": {
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "type": "string"
+                },
+                "params": {
+                    "additionalProperties": {},
+                    "type": "object"
+                }
+            },
+            "required": ["jsonrpc", "method"],
+            "type": "object"
+        },
+        "JSONRPCRequest": {
+            "description": "A request that expects a response.",
+            "properties": {
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "type": "string"
+                },
+                "params": {
+                    "additionalProperties": {},
+                    "type": "object"
+                }
+            },
+            "required": ["id", "jsonrpc", "method"],
+            "type": "object"
+        },
+        "JSONRPCResponse": {
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/JSONRPCResultResponse"
+                },
+                {
+                    "$ref": "#/$defs/JSONRPCErrorResponse"
+                }
+            ],
+            "description": "A response to a request, containing either the result or error."
+        },
+        "JSONRPCResultResponse": {
+            "description": "A successful (non-error) response to a request.",
+            "properties": {
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "result": {
+                    "$ref": "#/$defs/Result"
+                }
+            },
+            "required": ["id", "jsonrpc", "result"],
+            "type": "object"
+        },
+        "LegacyTitledEnumSchema": {
+            "description": "Use TitledSingleSelectEnumSchema instead.\nThis interface will be removed in a future version.",
+            "properties": {
+                "default": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "enum": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "enumNames": {
+                    "description": "(Legacy) Display names for enum values.\nNon-standard according to JSON schema 2020-12.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "type": {
+                    "const": "string",
+                    "type": "string"
+                }
+            },
+            "required": ["enum", "type"],
+            "type": "object"
+        },
+        "ListPromptsRequest": {
+            "description": "Sent from the client to request a list of prompts and prompt templates the server has.",
+            "properties": {
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "prompts/list",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/PaginatedRequestParams"
+                }
+            },
+            "required": ["id", "jsonrpc", "method"],
+            "type": "object"
+        },
+        "ListPromptsResult": {
+            "description": "The server's response to a prompts/list request from the client.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object"
+                },
+                "nextCursor": {
+                    "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
+                    "type": "string"
+                },
+                "prompts": {
+                    "items": {
+                        "$ref": "#/$defs/Prompt"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": ["prompts"],
+            "type": "object"
+        },
+        "ListResourceTemplatesRequest": {
+            "description": "Sent from the client to request a list of resource templates the server has.",
+            "properties": {
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "resources/templates/list",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/PaginatedRequestParams"
+                }
+            },
+            "required": ["id", "jsonrpc", "method"],
+            "type": "object"
+        },
+        "ListResourceTemplatesResult": {
+            "description": "The server's response to a resources/templates/list request from the client.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object"
+                },
+                "nextCursor": {
+                    "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
+                    "type": "string"
+                },
+                "resourceTemplates": {
+                    "items": {
+                        "$ref": "#/$defs/ResourceTemplate"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": ["resourceTemplates"],
+            "type": "object"
+        },
+        "ListResourcesRequest": {
+            "description": "Sent from the client to request a list of resources the server has.",
+            "properties": {
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "resources/list",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/PaginatedRequestParams"
+                }
+            },
+            "required": ["id", "jsonrpc", "method"],
+            "type": "object"
+        },
+        "ListResourcesResult": {
+            "description": "The server's response to a resources/list request from the client.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object"
+                },
+                "nextCursor": {
+                    "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
+                    "type": "string"
+                },
+                "resources": {
+                    "items": {
+                        "$ref": "#/$defs/Resource"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": ["resources"],
+            "type": "object"
+        },
+        "ListRootsRequest": {
+            "description": "Sent from the server to request a list of root URIs from the client. Roots allow\nservers to ask for specific directories or files to operate on. A common example\nfor roots is providing a set of repositories or directories a server should operate\non.\n\nThis request is typically used when the server needs to understand the file system\nstructure or access specific locations that the client has permission to read from.",
+            "properties": {
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "roots/list",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/RequestParams"
+                }
+            },
+            "required": ["id", "jsonrpc", "method"],
+            "type": "object"
+        },
+        "ListRootsResult": {
+            "description": "The client's response to a roots/list request from the server.\nThis result contains an array of Root objects, each representing a root directory\nor file that the server can operate on.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object"
+                },
+                "roots": {
+                    "items": {
+                        "$ref": "#/$defs/Root"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": ["roots"],
+            "type": "object"
+        },
+        "ListTasksRequest": {
+            "description": "A request to retrieve a list of tasks.",
+            "properties": {
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "tasks/list",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/PaginatedRequestParams"
+                }
+            },
+            "required": ["id", "jsonrpc", "method"],
+            "type": "object"
+        },
+        "ListTasksResult": {
+            "description": "The response to a tasks/list request.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object"
+                },
+                "nextCursor": {
+                    "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
+                    "type": "string"
+                },
+                "tasks": {
+                    "items": {
+                        "$ref": "#/$defs/Task"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": ["tasks"],
+            "type": "object"
+        },
+        "ListToolsRequest": {
+            "description": "Sent from the client to request a list of tools the server has.",
+            "properties": {
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "tools/list",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/PaginatedRequestParams"
+                }
+            },
+            "required": ["id", "jsonrpc", "method"],
+            "type": "object"
+        },
+        "ListToolsResult": {
+            "description": "The server's response to a tools/list request from the client.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object"
+                },
+                "nextCursor": {
+                    "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
+                    "type": "string"
+                },
+                "tools": {
+                    "items": {
+                        "$ref": "#/$defs/Tool"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": ["tools"],
+            "type": "object"
+        },
+        "LoggingLevel": {
+            "description": "The severity of a log message.\n\nThese map to syslog message severities, as specified in RFC-5424:\nhttps://datatracker.ietf.org/doc/html/rfc5424#section-6.2.1",
+            "enum": ["alert", "critical", "debug", "emergency", "error", "info", "notice", "warning"],
+            "type": "string"
+        },
+        "LoggingMessageNotification": {
+            "description": "JSONRPCNotification of a log message passed from server to client. If no logging/setLevel request has been sent from the client, the server MAY decide which messages to send automatically.",
+            "properties": {
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "notifications/message",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/LoggingMessageNotificationParams"
+                }
+            },
+            "required": ["jsonrpc", "method", "params"],
+            "type": "object"
+        },
+        "LoggingMessageNotificationParams": {
+            "description": "Parameters for a `notifications/message` notification.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object"
+                },
+                "data": {
+                    "description": "The data to be logged, such as a string message or an object. Any JSON serializable type is allowed here."
+                },
+                "level": {
+                    "$ref": "#/$defs/LoggingLevel",
+                    "description": "The severity of this log message."
+                },
+                "logger": {
+                    "description": "An optional name of the logger issuing this message.",
+                    "type": "string"
+                }
+            },
+            "required": ["data", "level"],
+            "type": "object"
+        },
+        "ModelHint": {
+            "description": "Hints to use for model selection.\n\nKeys not declared here are currently left unspecified by the spec and are up\nto the client to interpret.",
+            "properties": {
+                "name": {
+                    "description": "A hint for a model name.\n\nThe client SHOULD treat this as a substring of a model name; for example:\n - `claude-3-5-sonnet` should match `claude-3-5-sonnet-20241022`\n - `sonnet` should match `claude-3-5-sonnet-20241022`, `claude-3-sonnet-20240229`, etc.\n - `claude` should match any Claude model\n\nThe client MAY also map the string to a different provider's model name or a different model family, as long as it fills a similar niche; for example:\n - `gemini-1.5-flash` could match `claude-3-haiku-20240307`",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "ModelPreferences": {
+            "description": "The server's preferences for model selection, requested of the client during sampling.\n\nBecause LLMs can vary along multiple dimensions, choosing the \"best\" model is\nrarely straightforward.  Different models excel in different areas—some are\nfaster but less capable, others are more capable but more expensive, and so\non. This interface allows servers to express their priorities across multiple\ndimensions to help clients make an appropriate selection for their use case.\n\nThese preferences are always advisory. The client MAY ignore them. It is also\nup to the client to decide how to interpret these preferences and how to\nbalance them against other considerations.",
+            "properties": {
+                "costPriority": {
+                    "description": "How much to prioritize cost when selecting a model. A value of 0 means cost\nis not important, while a value of 1 means cost is the most important\nfactor.",
+                    "maximum": 1,
+                    "minimum": 0,
+                    "type": "number"
+                },
+                "hints": {
+                    "description": "Optional hints to use for model selection.\n\nIf multiple hints are specified, the client MUST evaluate them in order\n(such that the first match is taken).\n\nThe client SHOULD prioritize these hints over the numeric priorities, but\nMAY still use the priorities to select from ambiguous matches.",
+                    "items": {
+                        "$ref": "#/$defs/ModelHint"
+                    },
+                    "type": "array"
+                },
+                "intelligencePriority": {
+                    "description": "How much to prioritize intelligence and capabilities when selecting a\nmodel. A value of 0 means intelligence is not important, while a value of 1\nmeans intelligence is the most important factor.",
+                    "maximum": 1,
+                    "minimum": 0,
+                    "type": "number"
+                },
+                "speedPriority": {
+                    "description": "How much to prioritize sampling speed (latency) when selecting a model. A\nvalue of 0 means speed is not important, while a value of 1 means speed is\nthe most important factor.",
+                    "maximum": 1,
+                    "minimum": 0,
+                    "type": "number"
+                }
+            },
+            "type": "object"
+        },
+        "MultiSelectEnumSchema": {
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/UntitledMultiSelectEnumSchema"
+                },
+                {
+                    "$ref": "#/$defs/TitledMultiSelectEnumSchema"
+                }
+            ]
+        },
+        "Notification": {
+            "properties": {
+                "method": {
+                    "type": "string"
+                },
+                "params": {
+                    "additionalProperties": {},
+                    "type": "object"
+                }
+            },
+            "required": ["method"],
+            "type": "object"
+        },
+        "NotificationParams": {
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "NumberSchema": {
+            "properties": {
+                "default": {
+                    "type": "integer"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "maximum": {
+                    "type": "integer"
+                },
+                "minimum": {
+                    "type": "integer"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "type": {
+                    "enum": ["integer", "number"],
+                    "type": "string"
+                }
+            },
+            "required": ["type"],
+            "type": "object"
+        },
+        "PaginatedRequest": {
+            "properties": {
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/PaginatedRequestParams"
+                }
+            },
+            "required": ["id", "jsonrpc", "method"],
+            "type": "object"
+        },
+        "PaginatedRequestParams": {
+            "description": "Common parameters for paginated requests.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "properties": {
+                        "progressToken": {
+                            "$ref": "#/$defs/ProgressToken",
+                            "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
+                        }
+                    },
+                    "type": "object"
+                },
+                "cursor": {
+                    "description": "An opaque token representing the current pagination position.\nIf provided, the server should return results starting after this cursor.",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "PaginatedResult": {
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object"
+                },
+                "nextCursor": {
+                    "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "PingRequest": {
+            "description": "A ping, issued by either the server or the client, to check that the other party is still alive. The receiver must promptly respond, or else may be disconnected.",
+            "properties": {
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "ping",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/RequestParams"
+                }
+            },
+            "required": ["id", "jsonrpc", "method"],
+            "type": "object"
+        },
+        "PrimitiveSchemaDefinition": {
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/StringSchema"
+                },
+                {
+                    "$ref": "#/$defs/NumberSchema"
+                },
+                {
+                    "$ref": "#/$defs/BooleanSchema"
+                },
+                {
+                    "$ref": "#/$defs/UntitledSingleSelectEnumSchema"
+                },
+                {
+                    "$ref": "#/$defs/TitledSingleSelectEnumSchema"
+                },
+                {
+                    "$ref": "#/$defs/UntitledMultiSelectEnumSchema"
+                },
+                {
+                    "$ref": "#/$defs/TitledMultiSelectEnumSchema"
+                },
+                {
+                    "$ref": "#/$defs/LegacyTitledEnumSchema"
+                }
+            ],
+            "description": "Restricted schema definitions that only allow primitive types\nwithout nested objects or arrays."
+        },
+        "ProgressNotification": {
+            "description": "An out-of-band notification used to inform the receiver of a progress update for a long-running request.",
+            "properties": {
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "notifications/progress",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/ProgressNotificationParams"
+                }
+            },
+            "required": ["jsonrpc", "method", "params"],
+            "type": "object"
+        },
+        "ProgressNotificationParams": {
+            "description": "Parameters for a `notifications/progress` notification.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object"
+                },
+                "message": {
+                    "description": "An optional message describing the current progress.",
+                    "type": "string"
+                },
+                "progress": {
+                    "description": "The progress thus far. This should increase every time progress is made, even if the total is unknown.",
+                    "type": "number"
+                },
+                "progressToken": {
+                    "$ref": "#/$defs/ProgressToken",
+                    "description": "The progress token which was given in the initial request, used to associate this notification with the request that is proceeding."
+                },
+                "total": {
+                    "description": "Total number of items to process (or total progress required), if known.",
+                    "type": "number"
+                }
+            },
+            "required": ["progress", "progressToken"],
+            "type": "object"
+        },
+        "ProgressToken": {
+            "description": "A progress token, used to associate progress notifications with the original request.",
+            "type": ["string", "integer"]
+        },
+        "Prompt": {
+            "description": "A prompt or prompt template that the server offers.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object"
+                },
+                "arguments": {
+                    "description": "A list of arguments to use for templating the prompt.",
+                    "items": {
+                        "$ref": "#/$defs/PromptArgument"
+                    },
+                    "type": "array"
+                },
+                "description": {
+                    "description": "An optional description of what this prompt provides",
+                    "type": "string"
+                },
+                "icons": {
+                    "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
+                    "items": {
+                        "$ref": "#/$defs/Icon"
+                    },
+                    "type": "array"
+                },
+                "name": {
+                    "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for Tool,\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+                    "type": "string"
+                }
+            },
+            "required": ["name"],
+            "type": "object"
+        },
+        "PromptArgument": {
+            "description": "Describes an argument that a prompt can accept.",
+            "properties": {
+                "description": {
+                    "description": "A human-readable description of the argument.",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+                    "type": "string"
+                },
+                "required": {
+                    "description": "Whether this argument must be provided.",
+                    "type": "boolean"
+                },
+                "title": {
+                    "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for Tool,\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+                    "type": "string"
+                }
+            },
+            "required": ["name"],
+            "type": "object"
+        },
+        "PromptListChangedNotification": {
+            "description": "An optional notification from the server to the client, informing it that the list of prompts it offers has changed. This may be issued by servers without any previous subscription from the client.",
+            "properties": {
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "notifications/prompts/list_changed",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/NotificationParams"
+                }
+            },
+            "required": ["jsonrpc", "method"],
+            "type": "object"
+        },
+        "PromptMessage": {
+            "description": "Describes a message returned as part of a prompt.\n\nThis is similar to `SamplingMessage`, but also supports the embedding of\nresources from the MCP server.",
+            "properties": {
+                "content": {
+                    "$ref": "#/$defs/ContentBlock"
+                },
+                "role": {
+                    "$ref": "#/$defs/Role"
+                }
+            },
+            "required": ["content", "role"],
+            "type": "object"
+        },
+        "PromptReference": {
+            "description": "Identifies a prompt.",
+            "properties": {
+                "name": {
+                    "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for Tool,\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "ref/prompt",
+                    "type": "string"
+                }
+            },
+            "required": ["name", "type"],
+            "type": "object"
+        },
+        "ReadResourceRequest": {
+            "description": "Sent from the client to the server, to read a specific resource URI.",
+            "properties": {
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "resources/read",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/ReadResourceRequestParams"
+                }
+            },
+            "required": ["id", "jsonrpc", "method", "params"],
+            "type": "object"
+        },
+        "ReadResourceRequestParams": {
+            "description": "Parameters for a `resources/read` request.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "properties": {
+                        "progressToken": {
+                            "$ref": "#/$defs/ProgressToken",
+                            "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
+                        }
+                    },
+                    "type": "object"
+                },
+                "uri": {
+                    "description": "The URI of the resource. The URI can use any protocol; it is up to the server how to interpret it.",
+                    "format": "uri",
+                    "type": "string"
+                }
+            },
+            "required": ["uri"],
+            "type": "object"
+        },
+        "ReadResourceResult": {
+            "description": "The server's response to a resources/read request from the client.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object"
+                },
+                "contents": {
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/$defs/TextResourceContents"
+                            },
+                            {
+                                "$ref": "#/$defs/BlobResourceContents"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                }
+            },
+            "required": ["contents"],
+            "type": "object"
+        },
+        "RelatedTaskMetadata": {
+            "description": "Metadata for associating messages with a task.\nInclude this in the `_meta` field under the key `io.modelcontextprotocol/related-task`.",
+            "properties": {
+                "taskId": {
+                    "description": "The task identifier this message is associated with.",
+                    "type": "string"
+                }
+            },
+            "required": ["taskId"],
+            "type": "object"
+        },
+        "Request": {
+            "properties": {
+                "method": {
+                    "type": "string"
+                },
+                "params": {
+                    "additionalProperties": {},
+                    "type": "object"
+                }
+            },
+            "required": ["method"],
+            "type": "object"
+        },
+        "RequestId": {
+            "description": "A uniquely identifying ID for a request in JSON-RPC.",
+            "type": ["string", "integer"]
+        },
+        "RequestParams": {
+            "description": "Common params for any request.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "properties": {
+                        "progressToken": {
+                            "$ref": "#/$defs/ProgressToken",
+                            "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "Resource": {
+            "description": "A known resource that the server is capable of reading.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object"
+                },
+                "annotations": {
+                    "$ref": "#/$defs/Annotations",
+                    "description": "Optional annotations for the client."
+                },
+                "description": {
+                    "description": "A description of what this resource represents.\n\nThis can be used by clients to improve the LLM's understanding of available resources. It can be thought of like a \"hint\" to the model.",
+                    "type": "string"
+                },
+                "icons": {
+                    "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
+                    "items": {
+                        "$ref": "#/$defs/Icon"
+                    },
+                    "type": "array"
+                },
+                "mimeType": {
+                    "description": "The MIME type of this resource, if known.",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+                    "type": "string"
+                },
+                "size": {
+                    "description": "The size of the raw resource content, in bytes (i.e., before base64 encoding or any tokenization), if known.\n\nThis can be used by Hosts to display file sizes and estimate context window usage.",
+                    "type": "integer"
+                },
+                "title": {
+                    "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for Tool,\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+                    "type": "string"
+                },
+                "uri": {
+                    "description": "The URI of this resource.",
+                    "format": "uri",
+                    "type": "string"
+                }
+            },
+            "required": ["name", "uri"],
+            "type": "object"
+        },
+        "ResourceContents": {
+            "description": "The contents of a specific resource or sub-resource.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object"
+                },
+                "mimeType": {
+                    "description": "The MIME type of this resource, if known.",
+                    "type": "string"
+                },
+                "uri": {
+                    "description": "The URI of this resource.",
+                    "format": "uri",
+                    "type": "string"
+                }
+            },
+            "required": ["uri"],
+            "type": "object"
+        },
+        "ResourceLink": {
+            "description": "A resource that the server is capable of reading, included in a prompt or tool call result.\n\nNote: resource links returned by tools are not guaranteed to appear in the results of `resources/list` requests.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object"
+                },
+                "annotations": {
+                    "$ref": "#/$defs/Annotations",
+                    "description": "Optional annotations for the client."
+                },
+                "description": {
+                    "description": "A description of what this resource represents.\n\nThis can be used by clients to improve the LLM's understanding of available resources. It can be thought of like a \"hint\" to the model.",
+                    "type": "string"
+                },
+                "icons": {
+                    "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
+                    "items": {
+                        "$ref": "#/$defs/Icon"
+                    },
+                    "type": "array"
+                },
+                "mimeType": {
+                    "description": "The MIME type of this resource, if known.",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+                    "type": "string"
+                },
+                "size": {
+                    "description": "The size of the raw resource content, in bytes (i.e., before base64 encoding or any tokenization), if known.\n\nThis can be used by Hosts to display file sizes and estimate context window usage.",
+                    "type": "integer"
+                },
+                "title": {
+                    "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for Tool,\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "resource_link",
+                    "type": "string"
+                },
+                "uri": {
+                    "description": "The URI of this resource.",
+                    "format": "uri",
+                    "type": "string"
+                }
+            },
+            "required": ["name", "type", "uri"],
+            "type": "object"
+        },
+        "ResourceListChangedNotification": {
+            "description": "An optional notification from the server to the client, informing it that the list of resources it can read from has changed. This may be issued by servers without any previous subscription from the client.",
+            "properties": {
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "notifications/resources/list_changed",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/NotificationParams"
+                }
+            },
+            "required": ["jsonrpc", "method"],
+            "type": "object"
+        },
+        "ResourceRequestParams": {
+            "description": "Common parameters when working with resources.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "properties": {
+                        "progressToken": {
+                            "$ref": "#/$defs/ProgressToken",
+                            "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
+                        }
+                    },
+                    "type": "object"
+                },
+                "uri": {
+                    "description": "The URI of the resource. The URI can use any protocol; it is up to the server how to interpret it.",
+                    "format": "uri",
+                    "type": "string"
+                }
+            },
+            "required": ["uri"],
+            "type": "object"
+        },
+        "ResourceTemplate": {
+            "description": "A template description for resources available on the server.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object"
+                },
+                "annotations": {
+                    "$ref": "#/$defs/Annotations",
+                    "description": "Optional annotations for the client."
+                },
+                "description": {
+                    "description": "A description of what this template is for.\n\nThis can be used by clients to improve the LLM's understanding of available resources. It can be thought of like a \"hint\" to the model.",
+                    "type": "string"
+                },
+                "icons": {
+                    "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
+                    "items": {
+                        "$ref": "#/$defs/Icon"
+                    },
+                    "type": "array"
+                },
+                "mimeType": {
+                    "description": "The MIME type for all resources that match this template. This should only be included if all resources matching this template have the same type.",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for Tool,\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+                    "type": "string"
+                },
+                "uriTemplate": {
+                    "description": "A URI template (according to RFC 6570) that can be used to construct resource URIs.",
+                    "format": "uri-template",
+                    "type": "string"
+                }
+            },
+            "required": ["name", "uriTemplate"],
+            "type": "object"
+        },
+        "ResourceTemplateReference": {
+            "description": "A reference to a resource or resource template definition.",
+            "properties": {
+                "type": {
+                    "const": "ref/resource",
+                    "type": "string"
+                },
+                "uri": {
+                    "description": "The URI or URI template of the resource.",
+                    "format": "uri-template",
+                    "type": "string"
+                }
+            },
+            "required": ["type", "uri"],
+            "type": "object"
+        },
+        "ResourceUpdatedNotification": {
+            "description": "A notification from the server to the client, informing it that a resource has changed and may need to be read again. This should only be sent if the client previously sent a resources/subscribe request.",
+            "properties": {
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "notifications/resources/updated",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/ResourceUpdatedNotificationParams"
+                }
+            },
+            "required": ["jsonrpc", "method", "params"],
+            "type": "object"
+        },
+        "ResourceUpdatedNotificationParams": {
+            "description": "Parameters for a `notifications/resources/updated` notification.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object"
+                },
+                "uri": {
+                    "description": "The URI of the resource that has been updated. This might be a sub-resource of the one that the client actually subscribed to.",
+                    "format": "uri",
+                    "type": "string"
+                }
+            },
+            "required": ["uri"],
+            "type": "object"
+        },
+        "Result": {
+            "additionalProperties": {},
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "Role": {
+            "description": "The sender or recipient of messages and data in a conversation.",
+            "enum": ["assistant", "user"],
+            "type": "string"
+        },
+        "Root": {
+            "description": "Represents a root directory or file that the server can operate on.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object"
+                },
+                "name": {
+                    "description": "An optional name for the root. This can be used to provide a human-readable\nidentifier for the root, which may be useful for display purposes or for\nreferencing the root in other parts of the application.",
+                    "type": "string"
+                },
+                "uri": {
+                    "description": "The URI identifying the root. This *must* start with file:// for now.\nThis restriction may be relaxed in future versions of the protocol to allow\nother URI schemes.",
+                    "format": "uri",
+                    "type": "string"
+                }
+            },
+            "required": ["uri"],
+            "type": "object"
+        },
+        "RootsListChangedNotification": {
+            "description": "A notification from the client to the server, informing it that the list of roots has changed.\nThis notification should be sent whenever the client adds, removes, or modifies any root.\nThe server should then request an updated list of roots using the ListRootsRequest.",
+            "properties": {
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "notifications/roots/list_changed",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/NotificationParams"
+                }
+            },
+            "required": ["jsonrpc", "method"],
+            "type": "object"
+        },
+        "SamplingMessage": {
+            "description": "Describes a message issued to or received from an LLM API.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object"
+                },
+                "content": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/TextContent"
+                        },
+                        {
+                            "$ref": "#/$defs/ImageContent"
+                        },
+                        {
+                            "$ref": "#/$defs/AudioContent"
+                        },
+                        {
+                            "$ref": "#/$defs/ToolUseContent"
+                        },
+                        {
+                            "$ref": "#/$defs/ToolResultContent"
+                        },
+                        {
+                            "items": {
+                                "$ref": "#/$defs/SamplingMessageContentBlock"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "role": {
+                    "$ref": "#/$defs/Role"
+                }
+            },
+            "required": ["content", "role"],
+            "type": "object"
+        },
+        "SamplingMessageContentBlock": {
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/TextContent"
+                },
+                {
+                    "$ref": "#/$defs/ImageContent"
+                },
+                {
+                    "$ref": "#/$defs/AudioContent"
+                },
+                {
+                    "$ref": "#/$defs/ToolUseContent"
+                },
+                {
+                    "$ref": "#/$defs/ToolResultContent"
+                }
+            ]
+        },
+        "ServerCapabilities": {
+            "description": "Capabilities that a server may support. Known capabilities are defined here, in this schema, but this is not a closed set: any server can define its own, additional capabilities.",
+            "properties": {
+                "completions": {
+                    "additionalProperties": true,
+                    "description": "Present if the server supports argument autocompletion suggestions.",
+                    "properties": {},
+                    "type": "object"
+                },
+                "experimental": {
+                    "additionalProperties": {
+                        "additionalProperties": true,
+                        "properties": {},
+                        "type": "object"
+                    },
+                    "description": "Experimental, non-standard capabilities that the server supports.",
+                    "type": "object"
+                },
+                "logging": {
+                    "additionalProperties": true,
+                    "description": "Present if the server supports sending log messages to the client.",
+                    "properties": {},
+                    "type": "object"
+                },
+                "prompts": {
+                    "description": "Present if the server offers any prompt templates.",
+                    "properties": {
+                        "listChanged": {
+                            "description": "Whether this server supports notifications for changes to the prompt list.",
+                            "type": "boolean"
+                        }
+                    },
+                    "type": "object"
+                },
+                "resources": {
+                    "description": "Present if the server offers any resources to read.",
+                    "properties": {
+                        "listChanged": {
+                            "description": "Whether this server supports notifications for changes to the resource list.",
+                            "type": "boolean"
+                        },
+                        "subscribe": {
+                            "description": "Whether this server supports subscribing to resource updates.",
+                            "type": "boolean"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tasks": {
+                    "description": "Present if the server supports task-augmented requests.",
+                    "properties": {
+                        "cancel": {
+                            "additionalProperties": true,
+                            "description": "Whether this server supports tasks/cancel.",
+                            "properties": {},
+                            "type": "object"
+                        },
+                        "list": {
+                            "additionalProperties": true,
+                            "description": "Whether this server supports tasks/list.",
+                            "properties": {},
+                            "type": "object"
+                        },
+                        "requests": {
+                            "description": "Specifies which request types can be augmented with tasks.",
+                            "properties": {
+                                "tools": {
+                                    "description": "Task support for tool-related requests.",
+                                    "properties": {
+                                        "call": {
+                                            "additionalProperties": true,
+                                            "description": "Whether the server supports task-augmented tools/call requests.",
+                                            "properties": {},
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": {
+                    "description": "Present if the server offers any tools to call.",
+                    "properties": {
+                        "listChanged": {
+                            "description": "Whether this server supports notifications for changes to the tool list.",
+                            "type": "boolean"
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "ServerNotification": {
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/CancelledNotification"
+                },
+                {
+                    "$ref": "#/$defs/ProgressNotification"
+                },
+                {
+                    "$ref": "#/$defs/ResourceListChangedNotification"
+                },
+                {
+                    "$ref": "#/$defs/ResourceUpdatedNotification"
+                },
+                {
+                    "$ref": "#/$defs/PromptListChangedNotification"
+                },
+                {
+                    "$ref": "#/$defs/ToolListChangedNotification"
+                },
+                {
+                    "$ref": "#/$defs/TaskStatusNotification"
+                },
+                {
+                    "$ref": "#/$defs/LoggingMessageNotification"
+                },
+                {
+                    "$ref": "#/$defs/ElicitationCompleteNotification"
+                }
+            ]
+        },
+        "ServerRequest": {
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/PingRequest"
+                },
+                {
+                    "$ref": "#/$defs/GetTaskRequest"
+                },
+                {
+                    "$ref": "#/$defs/GetTaskPayloadRequest"
+                },
+                {
+                    "$ref": "#/$defs/CancelTaskRequest"
+                },
+                {
+                    "$ref": "#/$defs/ListTasksRequest"
+                },
+                {
+                    "$ref": "#/$defs/CreateMessageRequest"
+                },
+                {
+                    "$ref": "#/$defs/ListRootsRequest"
+                },
+                {
+                    "$ref": "#/$defs/ElicitRequest"
+                }
+            ]
+        },
+        "ServerResult": {
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/Result"
+                },
+                {
+                    "$ref": "#/$defs/InitializeResult"
+                },
+                {
+                    "$ref": "#/$defs/ListResourcesResult"
+                },
+                {
+                    "$ref": "#/$defs/ListResourceTemplatesResult"
+                },
+                {
+                    "$ref": "#/$defs/ReadResourceResult"
+                },
+                {
+                    "$ref": "#/$defs/ListPromptsResult"
+                },
+                {
+                    "$ref": "#/$defs/GetPromptResult"
+                },
+                {
+                    "$ref": "#/$defs/ListToolsResult"
+                },
+                {
+                    "$ref": "#/$defs/CallToolResult"
+                },
+                {
+                    "$ref": "#/$defs/GetTaskResult",
+                    "description": "The response to a tasks/get request."
+                },
+                {
+                    "$ref": "#/$defs/GetTaskPayloadResult"
+                },
+                {
+                    "$ref": "#/$defs/CancelTaskResult",
+                    "description": "The response to a tasks/cancel request."
+                },
+                {
+                    "$ref": "#/$defs/ListTasksResult"
+                },
+                {
+                    "$ref": "#/$defs/CompleteResult"
+                }
+            ]
+        },
+        "SetLevelRequest": {
+            "description": "A request from the client to the server, to enable or adjust logging.",
+            "properties": {
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "logging/setLevel",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/SetLevelRequestParams"
+                }
+            },
+            "required": ["id", "jsonrpc", "method", "params"],
+            "type": "object"
+        },
+        "SetLevelRequestParams": {
+            "description": "Parameters for a `logging/setLevel` request.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "properties": {
+                        "progressToken": {
+                            "$ref": "#/$defs/ProgressToken",
+                            "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
+                        }
+                    },
+                    "type": "object"
+                },
+                "level": {
+                    "$ref": "#/$defs/LoggingLevel",
+                    "description": "The level of logging that the client wants to receive from the server. The server should send all logs at this level and higher (i.e., more severe) to the client as notifications/message."
+                }
+            },
+            "required": ["level"],
+            "type": "object"
+        },
+        "SingleSelectEnumSchema": {
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/UntitledSingleSelectEnumSchema"
+                },
+                {
+                    "$ref": "#/$defs/TitledSingleSelectEnumSchema"
+                }
+            ]
+        },
+        "StringSchema": {
+            "properties": {
+                "default": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "format": {
+                    "enum": ["date", "date-time", "email", "uri"],
+                    "type": "string"
+                },
+                "maxLength": {
+                    "type": "integer"
+                },
+                "minLength": {
+                    "type": "integer"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "type": {
+                    "const": "string",
+                    "type": "string"
+                }
+            },
+            "required": ["type"],
+            "type": "object"
+        },
+        "SubscribeRequest": {
+            "description": "Sent from the client to request resources/updated notifications from the server whenever a particular resource changes.",
+            "properties": {
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "resources/subscribe",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/SubscribeRequestParams"
+                }
+            },
+            "required": ["id", "jsonrpc", "method", "params"],
+            "type": "object"
+        },
+        "SubscribeRequestParams": {
+            "description": "Parameters for a `resources/subscribe` request.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "properties": {
+                        "progressToken": {
+                            "$ref": "#/$defs/ProgressToken",
+                            "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
+                        }
+                    },
+                    "type": "object"
+                },
+                "uri": {
+                    "description": "The URI of the resource. The URI can use any protocol; it is up to the server how to interpret it.",
+                    "format": "uri",
+                    "type": "string"
+                }
+            },
+            "required": ["uri"],
+            "type": "object"
+        },
+        "Task": {
+            "description": "Data associated with a task.",
+            "properties": {
+                "createdAt": {
+                    "description": "ISO 8601 timestamp when the task was created.",
+                    "type": "string"
+                },
+                "lastUpdatedAt": {
+                    "description": "ISO 8601 timestamp when the task was last updated.",
+                    "type": "string"
+                },
+                "pollInterval": {
+                    "description": "Suggested polling interval in milliseconds.",
+                    "type": "integer"
+                },
+                "status": {
+                    "$ref": "#/$defs/TaskStatus",
+                    "description": "Current task state."
+                },
+                "statusMessage": {
+                    "description": "Optional human-readable message describing the current task state.\nThis can provide context for any status, including:\n- Reasons for \"cancelled\" status\n- Summaries for \"completed\" status\n- Diagnostic information for \"failed\" status (e.g., error details, what went wrong)",
+                    "type": "string"
+                },
+                "taskId": {
+                    "description": "The task identifier.",
+                    "type": "string"
+                },
+                "ttl": {
+                    "description": "Actual retention duration from creation in milliseconds, null for unlimited.",
+                    "type": ["integer", "null"]
+                }
+            },
+            "required": ["createdAt", "lastUpdatedAt", "status", "taskId", "ttl"],
+            "type": "object"
+        },
+        "TaskAugmentedRequestParams": {
+            "description": "Common params for any task-augmented request.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "properties": {
+                        "progressToken": {
+                            "$ref": "#/$defs/ProgressToken",
+                            "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
+                        }
+                    },
+                    "type": "object"
+                },
+                "task": {
+                    "$ref": "#/$defs/TaskMetadata",
+                    "description": "If specified, the caller is requesting task-augmented execution for this request.\nThe request will return a CreateTaskResult immediately, and the actual result can be\nretrieved later via tasks/result.\n\nTask augmentation is subject to capability negotiation - receivers MUST declare support\nfor task augmentation of specific request types in their capabilities."
+                }
+            },
+            "type": "object"
+        },
+        "TaskMetadata": {
+            "description": "Metadata for augmenting a request with task execution.\nInclude this in the `task` field of the request parameters.",
+            "properties": {
+                "ttl": {
+                    "description": "Requested duration in milliseconds to retain task from creation.",
+                    "type": "integer"
+                }
+            },
+            "type": "object"
+        },
+        "TaskStatus": {
+            "description": "The status of a task.",
+            "enum": ["cancelled", "completed", "failed", "input_required", "working"],
+            "type": "string"
+        },
+        "TaskStatusNotification": {
+            "description": "An optional notification from the receiver to the requestor, informing them that a task's status has changed. Receivers are not required to send these notifications.",
+            "properties": {
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "notifications/tasks/status",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/TaskStatusNotificationParams"
+                }
+            },
+            "required": ["jsonrpc", "method", "params"],
+            "type": "object"
+        },
+        "TaskStatusNotificationParams": {
+            "allOf": [
+                {
+                    "$ref": "#/$defs/NotificationParams"
+                },
+                {
+                    "$ref": "#/$defs/Task"
+                }
+            ],
+            "description": "Parameters for a `notifications/tasks/status` notification."
+        },
+        "TextContent": {
+            "description": "Text provided to or from an LLM.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object"
+                },
+                "annotations": {
+                    "$ref": "#/$defs/Annotations",
+                    "description": "Optional annotations for the client."
+                },
+                "text": {
+                    "description": "The text content of the message.",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "text",
+                    "type": "string"
+                }
+            },
+            "required": ["text", "type"],
+            "type": "object"
+        },
+        "TextResourceContents": {
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object"
+                },
+                "mimeType": {
+                    "description": "The MIME type of this resource, if known.",
+                    "type": "string"
+                },
+                "text": {
+                    "description": "The text of the item. This must only be set if the item can actually be represented as text (not binary data).",
+                    "type": "string"
+                },
+                "uri": {
+                    "description": "The URI of this resource.",
+                    "format": "uri",
+                    "type": "string"
+                }
+            },
+            "required": ["text", "uri"],
+            "type": "object"
+        },
+        "TitledMultiSelectEnumSchema": {
+            "description": "Schema for multiple-selection enumeration with display titles for each option.",
+            "properties": {
+                "default": {
+                    "description": "Optional default value.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "description": {
+                    "description": "Optional description for the enum field.",
+                    "type": "string"
+                },
+                "items": {
+                    "description": "Schema for array items with enum options and display labels.",
+                    "properties": {
+                        "anyOf": {
+                            "description": "Array of enum options with values and display labels.",
+                            "items": {
+                                "properties": {
+                                    "const": {
+                                        "description": "The constant enum value.",
+                                        "type": "string"
+                                    },
+                                    "title": {
+                                        "description": "Display title for this option.",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": ["const", "title"],
+                                "type": "object"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": ["anyOf"],
+                    "type": "object"
+                },
+                "maxItems": {
+                    "description": "Maximum number of items to select.",
+                    "type": "integer"
+                },
+                "minItems": {
+                    "description": "Minimum number of items to select.",
+                    "type": "integer"
+                },
+                "title": {
+                    "description": "Optional title for the enum field.",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "array",
+                    "type": "string"
+                }
+            },
+            "required": ["items", "type"],
+            "type": "object"
+        },
+        "TitledSingleSelectEnumSchema": {
+            "description": "Schema for single-selection enumeration with display titles for each option.",
+            "properties": {
+                "default": {
+                    "description": "Optional default value.",
+                    "type": "string"
+                },
+                "description": {
+                    "description": "Optional description for the enum field.",
+                    "type": "string"
+                },
+                "oneOf": {
+                    "description": "Array of enum options with values and display labels.",
+                    "items": {
+                        "properties": {
+                            "const": {
+                                "description": "The enum value.",
+                                "type": "string"
+                            },
+                            "title": {
+                                "description": "Display label for this option.",
+                                "type": "string"
+                            }
+                        },
+                        "required": ["const", "title"],
+                        "type": "object"
+                    },
+                    "type": "array"
+                },
+                "title": {
+                    "description": "Optional title for the enum field.",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "string",
+                    "type": "string"
+                }
+            },
+            "required": ["oneOf", "type"],
+            "type": "object"
+        },
+        "Tool": {
+            "description": "Definition for a tool the client can call.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object"
+                },
+                "annotations": {
+                    "$ref": "#/$defs/ToolAnnotations",
+                    "description": "Optional additional tool information.\n\nDisplay name precedence order is: title, annotations.title, then name."
+                },
+                "description": {
+                    "description": "A human-readable description of the tool.\n\nThis can be used by clients to improve the LLM's understanding of available tools. It can be thought of like a \"hint\" to the model.",
+                    "type": "string"
+                },
+                "execution": {
+                    "$ref": "#/$defs/ToolExecution",
+                    "description": "Execution-related properties for this tool."
+                },
+                "icons": {
+                    "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
+                    "items": {
+                        "$ref": "#/$defs/Icon"
+                    },
+                    "type": "array"
+                },
+                "inputSchema": {
+                    "description": "A JSON Schema object defining the expected parameters for the tool.",
+                    "properties": {
+                        "$schema": {
+                            "type": "string"
+                        },
+                        "properties": {
+                            "additionalProperties": {
+                                "additionalProperties": true,
+                                "properties": {},
+                                "type": "object"
+                            },
+                            "type": "object"
+                        },
+                        "required": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "type": {
+                            "const": "object",
+                            "type": "string"
+                        }
+                    },
+                    "required": ["type"],
+                    "type": "object"
+                },
+                "name": {
+                    "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+                    "type": "string"
+                },
+                "outputSchema": {
+                    "description": "An optional JSON Schema object defining the structure of the tool's output returned in\nthe structuredContent field of a CallToolResult.\n\nDefaults to JSON Schema 2020-12 when no explicit $schema is provided.\nCurrently restricted to type: \"object\" at the root level.",
+                    "properties": {
+                        "$schema": {
+                            "type": "string"
+                        },
+                        "properties": {
+                            "additionalProperties": {
+                                "additionalProperties": true,
+                                "properties": {},
+                                "type": "object"
+                            },
+                            "type": "object"
+                        },
+                        "required": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "type": {
+                            "const": "object",
+                            "type": "string"
+                        }
+                    },
+                    "required": ["type"],
+                    "type": "object"
+                },
+                "title": {
+                    "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for Tool,\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+                    "type": "string"
+                }
+            },
+            "required": ["inputSchema", "name"],
+            "type": "object"
+        },
+        "ToolAnnotations": {
+            "description": "Additional properties describing a Tool to clients.\n\nNOTE: all properties in ToolAnnotations are **hints**.\nThey are not guaranteed to provide a faithful description of\ntool behavior (including descriptive properties like `title`).\n\nClients should never make tool use decisions based on ToolAnnotations\nreceived from untrusted servers.",
+            "properties": {
+                "destructiveHint": {
+                    "description": "If true, the tool may perform destructive updates to its environment.\nIf false, the tool performs only additive updates.\n\n(This property is meaningful only when `readOnlyHint == false`)\n\nDefault: true",
+                    "type": "boolean"
+                },
+                "idempotentHint": {
+                    "description": "If true, calling the tool repeatedly with the same arguments\nwill have no additional effect on its environment.\n\n(This property is meaningful only when `readOnlyHint == false`)\n\nDefault: false",
+                    "type": "boolean"
+                },
+                "openWorldHint": {
+                    "description": "If true, this tool may interact with an \"open world\" of external\nentities. If false, the tool's domain of interaction is closed.\nFor example, the world of a web search tool is open, whereas that\nof a memory tool is not.\n\nDefault: true",
+                    "type": "boolean"
+                },
+                "readOnlyHint": {
+                    "description": "If true, the tool does not modify its environment.\n\nDefault: false",
+                    "type": "boolean"
+                },
+                "title": {
+                    "description": "A human-readable title for the tool.",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "ToolChoice": {
+            "description": "Controls tool selection behavior for sampling requests.",
+            "properties": {
+                "mode": {
+                    "description": "Controls the tool use ability of the model:\n- \"auto\": Model decides whether to use tools (default)\n- \"required\": Model MUST use at least one tool before completing\n- \"none\": Model MUST NOT use any tools",
+                    "enum": ["auto", "none", "required"],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "ToolExecution": {
+            "description": "Execution-related properties for a tool.",
+            "properties": {
+                "taskSupport": {
+                    "description": "Indicates whether this tool supports task-augmented execution.\nThis allows clients to handle long-running operations through polling\nthe task system.\n\n- \"forbidden\": Tool does not support task-augmented execution (default when absent)\n- \"optional\": Tool may support task-augmented execution\n- \"required\": Tool requires task-augmented execution\n\nDefault: \"forbidden\"",
+                    "enum": ["forbidden", "optional", "required"],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "ToolListChangedNotification": {
+            "description": "An optional notification from the server to the client, informing it that the list of tools it offers has changed. This may be issued by servers without any previous subscription from the client.",
+            "properties": {
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "notifications/tools/list_changed",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/NotificationParams"
+                }
+            },
+            "required": ["jsonrpc", "method"],
+            "type": "object"
+        },
+        "ToolResultContent": {
+            "description": "The result of a tool use, provided by the user back to the assistant.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "Optional metadata about the tool result. Clients SHOULD preserve this field when\nincluding tool results in subsequent sampling requests to enable caching optimizations.\n\nSee [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object"
+                },
+                "content": {
+                    "description": "The unstructured result content of the tool use.\n\nThis has the same format as CallToolResult.content and can include text, images,\naudio, resource links, and embedded resources.",
+                    "items": {
+                        "$ref": "#/$defs/ContentBlock"
+                    },
+                    "type": "array"
+                },
+                "isError": {
+                    "description": "Whether the tool use resulted in an error.\n\nIf true, the content typically describes the error that occurred.\nDefault: false",
+                    "type": "boolean"
+                },
+                "structuredContent": {
+                    "additionalProperties": {},
+                    "description": "An optional structured result object.\n\nIf the tool defined an outputSchema, this SHOULD conform to that schema.",
+                    "type": "object"
+                },
+                "toolUseId": {
+                    "description": "The ID of the tool use this result corresponds to.\n\nThis MUST match the ID from a previous ToolUseContent.",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "tool_result",
+                    "type": "string"
+                }
+            },
+            "required": ["content", "toolUseId", "type"],
+            "type": "object"
+        },
+        "ToolUseContent": {
+            "description": "A request from the assistant to call a tool.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "Optional metadata about the tool use. Clients SHOULD preserve this field when\nincluding tool uses in subsequent sampling requests to enable caching optimizations.\n\nSee [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "type": "object"
+                },
+                "id": {
+                    "description": "A unique identifier for this tool use.\n\nThis ID is used to match tool results to their corresponding tool uses.",
+                    "type": "string"
+                },
+                "input": {
+                    "additionalProperties": {},
+                    "description": "The arguments to pass to the tool, conforming to the tool's input schema.",
+                    "type": "object"
+                },
+                "name": {
+                    "description": "The name of the tool to call.",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "tool_use",
+                    "type": "string"
+                }
+            },
+            "required": ["id", "input", "name", "type"],
+            "type": "object"
+        },
+        "URLElicitationRequiredError": {
+            "description": "An error response that indicates that the server requires the client to provide additional information via an elicitation request.",
+            "properties": {
+                "error": {
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/Error"
+                        },
+                        {
+                            "properties": {
+                                "code": {
+                                    "const": -32042,
+                                    "type": "integer"
+                                },
+                                "data": {
+                                    "additionalProperties": {},
+                                    "properties": {
+                                        "elicitations": {
+                                            "items": {
+                                                "$ref": "#/$defs/ElicitRequestURLParams"
+                                            },
+                                            "type": "array"
+                                        }
+                                    },
+                                    "required": ["elicitations"],
+                                    "type": "object"
+                                }
+                            },
+                            "required": ["code", "data"],
+                            "type": "object"
+                        }
+                    ]
+                },
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                }
+            },
+            "required": ["error", "jsonrpc"],
+            "type": "object"
+        },
+        "UnsubscribeRequest": {
+            "description": "Sent from the client to request cancellation of resources/updated notifications from the server. This should follow a previous resources/subscribe request.",
+            "properties": {
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "resources/unsubscribe",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/UnsubscribeRequestParams"
+                }
+            },
+            "required": ["id", "jsonrpc", "method", "params"],
+            "type": "object"
+        },
+        "UnsubscribeRequestParams": {
+            "description": "Parameters for a `resources/unsubscribe` request.",
+            "properties": {
+                "_meta": {
+                    "additionalProperties": {},
+                    "description": "See [General fields: `_meta`](/specification/2025-11-25/basic/index#meta) for notes on `_meta` usage.",
+                    "properties": {
+                        "progressToken": {
+                            "$ref": "#/$defs/ProgressToken",
+                            "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
+                        }
+                    },
+                    "type": "object"
+                },
+                "uri": {
+                    "description": "The URI of the resource. The URI can use any protocol; it is up to the server how to interpret it.",
+                    "format": "uri",
+                    "type": "string"
+                }
+            },
+            "required": ["uri"],
+            "type": "object"
+        },
+        "UntitledMultiSelectEnumSchema": {
+            "description": "Schema for multiple-selection enumeration without display titles for options.",
+            "properties": {
+                "default": {
+                    "description": "Optional default value.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "description": {
+                    "description": "Optional description for the enum field.",
+                    "type": "string"
+                },
+                "items": {
+                    "description": "Schema for the array items.",
+                    "properties": {
+                        "enum": {
+                            "description": "Array of enum values to choose from.",
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "type": {
+                            "const": "string",
+                            "type": "string"
+                        }
+                    },
+                    "required": ["enum", "type"],
+                    "type": "object"
+                },
+                "maxItems": {
+                    "description": "Maximum number of items to select.",
+                    "type": "integer"
+                },
+                "minItems": {
+                    "description": "Minimum number of items to select.",
+                    "type": "integer"
+                },
+                "title": {
+                    "description": "Optional title for the enum field.",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "array",
+                    "type": "string"
+                }
+            },
+            "required": ["items", "type"],
+            "type": "object"
+        },
+        "UntitledSingleSelectEnumSchema": {
+            "description": "Schema for single-selection enumeration without display titles for options.",
+            "properties": {
+                "default": {
+                    "description": "Optional default value.",
+                    "type": "string"
+                },
+                "description": {
+                    "description": "Optional description for the enum field.",
+                    "type": "string"
+                },
+                "enum": {
+                    "description": "Array of enum values to choose from.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "title": {
+                    "description": "Optional title for the enum field.",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "string",
+                    "type": "string"
+                }
+            },
+            "required": ["enum", "type"],
+            "type": "object"
+        }
+    }
+}

--- a/packages/core/test/corpus/schema-twins/2025-11-25.schema.json
+++ b/packages/core/test/corpus/schema-twins/2025-11-25.schema.json
@@ -50,7 +50,11 @@
                     "type": "string"
                 }
             },
-            "required": ["data", "mimeType", "type"],
+            "required": [
+                "data",
+                "mimeType",
+                "type"
+            ],
             "type": "object"
         },
         "BaseMetadata": {
@@ -65,7 +69,9 @@
                     "type": "string"
                 }
             },
-            "required": ["name"],
+            "required": [
+                "name"
+            ],
             "type": "object"
         },
         "BlobResourceContents": {
@@ -90,7 +96,10 @@
                     "type": "string"
                 }
             },
-            "required": ["blob", "uri"],
+            "required": [
+                "blob",
+                "uri"
+            ],
             "type": "object"
         },
         "BooleanSchema": {
@@ -109,7 +118,9 @@
                     "type": "string"
                 }
             },
-            "required": ["type"],
+            "required": [
+                "type"
+            ],
             "type": "object"
         },
         "CallToolRequest": {
@@ -130,7 +141,12 @@
                     "$ref": "#/$defs/CallToolRequestParams"
                 }
             },
-            "required": ["id", "jsonrpc", "method", "params"],
+            "required": [
+                "id",
+                "jsonrpc",
+                "method",
+                "params"
+            ],
             "type": "object"
         },
         "CallToolRequestParams": {
@@ -161,7 +177,9 @@
                     "description": "If specified, the caller is requesting task-augmented execution for this request.\nThe request will return a CreateTaskResult immediately, and the actual result can be\nretrieved later via tasks/result.\n\nTask augmentation is subject to capability negotiation - receivers MUST declare support\nfor task augmentation of specific request types in their capabilities."
                 }
             },
-            "required": ["name"],
+            "required": [
+                "name"
+            ],
             "type": "object"
         },
         "CallToolResult": {
@@ -189,7 +207,9 @@
                     "type": "object"
                 }
             },
-            "required": ["content"],
+            "required": [
+                "content"
+            ],
             "type": "object"
         },
         "CancelTaskRequest": {
@@ -213,11 +233,18 @@
                             "type": "string"
                         }
                     },
-                    "required": ["taskId"],
+                    "required": [
+                        "taskId"
+                    ],
                     "type": "object"
                 }
             },
-            "required": ["id", "jsonrpc", "method", "params"],
+            "required": [
+                "id",
+                "jsonrpc",
+                "method",
+                "params"
+            ],
             "type": "object"
         },
         "CancelTaskResult": {
@@ -246,7 +273,11 @@
                     "$ref": "#/$defs/CancelledNotificationParams"
                 }
             },
-            "required": ["jsonrpc", "method", "params"],
+            "required": [
+                "jsonrpc",
+                "method",
+                "params"
+            ],
             "type": "object"
         },
         "CancelledNotificationParams": {
@@ -497,7 +528,12 @@
                     "$ref": "#/$defs/CompleteRequestParams"
                 }
             },
-            "required": ["id", "jsonrpc", "method", "params"],
+            "required": [
+                "id",
+                "jsonrpc",
+                "method",
+                "params"
+            ],
             "type": "object"
         },
         "CompleteRequestParams": {
@@ -526,7 +562,10 @@
                             "type": "string"
                         }
                     },
-                    "required": ["name", "value"],
+                    "required": [
+                        "name",
+                        "value"
+                    ],
                     "type": "object"
                 },
                 "context": {
@@ -553,7 +592,10 @@
                     ]
                 }
             },
-            "required": ["argument", "ref"],
+            "required": [
+                "argument",
+                "ref"
+            ],
             "type": "object"
         },
         "CompleteResult": {
@@ -582,11 +624,15 @@
                             "type": "array"
                         }
                     },
-                    "required": ["values"],
+                    "required": [
+                        "values"
+                    ],
                     "type": "object"
                 }
             },
-            "required": ["completion"],
+            "required": [
+                "completion"
+            ],
             "type": "object"
         },
         "ContentBlock": {
@@ -626,7 +672,12 @@
                     "$ref": "#/$defs/CreateMessageRequestParams"
                 }
             },
-            "required": ["id", "jsonrpc", "method", "params"],
+            "required": [
+                "id",
+                "jsonrpc",
+                "method",
+                "params"
+            ],
             "type": "object"
         },
         "CreateMessageRequestParams": {
@@ -645,7 +696,11 @@
                 },
                 "includeContext": {
                     "description": "A request to include context from one or more MCP servers (including the caller), to be attached to the prompt.\nThe client MAY ignore this request.\n\nDefault is \"none\". Values \"thisServer\" and \"allServers\" are soft-deprecated. Servers SHOULD only use these values if the client\ndeclares ClientCapabilities.sampling.context. These values may be removed in future spec releases.",
-                    "enum": ["allServers", "none", "thisServer"],
+                    "enum": [
+                        "allServers",
+                        "none",
+                        "thisServer"
+                    ],
                     "type": "string"
                 },
                 "maxTokens": {
@@ -697,7 +752,10 @@
                     "type": "array"
                 }
             },
-            "required": ["maxTokens", "messages"],
+            "required": [
+                "maxTokens",
+                "messages"
+            ],
             "type": "object"
         },
         "CreateMessageResult": {
@@ -745,7 +803,11 @@
                     "type": "string"
                 }
             },
-            "required": ["content", "model", "role"],
+            "required": [
+                "content",
+                "model",
+                "role"
+            ],
             "type": "object"
         },
         "CreateTaskResult": {
@@ -760,7 +822,9 @@
                     "$ref": "#/$defs/Task"
                 }
             },
-            "required": ["task"],
+            "required": [
+                "task"
+            ],
             "type": "object"
         },
         "Cursor": {
@@ -785,7 +849,12 @@
                     "$ref": "#/$defs/ElicitRequestParams"
                 }
             },
-            "required": ["id", "jsonrpc", "method", "params"],
+            "required": [
+                "id",
+                "jsonrpc",
+                "method",
+                "params"
+            ],
             "type": "object"
         },
         "ElicitRequestFormParams": {
@@ -834,7 +903,10 @@
                             "type": "string"
                         }
                     },
-                    "required": ["properties", "type"],
+                    "required": [
+                        "properties",
+                        "type"
+                    ],
                     "type": "object"
                 },
                 "task": {
@@ -842,7 +914,10 @@
                     "description": "If specified, the caller is requesting task-augmented execution for this request.\nThe request will return a CreateTaskResult immediately, and the actual result can be\nretrieved later via tasks/result.\n\nTask augmentation is subject to capability negotiation - receivers MUST declare support\nfor task augmentation of specific request types in their capabilities."
                 }
             },
-            "required": ["message", "requestedSchema"],
+            "required": [
+                "message",
+                "requestedSchema"
+            ],
             "type": "object"
         },
         "ElicitRequestParams": {
@@ -893,7 +968,12 @@
                     "type": "string"
                 }
             },
-            "required": ["elicitationId", "message", "mode", "url"],
+            "required": [
+                "elicitationId",
+                "message",
+                "mode",
+                "url"
+            ],
             "type": "object"
         },
         "ElicitResult": {
@@ -906,7 +986,11 @@
                 },
                 "action": {
                     "description": "The user action in response to the elicitation.\n- \"accept\": User submitted the form/confirmed the action\n- \"decline\": User explicitly decline the action\n- \"cancel\": User dismissed without making an explicit choice",
-                    "enum": ["accept", "cancel", "decline"],
+                    "enum": [
+                        "accept",
+                        "cancel",
+                        "decline"
+                    ],
                     "type": "string"
                 },
                 "content": {
@@ -919,7 +1003,11 @@
                                 "type": "array"
                             },
                             {
-                                "type": ["string", "integer", "boolean"]
+                                "type": [
+                                    "string",
+                                    "integer",
+                                    "boolean"
+                                ]
                             }
                         ]
                     },
@@ -927,7 +1015,9 @@
                     "type": "object"
                 }
             },
-            "required": ["action"],
+            "required": [
+                "action"
+            ],
             "type": "object"
         },
         "ElicitationCompleteNotification": {
@@ -948,11 +1038,17 @@
                             "type": "string"
                         }
                     },
-                    "required": ["elicitationId"],
+                    "required": [
+                        "elicitationId"
+                    ],
                     "type": "object"
                 }
             },
-            "required": ["jsonrpc", "method", "params"],
+            "required": [
+                "jsonrpc",
+                "method",
+                "params"
+            ],
             "type": "object"
         },
         "EmbeddedResource": {
@@ -982,7 +1078,10 @@
                     "type": "string"
                 }
             },
-            "required": ["resource", "type"],
+            "required": [
+                "resource",
+                "type"
+            ],
             "type": "object"
         },
         "EmptyResult": {
@@ -1021,7 +1120,10 @@
                     "type": "string"
                 }
             },
-            "required": ["code", "message"],
+            "required": [
+                "code",
+                "message"
+            ],
             "type": "object"
         },
         "GetPromptRequest": {
@@ -1042,7 +1144,12 @@
                     "$ref": "#/$defs/GetPromptRequestParams"
                 }
             },
-            "required": ["id", "jsonrpc", "method", "params"],
+            "required": [
+                "id",
+                "jsonrpc",
+                "method",
+                "params"
+            ],
             "type": "object"
         },
         "GetPromptRequestParams": {
@@ -1071,7 +1178,9 @@
                     "type": "string"
                 }
             },
-            "required": ["name"],
+            "required": [
+                "name"
+            ],
             "type": "object"
         },
         "GetPromptResult": {
@@ -1093,7 +1202,9 @@
                     "type": "array"
                 }
             },
-            "required": ["messages"],
+            "required": [
+                "messages"
+            ],
             "type": "object"
         },
         "GetTaskPayloadRequest": {
@@ -1117,11 +1228,18 @@
                             "type": "string"
                         }
                     },
-                    "required": ["taskId"],
+                    "required": [
+                        "taskId"
+                    ],
                     "type": "object"
                 }
             },
-            "required": ["id", "jsonrpc", "method", "params"],
+            "required": [
+                "id",
+                "jsonrpc",
+                "method",
+                "params"
+            ],
             "type": "object"
         },
         "GetTaskPayloadResult": {
@@ -1157,11 +1275,18 @@
                             "type": "string"
                         }
                     },
-                    "required": ["taskId"],
+                    "required": [
+                        "taskId"
+                    ],
                     "type": "object"
                 }
             },
-            "required": ["id", "jsonrpc", "method", "params"],
+            "required": [
+                "id",
+                "jsonrpc",
+                "method",
+                "params"
+            ],
             "type": "object"
         },
         "GetTaskResult": {
@@ -1196,11 +1321,16 @@
                 },
                 "theme": {
                     "description": "Optional specifier for the theme this icon is designed for. `light` indicates\nthe icon is designed to be used with a light background, and `dark` indicates\nthe icon is designed to be used with a dark background.\n\nIf not provided, the client should assume the icon can be used with any theme.",
-                    "enum": ["dark", "light"],
+                    "enum": [
+                        "dark",
+                        "light"
+                    ],
                     "type": "string"
                 }
             },
-            "required": ["src"],
+            "required": [
+                "src"
+            ],
             "type": "object"
         },
         "Icons": {
@@ -1242,7 +1372,11 @@
                     "type": "string"
                 }
             },
-            "required": ["data", "mimeType", "type"],
+            "required": [
+                "data",
+                "mimeType",
+                "type"
+            ],
             "type": "object"
         },
         "Implementation": {
@@ -1276,7 +1410,10 @@
                     "type": "string"
                 }
             },
-            "required": ["name", "version"],
+            "required": [
+                "name",
+                "version"
+            ],
             "type": "object"
         },
         "InitializeRequest": {
@@ -1297,7 +1434,12 @@
                     "$ref": "#/$defs/InitializeRequestParams"
                 }
             },
-            "required": ["id", "jsonrpc", "method", "params"],
+            "required": [
+                "id",
+                "jsonrpc",
+                "method",
+                "params"
+            ],
             "type": "object"
         },
         "InitializeRequestParams": {
@@ -1325,7 +1467,11 @@
                     "type": "string"
                 }
             },
-            "required": ["capabilities", "clientInfo", "protocolVersion"],
+            "required": [
+                "capabilities",
+                "clientInfo",
+                "protocolVersion"
+            ],
             "type": "object"
         },
         "InitializeResult": {
@@ -1351,7 +1497,11 @@
                     "$ref": "#/$defs/Implementation"
                 }
             },
-            "required": ["capabilities", "protocolVersion", "serverInfo"],
+            "required": [
+                "capabilities",
+                "protocolVersion",
+                "serverInfo"
+            ],
             "type": "object"
         },
         "InitializedNotification": {
@@ -1369,7 +1519,10 @@
                     "$ref": "#/$defs/NotificationParams"
                 }
             },
-            "required": ["jsonrpc", "method"],
+            "required": [
+                "jsonrpc",
+                "method"
+            ],
             "type": "object"
         },
         "JSONRPCErrorResponse": {
@@ -1386,7 +1539,10 @@
                     "type": "string"
                 }
             },
-            "required": ["error", "jsonrpc"],
+            "required": [
+                "error",
+                "jsonrpc"
+            ],
             "type": "object"
         },
         "JSONRPCMessage": {
@@ -1421,7 +1577,10 @@
                     "type": "object"
                 }
             },
-            "required": ["jsonrpc", "method"],
+            "required": [
+                "jsonrpc",
+                "method"
+            ],
             "type": "object"
         },
         "JSONRPCRequest": {
@@ -1442,7 +1601,11 @@
                     "type": "object"
                 }
             },
-            "required": ["id", "jsonrpc", "method"],
+            "required": [
+                "id",
+                "jsonrpc",
+                "method"
+            ],
             "type": "object"
         },
         "JSONRPCResponse": {
@@ -1470,7 +1633,11 @@
                     "$ref": "#/$defs/Result"
                 }
             },
-            "required": ["id", "jsonrpc", "result"],
+            "required": [
+                "id",
+                "jsonrpc",
+                "result"
+            ],
             "type": "object"
         },
         "LegacyTitledEnumSchema": {
@@ -1503,7 +1670,10 @@
                     "type": "string"
                 }
             },
-            "required": ["enum", "type"],
+            "required": [
+                "enum",
+                "type"
+            ],
             "type": "object"
         },
         "ListPromptsRequest": {
@@ -1524,7 +1694,11 @@
                     "$ref": "#/$defs/PaginatedRequestParams"
                 }
             },
-            "required": ["id", "jsonrpc", "method"],
+            "required": [
+                "id",
+                "jsonrpc",
+                "method"
+            ],
             "type": "object"
         },
         "ListPromptsResult": {
@@ -1546,7 +1720,9 @@
                     "type": "array"
                 }
             },
-            "required": ["prompts"],
+            "required": [
+                "prompts"
+            ],
             "type": "object"
         },
         "ListResourceTemplatesRequest": {
@@ -1567,7 +1743,11 @@
                     "$ref": "#/$defs/PaginatedRequestParams"
                 }
             },
-            "required": ["id", "jsonrpc", "method"],
+            "required": [
+                "id",
+                "jsonrpc",
+                "method"
+            ],
             "type": "object"
         },
         "ListResourceTemplatesResult": {
@@ -1589,7 +1769,9 @@
                     "type": "array"
                 }
             },
-            "required": ["resourceTemplates"],
+            "required": [
+                "resourceTemplates"
+            ],
             "type": "object"
         },
         "ListResourcesRequest": {
@@ -1610,7 +1792,11 @@
                     "$ref": "#/$defs/PaginatedRequestParams"
                 }
             },
-            "required": ["id", "jsonrpc", "method"],
+            "required": [
+                "id",
+                "jsonrpc",
+                "method"
+            ],
             "type": "object"
         },
         "ListResourcesResult": {
@@ -1632,7 +1818,9 @@
                     "type": "array"
                 }
             },
-            "required": ["resources"],
+            "required": [
+                "resources"
+            ],
             "type": "object"
         },
         "ListRootsRequest": {
@@ -1653,7 +1841,11 @@
                     "$ref": "#/$defs/RequestParams"
                 }
             },
-            "required": ["id", "jsonrpc", "method"],
+            "required": [
+                "id",
+                "jsonrpc",
+                "method"
+            ],
             "type": "object"
         },
         "ListRootsResult": {
@@ -1671,7 +1863,9 @@
                     "type": "array"
                 }
             },
-            "required": ["roots"],
+            "required": [
+                "roots"
+            ],
             "type": "object"
         },
         "ListTasksRequest": {
@@ -1692,7 +1886,11 @@
                     "$ref": "#/$defs/PaginatedRequestParams"
                 }
             },
-            "required": ["id", "jsonrpc", "method"],
+            "required": [
+                "id",
+                "jsonrpc",
+                "method"
+            ],
             "type": "object"
         },
         "ListTasksResult": {
@@ -1714,7 +1912,9 @@
                     "type": "array"
                 }
             },
-            "required": ["tasks"],
+            "required": [
+                "tasks"
+            ],
             "type": "object"
         },
         "ListToolsRequest": {
@@ -1735,7 +1935,11 @@
                     "$ref": "#/$defs/PaginatedRequestParams"
                 }
             },
-            "required": ["id", "jsonrpc", "method"],
+            "required": [
+                "id",
+                "jsonrpc",
+                "method"
+            ],
             "type": "object"
         },
         "ListToolsResult": {
@@ -1757,12 +1961,23 @@
                     "type": "array"
                 }
             },
-            "required": ["tools"],
+            "required": [
+                "tools"
+            ],
             "type": "object"
         },
         "LoggingLevel": {
             "description": "The severity of a log message.\n\nThese map to syslog message severities, as specified in RFC-5424:\nhttps://datatracker.ietf.org/doc/html/rfc5424#section-6.2.1",
-            "enum": ["alert", "critical", "debug", "emergency", "error", "info", "notice", "warning"],
+            "enum": [
+                "alert",
+                "critical",
+                "debug",
+                "emergency",
+                "error",
+                "info",
+                "notice",
+                "warning"
+            ],
             "type": "string"
         },
         "LoggingMessageNotification": {
@@ -1780,7 +1995,11 @@
                     "$ref": "#/$defs/LoggingMessageNotificationParams"
                 }
             },
-            "required": ["jsonrpc", "method", "params"],
+            "required": [
+                "jsonrpc",
+                "method",
+                "params"
+            ],
             "type": "object"
         },
         "LoggingMessageNotificationParams": {
@@ -1803,7 +2022,10 @@
                     "type": "string"
                 }
             },
-            "required": ["data", "level"],
+            "required": [
+                "data",
+                "level"
+            ],
             "type": "object"
         },
         "ModelHint": {
@@ -1867,7 +2089,9 @@
                     "type": "object"
                 }
             },
-            "required": ["method"],
+            "required": [
+                "method"
+            ],
             "type": "object"
         },
         "NotificationParams": {
@@ -1898,11 +2122,16 @@
                     "type": "string"
                 },
                 "type": {
-                    "enum": ["integer", "number"],
+                    "enum": [
+                        "integer",
+                        "number"
+                    ],
                     "type": "string"
                 }
             },
-            "required": ["type"],
+            "required": [
+                "type"
+            ],
             "type": "object"
         },
         "PaginatedRequest": {
@@ -1921,7 +2150,11 @@
                     "$ref": "#/$defs/PaginatedRequestParams"
                 }
             },
-            "required": ["id", "jsonrpc", "method"],
+            "required": [
+                "id",
+                "jsonrpc",
+                "method"
+            ],
             "type": "object"
         },
         "PaginatedRequestParams": {
@@ -1977,7 +2210,11 @@
                     "$ref": "#/$defs/RequestParams"
                 }
             },
-            "required": ["id", "jsonrpc", "method"],
+            "required": [
+                "id",
+                "jsonrpc",
+                "method"
+            ],
             "type": "object"
         },
         "PrimitiveSchemaDefinition": {
@@ -2024,7 +2261,11 @@
                     "$ref": "#/$defs/ProgressNotificationParams"
                 }
             },
-            "required": ["jsonrpc", "method", "params"],
+            "required": [
+                "jsonrpc",
+                "method",
+                "params"
+            ],
             "type": "object"
         },
         "ProgressNotificationParams": {
@@ -2052,12 +2293,18 @@
                     "type": "number"
                 }
             },
-            "required": ["progress", "progressToken"],
+            "required": [
+                "progress",
+                "progressToken"
+            ],
             "type": "object"
         },
         "ProgressToken": {
             "description": "A progress token, used to associate progress notifications with the original request.",
-            "type": ["string", "integer"]
+            "type": [
+                "string",
+                "integer"
+            ]
         },
         "Prompt": {
             "description": "A prompt or prompt template that the server offers.",
@@ -2094,7 +2341,9 @@
                     "type": "string"
                 }
             },
-            "required": ["name"],
+            "required": [
+                "name"
+            ],
             "type": "object"
         },
         "PromptArgument": {
@@ -2117,7 +2366,9 @@
                     "type": "string"
                 }
             },
-            "required": ["name"],
+            "required": [
+                "name"
+            ],
             "type": "object"
         },
         "PromptListChangedNotification": {
@@ -2135,7 +2386,10 @@
                     "$ref": "#/$defs/NotificationParams"
                 }
             },
-            "required": ["jsonrpc", "method"],
+            "required": [
+                "jsonrpc",
+                "method"
+            ],
             "type": "object"
         },
         "PromptMessage": {
@@ -2148,7 +2402,10 @@
                     "$ref": "#/$defs/Role"
                 }
             },
-            "required": ["content", "role"],
+            "required": [
+                "content",
+                "role"
+            ],
             "type": "object"
         },
         "PromptReference": {
@@ -2167,7 +2424,10 @@
                     "type": "string"
                 }
             },
-            "required": ["name", "type"],
+            "required": [
+                "name",
+                "type"
+            ],
             "type": "object"
         },
         "ReadResourceRequest": {
@@ -2188,7 +2448,12 @@
                     "$ref": "#/$defs/ReadResourceRequestParams"
                 }
             },
-            "required": ["id", "jsonrpc", "method", "params"],
+            "required": [
+                "id",
+                "jsonrpc",
+                "method",
+                "params"
+            ],
             "type": "object"
         },
         "ReadResourceRequestParams": {
@@ -2211,7 +2476,9 @@
                     "type": "string"
                 }
             },
-            "required": ["uri"],
+            "required": [
+                "uri"
+            ],
             "type": "object"
         },
         "ReadResourceResult": {
@@ -2236,7 +2503,9 @@
                     "type": "array"
                 }
             },
-            "required": ["contents"],
+            "required": [
+                "contents"
+            ],
             "type": "object"
         },
         "RelatedTaskMetadata": {
@@ -2247,7 +2516,9 @@
                     "type": "string"
                 }
             },
-            "required": ["taskId"],
+            "required": [
+                "taskId"
+            ],
             "type": "object"
         },
         "Request": {
@@ -2260,12 +2531,17 @@
                     "type": "object"
                 }
             },
-            "required": ["method"],
+            "required": [
+                "method"
+            ],
             "type": "object"
         },
         "RequestId": {
             "description": "A uniquely identifying ID for a request in JSON-RPC.",
-            "type": ["string", "integer"]
+            "type": [
+                "string",
+                "integer"
+            ]
         },
         "RequestParams": {
             "description": "Common params for any request.",
@@ -2329,7 +2605,10 @@
                     "type": "string"
                 }
             },
-            "required": ["name", "uri"],
+            "required": [
+                "name",
+                "uri"
+            ],
             "type": "object"
         },
         "ResourceContents": {
@@ -2350,7 +2629,9 @@
                     "type": "string"
                 }
             },
-            "required": ["uri"],
+            "required": [
+                "uri"
+            ],
             "type": "object"
         },
         "ResourceLink": {
@@ -2402,7 +2683,11 @@
                     "type": "string"
                 }
             },
-            "required": ["name", "type", "uri"],
+            "required": [
+                "name",
+                "type",
+                "uri"
+            ],
             "type": "object"
         },
         "ResourceListChangedNotification": {
@@ -2420,7 +2705,10 @@
                     "$ref": "#/$defs/NotificationParams"
                 }
             },
-            "required": ["jsonrpc", "method"],
+            "required": [
+                "jsonrpc",
+                "method"
+            ],
             "type": "object"
         },
         "ResourceRequestParams": {
@@ -2443,7 +2731,9 @@
                     "type": "string"
                 }
             },
-            "required": ["uri"],
+            "required": [
+                "uri"
+            ],
             "type": "object"
         },
         "ResourceTemplate": {
@@ -2487,7 +2777,10 @@
                     "type": "string"
                 }
             },
-            "required": ["name", "uriTemplate"],
+            "required": [
+                "name",
+                "uriTemplate"
+            ],
             "type": "object"
         },
         "ResourceTemplateReference": {
@@ -2503,7 +2796,10 @@
                     "type": "string"
                 }
             },
-            "required": ["type", "uri"],
+            "required": [
+                "type",
+                "uri"
+            ],
             "type": "object"
         },
         "ResourceUpdatedNotification": {
@@ -2521,7 +2817,11 @@
                     "$ref": "#/$defs/ResourceUpdatedNotificationParams"
                 }
             },
-            "required": ["jsonrpc", "method", "params"],
+            "required": [
+                "jsonrpc",
+                "method",
+                "params"
+            ],
             "type": "object"
         },
         "ResourceUpdatedNotificationParams": {
@@ -2538,7 +2838,9 @@
                     "type": "string"
                 }
             },
-            "required": ["uri"],
+            "required": [
+                "uri"
+            ],
             "type": "object"
         },
         "Result": {
@@ -2554,7 +2856,10 @@
         },
         "Role": {
             "description": "The sender or recipient of messages and data in a conversation.",
-            "enum": ["assistant", "user"],
+            "enum": [
+                "assistant",
+                "user"
+            ],
             "type": "string"
         },
         "Root": {
@@ -2575,7 +2880,9 @@
                     "type": "string"
                 }
             },
-            "required": ["uri"],
+            "required": [
+                "uri"
+            ],
             "type": "object"
         },
         "RootsListChangedNotification": {
@@ -2593,7 +2900,10 @@
                     "$ref": "#/$defs/NotificationParams"
                 }
             },
-            "required": ["jsonrpc", "method"],
+            "required": [
+                "jsonrpc",
+                "method"
+            ],
             "type": "object"
         },
         "SamplingMessage": {
@@ -2633,7 +2943,10 @@
                     "$ref": "#/$defs/Role"
                 }
             },
-            "required": ["content", "role"],
+            "required": [
+                "content",
+                "role"
+            ],
             "type": "object"
         },
         "SamplingMessageContentBlock": {
@@ -2877,7 +3190,12 @@
                     "$ref": "#/$defs/SetLevelRequestParams"
                 }
             },
-            "required": ["id", "jsonrpc", "method", "params"],
+            "required": [
+                "id",
+                "jsonrpc",
+                "method",
+                "params"
+            ],
             "type": "object"
         },
         "SetLevelRequestParams": {
@@ -2899,7 +3217,9 @@
                     "description": "The level of logging that the client wants to receive from the server. The server should send all logs at this level and higher (i.e., more severe) to the client as notifications/message."
                 }
             },
-            "required": ["level"],
+            "required": [
+                "level"
+            ],
             "type": "object"
         },
         "SingleSelectEnumSchema": {
@@ -2921,7 +3241,12 @@
                     "type": "string"
                 },
                 "format": {
-                    "enum": ["date", "date-time", "email", "uri"],
+                    "enum": [
+                        "date",
+                        "date-time",
+                        "email",
+                        "uri"
+                    ],
                     "type": "string"
                 },
                 "maxLength": {
@@ -2938,7 +3263,9 @@
                     "type": "string"
                 }
             },
-            "required": ["type"],
+            "required": [
+                "type"
+            ],
             "type": "object"
         },
         "SubscribeRequest": {
@@ -2959,7 +3286,12 @@
                     "$ref": "#/$defs/SubscribeRequestParams"
                 }
             },
-            "required": ["id", "jsonrpc", "method", "params"],
+            "required": [
+                "id",
+                "jsonrpc",
+                "method",
+                "params"
+            ],
             "type": "object"
         },
         "SubscribeRequestParams": {
@@ -2982,7 +3314,9 @@
                     "type": "string"
                 }
             },
-            "required": ["uri"],
+            "required": [
+                "uri"
+            ],
             "type": "object"
         },
         "Task": {
@@ -3014,10 +3348,19 @@
                 },
                 "ttl": {
                     "description": "Actual retention duration from creation in milliseconds, null for unlimited.",
-                    "type": ["integer", "null"]
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
                 }
             },
-            "required": ["createdAt", "lastUpdatedAt", "status", "taskId", "ttl"],
+            "required": [
+                "createdAt",
+                "lastUpdatedAt",
+                "status",
+                "taskId",
+                "ttl"
+            ],
             "type": "object"
         },
         "TaskAugmentedRequestParams": {
@@ -3053,7 +3396,13 @@
         },
         "TaskStatus": {
             "description": "The status of a task.",
-            "enum": ["cancelled", "completed", "failed", "input_required", "working"],
+            "enum": [
+                "cancelled",
+                "completed",
+                "failed",
+                "input_required",
+                "working"
+            ],
             "type": "string"
         },
         "TaskStatusNotification": {
@@ -3071,7 +3420,11 @@
                     "$ref": "#/$defs/TaskStatusNotificationParams"
                 }
             },
-            "required": ["jsonrpc", "method", "params"],
+            "required": [
+                "jsonrpc",
+                "method",
+                "params"
+            ],
             "type": "object"
         },
         "TaskStatusNotificationParams": {
@@ -3106,7 +3459,10 @@
                     "type": "string"
                 }
             },
-            "required": ["text", "type"],
+            "required": [
+                "text",
+                "type"
+            ],
             "type": "object"
         },
         "TextResourceContents": {
@@ -3130,7 +3486,10 @@
                     "type": "string"
                 }
             },
-            "required": ["text", "uri"],
+            "required": [
+                "text",
+                "uri"
+            ],
             "type": "object"
         },
         "TitledMultiSelectEnumSchema": {
@@ -3163,13 +3522,18 @@
                                         "type": "string"
                                     }
                                 },
-                                "required": ["const", "title"],
+                                "required": [
+                                    "const",
+                                    "title"
+                                ],
                                 "type": "object"
                             },
                             "type": "array"
                         }
                     },
-                    "required": ["anyOf"],
+                    "required": [
+                        "anyOf"
+                    ],
                     "type": "object"
                 },
                 "maxItems": {
@@ -3189,7 +3553,10 @@
                     "type": "string"
                 }
             },
-            "required": ["items", "type"],
+            "required": [
+                "items",
+                "type"
+            ],
             "type": "object"
         },
         "TitledSingleSelectEnumSchema": {
@@ -3216,7 +3583,10 @@
                                 "type": "string"
                             }
                         },
-                        "required": ["const", "title"],
+                        "required": [
+                            "const",
+                            "title"
+                        ],
                         "type": "object"
                     },
                     "type": "array"
@@ -3230,7 +3600,10 @@
                     "type": "string"
                 }
             },
-            "required": ["oneOf", "type"],
+            "required": [
+                "oneOf",
+                "type"
+            ],
             "type": "object"
         },
         "Tool": {
@@ -3285,7 +3658,9 @@
                             "type": "string"
                         }
                     },
-                    "required": ["type"],
+                    "required": [
+                        "type"
+                    ],
                     "type": "object"
                 },
                 "name": {
@@ -3317,7 +3692,9 @@
                             "type": "string"
                         }
                     },
-                    "required": ["type"],
+                    "required": [
+                        "type"
+                    ],
                     "type": "object"
                 },
                 "title": {
@@ -3325,7 +3702,10 @@
                     "type": "string"
                 }
             },
-            "required": ["inputSchema", "name"],
+            "required": [
+                "inputSchema",
+                "name"
+            ],
             "type": "object"
         },
         "ToolAnnotations": {
@@ -3359,7 +3739,11 @@
             "properties": {
                 "mode": {
                     "description": "Controls the tool use ability of the model:\n- \"auto\": Model decides whether to use tools (default)\n- \"required\": Model MUST use at least one tool before completing\n- \"none\": Model MUST NOT use any tools",
-                    "enum": ["auto", "none", "required"],
+                    "enum": [
+                        "auto",
+                        "none",
+                        "required"
+                    ],
                     "type": "string"
                 }
             },
@@ -3370,7 +3754,11 @@
             "properties": {
                 "taskSupport": {
                     "description": "Indicates whether this tool supports task-augmented execution.\nThis allows clients to handle long-running operations through polling\nthe task system.\n\n- \"forbidden\": Tool does not support task-augmented execution (default when absent)\n- \"optional\": Tool may support task-augmented execution\n- \"required\": Tool requires task-augmented execution\n\nDefault: \"forbidden\"",
-                    "enum": ["forbidden", "optional", "required"],
+                    "enum": [
+                        "forbidden",
+                        "optional",
+                        "required"
+                    ],
                     "type": "string"
                 }
             },
@@ -3391,7 +3779,10 @@
                     "$ref": "#/$defs/NotificationParams"
                 }
             },
-            "required": ["jsonrpc", "method"],
+            "required": [
+                "jsonrpc",
+                "method"
+            ],
             "type": "object"
         },
         "ToolResultContent": {
@@ -3427,7 +3818,11 @@
                     "type": "string"
                 }
             },
-            "required": ["content", "toolUseId", "type"],
+            "required": [
+                "content",
+                "toolUseId",
+                "type"
+            ],
             "type": "object"
         },
         "ToolUseContent": {
@@ -3456,7 +3851,12 @@
                     "type": "string"
                 }
             },
-            "required": ["id", "input", "name", "type"],
+            "required": [
+                "id",
+                "input",
+                "name",
+                "type"
+            ],
             "type": "object"
         },
         "URLElicitationRequiredError": {
@@ -3483,11 +3883,16 @@
                                             "type": "array"
                                         }
                                     },
-                                    "required": ["elicitations"],
+                                    "required": [
+                                        "elicitations"
+                                    ],
                                     "type": "object"
                                 }
                             },
-                            "required": ["code", "data"],
+                            "required": [
+                                "code",
+                                "data"
+                            ],
                             "type": "object"
                         }
                     ]
@@ -3500,7 +3905,10 @@
                     "type": "string"
                 }
             },
-            "required": ["error", "jsonrpc"],
+            "required": [
+                "error",
+                "jsonrpc"
+            ],
             "type": "object"
         },
         "UnsubscribeRequest": {
@@ -3521,7 +3929,12 @@
                     "$ref": "#/$defs/UnsubscribeRequestParams"
                 }
             },
-            "required": ["id", "jsonrpc", "method", "params"],
+            "required": [
+                "id",
+                "jsonrpc",
+                "method",
+                "params"
+            ],
             "type": "object"
         },
         "UnsubscribeRequestParams": {
@@ -3544,7 +3957,9 @@
                     "type": "string"
                 }
             },
-            "required": ["uri"],
+            "required": [
+                "uri"
+            ],
             "type": "object"
         },
         "UntitledMultiSelectEnumSchema": {
@@ -3576,7 +3991,10 @@
                             "type": "string"
                         }
                     },
-                    "required": ["enum", "type"],
+                    "required": [
+                        "enum",
+                        "type"
+                    ],
                     "type": "object"
                 },
                 "maxItems": {
@@ -3596,7 +4014,10 @@
                     "type": "string"
                 }
             },
-            "required": ["items", "type"],
+            "required": [
+                "items",
+                "type"
+            ],
             "type": "object"
         },
         "UntitledSingleSelectEnumSchema": {
@@ -3626,8 +4047,12 @@
                     "type": "string"
                 }
             },
-            "required": ["enum", "type"],
+            "required": [
+                "enum",
+                "type"
+            ],
             "type": "object"
         }
     }
 }
+

--- a/packages/core/test/corpus/schema-twins/2026-07-28.schema.json
+++ b/packages/core/test/corpus/schema-twins/2026-07-28.schema.json
@@ -1,0 +1,3407 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$defs": {
+        "Annotations": {
+            "description": "Optional annotations for the client. The client can use annotations to inform how objects are used or displayed",
+            "properties": {
+                "audience": {
+                    "description": "Describes who the intended audience of this object or data is.\n\nIt can include multiple entries to indicate content useful for multiple audiences (e.g., `[\"user\", \"assistant\"]`).",
+                    "items": {
+                        "$ref": "#/$defs/Role"
+                    },
+                    "type": "array"
+                },
+                "lastModified": {
+                    "description": "The moment the resource was last modified, as an ISO 8601 formatted string.\n\nShould be an ISO 8601 formatted string (e.g., \"2025-01-12T15:00:58Z\").\n\nExamples: last activity timestamp in an open file, timestamp when the resource\nwas attached, etc.",
+                    "type": "string"
+                },
+                "priority": {
+                    "description": "Describes how important this data is for operating the server.\n\nA value of 1 means \"most important,\" and indicates that the data is\neffectively required, while 0 means \"least important,\" and indicates that\nthe data is entirely optional.",
+                    "maximum": 1,
+                    "minimum": 0,
+                    "type": "number"
+                }
+            },
+            "type": "object"
+        },
+        "AudioContent": {
+            "description": "Audio provided to or from an LLM.",
+            "properties": {
+                "_meta": {
+                    "$ref": "#/$defs/MetaObject"
+                },
+                "annotations": {
+                    "$ref": "#/$defs/Annotations",
+                    "description": "Optional annotations for the client."
+                },
+                "data": {
+                    "description": "The base64-encoded audio data.",
+                    "format": "byte",
+                    "type": "string"
+                },
+                "mimeType": {
+                    "description": "The MIME type of the audio. Different providers may support different audio types.",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "audio",
+                    "type": "string"
+                }
+            },
+            "required": ["data", "mimeType", "type"],
+            "type": "object"
+        },
+        "BaseMetadata": {
+            "description": "Base interface for metadata with name (identifier) and title (display name) properties.",
+            "properties": {
+                "name": {
+                    "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for {@link Tool},\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+                    "type": "string"
+                }
+            },
+            "required": ["name"],
+            "type": "object"
+        },
+        "BlobResourceContents": {
+            "properties": {
+                "_meta": {
+                    "$ref": "#/$defs/MetaObject"
+                },
+                "blob": {
+                    "description": "A base64-encoded string representing the binary data of the item.",
+                    "format": "byte",
+                    "type": "string"
+                },
+                "mimeType": {
+                    "description": "The MIME type of this resource, if known.",
+                    "type": "string"
+                },
+                "uri": {
+                    "description": "The URI of this resource.",
+                    "format": "uri",
+                    "type": "string"
+                }
+            },
+            "required": ["blob", "uri"],
+            "type": "object"
+        },
+        "BooleanSchema": {
+            "properties": {
+                "default": {
+                    "type": "boolean"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "type": {
+                    "const": "boolean",
+                    "type": "string"
+                }
+            },
+            "required": ["type"],
+            "type": "object"
+        },
+        "CacheableResult": {
+            "description": "A result that supports a time-to-live (TTL) hint for client-side caching.",
+            "properties": {
+                "_meta": {
+                    "$ref": "#/$defs/MetaObject"
+                },
+                "cacheScope": {
+                    "description": "Indicates the intended scope of the cached response, analogous to HTTP\n`Cache-Control: public` vs `Cache-Control: private`.\n\n- `\"public\"`: Any client or intermediary (e.g., shared gateway, proxy)\n  MAY cache the response and serve it to any user.\n- `\"private\"`: Only the requesting user's client MAY cache the response.\n  Shared caches (e.g., multi-tenant gateways) MUST NOT serve a cached\n  copy to a different user.",
+                    "enum": ["private", "public"],
+                    "type": "string"
+                },
+                "resultType": {
+                    "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
+                    "type": "string"
+                },
+                "ttlMs": {
+                    "description": "A hint from the server indicating how long (in milliseconds) the\nclient MAY cache this response before re-fetching. Semantics are\nanalogous to HTTP Cache-Control max-age.\n\n- If 0, The response SHOULD be considered immediately stale,\n  The client MAY re-fetch every time the result is needed.\n- If positive, the client SHOULD consider the result fresh for this many\n  milliseconds after receiving the response.",
+                    "minimum": 0,
+                    "type": "integer"
+                }
+            },
+            "required": ["cacheScope", "resultType", "ttlMs"],
+            "type": "object"
+        },
+        "CallToolRequest": {
+            "description": "Used by the client to invoke a tool provided by the server.",
+            "properties": {
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "tools/call",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/CallToolRequestParams"
+                }
+            },
+            "required": ["id", "jsonrpc", "method", "params"],
+            "type": "object"
+        },
+        "CallToolRequestParams": {
+            "description": "Parameters for a `tools/call` request.",
+            "properties": {
+                "_meta": {
+                    "$ref": "#/$defs/RequestMetaObject"
+                },
+                "arguments": {
+                    "additionalProperties": {},
+                    "description": "Arguments to use for the tool call.",
+                    "type": "object"
+                },
+                "inputResponses": {
+                    "$ref": "#/$defs/InputResponses"
+                },
+                "name": {
+                    "description": "The name of the tool.",
+                    "type": "string"
+                },
+                "requestState": {
+                    "type": "string"
+                }
+            },
+            "required": ["_meta", "name"],
+            "type": "object"
+        },
+        "CallToolResult": {
+            "description": "The result returned by the server for a {@link CallToolRequesttools/call} request.",
+            "properties": {
+                "_meta": {
+                    "$ref": "#/$defs/MetaObject"
+                },
+                "content": {
+                    "description": "A list of content objects that represent the unstructured result of the tool call.",
+                    "items": {
+                        "$ref": "#/$defs/ContentBlock"
+                    },
+                    "type": "array"
+                },
+                "isError": {
+                    "description": "Whether the tool call ended in an error.\n\nIf not set, this is assumed to be false (the call was successful).\n\nAny errors that originate from the tool SHOULD be reported inside the result\nobject, with `isError` set to true, _not_ as an MCP protocol-level error\nresponse. Otherwise, the LLM would not be able to see that an error occurred\nand self-correct.\n\nHowever, any errors in _finding_ the tool, an error indicating that the\nserver does not support tool calls, or any other exceptional conditions,\nshould be reported as an MCP error response.",
+                    "type": "boolean"
+                },
+                "resultType": {
+                    "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
+                    "type": "string"
+                },
+                "structuredContent": {
+                    "description": "An optional JSON value that represents the structured result of the tool call.\n\nThis can be any JSON value (object, array, string, number, boolean, or null)\nthat conforms to the tool's outputSchema if one is defined."
+                }
+            },
+            "required": ["content", "resultType"],
+            "type": "object"
+        },
+        "CallToolResultResponse": {
+            "description": "A successful response from the server for a {@link CallToolRequesttools/call} request.",
+            "properties": {
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "result": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/InputRequiredResult"
+                        },
+                        {
+                            "$ref": "#/$defs/CallToolResult"
+                        }
+                    ]
+                }
+            },
+            "required": ["id", "jsonrpc", "result"],
+            "type": "object"
+        },
+        "CancelledNotification": {
+            "description": "This notification can be sent by either side to indicate that it is cancelling a previously-issued request.\n\nThe request SHOULD still be in-flight, but due to communication latency, it is always possible that this notification MAY arrive after the request has already finished.\n\nThis notification indicates that the result will be unused, so any associated processing SHOULD cease.",
+            "properties": {
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "notifications/cancelled",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/CancelledNotificationParams"
+                }
+            },
+            "required": ["jsonrpc", "method", "params"],
+            "type": "object"
+        },
+        "CancelledNotificationParams": {
+            "description": "Parameters for a `notifications/cancelled` notification.",
+            "properties": {
+                "_meta": {
+                    "$ref": "#/$defs/MetaObject"
+                },
+                "reason": {
+                    "description": "An optional string describing the reason for the cancellation. This MAY be logged or presented to the user.",
+                    "type": "string"
+                },
+                "requestId": {
+                    "$ref": "#/$defs/RequestId",
+                    "description": "The ID of the request to cancel.\n\nThis MUST correspond to the ID of a request previously issued in the same direction."
+                }
+            },
+            "type": "object"
+        },
+        "ClientCapabilities": {
+            "description": "Capabilities a client may support. Known capabilities are defined here, in this schema, but this is not a closed set: any client can define its own, additional capabilities.",
+            "properties": {
+                "elicitation": {
+                    "description": "Present if the client supports elicitation from the server.",
+                    "properties": {
+                        "form": {
+                            "$ref": "#/$defs/JSONObject"
+                        },
+                        "url": {
+                            "$ref": "#/$defs/JSONObject"
+                        }
+                    },
+                    "type": "object"
+                },
+                "experimental": {
+                    "additionalProperties": {
+                        "$ref": "#/$defs/JSONObject"
+                    },
+                    "description": "Experimental, non-standard capabilities that the client supports.",
+                    "type": "object"
+                },
+                "extensions": {
+                    "additionalProperties": {
+                        "$ref": "#/$defs/JSONObject"
+                    },
+                    "description": "Optional MCP extensions that the client supports. Keys are extension identifiers\n(e.g., \"io.modelcontextprotocol/oauth-client-credentials\"), and values are\nper-extension settings objects. An empty object indicates support with no settings.\n\nKeys MUST follow the {@link MetaObject`_meta` key naming rules}, with a\nmandatory prefix.",
+                    "type": "object"
+                },
+                "roots": {
+                    "description": "Present if the client supports listing roots.",
+                    "properties": {},
+                    "type": "object"
+                },
+                "sampling": {
+                    "description": "Present if the client supports sampling from an LLM.",
+                    "properties": {
+                        "context": {
+                            "$ref": "#/$defs/JSONObject",
+                            "description": "Whether the client supports context inclusion via `includeContext` parameter.\nIf not declared, servers SHOULD only use `includeContext: \"none\"` (or omit it)."
+                        },
+                        "tools": {
+                            "$ref": "#/$defs/JSONObject",
+                            "description": "Whether the client supports tool use via `tools` and `toolChoice` parameters."
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "ClientNotification": {
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/CancelledNotification"
+                },
+                {
+                    "$ref": "#/$defs/ProgressNotification"
+                }
+            ]
+        },
+        "ClientRequest": {
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/DiscoverRequest"
+                },
+                {
+                    "$ref": "#/$defs/ListResourcesRequest"
+                },
+                {
+                    "$ref": "#/$defs/ListResourceTemplatesRequest"
+                },
+                {
+                    "$ref": "#/$defs/ReadResourceRequest"
+                },
+                {
+                    "$ref": "#/$defs/SubscriptionsListenRequest"
+                },
+                {
+                    "$ref": "#/$defs/ListPromptsRequest"
+                },
+                {
+                    "$ref": "#/$defs/GetPromptRequest"
+                },
+                {
+                    "$ref": "#/$defs/ListToolsRequest"
+                },
+                {
+                    "$ref": "#/$defs/CallToolRequest"
+                },
+                {
+                    "$ref": "#/$defs/CompleteRequest"
+                }
+            ]
+        },
+        "ClientResult": {
+            "$ref": "#/$defs/Result",
+            "description": "Common result fields."
+        },
+        "CompleteRequest": {
+            "description": "A request from the client to the server, to ask for completion options.",
+            "properties": {
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "completion/complete",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/CompleteRequestParams"
+                }
+            },
+            "required": ["id", "jsonrpc", "method", "params"],
+            "type": "object"
+        },
+        "CompleteRequestParams": {
+            "description": "Parameters for a `completion/complete` request.",
+            "properties": {
+                "_meta": {
+                    "$ref": "#/$defs/RequestMetaObject"
+                },
+                "argument": {
+                    "description": "The argument's information",
+                    "properties": {
+                        "name": {
+                            "description": "The name of the argument",
+                            "type": "string"
+                        },
+                        "value": {
+                            "description": "The value of the argument to use for completion matching.",
+                            "type": "string"
+                        }
+                    },
+                    "required": ["name", "value"],
+                    "type": "object"
+                },
+                "context": {
+                    "description": "Additional, optional context for completions",
+                    "properties": {
+                        "arguments": {
+                            "additionalProperties": {
+                                "type": "string"
+                            },
+                            "description": "Previously-resolved variables in a URI template or prompt.",
+                            "type": "object"
+                        }
+                    },
+                    "type": "object"
+                },
+                "ref": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/PromptReference"
+                        },
+                        {
+                            "$ref": "#/$defs/ResourceTemplateReference"
+                        }
+                    ]
+                }
+            },
+            "required": ["_meta", "argument", "ref"],
+            "type": "object"
+        },
+        "CompleteResult": {
+            "description": "The result returned by the server for a {@link CompleteRequestcompletion/complete} request.",
+            "properties": {
+                "_meta": {
+                    "$ref": "#/$defs/MetaObject"
+                },
+                "completion": {
+                    "properties": {
+                        "hasMore": {
+                            "description": "Indicates whether there are additional completion options beyond those provided in the current response, even if the exact total is unknown.",
+                            "type": "boolean"
+                        },
+                        "total": {
+                            "description": "The total number of completion options available. This can exceed the number of values actually sent in the response.",
+                            "type": "integer"
+                        },
+                        "values": {
+                            "description": "An array of completion values. Must not exceed 100 items.",
+                            "items": {
+                                "type": "string"
+                            },
+                            "maxItems": 100,
+                            "type": "array"
+                        }
+                    },
+                    "required": ["values"],
+                    "type": "object"
+                },
+                "resultType": {
+                    "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
+                    "type": "string"
+                }
+            },
+            "required": ["completion", "resultType"],
+            "type": "object"
+        },
+        "CompleteResultResponse": {
+            "description": "A successful response from the server for a {@link CompleteRequestcompletion/complete} request.",
+            "properties": {
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "result": {
+                    "$ref": "#/$defs/CompleteResult"
+                }
+            },
+            "required": ["id", "jsonrpc", "result"],
+            "type": "object"
+        },
+        "ContentBlock": {
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/TextContent"
+                },
+                {
+                    "$ref": "#/$defs/ImageContent"
+                },
+                {
+                    "$ref": "#/$defs/AudioContent"
+                },
+                {
+                    "$ref": "#/$defs/ResourceLink"
+                },
+                {
+                    "$ref": "#/$defs/EmbeddedResource"
+                }
+            ]
+        },
+        "CreateMessageRequest": {
+            "description": "A request from the server to sample an LLM via the client. The client has full discretion over which model to select. The client should also inform the user before beginning sampling, to allow them to inspect the request (human in the loop) and decide whether to approve it.",
+            "properties": {
+                "method": {
+                    "const": "sampling/createMessage",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/CreateMessageRequestParams"
+                }
+            },
+            "required": ["method", "params"],
+            "type": "object"
+        },
+        "CreateMessageRequestParams": {
+            "description": "Parameters for a `sampling/createMessage` request.",
+            "properties": {
+                "includeContext": {
+                    "description": "A request to include context from one or more MCP servers (including the caller), to be attached to the prompt.\nThe client MAY ignore this request.\n\nDefault is `\"none\"`. The values `\"thisServer\"` and `\"allServers\"` are deprecated (SEP-2596): servers SHOULD\nomit this field or use `\"none\"`, and SHOULD only use the deprecated values if the client declares\n{@link ClientCapabilities.sampling.context}.",
+                    "enum": ["allServers", "none", "thisServer"],
+                    "type": "string"
+                },
+                "maxTokens": {
+                    "description": "The requested maximum number of tokens to sample (to prevent runaway completions).\n\nThe client MAY choose to sample fewer tokens than the requested maximum.",
+                    "type": "integer"
+                },
+                "messages": {
+                    "items": {
+                        "$ref": "#/$defs/SamplingMessage"
+                    },
+                    "type": "array"
+                },
+                "metadata": {
+                    "$ref": "#/$defs/JSONObject",
+                    "description": "Optional metadata to pass through to the LLM provider. The format of this metadata is provider-specific."
+                },
+                "modelPreferences": {
+                    "$ref": "#/$defs/ModelPreferences",
+                    "description": "The server's preferences for which model to select. The client MAY ignore these preferences."
+                },
+                "stopSequences": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "systemPrompt": {
+                    "description": "An optional system prompt the server wants to use for sampling. The client MAY modify or omit this prompt.",
+                    "type": "string"
+                },
+                "temperature": {
+                    "type": "number"
+                },
+                "toolChoice": {
+                    "$ref": "#/$defs/ToolChoice",
+                    "description": "Controls how the model uses tools.\nThe client MUST return an error if this field is provided but {@link ClientCapabilities.sampling.tools} is not declared.\nDefault is `{ mode: \"auto\" }`."
+                },
+                "tools": {
+                    "description": "Tools that the model may use during generation.\nThe client MUST return an error if this field is provided but {@link ClientCapabilities.sampling.tools} is not declared.",
+                    "items": {
+                        "$ref": "#/$defs/Tool"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": ["maxTokens", "messages"],
+            "type": "object"
+        },
+        "CreateMessageResult": {
+            "description": "The result returned by the client for a {@link CreateMessageRequestsampling/createMessage} request.\nThe client should inform the user before returning the sampled message, to allow them\nto inspect the response (human in the loop) and decide whether to allow the server to see it.",
+            "properties": {
+                "_meta": {
+                    "$ref": "#/$defs/MetaObject"
+                },
+                "content": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/TextContent"
+                        },
+                        {
+                            "$ref": "#/$defs/ImageContent"
+                        },
+                        {
+                            "$ref": "#/$defs/AudioContent"
+                        },
+                        {
+                            "$ref": "#/$defs/ToolUseContent"
+                        },
+                        {
+                            "$ref": "#/$defs/ToolResultContent"
+                        },
+                        {
+                            "items": {
+                                "$ref": "#/$defs/SamplingMessageContentBlock"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "model": {
+                    "description": "The name of the model that generated the message.",
+                    "type": "string"
+                },
+                "role": {
+                    "$ref": "#/$defs/Role"
+                },
+                "stopReason": {
+                    "description": "The reason why sampling stopped, if known.\n\nStandard values:\n- `\"endTurn\"`: Natural end of the assistant's turn\n- `\"stopSequence\"`: A stop sequence was encountered\n- `\"maxTokens\"`: Maximum token limit was reached\n- `\"toolUse\"`: The model wants to use one or more tools\n\nThis field is an open string to allow for provider-specific stop reasons.",
+                    "type": "string"
+                }
+            },
+            "required": ["content", "model", "role"],
+            "type": "object"
+        },
+        "Cursor": {
+            "description": "An opaque token used to represent a cursor for pagination.",
+            "type": "string"
+        },
+        "DiscoverRequest": {
+            "description": "A request from the client asking the server to advertise its supported\nprotocol versions, capabilities, and other metadata. Servers **MUST**\nimplement `server/discover`. Clients **MAY** call it but are not required\nto — version negotiation can also happen inline via per-request `_meta`.",
+            "properties": {
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "server/discover",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/RequestParams"
+                }
+            },
+            "required": ["id", "jsonrpc", "method", "params"],
+            "type": "object"
+        },
+        "DiscoverResult": {
+            "description": "The result returned by the server for a {@link DiscoverRequestserver/discover} request.",
+            "properties": {
+                "_meta": {
+                    "$ref": "#/$defs/MetaObject"
+                },
+                "cacheScope": {
+                    "description": "Indicates the intended scope of the cached response, analogous to HTTP\n`Cache-Control: public` vs `Cache-Control: private`.\n\n- `\"public\"`: Any client or intermediary (e.g., shared gateway, proxy)\n  MAY cache the response and serve it to any user.\n- `\"private\"`: Only the requesting user's client MAY cache the response.\n  Shared caches (e.g., multi-tenant gateways) MUST NOT serve a cached\n  copy to a different user.",
+                    "enum": ["private", "public"],
+                    "type": "string"
+                },
+                "capabilities": {
+                    "$ref": "#/$defs/ServerCapabilities",
+                    "description": "The capabilities of the server."
+                },
+                "instructions": {
+                    "description": "Natural-language guidance describing the server and its features.\n\nThis can be used by clients to improve an LLM's understanding of\navailable tools (e.g., by including it in a system prompt). It should\nfocus on information that helps the model use the server effectively\nand should not duplicate information already in tool descriptions.",
+                    "type": "string"
+                },
+                "resultType": {
+                    "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
+                    "type": "string"
+                },
+                "serverInfo": {
+                    "$ref": "#/$defs/Implementation",
+                    "description": "Information about the server software implementation."
+                },
+                "supportedVersions": {
+                    "description": "MCP Protocol Versions this server supports. The client should choose a\nversion from this list for use in subsequent requests.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "ttlMs": {
+                    "description": "A hint from the server indicating how long (in milliseconds) the\nclient MAY cache this response before re-fetching. Semantics are\nanalogous to HTTP Cache-Control max-age.\n\n- If 0, The response SHOULD be considered immediately stale,\n  The client MAY re-fetch every time the result is needed.\n- If positive, the client SHOULD consider the result fresh for this many\n  milliseconds after receiving the response.",
+                    "minimum": 0,
+                    "type": "integer"
+                }
+            },
+            "required": ["cacheScope", "capabilities", "resultType", "serverInfo", "supportedVersions", "ttlMs"],
+            "type": "object"
+        },
+        "DiscoverResultResponse": {
+            "description": "A successful response from the server for a {@link DiscoverRequestserver/discover} request.",
+            "properties": {
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "result": {
+                    "$ref": "#/$defs/DiscoverResult"
+                }
+            },
+            "required": ["id", "jsonrpc", "result"],
+            "type": "object"
+        },
+        "ElicitRequest": {
+            "description": "A request from the server to elicit additional information from the user via the client.",
+            "properties": {
+                "method": {
+                    "const": "elicitation/create",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/ElicitRequestParams"
+                }
+            },
+            "required": ["method", "params"],
+            "type": "object"
+        },
+        "ElicitRequestFormParams": {
+            "description": "The parameters for a request to elicit non-sensitive information from the user via a form in the client.",
+            "properties": {
+                "message": {
+                    "description": "The message to present to the user describing what information is being requested.",
+                    "type": "string"
+                },
+                "mode": {
+                    "const": "form",
+                    "description": "The elicitation mode.",
+                    "type": "string"
+                },
+                "requestedSchema": {
+                    "description": "A restricted subset of JSON Schema.\nOnly top-level properties are allowed, without nesting.",
+                    "properties": {
+                        "$schema": {
+                            "type": "string"
+                        },
+                        "properties": {
+                            "additionalProperties": {
+                                "$ref": "#/$defs/PrimitiveSchemaDefinition"
+                            },
+                            "type": "object"
+                        },
+                        "required": {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "type": {
+                            "const": "object",
+                            "type": "string"
+                        }
+                    },
+                    "required": ["properties", "type"],
+                    "type": "object"
+                }
+            },
+            "required": ["message", "requestedSchema"],
+            "type": "object"
+        },
+        "ElicitRequestParams": {
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/ElicitRequestFormParams"
+                },
+                {
+                    "$ref": "#/$defs/ElicitRequestURLParams"
+                }
+            ],
+            "description": "The parameters for a request to elicit additional information from the user via the client."
+        },
+        "ElicitRequestURLParams": {
+            "description": "The parameters for a request to elicit information from the user via a URL in the client.",
+            "properties": {
+                "elicitationId": {
+                    "description": "The ID of the elicitation, which must be unique within the context of the server.\nThe client MUST treat this ID as an opaque value.",
+                    "type": "string"
+                },
+                "message": {
+                    "description": "The message to present to the user explaining why the interaction is needed.",
+                    "type": "string"
+                },
+                "mode": {
+                    "const": "url",
+                    "description": "The elicitation mode.",
+                    "type": "string"
+                },
+                "url": {
+                    "description": "The URL that the user should navigate to.",
+                    "format": "uri",
+                    "type": "string"
+                }
+            },
+            "required": ["elicitationId", "message", "mode", "url"],
+            "type": "object"
+        },
+        "ElicitResult": {
+            "description": "The result returned by the client for an {@link ElicitRequestelicitation/create} request.",
+            "properties": {
+                "action": {
+                    "description": "The user action in response to the elicitation.\n- `\"accept\"`: User submitted the form/confirmed the action\n- `\"decline\"`: User explicitly declined the action\n- `\"cancel\"`: User dismissed without making an explicit choice",
+                    "enum": ["accept", "cancel", "decline"],
+                    "type": "string"
+                },
+                "content": {
+                    "additionalProperties": {
+                        "anyOf": [
+                            {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            },
+                            {
+                                "type": ["string", "integer", "boolean"]
+                            }
+                        ]
+                    },
+                    "description": "The submitted form data, only present when action is `\"accept\"` and mode was `\"form\"`.\nContains values matching the requested schema.\nOmitted for out-of-band mode responses.",
+                    "type": "object"
+                }
+            },
+            "required": ["action"],
+            "type": "object"
+        },
+        "ElicitationCompleteNotification": {
+            "description": "An optional notification from the server to the client, informing it of a completion of a out-of-band elicitation request.",
+            "properties": {
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "notifications/elicitation/complete",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/ElicitationCompleteNotificationParams"
+                }
+            },
+            "required": ["jsonrpc", "method", "params"],
+            "type": "object"
+        },
+        "ElicitationCompleteNotificationParams": {
+            "description": "Parameters for a {@link ElicitationCompleteNotificationnotifications/elicitation/complete} notification.",
+            "properties": {
+                "_meta": {
+                    "$ref": "#/$defs/MetaObject"
+                },
+                "elicitationId": {
+                    "description": "The ID of the elicitation that completed.",
+                    "type": "string"
+                }
+            },
+            "required": ["elicitationId"],
+            "type": "object"
+        },
+        "EmbeddedResource": {
+            "description": "The contents of a resource, embedded into a prompt or tool call result.\n\nIt is up to the client how best to render embedded resources for the benefit\nof the LLM and/or the user.",
+            "properties": {
+                "_meta": {
+                    "$ref": "#/$defs/MetaObject"
+                },
+                "annotations": {
+                    "$ref": "#/$defs/Annotations",
+                    "description": "Optional annotations for the client."
+                },
+                "resource": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/TextResourceContents"
+                        },
+                        {
+                            "$ref": "#/$defs/BlobResourceContents"
+                        }
+                    ]
+                },
+                "type": {
+                    "const": "resource",
+                    "type": "string"
+                }
+            },
+            "required": ["resource", "type"],
+            "type": "object"
+        },
+        "EmptyResult": {
+            "$ref": "#/$defs/Result",
+            "description": "Common result fields."
+        },
+        "EnumSchema": {
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/UntitledSingleSelectEnumSchema"
+                },
+                {
+                    "$ref": "#/$defs/TitledSingleSelectEnumSchema"
+                },
+                {
+                    "$ref": "#/$defs/UntitledMultiSelectEnumSchema"
+                },
+                {
+                    "$ref": "#/$defs/TitledMultiSelectEnumSchema"
+                },
+                {
+                    "$ref": "#/$defs/LegacyTitledEnumSchema"
+                }
+            ]
+        },
+        "Error": {
+            "properties": {
+                "code": {
+                    "description": "The error type that occurred.",
+                    "type": "integer"
+                },
+                "data": {
+                    "description": "Additional information about the error. The value of this member is defined by the sender (e.g. detailed error information, nested errors etc.)."
+                },
+                "message": {
+                    "description": "A short description of the error. The message SHOULD be limited to a concise single sentence.",
+                    "type": "string"
+                }
+            },
+            "required": ["code", "message"],
+            "type": "object"
+        },
+        "GetPromptRequest": {
+            "description": "Used by the client to get a prompt provided by the server.",
+            "properties": {
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "prompts/get",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/GetPromptRequestParams"
+                }
+            },
+            "required": ["id", "jsonrpc", "method", "params"],
+            "type": "object"
+        },
+        "GetPromptRequestParams": {
+            "description": "Parameters for a `prompts/get` request.",
+            "properties": {
+                "_meta": {
+                    "$ref": "#/$defs/RequestMetaObject"
+                },
+                "arguments": {
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "description": "Arguments to use for templating the prompt.",
+                    "type": "object"
+                },
+                "inputResponses": {
+                    "$ref": "#/$defs/InputResponses"
+                },
+                "name": {
+                    "description": "The name of the prompt or prompt template.",
+                    "type": "string"
+                },
+                "requestState": {
+                    "type": "string"
+                }
+            },
+            "required": ["_meta", "name"],
+            "type": "object"
+        },
+        "GetPromptResult": {
+            "description": "The result returned by the server for a {@link GetPromptRequestprompts/get} request.",
+            "properties": {
+                "_meta": {
+                    "$ref": "#/$defs/MetaObject"
+                },
+                "description": {
+                    "description": "An optional description for the prompt.",
+                    "type": "string"
+                },
+                "messages": {
+                    "items": {
+                        "$ref": "#/$defs/PromptMessage"
+                    },
+                    "type": "array"
+                },
+                "resultType": {
+                    "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
+                    "type": "string"
+                }
+            },
+            "required": ["messages", "resultType"],
+            "type": "object"
+        },
+        "GetPromptResultResponse": {
+            "description": "A successful response from the server for a {@link GetPromptRequestprompts/get} request.",
+            "properties": {
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "result": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/InputRequiredResult"
+                        },
+                        {
+                            "$ref": "#/$defs/GetPromptResult"
+                        }
+                    ]
+                }
+            },
+            "required": ["id", "jsonrpc", "result"],
+            "type": "object"
+        },
+        "Icon": {
+            "description": "An optionally-sized icon that can be displayed in a user interface.",
+            "properties": {
+                "mimeType": {
+                    "description": "Optional MIME type override if the source MIME type is missing or generic.\nFor example: `\"image/png\"`, `\"image/jpeg\"`, or `\"image/svg+xml\"`.",
+                    "type": "string"
+                },
+                "sizes": {
+                    "description": "Optional array of strings that specify sizes at which the icon can be used.\nEach string should be in WxH format (e.g., `\"48x48\"`, `\"96x96\"`) or `\"any\"` for scalable formats like SVG.\n\nIf not provided, the client should assume that the icon can be used at any size.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "src": {
+                    "description": "A standard URI pointing to an icon resource. May be an HTTP/HTTPS URL or a\n`data:` URI with Base64-encoded image data.\n\nConsumers SHOULD take steps to ensure URLs serving icons are from the\nsame domain as the client/server or a trusted domain.\n\nConsumers SHOULD take appropriate precautions when consuming SVGs as they can contain\nexecutable JavaScript.",
+                    "format": "uri",
+                    "type": "string"
+                },
+                "theme": {
+                    "description": "Optional specifier for the theme this icon is designed for. `\"light\"` indicates\nthe icon is designed to be used with a light background, and `\"dark\"` indicates\nthe icon is designed to be used with a dark background.\n\nIf not provided, the client should assume the icon can be used with any theme.",
+                    "enum": ["dark", "light"],
+                    "type": "string"
+                }
+            },
+            "required": ["src"],
+            "type": "object"
+        },
+        "Icons": {
+            "description": "Base interface to add `icons` property.",
+            "properties": {
+                "icons": {
+                    "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
+                    "items": {
+                        "$ref": "#/$defs/Icon"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
+        "ImageContent": {
+            "description": "An image provided to or from an LLM.",
+            "properties": {
+                "_meta": {
+                    "$ref": "#/$defs/MetaObject"
+                },
+                "annotations": {
+                    "$ref": "#/$defs/Annotations",
+                    "description": "Optional annotations for the client."
+                },
+                "data": {
+                    "description": "The base64-encoded image data.",
+                    "format": "byte",
+                    "type": "string"
+                },
+                "mimeType": {
+                    "description": "The MIME type of the image. Different providers may support different image types.",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "image",
+                    "type": "string"
+                }
+            },
+            "required": ["data", "mimeType", "type"],
+            "type": "object"
+        },
+        "Implementation": {
+            "description": "Describes the MCP implementation.",
+            "properties": {
+                "description": {
+                    "description": "An optional human-readable description of what this implementation does.\n\nThis can be used by clients or servers to provide context about their purpose\nand capabilities. For example, a server might describe the types of resources\nor tools it provides, while a client might describe its intended use case.",
+                    "type": "string"
+                },
+                "icons": {
+                    "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
+                    "items": {
+                        "$ref": "#/$defs/Icon"
+                    },
+                    "type": "array"
+                },
+                "name": {
+                    "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for {@link Tool},\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+                    "type": "string"
+                },
+                "version": {
+                    "description": "The version of this implementation.",
+                    "type": "string"
+                },
+                "websiteUrl": {
+                    "description": "An optional URL of the website for this implementation.",
+                    "format": "uri",
+                    "type": "string"
+                }
+            },
+            "required": ["name", "version"],
+            "type": "object"
+        },
+        "InputRequest": {
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/CreateMessageRequest"
+                },
+                {
+                    "$ref": "#/$defs/ListRootsRequest"
+                },
+                {
+                    "$ref": "#/$defs/ElicitRequest"
+                }
+            ]
+        },
+        "InputRequests": {
+            "additionalProperties": {
+                "$ref": "#/$defs/InputRequest"
+            },
+            "description": "A map of server-initiated requests that the client must fulfill.\nKeys are server-assigned identifiers; values are the request objects.",
+            "type": "object"
+        },
+        "InputRequiredResult": {
+            "description": "An InputRequiredResult sent by the server to indicate that additional input is needed\nbefore the request can be completed.\n\nAt least one of `inputRequests` or `requestState` MUST be present.",
+            "properties": {
+                "_meta": {
+                    "$ref": "#/$defs/MetaObject"
+                },
+                "inputRequests": {
+                    "$ref": "#/$defs/InputRequests"
+                },
+                "requestState": {
+                    "type": "string"
+                },
+                "resultType": {
+                    "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
+                    "type": "string"
+                }
+            },
+            "required": ["resultType"],
+            "type": "object"
+        },
+        "InputResponse": {
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/CreateMessageResult"
+                },
+                {
+                    "$ref": "#/$defs/ListRootsResult"
+                },
+                {
+                    "$ref": "#/$defs/ElicitResult"
+                }
+            ]
+        },
+        "InputResponseRequestParams": {
+            "properties": {
+                "_meta": {
+                    "$ref": "#/$defs/RequestMetaObject"
+                },
+                "inputResponses": {
+                    "$ref": "#/$defs/InputResponses"
+                },
+                "requestState": {
+                    "type": "string"
+                }
+            },
+            "required": ["_meta"],
+            "type": "object"
+        },
+        "InputResponses": {
+            "additionalProperties": {
+                "$ref": "#/$defs/InputResponse"
+            },
+            "description": "A map of client responses to server-initiated requests.\nKeys correspond to the keys in the {@link InputRequests} map;\nvalues are the client's result for each request.",
+            "type": "object"
+        },
+        "InternalError": {
+            "description": "A JSON-RPC error indicating that an internal error occurred on the receiver. This error is returned when the receiver encounters an unexpected condition that prevents it from fulfilling the request.",
+            "properties": {
+                "code": {
+                    "const": -32603,
+                    "description": "The error type that occurred.",
+                    "type": "integer"
+                },
+                "data": {
+                    "description": "Additional information about the error. The value of this member is defined by the sender (e.g. detailed error information, nested errors etc.)."
+                },
+                "message": {
+                    "description": "A short description of the error. The message SHOULD be limited to a concise single sentence.",
+                    "type": "string"
+                }
+            },
+            "required": ["code", "message"],
+            "type": "object"
+        },
+        "InvalidParamsError": {
+            "description": "A JSON-RPC error indicating that the method parameters are invalid or malformed.\n\nIn MCP, this error is returned in various contexts when request parameters fail validation:\n\n- **Tools**: Unknown tool name or invalid tool arguments\n- **Prompts**: Unknown prompt name or missing required arguments\n- **Pagination**: Invalid or expired cursor values\n- **Logging**: Invalid log level\n- **Elicitation**: Server requests an elicitation mode not declared in client capabilities\n- **Sampling**: Missing tool result or tool results mixed with other content",
+            "properties": {
+                "code": {
+                    "const": -32602,
+                    "description": "The error type that occurred.",
+                    "type": "integer"
+                },
+                "data": {
+                    "description": "Additional information about the error. The value of this member is defined by the sender (e.g. detailed error information, nested errors etc.)."
+                },
+                "message": {
+                    "description": "A short description of the error. The message SHOULD be limited to a concise single sentence.",
+                    "type": "string"
+                }
+            },
+            "required": ["code", "message"],
+            "type": "object"
+        },
+        "InvalidRequestError": {
+            "description": "A JSON-RPC error indicating that the request is not a valid request object. This error is returned when the message structure does not conform to the JSON-RPC 2.0 specification requirements for a request (e.g., missing required fields like `jsonrpc` or `method`, or using invalid types for these fields).",
+            "properties": {
+                "code": {
+                    "const": -32600,
+                    "description": "The error type that occurred.",
+                    "type": "integer"
+                },
+                "data": {
+                    "description": "Additional information about the error. The value of this member is defined by the sender (e.g. detailed error information, nested errors etc.)."
+                },
+                "message": {
+                    "description": "A short description of the error. The message SHOULD be limited to a concise single sentence.",
+                    "type": "string"
+                }
+            },
+            "required": ["code", "message"],
+            "type": "object"
+        },
+        "JSONArray": {
+            "items": {
+                "$ref": "#/$defs/JSONValue"
+            },
+            "type": "array"
+        },
+        "JSONObject": {
+            "additionalProperties": {
+                "$ref": "#/$defs/JSONValue"
+            },
+            "type": "object"
+        },
+        "JSONRPCErrorResponse": {
+            "description": "A response to a request that indicates an error occurred.",
+            "properties": {
+                "error": {
+                    "$ref": "#/$defs/Error"
+                },
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                }
+            },
+            "required": ["error", "jsonrpc"],
+            "type": "object"
+        },
+        "JSONRPCMessage": {
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/JSONRPCRequest"
+                },
+                {
+                    "$ref": "#/$defs/JSONRPCNotification"
+                },
+                {
+                    "$ref": "#/$defs/JSONRPCResultResponse"
+                },
+                {
+                    "$ref": "#/$defs/JSONRPCErrorResponse"
+                }
+            ],
+            "description": "Refers to any valid JSON-RPC object that can be decoded off the wire, or encoded to be sent."
+        },
+        "JSONRPCNotification": {
+            "description": "A notification which does not expect a response.",
+            "properties": {
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "type": "string"
+                },
+                "params": {
+                    "additionalProperties": {},
+                    "type": "object"
+                }
+            },
+            "required": ["jsonrpc", "method"],
+            "type": "object"
+        },
+        "JSONRPCRequest": {
+            "description": "A request that expects a response.",
+            "properties": {
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "type": "string"
+                },
+                "params": {
+                    "additionalProperties": {},
+                    "type": "object"
+                }
+            },
+            "required": ["id", "jsonrpc", "method"],
+            "type": "object"
+        },
+        "JSONRPCResponse": {
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/JSONRPCResultResponse"
+                },
+                {
+                    "$ref": "#/$defs/JSONRPCErrorResponse"
+                }
+            ],
+            "description": "A response to a request, containing either the result or error."
+        },
+        "JSONRPCResultResponse": {
+            "description": "A successful (non-error) response to a request.",
+            "properties": {
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "result": {
+                    "$ref": "#/$defs/Result"
+                }
+            },
+            "required": ["id", "jsonrpc", "result"],
+            "type": "object"
+        },
+        "JSONValue": {
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/JSONObject"
+                },
+                {
+                    "items": {
+                        "$ref": "#/$defs/JSONValue"
+                    },
+                    "type": "array"
+                },
+                {
+                    "type": ["string", "integer", "boolean"]
+                }
+            ]
+        },
+        "LegacyTitledEnumSchema": {
+            "description": "Use {@link TitledSingleSelectEnumSchema} instead.\nThis interface will be removed in a future version.",
+            "properties": {
+                "default": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "enum": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "enumNames": {
+                    "description": "(Legacy) Display names for enum values.\nNon-standard according to JSON schema 2020-12.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "type": {
+                    "const": "string",
+                    "type": "string"
+                }
+            },
+            "required": ["enum", "type"],
+            "type": "object"
+        },
+        "ListPromptsRequest": {
+            "description": "Sent from the client to request a list of prompts and prompt templates the server has.",
+            "properties": {
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "prompts/list",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/PaginatedRequestParams"
+                }
+            },
+            "required": ["id", "jsonrpc", "method", "params"],
+            "type": "object"
+        },
+        "ListPromptsResult": {
+            "description": "The result returned by the server for a {@link ListPromptsRequestprompts/list} request.",
+            "properties": {
+                "_meta": {
+                    "$ref": "#/$defs/MetaObject"
+                },
+                "cacheScope": {
+                    "description": "Indicates the intended scope of the cached response, analogous to HTTP\n`Cache-Control: public` vs `Cache-Control: private`.\n\n- `\"public\"`: Any client or intermediary (e.g., shared gateway, proxy)\n  MAY cache the response and serve it to any user.\n- `\"private\"`: Only the requesting user's client MAY cache the response.\n  Shared caches (e.g., multi-tenant gateways) MUST NOT serve a cached\n  copy to a different user.",
+                    "enum": ["private", "public"],
+                    "type": "string"
+                },
+                "nextCursor": {
+                    "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
+                    "type": "string"
+                },
+                "prompts": {
+                    "items": {
+                        "$ref": "#/$defs/Prompt"
+                    },
+                    "type": "array"
+                },
+                "resultType": {
+                    "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
+                    "type": "string"
+                },
+                "ttlMs": {
+                    "description": "A hint from the server indicating how long (in milliseconds) the\nclient MAY cache this response before re-fetching. Semantics are\nanalogous to HTTP Cache-Control max-age.\n\n- If 0, The response SHOULD be considered immediately stale,\n  The client MAY re-fetch every time the result is needed.\n- If positive, the client SHOULD consider the result fresh for this many\n  milliseconds after receiving the response.",
+                    "minimum": 0,
+                    "type": "integer"
+                }
+            },
+            "required": ["cacheScope", "prompts", "resultType", "ttlMs"],
+            "type": "object"
+        },
+        "ListPromptsResultResponse": {
+            "description": "A successful response from the server for a {@link ListPromptsRequestprompts/list} request.",
+            "properties": {
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "result": {
+                    "$ref": "#/$defs/ListPromptsResult"
+                }
+            },
+            "required": ["id", "jsonrpc", "result"],
+            "type": "object"
+        },
+        "ListResourceTemplatesRequest": {
+            "description": "Sent from the client to request a list of resource templates the server has.",
+            "properties": {
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "resources/templates/list",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/PaginatedRequestParams"
+                }
+            },
+            "required": ["id", "jsonrpc", "method", "params"],
+            "type": "object"
+        },
+        "ListResourceTemplatesResult": {
+            "description": "The result returned by the server for a {@link ListResourceTemplatesRequestresources/templates/list} request.",
+            "properties": {
+                "_meta": {
+                    "$ref": "#/$defs/MetaObject"
+                },
+                "cacheScope": {
+                    "description": "Indicates the intended scope of the cached response, analogous to HTTP\n`Cache-Control: public` vs `Cache-Control: private`.\n\n- `\"public\"`: Any client or intermediary (e.g., shared gateway, proxy)\n  MAY cache the response and serve it to any user.\n- `\"private\"`: Only the requesting user's client MAY cache the response.\n  Shared caches (e.g., multi-tenant gateways) MUST NOT serve a cached\n  copy to a different user.",
+                    "enum": ["private", "public"],
+                    "type": "string"
+                },
+                "nextCursor": {
+                    "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
+                    "type": "string"
+                },
+                "resourceTemplates": {
+                    "items": {
+                        "$ref": "#/$defs/ResourceTemplate"
+                    },
+                    "type": "array"
+                },
+                "resultType": {
+                    "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
+                    "type": "string"
+                },
+                "ttlMs": {
+                    "description": "A hint from the server indicating how long (in milliseconds) the\nclient MAY cache this response before re-fetching. Semantics are\nanalogous to HTTP Cache-Control max-age.\n\n- If 0, The response SHOULD be considered immediately stale,\n  The client MAY re-fetch every time the result is needed.\n- If positive, the client SHOULD consider the result fresh for this many\n  milliseconds after receiving the response.",
+                    "minimum": 0,
+                    "type": "integer"
+                }
+            },
+            "required": ["cacheScope", "resourceTemplates", "resultType", "ttlMs"],
+            "type": "object"
+        },
+        "ListResourceTemplatesResultResponse": {
+            "description": "A successful response from the server for a {@link ListResourceTemplatesRequestresources/templates/list} request.",
+            "properties": {
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "result": {
+                    "$ref": "#/$defs/ListResourceTemplatesResult"
+                }
+            },
+            "required": ["id", "jsonrpc", "result"],
+            "type": "object"
+        },
+        "ListResourcesRequest": {
+            "description": "Sent from the client to request a list of resources the server has.",
+            "properties": {
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "resources/list",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/PaginatedRequestParams"
+                }
+            },
+            "required": ["id", "jsonrpc", "method", "params"],
+            "type": "object"
+        },
+        "ListResourcesResult": {
+            "description": "The result returned by the server for a {@link ListResourcesRequestresources/list} request.",
+            "properties": {
+                "_meta": {
+                    "$ref": "#/$defs/MetaObject"
+                },
+                "cacheScope": {
+                    "description": "Indicates the intended scope of the cached response, analogous to HTTP\n`Cache-Control: public` vs `Cache-Control: private`.\n\n- `\"public\"`: Any client or intermediary (e.g., shared gateway, proxy)\n  MAY cache the response and serve it to any user.\n- `\"private\"`: Only the requesting user's client MAY cache the response.\n  Shared caches (e.g., multi-tenant gateways) MUST NOT serve a cached\n  copy to a different user.",
+                    "enum": ["private", "public"],
+                    "type": "string"
+                },
+                "nextCursor": {
+                    "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
+                    "type": "string"
+                },
+                "resources": {
+                    "items": {
+                        "$ref": "#/$defs/Resource"
+                    },
+                    "type": "array"
+                },
+                "resultType": {
+                    "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
+                    "type": "string"
+                },
+                "ttlMs": {
+                    "description": "A hint from the server indicating how long (in milliseconds) the\nclient MAY cache this response before re-fetching. Semantics are\nanalogous to HTTP Cache-Control max-age.\n\n- If 0, The response SHOULD be considered immediately stale,\n  The client MAY re-fetch every time the result is needed.\n- If positive, the client SHOULD consider the result fresh for this many\n  milliseconds after receiving the response.",
+                    "minimum": 0,
+                    "type": "integer"
+                }
+            },
+            "required": ["cacheScope", "resources", "resultType", "ttlMs"],
+            "type": "object"
+        },
+        "ListResourcesResultResponse": {
+            "description": "A successful response from the server for a {@link ListResourcesRequestresources/list} request.",
+            "properties": {
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "result": {
+                    "$ref": "#/$defs/ListResourcesResult"
+                }
+            },
+            "required": ["id", "jsonrpc", "result"],
+            "type": "object"
+        },
+        "ListRootsRequest": {
+            "description": "Sent from the server to request a list of root URIs from the client. Roots allow\nservers to ask for specific directories or files to operate on. A common example\nfor roots is providing a set of repositories or directories a server should operate\non.\n\nThis request is typically used when the server needs to understand the file system\nstructure or access specific locations that the client has permission to read from.",
+            "properties": {
+                "method": {
+                    "const": "roots/list",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/RequestParams"
+                }
+            },
+            "required": ["method"],
+            "type": "object"
+        },
+        "ListRootsResult": {
+            "description": "The result returned by the client for a {@link ListRootsRequestroots/list} request.\nThis result contains an array of {@link Root} objects, each representing a root directory\nor file that the server can operate on.",
+            "properties": {
+                "roots": {
+                    "items": {
+                        "$ref": "#/$defs/Root"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": ["roots"],
+            "type": "object"
+        },
+        "ListToolsRequest": {
+            "description": "Sent from the client to request a list of tools the server has.",
+            "properties": {
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "tools/list",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/PaginatedRequestParams"
+                }
+            },
+            "required": ["id", "jsonrpc", "method", "params"],
+            "type": "object"
+        },
+        "ListToolsResult": {
+            "description": "The result returned by the server for a {@link ListToolsRequesttools/list} request.",
+            "properties": {
+                "_meta": {
+                    "$ref": "#/$defs/MetaObject"
+                },
+                "cacheScope": {
+                    "description": "Indicates the intended scope of the cached response, analogous to HTTP\n`Cache-Control: public` vs `Cache-Control: private`.\n\n- `\"public\"`: Any client or intermediary (e.g., shared gateway, proxy)\n  MAY cache the response and serve it to any user.\n- `\"private\"`: Only the requesting user's client MAY cache the response.\n  Shared caches (e.g., multi-tenant gateways) MUST NOT serve a cached\n  copy to a different user.",
+                    "enum": ["private", "public"],
+                    "type": "string"
+                },
+                "nextCursor": {
+                    "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
+                    "type": "string"
+                },
+                "resultType": {
+                    "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
+                    "type": "string"
+                },
+                "tools": {
+                    "items": {
+                        "$ref": "#/$defs/Tool"
+                    },
+                    "type": "array"
+                },
+                "ttlMs": {
+                    "description": "A hint from the server indicating how long (in milliseconds) the\nclient MAY cache this response before re-fetching. Semantics are\nanalogous to HTTP Cache-Control max-age.\n\n- If 0, The response SHOULD be considered immediately stale,\n  The client MAY re-fetch every time the result is needed.\n- If positive, the client SHOULD consider the result fresh for this many\n  milliseconds after receiving the response.",
+                    "minimum": 0,
+                    "type": "integer"
+                }
+            },
+            "required": ["cacheScope", "resultType", "tools", "ttlMs"],
+            "type": "object"
+        },
+        "ListToolsResultResponse": {
+            "description": "A successful response from the server for a {@link ListToolsRequesttools/list} request.",
+            "properties": {
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "result": {
+                    "$ref": "#/$defs/ListToolsResult"
+                }
+            },
+            "required": ["id", "jsonrpc", "result"],
+            "type": "object"
+        },
+        "LoggingLevel": {
+            "description": "The severity of a log message.\n\nThese map to syslog message severities, as specified in RFC-5424:\nhttps://datatracker.ietf.org/doc/html/rfc5424#section-6.2.1",
+            "enum": ["alert", "critical", "debug", "emergency", "error", "info", "notice", "warning"],
+            "type": "string"
+        },
+        "LoggingMessageNotification": {
+            "description": "JSONRPCNotification of a log message passed from server to client. The client opts in by setting `\"io.modelcontextprotocol/logLevel\"` in a request's `_meta`.",
+            "properties": {
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "notifications/message",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/LoggingMessageNotificationParams"
+                }
+            },
+            "required": ["jsonrpc", "method", "params"],
+            "type": "object"
+        },
+        "LoggingMessageNotificationParams": {
+            "description": "Parameters for a `notifications/message` notification.",
+            "properties": {
+                "_meta": {
+                    "$ref": "#/$defs/MetaObject"
+                },
+                "data": {
+                    "description": "The data to be logged, such as a string message or an object. Any JSON serializable type is allowed here."
+                },
+                "level": {
+                    "$ref": "#/$defs/LoggingLevel",
+                    "description": "The severity of this log message."
+                },
+                "logger": {
+                    "description": "An optional name of the logger issuing this message.",
+                    "type": "string"
+                }
+            },
+            "required": ["data", "level"],
+            "type": "object"
+        },
+        "MetaObject": {
+            "description": "Represents the contents of a `_meta` field, which clients and servers use to attach additional metadata to their interactions.\n\nCertain key names are reserved by MCP for protocol-level metadata; implementations MUST NOT make assumptions about values at these keys. Additionally, specific schema definitions may reserve particular names for purpose-specific metadata, as declared in those definitions.\n\nValid keys have two segments:\n\n**Prefix:**\n- Optional — if specified, MUST be a series of _labels_ separated by dots (`.`), followed by a slash (`/`).\n- Labels MUST start with a letter and end with a letter or digit. Interior characters may be letters, digits, or hyphens (`-`).\n- Implementations SHOULD use reverse DNS notation (e.g., `com.example/` rather than `example.com/`).\n- Any prefix where the second label is `modelcontextprotocol` or `mcp` is **reserved** for MCP use. For example: `io.modelcontextprotocol/`, `dev.mcp/`, `org.modelcontextprotocol.api/`, and `com.mcp.tools/` are all reserved. However, `com.example.mcp/` is NOT reserved, as the second label is `example`.\n\n**Name:**\n- Unless empty, MUST start and end with an alphanumeric character (`[a-z0-9A-Z]`).\n- Interior characters may be alphanumeric, hyphens (`-`), underscores (`_`), or dots (`.`).",
+            "type": "object"
+        },
+        "MethodNotFoundError": {
+            "description": "A JSON-RPC error indicating that the requested method does not exist or is not available.\n\nIn MCP, a server returns this error when a client invokes a method the server does not implement — either a genuinely unknown method, or one gated behind a server capability the server did not advertise (e.g., calling `prompts/list` when the `prompts` capability was not advertised).\n\nA request that requires a client capability the client did not declare is signalled instead by {@link MissingRequiredClientCapabilityError} (`-32003`).",
+            "properties": {
+                "code": {
+                    "const": -32601,
+                    "description": "The error type that occurred.",
+                    "type": "integer"
+                },
+                "data": {
+                    "description": "Additional information about the error. The value of this member is defined by the sender (e.g. detailed error information, nested errors etc.)."
+                },
+                "message": {
+                    "description": "A short description of the error. The message SHOULD be limited to a concise single sentence.",
+                    "type": "string"
+                }
+            },
+            "required": ["code", "message"],
+            "type": "object"
+        },
+        "MissingRequiredClientCapabilityError": {
+            "description": "Returned when processing a request requires a capability the client did not\ndeclare in `clientCapabilities`. For HTTP, the response status code MUST be\n`400 Bad Request`.",
+            "properties": {
+                "error": {
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/Error"
+                        },
+                        {
+                            "properties": {
+                                "code": {
+                                    "const": -32003,
+                                    "type": "integer"
+                                },
+                                "data": {
+                                    "properties": {
+                                        "requiredCapabilities": {
+                                            "$ref": "#/$defs/ClientCapabilities",
+                                            "description": "The capabilities the server requires from the client to process this request."
+                                        }
+                                    },
+                                    "required": ["requiredCapabilities"],
+                                    "type": "object"
+                                }
+                            },
+                            "required": ["code", "data"],
+                            "type": "object"
+                        }
+                    ]
+                },
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                }
+            },
+            "required": ["error", "jsonrpc"],
+            "type": "object"
+        },
+        "ModelHint": {
+            "description": "Hints to use for model selection.\n\nKeys not declared here are currently left unspecified by the spec and are up\nto the client to interpret.",
+            "properties": {
+                "name": {
+                    "description": "A hint for a model name.\n\nThe client SHOULD treat this as a substring of a model name; for example:\n - `claude-3-5-sonnet` should match `claude-3-5-sonnet-20241022`\n - `sonnet` should match `claude-3-5-sonnet-20241022`, `claude-3-sonnet-20240229`, etc.\n - `claude` should match any Claude model\n\nThe client MAY also map the string to a different provider's model name or a different model family, as long as it fills a similar niche; for example:\n - `gemini-1.5-flash` could match `claude-3-haiku-20240307`",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "ModelPreferences": {
+            "description": "The server's preferences for model selection, requested of the client during sampling.\n\nBecause LLMs can vary along multiple dimensions, choosing the \"best\" model is\nrarely straightforward.  Different models excel in different areas—some are\nfaster but less capable, others are more capable but more expensive, and so\non. This interface allows servers to express their priorities across multiple\ndimensions to help clients make an appropriate selection for their use case.\n\nThese preferences are always advisory. The client MAY ignore them. It is also\nup to the client to decide how to interpret these preferences and how to\nbalance them against other considerations.",
+            "properties": {
+                "costPriority": {
+                    "description": "How much to prioritize cost when selecting a model. A value of 0 means cost\nis not important, while a value of 1 means cost is the most important\nfactor.",
+                    "maximum": 1,
+                    "minimum": 0,
+                    "type": "number"
+                },
+                "hints": {
+                    "description": "Optional hints to use for model selection.\n\nIf multiple hints are specified, the client MUST evaluate them in order\n(such that the first match is taken).\n\nThe client SHOULD prioritize these hints over the numeric priorities, but\nMAY still use the priorities to select from ambiguous matches.",
+                    "items": {
+                        "$ref": "#/$defs/ModelHint"
+                    },
+                    "type": "array"
+                },
+                "intelligencePriority": {
+                    "description": "How much to prioritize intelligence and capabilities when selecting a\nmodel. A value of 0 means intelligence is not important, while a value of 1\nmeans intelligence is the most important factor.",
+                    "maximum": 1,
+                    "minimum": 0,
+                    "type": "number"
+                },
+                "speedPriority": {
+                    "description": "How much to prioritize sampling speed (latency) when selecting a model. A\nvalue of 0 means speed is not important, while a value of 1 means speed is\nthe most important factor.",
+                    "maximum": 1,
+                    "minimum": 0,
+                    "type": "number"
+                }
+            },
+            "type": "object"
+        },
+        "MultiSelectEnumSchema": {
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/UntitledMultiSelectEnumSchema"
+                },
+                {
+                    "$ref": "#/$defs/TitledMultiSelectEnumSchema"
+                }
+            ]
+        },
+        "Notification": {
+            "properties": {
+                "method": {
+                    "type": "string"
+                },
+                "params": {
+                    "additionalProperties": {},
+                    "type": "object"
+                }
+            },
+            "required": ["method"],
+            "type": "object"
+        },
+        "NotificationParams": {
+            "description": "Common params for any notification.",
+            "properties": {
+                "_meta": {
+                    "$ref": "#/$defs/MetaObject"
+                }
+            },
+            "type": "object"
+        },
+        "NumberSchema": {
+            "properties": {
+                "default": {
+                    "type": "number"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "maximum": {
+                    "type": "number"
+                },
+                "minimum": {
+                    "type": "number"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "type": {
+                    "enum": ["integer", "number"],
+                    "type": "string"
+                }
+            },
+            "required": ["type"],
+            "type": "object"
+        },
+        "PaginatedRequest": {
+            "properties": {
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/PaginatedRequestParams"
+                }
+            },
+            "required": ["id", "jsonrpc", "method", "params"],
+            "type": "object"
+        },
+        "PaginatedRequestParams": {
+            "description": "Common params for paginated requests.",
+            "properties": {
+                "_meta": {
+                    "$ref": "#/$defs/RequestMetaObject"
+                },
+                "cursor": {
+                    "description": "An opaque token representing the current pagination position.\nIf provided, the server should return results starting after this cursor.",
+                    "type": "string"
+                }
+            },
+            "required": ["_meta"],
+            "type": "object"
+        },
+        "PaginatedResult": {
+            "properties": {
+                "_meta": {
+                    "$ref": "#/$defs/MetaObject"
+                },
+                "nextCursor": {
+                    "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
+                    "type": "string"
+                },
+                "resultType": {
+                    "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
+                    "type": "string"
+                }
+            },
+            "required": ["resultType"],
+            "type": "object"
+        },
+        "ParseError": {
+            "description": "A JSON-RPC error indicating that invalid JSON was received by the server. This error is returned when the server cannot parse the JSON text of a message.",
+            "properties": {
+                "code": {
+                    "const": -32700,
+                    "description": "The error type that occurred.",
+                    "type": "integer"
+                },
+                "data": {
+                    "description": "Additional information about the error. The value of this member is defined by the sender (e.g. detailed error information, nested errors etc.)."
+                },
+                "message": {
+                    "description": "A short description of the error. The message SHOULD be limited to a concise single sentence.",
+                    "type": "string"
+                }
+            },
+            "required": ["code", "message"],
+            "type": "object"
+        },
+        "PrimitiveSchemaDefinition": {
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/StringSchema"
+                },
+                {
+                    "$ref": "#/$defs/NumberSchema"
+                },
+                {
+                    "$ref": "#/$defs/BooleanSchema"
+                },
+                {
+                    "$ref": "#/$defs/UntitledSingleSelectEnumSchema"
+                },
+                {
+                    "$ref": "#/$defs/TitledSingleSelectEnumSchema"
+                },
+                {
+                    "$ref": "#/$defs/UntitledMultiSelectEnumSchema"
+                },
+                {
+                    "$ref": "#/$defs/TitledMultiSelectEnumSchema"
+                },
+                {
+                    "$ref": "#/$defs/LegacyTitledEnumSchema"
+                }
+            ],
+            "description": "Restricted schema definitions that only allow primitive types\nwithout nested objects or arrays."
+        },
+        "ProgressNotification": {
+            "description": "An out-of-band notification used to inform the receiver of a progress update for a long-running request.",
+            "properties": {
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "notifications/progress",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/ProgressNotificationParams"
+                }
+            },
+            "required": ["jsonrpc", "method", "params"],
+            "type": "object"
+        },
+        "ProgressNotificationParams": {
+            "description": "Parameters for a {@link ProgressNotificationnotifications/progress} notification.",
+            "properties": {
+                "_meta": {
+                    "$ref": "#/$defs/MetaObject"
+                },
+                "message": {
+                    "description": "An optional message describing the current progress.",
+                    "type": "string"
+                },
+                "progress": {
+                    "description": "The progress thus far. This should increase every time progress is made, even if the total is unknown.",
+                    "type": "number"
+                },
+                "progressToken": {
+                    "$ref": "#/$defs/ProgressToken",
+                    "description": "The progress token which was given in the initial request, used to associate this notification with the request that is proceeding."
+                },
+                "total": {
+                    "description": "Total number of items to process (or total progress required), if known.",
+                    "type": "number"
+                }
+            },
+            "required": ["progress", "progressToken"],
+            "type": "object"
+        },
+        "ProgressToken": {
+            "description": "A progress token, used to associate progress notifications with the original request.",
+            "type": ["string", "integer"]
+        },
+        "Prompt": {
+            "description": "A prompt or prompt template that the server offers.",
+            "properties": {
+                "_meta": {
+                    "$ref": "#/$defs/MetaObject"
+                },
+                "arguments": {
+                    "description": "A list of arguments to use for templating the prompt.",
+                    "items": {
+                        "$ref": "#/$defs/PromptArgument"
+                    },
+                    "type": "array"
+                },
+                "description": {
+                    "description": "An optional description of what this prompt provides",
+                    "type": "string"
+                },
+                "icons": {
+                    "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
+                    "items": {
+                        "$ref": "#/$defs/Icon"
+                    },
+                    "type": "array"
+                },
+                "name": {
+                    "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for {@link Tool},\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+                    "type": "string"
+                }
+            },
+            "required": ["name"],
+            "type": "object"
+        },
+        "PromptArgument": {
+            "description": "Describes an argument that a prompt can accept.",
+            "properties": {
+                "description": {
+                    "description": "A human-readable description of the argument.",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+                    "type": "string"
+                },
+                "required": {
+                    "description": "Whether this argument must be provided.",
+                    "type": "boolean"
+                },
+                "title": {
+                    "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for {@link Tool},\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+                    "type": "string"
+                }
+            },
+            "required": ["name"],
+            "type": "object"
+        },
+        "PromptListChangedNotification": {
+            "description": "An optional notification from the server to the client, informing it that the list of prompts it offers has changed. This may be issued by servers without any previous subscription from the client.",
+            "properties": {
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "notifications/prompts/list_changed",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/NotificationParams"
+                }
+            },
+            "required": ["jsonrpc", "method"],
+            "type": "object"
+        },
+        "PromptMessage": {
+            "description": "Describes a message returned as part of a prompt.\n\nThis is similar to {@link SamplingMessage}, but also supports the embedding of\nresources from the MCP server.",
+            "properties": {
+                "content": {
+                    "$ref": "#/$defs/ContentBlock"
+                },
+                "role": {
+                    "$ref": "#/$defs/Role"
+                }
+            },
+            "required": ["content", "role"],
+            "type": "object"
+        },
+        "PromptReference": {
+            "description": "Identifies a prompt.",
+            "properties": {
+                "name": {
+                    "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for {@link Tool},\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "ref/prompt",
+                    "type": "string"
+                }
+            },
+            "required": ["name", "type"],
+            "type": "object"
+        },
+        "ReadResourceRequest": {
+            "description": "Sent from the client to the server, to read a specific resource URI.",
+            "properties": {
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "resources/read",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/ReadResourceRequestParams"
+                }
+            },
+            "required": ["id", "jsonrpc", "method", "params"],
+            "type": "object"
+        },
+        "ReadResourceRequestParams": {
+            "description": "Parameters for a `resources/read` request.",
+            "properties": {
+                "_meta": {
+                    "$ref": "#/$defs/RequestMetaObject"
+                },
+                "inputResponses": {
+                    "$ref": "#/$defs/InputResponses"
+                },
+                "requestState": {
+                    "type": "string"
+                },
+                "uri": {
+                    "description": "The URI of the resource. The URI can use any protocol; it is up to the server how to interpret it.",
+                    "format": "uri",
+                    "type": "string"
+                }
+            },
+            "required": ["_meta", "uri"],
+            "type": "object"
+        },
+        "ReadResourceResult": {
+            "description": "The result returned by the server for a {@link ReadResourceRequestresources/read} request.",
+            "properties": {
+                "_meta": {
+                    "$ref": "#/$defs/MetaObject"
+                },
+                "cacheScope": {
+                    "description": "Indicates the intended scope of the cached response, analogous to HTTP\n`Cache-Control: public` vs `Cache-Control: private`.\n\n- `\"public\"`: Any client or intermediary (e.g., shared gateway, proxy)\n  MAY cache the response and serve it to any user.\n- `\"private\"`: Only the requesting user's client MAY cache the response.\n  Shared caches (e.g., multi-tenant gateways) MUST NOT serve a cached\n  copy to a different user.",
+                    "enum": ["private", "public"],
+                    "type": "string"
+                },
+                "contents": {
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/$defs/TextResourceContents"
+                            },
+                            {
+                                "$ref": "#/$defs/BlobResourceContents"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "resultType": {
+                    "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
+                    "type": "string"
+                },
+                "ttlMs": {
+                    "description": "A hint from the server indicating how long (in milliseconds) the\nclient MAY cache this response before re-fetching. Semantics are\nanalogous to HTTP Cache-Control max-age.\n\n- If 0, The response SHOULD be considered immediately stale,\n  The client MAY re-fetch every time the result is needed.\n- If positive, the client SHOULD consider the result fresh for this many\n  milliseconds after receiving the response.",
+                    "minimum": 0,
+                    "type": "integer"
+                }
+            },
+            "required": ["cacheScope", "contents", "resultType", "ttlMs"],
+            "type": "object"
+        },
+        "ReadResourceResultResponse": {
+            "description": "A successful response from the server for a {@link ReadResourceRequestresources/read} request.",
+            "properties": {
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "result": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/InputRequiredResult"
+                        },
+                        {
+                            "$ref": "#/$defs/ReadResourceResult"
+                        }
+                    ]
+                }
+            },
+            "required": ["id", "jsonrpc", "result"],
+            "type": "object"
+        },
+        "Request": {
+            "properties": {
+                "method": {
+                    "type": "string"
+                },
+                "params": {
+                    "additionalProperties": {},
+                    "type": "object"
+                }
+            },
+            "required": ["method"],
+            "type": "object"
+        },
+        "RequestId": {
+            "description": "A uniquely identifying ID for a request in JSON-RPC.",
+            "type": ["string", "integer"]
+        },
+        "RequestMetaObject": {
+            "description": "Extends {@link MetaObject} with additional request-specific fields. All key naming rules from `MetaObject` apply.",
+            "properties": {
+                "io.modelcontextprotocol/clientCapabilities": {
+                    "$ref": "#/$defs/ClientCapabilities",
+                    "description": "The client's capabilities for this specific request. Required.\n\nCapabilities are declared per-request rather than once at initialization;\nan empty object means the client supports no optional capabilities.\nServers MUST NOT infer capabilities from prior requests."
+                },
+                "io.modelcontextprotocol/clientInfo": {
+                    "$ref": "#/$defs/Implementation",
+                    "description": "Identifies the client software making the request. Required.\n\nThe {@link Implementation} schema requires `name` and `version`; other\nfields are optional."
+                },
+                "io.modelcontextprotocol/logLevel": {
+                    "$ref": "#/$defs/LoggingLevel",
+                    "description": "The desired log level for this request. Optional.\n\nIf absent, the server MUST NOT send any {@link LoggingMessageNotificationnotifications/message}\nnotifications for this request. The client opts in to log messages by\nexplicitly setting a level. Replaces the former `logging/setLevel` RPC."
+                },
+                "io.modelcontextprotocol/protocolVersion": {
+                    "description": "The MCP Protocol Version being used for this request. Required.\n\nFor the HTTP transport, this value MUST match the `MCP-Protocol-Version`\nheader; otherwise the server MUST return a `400 Bad Request`. If the\nserver does not support the requested version, it MUST return an\n{@link UnsupportedProtocolVersionError}.",
+                    "type": "string"
+                },
+                "progressToken": {
+                    "$ref": "#/$defs/ProgressToken",
+                    "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by {@link ProgressNotificationnotifications/progress}). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
+                }
+            },
+            "required": [
+                "io.modelcontextprotocol/clientCapabilities",
+                "io.modelcontextprotocol/clientInfo",
+                "io.modelcontextprotocol/protocolVersion"
+            ],
+            "type": "object"
+        },
+        "RequestParams": {
+            "description": "Common params for any request.",
+            "properties": {
+                "_meta": {
+                    "$ref": "#/$defs/RequestMetaObject"
+                }
+            },
+            "required": ["_meta"],
+            "type": "object"
+        },
+        "Resource": {
+            "description": "A known resource that the server is capable of reading.",
+            "properties": {
+                "_meta": {
+                    "$ref": "#/$defs/MetaObject"
+                },
+                "annotations": {
+                    "$ref": "#/$defs/Annotations",
+                    "description": "Optional annotations for the client."
+                },
+                "description": {
+                    "description": "A description of what this resource represents.\n\nThis can be used by clients to improve the LLM's understanding of available resources. It can be thought of like a \"hint\" to the model.",
+                    "type": "string"
+                },
+                "icons": {
+                    "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
+                    "items": {
+                        "$ref": "#/$defs/Icon"
+                    },
+                    "type": "array"
+                },
+                "mimeType": {
+                    "description": "The MIME type of this resource, if known.",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+                    "type": "string"
+                },
+                "size": {
+                    "description": "The size of the raw resource content, in bytes (i.e., before base64 encoding or any tokenization), if known.\n\nThis can be used by Hosts to display file sizes and estimate context window usage.",
+                    "type": "integer"
+                },
+                "title": {
+                    "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for {@link Tool},\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+                    "type": "string"
+                },
+                "uri": {
+                    "description": "The URI of this resource.",
+                    "format": "uri",
+                    "type": "string"
+                }
+            },
+            "required": ["name", "uri"],
+            "type": "object"
+        },
+        "ResourceContents": {
+            "description": "The contents of a specific resource or sub-resource.",
+            "properties": {
+                "_meta": {
+                    "$ref": "#/$defs/MetaObject"
+                },
+                "mimeType": {
+                    "description": "The MIME type of this resource, if known.",
+                    "type": "string"
+                },
+                "uri": {
+                    "description": "The URI of this resource.",
+                    "format": "uri",
+                    "type": "string"
+                }
+            },
+            "required": ["uri"],
+            "type": "object"
+        },
+        "ResourceLink": {
+            "description": "A resource that the server is capable of reading, included in a prompt or tool call result.\n\nNote: resource links returned by tools are not guaranteed to appear in the results of {@link ListResourcesRequestresources/list} requests.",
+            "properties": {
+                "_meta": {
+                    "$ref": "#/$defs/MetaObject"
+                },
+                "annotations": {
+                    "$ref": "#/$defs/Annotations",
+                    "description": "Optional annotations for the client."
+                },
+                "description": {
+                    "description": "A description of what this resource represents.\n\nThis can be used by clients to improve the LLM's understanding of available resources. It can be thought of like a \"hint\" to the model.",
+                    "type": "string"
+                },
+                "icons": {
+                    "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
+                    "items": {
+                        "$ref": "#/$defs/Icon"
+                    },
+                    "type": "array"
+                },
+                "mimeType": {
+                    "description": "The MIME type of this resource, if known.",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+                    "type": "string"
+                },
+                "size": {
+                    "description": "The size of the raw resource content, in bytes (i.e., before base64 encoding or any tokenization), if known.\n\nThis can be used by Hosts to display file sizes and estimate context window usage.",
+                    "type": "integer"
+                },
+                "title": {
+                    "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for {@link Tool},\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "resource_link",
+                    "type": "string"
+                },
+                "uri": {
+                    "description": "The URI of this resource.",
+                    "format": "uri",
+                    "type": "string"
+                }
+            },
+            "required": ["name", "type", "uri"],
+            "type": "object"
+        },
+        "ResourceListChangedNotification": {
+            "description": "An optional notification from the server to the client, informing it that the list of resources it can read from has changed. This may be issued by servers without any previous subscription from the client.",
+            "properties": {
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "notifications/resources/list_changed",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/NotificationParams"
+                }
+            },
+            "required": ["jsonrpc", "method"],
+            "type": "object"
+        },
+        "ResourceRequestParams": {
+            "description": "Common params for resource-related requests.",
+            "properties": {
+                "_meta": {
+                    "$ref": "#/$defs/RequestMetaObject"
+                },
+                "uri": {
+                    "description": "The URI of the resource. The URI can use any protocol; it is up to the server how to interpret it.",
+                    "format": "uri",
+                    "type": "string"
+                }
+            },
+            "required": ["_meta", "uri"],
+            "type": "object"
+        },
+        "ResourceTemplate": {
+            "description": "A template description for resources available on the server.",
+            "properties": {
+                "_meta": {
+                    "$ref": "#/$defs/MetaObject"
+                },
+                "annotations": {
+                    "$ref": "#/$defs/Annotations",
+                    "description": "Optional annotations for the client."
+                },
+                "description": {
+                    "description": "A description of what this template is for.\n\nThis can be used by clients to improve the LLM's understanding of available resources. It can be thought of like a \"hint\" to the model.",
+                    "type": "string"
+                },
+                "icons": {
+                    "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
+                    "items": {
+                        "$ref": "#/$defs/Icon"
+                    },
+                    "type": "array"
+                },
+                "mimeType": {
+                    "description": "The MIME type for all resources that match this template. This should only be included if all resources matching this template have the same type.",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for {@link Tool},\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+                    "type": "string"
+                },
+                "uriTemplate": {
+                    "description": "A URI template (according to RFC 6570) that can be used to construct resource URIs.",
+                    "format": "uri-template",
+                    "type": "string"
+                }
+            },
+            "required": ["name", "uriTemplate"],
+            "type": "object"
+        },
+        "ResourceTemplateReference": {
+            "description": "A reference to a resource or resource template definition.",
+            "properties": {
+                "type": {
+                    "const": "ref/resource",
+                    "type": "string"
+                },
+                "uri": {
+                    "description": "The URI or URI template of the resource.",
+                    "format": "uri-template",
+                    "type": "string"
+                }
+            },
+            "required": ["type", "uri"],
+            "type": "object"
+        },
+        "ResourceUpdatedNotification": {
+            "description": "A notification from the server to the client, informing it that a resource has changed and may need to be read again. This is only sent for resources the client opted in to via the `resourceSubscriptions` field of a {@link SubscriptionsListenRequestsubscriptions/listen} request.",
+            "properties": {
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "notifications/resources/updated",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/ResourceUpdatedNotificationParams"
+                }
+            },
+            "required": ["jsonrpc", "method", "params"],
+            "type": "object"
+        },
+        "ResourceUpdatedNotificationParams": {
+            "description": "Parameters for a `notifications/resources/updated` notification.",
+            "properties": {
+                "_meta": {
+                    "$ref": "#/$defs/MetaObject"
+                },
+                "uri": {
+                    "description": "The URI of the resource that has been updated. This might be a sub-resource of the one that the client actually subscribed to.",
+                    "format": "uri",
+                    "type": "string"
+                }
+            },
+            "required": ["uri"],
+            "type": "object"
+        },
+        "Result": {
+            "additionalProperties": {},
+            "description": "Common result fields.",
+            "properties": {
+                "_meta": {
+                    "$ref": "#/$defs/MetaObject"
+                },
+                "resultType": {
+                    "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
+                    "type": "string"
+                }
+            },
+            "required": ["resultType"],
+            "type": "object"
+        },
+        "ResultType": {
+            "description": "Indicates the type of a {@link Result} object, allowing the client to\ndetermine how to parse the response.\n\ncomplete - the request completed successfully and the result contains the final content.\ninput_required - the request requires additional input and the result contains an {@link InputRequiredResult} object with instructions for the client to provide additional input before retrying the original request.",
+            "type": "string"
+        },
+        "Role": {
+            "description": "The sender or recipient of messages and data in a conversation.",
+            "enum": ["assistant", "user"],
+            "type": "string"
+        },
+        "Root": {
+            "description": "Represents a root directory or file that the server can operate on.",
+            "properties": {
+                "_meta": {
+                    "$ref": "#/$defs/MetaObject"
+                },
+                "name": {
+                    "description": "An optional name for the root. This can be used to provide a human-readable\nidentifier for the root, which may be useful for display purposes or for\nreferencing the root in other parts of the application.",
+                    "type": "string"
+                },
+                "uri": {
+                    "description": "The URI identifying the root. This *must* start with `file://` for now.\nThis restriction may be relaxed in future versions of the protocol to allow\nother URI schemes.",
+                    "format": "uri",
+                    "type": "string"
+                }
+            },
+            "required": ["uri"],
+            "type": "object"
+        },
+        "SamplingMessage": {
+            "description": "Describes a message issued to or received from an LLM API.",
+            "properties": {
+                "_meta": {
+                    "$ref": "#/$defs/MetaObject"
+                },
+                "content": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/TextContent"
+                        },
+                        {
+                            "$ref": "#/$defs/ImageContent"
+                        },
+                        {
+                            "$ref": "#/$defs/AudioContent"
+                        },
+                        {
+                            "$ref": "#/$defs/ToolUseContent"
+                        },
+                        {
+                            "$ref": "#/$defs/ToolResultContent"
+                        },
+                        {
+                            "items": {
+                                "$ref": "#/$defs/SamplingMessageContentBlock"
+                            },
+                            "type": "array"
+                        }
+                    ]
+                },
+                "role": {
+                    "$ref": "#/$defs/Role"
+                }
+            },
+            "required": ["content", "role"],
+            "type": "object"
+        },
+        "SamplingMessageContentBlock": {
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/TextContent"
+                },
+                {
+                    "$ref": "#/$defs/ImageContent"
+                },
+                {
+                    "$ref": "#/$defs/AudioContent"
+                },
+                {
+                    "$ref": "#/$defs/ToolUseContent"
+                },
+                {
+                    "$ref": "#/$defs/ToolResultContent"
+                }
+            ]
+        },
+        "ServerCapabilities": {
+            "description": "Capabilities that a server may support. Known capabilities are defined here, in this schema, but this is not a closed set: any server can define its own, additional capabilities.",
+            "properties": {
+                "completions": {
+                    "$ref": "#/$defs/JSONObject",
+                    "description": "Present if the server supports argument autocompletion suggestions."
+                },
+                "experimental": {
+                    "additionalProperties": {
+                        "$ref": "#/$defs/JSONObject"
+                    },
+                    "description": "Experimental, non-standard capabilities that the server supports.",
+                    "type": "object"
+                },
+                "extensions": {
+                    "additionalProperties": {
+                        "$ref": "#/$defs/JSONObject"
+                    },
+                    "description": "Optional MCP extensions that the server supports. Keys are extension identifiers\n(e.g., \"io.modelcontextprotocol/tasks\"), and values are per-extension settings\nobjects. An empty object indicates support with no settings.\n\nKeys MUST follow the {@link MetaObject`_meta` key naming rules}, with a\nmandatory prefix.",
+                    "type": "object"
+                },
+                "logging": {
+                    "$ref": "#/$defs/JSONObject",
+                    "description": "Present if the server supports sending log messages to the client."
+                },
+                "prompts": {
+                    "description": "Present if the server offers any prompt templates.",
+                    "properties": {
+                        "listChanged": {
+                            "description": "Whether this server supports notifications for changes to the prompt list.",
+                            "type": "boolean"
+                        }
+                    },
+                    "type": "object"
+                },
+                "resources": {
+                    "description": "Present if the server offers any resources to read.",
+                    "properties": {
+                        "listChanged": {
+                            "description": "Whether this server supports notifications for changes to the resource list.",
+                            "type": "boolean"
+                        },
+                        "subscribe": {
+                            "description": "Whether this server supports subscribing to resource updates.",
+                            "type": "boolean"
+                        }
+                    },
+                    "type": "object"
+                },
+                "tools": {
+                    "description": "Present if the server offers any tools to call.",
+                    "properties": {
+                        "listChanged": {
+                            "description": "Whether this server supports notifications for changes to the tool list.",
+                            "type": "boolean"
+                        }
+                    },
+                    "type": "object"
+                }
+            },
+            "type": "object"
+        },
+        "ServerNotification": {
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/CancelledNotification"
+                },
+                {
+                    "$ref": "#/$defs/ProgressNotification"
+                },
+                {
+                    "$ref": "#/$defs/ResourceListChangedNotification"
+                },
+                {
+                    "$ref": "#/$defs/SubscriptionsAcknowledgedNotification"
+                },
+                {
+                    "$ref": "#/$defs/ResourceUpdatedNotification"
+                },
+                {
+                    "$ref": "#/$defs/PromptListChangedNotification"
+                },
+                {
+                    "$ref": "#/$defs/ToolListChangedNotification"
+                },
+                {
+                    "$ref": "#/$defs/LoggingMessageNotification"
+                },
+                {
+                    "$ref": "#/$defs/ElicitationCompleteNotification"
+                }
+            ]
+        },
+        "ServerResult": {
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/Result"
+                },
+                {
+                    "$ref": "#/$defs/InputRequiredResult"
+                },
+                {
+                    "$ref": "#/$defs/DiscoverResult"
+                },
+                {
+                    "$ref": "#/$defs/ListResourcesResult"
+                },
+                {
+                    "$ref": "#/$defs/ListResourceTemplatesResult"
+                },
+                {
+                    "$ref": "#/$defs/ReadResourceResult"
+                },
+                {
+                    "$ref": "#/$defs/ListPromptsResult"
+                },
+                {
+                    "$ref": "#/$defs/GetPromptResult"
+                },
+                {
+                    "$ref": "#/$defs/ListToolsResult"
+                },
+                {
+                    "$ref": "#/$defs/CallToolResult"
+                },
+                {
+                    "$ref": "#/$defs/CompleteResult"
+                }
+            ]
+        },
+        "SingleSelectEnumSchema": {
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/UntitledSingleSelectEnumSchema"
+                },
+                {
+                    "$ref": "#/$defs/TitledSingleSelectEnumSchema"
+                }
+            ]
+        },
+        "StringSchema": {
+            "properties": {
+                "default": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "format": {
+                    "enum": ["date", "date-time", "email", "uri"],
+                    "type": "string"
+                },
+                "maxLength": {
+                    "type": "integer"
+                },
+                "minLength": {
+                    "type": "integer"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "type": {
+                    "const": "string",
+                    "type": "string"
+                }
+            },
+            "required": ["type"],
+            "type": "object"
+        },
+        "SubscriptionFilter": {
+            "description": "The set of notification types a client may opt in to on a\n{@link SubscriptionsListenRequestsubscriptions/listen} request.\n\nEach notification type is **opt-in**; the server **MUST NOT** send\nnotification types the client has not explicitly requested here.",
+            "properties": {
+                "promptsListChanged": {
+                    "description": "If true, receive {@link PromptListChangedNotificationnotifications/prompts/list_changed}.",
+                    "type": "boolean"
+                },
+                "resourceSubscriptions": {
+                    "description": "Subscribe to {@link ResourceUpdatedNotificationnotifications/resources/updated} for these resource URIs.\nReplaces the former `resources/subscribe` RPC.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "resourcesListChanged": {
+                    "description": "If true, receive {@link ResourceListChangedNotificationnotifications/resources/list_changed}.",
+                    "type": "boolean"
+                },
+                "toolsListChanged": {
+                    "description": "If true, receive {@link ToolListChangedNotificationnotifications/tools/list_changed}.",
+                    "type": "boolean"
+                }
+            },
+            "type": "object"
+        },
+        "SubscriptionsAcknowledgedNotification": {
+            "description": "Sent by the server as the first message on a\n{@link SubscriptionsListenRequestsubscriptions/listen} stream to acknowledge\nthat the subscription has been established and to report which notification\ntypes it agreed to honor.",
+            "properties": {
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "notifications/subscriptions/acknowledged",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/SubscriptionsAcknowledgedNotificationParams"
+                }
+            },
+            "required": ["jsonrpc", "method", "params"],
+            "type": "object"
+        },
+        "SubscriptionsAcknowledgedNotificationParams": {
+            "description": "Parameters for a {@link SubscriptionsAcknowledgedNotificationnotifications/subscriptions/acknowledged} notification.",
+            "properties": {
+                "_meta": {
+                    "$ref": "#/$defs/MetaObject"
+                },
+                "notifications": {
+                    "$ref": "#/$defs/SubscriptionFilter",
+                    "description": "The subset of requested notification types the server agreed to honor.\nOnly includes notification types the server actually supports; if the\nclient requested an unsupported type (e.g., `promptsListChanged` when\nthe server has no prompts), it is omitted from this set."
+                }
+            },
+            "required": ["notifications"],
+            "type": "object"
+        },
+        "SubscriptionsListenRequest": {
+            "description": "Sent from the client to open a long-lived channel for receiving notifications\noutside the context of a specific request. Replaces the previous HTTP GET\nendpoint and ensures consistent behavior between HTTP and STDIO.",
+            "properties": {
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "subscriptions/listen",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/SubscriptionsListenRequestParams"
+                }
+            },
+            "required": ["id", "jsonrpc", "method", "params"],
+            "type": "object"
+        },
+        "SubscriptionsListenRequestParams": {
+            "description": "Parameters for a {@link SubscriptionsListenRequestsubscriptions/listen} request.",
+            "properties": {
+                "_meta": {
+                    "$ref": "#/$defs/RequestMetaObject"
+                },
+                "notifications": {
+                    "$ref": "#/$defs/SubscriptionFilter",
+                    "description": "The notifications the client opts in to on this stream. The server\n**MUST NOT** send notification types the client has not explicitly\nrequested."
+                }
+            },
+            "required": ["_meta", "notifications"],
+            "type": "object"
+        },
+        "TextContent": {
+            "description": "Text provided to or from an LLM.",
+            "properties": {
+                "_meta": {
+                    "$ref": "#/$defs/MetaObject"
+                },
+                "annotations": {
+                    "$ref": "#/$defs/Annotations",
+                    "description": "Optional annotations for the client."
+                },
+                "text": {
+                    "description": "The text content of the message.",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "text",
+                    "type": "string"
+                }
+            },
+            "required": ["text", "type"],
+            "type": "object"
+        },
+        "TextResourceContents": {
+            "properties": {
+                "_meta": {
+                    "$ref": "#/$defs/MetaObject"
+                },
+                "mimeType": {
+                    "description": "The MIME type of this resource, if known.",
+                    "type": "string"
+                },
+                "text": {
+                    "description": "The text of the item. This must only be set if the item can actually be represented as text (not binary data).",
+                    "type": "string"
+                },
+                "uri": {
+                    "description": "The URI of this resource.",
+                    "format": "uri",
+                    "type": "string"
+                }
+            },
+            "required": ["text", "uri"],
+            "type": "object"
+        },
+        "TitledMultiSelectEnumSchema": {
+            "description": "Schema for multiple-selection enumeration with display titles for each option.",
+            "properties": {
+                "default": {
+                    "description": "Optional default value.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "description": {
+                    "description": "Optional description for the enum field.",
+                    "type": "string"
+                },
+                "items": {
+                    "description": "Schema for array items with enum options and display labels.",
+                    "properties": {
+                        "anyOf": {
+                            "description": "Array of enum options with values and display labels.",
+                            "items": {
+                                "properties": {
+                                    "const": {
+                                        "description": "The constant enum value.",
+                                        "type": "string"
+                                    },
+                                    "title": {
+                                        "description": "Display title for this option.",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": ["const", "title"],
+                                "type": "object"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": ["anyOf"],
+                    "type": "object"
+                },
+                "maxItems": {
+                    "description": "Maximum number of items to select.",
+                    "type": "integer"
+                },
+                "minItems": {
+                    "description": "Minimum number of items to select.",
+                    "type": "integer"
+                },
+                "title": {
+                    "description": "Optional title for the enum field.",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "array",
+                    "type": "string"
+                }
+            },
+            "required": ["items", "type"],
+            "type": "object"
+        },
+        "TitledSingleSelectEnumSchema": {
+            "description": "Schema for single-selection enumeration with display titles for each option.",
+            "properties": {
+                "default": {
+                    "description": "Optional default value.",
+                    "type": "string"
+                },
+                "description": {
+                    "description": "Optional description for the enum field.",
+                    "type": "string"
+                },
+                "oneOf": {
+                    "description": "Array of enum options with values and display labels.",
+                    "items": {
+                        "properties": {
+                            "const": {
+                                "description": "The enum value.",
+                                "type": "string"
+                            },
+                            "title": {
+                                "description": "Display label for this option.",
+                                "type": "string"
+                            }
+                        },
+                        "required": ["const", "title"],
+                        "type": "object"
+                    },
+                    "type": "array"
+                },
+                "title": {
+                    "description": "Optional title for the enum field.",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "string",
+                    "type": "string"
+                }
+            },
+            "required": ["oneOf", "type"],
+            "type": "object"
+        },
+        "Tool": {
+            "description": "Definition for a tool the client can call.",
+            "properties": {
+                "_meta": {
+                    "$ref": "#/$defs/MetaObject"
+                },
+                "annotations": {
+                    "$ref": "#/$defs/ToolAnnotations",
+                    "description": "Optional additional tool information.\n\nDisplay name precedence order is: `title`, `annotations.title`, then `name`."
+                },
+                "description": {
+                    "description": "A human-readable description of the tool.\n\nThis can be used by clients to improve the LLM's understanding of available tools. It can be thought of like a \"hint\" to the model.",
+                    "type": "string"
+                },
+                "icons": {
+                    "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
+                    "items": {
+                        "$ref": "#/$defs/Icon"
+                    },
+                    "type": "array"
+                },
+                "inputSchema": {
+                    "additionalProperties": {},
+                    "description": "A JSON Schema object defining the expected parameters for the tool.\n\nTool arguments are always JSON objects, so `type: \"object\"` is required at the root.\nBeyond that, any JSON Schema 2020-12 keyword may appear alongside `type` — including\ncomposition keywords (`oneOf`, `anyOf`, `allOf`, `not`), conditional keywords\n(`if`/`then`/`else`), reference keywords (`$ref`, `$defs`, `$anchor`), and any other\nstandard validation or annotation keywords.\n\nDefaults to JSON Schema 2020-12 when no explicit `$schema` is provided.",
+                    "properties": {
+                        "$schema": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "const": "object",
+                            "type": "string"
+                        }
+                    },
+                    "required": ["type"],
+                    "type": "object"
+                },
+                "name": {
+                    "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+                    "type": "string"
+                },
+                "outputSchema": {
+                    "additionalProperties": {},
+                    "description": "An optional JSON Schema object defining the structure of the tool's output returned in\nthe structuredContent field of a {@link CallToolResult}. This can be any valid JSON Schema 2020-12.\n\nDefaults to JSON Schema 2020-12 when no explicit `$schema` is provided.",
+                    "properties": {
+                        "$schema": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                "title": {
+                    "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for {@link Tool},\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+                    "type": "string"
+                }
+            },
+            "required": ["inputSchema", "name"],
+            "type": "object"
+        },
+        "ToolAnnotations": {
+            "description": "Additional properties describing a {@link Tool} to clients.\n\nNOTE: all properties in `ToolAnnotations` are **hints**.\nThey are not guaranteed to provide a faithful description of\ntool behavior (including descriptive properties like `title`).\n\nClients should never make tool use decisions based on `ToolAnnotations`\nreceived from untrusted servers.",
+            "properties": {
+                "destructiveHint": {
+                    "description": "If true, the tool may perform destructive updates to its environment.\nIf false, the tool performs only additive updates.\n\n(This property is meaningful only when `readOnlyHint == false`)\n\nDefault: true",
+                    "type": "boolean"
+                },
+                "idempotentHint": {
+                    "description": "If true, calling the tool repeatedly with the same arguments\nwill have no additional effect on its environment.\n\n(This property is meaningful only when `readOnlyHint == false`)\n\nDefault: false",
+                    "type": "boolean"
+                },
+                "openWorldHint": {
+                    "description": "If true, this tool may interact with an \"open world\" of external\nentities. If false, the tool's domain of interaction is closed.\nFor example, the world of a web search tool is open, whereas that\nof a memory tool is not.\n\nDefault: true",
+                    "type": "boolean"
+                },
+                "readOnlyHint": {
+                    "description": "If true, the tool does not modify its environment.\n\nDefault: false",
+                    "type": "boolean"
+                },
+                "title": {
+                    "description": "A human-readable title for the tool.",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "ToolChoice": {
+            "description": "Controls tool selection behavior for sampling requests.",
+            "properties": {
+                "mode": {
+                    "description": "Controls the tool use ability of the model:\n- `\"auto\"`: Model decides whether to use tools (default)\n- `\"required\"`: Model MUST use at least one tool before completing\n- `\"none\"`: Model MUST NOT use any tools",
+                    "enum": ["auto", "none", "required"],
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "ToolListChangedNotification": {
+            "description": "An optional notification from the server to the client, informing it that the list of tools it offers has changed. This may be issued by servers without any previous subscription from the client.",
+            "properties": {
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                },
+                "method": {
+                    "const": "notifications/tools/list_changed",
+                    "type": "string"
+                },
+                "params": {
+                    "$ref": "#/$defs/NotificationParams"
+                }
+            },
+            "required": ["jsonrpc", "method"],
+            "type": "object"
+        },
+        "ToolResultContent": {
+            "description": "The result of a tool use, provided by the user back to the assistant.",
+            "properties": {
+                "_meta": {
+                    "$ref": "#/$defs/MetaObject",
+                    "description": "Optional metadata about the tool result. Clients SHOULD preserve this field when\nincluding tool results in subsequent sampling requests to enable caching optimizations."
+                },
+                "content": {
+                    "description": "The unstructured result content of the tool use.\n\nThis has the same format as {@link CallToolResult.content} and can include text, images,\naudio, resource links, and embedded resources.",
+                    "items": {
+                        "$ref": "#/$defs/ContentBlock"
+                    },
+                    "type": "array"
+                },
+                "isError": {
+                    "description": "Whether the tool use resulted in an error.\n\nIf true, the content typically describes the error that occurred.\nDefault: false",
+                    "type": "boolean"
+                },
+                "structuredContent": {
+                    "description": "An optional structured result value.\n\nThis can be any JSON value (object, array, string, number, boolean, or null).\nIf the tool defined an {@link Tool.outputSchema}, this SHOULD conform to that schema."
+                },
+                "toolUseId": {
+                    "description": "The ID of the tool use this result corresponds to.\n\nThis MUST match the ID from a previous {@link ToolUseContent}.",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "tool_result",
+                    "type": "string"
+                }
+            },
+            "required": ["content", "toolUseId", "type"],
+            "type": "object"
+        },
+        "ToolUseContent": {
+            "description": "A request from the assistant to call a tool.",
+            "properties": {
+                "_meta": {
+                    "$ref": "#/$defs/MetaObject",
+                    "description": "Optional metadata about the tool use. Clients SHOULD preserve this field when\nincluding tool uses in subsequent sampling requests to enable caching optimizations."
+                },
+                "id": {
+                    "description": "A unique identifier for this tool use.\n\nThis ID is used to match tool results to their corresponding tool uses.",
+                    "type": "string"
+                },
+                "input": {
+                    "additionalProperties": {},
+                    "description": "The arguments to pass to the tool, conforming to the tool's input schema.",
+                    "type": "object"
+                },
+                "name": {
+                    "description": "The name of the tool to call.",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "tool_use",
+                    "type": "string"
+                }
+            },
+            "required": ["id", "input", "name", "type"],
+            "type": "object"
+        },
+        "UnsupportedProtocolVersionError": {
+            "description": "Returned when the request's protocol version is unknown to the server or\nunsupported (e.g., a known experimental or draft version the server has\nchosen not to implement). For HTTP, the response status code MUST be\n`400 Bad Request`.",
+            "properties": {
+                "error": {
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/Error"
+                        },
+                        {
+                            "properties": {
+                                "code": {
+                                    "const": -32004,
+                                    "type": "integer"
+                                },
+                                "data": {
+                                    "properties": {
+                                        "requested": {
+                                            "description": "The protocol version that was requested by the client.",
+                                            "type": "string"
+                                        },
+                                        "supported": {
+                                            "description": "Protocol versions the server supports. The client should choose a\nmutually supported version from this list and retry.",
+                                            "items": {
+                                                "type": "string"
+                                            },
+                                            "type": "array"
+                                        }
+                                    },
+                                    "required": ["requested", "supported"],
+                                    "type": "object"
+                                }
+                            },
+                            "required": ["code", "data"],
+                            "type": "object"
+                        }
+                    ]
+                },
+                "id": {
+                    "$ref": "#/$defs/RequestId"
+                },
+                "jsonrpc": {
+                    "const": "2.0",
+                    "type": "string"
+                }
+            },
+            "required": ["error", "jsonrpc"],
+            "type": "object"
+        },
+        "UntitledMultiSelectEnumSchema": {
+            "description": "Schema for multiple-selection enumeration without display titles for options.",
+            "properties": {
+                "default": {
+                    "description": "Optional default value.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "description": {
+                    "description": "Optional description for the enum field.",
+                    "type": "string"
+                },
+                "items": {
+                    "description": "Schema for the array items.",
+                    "properties": {
+                        "enum": {
+                            "description": "Array of enum values to choose from.",
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        "type": {
+                            "const": "string",
+                            "type": "string"
+                        }
+                    },
+                    "required": ["enum", "type"],
+                    "type": "object"
+                },
+                "maxItems": {
+                    "description": "Maximum number of items to select.",
+                    "type": "integer"
+                },
+                "minItems": {
+                    "description": "Minimum number of items to select.",
+                    "type": "integer"
+                },
+                "title": {
+                    "description": "Optional title for the enum field.",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "array",
+                    "type": "string"
+                }
+            },
+            "required": ["items", "type"],
+            "type": "object"
+        },
+        "UntitledSingleSelectEnumSchema": {
+            "description": "Schema for single-selection enumeration without display titles for options.",
+            "properties": {
+                "default": {
+                    "description": "Optional default value.",
+                    "type": "string"
+                },
+                "description": {
+                    "description": "Optional description for the enum field.",
+                    "type": "string"
+                },
+                "enum": {
+                    "description": "Array of enum values to choose from.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "title": {
+                    "description": "Optional title for the enum field.",
+                    "type": "string"
+                },
+                "type": {
+                    "const": "string",
+                    "type": "string"
+                }
+            },
+            "required": ["enum", "type"],
+            "type": "object"
+        }
+    }
+}

--- a/packages/core/test/corpus/schema-twins/2026-07-28.schema.json
+++ b/packages/core/test/corpus/schema-twins/2026-07-28.schema.json
@@ -48,7 +48,11 @@
                     "type": "string"
                 }
             },
-            "required": ["data", "mimeType", "type"],
+            "required": [
+                "data",
+                "mimeType",
+                "type"
+            ],
             "type": "object"
         },
         "BaseMetadata": {
@@ -63,7 +67,9 @@
                     "type": "string"
                 }
             },
-            "required": ["name"],
+            "required": [
+                "name"
+            ],
             "type": "object"
         },
         "BlobResourceContents": {
@@ -86,7 +92,10 @@
                     "type": "string"
                 }
             },
-            "required": ["blob", "uri"],
+            "required": [
+                "blob",
+                "uri"
+            ],
             "type": "object"
         },
         "BooleanSchema": {
@@ -105,7 +114,9 @@
                     "type": "string"
                 }
             },
-            "required": ["type"],
+            "required": [
+                "type"
+            ],
             "type": "object"
         },
         "CacheableResult": {
@@ -116,7 +127,10 @@
                 },
                 "cacheScope": {
                     "description": "Indicates the intended scope of the cached response, analogous to HTTP\n`Cache-Control: public` vs `Cache-Control: private`.\n\n- `\"public\"`: Any client or intermediary (e.g., shared gateway, proxy)\n  MAY cache the response and serve it to any user.\n- `\"private\"`: Only the requesting user's client MAY cache the response.\n  Shared caches (e.g., multi-tenant gateways) MUST NOT serve a cached\n  copy to a different user.",
-                    "enum": ["private", "public"],
+                    "enum": [
+                        "private",
+                        "public"
+                    ],
                     "type": "string"
                 },
                 "resultType": {
@@ -129,7 +143,11 @@
                     "type": "integer"
                 }
             },
-            "required": ["cacheScope", "resultType", "ttlMs"],
+            "required": [
+                "cacheScope",
+                "resultType",
+                "ttlMs"
+            ],
             "type": "object"
         },
         "CallToolRequest": {
@@ -150,7 +168,12 @@
                     "$ref": "#/$defs/CallToolRequestParams"
                 }
             },
-            "required": ["id", "jsonrpc", "method", "params"],
+            "required": [
+                "id",
+                "jsonrpc",
+                "method",
+                "params"
+            ],
             "type": "object"
         },
         "CallToolRequestParams": {
@@ -175,7 +198,10 @@
                     "type": "string"
                 }
             },
-            "required": ["_meta", "name"],
+            "required": [
+                "_meta",
+                "name"
+            ],
             "type": "object"
         },
         "CallToolResult": {
@@ -203,7 +229,10 @@
                     "description": "An optional JSON value that represents the structured result of the tool call.\n\nThis can be any JSON value (object, array, string, number, boolean, or null)\nthat conforms to the tool's outputSchema if one is defined."
                 }
             },
-            "required": ["content", "resultType"],
+            "required": [
+                "content",
+                "resultType"
+            ],
             "type": "object"
         },
         "CallToolResultResponse": {
@@ -227,7 +256,11 @@
                     ]
                 }
             },
-            "required": ["id", "jsonrpc", "result"],
+            "required": [
+                "id",
+                "jsonrpc",
+                "result"
+            ],
             "type": "object"
         },
         "CancelledNotification": {
@@ -245,7 +278,11 @@
                     "$ref": "#/$defs/CancelledNotificationParams"
                 }
             },
-            "required": ["jsonrpc", "method", "params"],
+            "required": [
+                "jsonrpc",
+                "method",
+                "params"
+            ],
             "type": "object"
         },
         "CancelledNotificationParams": {
@@ -382,7 +419,12 @@
                     "$ref": "#/$defs/CompleteRequestParams"
                 }
             },
-            "required": ["id", "jsonrpc", "method", "params"],
+            "required": [
+                "id",
+                "jsonrpc",
+                "method",
+                "params"
+            ],
             "type": "object"
         },
         "CompleteRequestParams": {
@@ -403,7 +445,10 @@
                             "type": "string"
                         }
                     },
-                    "required": ["name", "value"],
+                    "required": [
+                        "name",
+                        "value"
+                    ],
                     "type": "object"
                 },
                 "context": {
@@ -430,7 +475,11 @@
                     ]
                 }
             },
-            "required": ["_meta", "argument", "ref"],
+            "required": [
+                "_meta",
+                "argument",
+                "ref"
+            ],
             "type": "object"
         },
         "CompleteResult": {
@@ -458,7 +507,9 @@
                             "type": "array"
                         }
                     },
-                    "required": ["values"],
+                    "required": [
+                        "values"
+                    ],
                     "type": "object"
                 },
                 "resultType": {
@@ -466,7 +517,10 @@
                     "type": "string"
                 }
             },
-            "required": ["completion", "resultType"],
+            "required": [
+                "completion",
+                "resultType"
+            ],
             "type": "object"
         },
         "CompleteResultResponse": {
@@ -483,7 +537,11 @@
                     "$ref": "#/$defs/CompleteResult"
                 }
             },
-            "required": ["id", "jsonrpc", "result"],
+            "required": [
+                "id",
+                "jsonrpc",
+                "result"
+            ],
             "type": "object"
         },
         "ContentBlock": {
@@ -516,7 +574,10 @@
                     "$ref": "#/$defs/CreateMessageRequestParams"
                 }
             },
-            "required": ["method", "params"],
+            "required": [
+                "method",
+                "params"
+            ],
             "type": "object"
         },
         "CreateMessageRequestParams": {
@@ -524,7 +585,11 @@
             "properties": {
                 "includeContext": {
                     "description": "A request to include context from one or more MCP servers (including the caller), to be attached to the prompt.\nThe client MAY ignore this request.\n\nDefault is `\"none\"`. The values `\"thisServer\"` and `\"allServers\"` are deprecated (SEP-2596): servers SHOULD\nomit this field or use `\"none\"`, and SHOULD only use the deprecated values if the client declares\n{@link ClientCapabilities.sampling.context}.",
-                    "enum": ["allServers", "none", "thisServer"],
+                    "enum": [
+                        "allServers",
+                        "none",
+                        "thisServer"
+                    ],
                     "type": "string"
                 },
                 "maxTokens": {
@@ -570,7 +635,10 @@
                     "type": "array"
                 }
             },
-            "required": ["maxTokens", "messages"],
+            "required": [
+                "maxTokens",
+                "messages"
+            ],
             "type": "object"
         },
         "CreateMessageResult": {
@@ -616,7 +684,11 @@
                     "type": "string"
                 }
             },
-            "required": ["content", "model", "role"],
+            "required": [
+                "content",
+                "model",
+                "role"
+            ],
             "type": "object"
         },
         "Cursor": {
@@ -641,7 +713,12 @@
                     "$ref": "#/$defs/RequestParams"
                 }
             },
-            "required": ["id", "jsonrpc", "method", "params"],
+            "required": [
+                "id",
+                "jsonrpc",
+                "method",
+                "params"
+            ],
             "type": "object"
         },
         "DiscoverResult": {
@@ -652,7 +729,10 @@
                 },
                 "cacheScope": {
                     "description": "Indicates the intended scope of the cached response, analogous to HTTP\n`Cache-Control: public` vs `Cache-Control: private`.\n\n- `\"public\"`: Any client or intermediary (e.g., shared gateway, proxy)\n  MAY cache the response and serve it to any user.\n- `\"private\"`: Only the requesting user's client MAY cache the response.\n  Shared caches (e.g., multi-tenant gateways) MUST NOT serve a cached\n  copy to a different user.",
-                    "enum": ["private", "public"],
+                    "enum": [
+                        "private",
+                        "public"
+                    ],
                     "type": "string"
                 },
                 "capabilities": {
@@ -684,7 +764,14 @@
                     "type": "integer"
                 }
             },
-            "required": ["cacheScope", "capabilities", "resultType", "serverInfo", "supportedVersions", "ttlMs"],
+            "required": [
+                "cacheScope",
+                "capabilities",
+                "resultType",
+                "serverInfo",
+                "supportedVersions",
+                "ttlMs"
+            ],
             "type": "object"
         },
         "DiscoverResultResponse": {
@@ -701,7 +788,11 @@
                     "$ref": "#/$defs/DiscoverResult"
                 }
             },
-            "required": ["id", "jsonrpc", "result"],
+            "required": [
+                "id",
+                "jsonrpc",
+                "result"
+            ],
             "type": "object"
         },
         "ElicitRequest": {
@@ -715,7 +806,10 @@
                     "$ref": "#/$defs/ElicitRequestParams"
                 }
             },
-            "required": ["method", "params"],
+            "required": [
+                "method",
+                "params"
+            ],
             "type": "object"
         },
         "ElicitRequestFormParams": {
@@ -753,11 +847,17 @@
                             "type": "string"
                         }
                     },
-                    "required": ["properties", "type"],
+                    "required": [
+                        "properties",
+                        "type"
+                    ],
                     "type": "object"
                 }
             },
-            "required": ["message", "requestedSchema"],
+            "required": [
+                "message",
+                "requestedSchema"
+            ],
             "type": "object"
         },
         "ElicitRequestParams": {
@@ -793,7 +893,12 @@
                     "type": "string"
                 }
             },
-            "required": ["elicitationId", "message", "mode", "url"],
+            "required": [
+                "elicitationId",
+                "message",
+                "mode",
+                "url"
+            ],
             "type": "object"
         },
         "ElicitResult": {
@@ -801,7 +906,11 @@
             "properties": {
                 "action": {
                     "description": "The user action in response to the elicitation.\n- `\"accept\"`: User submitted the form/confirmed the action\n- `\"decline\"`: User explicitly declined the action\n- `\"cancel\"`: User dismissed without making an explicit choice",
-                    "enum": ["accept", "cancel", "decline"],
+                    "enum": [
+                        "accept",
+                        "cancel",
+                        "decline"
+                    ],
                     "type": "string"
                 },
                 "content": {
@@ -814,7 +923,11 @@
                                 "type": "array"
                             },
                             {
-                                "type": ["string", "integer", "boolean"]
+                                "type": [
+                                    "string",
+                                    "integer",
+                                    "boolean"
+                                ]
                             }
                         ]
                     },
@@ -822,7 +935,9 @@
                     "type": "object"
                 }
             },
-            "required": ["action"],
+            "required": [
+                "action"
+            ],
             "type": "object"
         },
         "ElicitationCompleteNotification": {
@@ -840,7 +955,11 @@
                     "$ref": "#/$defs/ElicitationCompleteNotificationParams"
                 }
             },
-            "required": ["jsonrpc", "method", "params"],
+            "required": [
+                "jsonrpc",
+                "method",
+                "params"
+            ],
             "type": "object"
         },
         "ElicitationCompleteNotificationParams": {
@@ -854,7 +973,9 @@
                     "type": "string"
                 }
             },
-            "required": ["elicitationId"],
+            "required": [
+                "elicitationId"
+            ],
             "type": "object"
         },
         "EmbeddedResource": {
@@ -882,7 +1003,10 @@
                     "type": "string"
                 }
             },
-            "required": ["resource", "type"],
+            "required": [
+                "resource",
+                "type"
+            ],
             "type": "object"
         },
         "EmptyResult": {
@@ -922,7 +1046,10 @@
                     "type": "string"
                 }
             },
-            "required": ["code", "message"],
+            "required": [
+                "code",
+                "message"
+            ],
             "type": "object"
         },
         "GetPromptRequest": {
@@ -943,7 +1070,12 @@
                     "$ref": "#/$defs/GetPromptRequestParams"
                 }
             },
-            "required": ["id", "jsonrpc", "method", "params"],
+            "required": [
+                "id",
+                "jsonrpc",
+                "method",
+                "params"
+            ],
             "type": "object"
         },
         "GetPromptRequestParams": {
@@ -970,7 +1102,10 @@
                     "type": "string"
                 }
             },
-            "required": ["_meta", "name"],
+            "required": [
+                "_meta",
+                "name"
+            ],
             "type": "object"
         },
         "GetPromptResult": {
@@ -994,7 +1129,10 @@
                     "type": "string"
                 }
             },
-            "required": ["messages", "resultType"],
+            "required": [
+                "messages",
+                "resultType"
+            ],
             "type": "object"
         },
         "GetPromptResultResponse": {
@@ -1018,7 +1156,11 @@
                     ]
                 }
             },
-            "required": ["id", "jsonrpc", "result"],
+            "required": [
+                "id",
+                "jsonrpc",
+                "result"
+            ],
             "type": "object"
         },
         "Icon": {
@@ -1042,11 +1184,16 @@
                 },
                 "theme": {
                     "description": "Optional specifier for the theme this icon is designed for. `\"light\"` indicates\nthe icon is designed to be used with a light background, and `\"dark\"` indicates\nthe icon is designed to be used with a dark background.\n\nIf not provided, the client should assume the icon can be used with any theme.",
-                    "enum": ["dark", "light"],
+                    "enum": [
+                        "dark",
+                        "light"
+                    ],
                     "type": "string"
                 }
             },
-            "required": ["src"],
+            "required": [
+                "src"
+            ],
             "type": "object"
         },
         "Icons": {
@@ -1086,7 +1233,11 @@
                     "type": "string"
                 }
             },
-            "required": ["data", "mimeType", "type"],
+            "required": [
+                "data",
+                "mimeType",
+                "type"
+            ],
             "type": "object"
         },
         "Implementation": {
@@ -1121,7 +1272,10 @@
                     "type": "string"
                 }
             },
-            "required": ["name", "version"],
+            "required": [
+                "name",
+                "version"
+            ],
             "type": "object"
         },
         "InputRequest": {
@@ -1161,7 +1315,9 @@
                     "type": "string"
                 }
             },
-            "required": ["resultType"],
+            "required": [
+                "resultType"
+            ],
             "type": "object"
         },
         "InputResponse": {
@@ -1189,7 +1345,9 @@
                     "type": "string"
                 }
             },
-            "required": ["_meta"],
+            "required": [
+                "_meta"
+            ],
             "type": "object"
         },
         "InputResponses": {
@@ -1215,7 +1373,10 @@
                     "type": "string"
                 }
             },
-            "required": ["code", "message"],
+            "required": [
+                "code",
+                "message"
+            ],
             "type": "object"
         },
         "InvalidParamsError": {
@@ -1234,7 +1395,10 @@
                     "type": "string"
                 }
             },
-            "required": ["code", "message"],
+            "required": [
+                "code",
+                "message"
+            ],
             "type": "object"
         },
         "InvalidRequestError": {
@@ -1253,7 +1417,10 @@
                     "type": "string"
                 }
             },
-            "required": ["code", "message"],
+            "required": [
+                "code",
+                "message"
+            ],
             "type": "object"
         },
         "JSONArray": {
@@ -1282,7 +1449,10 @@
                     "type": "string"
                 }
             },
-            "required": ["error", "jsonrpc"],
+            "required": [
+                "error",
+                "jsonrpc"
+            ],
             "type": "object"
         },
         "JSONRPCMessage": {
@@ -1317,7 +1487,10 @@
                     "type": "object"
                 }
             },
-            "required": ["jsonrpc", "method"],
+            "required": [
+                "jsonrpc",
+                "method"
+            ],
             "type": "object"
         },
         "JSONRPCRequest": {
@@ -1338,7 +1511,11 @@
                     "type": "object"
                 }
             },
-            "required": ["id", "jsonrpc", "method"],
+            "required": [
+                "id",
+                "jsonrpc",
+                "method"
+            ],
             "type": "object"
         },
         "JSONRPCResponse": {
@@ -1366,7 +1543,11 @@
                     "$ref": "#/$defs/Result"
                 }
             },
-            "required": ["id", "jsonrpc", "result"],
+            "required": [
+                "id",
+                "jsonrpc",
+                "result"
+            ],
             "type": "object"
         },
         "JSONValue": {
@@ -1381,7 +1562,11 @@
                     "type": "array"
                 },
                 {
-                    "type": ["string", "integer", "boolean"]
+                    "type": [
+                        "string",
+                        "integer",
+                        "boolean"
+                    ]
                 }
             ]
         },
@@ -1415,7 +1600,10 @@
                     "type": "string"
                 }
             },
-            "required": ["enum", "type"],
+            "required": [
+                "enum",
+                "type"
+            ],
             "type": "object"
         },
         "ListPromptsRequest": {
@@ -1436,7 +1624,12 @@
                     "$ref": "#/$defs/PaginatedRequestParams"
                 }
             },
-            "required": ["id", "jsonrpc", "method", "params"],
+            "required": [
+                "id",
+                "jsonrpc",
+                "method",
+                "params"
+            ],
             "type": "object"
         },
         "ListPromptsResult": {
@@ -1447,7 +1640,10 @@
                 },
                 "cacheScope": {
                     "description": "Indicates the intended scope of the cached response, analogous to HTTP\n`Cache-Control: public` vs `Cache-Control: private`.\n\n- `\"public\"`: Any client or intermediary (e.g., shared gateway, proxy)\n  MAY cache the response and serve it to any user.\n- `\"private\"`: Only the requesting user's client MAY cache the response.\n  Shared caches (e.g., multi-tenant gateways) MUST NOT serve a cached\n  copy to a different user.",
-                    "enum": ["private", "public"],
+                    "enum": [
+                        "private",
+                        "public"
+                    ],
                     "type": "string"
                 },
                 "nextCursor": {
@@ -1470,7 +1666,12 @@
                     "type": "integer"
                 }
             },
-            "required": ["cacheScope", "prompts", "resultType", "ttlMs"],
+            "required": [
+                "cacheScope",
+                "prompts",
+                "resultType",
+                "ttlMs"
+            ],
             "type": "object"
         },
         "ListPromptsResultResponse": {
@@ -1487,7 +1688,11 @@
                     "$ref": "#/$defs/ListPromptsResult"
                 }
             },
-            "required": ["id", "jsonrpc", "result"],
+            "required": [
+                "id",
+                "jsonrpc",
+                "result"
+            ],
             "type": "object"
         },
         "ListResourceTemplatesRequest": {
@@ -1508,7 +1713,12 @@
                     "$ref": "#/$defs/PaginatedRequestParams"
                 }
             },
-            "required": ["id", "jsonrpc", "method", "params"],
+            "required": [
+                "id",
+                "jsonrpc",
+                "method",
+                "params"
+            ],
             "type": "object"
         },
         "ListResourceTemplatesResult": {
@@ -1519,7 +1729,10 @@
                 },
                 "cacheScope": {
                     "description": "Indicates the intended scope of the cached response, analogous to HTTP\n`Cache-Control: public` vs `Cache-Control: private`.\n\n- `\"public\"`: Any client or intermediary (e.g., shared gateway, proxy)\n  MAY cache the response and serve it to any user.\n- `\"private\"`: Only the requesting user's client MAY cache the response.\n  Shared caches (e.g., multi-tenant gateways) MUST NOT serve a cached\n  copy to a different user.",
-                    "enum": ["private", "public"],
+                    "enum": [
+                        "private",
+                        "public"
+                    ],
                     "type": "string"
                 },
                 "nextCursor": {
@@ -1542,7 +1755,12 @@
                     "type": "integer"
                 }
             },
-            "required": ["cacheScope", "resourceTemplates", "resultType", "ttlMs"],
+            "required": [
+                "cacheScope",
+                "resourceTemplates",
+                "resultType",
+                "ttlMs"
+            ],
             "type": "object"
         },
         "ListResourceTemplatesResultResponse": {
@@ -1559,7 +1777,11 @@
                     "$ref": "#/$defs/ListResourceTemplatesResult"
                 }
             },
-            "required": ["id", "jsonrpc", "result"],
+            "required": [
+                "id",
+                "jsonrpc",
+                "result"
+            ],
             "type": "object"
         },
         "ListResourcesRequest": {
@@ -1580,7 +1802,12 @@
                     "$ref": "#/$defs/PaginatedRequestParams"
                 }
             },
-            "required": ["id", "jsonrpc", "method", "params"],
+            "required": [
+                "id",
+                "jsonrpc",
+                "method",
+                "params"
+            ],
             "type": "object"
         },
         "ListResourcesResult": {
@@ -1591,7 +1818,10 @@
                 },
                 "cacheScope": {
                     "description": "Indicates the intended scope of the cached response, analogous to HTTP\n`Cache-Control: public` vs `Cache-Control: private`.\n\n- `\"public\"`: Any client or intermediary (e.g., shared gateway, proxy)\n  MAY cache the response and serve it to any user.\n- `\"private\"`: Only the requesting user's client MAY cache the response.\n  Shared caches (e.g., multi-tenant gateways) MUST NOT serve a cached\n  copy to a different user.",
-                    "enum": ["private", "public"],
+                    "enum": [
+                        "private",
+                        "public"
+                    ],
                     "type": "string"
                 },
                 "nextCursor": {
@@ -1614,7 +1844,12 @@
                     "type": "integer"
                 }
             },
-            "required": ["cacheScope", "resources", "resultType", "ttlMs"],
+            "required": [
+                "cacheScope",
+                "resources",
+                "resultType",
+                "ttlMs"
+            ],
             "type": "object"
         },
         "ListResourcesResultResponse": {
@@ -1631,7 +1866,11 @@
                     "$ref": "#/$defs/ListResourcesResult"
                 }
             },
-            "required": ["id", "jsonrpc", "result"],
+            "required": [
+                "id",
+                "jsonrpc",
+                "result"
+            ],
             "type": "object"
         },
         "ListRootsRequest": {
@@ -1645,7 +1884,9 @@
                     "$ref": "#/$defs/RequestParams"
                 }
             },
-            "required": ["method"],
+            "required": [
+                "method"
+            ],
             "type": "object"
         },
         "ListRootsResult": {
@@ -1658,7 +1899,9 @@
                     "type": "array"
                 }
             },
-            "required": ["roots"],
+            "required": [
+                "roots"
+            ],
             "type": "object"
         },
         "ListToolsRequest": {
@@ -1679,7 +1922,12 @@
                     "$ref": "#/$defs/PaginatedRequestParams"
                 }
             },
-            "required": ["id", "jsonrpc", "method", "params"],
+            "required": [
+                "id",
+                "jsonrpc",
+                "method",
+                "params"
+            ],
             "type": "object"
         },
         "ListToolsResult": {
@@ -1690,7 +1938,10 @@
                 },
                 "cacheScope": {
                     "description": "Indicates the intended scope of the cached response, analogous to HTTP\n`Cache-Control: public` vs `Cache-Control: private`.\n\n- `\"public\"`: Any client or intermediary (e.g., shared gateway, proxy)\n  MAY cache the response and serve it to any user.\n- `\"private\"`: Only the requesting user's client MAY cache the response.\n  Shared caches (e.g., multi-tenant gateways) MUST NOT serve a cached\n  copy to a different user.",
-                    "enum": ["private", "public"],
+                    "enum": [
+                        "private",
+                        "public"
+                    ],
                     "type": "string"
                 },
                 "nextCursor": {
@@ -1713,7 +1964,12 @@
                     "type": "integer"
                 }
             },
-            "required": ["cacheScope", "resultType", "tools", "ttlMs"],
+            "required": [
+                "cacheScope",
+                "resultType",
+                "tools",
+                "ttlMs"
+            ],
             "type": "object"
         },
         "ListToolsResultResponse": {
@@ -1730,12 +1986,25 @@
                     "$ref": "#/$defs/ListToolsResult"
                 }
             },
-            "required": ["id", "jsonrpc", "result"],
+            "required": [
+                "id",
+                "jsonrpc",
+                "result"
+            ],
             "type": "object"
         },
         "LoggingLevel": {
             "description": "The severity of a log message.\n\nThese map to syslog message severities, as specified in RFC-5424:\nhttps://datatracker.ietf.org/doc/html/rfc5424#section-6.2.1",
-            "enum": ["alert", "critical", "debug", "emergency", "error", "info", "notice", "warning"],
+            "enum": [
+                "alert",
+                "critical",
+                "debug",
+                "emergency",
+                "error",
+                "info",
+                "notice",
+                "warning"
+            ],
             "type": "string"
         },
         "LoggingMessageNotification": {
@@ -1753,7 +2022,11 @@
                     "$ref": "#/$defs/LoggingMessageNotificationParams"
                 }
             },
-            "required": ["jsonrpc", "method", "params"],
+            "required": [
+                "jsonrpc",
+                "method",
+                "params"
+            ],
             "type": "object"
         },
         "LoggingMessageNotificationParams": {
@@ -1774,7 +2047,10 @@
                     "type": "string"
                 }
             },
-            "required": ["data", "level"],
+            "required": [
+                "data",
+                "level"
+            ],
             "type": "object"
         },
         "MetaObject": {
@@ -1797,7 +2073,10 @@
                     "type": "string"
                 }
             },
-            "required": ["code", "message"],
+            "required": [
+                "code",
+                "message"
+            ],
             "type": "object"
         },
         "MissingRequiredClientCapabilityError": {
@@ -1821,11 +2100,16 @@
                                             "description": "The capabilities the server requires from the client to process this request."
                                         }
                                     },
-                                    "required": ["requiredCapabilities"],
+                                    "required": [
+                                        "requiredCapabilities"
+                                    ],
                                     "type": "object"
                                 }
                             },
-                            "required": ["code", "data"],
+                            "required": [
+                                "code",
+                                "data"
+                            ],
                             "type": "object"
                         }
                     ]
@@ -1838,7 +2122,10 @@
                     "type": "string"
                 }
             },
-            "required": ["error", "jsonrpc"],
+            "required": [
+                "error",
+                "jsonrpc"
+            ],
             "type": "object"
         },
         "ModelHint": {
@@ -1902,7 +2189,9 @@
                     "type": "object"
                 }
             },
-            "required": ["method"],
+            "required": [
+                "method"
+            ],
             "type": "object"
         },
         "NotificationParams": {
@@ -1932,11 +2221,16 @@
                     "type": "string"
                 },
                 "type": {
-                    "enum": ["integer", "number"],
+                    "enum": [
+                        "integer",
+                        "number"
+                    ],
                     "type": "string"
                 }
             },
-            "required": ["type"],
+            "required": [
+                "type"
+            ],
             "type": "object"
         },
         "PaginatedRequest": {
@@ -1955,7 +2249,12 @@
                     "$ref": "#/$defs/PaginatedRequestParams"
                 }
             },
-            "required": ["id", "jsonrpc", "method", "params"],
+            "required": [
+                "id",
+                "jsonrpc",
+                "method",
+                "params"
+            ],
             "type": "object"
         },
         "PaginatedRequestParams": {
@@ -1969,7 +2268,9 @@
                     "type": "string"
                 }
             },
-            "required": ["_meta"],
+            "required": [
+                "_meta"
+            ],
             "type": "object"
         },
         "PaginatedResult": {
@@ -1986,7 +2287,9 @@
                     "type": "string"
                 }
             },
-            "required": ["resultType"],
+            "required": [
+                "resultType"
+            ],
             "type": "object"
         },
         "ParseError": {
@@ -2005,7 +2308,10 @@
                     "type": "string"
                 }
             },
-            "required": ["code", "message"],
+            "required": [
+                "code",
+                "message"
+            ],
             "type": "object"
         },
         "PrimitiveSchemaDefinition": {
@@ -2052,7 +2358,11 @@
                     "$ref": "#/$defs/ProgressNotificationParams"
                 }
             },
-            "required": ["jsonrpc", "method", "params"],
+            "required": [
+                "jsonrpc",
+                "method",
+                "params"
+            ],
             "type": "object"
         },
         "ProgressNotificationParams": {
@@ -2078,12 +2388,18 @@
                     "type": "number"
                 }
             },
-            "required": ["progress", "progressToken"],
+            "required": [
+                "progress",
+                "progressToken"
+            ],
             "type": "object"
         },
         "ProgressToken": {
             "description": "A progress token, used to associate progress notifications with the original request.",
-            "type": ["string", "integer"]
+            "type": [
+                "string",
+                "integer"
+            ]
         },
         "Prompt": {
             "description": "A prompt or prompt template that the server offers.",
@@ -2118,7 +2434,9 @@
                     "type": "string"
                 }
             },
-            "required": ["name"],
+            "required": [
+                "name"
+            ],
             "type": "object"
         },
         "PromptArgument": {
@@ -2141,7 +2459,9 @@
                     "type": "string"
                 }
             },
-            "required": ["name"],
+            "required": [
+                "name"
+            ],
             "type": "object"
         },
         "PromptListChangedNotification": {
@@ -2159,7 +2479,10 @@
                     "$ref": "#/$defs/NotificationParams"
                 }
             },
-            "required": ["jsonrpc", "method"],
+            "required": [
+                "jsonrpc",
+                "method"
+            ],
             "type": "object"
         },
         "PromptMessage": {
@@ -2172,7 +2495,10 @@
                     "$ref": "#/$defs/Role"
                 }
             },
-            "required": ["content", "role"],
+            "required": [
+                "content",
+                "role"
+            ],
             "type": "object"
         },
         "PromptReference": {
@@ -2191,7 +2517,10 @@
                     "type": "string"
                 }
             },
-            "required": ["name", "type"],
+            "required": [
+                "name",
+                "type"
+            ],
             "type": "object"
         },
         "ReadResourceRequest": {
@@ -2212,7 +2541,12 @@
                     "$ref": "#/$defs/ReadResourceRequestParams"
                 }
             },
-            "required": ["id", "jsonrpc", "method", "params"],
+            "required": [
+                "id",
+                "jsonrpc",
+                "method",
+                "params"
+            ],
             "type": "object"
         },
         "ReadResourceRequestParams": {
@@ -2233,7 +2567,10 @@
                     "type": "string"
                 }
             },
-            "required": ["_meta", "uri"],
+            "required": [
+                "_meta",
+                "uri"
+            ],
             "type": "object"
         },
         "ReadResourceResult": {
@@ -2244,7 +2581,10 @@
                 },
                 "cacheScope": {
                     "description": "Indicates the intended scope of the cached response, analogous to HTTP\n`Cache-Control: public` vs `Cache-Control: private`.\n\n- `\"public\"`: Any client or intermediary (e.g., shared gateway, proxy)\n  MAY cache the response and serve it to any user.\n- `\"private\"`: Only the requesting user's client MAY cache the response.\n  Shared caches (e.g., multi-tenant gateways) MUST NOT serve a cached\n  copy to a different user.",
-                    "enum": ["private", "public"],
+                    "enum": [
+                        "private",
+                        "public"
+                    ],
                     "type": "string"
                 },
                 "contents": {
@@ -2270,7 +2610,12 @@
                     "type": "integer"
                 }
             },
-            "required": ["cacheScope", "contents", "resultType", "ttlMs"],
+            "required": [
+                "cacheScope",
+                "contents",
+                "resultType",
+                "ttlMs"
+            ],
             "type": "object"
         },
         "ReadResourceResultResponse": {
@@ -2294,7 +2639,11 @@
                     ]
                 }
             },
-            "required": ["id", "jsonrpc", "result"],
+            "required": [
+                "id",
+                "jsonrpc",
+                "result"
+            ],
             "type": "object"
         },
         "Request": {
@@ -2307,12 +2656,17 @@
                     "type": "object"
                 }
             },
-            "required": ["method"],
+            "required": [
+                "method"
+            ],
             "type": "object"
         },
         "RequestId": {
             "description": "A uniquely identifying ID for a request in JSON-RPC.",
-            "type": ["string", "integer"]
+            "type": [
+                "string",
+                "integer"
+            ]
         },
         "RequestMetaObject": {
             "description": "Extends {@link MetaObject} with additional request-specific fields. All key naming rules from `MetaObject` apply.",
@@ -2352,7 +2706,9 @@
                     "$ref": "#/$defs/RequestMetaObject"
                 }
             },
-            "required": ["_meta"],
+            "required": [
+                "_meta"
+            ],
             "type": "object"
         },
         "Resource": {
@@ -2398,7 +2754,10 @@
                     "type": "string"
                 }
             },
-            "required": ["name", "uri"],
+            "required": [
+                "name",
+                "uri"
+            ],
             "type": "object"
         },
         "ResourceContents": {
@@ -2417,7 +2776,9 @@
                     "type": "string"
                 }
             },
-            "required": ["uri"],
+            "required": [
+                "uri"
+            ],
             "type": "object"
         },
         "ResourceLink": {
@@ -2467,7 +2828,11 @@
                     "type": "string"
                 }
             },
-            "required": ["name", "type", "uri"],
+            "required": [
+                "name",
+                "type",
+                "uri"
+            ],
             "type": "object"
         },
         "ResourceListChangedNotification": {
@@ -2485,7 +2850,10 @@
                     "$ref": "#/$defs/NotificationParams"
                 }
             },
-            "required": ["jsonrpc", "method"],
+            "required": [
+                "jsonrpc",
+                "method"
+            ],
             "type": "object"
         },
         "ResourceRequestParams": {
@@ -2500,7 +2868,10 @@
                     "type": "string"
                 }
             },
-            "required": ["_meta", "uri"],
+            "required": [
+                "_meta",
+                "uri"
+            ],
             "type": "object"
         },
         "ResourceTemplate": {
@@ -2542,7 +2913,10 @@
                     "type": "string"
                 }
             },
-            "required": ["name", "uriTemplate"],
+            "required": [
+                "name",
+                "uriTemplate"
+            ],
             "type": "object"
         },
         "ResourceTemplateReference": {
@@ -2558,7 +2932,10 @@
                     "type": "string"
                 }
             },
-            "required": ["type", "uri"],
+            "required": [
+                "type",
+                "uri"
+            ],
             "type": "object"
         },
         "ResourceUpdatedNotification": {
@@ -2576,7 +2953,11 @@
                     "$ref": "#/$defs/ResourceUpdatedNotificationParams"
                 }
             },
-            "required": ["jsonrpc", "method", "params"],
+            "required": [
+                "jsonrpc",
+                "method",
+                "params"
+            ],
             "type": "object"
         },
         "ResourceUpdatedNotificationParams": {
@@ -2591,7 +2972,9 @@
                     "type": "string"
                 }
             },
-            "required": ["uri"],
+            "required": [
+                "uri"
+            ],
             "type": "object"
         },
         "Result": {
@@ -2606,7 +2989,9 @@
                     "type": "string"
                 }
             },
-            "required": ["resultType"],
+            "required": [
+                "resultType"
+            ],
             "type": "object"
         },
         "ResultType": {
@@ -2615,7 +3000,10 @@
         },
         "Role": {
             "description": "The sender or recipient of messages and data in a conversation.",
-            "enum": ["assistant", "user"],
+            "enum": [
+                "assistant",
+                "user"
+            ],
             "type": "string"
         },
         "Root": {
@@ -2634,7 +3022,9 @@
                     "type": "string"
                 }
             },
-            "required": ["uri"],
+            "required": [
+                "uri"
+            ],
             "type": "object"
         },
         "SamplingMessage": {
@@ -2672,7 +3062,10 @@
                     "$ref": "#/$defs/Role"
                 }
             },
-            "required": ["content", "role"],
+            "required": [
+                "content",
+                "role"
+            ],
             "type": "object"
         },
         "SamplingMessageContentBlock": {
@@ -2843,7 +3236,12 @@
                     "type": "string"
                 },
                 "format": {
-                    "enum": ["date", "date-time", "email", "uri"],
+                    "enum": [
+                        "date",
+                        "date-time",
+                        "email",
+                        "uri"
+                    ],
                     "type": "string"
                 },
                 "maxLength": {
@@ -2860,7 +3258,9 @@
                     "type": "string"
                 }
             },
-            "required": ["type"],
+            "required": [
+                "type"
+            ],
             "type": "object"
         },
         "SubscriptionFilter": {
@@ -2903,7 +3303,11 @@
                     "$ref": "#/$defs/SubscriptionsAcknowledgedNotificationParams"
                 }
             },
-            "required": ["jsonrpc", "method", "params"],
+            "required": [
+                "jsonrpc",
+                "method",
+                "params"
+            ],
             "type": "object"
         },
         "SubscriptionsAcknowledgedNotificationParams": {
@@ -2917,7 +3321,9 @@
                     "description": "The subset of requested notification types the server agreed to honor.\nOnly includes notification types the server actually supports; if the\nclient requested an unsupported type (e.g., `promptsListChanged` when\nthe server has no prompts), it is omitted from this set."
                 }
             },
-            "required": ["notifications"],
+            "required": [
+                "notifications"
+            ],
             "type": "object"
         },
         "SubscriptionsListenRequest": {
@@ -2938,7 +3344,12 @@
                     "$ref": "#/$defs/SubscriptionsListenRequestParams"
                 }
             },
-            "required": ["id", "jsonrpc", "method", "params"],
+            "required": [
+                "id",
+                "jsonrpc",
+                "method",
+                "params"
+            ],
             "type": "object"
         },
         "SubscriptionsListenRequestParams": {
@@ -2952,7 +3363,10 @@
                     "description": "The notifications the client opts in to on this stream. The server\n**MUST NOT** send notification types the client has not explicitly\nrequested."
                 }
             },
-            "required": ["_meta", "notifications"],
+            "required": [
+                "_meta",
+                "notifications"
+            ],
             "type": "object"
         },
         "TextContent": {
@@ -2974,7 +3388,10 @@
                     "type": "string"
                 }
             },
-            "required": ["text", "type"],
+            "required": [
+                "text",
+                "type"
+            ],
             "type": "object"
         },
         "TextResourceContents": {
@@ -2996,7 +3413,10 @@
                     "type": "string"
                 }
             },
-            "required": ["text", "uri"],
+            "required": [
+                "text",
+                "uri"
+            ],
             "type": "object"
         },
         "TitledMultiSelectEnumSchema": {
@@ -3029,13 +3449,18 @@
                                         "type": "string"
                                     }
                                 },
-                                "required": ["const", "title"],
+                                "required": [
+                                    "const",
+                                    "title"
+                                ],
                                 "type": "object"
                             },
                             "type": "array"
                         }
                     },
-                    "required": ["anyOf"],
+                    "required": [
+                        "anyOf"
+                    ],
                     "type": "object"
                 },
                 "maxItems": {
@@ -3055,7 +3480,10 @@
                     "type": "string"
                 }
             },
-            "required": ["items", "type"],
+            "required": [
+                "items",
+                "type"
+            ],
             "type": "object"
         },
         "TitledSingleSelectEnumSchema": {
@@ -3082,7 +3510,10 @@
                                 "type": "string"
                             }
                         },
-                        "required": ["const", "title"],
+                        "required": [
+                            "const",
+                            "title"
+                        ],
                         "type": "object"
                     },
                     "type": "array"
@@ -3096,7 +3527,10 @@
                     "type": "string"
                 }
             },
-            "required": ["oneOf", "type"],
+            "required": [
+                "oneOf",
+                "type"
+            ],
             "type": "object"
         },
         "Tool": {
@@ -3132,7 +3566,9 @@
                             "type": "string"
                         }
                     },
-                    "required": ["type"],
+                    "required": [
+                        "type"
+                    ],
                     "type": "object"
                 },
                 "name": {
@@ -3154,7 +3590,10 @@
                     "type": "string"
                 }
             },
-            "required": ["inputSchema", "name"],
+            "required": [
+                "inputSchema",
+                "name"
+            ],
             "type": "object"
         },
         "ToolAnnotations": {
@@ -3188,7 +3627,11 @@
             "properties": {
                 "mode": {
                     "description": "Controls the tool use ability of the model:\n- `\"auto\"`: Model decides whether to use tools (default)\n- `\"required\"`: Model MUST use at least one tool before completing\n- `\"none\"`: Model MUST NOT use any tools",
-                    "enum": ["auto", "none", "required"],
+                    "enum": [
+                        "auto",
+                        "none",
+                        "required"
+                    ],
                     "type": "string"
                 }
             },
@@ -3209,7 +3652,10 @@
                     "$ref": "#/$defs/NotificationParams"
                 }
             },
-            "required": ["jsonrpc", "method"],
+            "required": [
+                "jsonrpc",
+                "method"
+            ],
             "type": "object"
         },
         "ToolResultContent": {
@@ -3242,7 +3688,11 @@
                     "type": "string"
                 }
             },
-            "required": ["content", "toolUseId", "type"],
+            "required": [
+                "content",
+                "toolUseId",
+                "type"
+            ],
             "type": "object"
         },
         "ToolUseContent": {
@@ -3270,7 +3720,12 @@
                     "type": "string"
                 }
             },
-            "required": ["id", "input", "name", "type"],
+            "required": [
+                "id",
+                "input",
+                "name",
+                "type"
+            ],
             "type": "object"
         },
         "UnsupportedProtocolVersionError": {
@@ -3301,11 +3756,17 @@
                                             "type": "array"
                                         }
                                     },
-                                    "required": ["requested", "supported"],
+                                    "required": [
+                                        "requested",
+                                        "supported"
+                                    ],
                                     "type": "object"
                                 }
                             },
-                            "required": ["code", "data"],
+                            "required": [
+                                "code",
+                                "data"
+                            ],
                             "type": "object"
                         }
                     ]
@@ -3318,7 +3779,10 @@
                     "type": "string"
                 }
             },
-            "required": ["error", "jsonrpc"],
+            "required": [
+                "error",
+                "jsonrpc"
+            ],
             "type": "object"
         },
         "UntitledMultiSelectEnumSchema": {
@@ -3350,7 +3814,10 @@
                             "type": "string"
                         }
                     },
-                    "required": ["enum", "type"],
+                    "required": [
+                        "enum",
+                        "type"
+                    ],
                     "type": "object"
                 },
                 "maxItems": {
@@ -3370,7 +3837,10 @@
                     "type": "string"
                 }
             },
-            "required": ["items", "type"],
+            "required": [
+                "items",
+                "type"
+            ],
             "type": "object"
         },
         "UntitledSingleSelectEnumSchema": {
@@ -3400,8 +3870,12 @@
                     "type": "string"
                 }
             },
-            "required": ["enum", "type"],
+            "required": [
+                "enum",
+                "type"
+            ],
             "type": "object"
         }
     }
 }
+

--- a/packages/core/test/corpus/schema-twins/manifest.json
+++ b/packages/core/test/corpus/schema-twins/manifest.json
@@ -1,5 +1,5 @@
 {
-    "comment": "Vendored schema.json twins (TEST-ONLY conformance oracles; never bundled, never runtime). Refresh ATOMICALLY with the matching spec.types anchor (see packages/core/src/types/README.md lifecycle rule 4).",
+    "comment": "Vendored schema.json twins (TEST-ONLY conformance oracles; never bundled, never runtime). RAW upstream bytes - never reformat: each file is locked to the sha256/bytes below by schemaTwinConformance. Refresh via `pnpm fetch:schema-twins [sha]`, ATOMICALLY with the matching spec.types anchor (see packages/core/src/types/README.md lifecycle rule 4).",
     "source": {
         "repository": "modelcontextprotocol/modelcontextprotocol",
         "commit": "0168c57fc74aba6e6dcf8f0b7191db3caaa5ad65"

--- a/packages/core/test/corpus/schema-twins/manifest.json
+++ b/packages/core/test/corpus/schema-twins/manifest.json
@@ -1,0 +1,19 @@
+{
+    "comment": "Vendored schema.json twins (TEST-ONLY conformance oracles; never bundled, never runtime). Refresh ATOMICALLY with the matching spec.types anchor (see packages/core/src/types/README.md lifecycle rule 4).",
+    "source": {
+        "repository": "modelcontextprotocol/modelcontextprotocol",
+        "commit": "0168c57fc74aba6e6dcf8f0b7191db3caaa5ad65"
+    },
+    "files": {
+        "2026-07-28": {
+            "sha256": "afaf886c06dd8d3cbdd556d81b6483b9018112aaf7ee284fa116eca58baf54fc",
+            "bytes": 172822,
+            "upstreamPath": "schema/draft/schema.json"
+        },
+        "2025-11-25": {
+            "sha256": "7b2d96fd95efd2216aa953606b83f5a740ddeaa5ebd3a5d27b45a8296545a118",
+            "bytes": 174326,
+            "upstreamPath": "schema/2025-11-25/schema.json"
+        }
+    }
+}

--- a/packages/core/test/corpus/specCorpus.test.ts
+++ b/packages/core/test/corpus/specCorpus.test.ts
@@ -78,8 +78,9 @@ const PENDING_2026: Record<string, string> = {
  * parse, so the entry is removed the moment the widening lands.
  */
 const PENDING_2026_FILES: Record<string, string> = {
-    'CallToolResult/result-with-array-structured-content.json': 'array structuredContent (SEP-2549) is not modeled yet',
-    'Tool/tool-with-array-output-schema.json': 'array outputSchema (SEP-2549) is not modeled yet'
+    // (empty — the SEP-2549 array-shape widenings burned when the 2026-era
+    // wire module landed anchor-exact Tool/CallToolResult forks; the two
+    // examples are real pins now.)
 };
 
 type AnyZod = z.ZodType;

--- a/packages/core/test/shared/protocol.test.ts
+++ b/packages/core/test/shared/protocol.test.ts
@@ -955,6 +955,31 @@ describe('codec-seam hardening in the protocol funnels', () => {
 
         await protocol.close();
     });
+
+    test('a synchronous throw out of codec.decodeResult rejects the request instead of escaping into transport.onmessage', async () => {
+        const [protocolTx, peerTx] = InMemoryTransport.createLinkedPair();
+        peerTx.onmessage = message => {
+            const request = message as JSONRPCRequest;
+            void peerTx.send({ jsonrpc: '2.0', id: request.id, result: {} });
+        };
+        await peerTx.start();
+
+        const protocol = createTestProtocol();
+        await protocol.connect(protocolTx);
+
+        // The response callback runs synchronously inside _onresponse; an
+        // unguarded throw here would propagate into the transport instead of
+        // failing the request. (The concrete production vector is the 2026
+        // codec's method-keyed schema lookup — see the own-key guard in
+        // rev2026-07-28/codec.ts.)
+        vi.spyOn(rev2025Codec, 'decodeResult').mockImplementationOnce(() => {
+            throw new Error('decode exploded');
+        });
+
+        await expect(protocol.request({ method: 'ping' })).rejects.toThrow('decode exploded');
+
+        await protocol.close();
+    });
 });
 
 describe('inbound validation precedence: −32601 outranks envelope −32602', () => {

--- a/packages/core/test/shared/rawResultTypeFirst.test.ts
+++ b/packages/core/test/shared/rawResultTypeFirst.test.ts
@@ -154,6 +154,21 @@ describe('raw-first resultType handling — 2025 era (strip-on-lift, Q1-SD3 ii)'
         await protocol.close();
     });
 
+    test('strip-on-lift is VALUE-BLIND: a foreign input_required WITH a valid body resolves, member stripped', async () => {
+        // The strip keys on the member's PRESENCE, never its value — even the
+        // driver kind is foreign vocabulary on this era. With a valid body
+        // the request resolves; the stripped key never surfaces. (The
+        // sibling test above covers the invalid-body arm: there the strip
+        // also runs, and validation then rejects on the actual content.)
+        const protocol = await wireWithRawResult({ resultType: 'input_required', content: [{ type: 'text', text: 'ok' }] });
+
+        const result = await protocol.request({ method: 'tools/call', params: { name: 'echo', arguments: {} } });
+        expect(result.content).toEqual([{ type: 'text', text: 'ok' }]);
+        expect('resultType' in result).toBe(false);
+
+        await protocol.close();
+    });
+
     test('a foreign non-string resultType is stripped; an otherwise-valid result resolves without it', async () => {
         const protocol = await wireWithRawResult({ resultType: 42, content: [{ type: 'text', text: 'ok' }] });
 

--- a/packages/core/test/shared/rawResultTypeFirst.test.ts
+++ b/packages/core/test/shared/rawResultTypeFirst.test.ts
@@ -1,27 +1,35 @@
 /**
- * Raw-first result discrimination: the client funnel inspects the raw
- * `resultType` member BEFORE any schema validation.
+ * Raw-first result discrimination (V-1) — relocated to its structural home:
+ * step 1 of the era codec's `decodeResult`, BEFORE any schema validation
+ * (Q1 increment 2; previously a funnel insertion in `_requestWithSchema`).
  *
- * The hazard this closes: tolerant result schemas (defaults filling absent
- * members, loose passthrough) would otherwise mask a non-complete result —
- * e.g. an `input_required` body parsing as a successful empty tool result.
- * The raw check runs first, so:
+ * The postures are ERA-SCOPED (Q1-SD3):
  *
- *  - `input_required` (or any non-`complete` kind) → typed local error
- *    carrying the discriminated kind; never a hollow success; no retry.
- *  - non-string `resultType` → typed invalid-result error (checked raw,
- *    before any schema could coerce or tolerate it).
- *  - `'complete'` → the discriminator is consumed (stripped) and the result
- *    parses as the public shape.
- *  - absent → untouched (2025-era behavior, byte-identical).
+ *  2026 era (the connection negotiated '2026-07-28'):
+ *  - `resultType` is REQUIRED. Absent → typed error NAMING the spec
+ *    violation (the absent⇒complete bridge is scoped to earlier-revision
+ *    servers and deliberately NOT extended to modern traffic).
+ *  - `input_required` → discriminated driver payload, surfaced as a typed
+ *    local error until the multi-round-trip driver (M4.1) consumes it.
+ *  - unknown kinds → invalid, no retry. Non-string → invalid.
+ *  - `'complete'` → wire-exact parse (resultType present) then lift.
+ *
+ *  2025 era (any legacy version / unbound instance):
+ *  - `resultType` is FOREIGN vocabulary → strip-on-lift (tolerate-and-drop,
+ *    whatever its value); validation then judges the actual content. This is
+ *    a deliberate behavior migration from the era-blind funnel arm (ledgered;
+ *    changeset: codec-split-wire-break).
+ *
+ * Either way, the V-1 invariant holds: a non-complete body can NEVER be
+ * masked into a hollow success by a tolerant result schema.
  */
 import { describe, expect, test } from 'vitest';
 
 import { SdkError, SdkErrorCode } from '../../src/errors/sdkErrors.js';
 import type { BaseContext } from '../../src/shared/protocol.js';
-import { Protocol } from '../../src/shared/protocol.js';
-import { InMemoryTransport } from '../../src/util/inMemory.js';
+import { Protocol, setNegotiatedProtocolVersion } from '../../src/shared/protocol.js';
 import type { JSONRPCRequest } from '../../src/types/index.js';
+import { InMemoryTransport } from '../../src/util/inMemory.js';
 
 class TestProtocol extends Protocol<BaseContext> {
     protected assertCapabilityForMethod(): void {}
@@ -33,7 +41,7 @@ class TestProtocol extends Protocol<BaseContext> {
 }
 
 /** Wire a protocol whose peer answers every request with the given raw result body. */
-async function wireWithRawResult(rawResult: unknown): Promise<TestProtocol> {
+async function wireWithRawResult(rawResult: unknown, era?: '2026-07-28'): Promise<TestProtocol> {
     const [clientTx, serverTx] = InMemoryTransport.createLinkedPair();
     serverTx.onmessage = message => {
         const request = message as JSONRPCRequest;
@@ -42,24 +50,27 @@ async function wireWithRawResult(rawResult: unknown): Promise<TestProtocol> {
     await serverTx.start();
     const protocol = new TestProtocol();
     await protocol.connect(clientTx);
+    if (era) setNegotiatedProtocolVersion(protocol, era);
     return protocol;
 }
 
-describe('raw-first resultType discrimination in the request funnel', () => {
-    test('an input_required body surfaces the discriminated kind, never an empty-content success', async () => {
-        // The exact masking hazard: tools/call's result schema defaults
-        // content to [] — without the raw-first check this body would
-        // resolve as { content: [] }.
-        const protocol = await wireWithRawResult({
-            resultType: 'input_required',
-            inputRequests: { 'elicit-1': { method: 'elicitation/create', params: { mode: 'form', message: 'Name?' } } },
-            requestState: 'opaque'
-        });
+const INPUT_REQUIRED_BODY = {
+    resultType: 'input_required',
+    inputRequests: { 'elicit-1': { method: 'elicitation/create', params: { mode: 'form', message: 'Name?' } } },
+    requestState: 'opaque'
+};
 
-        const outcome = await protocol.request({ method: 'tools/call', params: { name: 'echo', arguments: {} } }).then(
-            result => ({ resolved: result as unknown }),
-            error => ({ rejected: error as unknown })
-        );
+async function settle(protocol: TestProtocol): Promise<{ resolved: unknown } | { rejected: unknown }> {
+    return protocol.request({ method: 'tools/call', params: { name: 'echo', arguments: {} } }).then(
+        result => ({ resolved: result as unknown }),
+        error => ({ rejected: error as unknown })
+    );
+}
+
+describe('raw-first resultType discrimination — 2026 era (codec decode step 1)', () => {
+    test('an input_required body surfaces the discriminated kind, never an empty-content success', async () => {
+        const protocol = await wireWithRawResult(INPUT_REQUIRED_BODY, '2026-07-28');
+        const outcome = await settle(protocol);
 
         expect('resolved' in outcome, 'must not resolve as a success').toBe(false);
         const rejection = (outcome as { rejected: unknown }).rejected;
@@ -72,47 +83,82 @@ describe('raw-first resultType discrimination in the request funnel', () => {
     });
 
     test('an unrecognized resultType kind is invalid — surfaced, no retry', async () => {
-        const protocol = await wireWithRawResult({ resultType: 'mystery-kind', content: [] });
+        const protocol = await wireWithRawResult({ resultType: 'mystery-kind', content: [] }, '2026-07-28');
+        const outcome = await settle(protocol);
 
-        const rejection = await protocol
-            .request({ method: 'tools/call', params: { name: 'echo', arguments: {} } })
-            .catch((error: unknown) => error);
+        expect('rejected' in outcome).toBe(true);
+        const rejection = (outcome as { rejected: unknown }).rejected as SdkError;
         expect(rejection).toBeInstanceOf(SdkError);
-        expect((rejection as SdkError).code).toBe(SdkErrorCode.UnsupportedResultType);
-        expect((rejection as SdkError).data).toMatchObject({ resultType: 'mystery-kind' });
+        expect(rejection.code).toBe(SdkErrorCode.UnsupportedResultType);
+        expect(rejection.data).toMatchObject({ resultType: 'mystery-kind' });
 
         await protocol.close();
     });
 
-    test('a non-string resultType can never surface as a success (rejected in the funnel)', async () => {
-        // Pre-codec-split, a non-string resultType died at JSON-RPC envelope
-        // classification because the SHARED wire schema typed the member as
-        // an optional string. With resultType cut from the neutral schemas
-        // (Q1 increment 2 — the masking surface is gone), the loose envelope
-        // passes the foreign key through and the funnel's defensive raw-type
-        // arm rejects it IN-BAND with a typed error. Either way it can never
-        // be masked into a success — which is the V-1 invariant this test
-        // exists to pin.
-        const protocol = await wireWithRawResult({ resultType: 42, content: [] });
+    test('ABSENT resultType is a spec violation on the modern leg — typed error naming it (Q1-SD3 i)', async () => {
+        // The absent⇒complete bridge is scoped to earlier-revision servers;
+        // a 2026-negotiated peer that omits the REQUIRED member is broken.
+        const protocol = await wireWithRawResult({ content: [{ type: 'text', text: 'looks fine' }] }, '2026-07-28');
+        const outcome = await settle(protocol);
 
-        const rejection = await protocol
-            .request({ method: 'tools/call', params: { name: 'echo', arguments: {} } })
-            .catch((error: unknown) => error);
+        expect('rejected' in outcome).toBe(true);
+        const rejection = (outcome as { rejected: unknown }).rejected as SdkError;
         expect(rejection).toBeInstanceOf(SdkError);
-        expect((rejection as SdkError).code).toBe(SdkErrorCode.InvalidResult);
-        expect((rejection as SdkError).data).toMatchObject({ resultType: 42 });
+        expect(rejection.code).toBe(SdkErrorCode.InvalidResult);
+        expect(rejection.message).toContain('missing required resultType');
+        expect(rejection.data).toMatchObject({ method: 'tools/call', violation: 'missing-resultType' });
+
+        await protocol.close();
+    });
+
+    test('a non-string resultType can never surface as a success', async () => {
+        const protocol = await wireWithRawResult({ resultType: 42, content: [] }, '2026-07-28');
+        const outcome = await settle(protocol);
+
+        expect('rejected' in outcome).toBe(true);
+        const rejection = (outcome as { rejected: unknown }).rejected as SdkError;
+        expect(rejection).toBeInstanceOf(SdkError);
+        expect(rejection.code).toBe(SdkErrorCode.InvalidResult);
+        expect(rejection.data).toMatchObject({ resultType: 42 });
 
         await protocol.close();
     });
 
     test("resultType 'complete' is consumed: the result resolves without the wire member", async () => {
-        const protocol = await wireWithRawResult({
-            resultType: 'complete',
-            content: [{ type: 'text', text: 'done' }]
-        });
+        const protocol = await wireWithRawResult({ resultType: 'complete', content: [{ type: 'text', text: 'done' }] }, '2026-07-28');
 
         const result = await protocol.request({ method: 'tools/call', params: { name: 'echo', arguments: {} } });
         expect(result.content).toEqual([{ type: 'text', text: 'done' }]);
+        expect('resultType' in result).toBe(false);
+
+        await protocol.close();
+    });
+});
+
+describe('raw-first resultType handling — 2025 era (strip-on-lift, Q1-SD3 ii)', () => {
+    test('a foreign input_required body is stripped, then validation judges the content — never a silent success', async () => {
+        // BEHAVIOR MIGRATION (ledgered): pre-split, the era-blind funnel arm
+        // rejected this with UnsupportedResultType on every leg. On the 2025
+        // era resultType carries no meaning — the ruled posture strips the
+        // foreign key and lets validation decide. The body has no content,
+        // so it fails the (default-free) tools/call result schema LOUDLY —
+        // the V-1 invariant (never a hollow success) holds.
+        const protocol = await wireWithRawResult(INPUT_REQUIRED_BODY);
+        const outcome = await settle(protocol);
+
+        expect('resolved' in outcome, 'must not resolve as a success').toBe(false);
+        const rejection = (outcome as { rejected: unknown }).rejected as SdkError;
+        expect(rejection).toBeInstanceOf(SdkError);
+        expect(rejection.code).toBe(SdkErrorCode.InvalidResult);
+
+        await protocol.close();
+    });
+
+    test('a foreign non-string resultType is stripped; an otherwise-valid result resolves without it', async () => {
+        const protocol = await wireWithRawResult({ resultType: 42, content: [{ type: 'text', text: 'ok' }] });
+
+        const result = await protocol.request({ method: 'tools/call', params: { name: 'echo', arguments: {} } });
+        expect(result.content).toEqual([{ type: 'text', text: 'ok' }]);
         expect('resultType' in result).toBe(false);
 
         await protocol.close();
@@ -121,20 +167,18 @@ describe('raw-first resultType discrimination in the request funnel', () => {
     test("resultType 'complete' on a strict empty result still parses (stripped before validation)", async () => {
         const protocol = await wireWithRawResult({ resultType: 'complete' });
 
-        // EmptyResultSchema is strict; the discriminator is consumed before
-        // validation, so the 2026-era ack parses as the public empty result.
         const result = await protocol.request({ method: 'ping' });
         expect(result).toEqual({});
 
         await protocol.close();
     });
 
-    test('absent resultType is untouched 2025-era behavior', async () => {
-        const protocol = await wireWithRawResult({ content: [{ type: 'text', text: 'plain' }], extra: 'kept' });
+    test('absent resultType is untouched 2025-era behavior (siblings kept)', async () => {
+        const protocol = await wireWithRawResult({ content: [{ type: 'text', text: 'plain' }], extraSibling: 'kept' });
 
         const result = await protocol.request({ method: 'tools/call', params: { name: 'echo', arguments: {} } });
         expect(result.content).toEqual([{ type: 'text', text: 'plain' }]);
-        expect((result as Record<string, unknown>).extra).toBe('kept');
+        expect((result as Record<string, unknown>).extraSibling).toBe('kept');
 
         await protocol.close();
     });

--- a/packages/core/test/shared/rawResultTypeFirst.test.ts
+++ b/packages/core/test/shared/rawResultTypeFirst.test.ts
@@ -183,3 +183,19 @@ describe('raw-first resultType handling — 2025 era (strip-on-lift, Q1-SD3 ii)'
         await protocol.close();
     });
 });
+
+describe('decode step 2 — the wire-exact schema lookup is own-key only', () => {
+    test("a prototype-chain method name (e.g. 'constructor') skips the wire-exact parse instead of throwing", async () => {
+        const { rev2026Codec } = await import('../../src/wire/rev2026-07-28/codec.js');
+        // A bare object-prototype hit would surface Function (not a schema)
+        // and throw a TypeError out of the decode hop. The lookup must treat
+        // non-own keys exactly like unknown methods: no wire-exact parse,
+        // straight to the lift.
+        const decoded = rev2026Codec.decodeResult('constructor', { resultType: 'complete', anything: 'kept' });
+        expect(decoded.kind).toBe('complete');
+        if (decoded.kind === 'complete') {
+            expect((decoded.result as Record<string, unknown>).anything).toBe('kept');
+            expect('resultType' in decoded.result).toBe(false);
+        }
+    });
+});

--- a/packages/core/test/spec.types.2025-11-25.test.ts
+++ b/packages/core/test/spec.types.2025-11-25.test.ts
@@ -1,13 +1,16 @@
 /**
- * Compares the SDK's types against the frozen 2025-11-25 release schema
- * (spec.types.2025-11-25.ts). The 2026-07-28 comparison lives in
+ * Per-revision parity against the FROZEN 2025-11-25 release schema
+ * (spec.types.2025-11-25.ts). The draft comparison lives in
  * spec.types.2026-07-28.test.ts.
  *
- * This contains:
- * - Static type checks to verify the Spec's types are compatible with the SDK's types
- *   (mutually assignable — no type-level workarounds should be needed)
- * - Runtime checks to verify each Spec type has a static check
- *   (note: a few don't have SDK types, see MISSING_SDK_TYPES below)
+ * Q1 increment 2 retired the 20 `@ts-expect-error` affordances this file
+ * used to carry: where the neutral public types deliberately follow the
+ * 2026-07-28 typing (the shared-tier adjudications), the comparisons now
+ * target the 2025-era WIRE-VIEW types (`wire/rev2025-11-25/wireTypes.ts`),
+ * which restate the anchor shape exactly and document each adjudication in
+ * one place. Zero affordances remain: every check below is exact, both
+ * directions, and the key-parity pins include the previously-suppressed
+ * names (PromptArgument/PromptReference `title`, the capabilities key sets).
  */
 import fs from 'node:fs';
 import path from 'node:path';
@@ -19,6 +22,21 @@ import type * as SDKTypes from '../src/types/index.js';
 // Role-union comparisons against this FROZEN revision's anchor therefore
 // target the wire-era artifacts.
 import type * as Wire2025 from '../src/wire/rev2025-11-25/schemas.js';
+import type {
+    Wire2025ClientCapabilities,
+    Wire2025ClientRequestView,
+    Wire2025CreateMessageRequest,
+    Wire2025CreateMessageRequestParams,
+    Wire2025InitializeRequest,
+    Wire2025InitializeRequestParams,
+    Wire2025InitializeResult,
+    Wire2025ListToolsResult,
+    Wire2025PromptArgument,
+    Wire2025PromptReference,
+    Wire2025ServerCapabilities,
+    Wire2025ServerRequestView,
+    Wire2025Tool
+} from '../src/wire/rev2025-11-25/wireTypes.js';
 import type * as z4 from 'zod/v4';
 
 type Wire2025ClientRequest = z4.infer<typeof Wire2025.ClientRequestSchema>;
@@ -49,8 +67,7 @@ const sdkTypeChecks = {
         sdk = spec;
         spec = sdk;
     },
-    InitializeRequestParams: (sdk: SDKTypes.InitializeRequestParams, spec: SpecTypes.InitializeRequestParams) => {
-        // @ts-expect-error 2025-11-25 types capabilities.experimental values as `object`; the SDK follows the 2026-07-28 schema's JSONObject
+    InitializeRequestParams: (sdk: Wire2025InitializeRequestParams, spec: SpecTypes.InitializeRequestParams) => {
         sdk = spec;
         spec = sdk;
     },
@@ -100,10 +117,8 @@ const sdkTypeChecks = {
         sdk = spec;
         spec = sdk;
     },
-    CreateMessageRequestParams: (sdk: SDKTypes.CreateMessageRequestParams, spec: SpecTypes.CreateMessageRequestParams) => {
-        // @ts-expect-error 2025-11-25 types `metadata` as `object`; the SDK follows the 2026-07-28 schema's JSONObject
+    CreateMessageRequestParams: (sdk: Wire2025CreateMessageRequestParams, spec: SpecTypes.CreateMessageRequestParams) => {
         sdk = spec;
-        // @ts-expect-error the SDK's JSONValue-typed tool inputSchema properties are not assignable to 2025-11-25's `object`
         spec = sdk;
     },
     CompleteRequestParams: (sdk: SDKTypes.CompleteRequestParams, spec: SpecTypes.CompleteRequestParams) => {
@@ -257,20 +272,16 @@ const sdkTypeChecks = {
         sdk = spec;
         spec = sdk;
     },
-    Tool: (sdk: SDKTypes.Tool, spec: SpecTypes.Tool) => {
-        // @ts-expect-error 2025-11-25 types inputSchema/outputSchema properties as `object`; the SDK follows the 2026-07-28 schema's JSONValue
+    Tool: (sdk: Wire2025Tool, spec: SpecTypes.Tool) => {
         sdk = spec;
-        // @ts-expect-error the SDK's JSONValue-typed inputSchema/outputSchema properties are not assignable to 2025-11-25's `object`
         spec = sdk;
     },
     ListToolsRequest: (sdk: WithJSONRPCRequest<SDKTypes.ListToolsRequest>, spec: SpecTypes.ListToolsRequest) => {
         sdk = spec;
         spec = sdk;
     },
-    ListToolsResult: (sdk: SDKTypes.ListToolsResult, spec: SpecTypes.ListToolsResult) => {
-        // @ts-expect-error 2025-11-25 vs 2026-07-28 Tool typing; see the Tool check above
+    ListToolsResult: (sdk: Wire2025ListToolsResult, spec: SpecTypes.ListToolsResult) => {
         sdk = spec;
-        // @ts-expect-error 2025-11-25 vs 2026-07-28 Tool typing; see the Tool check above
         spec = sdk;
     },
     CallToolResult: (sdk: SDKTypes.CallToolResult, spec: SpecTypes.CallToolResult) => {
@@ -489,41 +500,32 @@ const sdkTypeChecks = {
         sdk = spec;
         spec = sdk;
     },
-    CreateMessageRequest: (sdk: WithJSONRPCRequest<SDKTypes.CreateMessageRequest>, spec: SpecTypes.CreateMessageRequest) => {
-        // @ts-expect-error 2025-11-25 vs 2026-07-28 typing of params metadata/tools; see the CreateMessageRequestParams check above
-        sdk = spec;
-        // @ts-expect-error 2025-11-25 vs 2026-07-28 typing of params metadata/tools; see the CreateMessageRequestParams check above
-        spec = sdk;
-    },
-    InitializeRequest: (sdk: WithJSONRPCRequest<SDKTypes.InitializeRequest>, spec: SpecTypes.InitializeRequest) => {
-        // @ts-expect-error 2025-11-25 types capabilities.experimental values as `object`; the SDK follows the 2026-07-28 schema's JSONObject
+    CreateMessageRequest: (sdk: WithJSONRPCRequest<Wire2025CreateMessageRequest>, spec: SpecTypes.CreateMessageRequest) => {
         sdk = spec;
         spec = sdk;
     },
-    InitializeResult: (sdk: SDKTypes.InitializeResult, spec: SpecTypes.InitializeResult) => {
-        // @ts-expect-error 2025-11-25 types capabilities.experimental values as `object`; the SDK follows the 2026-07-28 schema's JSONObject
+    InitializeRequest: (sdk: WithJSONRPCRequest<Wire2025InitializeRequest>, spec: SpecTypes.InitializeRequest) => {
         sdk = spec;
         spec = sdk;
     },
-    ClientCapabilities: (sdk: SDKTypes.ClientCapabilities, spec: SpecTypes.ClientCapabilities) => {
-        // @ts-expect-error 2025-11-25 types experimental/sampling/elicitation/tasks blobs as `object`; the SDK follows the 2026-07-28 schema's JSONObject
+    InitializeResult: (sdk: Wire2025InitializeResult, spec: SpecTypes.InitializeResult) => {
         sdk = spec;
         spec = sdk;
     },
-    ServerCapabilities: (sdk: SDKTypes.ServerCapabilities, spec: SpecTypes.ServerCapabilities) => {
-        // @ts-expect-error 2025-11-25 types experimental/logging/completions/tasks blobs as `object`; the SDK follows the 2026-07-28 schema's JSONObject
+    ClientCapabilities: (sdk: Wire2025ClientCapabilities, spec: SpecTypes.ClientCapabilities) => {
         sdk = spec;
         spec = sdk;
     },
-    ClientRequest: (sdk: WithJSONRPCRequest<Wire2025ClientRequest>, spec: SpecTypes.ClientRequest) => {
-        // @ts-expect-error 2025-11-25 types capabilities.experimental values as `object` (via the InitializeRequest member); the SDK follows the 2026-07-28 schema's JSONObject
+    ServerCapabilities: (sdk: Wire2025ServerCapabilities, spec: SpecTypes.ServerCapabilities) => {
         sdk = spec;
         spec = sdk;
     },
-    ServerRequest: (sdk: WithJSONRPCRequest<Wire2025ServerRequest>, spec: SpecTypes.ServerRequest) => {
-        // @ts-expect-error 2025-11-25 vs 2026-07-28 typing of CreateMessageRequest params; see the CreateMessageRequestParams check above
+    ClientRequest: (sdk: WithJSONRPCRequest<Wire2025ClientRequestView>, spec: SpecTypes.ClientRequest) => {
         sdk = spec;
-        // @ts-expect-error 2025-11-25 vs 2026-07-28 typing of CreateMessageRequest params; see the CreateMessageRequestParams check above
+        spec = sdk;
+    },
+    ServerRequest: (sdk: WithJSONRPCRequest<Wire2025ServerRequestView>, spec: SpecTypes.ServerRequest) => {
+        sdk = spec;
         spec = sdk;
     },
     LoggingMessageNotification: (sdk: WithJSONRPC<SDKTypes.LoggingMessageNotification>, spec: SpecTypes.LoggingMessageNotification) => {
@@ -727,8 +729,7 @@ type _K_JSONRPCNotification = Assert<AssertExactKeys<SDKTypes.JSONRPCNotificatio
 type _K_EmptyResult = Assert<AssertExactKeys<SDKTypes.EmptyResult, SpecTypes.EmptyResult>>;
 type _K_Notification = Assert<AssertExactKeys<SDKTypes.Notification, SpecTypes.Notification>>;
 type _K_ResourceTemplateReference = Assert<AssertExactKeys<SDKTypes.ResourceTemplateReference, SpecTypes.ResourceTemplateReference>>;
-// @ts-expect-error Genuine mismatch: SDK PromptReference is missing 'title' from spec
-type _K_PromptReference = Assert<AssertExactKeys<SDKTypes.PromptReference, SpecTypes.PromptReference>>;
+type _K_PromptReference = Assert<AssertExactKeys<Wire2025PromptReference, SpecTypes.PromptReference>>;
 type _K_ToolAnnotations = Assert<AssertExactKeys<SDKTypes.ToolAnnotations, SpecTypes.ToolAnnotations>>;
 type _K_Tool = Assert<AssertExactKeys<SDKTypes.Tool, SpecTypes.Tool>>;
 type _K_ListToolsResult = Assert<AssertExactKeys<SDKTypes.ListToolsResult, SpecTypes.ListToolsResult>>;
@@ -740,8 +741,7 @@ type _K_ResourceContents = Assert<AssertExactKeys<SDKTypes.ResourceContents, Spe
 type _K_TextResourceContents = Assert<AssertExactKeys<SDKTypes.TextResourceContents, SpecTypes.TextResourceContents>>;
 type _K_BlobResourceContents = Assert<AssertExactKeys<SDKTypes.BlobResourceContents, SpecTypes.BlobResourceContents>>;
 type _K_Resource = Assert<AssertExactKeys<SDKTypes.Resource, SpecTypes.Resource>>;
-// @ts-expect-error Genuine mismatch: SDK PromptArgument is missing 'title' from spec
-type _K_PromptArgument = Assert<AssertExactKeys<SDKTypes.PromptArgument, SpecTypes.PromptArgument>>;
+type _K_PromptArgument = Assert<AssertExactKeys<Wire2025PromptArgument, SpecTypes.PromptArgument>>;
 type _K_Prompt = Assert<AssertExactKeys<SDKTypes.Prompt, SpecTypes.Prompt>>;
 type _K_ListPromptsResult = Assert<AssertExactKeys<SDKTypes.ListPromptsResult, SpecTypes.ListPromptsResult>>;
 type _K_GetPromptResult = Assert<AssertExactKeys<SDKTypes.GetPromptResult, SpecTypes.GetPromptResult>>;
@@ -768,10 +768,8 @@ type _K_LegacyTitledEnumSchema = Assert<AssertExactKeys<SDKTypes.LegacyTitledEnu
 type _K_JSONRPCErrorResponse = Assert<AssertExactKeys<SDKTypes.JSONRPCErrorResponse, SpecTypes.JSONRPCErrorResponse>>;
 type _K_JSONRPCResultResponse = Assert<AssertExactKeys<SDKTypes.JSONRPCResultResponse, SpecTypes.JSONRPCResultResponse>>;
 type _K_InitializeResult = Assert<AssertExactKeys<SDKTypes.InitializeResult, SpecTypes.InitializeResult>>;
-// @ts-expect-error SDK follows the 2026-07-28 schema's `extensions` capability key; not in released 2025-11-25
-type _K_ClientCapabilities = Assert<AssertExactKeys<SDKTypes.ClientCapabilities, SpecTypes.ClientCapabilities>>;
-// @ts-expect-error SDK follows the 2026-07-28 schema's `extensions` capability key; not in released 2025-11-25
-type _K_ServerCapabilities = Assert<AssertExactKeys<SDKTypes.ServerCapabilities, SpecTypes.ServerCapabilities>>;
+type _K_ClientCapabilities = Assert<AssertExactKeys<Wire2025ClientCapabilities, SpecTypes.ClientCapabilities>>;
+type _K_ServerCapabilities = Assert<AssertExactKeys<Wire2025ServerCapabilities, SpecTypes.ServerCapabilities>>;
 type _K_SamplingMessage = Assert<AssertExactKeys<SDKTypes.SamplingMessage, SpecTypes.SamplingMessage>>;
 type _K_Icon = Assert<AssertExactKeys<SDKTypes.Icon, SpecTypes.Icon>>;
 type _K_Icons = Assert<AssertExactKeys<SDKTypes.Icons, SpecTypes.Icons>>;

--- a/packages/core/test/spec.types.2026-07-28.test.ts
+++ b/packages/core/test/spec.types.2026-07-28.test.ts
@@ -1,15 +1,20 @@
 /**
- * Compares the SDK's types against the upcoming 2026-07-28 schema (spec.types.2026-07-28.ts).
- * The frozen-release comparison lives in spec.types.2025-11-25.test.ts.
+ * Per-revision parity: the 2026-era WIRE artifacts against the 2026-07-28
+ * anchor (spec.types.2026-07-28.ts). The frozen-release comparison lives in
+ * spec.types.2025-11-25.test.ts.
  *
- * The SDK does not implement the 2026-07-28 surface yet: every 2026-07-28 type whose shape the SDK
- * does not (yet) match is listed in MISSING_SDK_TYPES_2026_07_28 below. Removing a name from
- * that list forces a real mutual-assignability check to be added to sdkTypeChecks (the
- * completeness tests below fail otherwise) — implementation work burns the list down.
+ * Q1 increment 2 retired the old 67-name burn-down list (whose "permanent
+ * stratum" could never burn under a single shared schema set): the SDK now
+ * models era-specific wire shapes in `wire/rev2026-07-28/`, and everything
+ * that module models is compared here EXACTLY — wire-true request views
+ * (envelope-required `_meta`), resultType-required result wrappers, the
+ * forked Tool/SamplingMessage payloads, response envelopes, and discover.
  *
- * Unlike MISSING_SDK_TYPES in the 2025-11-25 comparison, names in this list may well
- * exist in the SDK (e.g. RequestParams) — they are listed because the 2026-07-28 revision changed
- * their shape, not necessarily because the SDK lacks them.
+ * What remains unmodeled lives in FEATURE_OWNED_PENDING_2026 below: every
+ * entry is OWNED by a named feature issue and is stale-checked — adding a
+ * check for a pending name forces the entry's removal, and the completeness
+ * tests fail on any spec type that is neither checked nor owned. There is no
+ * permanent stratum: when the owning features land, the list reaches zero.
  */
 import fs from 'node:fs';
 import path from 'node:path';
@@ -21,6 +26,8 @@ import {
 } from '../src/types/spec.types.2026-07-28.js';
 import type * as SpecTypes from '../src/types/spec.types.2026-07-28.js';
 import type * as SDKTypes from '../src/types/index.js';
+import type * as Wire2026 from '../src/wire/rev2026-07-28/schemas.js';
+import type * as z4 from 'zod/v4';
 import {
     CLIENT_CAPABILITIES_META_KEY,
     CLIENT_INFO_META_KEY,
@@ -36,6 +43,40 @@ type WithJSONRPC<T> = T & { jsonrpc: '2.0' };
 
 // Adds the `jsonrpc` and `id` properties to a type, to match the on-wire format of requests.
 type WithJSONRPCRequest<T> = T & { jsonrpc: '2.0'; id: SDKTypes.RequestId };
+
+/* The 2026-era wire artifacts under comparison (inferred from the era module's
+ * Zod schemas — the same objects the codec parses with). */
+type WResult = z4.infer<typeof Wire2026.ResultSchema>;
+type WResultType = z4.infer<typeof Wire2026.ResultTypeSchema>;
+type WPaginatedResult = z4.infer<typeof Wire2026.PaginatedResultSchema>;
+type WCacheableResult = z4.infer<typeof Wire2026.CacheableResultSchema>;
+type WCallToolResult = z4.infer<typeof Wire2026.CallToolResultSchema>;
+type WCompleteResult = z4.infer<typeof Wire2026.CompleteResultSchema>;
+type WGetPromptResult = z4.infer<typeof Wire2026.GetPromptResultSchema>;
+type WListPromptsResult = z4.infer<typeof Wire2026.ListPromptsResultSchema>;
+type WListResourceTemplatesResult = z4.infer<typeof Wire2026.ListResourceTemplatesResultSchema>;
+type WListResourcesResult = z4.infer<typeof Wire2026.ListResourcesResultSchema>;
+type WListToolsResult = z4.infer<typeof Wire2026.ListToolsResultSchema>;
+type WReadResourceResult = z4.infer<typeof Wire2026.ReadResourceResultSchema>;
+type WDiscoverResult = z4.infer<typeof Wire2026.DiscoverResultSchema>;
+type WTool = z4.infer<typeof Wire2026.ToolSchema>;
+type WSamplingMessage = z4.infer<typeof Wire2026.SamplingMessageSchema>;
+type WJSONRPCResultResponse = z4.infer<typeof Wire2026.JSONRPCResultResponseSchema>;
+type WCompleteRequest = z4.infer<typeof Wire2026.CompleteRequestSchema>;
+type WListPromptsRequest = z4.infer<typeof Wire2026.ListPromptsRequestSchema>;
+type WListResourceTemplatesRequest = z4.infer<typeof Wire2026.ListResourceTemplatesRequestSchema>;
+type WListResourcesRequest = z4.infer<typeof Wire2026.ListResourcesRequestSchema>;
+type WListToolsRequest = z4.infer<typeof Wire2026.ListToolsRequestSchema>;
+type WReadResourceRequest = z4.infer<typeof Wire2026.ReadResourceRequestSchema>;
+type WDiscoverRequest = z4.infer<typeof Wire2026.DiscoverRequestSchema>;
+// Param/base shapes derived from the request views (no second source of truth):
+type WRequestParams = NonNullable<WDiscoverRequest['params']>;
+type WPaginatedRequestParams = WListToolsRequest['params'];
+type WResourceRequestParams = WReadResourceRequest['params'];
+type WCompleteRequestParams = WCompleteRequest['params'];
+// PaginatedRequest in the anchor keeps `method: string` (it is the base, not
+// a concrete method) — composed from the derived params shape.
+type WPaginatedRequest = WithJSONRPCRequest<{ method: string; params: WPaginatedRequestParams }>;
 
 const sdkTypeChecks = {
     JSONValue: (sdk: SDKTypes.JSONValue, spec: SpecTypes.JSONValue) => {
@@ -378,126 +419,245 @@ const sdkTypeChecks = {
     }
 };
 
+/* 2026-era wire parity checks (Q1 increment 2) — appended to sdkTypeChecks. */
+const wireParityChecks = {
+    Result: (sdk: WResult, spec: SpecTypes.Result) => {
+        sdk = spec;
+        spec = sdk;
+    },
+    ResultType: (sdk: WResultType, spec: SpecTypes.ResultType) => {
+        sdk = spec;
+        spec = sdk;
+    },
+    EmptyResult: (sdk: WResult, spec: SpecTypes.EmptyResult) => {
+        sdk = spec;
+        spec = sdk;
+    },
+    ClientResult: (sdk: WResult, spec: SpecTypes.ClientResult) => {
+        sdk = spec;
+        spec = sdk;
+    },
+    PaginatedResult: (sdk: WPaginatedResult, spec: SpecTypes.PaginatedResult) => {
+        sdk = spec;
+        spec = sdk;
+    },
+    CacheableResult: (sdk: WCacheableResult, spec: SpecTypes.CacheableResult) => {
+        sdk = spec;
+        spec = sdk;
+    },
+    CallToolResult: (sdk: WCallToolResult, spec: SpecTypes.CallToolResult) => {
+        sdk = spec;
+        spec = sdk;
+    },
+    CompleteResult: (sdk: WCompleteResult, spec: SpecTypes.CompleteResult) => {
+        sdk = spec;
+        spec = sdk;
+    },
+    GetPromptResult: (sdk: WGetPromptResult, spec: SpecTypes.GetPromptResult) => {
+        sdk = spec;
+        spec = sdk;
+    },
+    ListPromptsResult: (sdk: WListPromptsResult, spec: SpecTypes.ListPromptsResult) => {
+        sdk = spec;
+        spec = sdk;
+    },
+    ListResourceTemplatesResult: (sdk: WListResourceTemplatesResult, spec: SpecTypes.ListResourceTemplatesResult) => {
+        sdk = spec;
+        spec = sdk;
+    },
+    ListResourcesResult: (sdk: WListResourcesResult, spec: SpecTypes.ListResourcesResult) => {
+        sdk = spec;
+        spec = sdk;
+    },
+    ListToolsResult: (sdk: WListToolsResult, spec: SpecTypes.ListToolsResult) => {
+        sdk = spec;
+        spec = sdk;
+    },
+    ReadResourceResult: (sdk: WReadResourceResult, spec: SpecTypes.ReadResourceResult) => {
+        sdk = spec;
+        spec = sdk;
+    },
+    DiscoverResult: (sdk: WDiscoverResult, spec: SpecTypes.DiscoverResult) => {
+        sdk = spec;
+        spec = sdk;
+    },
+    DiscoverRequest: (sdk: WithJSONRPCRequest<WDiscoverRequest>, spec: SpecTypes.DiscoverRequest) => {
+        sdk = spec;
+        spec = sdk;
+    },
+    Tool: (sdk: WTool, spec: SpecTypes.Tool) => {
+        sdk = spec;
+        spec = sdk;
+    },
+    SamplingMessage: (sdk: WSamplingMessage, spec: SpecTypes.SamplingMessage) => {
+        sdk = spec;
+        spec = sdk;
+    },
+    SamplingMessageContentBlock: (
+        sdk: z4.infer<typeof Wire2026.SamplingMessageContentBlockSchema>,
+        spec: SpecTypes.SamplingMessageContentBlock
+    ) => {
+        sdk = spec;
+        spec = sdk;
+    },
+    ToolResultContent: (sdk: z4.infer<typeof Wire2026.ToolResultContentSchema>, spec: SpecTypes.ToolResultContent) => {
+        sdk = spec;
+        spec = sdk;
+    },
+    Notification: (sdk: SDKTypes.Notification, spec: SpecTypes.Notification) => {
+        sdk = spec;
+        spec = sdk;
+    },
+    JSONRPCResultResponse: (sdk: WJSONRPCResultResponse, spec: SpecTypes.JSONRPCResultResponse) => {
+        sdk = spec;
+        spec = sdk;
+    },
+    JSONRPCResponse: (sdk: WJSONRPCResultResponse | SDKTypes.JSONRPCErrorResponse, spec: SpecTypes.JSONRPCResponse) => {
+        sdk = spec;
+        spec = sdk;
+    },
+    JSONRPCMessage: (
+        sdk: SDKTypes.JSONRPCRequest | WithJSONRPC<SDKTypes.JSONRPCNotification> | WJSONRPCResultResponse | SDKTypes.JSONRPCErrorResponse,
+        spec: SpecTypes.JSONRPCMessage
+    ) => {
+        sdk = spec;
+        spec = sdk;
+    },
+    CompleteResultResponse: (sdk: z4.infer<typeof Wire2026.CompleteResultResponseSchema>, spec: SpecTypes.CompleteResultResponse) => {
+        sdk = spec;
+        spec = sdk;
+    },
+    ListPromptsResultResponse: (
+        sdk: z4.infer<typeof Wire2026.ListPromptsResultResponseSchema>,
+        spec: SpecTypes.ListPromptsResultResponse
+    ) => {
+        sdk = spec;
+        spec = sdk;
+    },
+    ListResourceTemplatesResultResponse: (
+        sdk: z4.infer<typeof Wire2026.ListResourceTemplatesResultResponseSchema>,
+        spec: SpecTypes.ListResourceTemplatesResultResponse
+    ) => {
+        sdk = spec;
+        spec = sdk;
+    },
+    ListResourcesResultResponse: (
+        sdk: z4.infer<typeof Wire2026.ListResourcesResultResponseSchema>,
+        spec: SpecTypes.ListResourcesResultResponse
+    ) => {
+        sdk = spec;
+        spec = sdk;
+    },
+    ListToolsResultResponse: (sdk: z4.infer<typeof Wire2026.ListToolsResultResponseSchema>, spec: SpecTypes.ListToolsResultResponse) => {
+        sdk = spec;
+        spec = sdk;
+    },
+    DiscoverResultResponse: (sdk: z4.infer<typeof Wire2026.DiscoverResultResponseSchema>, spec: SpecTypes.DiscoverResultResponse) => {
+        sdk = spec;
+        spec = sdk;
+    },
+    RequestParams: (sdk: WRequestParams, spec: SpecTypes.RequestParams) => {
+        sdk = spec;
+        spec = sdk;
+    },
+    PaginatedRequestParams: (sdk: WPaginatedRequestParams, spec: SpecTypes.PaginatedRequestParams) => {
+        sdk = spec;
+        spec = sdk;
+    },
+    ResourceRequestParams: (sdk: WResourceRequestParams, spec: SpecTypes.ResourceRequestParams) => {
+        sdk = spec;
+        spec = sdk;
+    },
+    CompleteRequestParams: (sdk: WCompleteRequestParams, spec: SpecTypes.CompleteRequestParams) => {
+        sdk = spec;
+        spec = sdk;
+    },
+    PaginatedRequest: (sdk: WPaginatedRequest, spec: SpecTypes.PaginatedRequest) => {
+        sdk = spec;
+        spec = sdk;
+    },
+    CompleteRequest: (sdk: WithJSONRPCRequest<WCompleteRequest>, spec: SpecTypes.CompleteRequest) => {
+        sdk = spec;
+        spec = sdk;
+    },
+    ListPromptsRequest: (sdk: WithJSONRPCRequest<WListPromptsRequest>, spec: SpecTypes.ListPromptsRequest) => {
+        sdk = spec;
+        spec = sdk;
+    },
+    ListResourceTemplatesRequest: (
+        sdk: WithJSONRPCRequest<WListResourceTemplatesRequest>,
+        spec: SpecTypes.ListResourceTemplatesRequest
+    ) => {
+        sdk = spec;
+        spec = sdk;
+    },
+    ListResourcesRequest: (sdk: WithJSONRPCRequest<WListResourcesRequest>, spec: SpecTypes.ListResourcesRequest) => {
+        sdk = spec;
+        spec = sdk;
+    },
+    ListToolsRequest: (sdk: WithJSONRPCRequest<WListToolsRequest>, spec: SpecTypes.ListToolsRequest) => {
+        sdk = spec;
+        spec = sdk;
+    }
+};
+
+const allTypeChecks = { ...sdkTypeChecks, ...wireParityChecks };
+
 // Generated from the 2026-07-28 schema by `pnpm run fetch:spec-types 2026-07-28 <sha>`.
 const SPEC_TYPES_FILE = path.resolve(__dirname, '../src/types/spec.types.2026-07-28.ts');
 
 /**
- * 2026-07-28 spec types the SDK does not match yet. Spec-implementation work for the
- * 2026-07-28 release removes entries from this list as the SDK adopts each shape.
+ * Spec types the 2026-era wire module does not model yet — every entry is
+ * OWNED by a named feature issue (no permanent stratum; the list reaches
+ * zero as the owners land). Adding a parity check for one of these names
+ * forces the entry's removal (stale-check below).
  */
-const MISSING_SDK_TYPES_2026_07_28 = [
+const FEATURE_OWNED_PENDING_2026: Record<string, string> = {
     // Inlined in the SDK (same as the 2025-11-25 comparison):
-    'Error', // The inner error object of a JSONRPCError
+    Error: 'the inner error object of a JSONRPCError is inlined in the SDK',
 
-    // SEP-2575 per-request envelope: 2026-07-28 requests REQUIRE a `_meta` envelope
-    // (`io.modelcontextprotocol/protocolVersion`, clientInfo, clientCapabilities). The
-    // envelope itself is modeled by RequestMetaEnvelope (see sdkTypeChecks above); the
-    // request shapes below stay here because the SDK wire schemas deliberately keep
-    // `_meta` lenient — the same schemas parse pre-2026 requests (no envelope) and 2026
-    // requests, with envelope requiredness enforced per request at dispatch. They burn
-    // only if the SDK ever models era-specific request types.
-    'RequestParams',
-    'PaginatedRequestParams',
-    'ResourceRequestParams',
-    'CallToolRequestParams',
-    'CompleteRequestParams',
-    'GetPromptRequestParams',
-    'ReadResourceRequestParams',
-    'CreateMessageRequestParams',
-    'PaginatedRequest',
-    'CallToolRequest',
-    'CompleteRequest',
-    'GetPromptRequest',
-    'ListPromptsRequest',
-    'ListResourceTemplatesRequest',
-    'ListResourcesRequest',
-    'ListRootsRequest',
-    'ListToolsRequest',
-    'ReadResourceRequest',
-    'CreateMessageRequest',
-    'ClientRequest',
+    // M4.1 MRTR (#13): the in-band input-request surface and the demoted
+    // sampling/elicitation/roots shapes (wire requests in 2025, in-band
+    // InputRequest payloads in 2026 — the SDK models them when the
+    // multi-round-trip driver lands):
+    InputRequest: 'M4.1 MRTR (#13)',
+    InputRequests: 'M4.1 MRTR (#13)',
+    InputRequiredResult: 'M4.1 MRTR (#13)',
+    InputResponse: 'M4.1 MRTR (#13)',
+    InputResponseRequestParams: 'M4.1 MRTR (#13)',
+    InputResponses: 'M4.1 MRTR (#13)',
+    CreateMessageRequest: 'M4.1 MRTR (#13) — demoted to an in-band payload in 2026',
+    CreateMessageRequestParams: 'M4.1 MRTR (#13) — demoted to an in-band payload in 2026',
+    CreateMessageResult: 'M4.1 MRTR (#13) — in-band response shape',
+    ElicitResult: 'M4.1 MRTR (#13) — in-band response shape',
+    ListRootsRequest: 'M4.1 MRTR (#13) — demoted to an in-band payload in 2026',
+    ListRootsResult: 'M4.1 MRTR (#13) — in-band response shape',
+    ServerResult: 'M4.1 MRTR (#13) — the union gains InputRequiredResult',
+    CallToolRequestParams: 'M4.1 MRTR (#13) — params extend InputResponseRequestParams (the retry channel)',
+    CallToolRequest: 'M4.1 MRTR (#13) — params extend InputResponseRequestParams (the retry channel)',
+    GetPromptRequestParams: 'M4.1 MRTR (#13) — params extend InputResponseRequestParams (the retry channel)',
+    GetPromptRequest: 'M4.1 MRTR (#13) — params extend InputResponseRequestParams (the retry channel)',
+    ReadResourceRequestParams: 'M4.1 MRTR (#13) — params extend InputResponseRequestParams (the retry channel)',
+    ReadResourceRequest: 'M4.1 MRTR (#13) — params extend InputResponseRequestParams (the retry channel)',
+    CallToolResultResponse: 'M4.1 MRTR (#13) — the result union gains InputRequiredResult',
+    GetPromptResultResponse: 'M4.1 MRTR (#13) — the result union gains InputRequiredResult',
+    ReadResourceResultResponse: 'M4.1 MRTR (#13) — the result union gains InputRequiredResult',
 
-    // SEP-2322 (MRTR) → PR for MRTR: 2026-07-28 results carry a required `resultType`
-    // discriminator. The SDK base result schema carries `resultType` as an optional
-    // passthrough only (absent means "complete"); per-result modeling lands with MRTR.
-    'Result',
-    'EmptyResult',
-    'PaginatedResult',
-    'CallToolResult',
-    'CompleteResult',
-    'ElicitResult',
-    'GetPromptResult',
-    'ListPromptsResult',
-    'ListResourceTemplatesResult',
-    'ListResourcesResult',
-    'ListRootsResult',
-    'ListToolsResult',
-    'ReadResourceResult',
-    'CreateMessageResult',
-    'ClientResult',
-    'ServerResult',
-    'ResultType',
+    // M6.1 subscriptions/listen (#14):
+    SubscriptionFilter: 'M6.1 subscriptions/listen (#14)',
+    SubscriptionsAcknowledgedNotification: 'M6.1 subscriptions/listen (#14)',
+    SubscriptionsAcknowledgedNotificationParams: 'M6.1 subscriptions/listen (#14)',
+    SubscriptionsListenRequest: 'M6.1 subscriptions/listen (#14)',
+    SubscriptionsListenRequestParams: 'M6.1 subscriptions/listen (#14)',
+    ClientRequest: 'M6.1 subscriptions/listen (#14) — the union gains SubscriptionsListenRequest',
+    ServerNotification: 'M6.1 subscriptions/listen (#14) — the union gains the acknowledged notification',
 
-    // SEP-2549 cacheable results: `ttlMs`/`cacheScope` caching hints on the list/read
-    // result shapes → PR for SEP-2549:
-    'CacheableResult',
+    // M1.2 validation ladder (#8): the per-code error response envelopes:
+    MissingRequiredClientCapabilityError: 'M1.2 validation ladder (#8)',
+    UnsupportedProtocolVersionError: 'M1.2 validation ladder (#8)'
+};
 
-    // Response envelopes embedding the changed Result shape → PR for MRTR:
-    'JSONRPCResultResponse',
-    'JSONRPCResponse',
-    'JSONRPCMessage',
-    'CallToolResultResponse',
-    'CompleteResultResponse',
-    'GetPromptResultResponse',
-    'ListPromptsResultResponse',
-    'ListResourceTemplatesResultResponse',
-    'ListResourcesResultResponse',
-    'ListToolsResultResponse',
-    'ReadResourceResultResponse',
-
-    // SEP-2575 sessionless discovery: the SDK ships the wire shapes
-    // (DiscoverRequestSchema / DiscoverResultSchema), but the 2026-07-28 shapes embed the
-    // required `_meta` envelope (request) and required `resultType` (result → MRTR PR),
-    // and DiscoverResult now extends CacheableResult (required `ttlMs`/`cacheScope`
-    // → PR for SEP-2549), so they do not match yet; DiscoverResultResponse is a
-    // response wrapper (→ MRTR PR):
-    'DiscoverRequest',
-    'DiscoverResult',
-    'DiscoverResultResponse',
-
-    // SEP-2567 input requests/responses (new surface) → PR for MRTR:
-    'InputRequest',
-    'InputRequests',
-    'InputRequiredResult',
-    'InputResponse',
-    'InputResponseRequestParams',
-    'InputResponses',
-
-    // 2026-07-28 subscriptions surface (new) → PR for subscriptions/listen:
-    'SubscriptionFilter',
-    'SubscriptionsAcknowledgedNotification',
-    'SubscriptionsAcknowledgedNotificationParams',
-    'SubscriptionsListenRequest',
-    'SubscriptionsListenRequestParams',
-
-    // New typed protocol errors: the SDK ships -32003/-32004 as ProtocolErrorCode
-    // entries plus the UnsupportedProtocolVersionError class (errors.ts); the spec's
-    // per-code error *response envelope* interfaces are not modeled as wire types:
-    'MissingRequiredClientCapabilityError',
-    'UnsupportedProtocolVersionError',
-
-    // Other shapes changed in the 2026-07-28 schema: sampling content changes (SamplingMessage,
-    // SamplingMessageContentBlock, ToolResultContent) → backchannel PR; open tool
-    // input/output schema typing (Tool); loosened Notification.params (Notification);
-    // server notification union, which gains the subscriptions ack (ServerNotification →
-    // PR for subscriptions/listen):
-    'SamplingMessage',
-    'SamplingMessageContentBlock',
-    'ToolResultContent',
-    'Tool',
-    'Notification',
-    'ServerNotification'
-];
+const MISSING_SDK_TYPES_2026_07_28 = Object.keys(FEATURE_OWNED_PENDING_2026);
 
 function extractExportedTypes(source: string): string[] {
     const matches = [...source.matchAll(/export\s+(?:interface|class|type)\s+(\w+)\b/g)];
@@ -540,7 +700,7 @@ describe('Spec Types (2026-07-28)', () => {
         const missingTests = [];
 
         for (const typeName of typesToCheck) {
-            if (!sdkTypeChecks[typeName as keyof typeof sdkTypeChecks]) {
+            if (!allTypeChecks[typeName as keyof typeof allTypeChecks]) {
                 missingTests.push(typeName);
             }
         }
@@ -548,12 +708,15 @@ describe('Spec Types (2026-07-28)', () => {
         expect(missingTests).toHaveLength(0);
     });
 
-    describe('Missing SDK Types', () => {
-        it.each(MISSING_SDK_TYPES_2026_07_28)(
-            '%s should not be present in MISSING_SDK_TYPES_2026_07_28 if it has a compatibility test',
-            type => {
-                expect(sdkTypeChecks[type as keyof typeof sdkTypeChecks]).toBeUndefined();
+    describe('Feature-owned pending entries', () => {
+        it.each(MISSING_SDK_TYPES_2026_07_28)('%s must not be pending once it has a parity check (stale-check)', type => {
+            expect(allTypeChecks[type as keyof typeof allTypeChecks]).toBeUndefined();
+        });
+
+        it('every pending entry names its owner', () => {
+            for (const [name, owner] of Object.entries(FEATURE_OWNED_PENDING_2026)) {
+                expect(owner.length, name).toBeGreaterThan(0);
             }
-        );
+        });
     });
 });

--- a/packages/core/test/types/schemaBoundaryPins.test.ts
+++ b/packages/core/test/types/schemaBoundaryPins.test.ts
@@ -17,6 +17,7 @@ import { describe, expect, test } from 'vitest';
 import {
     CallToolRequestSchema,
     CallToolResultSchema,
+    ClientCapabilitiesSchema,
     CompleteResultSchema,
     EmptyResultSchema,
     JSONRPCErrorResponseSchema,
@@ -27,7 +28,11 @@ import {
 } from '../../src/types/index.js';
 // The per-request envelope is wire-only vocabulary and now lives in the
 // 2026-era wire module (Q1 increment 2); its accept/reject line is unchanged.
-import { RequestMetaEnvelopeSchema } from '../../src/wire/rev2026-07-28/schemas.js';
+import {
+    ClientCapabilities2026Schema,
+    ListToolsResultSchema as Wire2026ListToolsResultSchema,
+    RequestMetaEnvelopeSchema
+} from '../../src/wire/rev2026-07-28/schemas.js';
 import type {
     CallToolResult,
     CompleteResult,
@@ -199,6 +204,52 @@ describe('RequestMetaEnvelopeSchema', () => {
     test('is loose: foreign _meta keys pass through', () => {
         const parsed = RequestMetaEnvelopeSchema.parse({ ...validEnvelope, 'com.example/custom': 'kept' });
         expect((parsed as Record<string, unknown>)['com.example/custom']).toBe('kept');
+    });
+
+    test('clientCapabilities are validated with the 2026 fork: tasks is not vocabulary on this revision', () => {
+        // The envelope composes ClientCapabilities2026Schema (the shared
+        // shape minus the deleted `tasks` key), matching the server-side
+        // fork wired into DiscoverResultSchema. A tasks-bearing claim is
+        // foreign vocabulary: it neither validates as a capability (a
+        // malformed value cannot reject the envelope) nor survives the parse.
+        const withMalformedTasks = {
+            ...validEnvelope,
+            'io.modelcontextprotocol/clientCapabilities': { tasks: 'not-an-object' }
+        };
+        expect(RequestMetaEnvelopeSchema.safeParse(withMalformedTasks).success).toBe(true);
+
+        const parsed = RequestMetaEnvelopeSchema.parse({
+            ...validEnvelope,
+            'io.modelcontextprotocol/clientCapabilities': { sampling: {}, tasks: { requests: {} } }
+        });
+        const capabilities = parsed['io.modelcontextprotocol/clientCapabilities'] as Record<string, unknown>;
+        expect(capabilities.sampling).toEqual({});
+        expect('tasks' in capabilities).toBe(false);
+    });
+
+    test('the 2026 client-capabilities fork tracks the shared shape exactly (minus tasks, by reference)', () => {
+        // The fork lists its members explicitly (dts-rollup determinism — see
+        // rev2026-07-28/schemas.ts); this oracle keeps the explicit list from
+        // drifting: same keys as the shared schema minus `tasks`, and every
+        // member is the SAME schema object, composed by reference.
+        const sharedKeys = Object.keys(ClientCapabilitiesSchema.shape).filter(key => key !== 'tasks');
+        expect(Object.keys(ClientCapabilities2026Schema.shape)).toEqual(sharedKeys);
+        for (const key of sharedKeys) {
+            expect(
+                (ClientCapabilities2026Schema.shape as Record<string, unknown>)[key],
+                `member '${key}' must be composed by reference from the shared shape`
+            ).toBe((ClientCapabilitiesSchema.shape as Record<string, unknown>)[key]);
+        }
+    });
+});
+
+describe('2026 wire result members', () => {
+    test('ttlMs is an integer at the wire boundary (anchor parity: the twin says integer)', () => {
+        // Type-level parity is structurally blind to this (TS can only say
+        // `number`), so pin it at the runtime boundary.
+        const base = { resultType: 'complete', ttlMs: 1500, cacheScope: 'public', tools: [] };
+        expect(Wire2026ListToolsResultSchema.safeParse(base).success).toBe(true);
+        expect(Wire2026ListToolsResultSchema.safeParse({ ...base, ttlMs: 1500.5 }).success).toBe(false);
     });
 });
 

--- a/packages/core/test/wire/eraGates.test.ts
+++ b/packages/core/test/wire/eraGates.test.ts
@@ -1,35 +1,45 @@
 /**
  * Physical deletions through real dispatch (Q1 increment 2).
  *
+ * Era is INSTANCE state: the negotiated protocol version held by the
+ * Protocol instance selects the wire codec for everything the connection
+ * sends and receives. Legacy is the default (hand-constructed instances and
+ * pre-negotiation traffic); modern-era instances get their version set
+ * through the package-internal hook (`setNegotiatedProtocolVersion`) — the
+ * same channel the modern-era server entry will use at instance binding.
+ *
  * Registry membership is the deletion story, and these tests prove it at the
  * protocol funnels, in both directions:
  *
- *  - inbound: a 2026-classified `tasks/get` gets −32601 BY ABSENCE — even
- *    with a handler registered (a custom handler cannot shadow a deleted
- *    spec method across eras); era-mismatched spec notifications are
+ *  - inbound: `tasks/get` on a modern-era instance gets −32601 BY ABSENCE —
+ *    even with a handler registered (a custom handler cannot shadow a
+ *    deleted spec method across eras); era-deleted spec notifications are
  *    silently dropped even with a handler registered.
  *  - outbound: an era-mismatched spec method dies locally with
  *    `SdkErrorCode.MethodNotSupportedByProtocolVersion` before anything
  *    reaches the transport.
  *  - the 2026 era requires the per-request envelope (−32602 when missing).
- *  - the stamp seam: 2026-classified responses carry `resultType:
- *    'complete'`; 2025-era responses NEVER carry it (the 2025 codec has no
- *    stamp code path — the never-stamp guarantee).
+ *  - the stamp seam: 2026-era responses carry `resultType: 'complete'`;
+ *    2025-era responses NEVER carry it (the 2025 codec has no stamp code
+ *    path — the never-stamp guarantee).
  *  - encode-side deleted-field strictness (Q1-SD3 iii): `execution` is
  *    stripped from tools and `tasks` from capability objects on 2026-era
  *    emissions; both survive untouched on the 2025 era.
  *
- * Classification is INJECTED via MessageExtraInfo (this layer only consumes
- * it; the production classifier is the entry/edge's job).
+ * `MessageExtraInfo.classification` (INJECTED here; the production
+ * classifier is the entry/edge's job) no longer selects the era per message:
+ * the funnel VALIDATES it against the instance era — a mismatch is an
+ * entry/routing error (typed −32004 rejection / notification drop, plus
+ * onerror), and unclassified traffic on a legacy instance behaves exactly as
+ * before the codec split (the B-2 rule).
  */
 import { describe, expect, test } from 'vitest';
 
 import { SdkError, SdkErrorCode } from '../../src/errors/sdkErrors.js';
 import type { BaseContext } from '../../src/shared/protocol.js';
-import { Protocol } from '../../src/shared/protocol.js';
+import { Protocol, setNegotiatedProtocolVersion } from '../../src/shared/protocol.js';
 import type { JSONRPCMessage, MessageClassification, Result } from '../../src/types/index.js';
 import { InMemoryTransport } from '../../src/util/inMemory.js';
-import { bindWireVersion } from '../../src/wire/codec.js';
 import * as z from 'zod/v4';
 
 class TestProtocol extends Protocol<BaseContext> {
@@ -55,25 +65,41 @@ interface Harness {
     deliver: (message: JSONRPCMessage, classification?: MessageClassification) => void;
     /** Messages the receiver sent back (responses, notifications). */
     sent: JSONRPCMessage[];
+    /** Out-of-band errors surfaced via the receiver's onerror. */
+    errors: Error[];
     flush: () => Promise<void>;
 }
 
-async function harness(setup?: (receiver: TestProtocol) => void): Promise<Harness> {
+interface HarnessOptions {
+    /**
+     * Marks the instance's era through the package-internal hook (the same
+     * channel the modern-era server entry uses at instance binding). Omitted
+     * = legacy default, exactly like a hand-constructed instance.
+     */
+    era?: '2025-11-25' | '2026-07-28';
+    setup?: (receiver: TestProtocol) => void;
+}
+
+async function harness(options: HarnessOptions = {}): Promise<Harness> {
     const [peerTx, receiverTx] = InMemoryTransport.createLinkedPair();
     const sent: JSONRPCMessage[] = [];
     peerTx.onmessage = message => void sent.push(message);
     await peerTx.start();
 
     const receiver = new TestProtocol();
-    setup?.(receiver);
+    const errors: Error[] = [];
+    receiver.onerror = error => void errors.push(error);
+    options.setup?.(receiver);
+    if (options.era !== undefined) setNegotiatedProtocolVersion(receiver, options.era);
     await receiver.connect(receiverTx);
 
     return {
         receiver,
         // Invoke the receiver-side transport callback directly so the test
-        // controls MessageExtraInfo (the classification consumption seam).
+        // controls MessageExtraInfo (the classification handoff seam).
         deliver: (message, classification) => receiverTx.onmessage?.(message, classification ? ({ classification } as never) : undefined),
         sent,
+        errors,
         flush: () => new Promise(resolve => setTimeout(resolve, 10))
     };
 }
@@ -81,18 +107,22 @@ async function harness(setup?: (receiver: TestProtocol) => void): Promise<Harnes
 const errorOf = (msg: JSONRPCMessage | undefined) => (msg as { error?: { code: number; message: string } } | undefined)?.error;
 const resultOf = (msg: JSONRPCMessage | undefined) => (msg as { result?: Record<string, unknown> } | undefined)?.result;
 
-describe('inbound era gates — deletions are physical', () => {
-    test('2026-classified tasks/get is −32601 BY ABSENCE even with a handler registered', async () => {
-        let handlerRan = false;
-        const h = await harness(receiver => {
-            // A custom (3-arg) handler deliberately shadowing the deleted
-            // spec method: it may serve the 2025 era only.
-            receiver.setRequestHandler('tasks/get', { params: z.looseObject({ taskId: z.string() }) }, () => {
-                handlerRan = true;
-                return {} as Result;
-            });
+describe('inbound era gates — deletions are physical, era is instance state', () => {
+    const registerTasksGetHandler = (onRun: () => void) => (receiver: TestProtocol) => {
+        // A custom (3-arg) handler deliberately shadowing the deleted
+        // spec method: it may serve the 2025 era only.
+        receiver.setRequestHandler('tasks/get', { params: z.looseObject({ taskId: z.string() }) }, () => {
+            onRun();
+            return {} as Result;
         });
+    };
 
+    test('a modern-era instance answers tasks/get with −32601 BY ABSENCE even with a handler registered', async () => {
+        let handlerRan = false;
+        const h = await harness({ era: '2026-07-28', setup: registerTasksGetHandler(() => (handlerRan = true)) });
+
+        // A matching modern classification rides along untouched — the
+        // handoff check accepts it; the era gate still answers by absence.
         h.deliver(
             { jsonrpc: '2.0', id: 1, method: 'tasks/get', params: { taskId: 't-1', _meta: { ...ENVELOPE } } } as JSONRPCMessage,
             MODERN
@@ -104,16 +134,12 @@ describe('inbound era gates — deletions are physical', () => {
         expect(errorOf(h.sent[0])).toMatchObject({ code: -32601, message: 'Method not found' });
     });
 
-    test('the SAME instance serves legacy tasks/get with that handler (per-request era truth)', async () => {
+    test('a legacy-era instance (the default) serves tasks/get with that handler — era is fixed per instance', async () => {
         let handlerRan = false;
-        const h = await harness(receiver => {
-            receiver.setRequestHandler('tasks/get', { params: z.looseObject({ taskId: z.string() }) }, () => {
-                handlerRan = true;
-                return {} as Result;
-            });
-        });
+        const h = await harness({ setup: registerTasksGetHandler(() => (handlerRan = true)) });
 
-        // Unclassified ⇒ legacy (Q2 default posture).
+        // Unclassified, hand-wired instance ⇒ legacy default (B-2): exactly
+        // the pre-split behavior.
         h.deliver({ jsonrpc: '2.0', id: 2, method: 'tasks/get', params: { taskId: 't-1' } } as JSONRPCMessage);
         await h.flush();
 
@@ -121,59 +147,76 @@ describe('inbound era gates — deletions are physical', () => {
         expect(resultOf(h.sent[0])).toBeDefined();
     });
 
-    test('2026-classified ping is −32601 by absence (the built-in pong cannot cross eras)', async () => {
-        const h = await harness();
-        h.deliver({ jsonrpc: '2.0', id: 3, method: 'ping', params: { _meta: { ...ENVELOPE } } } as JSONRPCMessage, MODERN);
-        await h.flush();
-        expect(errorOf(h.sent[0])).toMatchObject({ code: -32601 });
+    test('ping on a modern-era instance is −32601 by absence (the built-in pong cannot cross eras)', async () => {
+        const modern = await harness({ era: '2026-07-28' });
+        modern.deliver({ jsonrpc: '2.0', id: 3, method: 'ping', params: { _meta: { ...ENVELOPE } } } as JSONRPCMessage, MODERN);
+        await modern.flush();
+        expect(errorOf(modern.sent[0])).toMatchObject({ code: -32601 });
 
-        // …while the 2025 era keeps the automatic pong.
-        h.deliver({ jsonrpc: '2.0', id: 4, method: 'ping' } as JSONRPCMessage);
-        await h.flush();
-        expect(resultOf(h.sent[1])).toEqual({});
+        // …while a legacy-era instance keeps the automatic pong.
+        const legacy = await harness();
+        legacy.deliver({ jsonrpc: '2.0', id: 4, method: 'ping' } as JSONRPCMessage);
+        await legacy.flush();
+        expect(resultOf(legacy.sent[0])).toEqual({});
     });
 
-    test('a 2026-classified spec notification that the era deleted is dropped even with a handler', async () => {
+    test('a spec notification the modern era deleted is dropped even with a handler', async () => {
         let delivered = 0;
-        const h = await harness(receiver => {
+        const registerHandler = (receiver: TestProtocol) => {
             receiver.setNotificationHandler('notifications/tasks/status', { params: z.looseObject({}) }, () => {
                 delivered += 1;
             });
-        });
+        };
 
-        h.deliver(
+        const modern = await harness({ era: '2026-07-28', setup: registerHandler });
+        modern.deliver(
             { jsonrpc: '2.0', method: 'notifications/tasks/status', params: { taskId: 't', status: 'working' } } as JSONRPCMessage,
             MODERN
         );
-        await h.flush();
+        await modern.flush();
         expect(delivered).toBe(0);
 
-        // Legacy leg: delivered.
-        h.deliver({ jsonrpc: '2.0', method: 'notifications/tasks/status', params: { taskId: 't', status: 'working' } } as JSONRPCMessage);
-        await h.flush();
+        // Legacy-era instance: delivered.
+        const legacy = await harness({ setup: registerHandler });
+        legacy.deliver({
+            jsonrpc: '2.0',
+            method: 'notifications/tasks/status',
+            params: { taskId: 't', status: 'working' }
+        } as JSONRPCMessage);
+        await legacy.flush();
         expect(delivered).toBe(1);
     });
 
     test('out-of-universe custom methods stay era-blind (consumer-owned)', async () => {
         let served = 0;
-        const h = await harness(receiver => {
+        const registerHandler = (receiver: TestProtocol) => {
             receiver.setRequestHandler('acme/anything', { params: z.looseObject({}) }, () => {
                 served += 1;
                 return {} as Result;
             });
-        });
+        };
 
-        h.deliver({ jsonrpc: '2.0', id: 5, method: 'acme/anything', params: { _meta: { ...ENVELOPE } } } as JSONRPCMessage, MODERN);
-        h.deliver({ jsonrpc: '2.0', id: 6, method: 'acme/anything', params: {} } as JSONRPCMessage);
-        await h.flush();
+        // Served on a modern-era instance (envelope present, as 2026 requires)…
+        const modern = await harness({ era: '2026-07-28', setup: registerHandler });
+        modern.deliver({ jsonrpc: '2.0', id: 5, method: 'acme/anything', params: { _meta: { ...ENVELOPE } } } as JSONRPCMessage, MODERN);
+        // …and on a legacy-era instance, bare: the era gate never blocks
+        // methods outside the spec universe on either era.
+        const legacy = await harness({ setup: registerHandler });
+        legacy.deliver({ jsonrpc: '2.0', id: 6, method: 'acme/anything', params: {} } as JSONRPCMessage);
+
+        await modern.flush();
+        await legacy.flush();
         expect(served).toBe(2);
     });
 });
 
 describe('2026-era envelope requiredness at dispatch', () => {
-    test('a modern-classified request without the envelope is −32602 naming the requirement', async () => {
-        const h = await harness(receiver => {
-            receiver.setRequestHandler('tools/list', () => ({ tools: [] }));
+    test('a modern-era request without the envelope is −32602 naming the requirement', async () => {
+        const h = await harness({
+            era: '2026-07-28',
+            setup: receiver => {
+                receiver.setRequestHandler('tools/list', () => ({ tools: [] }));
+            }
         });
 
         h.deliver({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} } as JSONRPCMessage, MODERN);
@@ -184,9 +227,12 @@ describe('2026-era envelope requiredness at dispatch', () => {
         expect(error?.message).toContain('_meta envelope');
     });
 
-    test('a modern-classified request with a valid envelope is served (handler sees the 2025 shape)', async () => {
-        const h = await harness(receiver => {
-            receiver.setRequestHandler('tools/list', () => ({ tools: [] }));
+    test('a modern-era request with a valid envelope is served (handler sees the 2025 shape)', async () => {
+        const h = await harness({
+            era: '2026-07-28',
+            setup: receiver => {
+                receiver.setRequestHandler('tools/list', () => ({ tools: [] }));
+            }
         });
 
         h.deliver({ jsonrpc: '2.0', id: 2, method: 'tools/list', params: { _meta: { ...ENVELOPE } } } as JSONRPCMessage, MODERN);
@@ -196,8 +242,10 @@ describe('2026-era envelope requiredness at dispatch', () => {
     });
 
     test('the 2025 era never requires an envelope', async () => {
-        const h = await harness(receiver => {
-            receiver.setRequestHandler('tools/list', () => ({ tools: [] }));
+        const h = await harness({
+            setup: receiver => {
+                receiver.setRequestHandler('tools/list', () => ({ tools: [] }));
+            }
         });
 
         h.deliver({ jsonrpc: '2.0', id: 3, method: 'tools/list', params: {} } as JSONRPCMessage);
@@ -211,7 +259,7 @@ describe('2026-era envelope requiredness at dispatch', () => {
         // with the validation-ladder milestone; this pins the
         // −32601-over-−32602 rule on the modern leg). All three −32601
         // producers win over the envelope −32602:
-        const h = await harness();
+        const h = await harness({ era: '2026-07-28' });
 
         // (a) out-of-universe method, no handler registered;
         h.deliver({ jsonrpc: '2.0', id: 4, method: 'acme/no-such-method', params: {} } as JSONRPCMessage, MODERN);
@@ -229,9 +277,12 @@ describe('2026-era envelope requiredness at dispatch', () => {
 });
 
 describe('the stamp seam and the never-stamp guarantee', () => {
-    test('2026-classified responses are stamped resultType: complete', async () => {
-        const h = await harness(receiver => {
-            receiver.setRequestHandler('tools/list', () => ({ tools: [] }));
+    test('2026-era responses are stamped resultType: complete', async () => {
+        const h = await harness({
+            era: '2026-07-28',
+            setup: receiver => {
+                receiver.setRequestHandler('tools/list', () => ({ tools: [] }));
+            }
         });
 
         h.deliver({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: { _meta: { ...ENVELOPE } } } as JSONRPCMessage, MODERN);
@@ -241,8 +292,10 @@ describe('the stamp seam and the never-stamp guarantee', () => {
     });
 
     test('2025-era responses NEVER carry resultType (no stamp code path exists)', async () => {
-        const h = await harness(receiver => {
-            receiver.setRequestHandler('tools/list', () => ({ tools: [] }));
+        const h = await harness({
+            setup: receiver => {
+                receiver.setRequestHandler('tools/list', () => ({ tools: [] }));
+            }
         });
 
         h.deliver({ jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} } as JSONRPCMessage);
@@ -268,8 +321,11 @@ describe('encode-side deleted-field strictness (Q1-SD3 iii)', () => {
     };
 
     test('execution.taskSupport is stripped from 2026-era tools/list emissions', async () => {
-        const h = await harness(receiver => {
-            receiver.setRequestHandler('tools/list', (() => ({ tools: [TOOL_WITH_EXECUTION] })) as never);
+        const h = await harness({
+            era: '2026-07-28',
+            setup: receiver => {
+                receiver.setRequestHandler('tools/list', (() => ({ tools: [TOOL_WITH_EXECUTION] })) as never);
+            }
         });
 
         h.deliver({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: { _meta: { ...ENVELOPE } } } as JSONRPCMessage, MODERN);
@@ -281,8 +337,10 @@ describe('encode-side deleted-field strictness (Q1-SD3 iii)', () => {
     });
 
     test('the same handler emits execution untouched on the 2025 era (era-invisible handlers)', async () => {
-        const h = await harness(receiver => {
-            receiver.setRequestHandler('tools/list', (() => ({ tools: [TOOL_WITH_EXECUTION] })) as never);
+        const h = await harness({
+            setup: receiver => {
+                receiver.setRequestHandler('tools/list', (() => ({ tools: [TOOL_WITH_EXECUTION] })) as never);
+            }
         });
 
         h.deliver({ jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} } as JSONRPCMessage);
@@ -293,17 +351,20 @@ describe('encode-side deleted-field strictness (Q1-SD3 iii)', () => {
     });
 
     test('capabilities.tasks is stripped from 2026-era capability-carrying emissions (server/discover)', async () => {
-        const h = await harness(receiver => {
-            receiver.setRequestHandler(
-                'server/discover' as never,
-                (() => ({
-                    ttlMs: 0,
-                    cacheScope: 'private',
-                    supportedVersions: ['2026-07-28'],
-                    capabilities: { tools: {}, tasks: { list: {} } },
-                    serverInfo: { name: 's', version: '0' }
-                })) as never
-            );
+        const h = await harness({
+            era: '2026-07-28',
+            setup: receiver => {
+                receiver.setRequestHandler(
+                    'server/discover' as never,
+                    (() => ({
+                        ttlMs: 0,
+                        cacheScope: 'private',
+                        supportedVersions: ['2026-07-28'],
+                        capabilities: { tools: {}, tasks: { list: {} } },
+                        serverInfo: { name: 's', version: '0' }
+                    })) as never
+                );
+            }
         });
 
         h.deliver({ jsonrpc: '2.0', id: 3, method: 'server/discover', params: { _meta: { ...ENVELOPE } } } as JSONRPCMessage, MODERN);
@@ -315,10 +376,92 @@ describe('encode-side deleted-field strictness (Q1-SD3 iii)', () => {
     });
 });
 
+describe('the edge→instance handoff — classification is validated, never an era switch', () => {
+    test('a modern-classified request on a legacy-era instance is an entry/routing error: typed −32004, handler never runs', async () => {
+        let handlerRan = false;
+        const h = await harness({
+            setup: receiver => {
+                receiver.setRequestHandler('tools/list', () => {
+                    handlerRan = true;
+                    return { tools: [] };
+                });
+            }
+        });
+
+        h.deliver({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: { _meta: { ...ENVELOPE } } } as JSONRPCMessage, MODERN);
+        await h.flush();
+
+        expect(handlerRan).toBe(false);
+        expect(h.sent).toHaveLength(1);
+        const error = errorOf(h.sent[0]);
+        expect(error?.code).toBe(-32004);
+        expect(error?.message).toContain('Unsupported protocol version');
+        // Surfaced out of band too: the mismatch is the entry's bug, not the peer's.
+        expect(h.errors.some(e => e.message.includes('Era mismatch'))).toBe(true);
+    });
+
+    test('a legacy-classified request on a modern-era instance is rejected the same way', async () => {
+        const h = await harness({
+            era: '2026-07-28',
+            setup: receiver => {
+                receiver.setRequestHandler('tools/list', () => ({ tools: [] }));
+            }
+        });
+
+        h.deliver({ jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} } as JSONRPCMessage, {
+            era: 'legacy',
+            revision: '2025-11-25'
+        });
+        await h.flush();
+
+        expect(errorOf(h.sent[0])).toMatchObject({ code: -32004 });
+        expect(h.errors.some(e => e.message.includes('Era mismatch'))).toBe(true);
+    });
+
+    test('a modern-classified notification on a legacy-era instance is dropped, with onerror', async () => {
+        let delivered = 0;
+        const h = await harness({
+            setup: receiver => {
+                receiver.setNotificationHandler('notifications/progress', () => {
+                    delivered += 1;
+                });
+            }
+        });
+
+        h.deliver(
+            { jsonrpc: '2.0', method: 'notifications/progress', params: { progressToken: 1, progress: 1 } } as JSONRPCMessage,
+            MODERN
+        );
+        await h.flush();
+
+        expect(delivered).toBe(0);
+        expect(h.sent).toHaveLength(0);
+        expect(h.errors.some(e => e.message.includes('Era mismatch'))).toBe(true);
+    });
+
+    test('a matching classification rides along untouched (and unclassified legacy traffic is byte-identical — B-2)', async () => {
+        const h = await harness({
+            setup: receiver => {
+                receiver.setRequestHandler('tools/list', () => ({ tools: [] }));
+            }
+        });
+
+        // Matching legacy classification.
+        h.deliver({ jsonrpc: '2.0', id: 3, method: 'tools/list', params: {} } as JSONRPCMessage, { era: 'legacy' });
+        // Unclassified (the hand-wired transport posture).
+        h.deliver({ jsonrpc: '2.0', id: 4, method: 'tools/list', params: {} } as JSONRPCMessage);
+        await h.flush();
+
+        expect(h.sent).toHaveLength(2);
+        expect(resultOf(h.sent[0])).toMatchObject({ tools: [] });
+        expect(resultOf(h.sent[1])).toMatchObject({ tools: [] });
+        expect(h.errors).toHaveLength(0);
+    });
+});
+
 describe('outbound era gates — typed local error before the transport', () => {
-    test('a 2026-bound instance cannot send 2025-only spec methods', async () => {
-        const h = await harness();
-        bindWireVersion(h.receiver, '2026-07-28');
+    test('a 2026-era instance cannot send 2025-only spec methods', async () => {
+        const h = await harness({ era: '2026-07-28' });
 
         for (const method of ['tasks/get', 'ping', 'logging/setLevel', 'resources/subscribe']) {
             const attempt = () => h.receiver.request({ method } as never);
@@ -334,9 +477,8 @@ describe('outbound era gates — typed local error before the transport', () => 
         expect(h.sent).toHaveLength(0);
     });
 
-    test('a legacy-bound instance cannot send server/discover', async () => {
-        const h = await harness();
-        bindWireVersion(h.receiver, '2025-11-25');
+    test('a legacy-era instance cannot send server/discover', async () => {
+        const h = await harness({ era: '2025-11-25' });
 
         expect(() => h.receiver.request({ method: 'server/discover' } as never)).toThrow(SdkError);
         try {
@@ -348,8 +490,7 @@ describe('outbound era gates — typed local error before the transport', () => 
     });
 
     test('outbound era-mismatched spec notifications die locally too', async () => {
-        const h = await harness();
-        bindWireVersion(h.receiver, '2026-07-28');
+        const h = await harness({ era: '2026-07-28' });
 
         await expect(h.receiver.notification({ method: 'notifications/roots/list_changed' })).rejects.toMatchObject({
             code: SdkErrorCode.MethodNotSupportedByProtocolVersion
@@ -358,9 +499,10 @@ describe('outbound era gates — typed local error before the transport', () => 
     });
 
     test('pre-negotiation bootstrap pins still route initialize to the 2025 era', async () => {
-        // An UNBOUND instance may always send the legacy handshake; binding a
-        // modern version afterwards closes it (the pin is pre-negotiation
-        // only — a negotiated session never re-routes onto the other era).
+        // An instance with NO negotiated version may always send the legacy
+        // handshake; setting a modern version afterwards closes it (the pin
+        // applies only while the negotiated version is unset — a negotiated
+        // session never re-routes onto the other era).
         const h = await harness();
         const pending = h.receiver.request({
             method: 'initialize',
@@ -373,8 +515,7 @@ describe('outbound era gates — typed local error before the transport', () => 
         expect((h.sent[0] as { method?: string }).method).toBe('initialize');
         await h.receiver.close();
 
-        const h2 = await harness();
-        bindWireVersion(h2.receiver, '2026-07-28');
+        const h2 = await harness({ era: '2026-07-28' });
         expect(() =>
             h2.receiver.request({
                 method: 'initialize',

--- a/packages/core/test/wire/eraGates.test.ts
+++ b/packages/core/test/wire/eraGates.test.ts
@@ -204,6 +204,28 @@ describe('2026-era envelope requiredness at dispatch', () => {
         await h.flush();
         expect(resultOf(h.sent[0])).toMatchObject({ tools: [] });
     });
+
+    test('−32601 outranks the missing envelope: unknown/era-deleted/unserved methods answer method-not-found', async () => {
+        // Method existence outranks parameter validity (the canonical
+        // precedence table for the full inbound validation ladder arrives
+        // with the validation-ladder milestone; this pins the
+        // −32601-over-−32602 rule on the modern leg). All three −32601
+        // producers win over the envelope −32602:
+        const h = await harness();
+
+        // (a) out-of-universe method, no handler registered;
+        h.deliver({ jsonrpc: '2.0', id: 4, method: 'acme/no-such-method', params: {} } as JSONRPCMessage, MODERN);
+        // (b) spec method deleted from the era (the era gate runs first);
+        h.deliver({ jsonrpc: '2.0', id: 5, method: 'tasks/get', params: { taskId: 't-1' } } as JSONRPCMessage, MODERN);
+        // (c) spec method IN era but with no handler registered.
+        h.deliver({ jsonrpc: '2.0', id: 6, method: 'tools/list', params: {} } as JSONRPCMessage, MODERN);
+        await h.flush();
+
+        expect(h.sent).toHaveLength(3);
+        for (const message of h.sent) {
+            expect(errorOf(message)).toMatchObject({ code: -32601, message: 'Method not found' });
+        }
+    });
 });
 
 describe('the stamp seam and the never-stamp guarantee', () => {

--- a/packages/core/test/wire/eraGates.test.ts
+++ b/packages/core/test/wire/eraGates.test.ts
@@ -1,0 +1,409 @@
+/**
+ * Physical deletions through real dispatch (Q1 increment 2).
+ *
+ * Registry membership is the deletion story, and these tests prove it at the
+ * protocol funnels, in both directions:
+ *
+ *  - inbound: a 2026-classified `tasks/get` gets −32601 BY ABSENCE — even
+ *    with a handler registered (a custom handler cannot shadow a deleted
+ *    spec method across eras); era-mismatched spec notifications are
+ *    silently dropped even with a handler registered.
+ *  - outbound: an era-mismatched spec method dies locally with
+ *    `SdkErrorCode.MethodNotSupportedByProtocolVersion` before anything
+ *    reaches the transport.
+ *  - the 2026 era requires the per-request envelope (−32602 when missing).
+ *  - the stamp seam: 2026-classified responses carry `resultType:
+ *    'complete'`; 2025-era responses NEVER carry it (the 2025 codec has no
+ *    stamp code path — the never-stamp guarantee).
+ *  - encode-side deleted-field strictness (Q1-SD3 iii): `execution` is
+ *    stripped from tools and `tasks` from capability objects on 2026-era
+ *    emissions; both survive untouched on the 2025 era.
+ *
+ * Classification is INJECTED via MessageExtraInfo (this layer only consumes
+ * it; the production classifier is the entry/edge's job).
+ */
+import { describe, expect, test } from 'vitest';
+
+import { SdkError, SdkErrorCode } from '../../src/errors/sdkErrors.js';
+import type { BaseContext } from '../../src/shared/protocol.js';
+import { Protocol } from '../../src/shared/protocol.js';
+import type { JSONRPCMessage, MessageClassification, Result } from '../../src/types/index.js';
+import { InMemoryTransport } from '../../src/util/inMemory.js';
+import { bindWireVersion } from '../../src/wire/codec.js';
+import * as z from 'zod/v4';
+
+class TestProtocol extends Protocol<BaseContext> {
+    protected assertCapabilityForMethod(): void {}
+    protected assertNotificationCapability(): void {}
+    protected assertRequestHandlerCapability(): void {}
+    protected buildContext(ctx: BaseContext): BaseContext {
+        return ctx;
+    }
+}
+
+const MODERN: MessageClassification = { era: 'modern', revision: '2026-07-28' };
+
+const ENVELOPE = {
+    'io.modelcontextprotocol/protocolVersion': '2026-07-28',
+    'io.modelcontextprotocol/clientInfo': { name: 'era-client', version: '0.0.0' },
+    'io.modelcontextprotocol/clientCapabilities': {}
+};
+
+interface Harness {
+    receiver: TestProtocol;
+    /** Deliver a raw message to the receiver, optionally classified. */
+    deliver: (message: JSONRPCMessage, classification?: MessageClassification) => void;
+    /** Messages the receiver sent back (responses, notifications). */
+    sent: JSONRPCMessage[];
+    flush: () => Promise<void>;
+}
+
+async function harness(setup?: (receiver: TestProtocol) => void): Promise<Harness> {
+    const [peerTx, receiverTx] = InMemoryTransport.createLinkedPair();
+    const sent: JSONRPCMessage[] = [];
+    peerTx.onmessage = message => void sent.push(message);
+    await peerTx.start();
+
+    const receiver = new TestProtocol();
+    setup?.(receiver);
+    await receiver.connect(receiverTx);
+
+    return {
+        receiver,
+        // Invoke the receiver-side transport callback directly so the test
+        // controls MessageExtraInfo (the classification consumption seam).
+        deliver: (message, classification) => receiverTx.onmessage?.(message, classification ? ({ classification } as never) : undefined),
+        sent,
+        flush: () => new Promise(resolve => setTimeout(resolve, 10))
+    };
+}
+
+const errorOf = (msg: JSONRPCMessage | undefined) => (msg as { error?: { code: number; message: string } } | undefined)?.error;
+const resultOf = (msg: JSONRPCMessage | undefined) => (msg as { result?: Record<string, unknown> } | undefined)?.result;
+
+describe('inbound era gates — deletions are physical', () => {
+    test('2026-classified tasks/get is −32601 BY ABSENCE even with a handler registered', async () => {
+        let handlerRan = false;
+        const h = await harness(receiver => {
+            // A custom (3-arg) handler deliberately shadowing the deleted
+            // spec method: it may serve the 2025 era only.
+            receiver.setRequestHandler('tasks/get', { params: z.looseObject({ taskId: z.string() }) }, () => {
+                handlerRan = true;
+                return {} as Result;
+            });
+        });
+
+        h.deliver(
+            { jsonrpc: '2.0', id: 1, method: 'tasks/get', params: { taskId: 't-1', _meta: { ...ENVELOPE } } } as JSONRPCMessage,
+            MODERN
+        );
+        await h.flush();
+
+        expect(handlerRan).toBe(false);
+        expect(h.sent).toHaveLength(1);
+        expect(errorOf(h.sent[0])).toMatchObject({ code: -32601, message: 'Method not found' });
+    });
+
+    test('the SAME instance serves legacy tasks/get with that handler (per-request era truth)', async () => {
+        let handlerRan = false;
+        const h = await harness(receiver => {
+            receiver.setRequestHandler('tasks/get', { params: z.looseObject({ taskId: z.string() }) }, () => {
+                handlerRan = true;
+                return {} as Result;
+            });
+        });
+
+        // Unclassified ⇒ legacy (Q2 default posture).
+        h.deliver({ jsonrpc: '2.0', id: 2, method: 'tasks/get', params: { taskId: 't-1' } } as JSONRPCMessage);
+        await h.flush();
+
+        expect(handlerRan).toBe(true);
+        expect(resultOf(h.sent[0])).toBeDefined();
+    });
+
+    test('2026-classified ping is −32601 by absence (the built-in pong cannot cross eras)', async () => {
+        const h = await harness();
+        h.deliver({ jsonrpc: '2.0', id: 3, method: 'ping', params: { _meta: { ...ENVELOPE } } } as JSONRPCMessage, MODERN);
+        await h.flush();
+        expect(errorOf(h.sent[0])).toMatchObject({ code: -32601 });
+
+        // …while the 2025 era keeps the automatic pong.
+        h.deliver({ jsonrpc: '2.0', id: 4, method: 'ping' } as JSONRPCMessage);
+        await h.flush();
+        expect(resultOf(h.sent[1])).toEqual({});
+    });
+
+    test('a 2026-classified spec notification that the era deleted is dropped even with a handler', async () => {
+        let delivered = 0;
+        const h = await harness(receiver => {
+            receiver.setNotificationHandler('notifications/tasks/status', { params: z.looseObject({}) }, () => {
+                delivered += 1;
+            });
+        });
+
+        h.deliver(
+            { jsonrpc: '2.0', method: 'notifications/tasks/status', params: { taskId: 't', status: 'working' } } as JSONRPCMessage,
+            MODERN
+        );
+        await h.flush();
+        expect(delivered).toBe(0);
+
+        // Legacy leg: delivered.
+        h.deliver({ jsonrpc: '2.0', method: 'notifications/tasks/status', params: { taskId: 't', status: 'working' } } as JSONRPCMessage);
+        await h.flush();
+        expect(delivered).toBe(1);
+    });
+
+    test('out-of-universe custom methods stay era-blind (consumer-owned)', async () => {
+        let served = 0;
+        const h = await harness(receiver => {
+            receiver.setRequestHandler('acme/anything', { params: z.looseObject({}) }, () => {
+                served += 1;
+                return {} as Result;
+            });
+        });
+
+        h.deliver({ jsonrpc: '2.0', id: 5, method: 'acme/anything', params: { _meta: { ...ENVELOPE } } } as JSONRPCMessage, MODERN);
+        h.deliver({ jsonrpc: '2.0', id: 6, method: 'acme/anything', params: {} } as JSONRPCMessage);
+        await h.flush();
+        expect(served).toBe(2);
+    });
+});
+
+describe('2026-era envelope requiredness at dispatch', () => {
+    test('a modern-classified request without the envelope is −32602 naming the requirement', async () => {
+        const h = await harness(receiver => {
+            receiver.setRequestHandler('tools/list', () => ({ tools: [] }));
+        });
+
+        h.deliver({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} } as JSONRPCMessage, MODERN);
+        await h.flush();
+
+        const error = errorOf(h.sent[0]);
+        expect(error?.code).toBe(-32602);
+        expect(error?.message).toContain('_meta envelope');
+    });
+
+    test('a modern-classified request with a valid envelope is served (handler sees the 2025 shape)', async () => {
+        const h = await harness(receiver => {
+            receiver.setRequestHandler('tools/list', () => ({ tools: [] }));
+        });
+
+        h.deliver({ jsonrpc: '2.0', id: 2, method: 'tools/list', params: { _meta: { ...ENVELOPE } } } as JSONRPCMessage, MODERN);
+        await h.flush();
+
+        expect(resultOf(h.sent[0])).toMatchObject({ tools: [] });
+    });
+
+    test('the 2025 era never requires an envelope', async () => {
+        const h = await harness(receiver => {
+            receiver.setRequestHandler('tools/list', () => ({ tools: [] }));
+        });
+
+        h.deliver({ jsonrpc: '2.0', id: 3, method: 'tools/list', params: {} } as JSONRPCMessage);
+        await h.flush();
+        expect(resultOf(h.sent[0])).toMatchObject({ tools: [] });
+    });
+});
+
+describe('the stamp seam and the never-stamp guarantee', () => {
+    test('2026-classified responses are stamped resultType: complete', async () => {
+        const h = await harness(receiver => {
+            receiver.setRequestHandler('tools/list', () => ({ tools: [] }));
+        });
+
+        h.deliver({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: { _meta: { ...ENVELOPE } } } as JSONRPCMessage, MODERN);
+        await h.flush();
+
+        expect(resultOf(h.sent[0])).toMatchObject({ resultType: 'complete' });
+    });
+
+    test('2025-era responses NEVER carry resultType (no stamp code path exists)', async () => {
+        const h = await harness(receiver => {
+            receiver.setRequestHandler('tools/list', () => ({ tools: [] }));
+        });
+
+        h.deliver({ jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} } as JSONRPCMessage);
+        await h.flush();
+
+        const result = resultOf(h.sent[0]);
+        expect(result).toBeDefined();
+        expect(result && 'resultType' in result).toBe(false);
+    });
+
+    test('the 2025 codec encodeResult is the identity (same reference, nothing added)', async () => {
+        const { rev2025Codec } = await import('../../src/wire/rev2025-11-25/codec.js');
+        const result = { content: [{ type: 'text', text: 'x' }] } as unknown as Result;
+        expect(rev2025Codec.encodeResult('tools/call', result)).toBe(result);
+    });
+});
+
+describe('encode-side deleted-field strictness (Q1-SD3 iii)', () => {
+    const TOOL_WITH_EXECUTION = {
+        name: 'legacy-tool',
+        inputSchema: { type: 'object' },
+        execution: { taskSupport: 'optional' }
+    };
+
+    test('execution.taskSupport is stripped from 2026-era tools/list emissions', async () => {
+        const h = await harness(receiver => {
+            receiver.setRequestHandler('tools/list', (() => ({ tools: [TOOL_WITH_EXECUTION] })) as never);
+        });
+
+        h.deliver({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: { _meta: { ...ENVELOPE } } } as JSONRPCMessage, MODERN);
+        await h.flush();
+
+        const tools = resultOf(h.sent[0])?.tools as Array<Record<string, unknown>>;
+        expect(tools[0]).toMatchObject({ name: 'legacy-tool' });
+        expect('execution' in tools[0]!).toBe(false);
+    });
+
+    test('the same handler emits execution untouched on the 2025 era (era-invisible handlers)', async () => {
+        const h = await harness(receiver => {
+            receiver.setRequestHandler('tools/list', (() => ({ tools: [TOOL_WITH_EXECUTION] })) as never);
+        });
+
+        h.deliver({ jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} } as JSONRPCMessage);
+        await h.flush();
+
+        const tools = resultOf(h.sent[0])?.tools as Array<Record<string, unknown>>;
+        expect(tools[0]).toMatchObject({ name: 'legacy-tool', execution: { taskSupport: 'optional' } });
+    });
+
+    test('capabilities.tasks is stripped from 2026-era capability-carrying emissions (server/discover)', async () => {
+        const h = await harness(receiver => {
+            receiver.setRequestHandler(
+                'server/discover' as never,
+                (() => ({
+                    ttlMs: 0,
+                    cacheScope: 'private',
+                    supportedVersions: ['2026-07-28'],
+                    capabilities: { tools: {}, tasks: { list: {} } },
+                    serverInfo: { name: 's', version: '0' }
+                })) as never
+            );
+        });
+
+        h.deliver({ jsonrpc: '2.0', id: 3, method: 'server/discover', params: { _meta: { ...ENVELOPE } } } as JSONRPCMessage, MODERN);
+        await h.flush();
+
+        const result = resultOf(h.sent[0]);
+        expect(result).toMatchObject({ resultType: 'complete', capabilities: { tools: {} } });
+        expect('tasks' in (result?.capabilities as Record<string, unknown>)).toBe(false);
+    });
+});
+
+describe('outbound era gates — typed local error before the transport', () => {
+    test('a 2026-bound instance cannot send 2025-only spec methods', async () => {
+        const h = await harness();
+        bindWireVersion(h.receiver, '2026-07-28');
+
+        for (const method of ['tasks/get', 'ping', 'logging/setLevel', 'resources/subscribe']) {
+            const attempt = () => h.receiver.request({ method } as never);
+            expect(attempt, method).toThrow(SdkError);
+            try {
+                attempt();
+            } catch (error) {
+                expect((error as SdkError).code, method).toBe(SdkErrorCode.MethodNotSupportedByProtocolVersion);
+                expect((error as SdkError).data, method).toMatchObject({ method, era: '2026-07-28' });
+            }
+        }
+        // Nothing reached the transport.
+        expect(h.sent).toHaveLength(0);
+    });
+
+    test('a legacy-bound instance cannot send server/discover', async () => {
+        const h = await harness();
+        bindWireVersion(h.receiver, '2025-11-25');
+
+        expect(() => h.receiver.request({ method: 'server/discover' } as never)).toThrow(SdkError);
+        try {
+            h.receiver.request({ method: 'server/discover' } as never);
+        } catch (error) {
+            expect((error as SdkError).code).toBe(SdkErrorCode.MethodNotSupportedByProtocolVersion);
+        }
+        expect(h.sent).toHaveLength(0);
+    });
+
+    test('outbound era-mismatched spec notifications die locally too', async () => {
+        const h = await harness();
+        bindWireVersion(h.receiver, '2026-07-28');
+
+        await expect(h.receiver.notification({ method: 'notifications/roots/list_changed' })).rejects.toMatchObject({
+            code: SdkErrorCode.MethodNotSupportedByProtocolVersion
+        });
+        expect(h.sent).toHaveLength(0);
+    });
+
+    test('pre-negotiation bootstrap pins still route initialize to the 2025 era', async () => {
+        // An UNBOUND instance may always send the legacy handshake; binding a
+        // modern version afterwards closes it (the pin is pre-negotiation
+        // only — a negotiated session never re-routes onto the other era).
+        const h = await harness();
+        const pending = h.receiver.request({
+            method: 'initialize',
+            params: { protocolVersion: '2025-11-25', capabilities: {}, clientInfo: { name: 'c', version: '0' } }
+        });
+        pending.catch(() => undefined); // unanswered; we only assert the send happened
+        await h.flush();
+        // The handshake reached the wire (sent[] captures the peer's inbox).
+        expect(h.sent).toHaveLength(1);
+        expect((h.sent[0] as { method?: string }).method).toBe('initialize');
+        await h.receiver.close();
+
+        const h2 = await harness();
+        bindWireVersion(h2.receiver, '2026-07-28');
+        expect(() =>
+            h2.receiver.request({
+                method: 'initialize',
+                params: { protocolVersion: '2025-11-25', capabilities: {}, clientInfo: { name: 'c', version: '0' } }
+            })
+        ).toThrow(SdkError);
+    });
+});
+
+describe('T6 width-leak killed at both roots', () => {
+    test('2026 era: a task-shaped tools/call body can never parse as an empty success', async () => {
+        const { rev2026Codec } = await import('../../src/wire/rev2026-07-28/codec.js');
+        // resultType present-and-complete but the body is task-shaped: the
+        // wire-exact parse requires content — loud invalid, never {content: []}.
+        const decoded = rev2026Codec.decodeResult('tools/call', {
+            resultType: 'complete',
+            task: { taskId: 't-1', status: 'working' }
+        });
+        expect(decoded.kind).toBe('invalid');
+    });
+
+    test('2025 era: with the content default gone, a bare task-shaped body fails the plain schema loudly', async () => {
+        const { rev2025Codec } = await import('../../src/wire/rev2025-11-25/codec.js');
+        const { CallToolResultSchema } = await import('../../src/types/schemas.js');
+        const decoded = rev2025Codec.decodeResult('tools/call', { task: { taskId: 't-1', status: 'working' } });
+        expect(decoded.kind).toBe('complete');
+        if (decoded.kind === 'complete') {
+            // The plain schema (which IS the registry entry — the result map
+            // is aligned to the typed map, no task-widened union): no
+            // default([]) means no silent {content: []} masking.
+            expect(CallToolResultSchema.safeParse(decoded.result).success).toBe(false);
+        }
+        // The GENERIC path agrees: the registry serves the same plain schema,
+        // so even a fully conforming CreateTaskResult body is a loud schema
+        // failure (surfaced as a typed INVALID_RESULT — see
+        // test/shared/typedMapAlignment.test.ts). Task interop is the
+        // explicit-schema overload, never a silent union member.
+        const { getResultSchema } = await import('../../src/wire/rev2025-11-25/registry.js');
+        const plain = getResultSchema('tools/call');
+        expect(plain).toBe(CallToolResultSchema);
+        expect(
+            plain!.safeParse({
+                task: {
+                    taskId: '786af6b0-2779-48ed-9cc1-b8a8a25b8a86',
+                    status: 'working',
+                    createdAt: '2025-11-25T10:30:00Z',
+                    lastUpdatedAt: '2025-11-25T10:30:05Z',
+                    ttl: 60000,
+                    pollInterval: 5000
+                }
+            }).success
+        ).toBe(false);
+    });
+});

--- a/packages/core/test/wire/neutralKeyParity.test.ts
+++ b/packages/core/test/wire/neutralKeyParity.test.ts
@@ -1,0 +1,98 @@
+/**
+ * The neutralKeys pin family (Q1 increment 3):
+ *
+ *     neutralKeys(T) = wireKeys@rev(T) − WIRE_ONLY
+ *
+ * For every mapped result type, the NEUTRAL public type's declared keys must
+ * equal the revision's WIRE type's declared keys minus the wire-only set
+ * (`resultType` — the envelope keys and retry fields are params-side and
+ * never appear on result types). This closes BOTH inherited verification
+ * holes at once:
+ * - the old 2025 suite tolerated a phantom `resultType` key on every result
+ *   (`AssertExactKeysWithResultType`), and
+ * - the old 2026 suite had no key parity at all.
+ *
+ * OWNED PENDING DELTA (stale-checked): the 2026 cacheable results carry
+ * `ttlMs`/`cacheScope` on the wire. Those are CONSUMER-RELEVANT (cache fields
+ * are deliberately NOT wire-only — Q13) but the neutral model does not carry
+ * them until the cache-hint surface lands (M3.2/#12). Each cacheable entry
+ * below subtracts them explicitly; when M3.2 models them neutrally, the
+ * subtraction breaks the build and the entry burns.
+ */
+import { describe, expect, test } from 'vitest';
+import type * as z4 from 'zod/v4';
+
+import type * as SDK from '../../src/types/index.js';
+import type * as Wire2026 from '../../src/wire/rev2026-07-28/schemas.js';
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+type KnownKeys<T> = keyof { [K in keyof T as string extends K ? never : number extends K ? never : K]: T[K] };
+
+type AssertSameKeys<A, B> = [KnownKeys<A>] extends [KnownKeys<B>]
+    ? [KnownKeys<B>] extends [KnownKeys<A>]
+        ? true
+        : { _brand: 'KeyMismatch'; missingFromA: Exclude<KnownKeys<B>, KnownKeys<A>> }
+    : { _brand: 'KeyMismatch'; extraInA: Exclude<KnownKeys<A>, KnownKeys<B>> };
+
+type Assert<T extends true> = T;
+
+/** The wire-only key set on results (the hide set's result-side member). */
+type WIRE_ONLY = 'resultType';
+
+/** M3.2-owned pending delta: cache fields modeled on the wire, not yet neutrally. */
+type M32_PENDING = 'ttlMs' | 'cacheScope';
+
+type MinusWireOnly<T> = { [K in keyof T as K extends WIRE_ONLY ? never : K]: T[K] };
+type MinusWireOnlyAndCache<T> = { [K in keyof T as K extends WIRE_ONLY | M32_PENDING ? never : K]: T[K] };
+
+/* ---- 2026: neutralKeys(T) = wireKeys@2026(T) − WIRE_ONLY ---- */
+
+type _N26_Result = Assert<AssertSameKeys<SDK.Result, MinusWireOnly<z4.infer<typeof Wire2026.ResultSchema>>>>;
+type _N26_EmptyResult = Assert<AssertSameKeys<SDK.EmptyResult, MinusWireOnly<z4.infer<typeof Wire2026.ResultSchema>>>>;
+type _N26_CallToolResult = Assert<AssertSameKeys<SDK.CallToolResult, MinusWireOnly<z4.infer<typeof Wire2026.CallToolResultSchema>>>>;
+type _N26_CompleteResult = Assert<AssertSameKeys<SDK.CompleteResult, MinusWireOnly<z4.infer<typeof Wire2026.CompleteResultSchema>>>>;
+type _N26_GetPromptResult = Assert<AssertSameKeys<SDK.GetPromptResult, MinusWireOnly<z4.infer<typeof Wire2026.GetPromptResultSchema>>>>;
+// Cacheable results: ttlMs/cacheScope subtracted until M3.2 models them neutrally.
+type _N26_ListToolsResult = Assert<
+    AssertSameKeys<SDK.ListToolsResult, MinusWireOnlyAndCache<z4.infer<typeof Wire2026.ListToolsResultSchema>>>
+>;
+type _N26_ListPromptsResult = Assert<
+    AssertSameKeys<SDK.ListPromptsResult, MinusWireOnlyAndCache<z4.infer<typeof Wire2026.ListPromptsResultSchema>>>
+>;
+type _N26_ListResourcesResult = Assert<
+    AssertSameKeys<SDK.ListResourcesResult, MinusWireOnlyAndCache<z4.infer<typeof Wire2026.ListResourcesResultSchema>>>
+>;
+type _N26_ListResourceTemplatesResult = Assert<
+    AssertSameKeys<SDK.ListResourceTemplatesResult, MinusWireOnlyAndCache<z4.infer<typeof Wire2026.ListResourceTemplatesResultSchema>>>
+>;
+type _N26_ReadResourceResult = Assert<
+    AssertSameKeys<SDK.ReadResourceResult, MinusWireOnlyAndCache<z4.infer<typeof Wire2026.ReadResourceResultSchema>>>
+>;
+type _N26_DiscoverResult = Assert<
+    AssertSameKeys<SDK.DiscoverResult, MinusWireOnlyAndCache<z4.infer<typeof Wire2026.DiscoverResultSchema>>>
+>;
+
+/* ---- 2025: the wire schemas ARE the neutral schemas post-cut — pin that no
+ * result type re-grows a resultType slot (the masking surface stays dead). ---- */
+
+type DeclaresResultType<T> = 'resultType' extends KnownKeys<T> ? true : false;
+type _N25_Result = Assert<DeclaresResultType<SDK.Result> extends false ? true : false>;
+type _N25_EmptyResult = Assert<DeclaresResultType<SDK.EmptyResult> extends false ? true : false>;
+type _N25_CallToolResult = Assert<DeclaresResultType<SDK.CallToolResult> extends false ? true : false>;
+type _N25_InitializeResult = Assert<DeclaresResultType<SDK.InitializeResult> extends false ? true : false>;
+type _N25_CreateMessageResult = Assert<DeclaresResultType<SDK.CreateMessageResult> extends false ? true : false>;
+type _N25_ElicitResult = Assert<DeclaresResultType<SDK.ElicitResult> extends false ? true : false>;
+type _N25_ListRootsResult = Assert<DeclaresResultType<SDK.ListRootsResult> extends false ? true : false>;
+type _N25_GetTaskResult = Assert<DeclaresResultType<SDK.GetTaskResult> extends false ? true : false>;
+type _N25_ClientResult = Assert<DeclaresResultType<SDK.ClientResult> extends false ? true : false>;
+type _N25_ServerResult = Assert<DeclaresResultType<SDK.ServerResult> extends false ? true : false>;
+
+describe('neutralKeys pin family', () => {
+    test('the compile of this file IS the assertion (runtime guard against truncation)', () => {
+        // 11 per-type 2026 pins + 10 resultType-absence pins are enforced at
+        // type level above; this runtime test exists so the file cannot be
+        // silently excluded from the suite.
+        expect(true).toBe(true);
+    });
+});

--- a/packages/core/test/wire/registryDiffOracle.test.ts
+++ b/packages/core/test/wire/registryDiffOracle.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Registry-diff oracle (Q1 increment 3 — generation as ORACLE, never source).
+ *
+ * The per-era method registries are HAND-WRITTEN (a generator walking anchor
+ * method literals would silently re-admit the 2026-demoted server→client
+ * methods — the flavor-(b) trap). This oracle derives each revision's method
+ * universe FROM THE ANCHOR SOURCE at test time and fails LOUD — with the
+ * exact diff — whenever the anchor and the hand registry disagree, modulo a
+ * documented seed-decision list that is stale-checked in both directions.
+ *
+ * Seed decisions (every entry is a deliberate, owned divergence):
+ * - 2026 DEMOTIONS: `sampling/createMessage`, `elicitation/create`,
+ *   `roots/list` keep method literals in the anchor but are NOT wire request
+ *   methods in 2026 — the server→client JSON-RPC request channel is deleted
+ *   (`ServerRequest` has no 2026 export; the shapes survive only as in-band
+ *   `InputRequest` payloads, M4.1/#13).
+ * - 2026 DEFERRALS: `subscriptions/listen` and
+ *   `notifications/subscriptions/acknowledged` are real 2026 wire methods
+ *   whose SHELLS land with the subscriptions feature (M6.1/#14). The day #14
+ *   wires them, this oracle fails until the entries are removed — that
+ *   failure is the burn-down notification, by design.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, test } from 'vitest';
+
+import { rev2025NotificationMethods, rev2025RequestMethods } from '../../src/wire/rev2025-11-25/registry.js';
+import { rev2026NotificationMethods, rev2026RequestMethods } from '../../src/wire/rev2026-07-28/registry.js';
+
+const ANCHORS = {
+    '2025-11-25': path.resolve(__dirname, '../../src/types/spec.types.2025-11-25.ts'),
+    '2026-07-28': path.resolve(__dirname, '../../src/types/spec.types.2026-07-28.ts')
+} as const;
+
+/** Extract every `method: '<literal>'` from an anchor source. */
+function anchorMethods(revision: keyof typeof ANCHORS): { requests: string[]; notifications: string[] } {
+    const source = fs.readFileSync(ANCHORS[revision], 'utf8');
+    const literals = [...source.matchAll(/method:\s*'([^']+)'/g)].map(m => m[1]!);
+    const unique = [...new Set(literals)].sort();
+    return {
+        requests: unique.filter(m => !m.startsWith('notifications/')),
+        notifications: unique.filter(m => m.startsWith('notifications/'))
+    };
+}
+
+/** Anchor-side methods deliberately NOT in the hand registry (reason per entry). */
+const SEED_EXCLUSIONS: Record<string, Record<string, string>> = {
+    '2025-11-25': {},
+    '2026-07-28': {
+        'sampling/createMessage': 'DEMOTED to an in-band InputRequest payload (M4.1/#13) — not a 2026 wire request',
+        'elicitation/create': 'DEMOTED to an in-band InputRequest payload (M4.1/#13) — not a 2026 wire request',
+        'roots/list': 'DEMOTED to an in-band InputRequest payload (M4.1/#13) — not a 2026 wire request',
+        'subscriptions/listen': 'DEFERRED to the subscriptions feature (M6.1/#14)',
+        'notifications/subscriptions/acknowledged': 'DEFERRED to the subscriptions feature (M6.1/#14)'
+    }
+};
+
+const REGISTRIES = {
+    '2025-11-25': { requests: rev2025RequestMethods, notifications: rev2025NotificationMethods },
+    '2026-07-28': { requests: rev2026RequestMethods, notifications: rev2026NotificationMethods }
+} as const;
+
+describe.each(['2025-11-25', '2026-07-28'] as const)('registry-diff oracle %s', revision => {
+    const anchor = anchorMethods(revision);
+    const registry = REGISTRIES[revision];
+    const exclusions = SEED_EXCLUSIONS[revision]!;
+
+    test('every anchor method is in the hand registry or a documented seed exclusion', () => {
+        const missing = [...anchor.requests, ...anchor.notifications].filter(method => {
+            const inRegistry = registry.requests.includes(method) || registry.notifications.includes(method);
+            return !inRegistry && !(method in exclusions);
+        });
+        expect(
+            missing,
+            `Anchor methods absent from the ${revision} registry with NO seed decision — ` +
+                `wire them or add a documented exclusion (this is the loud failure the oracle exists for)`
+        ).toEqual([]);
+    });
+
+    test('the hand registry contains nothing beyond the anchor universe', () => {
+        const anchorSet = new Set([...anchor.requests, ...anchor.notifications]);
+        const extra = [...registry.requests, ...registry.notifications].filter(method => !anchorSet.has(method));
+        expect(extra, `Registry methods with no ${revision} anchor literal — era leak or typo`).toEqual([]);
+    });
+
+    test('seed exclusions are not stale (still in the anchor, still not in the registry)', () => {
+        for (const [method, reason] of Object.entries(exclusions)) {
+            const inAnchor = anchor.requests.includes(method) || anchor.notifications.includes(method);
+            expect(inAnchor, `${method}: exclusion no longer matches any anchor literal — remove it (${reason})`).toBe(true);
+            const inRegistry = registry.requests.includes(method) || registry.notifications.includes(method);
+            expect(inRegistry, `${method}: now wired in the registry — remove the stale exclusion (${reason})`).toBe(false);
+        }
+    });
+
+    test('the anchor universe is fully partitioned (sanity: counts add up)', () => {
+        const total = anchor.requests.length + anchor.notifications.length;
+        const covered =
+            registry.requests.filter(m => anchor.requests.includes(m)).length +
+            registry.notifications.filter(m => anchor.notifications.includes(m)).length +
+            Object.keys(exclusions).length;
+        expect(covered).toBe(total);
+    });
+});

--- a/packages/core/test/wire/schemaTwinConformance.test.ts
+++ b/packages/core/test/wire/schemaTwinConformance.test.ts
@@ -91,12 +91,13 @@ describe.each(['2025-11-25', '2026-07-28'] as const)('schema-twin conformance lo
     const twin = twinValidatorFactory(revision);
     const dirs = listTypeDirs(revision).filter(dir => twin.defs.has(dir));
 
-    test('the twin covers the corpus (sanity: most directories map to a $defs entry)', () => {
+    test('the twin covers the corpus (the unmapped set is pinned exactly)', () => {
         const unmapped = listTypeDirs(revision).filter(dir => !twin.defs.has(dir));
-        // Unmapped directories are SDK-named shapes with no spec def (e.g.
-        // bare error-object dirs vendored under SDK aliases). They must stay
-        // few — growth here means the twin and the corpus are drifting apart.
-        expect(unmapped.length, `directories without a twin def: ${unmapped.join(', ')}`).toBeLessThanOrEqual(6);
+        // Unmapped directories would be SDK-named shapes with no spec def.
+        // Today there are NONE — the set is pinned exactly, not bounded with
+        // slack: a new unmapped directory means the twin and the corpus are
+        // drifting apart and must be adjudicated here by name.
+        expect(unmapped).toEqual([]);
         expect(dirs.length).toBeGreaterThan(30);
     });
 

--- a/packages/core/test/wire/schemaTwinConformance.test.ts
+++ b/packages/core/test/wire/schemaTwinConformance.test.ts
@@ -20,6 +20,7 @@
  * Twin refresh is ATOMIC with the matching anchor (lifecycle rule 4,
  * packages/core/src/types/README.md); provenance in schema-twins/manifest.json.
  */
+import { createHash } from 'node:crypto';
 import { readdirSync, readFileSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 
@@ -29,6 +30,31 @@ import { describe, expect, test } from 'vitest';
 
 const FIXTURES_ROOT = join(__dirname, '../corpus/fixtures');
 const TWINS_ROOT = join(__dirname, '../corpus/schema-twins');
+
+interface TwinManifest {
+    source: { repository: string; commit: string };
+    files: Record<string, { sha256: string; bytes: number; upstreamPath: string }>;
+}
+
+const TWIN_MANIFEST = JSON.parse(readFileSync(join(TWINS_ROOT, 'manifest.json'), 'utf8')) as TwinManifest;
+
+describe('twin provenance integrity (the manifest lock)', () => {
+    // The twins' authority as generated oracles rests on them being the raw
+    // upstream artifacts, byte for byte. Hash the vendored files against the
+    // manifest's provenance values at test time so ANY rewrite — prettier, an
+    // editor, a manual touch-up — fails loudly. Refresh only via
+    // `pnpm fetch:schema-twins` (which recomputes these values from the
+    // fetched bytes), atomically with the matching spec.types anchor.
+    test.each(Object.keys(TWIN_MANIFEST.files))('%s twin is byte-identical to the upstream artifact pinned in the manifest', revision => {
+        const entry = TWIN_MANIFEST.files[revision]!;
+        const raw = readFileSync(join(TWINS_ROOT, `${revision}.schema.json`));
+        expect(raw.byteLength, `byte size drifted for ${revision} — the vendored twin was rewritten`).toBe(entry.bytes);
+        expect(
+            createHash('sha256').update(raw).digest('hex'),
+            `sha256 drifted for ${revision} — the vendored twin was rewritten (re-vendor raw bytes via pnpm fetch:schema-twins)`
+        ).toBe(entry.sha256);
+    });
+});
 
 type JsonSchema = { $defs?: Record<string, { required?: string[] }> };
 

--- a/packages/core/test/wire/schemaTwinConformance.test.ts
+++ b/packages/core/test/wire/schemaTwinConformance.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Schema-twin conformance lock (Q1 increment 3 — generation as ORACLE).
+ *
+ * The spec repository generates `schema.json` from the same normative
+ * `schema.ts` the anchors vendor. The twins vendored under
+ * `corpus/schema-twins/` (TEST-ONLY — never bundled, never runtime; the
+ * engines stay optional peers and the hot path stays hand-written Zod) give
+ * a generated, revision-exact validator for every named spec type. This
+ * suite locks the hand-written wire layer to them, per revision per fixture:
+ *
+ * - every accept-corpus fixture must satisfy the GENERATED validator for its
+ *   directory's spec type (catches twin/anchor desync and hand-corpus drift
+ *   — the 2025 mini-corpus is hand-built, so this is its only independent
+ *   referee), and
+ * - every fixture the SDK wire layer accepts must also be twin-valid
+ *   (agreement on the accept side; reject-side deltas are owned by the
+ *   dispatch-routed rejection corpus, since generated valid-only oracles are
+ *   blind to them).
+ *
+ * Twin refresh is ATOMIC with the matching anchor (lifecycle rule 4,
+ * packages/core/src/types/README.md); provenance in schema-twins/manifest.json.
+ */
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { Ajv2020 as Ajv } from 'ajv/dist/2020.js';
+import addFormats from 'ajv-formats';
+import { describe, expect, test } from 'vitest';
+
+const FIXTURES_ROOT = join(__dirname, '../corpus/fixtures');
+const TWINS_ROOT = join(__dirname, '../corpus/schema-twins');
+
+type JsonSchema = { $defs?: Record<string, { required?: string[] }> };
+
+function twinValidatorFactory(revision: string) {
+    const schema = JSON.parse(readFileSync(join(TWINS_ROOT, `${revision}.schema.json`), 'utf8')) as JsonSchema;
+    const ajv = new Ajv({ strict: false, allowUnionTypes: true });
+    addFormats.default ? addFormats.default(ajv) : (addFormats as unknown as (a: Ajv) => void)(ajv);
+    ajv.addSchema(schema, 'spec');
+    return {
+        defs: new Set(Object.keys(schema.$defs ?? {})),
+        requiredOf(typeName: string): string[] {
+            return schema.$defs?.[typeName]?.required ?? [];
+        },
+        validatorFor(typeName: string) {
+            return ajv.getSchema(`spec#/$defs/${typeName}`);
+        }
+    };
+}
+
+function listTypeDirs(revision: string): string[] {
+    const root = join(FIXTURES_ROOT, revision);
+    return readdirSync(root)
+        .filter(entry => statSync(join(root, entry)).isDirectory())
+        .sort();
+}
+
+function listFixtures(revision: string, dir: string): string[] {
+    return readdirSync(join(FIXTURES_ROOT, revision, dir))
+        .filter(file => file.endsWith('.json'))
+        .sort();
+}
+
+describe.each(['2025-11-25', '2026-07-28'] as const)('schema-twin conformance lock %s', revision => {
+    const twin = twinValidatorFactory(revision);
+    const dirs = listTypeDirs(revision).filter(dir => twin.defs.has(dir));
+
+    test('the twin covers the corpus (sanity: most directories map to a $defs entry)', () => {
+        const unmapped = listTypeDirs(revision).filter(dir => !twin.defs.has(dir));
+        // Unmapped directories are SDK-named shapes with no spec def (e.g.
+        // bare error-object dirs vendored under SDK aliases). They must stay
+        // few — growth here means the twin and the corpus are drifting apart.
+        expect(unmapped.length, `directories without a twin def: ${unmapped.join(', ')}`).toBeLessThanOrEqual(6);
+        expect(dirs.length).toBeGreaterThan(30);
+    });
+
+    describe.each(dirs)('%s', dir => {
+        test.each(listFixtures(revision, dir))('%s satisfies the generated spec validator', file => {
+            let fixture = JSON.parse(readFileSync(join(FIXTURES_ROOT, revision, dir, file), 'utf8')) as Record<string, unknown>;
+            // The hand-built 2025 mini-corpus stores BARE message shapes (the
+            // SDK parse surface); the spec defs model the full JSON-RPC wire
+            // message. Supply the neutral envelope members the def requires
+            // and the fixture deliberately omits — the PAYLOAD is what the
+            // fixtures pin, and it crosses to the twin verbatim.
+            const required = twin.requiredOf(dir);
+            if (typeof fixture === 'object' && fixture !== null && !('jsonrpc' in fixture)) {
+                if (required.includes('jsonrpc')) fixture = { jsonrpc: '2.0', ...fixture };
+                if (required.includes('id') && !('id' in fixture)) fixture = { id: 'twin-probe', ...fixture };
+            }
+            const validate = twin.validatorFor(dir);
+            expect(validate, `no compiled validator for ${dir}`).toBeDefined();
+            const valid = validate!(fixture);
+            expect(
+                valid,
+                `'${dir}/${file}' rejected by the generated ${revision} validator:\n${JSON.stringify(validate!.errors, null, 2)}`
+            ).toBe(true);
+        });
+    });
+});

--- a/scripts/fetch-schema-twins.ts
+++ b/scripts/fetch-schema-twins.ts
@@ -1,0 +1,73 @@
+/**
+ * Vendors the generated `schema.json` twins from the spec repository into
+ * `packages/core/test/corpus/schema-twins/` as RAW UPSTREAM BYTES.
+ *
+ * The twins are TEST-ONLY conformance oracles (never bundled, never runtime):
+ * `packages/core/test/wire/schemaTwinConformance.test.ts` compiles them into
+ * generated validators and locks the hand-written wire layer to them. Their
+ * authority rests on provenance, so they are vendored verbatim — no
+ * formatting of any kind (the directory is .prettierignore'd) — and each file
+ * is locked to the manifest's sha256/byte values at test time. Any rewrite
+ * (prettier, an editor, a manual touch-up) turns CI red.
+ *
+ * Refresh ATOMICALLY with the matching spec.types anchor (see
+ * packages/core/src/types/README.md lifecycle rule 4).
+ *
+ * Usage:
+ *   pnpm fetch:schema-twins [sha]   # default: the manifest's current source commit
+ *
+ * Sources are fetched from GitHub at the given commit, mirroring
+ * scripts/fetch-spec-types.ts; the manifest's provenance values (source
+ * commit, sha256, byte size) are recomputed from the fetched bytes.
+ */
+
+import { createHash } from 'node:crypto';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const PROJECT_ROOT = join(dirname(__filename), '..');
+
+const SPEC_REPO = 'modelcontextprotocol/modelcontextprotocol';
+const TWINS_DIR = join(PROJECT_ROOT, 'packages', 'core', 'test', 'corpus', 'schema-twins');
+const MANIFEST_PATH = join(TWINS_DIR, 'manifest.json');
+
+interface TwinManifest {
+    comment: string;
+    source: { repository: string; commit: string };
+    files: Record<string, { sha256: string; bytes: number; upstreamPath: string }>;
+}
+
+async function fetchRawBytes(sha: string, upstreamPath: string): Promise<Buffer> {
+    const url = `https://raw.githubusercontent.com/${SPEC_REPO}/${sha}/${upstreamPath}`;
+    const response = await fetch(url);
+    if (!response.ok) {
+        throw new Error(`Failed to fetch ${upstreamPath}: ${response.status} ${response.statusText}`);
+    }
+    return Buffer.from(await response.arrayBuffer());
+}
+
+async function main(): Promise<void> {
+    const manifest = JSON.parse(readFileSync(MANIFEST_PATH, 'utf8')) as TwinManifest;
+    const sha = process.argv[2] ?? manifest.source.commit;
+
+    for (const [revision, entry] of Object.entries(manifest.files)) {
+        console.log(`[${revision}] Fetching ${entry.upstreamPath} at ${sha}`);
+        const bytes = await fetchRawBytes(sha, entry.upstreamPath);
+        // Verbatim: the twin IS the upstream artifact, byte for byte.
+        writeFileSync(join(TWINS_DIR, `${revision}.schema.json`), bytes);
+        entry.sha256 = createHash('sha256').update(bytes).digest('hex');
+        entry.bytes = bytes.byteLength;
+        console.log(`[${revision}] ${entry.bytes} bytes, sha256 ${entry.sha256}`);
+    }
+
+    manifest.source = { repository: SPEC_REPO, commit: sha };
+    writeFileSync(MANIFEST_PATH, `${JSON.stringify(manifest, null, 4)}\n`, 'utf8');
+    console.log(`Updated ${MANIFEST_PATH}`);
+}
+
+main().catch((error: unknown) => {
+    console.error('Error:', error instanceof Error ? error.message : String(error));
+    process.exit(1);
+});

--- a/test/e2e/scenarios/raw-result-type.test.ts
+++ b/test/e2e/scenarios/raw-result-type.test.ts
@@ -1,12 +1,23 @@
 /**
- * Raw-first result discrimination through the full client path.
+ * Raw-first result discrimination through the full client path — ERA-SCOPED
+ * (Q1 increment 2: V-1 lives in the era codec's decodeResult, and the
+ * postures are ruled per era by Q1-SD3).
  *
- * A raw relay server (no SDK Server involved) answers tools/call with an
- * `input_required` body — the 2026-era multi-round-trip shape. The full
- * client stack (Client → protocol funnel → transport) must surface the
- * discriminated kind as a typed local error and never mask it into an
- * empty-content success (the tools/call result schema defaults `content` to
- * `[]`, which would otherwise swallow the body whole).
+ * A raw relay server (no SDK Server involved) answers tools/call with hand
+ * built bodies. The negotiated protocol version selects the wire era:
+ *
+ *  - Negotiated 2026-07-28: `resultType` is the REQUIRED discriminator. An
+ *    `input_required` body surfaces the discriminated kind as a typed local
+ *    error (the multi-round-trip driver consumes it when it lands); an
+ *    ABSENT `resultType` is a spec violation surfaced as a typed error
+ *    naming it.
+ *  - Negotiated legacy (2025 era): `resultType` is FOREIGN vocabulary —
+ *    strip-on-lift (Q1-SD3 ii; a deliberate, ledgered change from the
+ *    pre-split era-blind rejection — changeset: codec-split-wire-break). The
+ *    stripped body then fails the (default-free) result schema loudly
+ *    because it has no content.
+ *
+ * Either way the V-1 invariant holds: never an empty-content success.
  */
 import { Client, SdkError, SdkErrorCode, StreamableHTTPClientTransport } from '@modelcontextprotocol/client';
 import type { JSONRPCRequest } from '@modelcontextprotocol/server';
@@ -27,6 +38,9 @@ const INPUT_REQUIRED_BODY = {
     requestState: 'opaque-state'
 };
 
+/** A complete-looking body that omits the (2026-required) resultType. */
+const ABSENT_RESULT_TYPE_BODY = { content: [{ type: 'text', text: 'looks complete' }] };
+
 function initializeResult(requestedVersion: string) {
     return {
         protocolVersion: requestedVersion,
@@ -35,17 +49,19 @@ function initializeResult(requestedVersion: string) {
     };
 }
 
-/** Route a raw request to the relay's hand-built response body. */
-function respondTo(request: JSONRPCRequest): unknown {
-    if (request.method === 'initialize') {
-        const requested = (request.params as { protocolVersion?: string } | undefined)?.protocolVersion ?? LATEST_PROTOCOL_VERSION;
-        return initializeResult(requested);
-    }
-    if (request.method === 'tools/call') return INPUT_REQUIRED_BODY;
-    return {};
+function makeResponder(toolCallBody: unknown) {
+    return function respondTo(request: JSONRPCRequest): unknown {
+        if (request.method === 'initialize') {
+            const requested = (request.params as { protocolVersion?: string } | undefined)?.protocolVersion ?? LATEST_PROTOCOL_VERSION;
+            return initializeResult(requested);
+        }
+        if (request.method === 'tools/call') return toolCallBody;
+        return {};
+    };
 }
 
-async function connectInMemory(client: Client): Promise<void> {
+async function connectInMemory(client: Client, toolCallBody: unknown): Promise<void> {
+    const respondTo = makeResponder(toolCallBody);
     const [clientTx, serverTx] = InMemoryTransport.createLinkedPair();
     serverTx.onmessage = message => {
         const request = message as JSONRPCRequest;
@@ -56,7 +72,8 @@ async function connectInMemory(client: Client): Promise<void> {
     await client.connect(clientTx);
 }
 
-async function connectStreamableHttp(client: Client): Promise<void> {
+async function connectStreamableHttp(client: Client, toolCallBody: unknown): Promise<void> {
+    const respondTo = makeResponder(toolCallBody);
     // A hand HTTP handler (no SDK server): JSON responses, 202 for notifications.
     const fetchHandler = async (input: URL | string, init?: RequestInit): Promise<Response> => {
         const request = new Request(input, init);
@@ -69,24 +86,76 @@ async function connectStreamableHttp(client: Client): Promise<void> {
     await client.connect(new StreamableHTTPClientTransport(new URL('http://in-process/mcp'), { fetch: fetchHandler }));
 }
 
+async function callToolOutcome(client: Client): Promise<{ resolved: unknown } | { rejected: unknown }> {
+    return client.callTool({ name: 'anything', arguments: {} }).then(
+        result => ({ resolved: result as unknown }),
+        error => ({ rejected: error as unknown })
+    );
+}
+
 verifies('typescript:client:raw-result-type-first', async ({ transport }: TestArgs) => {
-    const client = new Client({ name: 'raw-result-type-client', version: '0' });
-    await (transport === 'inMemory' ? connectInMemory(client) : connectStreamableHttp(client));
+    // ---- Legacy negotiation (the relay echoes the client's default offer,
+    // so this connection negotiates a legacy version → 2025 era). ----
+    {
+        const client = new Client({ name: 'raw-result-type-client', version: '0' });
+        await (transport === 'inMemory'
+            ? connectInMemory(client, INPUT_REQUIRED_BODY)
+            : connectStreamableHttp(client, INPUT_REQUIRED_BODY));
 
-    try {
-        const outcome = await client.callTool({ name: 'anything', arguments: {} }).then(
-            result => ({ resolved: result as unknown }),
-            error => ({ rejected: error as unknown })
-        );
+        try {
+            const outcome = await callToolOutcome(client);
+            // Strip-on-lift (Q1-SD3 ii, ledgered): the foreign resultType is
+            // dropped; the body has no content, so validation fails LOUDLY.
+            // Never an empty-content success.
+            expect('resolved' in outcome, `must not resolve: ${JSON.stringify(outcome)}`).toBe(false);
+            const rejection = (outcome as { rejected: unknown }).rejected;
+            expect(rejection).toBeInstanceOf(SdkError);
+            expect((rejection as SdkError).code).toBe(SdkErrorCode.InvalidResult);
+        } finally {
+            await client.close();
+        }
+    }
 
-        // Never an empty-content success.
-        expect('resolved' in outcome, `must not resolve: ${JSON.stringify(outcome)}`).toBe(false);
-        const rejection = (outcome as { rejected: unknown }).rejected;
-        expect(rejection).toBeInstanceOf(SdkError);
-        const typed = rejection as SdkError;
-        expect(typed.code).toBe(SdkErrorCode.UnsupportedResultType);
-        expect(typed.data).toMatchObject({ resultType: 'input_required', method: 'tools/call' });
-    } finally {
-        await client.close();
+    // ---- Modern negotiation: the client opts into the draft revision, the
+    // relay echoes it back → 2026 era → V-1 discrimination in the codec. ----
+    {
+        const client = new Client({ name: 'raw-result-type-client', version: '0' }, { supportedProtocolVersions: ['2026-07-28'] });
+        await (transport === 'inMemory'
+            ? connectInMemory(client, INPUT_REQUIRED_BODY)
+            : connectStreamableHttp(client, INPUT_REQUIRED_BODY));
+
+        try {
+            const outcome = await callToolOutcome(client);
+            expect('resolved' in outcome, `must not resolve: ${JSON.stringify(outcome)}`).toBe(false);
+            const rejection = (outcome as { rejected: unknown }).rejected;
+            expect(rejection).toBeInstanceOf(SdkError);
+            const typed = rejection as SdkError;
+            expect(typed.code).toBe(SdkErrorCode.UnsupportedResultType);
+            expect(typed.data).toMatchObject({ resultType: 'input_required', method: 'tools/call' });
+        } finally {
+            await client.close();
+        }
+    }
+
+    // ---- Modern negotiation, absent resultType: the spec violation is
+    // surfaced as a typed error naming it (Q1-SD3 i — the absent⇒complete
+    // bridge applies only to earlier-revision servers). ----
+    {
+        const client = new Client({ name: 'raw-result-type-client', version: '0' }, { supportedProtocolVersions: ['2026-07-28'] });
+        await (transport === 'inMemory'
+            ? connectInMemory(client, ABSENT_RESULT_TYPE_BODY)
+            : connectStreamableHttp(client, ABSENT_RESULT_TYPE_BODY));
+
+        try {
+            const outcome = await callToolOutcome(client);
+            expect('resolved' in outcome, `must not resolve: ${JSON.stringify(outcome)}`).toBe(false);
+            const rejection = (outcome as { rejected: unknown }).rejected;
+            expect(rejection).toBeInstanceOf(SdkError);
+            const typed = rejection as SdkError;
+            expect(typed.code).toBe(SdkErrorCode.InvalidResult);
+            expect(String(typed.message)).toContain('missing required resultType');
+        } finally {
+            await client.close();
+        }
     }
 });


### PR DESCRIPTION
Lands the 2026-07-28 era codec — deletions become physical — plus the CI oracles that keep the hand-written wire layer honest against the spec anchors.

## Motivation and Context
With the codec interface in place (#2294), this PR adds the draft-revision era module: spec-exact 2026 schemas (envelope and `resultType` REQUIRED at parse — safe here because no 2025 traffic touches the module), the 2026 method registry (which physically lacks task methods: a modern-classified `tasks/get` answers −32601 even with a handler registered), encode-side strictness for deleted fields, and the stamp seam. The 2025 codec correspondingly has no stamp path and no discover/listen/MRTR — deletions are structural, not policed by tests.

The test restructure retires the legacy burn-down machinery: the MISSING-names list becomes exact per-revision wire-parity checks plus a feature-owned pending map (every entry names its owning milestone, stale-checked in both directions), and all `@ts-expect-error` affordances are replaced by a visible adjudication ledger.

CI oracles (test-only; zero dependency changes, no generated code in the hot path):
- **Registry-diff oracle**: anchor method literals vs the hand registries — fails loud on drift.
- **Schema-twin conformance lock**: vendored spec schema.json twins (test-only, provenance-pinned) validate every corpus fixture per revision — the hand-built 2025 corpus gains an independent referee.
- **neutralKeys parity pins**: per mapped type per revision, closing the key-parity gaps the old tolerance helpers left open.

## How Has This Been Tested?
Full suite green at tip: package suites, e2e (0 unexpected), conformance ×3 zero stale, `api-report:check` green twice (determinism), 188 corpus runs through the era modules + 176 twin-lock validations, codemod prebuild idempotent.

## Breaking Changes
None — everything per-revision lives inside the private bundled core; no public surface change beyond #2294's ledger (API reports byte-stable in this PR).

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
Stacked on #2294. The "negotiated version determines the wire" property cashes out as negotiated ERA (all five legacy versions → one 2025 codec) — disclosed in the codec module header.
