### PR TITLE
feat(server): opt-in stdio dual-era serving via ServerOptions.eraSupport; dual-era examples

### DIFF
--- a/.changeset/client-modern-era-inbound-drop.md
+++ b/.changeset/client-modern-era-inbound-drop.md
@@ -1,0 +1,6 @@
+---
+'@modelcontextprotocol/client': patch
+---
+
+Drop inbound JSON-RPC requests on connections that negotiated the 2026-07-28 draft revision instead of answering them: the modern era has no server→client request channel (server-initiated interactions are carried in `input_required` results), and the stdio transport forbids the
+client from writing JSON-RPC responses. Dropped requests are surfaced via `onerror`. Legacy-era connections, responses, and notifications are unchanged.

--- a/.changeset/server-era-support.md
+++ b/.changeset/server-era-support.md
@@ -1,0 +1,9 @@
+---
+'@modelcontextprotocol/server': minor
+---
+
+Add `ServerOptions.eraSupport: 'legacy' | 'dual-era' | 'modern'`, the opt-in for serving the 2026-07-28 draft revision on long-lived connections such as stdio. The default is `'legacy'` and preserves today's behavior exactly: nothing 2026-era is registered or advertised, and 2025
+wire behavior is unchanged by the upgrade. `'dual-era'` serves both protocol eras on the same connection, selecting the era per message (`initialize`-negotiated 2025 traffic as before, per-request `_meta` envelope traffic — including `server/discover` — on the modern era), while
+methods that exist in only one era stay invisible to the other. `'modern'` is strict 2026-only: requests without the envelope (including `initialize`) are answered with the unsupported-protocol-version error naming the supported revisions. A 2026-era revision in
+`supportedProtocolVersions` now requires declaring `eraSupport` (`'dual-era'` or `'modern'`); on a default `'legacy'` instance it throws a `TypeError` at construction instead of silently installing the `server/discover` handler. On dual-era instances the deprecated
+client-identity accessors keep their `initialize`-scoped semantics and are never backfilled from 2026-era requests; handlers read per-request identity from `ctx.mcpReq.envelope`.

--- a/docs/migration-SKILL.md
+++ b/docs/migration-SKILL.md
@@ -550,6 +550,15 @@ These can require code changes:
 - `Server.getClientCapabilities()`, `getClientVersion()` and `getNegotiatedProtocolVersion()` are deprecated but functional: prefer the per-request context (`ctx.mcpReq.envelope`) on 2026-07-28 requests. No mechanical change required yet; plan the move before the deprecations are removed.
 - `createMcpExpressApp()` / `createMcpHonoApp()` / `createMcpFastifyApp()` with a localhost-class `host` now also validate the `Origin` header by default (requests without an `Origin` header are unaffected). Browser-served clients on a non-localhost origin need `allowedOrigins: [...]`, which replaces the default localhost allowlist — Origin validation cannot be disabled for localhost-class binds.
 
+### Server (stdio / long-lived connections)
+
+- `ServerOptions.eraSupport?: 'legacy' | 'dual-era' | 'modern'` declares which protocol eras a hand-constructed `Server`/`McpServer` serves on its long-lived connection. Default `'legacy'` = today's behavior, byte-identical: do not add the option during a mechanical migration.
+- Serving the 2026-07-28 draft revision on stdio is the explicit opt-in `new McpServer(info, { eraSupport: 'dual-era' })` with an unchanged `connect(new StdioServerTransport())`. `'modern'` is strict 2026-only (envelope-less requests, including `initialize`, get the
+  unsupported-protocol-version error).
+- A 2026-era revision in `supportedProtocolVersions` now requires `eraSupport: 'dual-era' | 'modern'`; on a default (`'legacy'`) instance it throws a `TypeError` at construction (previously it silently installed the `server/discover` handler).
+- On dual-era instances `getClientCapabilities()` / `getClientVersion()` / `getNegotiatedProtocolVersion()` keep `initialize`-scoped semantics and are never backfilled from 2026-era requests; handlers read per-request identity from `ctx.mcpReq.envelope`.
+- A client whose connection negotiated a modern era drops inbound server→client JSON-RPC requests (the 2026 era has no such channel) instead of answering them; legacy-era connections are unchanged.
+
 ## 14. Runtime-Specific JSON Schema Validators (Enhancement)
 
 The SDK now auto-selects the appropriate JSON Schema validator based on runtime:

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1095,7 +1095,8 @@ What the values mean:
 Declaring `'dual-era'` or `'modern'` automatically adds the SDK's supported modern revisions to `supportedProtocolVersions`, and `'modern'` serves only those: a strict instance's supported list (what `server/discover` advertises and version-mismatch errors name) is modern-only.
 
 Directionality follows the era of the traffic: the 2026-07-28 revision has no server→client JSON-RPC request channel, so a `'modern'` instance cannot emit `sampling`/`elicitation`/`roots` wire requests (they fail locally with a typed error), while a `'dual-era'` instance
-can still send them to the 2025-era clients it serves via `initialize`. Symmetrically, a client whose connection negotiated a modern era drops inbound JSON-RPC requests instead of answering them.
+can still send them to the 2025-era clients it serves via `initialize`. On a `'dual-era'` instance the same local typed error applies per request: a handler that is serving a 2026-era request cannot send server→client requests through its request context
+(`ctx.mcpReq.send`, `ctx.mcpReq.elicitInput`, `ctx.mcpReq.requestSampling`) — only handlers serving 2025-era requests can. Symmetrically, a client whose connection negotiated a modern era drops inbound JSON-RPC requests instead of answering them.
 
 Declaring `eraSupport: 'dual-era'` is also an assertion that your handlers are ready to serve modern-era requests (for example, that they read per-request client identity from `ctx.mcpReq.envelope` rather than the connection-scoped accessors — see the next section). A
 future release may add per-handler era declarations as the basis for a safe automatic default; for now the connection-level `eraSupport` option is the whole opt-in surface.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1092,6 +1092,8 @@ What the values mean:
   2026-era request for a removed method (such as `logging/setLevel`) gets `-32601` too.
 - **`'modern'`** — strict 2026-only: requests without the per-request envelope (including `initialize`) are answered with the unsupported-protocol-version error naming the supported revisions; legacy-era notifications are dropped.
 
+Declaring `'dual-era'` or `'modern'` automatically adds the SDK's supported modern revisions to `supportedProtocolVersions`, and `'modern'` serves only those: a strict instance's supported list (what `server/discover` advertises and version-mismatch errors name) is modern-only.
+
 Directionality follows the era of the traffic: the 2026-07-28 revision has no server→client JSON-RPC request channel, so a `'modern'` instance cannot emit `sampling`/`elicitation`/`roots` wire requests (they fail locally with a typed error), while a `'dual-era'` instance
 can still send them to the 2025-era clients it serves via `initialize`. Symmetrically, a client whose connection negotiated a modern era drops inbound JSON-RPC requests instead of answering them.
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1025,9 +1025,9 @@ versionNegotiation: {
 }
 ```
 
-On the server side, a `Server`/`McpServer` whose `supportedProtocolVersions` list includes a 2026-era revision installs a `server/discover` handler, advertising only its modern revisions; servers with the default version list are byte-identical to before (they keep
+On the server side, a `Server`/`McpServer` serves `server/discover` (advertising only its modern revisions) when it declares modern-era support via the `eraSupport` option (see the stdio section below); servers constructed without it are byte-identical to before (they keep
 answering `-32601`, and the `initialize` handshake only ever negotiates 2025-era versions — a 2026-era revision is never accepted or counter-offered there). Serving the 2026 revision to ordinary HTTP traffic is done with the `createMcpHandler` entry point described in the
-next section; serving it over stdio arrives with a later release. The client can also issue the request directly via `client.discover()` on a 2026-era connection — a full typed round trip needs each request to carry the per-request `_meta` envelope (the negotiation probe
+next section; serving it on stdio (and other long-lived connections) is the `eraSupport` server option described after that. The client can also issue the request directly via `client.discover()` on a 2026-era connection — a full typed round trip needs each request to carry the per-request `_meta` envelope (the negotiation probe
 already does; automatic envelope emission for every request is a client-side follow-up) — while on a 2025-era connection the method is rejected locally with a typed error, since it does not exist on that protocol revision.
 
 ### Serving the 2026-07-28 draft revision over HTTP: `createMcpHandler`
@@ -1068,11 +1068,44 @@ The entry performs no Origin/Host validation (see the origin-validation middlewa
 request headers. Power users who want to compose routing themselves can use the exported `classifyInboundRequest` and `PerRequestHTTPServerTransport` building blocks directly; the handler faces are bound properties, so they can be detached and passed around
 (`const { fetch } = handler`).
 
+### Serving the 2026-07-28 draft revision on stdio: `eraSupport`
+
+A hand-constructed `Server`/`McpServer` — the shape every stdio server has — now takes an `eraSupport` option declaring which protocol eras it serves on its long-lived connection. **The default is `'legacy'`: if you do nothing, your server keeps speaking exactly the
+2025-era protocol it was written for** — the `initialize` handshake, the same wire bytes, no `server/discover`, nothing new advertised — and upgrading the SDK changes nothing about what it puts on the wire.
+
+Serving the 2026-07-28 draft revision is one explicit option; the transport stays unchanged:
+
+```typescript
+import { McpServer } from '@modelcontextprotocol/server';
+import { StdioServerTransport } from '@modelcontextprotocol/server/stdio';
+
+const server = new McpServer({ name: 'my-server', version: '1.0.0' }, { eraSupport: 'dual-era' });
+await server.connect(new StdioServerTransport());
+```
+
+What the values mean:
+
+- **`'legacy'` (default)** — today's behavior, unchanged: 2025-era serving negotiated via `initialize`. `server/discover` is not registered or advertised. Declaring a 2026-era revision in `supportedProtocolVersions` without changing `eraSupport` is now a construction-time
+  `TypeError` (previously it silently installed the discover handler) — serving the new revision is always an explicit declaration, never a side effect of a version list.
+- **`'dual-era'`** — both eras on the same connection, selected per message: plain 2025 clients keep using `initialize` and are served exactly as before, while 2026-capable clients negotiate via `server/discover` on the same pipe and every request carrying the per-request
+  `_meta` envelope is served on the modern era. Methods that exist in only one era stay invisible to the other: a 2025-era client asking for a 2026-only method (such as `server/discover` without an envelope) gets the same plain `-32601` a 2025 server would send, and a
+  2026-era request for a removed method (such as `logging/setLevel`) gets `-32601` too.
+- **`'modern'`** — strict 2026-only: requests without the per-request envelope (including `initialize`) are answered with the unsupported-protocol-version error naming the supported revisions; legacy-era notifications are dropped.
+
+Directionality follows the era of the traffic: the 2026-07-28 revision has no server→client JSON-RPC request channel, so a `'modern'` instance cannot emit `sampling`/`elicitation`/`roots` wire requests (they fail locally with a typed error), while a `'dual-era'` instance
+can still send them to the 2025-era clients it serves via `initialize`. Symmetrically, a client whose connection negotiated a modern era drops inbound JSON-RPC requests instead of answering them.
+
+Declaring `eraSupport: 'dual-era'` is also an assertion that your handlers are ready to serve modern-era requests (for example, that they read per-request client identity from `ctx.mcpReq.envelope` rather than the connection-scoped accessors — see the next section). A
+future release may add per-handler era declarations as the basis for a safe automatic default; for now the connection-level `eraSupport` option is the whole opt-in surface.
+
 ### Client identity accessors deprecated in favor of per-request context
 
 `Server.getClientCapabilities()`, `Server.getClientVersion()` and `Server.getNegotiatedProtocolVersion()` are deprecated (they remain functional). On 2026-07-28 requests the client's identity travels with each request in the validated `_meta` envelope and is available to
 handlers as `ctx.mcpReq.envelope`; instances serving that revision through `createMcpHandler` are backfilled per request, so existing code that calls the accessors keeps working on both eras. On 2025-era connections the accessors keep returning the `initialize`-scoped
 values, as before.
+
+On a long-lived dual-era instance (`eraSupport: 'dual-era'`, e.g. a stdio server) the accessors are **not** backfilled from modern requests: 2025-era and 2026-era messages interleave on one connection, so instance-level backfill would race. There the accessors keep their
+`initialize`-scoped semantics — they reflect what the legacy handshake negotiated (or `undefined` when none ran) — and handlers serving 2026-era requests read the per-request identity from `ctx.mcpReq.envelope`.
 
 ### Origin validation middleware and default arming
 

--- a/docs/server.md
+++ b/docs/server.md
@@ -62,6 +62,20 @@ const transport = new StdioServerTransport();
 await server.connect(transport);
 ```
 
+#### Serving the 2026-07-28 draft revision on stdio
+
+By default a stdio server speaks the 2025-era protocol it was written for (`eraSupport: 'legacy'`): nothing about its wire behavior changes when you upgrade the SDK. Serving the 2026-07-28 draft revision is one explicit option — the transport stays unchanged:
+
+```typescript
+const server = new McpServer({ name: 'my-server', version: '1.0.0' }, { eraSupport: 'dual-era' });
+await server.connect(new StdioServerTransport());
+```
+
+With `eraSupport: 'dual-era'` the same long-lived connection serves both eras, selected per message: plain 2025 clients keep using `initialize` and are served exactly as before, while 2026-capable clients negotiate via `server/discover` and send each request with the
+per-request `_meta` envelope. Methods that exist in only one era stay invisible to the other (a 2025-era client asking for a 2026-only method gets a plain `-32601`). `eraSupport: 'modern'` is strict 2026-only. On dual-era instances, read per-request client identity from
+`ctx.mcpReq.envelope` in your handlers rather than the connection-scoped accessors (see the [migration guide](./migration.md) for details). A runnable example lives at `examples/server/src/dualEraStdio.ts`, with a two-legged client at
+`examples/client/src/dualEraStdioClient.ts`.
+
 ## Server instructions
 
 Instructions describe how to use the server and its features — cross-tool relationships, workflow patterns, and constraints (see [Instructions](https://modelcontextprotocol.io/specification/latest/basic/lifecycle#instructions) in the MCP specification). Clients may add them to the system prompt. Instructions should not duplicate information already in tool descriptions.

--- a/examples/client/src/dualEraStdioClient.ts
+++ b/examples/client/src/dualEraStdioClient.ts
@@ -1,0 +1,64 @@
+/**
+ * Drives the dual-era stdio server example (`examples/server/src/dualEraStdio.ts`)
+ * with both kinds of client over a real child-process pipe:
+ *
+ * 1. a plain 2025 client — the `initialize` handshake, served exactly as today;
+ * 2. a 2026-capable client (`versionNegotiation: { mode: 'auto' }`) — the
+ *    `server/discover` probe negotiates the 2026-07-28 revision on the pipe
+ *    (no `initialize` is ever sent), and each modern request carries the
+ *    per-request `_meta` envelope. (Attaching the envelope explicitly is a
+ *    stop-gap: automatic per-request envelope emission is a client-side
+ *    follow-up.)
+ *
+ * Build `examples/server` first; this client spawns the built server via stdio:
+ *
+ *     pnpm --filter @modelcontextprotocol/examples-server build
+ *     tsx examples/client/src/dualEraStdioClient.ts
+ */
+import { Client, CLIENT_CAPABILITIES_META_KEY, CLIENT_INFO_META_KEY, PROTOCOL_VERSION_META_KEY } from '@modelcontextprotocol/client';
+import { StdioClientTransport } from '@modelcontextprotocol/client/stdio';
+
+const SERVER = { command: 'node', args: ['../server/dist/dualEraStdio.js'] };
+
+async function legacyLeg(): Promise<void> {
+    console.log('--- leg 1: plain 2025 client (initialize handshake) ---');
+    const client = new Client({ name: 'legacy-demo-client', version: '1.0.0' });
+    await client.connect(new StdioClientTransport(SERVER));
+
+    console.log('negotiated protocol version:', client.getNegotiatedProtocolVersion());
+    const tools = await client.listTools();
+    console.log(
+        'tools:',
+        tools.tools.map(tool => tool.name)
+    );
+    const result = await client.callTool({ name: 'greet', arguments: { name: '2025 client' } });
+    console.log('greet result:', JSON.stringify(result.content));
+    await client.close();
+}
+
+async function modernLeg(): Promise<void> {
+    console.log('--- leg 2: 2026-capable client (server/discover negotiation) ---');
+    const client = new Client({ name: 'modern-demo-client', version: '1.0.0' }, { versionNegotiation: { mode: 'auto' } });
+    await client.connect(new StdioClientTransport(SERVER));
+
+    const negotiated = client.getNegotiatedProtocolVersion();
+    console.log('negotiated protocol version:', negotiated);
+
+    // The per-request envelope every 2026-era request carries on the wire.
+    const envelope = {
+        [PROTOCOL_VERSION_META_KEY]: negotiated,
+        [CLIENT_INFO_META_KEY]: { name: 'modern-demo-client', version: '1.0.0' },
+        [CLIENT_CAPABILITIES_META_KEY]: {}
+    };
+
+    const result = await client.request({
+        method: 'tools/call',
+        params: { name: 'greet', arguments: { name: '2026 client' }, _meta: envelope }
+    });
+    console.log('greet result:', JSON.stringify(result.content));
+    await client.close();
+}
+
+await legacyLeg();
+await modernLeg();
+console.log('both legs served by the same dual-era stdio server.');

--- a/examples/client/src/dualEraStdioClient.ts
+++ b/examples/client/src/dualEraStdioClient.ts
@@ -10,15 +10,19 @@
  *    stop-gap: automatic per-request envelope emission is a client-side
  *    follow-up.)
  *
- * Build `examples/server` first; this client spawns the built server via stdio:
+ * The client spawns the server example directly from source over stdio:
  *
- *     pnpm --filter @modelcontextprotocol/examples-server build
  *     tsx examples/client/src/dualEraStdioClient.ts
  */
+import path from 'node:path';
+
 import { Client, CLIENT_CAPABILITIES_META_KEY, CLIENT_INFO_META_KEY, PROTOCOL_VERSION_META_KEY } from '@modelcontextprotocol/client';
 import { StdioClientTransport } from '@modelcontextprotocol/client/stdio';
 
-const SERVER = { command: 'node', args: ['../server/dist/dualEraStdio.js'] };
+// Spawn the sibling server example straight from its source (no build step),
+// located relative to this file so the demo runs from any working directory.
+const SERVER_SOURCE = path.resolve(import.meta.dirname, '../../server/src/dualEraStdio.ts');
+const SERVER = { command: 'npx', args: ['tsx', SERVER_SOURCE] };
 
 async function legacyLeg(): Promise<void> {
     console.log('--- leg 1: plain 2025 client (initialize handshake) ---');

--- a/examples/server/src/dualEraStdio.ts
+++ b/examples/server/src/dualEraStdio.ts
@@ -1,0 +1,68 @@
+/**
+ * Dual-era stdio serving with `eraSupport: 'dual-era'`: one server process,
+ * one long-lived pipe, both protocol eras.
+ *
+ * The same construction backs both legs — nothing about the transport or the
+ * tool changes per era:
+ *
+ * - a plain 2025 client connects with the `initialize` handshake and is served
+ *   exactly as today;
+ * - a 2026-capable client (`versionNegotiation: { mode: 'auto' }`) negotiates
+ *   the 2026-07-28 revision via `server/discover` on the same pipe and is
+ *   served on the modern era, message by message.
+ *
+ * Opting in is the single `eraSupport` option; the default (`'legacy'`)
+ * preserves today's behavior exactly.
+ *
+ * Run with `tsx examples/server/src/dualEraStdio.ts` (or point any stdio MCP
+ * client at it). `examples/client/src/dualEraStdioClient.ts` drives both legs
+ * against the built version of this file.
+ */
+import type { CallToolResult } from '@modelcontextprotocol/server';
+import { McpServer } from '@modelcontextprotocol/server';
+import { StdioServerTransport } from '@modelcontextprotocol/server/stdio';
+import * as z from 'zod/v4';
+
+// One construction for both legs: tools are defined once and served
+// identically to 2025-era and 2026-era clients.
+const buildServer = () => {
+    const server = new McpServer(
+        {
+            name: 'dual-era-stdio-server',
+            version: '1.0.0'
+        },
+        {
+            capabilities: { tools: {} },
+            instructions: 'A small dual-era stdio demo server.',
+            // The one declared act: serve both protocol eras on this long-lived pipe.
+            eraSupport: 'dual-era'
+        }
+    );
+
+    server.registerTool(
+        'greet',
+        {
+            description: 'Greets the caller',
+            inputSchema: z.object({ name: z.string().describe('Name to greet') })
+        },
+        async ({ name }): Promise<CallToolResult> => ({
+            content: [{ type: 'text', text: `Hello, ${name}!` }]
+        })
+    );
+
+    return server;
+};
+
+const server = buildServer();
+// The transport is unchanged: dual-era support is purely a server-options declaration.
+await server.connect(new StdioServerTransport());
+console.error('dual-era stdio server ready (serving 2025-era initialize and 2026-07-28 envelope traffic)');
+
+const exit = async () => {
+    await server.close();
+    // eslint-disable-next-line unicorn/no-process-exit
+    process.exit(0);
+};
+
+process.on('SIGINT', exit);
+process.on('SIGTERM', exit);

--- a/packages/client/src/client/client.ts
+++ b/packages/client/src/client/client.ts
@@ -14,6 +14,7 @@ import type {
     GetPromptRequest,
     GetPromptResult,
     Implementation,
+    JSONRPCNotification,
     JSONRPCRequest,
     JsonSchemaType,
     JsonSchemaValidator,
@@ -49,6 +50,8 @@ import {
     CreateMessageResultWithToolsSchema,
     DEFAULT_REQUEST_TIMEOUT_MSEC,
     DiscoverResultSchema,
+    isJSONRPCRequest,
+    isModernProtocolVersion,
     legacyProtocolVersions,
     ListChangedOptionsBaseSchema,
     mergeCapabilities,
@@ -273,6 +276,27 @@ export class Client extends Protocol<ClientContext> {
 
     protected override buildContext(ctx: BaseContext, _transportInfo?: MessageExtraInfo): ClientContext {
         return ctx;
+    }
+
+    /**
+     * Era-keyed direction enforcement for inbound traffic on channels whose
+     * transport does not classify (e.g. stdio): the 2026-07-28 era has no
+     * server→client JSON-RPC request channel — server-to-client interactions
+     * are carried in-band in `input_required` results — and on stdio the
+     * client must never write JSON-RPC responses. An inbound request arriving
+     * on a connection that negotiated a modern era is therefore dropped
+     * (surfaced via `onerror`) rather than answered. Connections on a legacy
+     * era — and all responses and notifications — keep today's dispatch path.
+     */
+    protected override _classifyInbound(message: JSONRPCRequest | JSONRPCNotification): 'drop' | undefined {
+        if (
+            this._negotiatedProtocolVersion !== undefined &&
+            isModernProtocolVersion(this._negotiatedProtocolVersion) &&
+            isJSONRPCRequest(message)
+        ) {
+            return 'drop';
+        }
+        return undefined;
     }
 
     /**

--- a/packages/client/test/client/modernEraInboundDrop.test.ts
+++ b/packages/client/test/client/modernEraInboundDrop.test.ts
@@ -1,0 +1,109 @@
+/**
+ * TS-01 directionality, client side: the 2026-07-28 era has no server→client
+ * JSON-RPC request channel, and on stdio the client must never write JSON-RPC
+ * responses — so an inbound request arriving on a connection that negotiated
+ * a modern era is dropped (surfaced via `onerror`), never answered. Legacy-era
+ * connections keep today's behavior (the client answers, e.g. with −32601 for
+ * methods it has no handler for).
+ */
+import type { JSONRPCMessage } from '@modelcontextprotocol/core';
+import { InMemoryTransport, LATEST_PROTOCOL_VERSION } from '@modelcontextprotocol/core';
+import { describe, expect, it } from 'vitest';
+
+import { Client } from '../../src/client/client.js';
+
+const MODERN = '2026-07-28';
+
+const flush = () => new Promise(resolve => setTimeout(resolve, 20));
+
+/**
+ * A scripted server side of an in-memory pair: answers `server/discover` (so a
+ * negotiating client lands on the modern era) or `initialize` (legacy era), and
+ * records everything the client writes.
+ */
+async function scriptedServerSide(eras: 'modern' | 'legacy') {
+    const [clientTx, serverTx] = InMemoryTransport.createLinkedPair();
+    const written: JSONRPCMessage[] = [];
+    serverTx.onmessage = message => {
+        written.push(message);
+        const request = message as { id?: number | string; method?: string };
+        if (request.method === 'server/discover' && request.id !== undefined) {
+            if (eras === 'modern') {
+                void serverTx.send({
+                    jsonrpc: '2.0',
+                    id: request.id,
+                    result: {
+                        resultType: 'complete',
+                        supportedVersions: [MODERN],
+                        capabilities: { tools: {} },
+                        serverInfo: { name: 'scripted-modern-server', version: '1.0.0' }
+                    }
+                });
+            } else {
+                void serverTx.send({
+                    jsonrpc: '2.0',
+                    id: request.id,
+                    error: { code: -32_601, message: 'Method not found' }
+                });
+            }
+            return;
+        }
+        if (request.method === 'initialize' && request.id !== undefined) {
+            void serverTx.send({
+                jsonrpc: '2.0',
+                id: request.id,
+                result: {
+                    protocolVersion: LATEST_PROTOCOL_VERSION,
+                    capabilities: {},
+                    serverInfo: { name: 'scripted-legacy-server', version: '1.0.0' }
+                }
+            });
+        }
+    };
+    await serverTx.start();
+    return { clientTx, serverTx, written };
+}
+
+describe('client inbound-drop on modern-era connections (TS-01)', () => {
+    it('drops an inbound server→client request without writing any response, surfacing it via onerror', async () => {
+        const { clientTx, serverTx, written } = await scriptedServerSide('modern');
+        const client = new Client({ name: 'drop-client', version: '1.0.0' }, { versionNegotiation: { mode: 'auto' } });
+        const errors: Error[] = [];
+        client.onerror = error => void errors.push(error);
+        await client.connect(clientTx);
+        expect(client.getNegotiatedProtocolVersion()).toBe(MODERN);
+
+        const before = written.length;
+        // A misbehaving "modern" server sends a server→client request (the
+        // channel is deleted in the 2026 era). The client must not answer.
+        await serverTx.send({
+            jsonrpc: '2.0',
+            id: 'rogue-1',
+            method: 'roots/list',
+            params: {}
+        });
+        await flush();
+
+        expect(written).toHaveLength(before);
+        expect(errors.some(error => error.message.includes('Dropped inbound request'))).toBe(true);
+
+        await client.close();
+    });
+
+    it('keeps answering inbound requests on legacy-era connections (control arm)', async () => {
+        const { clientTx, serverTx, written } = await scriptedServerSide('legacy');
+        const client = new Client({ name: 'legacy-client', version: '1.0.0' }, { versionNegotiation: { mode: 'auto' } });
+        await client.connect(clientTx);
+        expect(client.getNegotiatedProtocolVersion()).toBe(LATEST_PROTOCOL_VERSION);
+
+        await serverTx.send({ jsonrpc: '2.0', id: 'legacy-1', method: 'roots/list', params: {} });
+        await flush();
+
+        // Today's behavior: the client answers (here −32601, no roots handler installed).
+        const answer = written.find(message => (message as { id?: string }).id === 'legacy-1');
+        expect(answer).toBeDefined();
+        expect((answer as { error?: { code: number } }).error?.code).toBe(-32_601);
+
+        await client.close();
+    });
+});

--- a/packages/client/test/client/probeFixtureCorpus.test.ts
+++ b/packages/client/test/client/probeFixtureCorpus.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Merged first-contact fixture corpus (T9 probe edges ∪ wire-real shapes)
+ * binding the two pure modules of the negotiation path:
+ *
+ * - the probe-outcome classifier (`classifyProbeOutcome`): the five T9 probe
+ *   edges (plain-text 400; JSON-RPC `code: 0`; probe-success-then-no-overlap
+ *   → initialize on the SAME connection; legacy servers that 200-process
+ *   era-ambiguous first requests; numeric-id collision avoidance via a string
+ *   probe id) merged with the wire-real first-contact shapes a deployed 2025
+ *   TypeScript server actually answers (the −32000 "Unsupported protocol
+ *   version" literal and the 400/−32000 session-required body). Recognition
+ *   is a typed allowlist — codes and structured data — never message-text
+ *   sniffing.
+ * - the era predicate's per-message form is bound by
+ *   `packages/core/test/shared/classifyInboundMessage.test.ts` (T11).
+ *
+ * Probe RUNTIME (timeout/retry policy and the connect loop) is covered by the
+ * negotiation engine suites; this corpus pins classification only, plus the
+ * probe wire shape (string id, `server/discover` first, never a real request).
+ */
+import type { JSONRPCMessage, Transport } from '@modelcontextprotocol/core';
+import { LATEST_PROTOCOL_VERSION, PROTOCOL_VERSION_META_KEY } from '@modelcontextprotocol/core';
+import { describe, expect, it } from 'vitest';
+
+import { Client } from '../../src/client/client.js';
+import type { ProbeClassifierContext, ProbeOutcome, ProbeVerdict } from '../../src/client/probeClassifier.js';
+import { classifyProbeOutcome } from '../../src/client/probeClassifier.js';
+
+const MODERN = '2026-07-28';
+
+const baseContext: ProbeClassifierContext = {
+    clientModernVersions: [MODERN],
+    requestedVersion: MODERN,
+    fallbackAvailable: true,
+    environment: 'node',
+    transportKind: 'stdio'
+};
+
+/** The byte-exact first-contact literal a deployed 2025 stateless server answers a modern probe with. */
+const DEPLOYED_UNSUPPORTED_VERSION_BODY = JSON.stringify({
+    jsonrpc: '2.0',
+    id: null,
+    error: {
+        code: -32_000,
+        message: `Bad Request: Unsupported protocol version: ${MODERN} (supported versions: 2025-11-25, 2025-06-18, 2025-03-26, 2024-11-05, 2024-10-07)`
+    }
+});
+
+/** The session-required free-text shape a deployed stateful server answers a session-less probe with. */
+const DEPLOYED_SESSION_REQUIRED_BODY = JSON.stringify({
+    jsonrpc: '2.0',
+    id: null,
+    error: { code: -32_000, message: 'Bad Request: Server not initialized' }
+});
+
+interface CorpusRow {
+    name: string;
+    outcome: ProbeOutcome;
+    context?: Partial<ProbeClassifierContext>;
+    expected: ProbeVerdict['kind'];
+}
+
+const CORPUS: CorpusRow[] = [
+    // --- T9 edge 1: plain-text 400 (no JSON-RPC body at all).
+    {
+        name: 'T9: plain-text HTTP 400 → legacy fallback',
+        outcome: { kind: 'http-error', status: 400, body: 'Bad Request' },
+        expected: 'legacy'
+    },
+    // --- T9 edge 2: JSON-RPC error with code 0.
+    {
+        name: 'T9: JSON-RPC error code 0 → legacy fallback',
+        outcome: { kind: 'rpc-error', code: 0, message: 'unknown method' },
+        expected: 'legacy'
+    },
+    // --- T9 edge 3: probe success but no version overlap → initialize on the SAME connection.
+    {
+        name: 'T9: DiscoverResult with no mutual version + fallback available → legacy (initialize on the same connection)',
+        outcome: {
+            kind: 'result',
+            result: { supportedVersions: ['2027-01-01'], capabilities: {}, serverInfo: { name: 's', version: '1' } }
+        },
+        expected: 'legacy'
+    },
+    {
+        name: 'T9: DiscoverResult with no mutual version + NO fallback (pin / modern-only) → typed error, never initialize',
+        outcome: {
+            kind: 'result',
+            result: { supportedVersions: ['2027-01-01'], capabilities: {}, serverInfo: { name: 's', version: '1' } }
+        },
+        context: { fallbackAvailable: false },
+        expected: 'error'
+    },
+    // --- T9 edge 4: a legacy server that 200-processes an era-ambiguous first request.
+    // The probe is server/discover precisely so this comes back as an
+    // unrecognized result shape (never a DiscoverResult) and stays legacy.
+    {
+        name: 'T9: 200-processed era-ambiguous result (not a DiscoverResult) → legacy fallback',
+        outcome: { kind: 'result', result: { tools: [{ name: 'echo', inputSchema: { type: 'object' } }] } },
+        expected: 'legacy'
+    },
+    // --- Wire-real shape A: the deployed −32000 unsupported-protocol-version literal (HTTP 400).
+    {
+        name: 'wire-real: HTTP 400 with the deployed -32000 "Unsupported protocol version" literal → legacy fallback',
+        outcome: { kind: 'http-error', status: 400, body: DEPLOYED_UNSUPPORTED_VERSION_BODY },
+        expected: 'legacy'
+    },
+    // --- Wire-real shape B: the deployed 400/−32000 session-required free text.
+    {
+        name: 'wire-real: HTTP 400 with the deployed -32000 session-required body → legacy fallback',
+        outcome: { kind: 'http-error', status: 400, body: DEPLOYED_SESSION_REQUIRED_BODY },
+        expected: 'legacy'
+    },
+    // --- Typed-recognizer allowlist: text never upgrades, codes + structured data decide.
+    {
+        name: 'recognizer: -32601 whose message merely CONTAINS "Unsupported protocol version" is not modern evidence → legacy',
+        outcome: { kind: 'rpc-error', code: -32_601, message: `Unsupported protocol version: ${MODERN}` },
+        expected: 'legacy'
+    },
+    {
+        name: 'recognizer: -32004 with a structured supported list naming a mutual modern version → corrective continuation',
+        outcome: {
+            kind: 'rpc-error',
+            code: -32_004,
+            message: 'Unsupported protocol version',
+            data: { supported: [MODERN, LATEST_PROTOCOL_VERSION], requested: '2027-01-01' }
+        },
+        expected: 'corrective'
+    },
+    {
+        name: 'recognizer: -32004 without a parsable data.supported list is not actionable modern evidence → legacy',
+        outcome: { kind: 'rpc-error', code: -32_004, message: 'Unsupported protocol version' },
+        expected: 'legacy'
+    },
+    {
+        name: 'recognizer: -32004 with a legacy-only supported list is a definitive legacy signal → legacy',
+        outcome: {
+            kind: 'rpc-error',
+            code: -32_004,
+            message: 'Unsupported protocol version',
+            data: { supported: [LATEST_PROTOCOL_VERSION], requested: MODERN }
+        },
+        expected: 'legacy'
+    },
+    {
+        name: 'recognizer: a 200 result that merely mentions supportedVersions in a text field is not a DiscoverResult → legacy',
+        outcome: { kind: 'result', result: { content: [{ type: 'text', text: `supportedVersions: ["${MODERN}"]` }] } },
+        expected: 'legacy'
+    },
+    // --- Q12 transport-aware timeout rows (stdio falls back, HTTP stays a typed error).
+    {
+        name: 'timeout on stdio → legacy fallback (the stdio backward-compatibility rule)',
+        outcome: { kind: 'timeout', timeoutMs: 500 },
+        expected: 'legacy'
+    },
+    {
+        name: 'timeout on HTTP → typed connect error, never an era verdict',
+        outcome: { kind: 'timeout', timeoutMs: 500 },
+        context: { transportKind: 'http' },
+        expected: 'error'
+    },
+    // --- -32601 from a deployed legacy server (the common pre-initialize answer).
+    {
+        name: 'wire-real: -32601 method-not-found → legacy fallback',
+        outcome: { kind: 'rpc-error', code: -32_601, message: 'Method not found' },
+        expected: 'legacy'
+    }
+];
+
+describe('T9/T11 merged probe fixture corpus (probe classifier)', () => {
+    for (const row of CORPUS) {
+        it(row.name, () => {
+            const verdict = classifyProbeOutcome(row.outcome, { ...baseContext, ...row.context });
+            expect(verdict.kind).toBe(row.expected);
+        });
+    }
+
+    it('a DiscoverResult with a mutual version is the only result shape that yields a modern verdict', () => {
+        const verdict = classifyProbeOutcome(
+            {
+                kind: 'result',
+                result: { supportedVersions: [MODERN], capabilities: {}, serverInfo: { name: 's', version: '1' } }
+            },
+            baseContext
+        );
+        expect(verdict.kind).toBe('modern');
+        if (verdict.kind === 'modern') {
+            expect(verdict.version).toBe(MODERN);
+        }
+    });
+});
+
+describe('T9 edge 5: probe wire shape (string probe id on the shared pipe)', () => {
+    it('probes with server/discover before any real request, using a string request id and the protocol-version envelope key', async () => {
+        const written: JSONRPCMessage[] = [];
+        // A scripted silent-legacy transport: records what the client writes and
+        // never answers, so only the probe (and, after its timeout, the
+        // initialize fallback) ever reaches the wire.
+        const transport: Transport = {
+            async start() {},
+            async close() {},
+            async send(message) {
+                written.push(message);
+            }
+        };
+
+        const client = new Client(
+            { name: 'probe-shape-client', version: '1.0.0' },
+            { versionNegotiation: { mode: 'auto', probe: { timeoutMs: 50 } } }
+        );
+        // The silent transport also never answers initialize; the connect
+        // attempt eventually fails — the probe wire shape is what this pin is
+        // about.
+        await client.connect(transport, { timeout: 200 }).catch(() => {});
+
+        expect(written.length).toBeGreaterThan(0);
+        const probe = written[0] as { id?: unknown; method?: string; params?: { _meta?: Record<string, unknown> } };
+        expect(probe.method).toBe('server/discover');
+        // String probe id: the probe runs above the Protocol layer on the same
+        // shared pipe, so it must never collide with the numeric ids Protocol
+        // assigns to real requests.
+        expect(typeof probe.id).toBe('string');
+        expect(probe.params?._meta?.[PROTOCOL_VERSION_META_KEY]).toBe(MODERN);
+        // Never probe with the first real request: nothing other than the probe
+        // and the legacy initialize fallback is written during connect.
+        for (const message of written) {
+            const method = (message as { method?: string }).method;
+            expect(['server/discover', 'initialize', 'notifications/initialized']).toContain(method);
+        }
+    });
+});

--- a/packages/core/src/shared/inboundClassification.ts
+++ b/packages/core/src/shared/inboundClassification.ts
@@ -618,6 +618,50 @@ export function classifyInboundRequest(request: InboundHttpRequest): InboundClas
 }
 
 /* ------------------------------------------------------------------------ *
+ * Per-message classification (long-lived channels)
+ * ------------------------------------------------------------------------ */
+
+/**
+ * Classifies one inbound JSON-RPC message for a long-lived dual-era channel
+ * (stdio and other hand-wired transports with no HTTP edge): the body-primary
+ * predicate reduced to its per-message form — there is no header layer (the
+ * stdio transport carries all request metadata inline in the message body)
+ * and no HTTP method to route.
+ *
+ * - `initialize` is the legacy handshake by definition; the version it
+ *   requested is carried as the classification's `revision`.
+ * - A message whose `params._meta` carries the reserved protocol-version key
+ *   claims the per-request envelope mechanism and classifies into the era of
+ *   the named revision. Envelope validity is enforced at dispatch by the era
+ *   codec — a malformed envelope behind a present claim is a validation
+ *   error, never a silent fall back to legacy handling.
+ * - A message without that claim — including one carrying only
+ *   `progressToken` or other non-reserved `_meta` keys — is legacy-era
+ *   traffic.
+ *
+ * Pure and total over requests and notifications; consumed by the
+ * protocol-layer classification consult for dual-era server instances.
+ */
+export function classifyInboundMessage(message: { method: string; params?: unknown }): MessageClassification {
+    if (message.method === 'initialize') {
+        const params = message.params;
+        const requestedVersion =
+            isPlainObject(params) && typeof params['protocolVersion'] === 'string' ? params['protocolVersion'] : undefined;
+        // The classification's `revision` names the wire revision the message
+        // is classified INTO, so it only carries the requested version when
+        // that version is itself a legacy one — an `initialize` requesting a
+        // modern revision is still the legacy handshake (it never negotiates
+        // a modern era) and stays a bare legacy classification.
+        const legacyRevision = requestedVersion !== undefined && !isModernProtocolVersion(requestedVersion) ? requestedVersion : undefined;
+        return { era: 'legacy', ...(legacyRevision !== undefined && { revision: legacyRevision }) };
+    }
+    if (hasEnvelopeClaim(message.params)) {
+        return classificationForClaim(envelopeClaimVersion(message.params));
+    }
+    return { era: 'legacy' };
+}
+
+/* ------------------------------------------------------------------------ *
  * Modern-only (strict) mapping of legacy routes
  * ------------------------------------------------------------------------ */
 

--- a/packages/core/src/shared/protocol.ts
+++ b/packages/core/src/shared/protocol.ts
@@ -15,6 +15,7 @@ import type {
     JSONRPCResponse,
     JSONRPCResultResponse,
     LoggingLevel,
+    MessageClassification,
     MessageExtraInfo,
     Notification,
     NotificationMethod,
@@ -488,6 +489,28 @@ export abstract class Protocol<ContextT extends BaseContext> {
      */
     protected abstract buildContext(ctx: BaseContext, transportInfo?: MessageExtraInfo): ContextT;
 
+    /**
+     * Classification consult for inbound messages whose transport did not
+     * classify them at the edge — long-lived dual-era channels such as stdio,
+     * where the protocol era is decided per message rather than per request
+     * at an HTTP edge.
+     *
+     * Consulted ONLY when the transport supplied no
+     * {@linkcode MessageExtraInfo.classification}: an edge classification
+     * always wins and the hook is never reached for it. The returned
+     * classification populates the carrier; on an instance with no negotiated
+     * protocol version it also selects the wire era for this one message,
+     * while an instance bound to a negotiated version validates it exactly
+     * like an edge classification (a mismatch is the typed
+     * unsupported-protocol-version answer for requests, a drop for
+     * notifications). Returning `'drop'` discards the message without writing
+     * any response. The base implementation returns `undefined`: unclassified
+     * traffic keeps today's dispatch path unchanged.
+     */
+    protected _classifyInbound(_message: JSONRPCRequest | JSONRPCNotification): MessageClassification | 'drop' | undefined {
+        return undefined;
+    }
+
     private async _oncancel(notification: CancelledNotification): Promise<void> {
         if (!notification.params.requestId) {
             return;
@@ -627,9 +650,27 @@ export abstract class Protocol<ContextT extends BaseContext> {
 
         // Era is instance state: the negotiated protocol version selects the
         // codec for everything this connection receives (legacy until
-        // negotiated). Classification is no longer a per-message era switch —
-        // it is validated against the instance era below.
-        const codec = this._negotiatedWireCodec();
+        // negotiated). An edge classification is never a per-message era
+        // switch — it is validated against the instance era below.
+        let codec = this._negotiatedWireCodec();
+
+        // Classification consult (only when the transport did not classify;
+        // an edge classification always wins and never reaches the hook). On
+        // an unbound instance the hook's classification selects the era for
+        // this one message (long-lived dual-era channels); a bound instance
+        // validates it below exactly like an edge classification.
+        if (extra?.classification === undefined) {
+            const consulted = this._classifyInbound(rawNotification);
+            if (consulted === 'drop') {
+                return;
+            }
+            if (consulted !== undefined) {
+                extra = { ...extra, classification: consulted };
+                if (this._negotiatedProtocolVersion === undefined) {
+                    codec = codecForVersion(classifiedWireEra(consulted));
+                }
+            }
+        }
 
         // Edge→instance handoff check: a classification that disagrees with
         // the instance era means the entry routed another era's traffic onto
@@ -679,11 +720,30 @@ export abstract class Protocol<ContextT extends BaseContext> {
 
         // Era is instance state: the negotiated protocol version selects the
         // codec for everything this connection receives (legacy until
-        // negotiated). Classification (Q2; this layer only CONSUMES
-        // MessageExtraInfo.classification) is no longer a per-message era
-        // switch — it is validated against the instance era below. Hand-wired
-        // legacy transports never classify, so their behavior is untouched.
-        const codec = this._negotiatedWireCodec();
+        // negotiated). An edge classification (Q2; produced at the HTTP
+        // entry) is never a per-message era switch — it is validated against
+        // the instance era below. Hand-wired legacy transports never
+        // classify, so their behavior is untouched.
+        let codec = this._negotiatedWireCodec();
+
+        // Classification consult (only when the transport did not classify;
+        // an edge classification always wins and never reaches the hook). On
+        // an unbound instance the hook's classification selects the era for
+        // this one message (long-lived dual-era channels); a bound instance
+        // validates it below exactly like an edge classification.
+        if (extra?.classification === undefined) {
+            const consulted = this._classifyInbound(rawRequest);
+            if (consulted === 'drop') {
+                this._onerror(new Error(`Dropped inbound request '${rawRequest.method}': not servable on this connection's protocol era`));
+                return;
+            }
+            if (consulted !== undefined) {
+                extra = { ...extra, classification: consulted };
+                if (this._negotiatedProtocolVersion === undefined) {
+                    codec = codecForVersion(classifiedWireEra(consulted));
+                }
+            }
+        }
 
         // Capture the current transport at request time to ensure responses go to the correct client
         const capturedTransport = this._transport;

--- a/packages/core/src/types/types.ts
+++ b/packages/core/src/types/types.ts
@@ -618,7 +618,10 @@ export type ListChangedHandlers = {
  * `Client`/`Server` instance); the protocol layer validates a classified
  * message against that instance era at dispatch — a mismatch is treated as
  * an entry/routing error, never a per-message era switch. Unclassified
- * traffic is dispatched on the instance era unchanged.
+ * traffic is dispatched on the instance era unchanged, except on long-lived
+ * dual-era channels (e.g. a stdio server that declared dual-era support),
+ * where the protocol layer's own classification consult classifies each
+ * message and selects its era per message.
  */
 export interface MessageClassification {
     /**
@@ -646,7 +649,9 @@ export interface MessageExtraInfo {
      * Protocol-era classification of the message, when the transport
      * classified it at the edge. Validated by the protocol layer against the
      * instance's negotiated era at dispatch (the edge→instance handoff
-     * check); it does not select the era itself.
+     * check); an edge classification never selects the era itself. When the
+     * transport did not classify, the protocol layer's classification consult
+     * may populate this carrier per message (long-lived dual-era channels).
      */
     classification?: MessageClassification;
 

--- a/packages/core/src/wire/codec.ts
+++ b/packages/core/src/wire/codec.ts
@@ -173,12 +173,14 @@ export function codecForVersion(version: string | undefined): WireCodec {
 }
 
 /**
- * The wire era an edge classification names (Q2 — produced at the
- * transport/entry edge; this layer only CONSUMES it). The dispatch funnel no
- * longer resolves a codec FROM the classification: era is instance state, and
- * a classified inbound message is VALIDATED against the instance era — a
- * mismatch is an entry/routing error, never a per-message era switch. The
- * exact `revision` wins over the coarse era flag when both are present.
+ * The wire era a classification names (Q2 — produced at the transport/entry
+ * edge or, for long-lived dual-era channels, by the protocol layer's own
+ * per-message classification consult). For edge classifications the dispatch
+ * funnel never resolves a codec FROM the classification: era is instance
+ * state, and the classified message is VALIDATED against it — a mismatch is
+ * an entry/routing error. Only an unbound dual-era instance selects the
+ * message's codec from its classification (per-message era). The exact
+ * `revision` wins over the coarse era flag when both are present.
  */
 export function classifiedWireEra(classification: MessageClassification): WireEra {
     if (classification.revision !== undefined) return codecForVersion(classification.revision).era;

--- a/packages/core/test/shared/classifyInboundMessage.test.ts
+++ b/packages/core/test/shared/classifyInboundMessage.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Per-message era predicate for long-lived dual-era channels
+ * (`classifyInboundMessage`) — the body-primary rule (Q2) in its stdio form,
+ * with the T11 sharpening: classification keys on the SPECIFIC reserved
+ * envelope key (`io.modelcontextprotocol/protocolVersion`), never on bare
+ * `_meta` presence.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { classifyInboundMessage } from '../../src/shared/inboundClassification.js';
+import {
+    CLIENT_CAPABILITIES_META_KEY,
+    CLIENT_INFO_META_KEY,
+    LOG_LEVEL_META_KEY,
+    PROTOCOL_VERSION_META_KEY
+} from '../../src/types/index.js';
+
+const MODERN = '2026-07-28';
+
+const fullEnvelope = (version: string) => ({
+    [PROTOCOL_VERSION_META_KEY]: version,
+    [CLIENT_INFO_META_KEY]: { name: 'fixture-client', version: '1.0.0' },
+    [CLIENT_CAPABILITIES_META_KEY]: {}
+});
+
+describe('classifyInboundMessage (per-message body-primary predicate)', () => {
+    it('classifies `initialize` as legacy and carries the requested version as the revision', () => {
+        const classification = classifyInboundMessage({
+            method: 'initialize',
+            params: { protocolVersion: '2025-06-18', capabilities: {}, clientInfo: { name: 'c', version: '1' } }
+        });
+        expect(classification).toEqual({ era: 'legacy', revision: '2025-06-18' });
+    });
+
+    it('classifies `initialize` without a parsable protocolVersion as legacy with no revision', () => {
+        expect(classifyInboundMessage({ method: 'initialize', params: {} })).toEqual({ era: 'legacy' });
+        expect(classifyInboundMessage({ method: 'initialize' })).toEqual({ era: 'legacy' });
+    });
+
+    it('classifies `initialize` REQUESTING a modern revision as a bare legacy classification (initialize never negotiates a modern era)', () => {
+        const classification = classifyInboundMessage({
+            method: 'initialize',
+            params: { protocolVersion: MODERN, capabilities: {}, clientInfo: { name: 'c', version: '1' } }
+        });
+        expect(classification).toEqual({ era: 'legacy' });
+    });
+
+    it('classifies a message carrying the reserved protocol-version envelope key as modern with the claimed revision', () => {
+        const classification = classifyInboundMessage({
+            method: 'tools/list',
+            params: { _meta: fullEnvelope(MODERN) }
+        });
+        expect(classification).toEqual({ era: 'modern', revision: MODERN });
+    });
+
+    it('classifies an envelope claim naming a 2025-era revision as legacy with that revision', () => {
+        const classification = classifyInboundMessage({
+            method: 'tools/list',
+            params: { _meta: { [PROTOCOL_VERSION_META_KEY]: '2025-06-18' } }
+        });
+        expect(classification).toEqual({ era: 'legacy', revision: '2025-06-18' });
+    });
+
+    it('classifies a claim with a non-string protocol-version value as a modern claim (validated at dispatch, never silently legacy)', () => {
+        const classification = classifyInboundMessage({
+            method: 'tools/list',
+            params: { _meta: { [PROTOCOL_VERSION_META_KEY]: 42 } }
+        });
+        expect(classification).toEqual({ era: 'modern' });
+    });
+
+    it('T11: a legacy client carrying only `progressToken` in `_meta` classifies legacy — never bare `_meta` presence', () => {
+        const classification = classifyInboundMessage({
+            method: 'tools/call',
+            params: { name: 'echo', arguments: {}, _meta: { progressToken: 7 } }
+        });
+        expect(classification).toEqual({ era: 'legacy' });
+    });
+
+    it('T11: other reserved envelope keys without the protocol-version key do NOT constitute a claim', () => {
+        const classification = classifyInboundMessage({
+            method: 'tools/call',
+            params: {
+                name: 'echo',
+                arguments: {},
+                _meta: {
+                    [CLIENT_INFO_META_KEY]: { name: 'c', version: '1' },
+                    [CLIENT_CAPABILITIES_META_KEY]: {},
+                    [LOG_LEVEL_META_KEY]: 'info'
+                }
+            }
+        });
+        expect(classification).toEqual({ era: 'legacy' });
+    });
+
+    it('classifies a claim-less request as legacy', () => {
+        expect(classifyInboundMessage({ method: 'tools/list', params: {} })).toEqual({ era: 'legacy' });
+        expect(classifyInboundMessage({ method: 'ping' })).toEqual({ era: 'legacy' });
+    });
+
+    it('classifies notifications by the same body-primary rule', () => {
+        expect(classifyInboundMessage({ method: 'notifications/cancelled', params: { requestId: 1 } })).toEqual({ era: 'legacy' });
+        expect(
+            classifyInboundMessage({ method: 'notifications/cancelled', params: { requestId: 1, _meta: fullEnvelope(MODERN) } })
+        ).toEqual({ era: 'modern', revision: MODERN });
+    });
+});

--- a/packages/core/test/shared/protocolClassifyInboundHook.test.ts
+++ b/packages/core/test/shared/protocolClassifyInboundHook.test.ts
@@ -1,0 +1,255 @@
+/**
+ * The protocol-layer classification consult (`Protocol._classifyInbound`):
+ *
+ * - B-2 pin: when the transport supplied an edge classification, the hook is
+ *   NEVER consulted — the edge classification always wins.
+ * - The base implementation returns `undefined`, so unclassified traffic on
+ *   a default instance keeps today's dispatch path byte-identically.
+ * - A hook classification populates the `MessageExtraInfo.classification`
+ *   carrier and, on an UNBOUND instance (no negotiated protocol version),
+ *   selects the wire era for that one message (per-message era on long-lived
+ *   dual-era channels). On a BOUND instance it is validated exactly like an
+ *   edge classification (mismatch ⇒ −32004 for requests, drop for
+ *   notifications).
+ * - Returning `'drop'` discards the message without writing any response.
+ */
+import { describe, expect, it } from 'vitest';
+import * as z from 'zod/v4';
+
+import type { BaseContext } from '../../src/shared/protocol.js';
+import { Protocol, setNegotiatedProtocolVersion } from '../../src/shared/protocol.js';
+import type {
+    JSONRPCErrorResponse,
+    JSONRPCMessage,
+    JSONRPCNotification,
+    JSONRPCRequest,
+    JSONRPCResultResponse,
+    MessageClassification,
+    MessageExtraInfo,
+    Result
+} from '../../src/types/index.js';
+import {
+    CLIENT_CAPABILITIES_META_KEY,
+    CLIENT_INFO_META_KEY,
+    isJSONRPCErrorResponse,
+    isJSONRPCResultResponse,
+    PROTOCOL_VERSION_META_KEY
+} from '../../src/types/index.js';
+import { InMemoryTransport } from '../../src/util/inMemory.js';
+
+const MODERN = '2026-07-28';
+
+const modernEnvelope = {
+    [PROTOCOL_VERSION_META_KEY]: MODERN,
+    [CLIENT_INFO_META_KEY]: { name: 'hook-test-client', version: '1.0.0' },
+    [CLIENT_CAPABILITIES_META_KEY]: {}
+};
+
+class HookedProtocol extends Protocol<BaseContext> {
+    /** Messages the hook was consulted for (in order). */
+    consulted: Array<JSONRPCRequest | JSONRPCNotification> = [];
+    /** What the hook answers; `undefined` keeps the base behavior. */
+    verdict: ((message: JSONRPCRequest | JSONRPCNotification) => MessageClassification | 'drop' | undefined) | undefined;
+    /** The MessageExtraInfo handed to buildContext for the last dispatched request. */
+    lastExtra: MessageExtraInfo | undefined;
+
+    protected assertCapabilityForMethod(): void {}
+    protected assertNotificationCapability(): void {}
+    protected assertRequestHandlerCapability(): void {}
+    protected buildContext(ctx: BaseContext, transportInfo?: MessageExtraInfo): BaseContext {
+        this.lastExtra = transportInfo;
+        return ctx;
+    }
+
+    protected override _classifyInbound(message: JSONRPCRequest | JSONRPCNotification): MessageClassification | 'drop' | undefined {
+        this.consulted.push(message);
+        return this.verdict?.(message);
+    }
+}
+
+class BaseProtocol extends Protocol<BaseContext> {
+    protected assertCapabilityForMethod(): void {}
+    protected assertNotificationCapability(): void {}
+    protected assertRequestHandlerCapability(): void {}
+    protected buildContext(ctx: BaseContext): BaseContext {
+        return ctx;
+    }
+}
+
+const flush = () => new Promise(resolve => setTimeout(resolve, 10));
+
+async function wire<T extends Protocol<BaseContext>>(protocol: T) {
+    const [peerTx, protocolTx] = InMemoryTransport.createLinkedPair();
+    const sent: JSONRPCMessage[] = [];
+    peerTx.onmessage = message => void sent.push(message);
+    await peerTx.start();
+    const errors: Error[] = [];
+    protocol.onerror = error => void errors.push(error);
+    await protocol.connect(protocolTx);
+    return { peerTx, protocolTx, sent, errors };
+}
+
+describe('B-2: an edge classification always wins', () => {
+    it('never consults the hook for a message that already carries a classification', async () => {
+        const protocol = new HookedProtocol();
+        protocol.verdict = () => ({ era: 'modern', revision: MODERN });
+        const { protocolTx, sent } = await wire(protocol);
+
+        protocolTx.onmessage?.(
+            { jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} } as JSONRPCMessage,
+            // The in-memory transport's onmessage declares the narrower
+            // pre-classification extra type; the protocol layer reads the
+            // full MessageExtraInfo (same cast as the era-gate suite).
+            { classification: { era: 'legacy' } } as never
+        );
+        await flush();
+
+        expect(protocol.consulted).toHaveLength(0);
+        // The edge classification (legacy) matches the unbound instance era,
+        // so the request proceeds to today's path: no handler ⇒ −32601.
+        expect(sent).toHaveLength(1);
+        expect((sent[0] as JSONRPCErrorResponse).error.code).toBe(-32_601);
+        await protocol.close();
+    });
+
+    it('consults the hook when the transport did not classify', async () => {
+        const protocol = new HookedProtocol();
+        protocol.verdict = () => undefined;
+        const { peerTx, sent } = await wire(protocol);
+
+        await peerTx.send({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} });
+        await flush();
+
+        expect(protocol.consulted).toHaveLength(1);
+        expect(protocol.consulted[0]).toMatchObject({ method: 'tools/list' });
+        // `undefined` keeps today's path: no handler ⇒ −32601, no classification carrier.
+        expect(sent).toHaveLength(1);
+        expect((sent[0] as JSONRPCErrorResponse).error.code).toBe(-32_601);
+        await protocol.close();
+    });
+});
+
+describe("base implementation (no override) keeps today's dispatch", () => {
+    it('serves unclassified legacy traffic identically: handler runs, result is not stamped with 2026 wire fields', async () => {
+        const protocol = new BaseProtocol();
+        protocol.setRequestHandler('tools/list', () => ({ tools: [] }));
+        const { peerTx, sent } = await wire(protocol);
+
+        await peerTx.send({ jsonrpc: '2.0', id: 7, method: 'tools/list', params: {} });
+        await flush();
+
+        expect(sent).toHaveLength(1);
+        const response = sent[0] as JSONRPCResultResponse;
+        expect(isJSONRPCResultResponse(response)).toBe(true);
+        expect(response.result).toEqual({ tools: [] });
+        expect(JSON.stringify(response)).not.toContain('resultType');
+        await protocol.close();
+    });
+});
+
+describe('per-message era on an unbound instance (long-lived dual-era channels)', () => {
+    it('a hook classification of modern serves the message on the 2026 era: envelope honored, result stamped', async () => {
+        const protocol = new HookedProtocol();
+        protocol.verdict = message => (message.method === 'initialize' ? { era: 'legacy' } : { era: 'modern', revision: MODERN });
+        protocol.setRequestHandler('tools/list', () => ({ tools: [] }));
+        const { peerTx, sent } = await wire(protocol);
+
+        await peerTx.send({ jsonrpc: '2.0', id: 2, method: 'tools/list', params: { _meta: modernEnvelope } });
+        await flush();
+
+        expect(sent).toHaveLength(1);
+        const response = sent[0] as JSONRPCResultResponse;
+        expect(isJSONRPCResultResponse(response)).toBe(true);
+        expect((response.result as { resultType?: string }).resultType).toBe('complete');
+        // The carrier was populated and reached the handler context.
+        expect(protocol.lastExtra?.classification).toEqual({ era: 'modern', revision: MODERN });
+        await protocol.close();
+    });
+
+    it('a hook classification of legacy answers a 2026-only spec method with a plain −32601 (era gate by registry absence)', async () => {
+        const protocol = new HookedProtocol();
+        protocol.verdict = () => ({ era: 'legacy' });
+        // Even an installed handler cannot shadow the era gate.
+        protocol.setRequestHandler('server/discover', { params: z.looseObject({}) }, () => ({}) as Result);
+        const { peerTx, sent } = await wire(protocol);
+
+        await peerTx.send({ jsonrpc: '2.0', id: 3, method: 'server/discover', params: {} });
+        await flush();
+
+        expect(sent).toHaveLength(1);
+        const response = sent[0] as JSONRPCErrorResponse;
+        expect(isJSONRPCErrorResponse(response)).toBe(true);
+        expect(response.error).toEqual({ code: -32_601, message: 'Method not found' });
+        await protocol.close();
+    });
+});
+
+describe('hook classification on a BOUND instance is validated like an edge classification', () => {
+    it('a legacy-classified request on a modern-bound instance answers −32004 with the supported list', async () => {
+        const protocol = new HookedProtocol();
+        protocol.verdict = () => ({ era: 'legacy' });
+        const { peerTx, sent } = await wire(protocol);
+        setNegotiatedProtocolVersion(protocol, MODERN);
+
+        await peerTx.send({ jsonrpc: '2.0', id: 4, method: 'tools/list', params: {} });
+        await flush();
+
+        expect(sent).toHaveLength(1);
+        const error = (sent[0] as JSONRPCErrorResponse).error as { code: number; data?: { supported?: string[] } };
+        expect(error.code).toBe(-32_004);
+        expect(Array.isArray(error.data?.supported)).toBe(true);
+        await protocol.close();
+    });
+
+    it('a legacy-classified notification on a modern-bound instance is dropped (no handler invocation, no response)', async () => {
+        const protocol = new HookedProtocol();
+        protocol.verdict = () => ({ era: 'legacy' });
+        let invoked = 0;
+        protocol.fallbackNotificationHandler = async () => {
+            invoked += 1;
+        };
+        const { peerTx, sent, errors } = await wire(protocol);
+        setNegotiatedProtocolVersion(protocol, MODERN);
+
+        await peerTx.send({ jsonrpc: '2.0', method: 'notifications/initialized' });
+        await flush();
+
+        expect(invoked).toBe(0);
+        expect(sent).toHaveLength(0);
+        expect(errors.length).toBeGreaterThan(0);
+        await protocol.close();
+    });
+});
+
+describe("'drop' verdict", () => {
+    it('discards an inbound request without writing any response and surfaces it via onerror', async () => {
+        const protocol = new HookedProtocol();
+        protocol.verdict = () => 'drop';
+        protocol.setRequestHandler('tools/list', () => ({ tools: [] }));
+        const { peerTx, sent, errors } = await wire(protocol);
+
+        await peerTx.send({ jsonrpc: '2.0', id: 5, method: 'tools/list', params: {} });
+        await flush();
+
+        expect(sent).toHaveLength(0);
+        expect(errors.some(error => error.message.includes('Dropped inbound request'))).toBe(true);
+        await protocol.close();
+    });
+
+    it('discards an inbound notification without dispatching it', async () => {
+        const protocol = new HookedProtocol();
+        protocol.verdict = () => 'drop';
+        let invoked = 0;
+        protocol.fallbackNotificationHandler = async () => {
+            invoked += 1;
+        };
+        const { peerTx, sent } = await wire(protocol);
+
+        await peerTx.send({ jsonrpc: '2.0', method: 'notifications/initialized' });
+        await flush();
+
+        expect(invoked).toBe(0);
+        expect(sent).toHaveLength(0);
+        await protocol.close();
+    });
+});

--- a/packages/server/src/server/server.ts
+++ b/packages/server/src/server/server.ts
@@ -41,7 +41,10 @@ import {
     codecForVersion,
     CreateMessageResultSchema,
     CreateMessageResultWithToolsSchema,
+    envelopeClaimVersion,
     FIRST_MODERN_PROTOCOL_VERSION,
+    hasEnvelopeClaim,
+    isModernProtocolVersion,
     LATEST_PROTOCOL_VERSION,
     legacyProtocolVersions,
     LoggingLevelSchema,
@@ -51,9 +54,11 @@ import {
     Protocol,
     ProtocolError,
     ProtocolErrorCode,
+    requestMetaOf,
     SdkError,
     SdkErrorCode,
-    SUPPORTED_MODERN_PROTOCOL_VERSIONS
+    SUPPORTED_MODERN_PROTOCOL_VERSIONS,
+    validateEnvelopeMeta
 } from '@modelcontextprotocol/core';
 import { DefaultJsonSchemaValidator } from '@modelcontextprotocol/server/_shims';
 import * as z from 'zod/v4';
@@ -142,6 +147,30 @@ export type ServerOptions = ProtocolOptions & {
  * dispatch schema from the instance era) cannot be used here.
  */
 const DISCOVER_PARAMS_SCHEMA = z.looseObject({});
+
+/**
+ * Whether a message's params carry a per-request envelope claim that is both
+ * well-formed and names a modern protocol revision.
+ *
+ * The per-message form of the inbound classifier's `initialize` precedence
+ * rule: only such a claim overrides the `initialize` ⇒ legacy-handshake
+ * classification — a message carrying a valid modern envelope is a modern
+ * request regardless of its method name, and the modern era then answers
+ * `initialize` exactly like any other method it does not define
+ * (method-not-found). A malformed claim, or one naming a pre-2026 revision,
+ * keeps the legacy-handshake routing unchanged.
+ */
+function carriesValidModernEnvelopeClaim(params: unknown): boolean {
+    if (!hasEnvelopeClaim(params)) {
+        return false;
+    }
+    const claimedVersion = envelopeClaimVersion(params);
+    if (claimedVersion === undefined || !isModernProtocolVersion(claimedVersion)) {
+        return false;
+    }
+    const meta = requestMetaOf(params);
+    return meta !== undefined && validateEnvelopeMeta(meta).length === 0;
+}
 
 /*
  * Package-internal hooks for the per-request (2026-07-28) HTTP serving entry.
@@ -308,6 +337,20 @@ export class Server extends Protocol<ServerContext> {
     protected override _classifyInbound(message: JSONRPCRequest | JSONRPCNotification): MessageClassification | 'drop' | undefined {
         if (this._eraSupport === 'legacy') {
             return undefined;
+        }
+        // `initialize` is the legacy handshake by definition — unless the
+        // message carries a valid envelope claim naming a modern revision, in
+        // which case the claim wins: the message is classified like any other
+        // enveloped message and served on the modern era, where the era
+        // registry answers `initialize` with the same plain method-not-found
+        // it answers every other method that era does not define. A malformed
+        // or absent claim, or a claim naming a pre-2026 revision, keeps the
+        // legacy-handshake classification from the per-message predicate.
+        if (message.method === 'initialize' && carriesValidModernEnvelopeClaim(message.params)) {
+            const claimedVersion = envelopeClaimVersion(message.params);
+            if (claimedVersion !== undefined) {
+                return { era: 'modern', revision: claimedVersion };
+            }
         }
         return classifyInboundMessage(message);
     }

--- a/packages/server/src/server/server.ts
+++ b/packages/server/src/server/server.ts
@@ -14,6 +14,7 @@ import type {
     Implementation,
     InitializeRequest,
     InitializeResult,
+    JSONRPCNotification,
     JSONRPCRequest,
     JsonSchemaType,
     jsonSchemaValidator,
@@ -21,6 +22,7 @@ import type {
     ListRootsResult,
     LoggingLevel,
     LoggingMessageNotification,
+    MessageClassification,
     MessageExtraInfo,
     NotificationMethod,
     NotificationOptions,
@@ -35,6 +37,7 @@ import type {
     ToolUseContent
 } from '@modelcontextprotocol/core';
 import {
+    classifyInboundMessage,
     codecForVersion,
     CreateMessageResultSchema,
     CreateMessageResultWithToolsSchema,
@@ -48,9 +51,11 @@ import {
     ProtocolError,
     ProtocolErrorCode,
     SdkError,
-    SdkErrorCode
+    SdkErrorCode,
+    SUPPORTED_MODERN_PROTOCOL_VERSIONS
 } from '@modelcontextprotocol/core';
 import { DefaultJsonSchemaValidator } from '@modelcontextprotocol/server/_shims';
+import * as z from 'zod/v4';
 
 export type ServerOptions = ProtocolOptions & {
     /**
@@ -79,7 +84,56 @@ export type ServerOptions = ProtocolOptions & {
      * @default Runtime-selected validator (AJV-backed on Node.js, `@cfworker/json-schema`-backed on browser/workerd runtimes)
      */
     jsonSchemaValidator?: jsonSchemaValidator;
+
+    /**
+     * Which protocol eras this server serves on its long-lived connection
+     * (e.g. stdio): the 2025-era `initialize` family, the 2026-07-28
+     * per-request-envelope revision, or both.
+     *
+     * - `'legacy'` (the default) preserves exactly what existing code was
+     *   written for: the server speaks the 2025-era protocol negotiated via
+     *   `initialize`, never registers or advertises `server/discover`, and
+     *   upgrading the SDK changes nothing about what the instance puts on the
+     *   wire.
+     * - `'dual-era'` serves BOTH eras on the same connection, selecting the
+     *   era per message: `initialize`-negotiated 2025 traffic is served as
+     *   before, while messages carrying the 2026-07-28 per-request `_meta`
+     *   envelope (including `server/discover`) are served on the modern era.
+     *   Declaring dual-era support is an explicit act — the consumer asserts
+     *   that the server is ready to serve modern-era requests.
+     * - `'modern'` is strict 2026-07-28-only: requests without the
+     *   per-request envelope (including `initialize`) are answered with the
+     *   unsupported-protocol-version error naming the supported revisions.
+     *
+     * Opting in is one option away and the transport stays unchanged:
+     *
+     * ```ts
+     * const server = new McpServer({ name: 'my-server', version: '1.0.0' }, { eraSupport: 'dual-era' });
+     * await server.connect(new StdioServerTransport());
+     * ```
+     *
+     * A 2026-era revision in {@linkcode ProtocolOptions.supportedProtocolVersions}
+     * requires `'dual-era'` or `'modern'`; passing one on a (default)
+     * `'legacy'` instance throws a `TypeError` at construction.
+     *
+     * Per-request HTTP serving via `createMcpHandler` does not use this
+     * option: the entry classifies each request and binds the per-request
+     * instance itself.
+     *
+     * @default 'legacy'
+     */
+    eraSupport?: 'legacy' | 'dual-era' | 'modern';
 };
+
+/**
+ * Permissive params schema for the `server/discover` registration on servers
+ * that declared modern-era support. The discover request carries only the
+ * per-request `_meta` envelope, which the protocol layer lifts and validates
+ * before dispatch — and a long-lived dual-era instance is never bound to a
+ * single era, so the spec-method registration form (which resolves its
+ * dispatch schema from the instance era) cannot be used here.
+ */
+const DISCOVER_PARAMS_SCHEMA = z.looseObject({});
 
 /*
  * Package-internal hooks for the per-request (2026-07-28) HTTP serving entry.
@@ -159,6 +213,14 @@ export class Server extends Protocol<ServerContext> {
     private _capabilities: ServerCapabilities;
     private _instructions?: string;
     private _jsonSchemaValidator: jsonSchemaValidator;
+    private _eraSupport: 'legacy' | 'dual-era' | 'modern';
+    /**
+     * The protocol version a legacy `initialize` handshake negotiated on a
+     * dual-era instance. A dual-era instance is never bound to a single era
+     * (the era is selected per message), so the handshake result is recorded
+     * here only for the initialize-scoped accessor.
+     */
+    private _dualEraInitializeVersion?: string;
 
     /**
      * Callback for when initialization has fully completed (i.e., the client has sent an `notifications/initialized` notification).
@@ -176,19 +238,63 @@ export class Server extends Protocol<ServerContext> {
         this._capabilities = options?.capabilities ? { ...options.capabilities } : {};
         this._instructions = options?.instructions;
         this._jsonSchemaValidator = options?.jsonSchemaValidator ?? new DefaultJsonSchemaValidator();
+        this._eraSupport = options?.eraSupport ?? 'legacy';
 
         this.setRequestHandler('initialize', request => this._oninitialize(request));
         this.setNotificationHandler('notifications/initialized', () => this.oninitialized?.());
 
-        // server/discover is installed only when the supported-versions list
-        // carries a modern revision: a legacy-only server keeps answering -32601.
-        if (modernProtocolVersions(this._supportedProtocolVersions).length > 0) {
-            this.setRequestHandler('server/discover', () => this._ondiscover());
+        if (this._eraSupport === 'legacy') {
+            // The default preserves exactly what the code was written for:
+            // 2025-era serving only, nothing 2026-era registered or
+            // advertised. Serving a 2026-era revision is a declared act — a
+            // modern revision in the supported list without that declaration
+            // is a configuration error, never a silent behavior change.
+            const modernVersions = modernProtocolVersions(this._supportedProtocolVersions);
+            if (modernVersions.length > 0) {
+                throw new TypeError(
+                    `supportedProtocolVersions contains the protocol revision ${modernVersions[0]}, which this server does not serve ` +
+                        `with the default eraSupport of 'legacy'. Declare { eraSupport: 'dual-era' } (serve both eras) or ` +
+                        `{ eraSupport: 'modern' } (2026-era only) to serve it.`
+                );
+            }
+        } else {
+            // server/discover is registered (and modern revisions advertised)
+            // only on servers that declared modern-era support; the served
+            // modern revisions are added to the supported list so the
+            // advertisement and version-mismatch errors name them (a new
+            // array — the shared default constant is never mutated).
+            const missing = SUPPORTED_MODERN_PROTOCOL_VERSIONS.filter(version => !this._supportedProtocolVersions.includes(version));
+            if (missing.length > 0) {
+                this._supportedProtocolVersions = [...this._supportedProtocolVersions, ...missing];
+            }
+            this.setRequestHandler('server/discover', { params: DISCOVER_PARAMS_SCHEMA }, () => this._ondiscover());
+            if (this._eraSupport === 'modern') {
+                // A strict modern-only server is bound to the modern era from
+                // construction: requests classified into the 2025 era are
+                // answered with the typed unsupported-protocol-version error
+                // naming the supported revisions, never served.
+                this._negotiatedProtocolVersion = modernProtocolVersions(this._supportedProtocolVersions)[0];
+            }
         }
 
         if (this._capabilities.logging) {
             this._registerLoggingHandler();
         }
+    }
+
+    /**
+     * Per-message era classification for long-lived dual-era channels (e.g. a
+     * stdio server that declared modern-era support). Active only when the
+     * consumer opted in: default (`'legacy'`) instances return `undefined`,
+     * which keeps their dispatch byte-identical to today's. Transport-edge
+     * classification (the per-request HTTP entry) always wins and never
+     * reaches this hook.
+     */
+    protected override _classifyInbound(message: JSONRPCRequest | JSONRPCNotification): MessageClassification | 'drop' | undefined {
+        if (this._eraSupport === 'legacy') {
+            return undefined;
+        }
+        return classifyInboundMessage(message);
     }
 
     /**
@@ -469,7 +575,15 @@ export class Server extends Protocol<ServerContext> {
         // The negotiated version is the instance's connection state — it IS
         // the wire-era selection for everything this instance sends and
         // receives from here on (legacy handshake ⇒ a legacy-era version).
-        this._negotiatedProtocolVersion = protocolVersion;
+        // The one exception is a dual-era instance: it serves both eras on
+        // the same long-lived connection, selecting the era per message, so
+        // the handshake never binds the instance — the result is recorded
+        // only for the initialize-scoped accessor.
+        if (this._eraSupport === 'dual-era') {
+            this._dualEraInitializeVersion = protocolVersion;
+        } else {
+            this._negotiatedProtocolVersion = protocolVersion;
+        }
         this.transport?.setProtocolVersion?.(protocolVersion);
 
         return {
@@ -530,10 +644,13 @@ export class Server extends Protocol<ServerContext> {
      * 2026-07-28 (per-request envelope) requests `ctx.mcpReq.envelope` names the revision the
      * request was sent for, while on 2025-era connections this accessor keeps returning the
      * `initialize`-negotiated version. The accessor remains functional — instances serving the
-     * 2026-07-28 era report that revision.
+     * 2026-07-28 era report that revision. On a long-lived dual-era instance (`eraSupport:
+     * 'dual-era'`), where the era is selected per message, the accessor keeps its
+     * initialize-scoped semantics and reports what a legacy `initialize` handshake negotiated
+     * (or `undefined` when none ran).
      */
     getNegotiatedProtocolVersion(): string | undefined {
-        return this._negotiatedProtocolVersion;
+        return this._negotiatedProtocolVersion ?? this._dualEraInitializeVersion;
     }
 
     /**

--- a/packages/server/src/server/server.ts
+++ b/packages/server/src/server/server.ts
@@ -41,6 +41,7 @@ import {
     codecForVersion,
     CreateMessageResultSchema,
     CreateMessageResultWithToolsSchema,
+    FIRST_MODERN_PROTOCOL_VERSION,
     LATEST_PROTOCOL_VERSION,
     legacyProtocolVersions,
     LoggingLevelSchema,
@@ -331,19 +332,76 @@ export class Server extends Protocol<ServerContext> {
         });
     }
 
+    /**
+     * Era gate for context-related server→client requests, keyed off the era
+     * of the request currently being served (its classification).
+     *
+     * A long-lived dual-era instance is never bound to a single era, so the
+     * instance-level outbound era gate alone would let a handler that is
+     * serving a 2026-era request push a server→client wire request
+     * (sampling, elicitation, roots) onto the connection. The 2026-07-28
+     * revision has no server→client JSON-RPC request channel, so the client
+     * drops the request and the call hangs until timeout. The request
+     * context therefore applies the same typed local error a strict
+     * `'modern'` instance raises, per request: spec methods absent from the
+     * served era's registry fail fast before anything reaches the transport.
+     *
+     * Scope: the context request path only (`ctx.mcpReq.send`,
+     * `ctx.mcpReq.elicitInput`, `ctx.mcpReq.requestSampling`). Related
+     * notifications, requests served on the legacy era, and instance-level
+     * senders used outside a request context are unaffected.
+     */
+    private _assertContextRequestInServedEra(classification: MessageClassification | undefined, method: string): void {
+        if (classification === undefined) {
+            return;
+        }
+        const servedCodec = codecForVersion(
+            classification.revision ?? (classification.era === 'modern' ? FIRST_MODERN_PROTOCOL_VERSION : undefined)
+        );
+        // Mirrors the outbound era gate: only spec methods missing from the
+        // served era are gated; methods the served era defines (and
+        // consumer-owned extension methods) resolve exactly as before.
+        if (servedCodec.hasRequestMethod(method) || !codecForVersion(undefined).hasRequestMethod(method)) {
+            return;
+        }
+        throw new SdkError(
+            SdkErrorCode.MethodNotSupportedByProtocolVersion,
+            `Server-to-client requests are not available on protocol revision ${servedCodec.era}: ` +
+                `'${method}' cannot be sent while serving a request on that revision. ` +
+                `Servers obtain client input through request results once multi-round-trip support is available.`,
+            { method, era: servedCodec.era }
+        );
+    }
+
     protected override buildContext(ctx: BaseContext, transportInfo?: MessageExtraInfo): ServerContext {
         // Only create http when there's actual HTTP transport info or auth info
         const hasHttpInfo = ctx.http || transportInfo?.request || transportInfo?.closeSSEStream || transportInfo?.closeStandaloneSSEStream;
+        const classification = transportInfo?.classification;
+        // Context-related server→client requests are gated by the era of the
+        // request being served (see _assertContextRequestInServedEra);
+        // related notifications (`notify`, `log`) are unaffected.
+        const baseSend = ctx.mcpReq.send as (request: { method: string }, ...rest: unknown[]) => Promise<unknown>;
+        const send = ((request: { method: string }, ...rest: unknown[]) => {
+            this._assertContextRequestInServedEra(classification, request.method);
+            return baseSend(request, ...rest);
+        }) as BaseContext['mcpReq']['send'];
         return {
             ...ctx,
             mcpReq: {
                 ...ctx.mcpReq,
+                send,
                 // Deprecated as of protocol version 2026-07-28 (SEP-2577): `log` and
                 // `requestSampling` remain functional during the deprecation window
                 // (at least twelve months). See ServerContext for migration guidance.
                 log: (level, data, logger) => this.sendLoggingMessage({ level, data, logger }),
-                elicitInput: (params, options) => this.elicitInput(params, options),
-                requestSampling: (params, options) => this.createMessage(params, options)
+                elicitInput: async (params, options) => {
+                    this._assertContextRequestInServedEra(classification, 'elicitation/create');
+                    return this.elicitInput(params, options);
+                },
+                requestSampling: async (params, options) => {
+                    this._assertContextRequestInServedEra(classification, 'sampling/createMessage');
+                    return this.createMessage(params, options);
+                }
             },
             http: hasHttpInfo
                 ? {

--- a/packages/server/src/server/server.ts
+++ b/packages/server/src/server/server.ts
@@ -105,6 +105,13 @@ export type ServerOptions = ProtocolOptions & {
      *   per-request envelope (including `initialize`) are answered with the
      *   unsupported-protocol-version error naming the supported revisions.
      *
+     * Declaring `'dual-era'` or `'modern'` automatically adds the SDK's
+     * supported modern revisions to
+     * {@linkcode ProtocolOptions.supportedProtocolVersions}, and `'modern'`
+     * serves only those: a strict instance's supported-versions list (what
+     * `server/discover` advertises and version-mismatch errors name) is its
+     * modern subset.
+     *
      * Opting in is one option away and the transport stays unchanged:
      *
      * ```ts
@@ -269,11 +276,18 @@ export class Server extends Protocol<ServerContext> {
             }
             this.setRequestHandler('server/discover', { params: DISCOVER_PARAMS_SCHEMA }, () => this._ondiscover());
             if (this._eraSupport === 'modern') {
+                // A strict modern-only server serves only modern revisions, so
+                // the supported list is reduced to its modern subset — keeping
+                // the legacy entries would advertise revisions the instance
+                // never serves in the unsupported-protocol-version error's
+                // supported list, and `initialize` (the only other consumer of
+                // the legacy entries) is unreachable on a strict instance.
+                this._supportedProtocolVersions = modernProtocolVersions(this._supportedProtocolVersions);
                 // A strict modern-only server is bound to the modern era from
                 // construction: requests classified into the 2025 era are
                 // answered with the typed unsupported-protocol-version error
                 // naming the supported revisions, never served.
-                this._negotiatedProtocolVersion = modernProtocolVersions(this._supportedProtocolVersions)[0];
+                this._negotiatedProtocolVersion = this._supportedProtocolVersions[0];
             }
         }
 

--- a/packages/server/test/server/discover.test.ts
+++ b/packages/server/test/server/discover.test.ts
@@ -1,9 +1,11 @@
 /**
  * `server/discover` machinery + era-aware supported-version list semantics:
  *
- * - the handler is installed ONLY when the server's supported-versions list
- *   carries a modern (2026-07-28+) revision; default servers keep answering
- *   -32601 byte-identically to the deployed fleet
+ * - the handler is installed ONLY on servers that declare modern-era support
+ *   (`eraSupport: 'dual-era' | 'modern'`); default servers keep answering
+ *   -32601 byte-identically to the deployed fleet, and a modern (2026-07-28+)
+ *   revision in the supported-versions list without that declaration is a
+ *   construction-time TypeError
  * - the advertisement is modern-only (DV-30) and excludes the
  *   listChanged/subscribe-class capabilities (A11 rider — until the
  *   subscriptions/listen milestone lands)
@@ -12,12 +14,10 @@
  *   site, even when the supported list carries one — the guard that must hold
  *   BEFORE any LATEST/SUPPORTED constant bump.
  *
- * Era is instance state: an inbound `server/discover` is served only by a
- * modern-era instance (the method is physically absent from the legacy
- * registry). Production marking of modern instances is owned by the
- * server-entry milestone; these tests mark instances through the
- * package-internal hook the entry will use, and the modern-era request shape
- * carries the required per-request `_meta` envelope.
+ * The HTTP per-request entry still binds its instances to the modern era
+ * through the package-internal hook; the `markModern` arm of the harness
+ * stands in for that path, and the modern-era request shape carries the
+ * required per-request `_meta` envelope.
  */
 import type { DiscoverResult, JSONRPCMessage, JSONRPCRequest } from '@modelcontextprotocol/core';
 import {
@@ -92,7 +92,7 @@ describe('server/discover handler gating', () => {
     it('a server with a modern revision in its supported list serves discover on a modern-era instance', async () => {
         const server = new Server(
             { name: 'modern-server', version: '2.0.0' },
-            { capabilities: { tools: {} }, supportedProtocolVersions: DUAL_ERA_VERSIONS, instructions: 'hello' }
+            { capabilities: { tools: {} }, supportedProtocolVersions: DUAL_ERA_VERSIONS, eraSupport: 'dual-era', instructions: 'hello' }
         );
         const response = await sendRaw(server, discoverRequest, { markModern: true });
         expect(isJSONRPCResultResponse(response)).toBe(true);
@@ -118,7 +118,10 @@ describe('server/discover handler gating', () => {
 
 describe('discover advertisement constraints', () => {
     it('advertises modern-only versions (DV-30): no 2025-era string ever appears in supportedVersions', async () => {
-        const server = new Server({ name: 'test', version: '1.0.0' }, { capabilities: {}, supportedProtocolVersions: DUAL_ERA_VERSIONS });
+        const server = new Server(
+            { name: 'test', version: '1.0.0' },
+            { capabilities: {}, supportedProtocolVersions: DUAL_ERA_VERSIONS, eraSupport: 'dual-era' }
+        );
         const response = await sendRaw(server, discoverRequest, { markModern: true });
         if (!isJSONRPCResultResponse(response)) throw new Error('expected result');
         const result = DiscoverResultSchema.parse(response.result);
@@ -140,7 +143,8 @@ describe('discover advertisement constraints', () => {
                     logging: {},
                     completions: {}
                 },
-                supportedProtocolVersions: DUAL_ERA_VERSIONS
+                supportedProtocolVersions: DUAL_ERA_VERSIONS,
+                eraSupport: 'dual-era'
             }
         );
         const response = await sendRaw(server, discoverRequest, { markModern: true });
@@ -166,7 +170,10 @@ describe('discover advertisement constraints', () => {
         expect(capabilities).toEqual({ tools: { listChanged: true }, resources: { subscribe: true, listChanged: true } });
 
         // The legacy initialize advertisement still carries the full capability set.
-        const server = new Server({ name: 'test', version: '1.0.0' }, { capabilities, supportedProtocolVersions: DUAL_ERA_VERSIONS });
+        const server = new Server(
+            { name: 'test', version: '1.0.0' },
+            { capabilities, supportedProtocolVersions: DUAL_ERA_VERSIONS, eraSupport: 'dual-era' }
+        );
         const response = await sendRaw(server, initializeRequest(LATEST_PROTOCOL_VERSION));
         if (!isJSONRPCResultResponse(response)) throw new Error('expected result');
         const result = InitializeResultSchema.parse(response.result);
@@ -178,7 +185,10 @@ describe('discover advertisement constraints', () => {
 
 describe('era-aware counter-offer ordering (the guard that precedes any constant bump)', () => {
     it('an unknown requested version is countered with the latest LEGACY version even when the list carries a modern one', async () => {
-        const server = new Server({ name: 'test', version: '1.0.0' }, { capabilities: {}, supportedProtocolVersions: DUAL_ERA_VERSIONS });
+        const server = new Server(
+            { name: 'test', version: '1.0.0' },
+            { capabilities: {}, supportedProtocolVersions: DUAL_ERA_VERSIONS, eraSupport: 'dual-era' }
+        );
         const response = await sendRaw(server, initializeRequest('1999-01-01'));
         if (!isJSONRPCResultResponse(response)) throw new Error('expected result');
         const result = InitializeResultSchema.parse(response.result);
@@ -191,7 +201,10 @@ describe('era-aware counter-offer ordering (the guard that precedes any constant
     });
 
     it('an initialize REQUESTING the modern revision is also answered with the latest legacy version (initialize never negotiates a modern era)', async () => {
-        const server = new Server({ name: 'test', version: '1.0.0' }, { capabilities: {}, supportedProtocolVersions: DUAL_ERA_VERSIONS });
+        const server = new Server(
+            { name: 'test', version: '1.0.0' },
+            { capabilities: {}, supportedProtocolVersions: DUAL_ERA_VERSIONS, eraSupport: 'dual-era' }
+        );
         const response = await sendRaw(server, initializeRequest(MODERN));
         if (!isJSONRPCResultResponse(response)) throw new Error('expected result');
         const result = InitializeResultSchema.parse(response.result);

--- a/packages/server/test/server/dualEraServing.test.ts
+++ b/packages/server/test/server/dualEraServing.test.ts
@@ -59,9 +59,10 @@ const MODERN_ONLY_METHODS = ['server/discover', 'subscriptions/listen'];
 
 /**
  * Legacy-only methods whose modern-direction denial mirrors the gate.
- * (`initialize` is deliberately not in this list: per the body-primary
- * predicate it is the legacy handshake by definition, so even an enveloped
- * `initialize` is served as legacy rather than denied.)
+ * (`initialize` is not in this list only because it has its own dedicated
+ * coverage below: an `initialize` carrying a valid modern envelope claim is
+ * classified by the claim — the claim wins over the legacy-handshake rule —
+ * and is denied with the same plain −32601.)
  */
 const LEGACY_ONLY_METHODS = ['ping', 'logging/setLevel', 'resources/subscribe'];
 
@@ -241,6 +242,87 @@ describe('long-lived era gate + zero-2026-vocabulary leak test', () => {
             const error = (response as JSONRPCErrorResponse).error;
             expect(error.code).toBe(-32_601);
             expect(error.message).toBe('Method not found');
+        }
+        await close();
+    });
+});
+
+describe('enveloped initialize on a dual-era instance (a valid modern claim wins over the legacy-handshake rule)', () => {
+    it('an initialize carrying a valid modern envelope claim answers a plain −32601 and is never served by the legacy handshake', async () => {
+        const server = buildServer({ eraSupport: 'dual-era' });
+        const { request, close } = await wire(server);
+
+        const response = await request({ jsonrpc: '2.0', id: 30, method: 'initialize', params: { _meta: envelope() } });
+        expect(isJSONRPCErrorResponse(response)).toBe(true);
+        const error = (response as JSONRPCErrorResponse).error;
+        expect(error.code).toBe(-32_601);
+        expect(error.message).toBe('Method not found');
+        expect(error.data).toBeUndefined();
+
+        // Nothing beyond the normal method-not-found shape leaks 2026 vocabulary.
+        const serialized = JSON.stringify({ error, id: null });
+        for (const term of FORBIDDEN_2026_VOCABULARY) {
+            expect(serialized.toLowerCase()).not.toContain(term.toLowerCase());
+        }
+
+        // The legacy initialize path never ran: the initialize-scoped accessors stay unset.
+        expect(server.server.getNegotiatedProtocolVersion()).toBeUndefined();
+        expect(server.server.getClientVersion()).toBeUndefined();
+
+        // An envelope-less initialize on the same connection keeps today's behavior:
+        // the legacy handshake is served exactly as before, with zero 2026 vocabulary.
+        const init = await request(initializeRequest(31));
+        expect(isJSONRPCResultResponse(init)).toBe(true);
+        if (isJSONRPCResultResponse(init)) {
+            expect((init.result as { protocolVersion?: string }).protocolVersion).toBe(LATEST_PROTOCOL_VERSION);
+            expect(JSON.stringify(init)).not.toContain('resultType');
+            expect(JSON.stringify(init)).not.toContain('2026');
+        }
+        await close();
+    });
+
+    it('an initialize with a malformed envelope claim keeps the legacy handshake', async () => {
+        const server = buildServer({ eraSupport: 'dual-era' });
+        const { request, close } = await wire(server);
+
+        // The claim key is present but the envelope is incomplete — never a
+        // silent flip to the modern era; the legacy handshake serves it as before.
+        const response = await request({
+            jsonrpc: '2.0',
+            id: 40,
+            method: 'initialize',
+            params: {
+                protocolVersion: LATEST_PROTOCOL_VERSION,
+                capabilities: {},
+                clientInfo: { name: 'legacy-client', version: '1.0.0' },
+                _meta: { [PROTOCOL_VERSION_META_KEY]: MODERN }
+            }
+        });
+        expect(isJSONRPCResultResponse(response)).toBe(true);
+        if (isJSONRPCResultResponse(response)) {
+            expect((response.result as { protocolVersion?: string }).protocolVersion).toBe(LATEST_PROTOCOL_VERSION);
+        }
+        await close();
+    });
+
+    it('an initialize whose valid envelope claim names a pre-2026 revision keeps the legacy handshake', async () => {
+        const server = buildServer({ eraSupport: 'dual-era' });
+        const { request, close } = await wire(server);
+
+        const response = await request({
+            jsonrpc: '2.0',
+            id: 50,
+            method: 'initialize',
+            params: {
+                protocolVersion: LATEST_PROTOCOL_VERSION,
+                capabilities: {},
+                clientInfo: { name: 'legacy-client', version: '1.0.0' },
+                _meta: envelope({ [PROTOCOL_VERSION_META_KEY]: '2025-06-18' })
+            }
+        });
+        expect(isJSONRPCResultResponse(response)).toBe(true);
+        if (isJSONRPCResultResponse(response)) {
+            expect((response.result as { protocolVersion?: string }).protocolVersion).toBe(LATEST_PROTOCOL_VERSION);
         }
         await close();
     });

--- a/packages/server/test/server/dualEraServing.test.ts
+++ b/packages/server/test/server/dualEraServing.test.ts
@@ -1,0 +1,302 @@
+/**
+ * Long-lived dual-era serving (`eraSupport: 'dual-era'`) on one connection:
+ *
+ * - the legacy vertical (initialize → tools/list → tools/call) is served
+ *   exactly as a 2025 server serves it (no 2026 wire fields anywhere);
+ * - the modern vertical (server/discover → tools/list → tools/call, every
+ *   request carrying the per-request `_meta` envelope) is served on the
+ *   2026 era on the SAME connection;
+ * - the long-lived era gate: a message classified into the legacy era asking
+ *   for `server/discover`, `subscriptions/listen`, or any 2026-only method is
+ *   answered with a plain −32601 carrying ZERO 2026 vocabulary in message or
+ *   data (the dedicated leak test — the gate is not structural on a long-lived
+ *   instance, which hosts both registries); the modern-direction denial of
+ *   legacy-only methods mirrors it.
+ * - Q10-L2: a hand-constructed server with the default `eraSupport` serves a
+ *   scripted 2025 session with today's exact result shapes and zero 2026
+ *   vocabulary on the wire.
+ */
+import type { JSONRPCErrorResponse, JSONRPCMessage, JSONRPCNotification, JSONRPCRequest } from '@modelcontextprotocol/core';
+import {
+    CLIENT_CAPABILITIES_META_KEY,
+    CLIENT_INFO_META_KEY,
+    InMemoryTransport,
+    isJSONRPCErrorResponse,
+    isJSONRPCResultResponse,
+    LATEST_PROTOCOL_VERSION,
+    PROTOCOL_VERSION_META_KEY
+} from '@modelcontextprotocol/core';
+import { describe, expect, it } from 'vitest';
+import * as z from 'zod/v4';
+
+import { McpServer } from '../../src/server/mcp.js';
+
+const MODERN = '2026-07-28';
+
+/**
+ * 2026-era vocabulary that must never leak into a legacy-direction response.
+ * The gate answers with the same plain `-32601` a 2025 server answers for an
+ * unknown method — nothing in message or data may reveal that the instance
+ * also hosts the modern era.
+ */
+const FORBIDDEN_2026_VOCABULARY = [
+    '2026',
+    'discover',
+    'envelope',
+    'modern',
+    'dual',
+    'era',
+    '_meta',
+    'io.modelcontextprotocol',
+    'resultType',
+    'protocolVersion',
+    'protocol version',
+    'subscription'
+];
+
+/** The 2026-only request methods the era gate must hide from legacy-era traffic. */
+const MODERN_ONLY_METHODS = ['server/discover', 'subscriptions/listen'];
+
+/**
+ * Legacy-only methods whose modern-direction denial mirrors the gate.
+ * (`initialize` is deliberately not in this list: per the body-primary
+ * predicate it is the legacy handshake by definition, so even an enveloped
+ * `initialize` is served as legacy rather than denied.)
+ */
+const LEGACY_ONLY_METHODS = ['ping', 'logging/setLevel', 'resources/subscribe'];
+
+const envelope = (overrides?: Record<string, unknown>) => ({
+    [PROTOCOL_VERSION_META_KEY]: MODERN,
+    [CLIENT_INFO_META_KEY]: { name: 'modern-client', version: '1.0.0' },
+    [CLIENT_CAPABILITIES_META_KEY]: {},
+    ...overrides
+});
+
+function buildServer(options?: { eraSupport?: 'legacy' | 'dual-era' | 'modern' }) {
+    const server = new McpServer(
+        { name: 'dual-era-test-server', version: '1.0.0' },
+        {
+            capabilities: { tools: {} },
+            instructions: 'test instructions',
+            ...(options?.eraSupport ? { eraSupport: options.eraSupport } : {})
+        }
+    );
+    server.registerTool('echo', { description: 'Echoes the input text', inputSchema: z.object({ text: z.string() }) }, ({ text }) => ({
+        content: [{ type: 'text', text }]
+    }));
+    return server;
+}
+
+async function wire(server: McpServer) {
+    const [peerTx, serverTx] = InMemoryTransport.createLinkedPair();
+    const inbound: JSONRPCMessage[] = [];
+    const waiters = new Map<string | number, (message: JSONRPCMessage) => void>();
+    peerTx.onmessage = message => {
+        inbound.push(message);
+        const id = (message as { id?: string | number }).id;
+        const waiter = id === undefined ? undefined : waiters.get(id);
+        if (id !== undefined && waiter) {
+            waiters.delete(id);
+            waiter(message);
+        }
+    };
+    await server.connect(serverTx);
+    await peerTx.start();
+
+    const request = (message: JSONRPCRequest): Promise<JSONRPCMessage> =>
+        new Promise(resolve => {
+            waiters.set(message.id, resolve);
+            void peerTx.send(message);
+        });
+    const notify = (message: JSONRPCNotification): Promise<void> => peerTx.send(message);
+    return { request, notify, inbound, close: () => server.close() };
+}
+
+const initializeRequest = (id: number): JSONRPCRequest => ({
+    jsonrpc: '2.0',
+    id,
+    method: 'initialize',
+    params: { protocolVersion: LATEST_PROTOCOL_VERSION, capabilities: {}, clientInfo: { name: 'legacy-client', version: '1.0.0' } }
+});
+
+describe('dual-era serving on one long-lived connection', () => {
+    it('serves the legacy vertical and the modern vertical on the same connection, each on its own era', async () => {
+        const server = buildServer({ eraSupport: 'dual-era' });
+        const { request, notify, close } = await wire(server);
+
+        // --- Legacy vertical: initialize → initialized → tools/list → tools/call.
+        const init = await request(initializeRequest(1));
+        expect(isJSONRPCResultResponse(init)).toBe(true);
+        if (isJSONRPCResultResponse(init)) {
+            expect((init.result as { protocolVersion?: string }).protocolVersion).toBe(LATEST_PROTOCOL_VERSION);
+            expect(JSON.stringify(init)).not.toContain('resultType');
+            expect(JSON.stringify(init)).not.toContain('2026');
+        }
+        await notify({ jsonrpc: '2.0', method: 'notifications/initialized' });
+
+        const legacyList = await request({ jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} });
+        expect(isJSONRPCResultResponse(legacyList)).toBe(true);
+        if (isJSONRPCResultResponse(legacyList)) {
+            expect((legacyList.result as { tools: Array<{ name: string }> }).tools.map(tool => tool.name)).toEqual(['echo']);
+            expect(JSON.stringify(legacyList)).not.toContain('resultType');
+        }
+
+        const legacyCall = await request({
+            jsonrpc: '2.0',
+            id: 3,
+            method: 'tools/call',
+            params: { name: 'echo', arguments: { text: 'legacy leg' } }
+        });
+        expect(isJSONRPCResultResponse(legacyCall)).toBe(true);
+        if (isJSONRPCResultResponse(legacyCall)) {
+            expect((legacyCall.result as { content: unknown[] }).content).toEqual([{ type: 'text', text: 'legacy leg' }]);
+            expect(JSON.stringify(legacyCall)).not.toContain('resultType');
+        }
+
+        // --- Modern vertical on the SAME connection: discover → list → call,
+        // every request carrying the per-request envelope.
+        const discover = await request({ jsonrpc: '2.0', id: 4, method: 'server/discover', params: { _meta: envelope() } });
+        expect(isJSONRPCResultResponse(discover)).toBe(true);
+        if (isJSONRPCResultResponse(discover)) {
+            const result = discover.result as { supportedVersions?: string[]; resultType?: string };
+            expect(result.supportedVersions).toEqual([MODERN]);
+            expect(result.resultType).toBe('complete');
+        }
+
+        const modernList = await request({ jsonrpc: '2.0', id: 5, method: 'tools/list', params: { _meta: envelope() } });
+        expect(isJSONRPCResultResponse(modernList)).toBe(true);
+        if (isJSONRPCResultResponse(modernList)) {
+            const result = modernList.result as { tools: Array<{ name: string }>; resultType?: string };
+            expect(result.tools.map(tool => tool.name)).toEqual(['echo']);
+            expect(result.resultType).toBe('complete');
+        }
+
+        const modernCall = await request({
+            jsonrpc: '2.0',
+            id: 6,
+            method: 'tools/call',
+            params: { name: 'echo', arguments: { text: 'modern leg' }, _meta: envelope() }
+        });
+        expect(isJSONRPCResultResponse(modernCall)).toBe(true);
+        if (isJSONRPCResultResponse(modernCall)) {
+            const result = modernCall.result as { content: unknown[]; resultType?: string };
+            expect(result.content).toEqual([{ type: 'text', text: 'modern leg' }]);
+            expect(result.resultType).toBe('complete');
+        }
+
+        // The legacy leg is unaffected by the modern exchanges that ran in between.
+        const legacyAgain = await request({ jsonrpc: '2.0', id: 7, method: 'tools/list', params: {} });
+        expect(isJSONRPCResultResponse(legacyAgain)).toBe(true);
+        expect(JSON.stringify(legacyAgain)).not.toContain('resultType');
+
+        await close();
+    });
+
+    it('the modern era is reachable without any prior legacy handshake (envelope-first connection)', async () => {
+        const server = buildServer({ eraSupport: 'dual-era' });
+        const { request, close } = await wire(server);
+
+        const discover = await request({ jsonrpc: '2.0', id: 1, method: 'server/discover', params: { _meta: envelope() } });
+        expect(isJSONRPCResultResponse(discover)).toBe(true);
+        await close();
+    });
+});
+
+describe('long-lived era gate + zero-2026-vocabulary leak test', () => {
+    it('a legacy-classified request for any 2026-only method answers a plain −32601 with zero 2026 vocabulary in message or data', async () => {
+        const server = buildServer({ eraSupport: 'dual-era' });
+        const { request, close } = await wire(server);
+
+        // Establish the legacy leg first — the gate must hold on a connection
+        // that is actively serving 2025 traffic.
+        const init = await request(initializeRequest(1));
+        expect(isJSONRPCResultResponse(init)).toBe(true);
+
+        let id = 10;
+        for (const method of MODERN_ONLY_METHODS) {
+            // No envelope claim ⇒ classified legacy ⇒ the modern registry must be invisible.
+            const response = await request({ jsonrpc: '2.0', id: (id += 1), method, params: {} });
+            expect(isJSONRPCErrorResponse(response)).toBe(true);
+            const error = (response as JSONRPCErrorResponse).error;
+            expect(error.code).toBe(-32_601);
+            expect(error.message).toBe('Method not found');
+            expect(error.data).toBeUndefined();
+
+            const serialized = JSON.stringify({ error, id: null });
+            for (const term of FORBIDDEN_2026_VOCABULARY) {
+                expect(serialized.toLowerCase()).not.toContain(term.toLowerCase());
+            }
+        }
+        await close();
+    });
+
+    it('the modern-direction denial mirrors it: a modern-classified request for a legacy-only method answers −32601', async () => {
+        const server = buildServer({ eraSupport: 'dual-era' });
+        const { request, close } = await wire(server);
+
+        let id = 20;
+        for (const method of LEGACY_ONLY_METHODS) {
+            const response = await request({ jsonrpc: '2.0', id: (id += 1), method, params: { _meta: envelope() } });
+            expect(isJSONRPCErrorResponse(response)).toBe(true);
+            const error = (response as JSONRPCErrorResponse).error;
+            expect(error.code).toBe(-32_601);
+            expect(error.message).toBe('Method not found');
+        }
+        await close();
+    });
+});
+
+describe('Q10-L2: a hand-constructed server with the default eraSupport on 2025 traffic', () => {
+    it('serves a scripted 2025 session with the exact 2025 shapes and zero 2026 vocabulary on the wire', async () => {
+        const server = buildServer();
+        const { request, notify, inbound, close } = await wire(server);
+
+        const init = await request(initializeRequest(1));
+        expect(isJSONRPCResultResponse(init)).toBe(true);
+        if (isJSONRPCResultResponse(init)) {
+            expect(init.result).toEqual({
+                protocolVersion: LATEST_PROTOCOL_VERSION,
+                capabilities: { tools: { listChanged: true } },
+                serverInfo: { name: 'dual-era-test-server', version: '1.0.0' },
+                instructions: 'test instructions'
+            });
+        }
+        await notify({ jsonrpc: '2.0', method: 'notifications/initialized' });
+
+        const list = await request({ jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} });
+        expect(isJSONRPCResultResponse(list)).toBe(true);
+        if (isJSONRPCResultResponse(list)) {
+            const tools = (list.result as { tools: Array<Record<string, unknown>> }).tools;
+            expect(tools).toHaveLength(1);
+            expect(tools[0]).toMatchObject({ name: 'echo', description: 'Echoes the input text' });
+            expect(Object.keys(list.result as Record<string, unknown>).sort()).toEqual(['tools']);
+        }
+
+        const call = await request({ jsonrpc: '2.0', id: 3, method: 'tools/call', params: { name: 'echo', arguments: { text: 'hi' } } });
+        expect(isJSONRPCResultResponse(call)).toBe(true);
+        if (isJSONRPCResultResponse(call)) {
+            expect(call.result).toEqual({ content: [{ type: 'text', text: 'hi' }] });
+        }
+
+        const ping = await request({ jsonrpc: '2.0', id: 4, method: 'ping' });
+        expect(isJSONRPCResultResponse(ping)).toBe(true);
+        if (isJSONRPCResultResponse(ping)) {
+            expect(ping.result).toEqual({});
+        }
+
+        // A default instance keeps answering server/discover with -32601, byte-identical to the deployed fleet.
+        const discover = await request({ jsonrpc: '2.0', id: 5, method: 'server/discover', params: {} });
+        expect(isJSONRPCErrorResponse(discover)).toBe(true);
+        if (isJSONRPCErrorResponse(discover)) {
+            expect(discover.error).toEqual({ code: -32_601, message: 'Method not found' });
+        }
+
+        // Nothing the server wrote on this 2025 session carries 2026 wire vocabulary.
+        const wireBytes = JSON.stringify(inbound);
+        expect(wireBytes).not.toContain('resultType');
+        expect(wireBytes).not.toContain('2026');
+        expect(wireBytes).not.toContain('io.modelcontextprotocol/');
+
+        await close();
+    });
+});

--- a/packages/server/test/server/eraSupport.test.ts
+++ b/packages/server/test/server/eraSupport.test.ts
@@ -1,0 +1,267 @@
+/**
+ * `ServerOptions.eraSupport` — the stdio/long-lived-connection era opt-in:
+ *
+ * - default `'legacy'` for hand-constructed `Server`/`McpServer`: nothing
+ *   2026-era is registered or advertised, and a modern revision in
+ *   `supportedProtocolVersions` without the declaration is a construction-time
+ *   `TypeError` (never a silent behavior change).
+ * - `'dual-era'`: `server/discover` registered without any instance binding,
+ *   modern revisions advertised, both eras served per message.
+ * - `'modern'`: strict 2026-only — envelope-less requests (including
+ *   `initialize`) answer the unsupported-protocol-version error with the
+ *   supported list; legacy-classified notifications are dropped.
+ * - TS-01 directionality: a modern-bound instance cannot emit server→client
+ *   wire requests (typed local error); a dual-era instance serving the legacy
+ *   leg still can.
+ */
+import type { JSONRPCMessage, JSONRPCNotification, JSONRPCRequest } from '@modelcontextprotocol/core';
+import {
+    CLIENT_CAPABILITIES_META_KEY,
+    CLIENT_INFO_META_KEY,
+    InMemoryTransport,
+    isJSONRPCErrorResponse,
+    isJSONRPCResultResponse,
+    LATEST_PROTOCOL_VERSION,
+    PROTOCOL_VERSION_META_KEY,
+    SUPPORTED_PROTOCOL_VERSIONS
+} from '@modelcontextprotocol/core';
+import { describe, expect, it } from 'vitest';
+
+import { McpServer } from '../../src/server/mcp.js';
+import { Server } from '../../src/server/server.js';
+
+const MODERN = '2026-07-28';
+const DUAL_ERA_VERSIONS = [MODERN, ...SUPPORTED_PROTOCOL_VERSIONS];
+
+const envelope = (overrides?: Record<string, unknown>) => ({
+    [PROTOCOL_VERSION_META_KEY]: MODERN,
+    [CLIENT_INFO_META_KEY]: { name: 'era-test-client', version: '1.0.0' },
+    [CLIENT_CAPABILITIES_META_KEY]: {},
+    ...overrides
+});
+
+const initializeRequest = (id: number, requestedVersion = LATEST_PROTOCOL_VERSION): JSONRPCRequest => ({
+    jsonrpc: '2.0',
+    id,
+    method: 'initialize',
+    params: {
+        protocolVersion: requestedVersion,
+        capabilities: { sampling: {} },
+        clientInfo: { name: 'legacy-client', version: '1.0.0' }
+    }
+});
+
+interface Connectable {
+    connect(transport: InstanceType<typeof InMemoryTransport>): Promise<void>;
+    close(): Promise<void>;
+}
+
+/** Wires a server to one long-lived in-memory connection and returns request/notify drivers. */
+async function wireServer(server: Connectable) {
+    const [peerTx, serverTx] = InMemoryTransport.createLinkedPair();
+    const inbound: JSONRPCMessage[] = [];
+    const waiters = new Map<string | number, (message: JSONRPCMessage) => void>();
+    peerTx.onmessage = message => {
+        inbound.push(message);
+        const id = (message as { id?: string | number }).id;
+        const waiter = id === undefined ? undefined : waiters.get(id);
+        if (id !== undefined && waiter) {
+            waiters.delete(id);
+            waiter(message);
+        }
+    };
+    await server.connect(serverTx);
+    await peerTx.start();
+
+    const request = (message: JSONRPCRequest): Promise<JSONRPCMessage> =>
+        new Promise(resolve => {
+            waiters.set(message.id, resolve);
+            void peerTx.send(message);
+        });
+    const notify = (message: JSONRPCNotification): Promise<void> => peerTx.send(message);
+    const flush = () => new Promise(resolve => setTimeout(resolve, 10));
+    return { request, notify, flush, inbound, peerTx, close: () => server.close() };
+}
+
+describe('construction-time guard (default eraSupport is legacy)', () => {
+    it('throws a TypeError when supportedProtocolVersions carries a modern revision on a default instance', () => {
+        expect(() => new Server({ name: 't', version: '1' }, { capabilities: {}, supportedProtocolVersions: DUAL_ERA_VERSIONS })).toThrow(
+            TypeError
+        );
+        expect(() => new Server({ name: 't', version: '1' }, { capabilities: {}, supportedProtocolVersions: DUAL_ERA_VERSIONS })).toThrow(
+            /eraSupport/
+        );
+    });
+
+    it('throws for McpServer too (options are forwarded)', () => {
+        expect(() => new McpServer({ name: 't', version: '1' }, { supportedProtocolVersions: [MODERN] })).toThrow(TypeError);
+    });
+
+    it('does not throw when the modern revision is accompanied by a dual-era or modern declaration', () => {
+        expect(
+            () =>
+                new Server(
+                    { name: 't', version: '1' },
+                    { capabilities: {}, supportedProtocolVersions: DUAL_ERA_VERSIONS, eraSupport: 'dual-era' }
+                )
+        ).not.toThrow();
+        expect(
+            () => new Server({ name: 't', version: '1' }, { capabilities: {}, supportedProtocolVersions: [MODERN], eraSupport: 'modern' })
+        ).not.toThrow();
+    });
+
+    it('a default legacy-only construction stays exactly as before (no throw, no discover handler)', async () => {
+        const server = new Server({ name: 't', version: '1' }, { capabilities: {} });
+        const { request, close } = await wireServer(server);
+        const response = await request({ jsonrpc: '2.0', id: 1, method: 'server/discover', params: { _meta: envelope() } });
+        expect(isJSONRPCErrorResponse(response)).toBe(true);
+        if (isJSONRPCErrorResponse(response)) {
+            expect(response.error.code).toBe(-32_601);
+        }
+        await close();
+    });
+});
+
+describe("DV-30: server/discover is registered only when eraSupport !== 'legacy'", () => {
+    it('a dual-era server serves discover with no instance binding and advertises only modern revisions', async () => {
+        const server = new Server({ name: 'dual', version: '1' }, { capabilities: { tools: {} }, eraSupport: 'dual-era' });
+        const { request, close } = await wireServer(server);
+
+        const response = await request({ jsonrpc: '2.0', id: 1, method: 'server/discover', params: { _meta: envelope() } });
+        expect(isJSONRPCResultResponse(response)).toBe(true);
+        if (isJSONRPCResultResponse(response)) {
+            const result = response.result as { supportedVersions?: string[]; resultType?: string };
+            expect(result.supportedVersions).toEqual([MODERN]);
+            // Served on the modern era: the wire result carries the 2026 result discriminator.
+            expect(result.resultType).toBe('complete');
+        }
+        await close();
+    });
+
+    it('the served modern revisions are added to the supported list without mutating the shared default constant', () => {
+        const before = [...SUPPORTED_PROTOCOL_VERSIONS];
+        const server = new Server({ name: 'dual', version: '1' }, { capabilities: {}, eraSupport: 'dual-era' });
+        expect(SUPPORTED_PROTOCOL_VERSIONS).toEqual(before);
+        expect(server).toBeDefined();
+    });
+});
+
+describe("DV-31: strict 'modern' on a long-lived connection", () => {
+    async function wireModernServer() {
+        const server = new Server({ name: 'strict', version: '1' }, { capabilities: { tools: {} }, eraSupport: 'modern' });
+        server.setRequestHandler('tools/list', () => ({ tools: [] }));
+        return { server, ...(await wireServer(server)) };
+    }
+
+    it('an envelope-less non-initialize request answers −32004 with the supported list', async () => {
+        const { request, close } = await wireModernServer();
+        const response = await request({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} });
+        expect(isJSONRPCErrorResponse(response)).toBe(true);
+        if (isJSONRPCErrorResponse(response)) {
+            // Note: this cell shares its numeric code (−32004) with the
+            // still-disputed header/body mismatch family; the cell itself is
+            // settled (unsupported protocol version + supported list).
+            expect(response.error.code).toBe(-32_004);
+            const data = response.error.data as { supported?: string[]; requested?: string };
+            expect(data.supported).toContain(MODERN);
+            expect(typeof data.requested).toBe('string');
+        }
+        await close();
+    });
+
+    it('an envelope-less initialize answers −32004 with the supported list (never a legacy handshake)', async () => {
+        const { request, close } = await wireModernServer();
+        const response = await request(initializeRequest(2));
+        expect(isJSONRPCErrorResponse(response)).toBe(true);
+        if (isJSONRPCErrorResponse(response)) {
+            expect(response.error.code).toBe(-32_004);
+            expect((response.error.data as { supported?: string[] }).supported).toContain(MODERN);
+            expect((response.error.data as { requested?: string }).requested).toBe(LATEST_PROTOCOL_VERSION);
+        }
+        await close();
+    });
+
+    it('a legacy-classified notification is dropped without a response', async () => {
+        const { notify, flush, inbound, close } = await wireModernServer();
+        await notify({ jsonrpc: '2.0', method: 'notifications/initialized' });
+        await flush();
+        expect(inbound).toHaveLength(0);
+        await close();
+    });
+
+    it('an enveloped modern request is served', async () => {
+        const { request, close } = await wireModernServer();
+        const response = await request({ jsonrpc: '2.0', id: 3, method: 'tools/list', params: { _meta: envelope() } });
+        expect(isJSONRPCResultResponse(response)).toBe(true);
+        if (isJSONRPCResultResponse(response)) {
+            expect((response.result as { tools?: unknown[] }).tools).toEqual([]);
+            expect((response.result as { resultType?: string }).resultType).toBe('complete');
+        }
+        await close();
+    });
+});
+
+describe('TS-01 directionality (era-keyed direction enforcement)', () => {
+    it('a strict-modern instance cannot emit server→client wire requests: typed local error, nothing reaches the transport', async () => {
+        const server = new Server({ name: 'strict', version: '1' }, { capabilities: {}, eraSupport: 'modern' });
+        const { inbound, flush, close } = await wireServer(server);
+
+        await expect(
+            server.createMessage({ messages: [{ role: 'user', content: { type: 'text', text: 'hi' } }], maxTokens: 1 })
+        ).rejects.toThrow(/not supported by the negotiated protocol version/);
+        await flush();
+        expect(inbound).toHaveLength(0);
+        await close();
+    });
+
+    it('a dual-era instance serving the legacy leg still emits server→client requests (permitted per the message era)', async () => {
+        const server = new Server({ name: 'dual', version: '1' }, { capabilities: {}, eraSupport: 'dual-era' });
+        const { request, inbound, flush, close } = await wireServer(server);
+
+        // Legacy leg: the 2025 client initializes and declares sampling support.
+        const init = await request(initializeRequest(1));
+        expect(isJSONRPCResultResponse(init)).toBe(true);
+
+        // The server-initiated sampling request is legal on the legacy leg and reaches the wire.
+        const pending = server.createMessage({ messages: [{ role: 'user', content: { type: 'text', text: 'hi' } }], maxTokens: 1 });
+        pending.catch(() => {
+            // The peer never answers; the request is torn down with the connection below.
+        });
+        await flush();
+        expect(inbound.some(message => (message as JSONRPCRequest).method === 'sampling/createMessage')).toBe(true);
+        await close();
+    });
+});
+
+describe('accessor split on long-lived dual-era instances', () => {
+    it('getClientCapabilities/getClientVersion/getNegotiatedProtocolVersion keep initialize-scoped semantics; modern envelopes never backfill them', async () => {
+        const server = new Server({ name: 'dual', version: '1' }, { capabilities: { tools: {} }, eraSupport: 'dual-era' });
+        server.setRequestHandler('tools/list', () => ({ tools: [] }));
+        const { request, close } = await wireServer(server);
+
+        // Legacy handshake populates the initialize-scoped accessors.
+        const init = await request(initializeRequest(1));
+        expect(isJSONRPCResultResponse(init)).toBe(true);
+        expect(server.getClientVersion()).toEqual({ name: 'legacy-client', version: '1.0.0' });
+        expect(server.getClientCapabilities()).toEqual({ sampling: {} });
+        expect(server.getNegotiatedProtocolVersion()).toBe(LATEST_PROTOCOL_VERSION);
+
+        // A modern message carrying a different client identity in its envelope
+        // is served, but never backfills the instance-level accessors (per-message
+        // identity is read from the per-request context, not instance state).
+        const modern = await request({
+            jsonrpc: '2.0',
+            id: 2,
+            method: 'tools/list',
+            params: {
+                _meta: envelope({ [CLIENT_INFO_META_KEY]: { name: 'modern-client', version: '9.9.9' } })
+            }
+        });
+        expect(isJSONRPCResultResponse(modern)).toBe(true);
+        expect(server.getClientVersion()).toEqual({ name: 'legacy-client', version: '1.0.0' });
+        expect(server.getClientCapabilities()).toEqual({ sampling: {} });
+        expect(server.getNegotiatedProtocolVersion()).toBe(LATEST_PROTOCOL_VERSION);
+
+        await close();
+    });
+});

--- a/packages/server/test/server/eraSupport.test.ts
+++ b/packages/server/test/server/eraSupport.test.ts
@@ -12,7 +12,8 @@
  *   supported list; legacy-classified notifications are dropped.
  * - TS-01 directionality: a modern-bound instance cannot emit server→client
  *   wire requests (typed local error); a dual-era instance serving the legacy
- *   leg still can.
+ *   leg still can, while a handler serving a 2026-classified request gets the
+ *   same typed error from the ctx-related request path.
  */
 import type { JSONRPCMessage, JSONRPCNotification, JSONRPCRequest } from '@modelcontextprotocol/core';
 import {
@@ -23,6 +24,8 @@ import {
     isJSONRPCResultResponse,
     LATEST_PROTOCOL_VERSION,
     PROTOCOL_VERSION_META_KEY,
+    SdkError,
+    SdkErrorCode,
     SUPPORTED_PROTOCOL_VERSIONS
 } from '@modelcontextprotocol/core';
 import { describe, expect, it } from 'vitest';
@@ -258,6 +261,79 @@ describe('TS-01 directionality (era-keyed direction enforcement)', () => {
             // The peer never answers; the request is torn down with the connection below.
         });
         await flush();
+        expect(inbound.some(message => (message as JSONRPCRequest).method === 'sampling/createMessage')).toBe(true);
+        await close();
+    });
+
+    it('a handler serving a modern-classified request gets the typed error from the ctx sampling helper; nothing reaches the transport', async () => {
+        const server = new Server({ name: 'dual', version: '1' }, { capabilities: { tools: {} }, eraSupport: 'dual-era' });
+        let captured: unknown;
+        server.setRequestHandler('tools/list', async (_request, ctx) => {
+            try {
+                await ctx.mcpReq.requestSampling({ messages: [{ role: 'user', content: { type: 'text', text: 'hi' } }], maxTokens: 1 });
+            } catch (error) {
+                captured = error;
+            }
+            return { tools: [] };
+        });
+        const { request, inbound, flush, close } = await wireServer(server);
+
+        const response = await request({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: { _meta: envelope() } });
+        expect(isJSONRPCResultResponse(response)).toBe(true);
+        await flush();
+
+        expect(captured).toBeInstanceOf(SdkError);
+        expect((captured as SdkError).code).toBe(SdkErrorCode.MethodNotSupportedByProtocolVersion);
+        expect((captured as SdkError).message).toMatch(/not available on protocol revision 2026-07-28/);
+        expect(inbound.some(message => (message as JSONRPCRequest).method === 'sampling/createMessage')).toBe(false);
+        await close();
+    });
+
+    it('a raw ctx server→client request send while serving a modern-classified request is rejected the same way', async () => {
+        const server = new Server({ name: 'dual', version: '1' }, { capabilities: { tools: {} }, eraSupport: 'dual-era' });
+        let captured: unknown;
+        server.setRequestHandler('tools/list', async (_request, ctx) => {
+            try {
+                await ctx.mcpReq.send({ method: 'roots/list' });
+            } catch (error) {
+                captured = error;
+            }
+            return { tools: [] };
+        });
+        const { request, inbound, flush, close } = await wireServer(server);
+
+        const response = await request({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: { _meta: envelope() } });
+        expect(isJSONRPCResultResponse(response)).toBe(true);
+        await flush();
+
+        expect(captured).toBeInstanceOf(SdkError);
+        expect((captured as SdkError).code).toBe(SdkErrorCode.MethodNotSupportedByProtocolVersion);
+        expect(inbound.some(message => (message as JSONRPCRequest).method === 'roots/list')).toBe(false);
+        await close();
+    });
+
+    it('the same ctx sampling helper on a legacy-classified request still reaches the wire (permitted per the message era)', async () => {
+        const server = new Server({ name: 'dual', version: '1' }, { capabilities: { tools: {} }, eraSupport: 'dual-era' });
+        server.setRequestHandler('tools/list', (_request, ctx) => {
+            const pending = ctx.mcpReq.requestSampling({
+                messages: [{ role: 'user', content: { type: 'text', text: 'hi' } }],
+                maxTokens: 1
+            });
+            pending.catch(() => {
+                // The peer never answers; the request is torn down with the connection below.
+            });
+            return { tools: [] };
+        });
+        const { request, inbound, flush, close } = await wireServer(server);
+
+        // Legacy leg: the 2025 client initializes and declares sampling support.
+        const init = await request(initializeRequest(1));
+        expect(isJSONRPCResultResponse(init)).toBe(true);
+
+        const response = await request({ jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} });
+        expect(isJSONRPCResultResponse(response)).toBe(true);
+        await flush();
+
         expect(inbound.some(message => (message as JSONRPCRequest).method === 'sampling/createMessage')).toBe(true);
         await close();
     });

--- a/packages/server/test/server/eraSupport.test.ts
+++ b/packages/server/test/server/eraSupport.test.ts
@@ -186,6 +186,22 @@ describe("DV-31: strict 'modern' on a long-lived connection", () => {
         await close();
     });
 
+    it('an initialize carrying a valid modern envelope claim answers a plain −32601 (the claim wins over the legacy-handshake rule)', async () => {
+        const { request, close } = await wireModernServer();
+        const response = await request({ jsonrpc: '2.0', id: 5, method: 'initialize', params: { _meta: envelope() } });
+        expect(isJSONRPCErrorResponse(response)).toBe(true);
+        if (isJSONRPCErrorResponse(response)) {
+            // Classified by its valid modern claim, the request is served on the
+            // modern era, where `initialize` is answered like every other method
+            // that era does not define — never with the version error reserved
+            // for envelope-less requests.
+            expect(response.error.code).toBe(-32_601);
+            expect(response.error.message).toBe('Method not found');
+            expect(response.error.data).toBeUndefined();
+        }
+        await close();
+    });
+
     it('a legacy-classified notification is dropped without a response', async () => {
         const { notify, flush, inbound, close } = await wireModernServer();
         await notify({ jsonrpc: '2.0', method: 'notifications/initialized' });

--- a/packages/server/test/server/eraSupport.test.ts
+++ b/packages/server/test/server/eraSupport.test.ts
@@ -163,7 +163,9 @@ describe("DV-31: strict 'modern' on a long-lived connection", () => {
             // settled (unsupported protocol version + supported list).
             expect(response.error.code).toBe(-32_004);
             const data = response.error.data as { supported?: string[]; requested?: string };
-            expect(data.supported).toContain(MODERN);
+            // The strict instance serves only modern revisions, so the supported
+            // list it advertises names only those (never the legacy defaults).
+            expect(data.supported).toEqual([MODERN]);
             expect(typeof data.requested).toBe('string');
         }
         await close();
@@ -175,7 +177,7 @@ describe("DV-31: strict 'modern' on a long-lived connection", () => {
         expect(isJSONRPCErrorResponse(response)).toBe(true);
         if (isJSONRPCErrorResponse(response)) {
             expect(response.error.code).toBe(-32_004);
-            expect((response.error.data as { supported?: string[] }).supported).toContain(MODERN);
+            expect((response.error.data as { supported?: string[] }).supported).toEqual([MODERN]);
             expect((response.error.data as { requested?: string }).requested).toBe(LATEST_PROTOCOL_VERSION);
         }
         await close();
@@ -196,6 +198,34 @@ describe("DV-31: strict 'modern' on a long-lived connection", () => {
         if (isJSONRPCResultResponse(response)) {
             expect((response.result as { tools?: unknown[] }).tools).toEqual([]);
             expect((response.result as { resultType?: string }).resultType).toBe('complete');
+        }
+        await close();
+    });
+
+    it('server/discover advertises only modern revisions', async () => {
+        const { request, close } = await wireModernServer();
+        const response = await request({ jsonrpc: '2.0', id: 4, method: 'server/discover', params: { _meta: envelope() } });
+        expect(isJSONRPCResultResponse(response)).toBe(true);
+        if (isJSONRPCResultResponse(response)) {
+            expect((response.result as { supportedVersions?: string[] }).supportedVersions).toEqual([MODERN]);
+        }
+        await close();
+    });
+
+    it('a mixed legacy+modern supported list is reduced to its modern subset at construction', async () => {
+        const server = new Server(
+            { name: 'strict', version: '1' },
+            { capabilities: { tools: {} }, supportedProtocolVersions: DUAL_ERA_VERSIONS, eraSupport: 'modern' }
+        );
+        const { request, close } = await wireServer(server);
+
+        // The unsupported-protocol-version handoff names only the modern
+        // revisions: the legacy entries the consumer passed are never served
+        // by a strict instance, so they are not advertised either.
+        const response = await request({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} });
+        expect(isJSONRPCErrorResponse(response)).toBe(true);
+        if (isJSONRPCErrorResponse(response)) {
+            expect((response.error.data as { supported?: string[] }).supported).toEqual([MODERN]);
         }
         await close();
     });

--- a/test/integration/test/__fixtures__/dualEraStdioServer.ts
+++ b/test/integration/test/__fixtures__/dualEraStdioServer.ts
@@ -1,0 +1,29 @@
+/**
+ * A dual-era stdio server fixture: `eraSupport: 'dual-era'` on an otherwise
+ * ordinary hand-constructed McpServer connected to the unchanged
+ * StdioServerTransport. Spawned as a real child process by
+ * `test/server/dualEraStdio.test.ts`.
+ */
+import { McpServer } from '@modelcontextprotocol/server';
+import { StdioServerTransport } from '@modelcontextprotocol/server/stdio';
+import * as z from 'zod/v4';
+
+const server = new McpServer(
+    { name: 'dual-era-stdio-fixture', version: '1.0.0' },
+    { capabilities: { tools: {} }, instructions: 'dual-era stdio fixture', eraSupport: 'dual-era' }
+);
+
+server.registerTool('echo', { description: 'Echoes the input text', inputSchema: z.object({ text: z.string() }) }, async ({ text }) => ({
+    content: [{ type: 'text', text }]
+}));
+
+await server.connect(new StdioServerTransport());
+
+const exit = async () => {
+    await server.close();
+    // eslint-disable-next-line unicorn/no-process-exit
+    process.exit(0);
+};
+
+process.on('SIGINT', exit);
+process.on('SIGTERM', exit);

--- a/test/integration/test/client/client.test.ts
+++ b/test/integration/test/client/client.test.ts
@@ -6,7 +6,6 @@ import {
     ProtocolErrorCode,
     SdkError,
     SdkErrorCode,
-    setNegotiatedProtocolVersion,
     SUPPORTED_PROTOCOL_VERSIONS
 } from '@modelcontextprotocol/core';
 import { McpServer, Server } from '@modelcontextprotocol/server';
@@ -188,12 +187,15 @@ test('should run a fresh initialize handshake after close() when the previous co
     const supportedProtocolVersions = [MODERN_REVISION, ...SUPPORTED_PROTOCOL_VERSIONS];
 
     const connectModern = async (client: Client) => {
-        const server = new Server({ name: 'modern server', version: '1.0' }, { capabilities: {}, supportedProtocolVersions });
+        // Serving a 2026-era revision on a hand-constructed instance is a declared act
+        // (eraSupport); a dual-era instance answers the client's server/discover probe
+        // per message with no instance binding.
+        const server = new Server(
+            { name: 'modern server', version: '1.0' },
+            { capabilities: {}, supportedProtocolVersions, eraSupport: 'dual-era' }
+        );
         const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
         await server.connect(serverTransport);
-        // Stand-in for the modern-era server entry (instance binding): mark the server instance
-        // as serving the modern era so it can answer the client's server/discover probe.
-        setNegotiatedProtocolVersion(server, MODERN_REVISION);
         await client.connect(clientTransport);
     };
 

--- a/test/integration/test/client/discoverRoundtrip.test.ts
+++ b/test/integration/test/client/discoverRoundtrip.test.ts
@@ -4,17 +4,17 @@
  * era-aware counter-offer end to end (a legacy client against a server whose
  * supported list carries a 2026 revision never sees a 2026 version string).
  *
- * Era is instance state on the server: an inbound `server/discover` is served
- * only by a modern-era instance (the method is physically absent from the
- * legacy registry). Production binding of modern-era instances belongs to the
- * server-side entry that classifies inbound traffic; until it lands these
- * tests bind the instance through the package-internal hook it will use.
+ * Serving a 2026-era revision on a hand-constructed instance is a declared
+ * act: the servers under test pass `eraSupport: 'dual-era'` (a modern
+ * revision in the supported list without that declaration is a
+ * construction-time TypeError), and a dual-era instance answers the
+ * `server/discover` probe per message with no instance binding.
  */
 import type { Server as HttpServer } from 'node:http';
 import { createServer } from 'node:http';
 
 import { Client, StreamableHTTPClientTransport } from '@modelcontextprotocol/client';
-import { SdkError, SdkErrorCode, setNegotiatedProtocolVersion, SUPPORTED_PROTOCOL_VERSIONS } from '@modelcontextprotocol/core';
+import { SdkError, SdkErrorCode, SUPPORTED_PROTOCOL_VERSIONS } from '@modelcontextprotocol/core';
 import { NodeStreamableHTTPServerTransport } from '@modelcontextprotocol/node';
 import { McpServer } from '@modelcontextprotocol/server';
 import { listenOnRandomPort } from '@modelcontextprotocol/test-helpers';
@@ -39,14 +39,14 @@ describe('server/discover round-trip against a modern server', () => {
         while (cleanups.length > 0) await cleanups.pop()!();
     });
 
-    async function startServer(options: { modernEraInstance: boolean }) {
+    async function startServer(options: { kind: 'dual-era' | 'legacy-only' }) {
         const httpServer: HttpServer = createServer();
         const mcpServer = new McpServer(
             { name: 'dual-era-server', version: '2.0.0' },
             {
                 capabilities: { tools: { listChanged: true } },
-                supportedProtocolVersions: DUAL_ERA_VERSIONS,
-                instructions: 'dual era'
+                instructions: 'dual era',
+                ...(options.kind === 'dual-era' ? { supportedProtocolVersions: DUAL_ERA_VERSIONS, eraSupport: 'dual-era' as const } : {})
             }
         );
         mcpServer.registerTool('echo', { inputSchema: z.object({ text: z.string() }) }, ({ text }) => ({
@@ -54,11 +54,6 @@ describe('server/discover round-trip against a modern server', () => {
         }));
         const serverTransport = new NodeStreamableHTTPServerTransport({ sessionIdGenerator: undefined });
         await mcpServer.connect(serverTransport);
-        if (options.modernEraInstance) {
-            // Stand-in for the server-side entry (instance binding): mark the
-            // instance as serving the modern era so it can answer the probe.
-            setNegotiatedProtocolVersion(mcpServer.server, MODERN);
-        }
         httpServer.on('request', (req, res) => void serverTransport.handleRequest(req, res));
         const baseUrl = await listenOnRandomPort(httpServer);
         cleanups.push(async () => {
@@ -70,7 +65,7 @@ describe('server/discover round-trip against a modern server', () => {
     }
 
     it('pin-mode 2026 client: server/discover → version selection, no initialize ever sent', async () => {
-        const baseUrl = await startServer({ modernEraInstance: true });
+        const baseUrl = await startServer({ kind: 'dual-era' });
         const { bodies, fetchFn } = recordingFetch();
 
         const client = new Client({ name: 'pin-client', version: '1.0.0' }, { versionNegotiation: { mode: { pin: MODERN } } });
@@ -88,7 +83,7 @@ describe('server/discover round-trip against a modern server', () => {
     });
 
     it('auto-mode client selects the modern era on the same server', async () => {
-        const baseUrl = await startServer({ modernEraInstance: true });
+        const baseUrl = await startServer({ kind: 'dual-era' });
         const client = new Client({ name: 'auto-client', version: '1.0.0' }, { versionNegotiation: { mode: 'auto' } });
         await client.connect(new StreamableHTTPClientTransport(baseUrl));
         cleanups.push(() => client.close());
@@ -96,12 +91,11 @@ describe('server/discover round-trip against a modern server', () => {
         expect(client.getNegotiatedProtocolVersion()).toBe(MODERN);
     });
 
-    it('auto-mode against the same server NOT bound to the modern era falls back to the legacy handshake', async () => {
-        // A server instance serves the legacy era until it is bound to the
-        // modern one (binding is owned by the server-side entry); the probe is
-        // answered -32601 and the client falls back cleanly on the same
-        // connection.
-        const baseUrl = await startServer({ modernEraInstance: false });
+    it('auto-mode against a server that has not opted into modern-era support falls back to the legacy handshake', async () => {
+        // A hand-constructed server with the default eraSupport never serves
+        // server/discover: the probe is answered -32601 and the client falls
+        // back cleanly on the same connection.
+        const baseUrl = await startServer({ kind: 'legacy-only' });
         const client = new Client({ name: 'auto-client', version: '1.0.0' }, { versionNegotiation: { mode: 'auto' } });
         await client.connect(new StreamableHTTPClientTransport(baseUrl));
         cleanups.push(() => client.close());
@@ -111,8 +105,8 @@ describe('server/discover round-trip against a modern server', () => {
         expect(result.content).toEqual([{ type: 'text', text: 'fallback' }]);
     });
 
-    it('a plain legacy client against a server with a dual-era list never meets a 2026 version string (counter-offer ordering, e2e)', async () => {
-        const baseUrl = await startServer({ modernEraInstance: false });
+    it('a plain legacy client against a dual-era server never meets a 2026 version string (counter-offer ordering, e2e)', async () => {
+        const baseUrl = await startServer({ kind: 'dual-era' });
         const { fetchFn } = recordingFetch();
 
         const responses: string[] = [];

--- a/test/integration/test/server/dualEraStdio.test.ts
+++ b/test/integration/test/server/dualEraStdio.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Real-pipe dual-era stdio coverage: the fixture server
+ * (`__fixtures__/dualEraStdioServer.ts`, `eraSupport: 'dual-era'`, unchanged
+ * `StdioServerTransport`) is spawned as a real child process and driven over
+ * its stdio pipe by
+ *
+ * - a plain 2025 client (the `initialize` vertical, served exactly as today),
+ * - the negotiating client in auto mode (the 2026-07-28 vertical:
+ *   `server/discover` on the pipe, then list → call with the per-request
+ *   envelope), and
+ * - the long-lived era-gate negative on one connection: a legacy-classified
+ *   `server/discover` answers a plain −32601 with zero 2026 vocabulary, while
+ *   the same connection keeps serving both eras.
+ *
+ * Stdio behavior has no conformance harness (upstream conformance issue #258);
+ * this SDK e2e suite is its referee.
+ */
+import path from 'node:path';
+
+import { Client } from '@modelcontextprotocol/client';
+import { StdioClientTransport } from '@modelcontextprotocol/client/stdio';
+import type { JSONRPCMessage } from '@modelcontextprotocol/core';
+import {
+    CLIENT_CAPABILITIES_META_KEY,
+    CLIENT_INFO_META_KEY,
+    LATEST_PROTOCOL_VERSION,
+    PROTOCOL_VERSION_META_KEY
+} from '@modelcontextprotocol/core';
+import { describe, expect, it, vi } from 'vitest';
+
+const FIXTURES_DIR = path.resolve(__dirname, '../__fixtures__');
+const MODERN = '2026-07-28';
+
+const FORBIDDEN_2026_VOCABULARY = ['2026', 'discover', 'envelope', 'modern', 'era', '_meta', 'io.modelcontextprotocol', 'resultType'];
+
+function spawnFixtureTransport(): StdioClientTransport {
+    return new StdioClientTransport({
+        command: process.execPath,
+        args: ['--import', 'tsx', 'dualEraStdioServer.ts'],
+        cwd: FIXTURES_DIR
+    });
+}
+
+/** Records every message the server writes onto the pipe (without detaching the client). */
+function recordInbound(transport: StdioClientTransport): JSONRPCMessage[] {
+    const inbound: JSONRPCMessage[] = [];
+    const original = transport.onmessage;
+    transport.onmessage = (message, extra) => {
+        inbound.push(message);
+        original?.(message, extra);
+    };
+    return inbound;
+}
+
+/** Records every message the client writes onto the pipe. */
+function recordOutbound(transport: StdioClientTransport): JSONRPCMessage[] {
+    const outbound: JSONRPCMessage[] = [];
+    const originalSend = transport.send.bind(transport);
+    transport.send = async (message, options) => {
+        outbound.push(message);
+        return originalSend(message, options);
+    };
+    return outbound;
+}
+
+/** Sends a raw JSON-RPC request on the live pipe and resolves with the matching response. */
+async function rawRequest(transport: StdioClientTransport, inbound: JSONRPCMessage[], request: JSONRPCMessage): Promise<JSONRPCMessage> {
+    const id = (request as { id: string | number }).id;
+    const seen = inbound.length;
+    await transport.send(request);
+    return vi.waitFor(
+        () => {
+            const match = inbound.slice(seen).find(message => (message as { id?: string | number }).id === id);
+            if (!match) throw new Error('no response yet');
+            return match;
+        },
+        { timeout: 5000 }
+    );
+}
+
+describe('dual-era stdio server over a real child-process pipe', () => {
+    vi.setConfig({ testTimeout: 30_000 });
+
+    it('legacy vertical: a plain 2025 client is served via initialize, and the era gate stays vocabulary-clean on the same connection', async () => {
+        const transport = spawnFixtureTransport();
+        const client = new Client({ name: 'legacy-pipe-client', version: '1.0.0' });
+        // Raw writes below produce responses the protocol layer does not track.
+        client.onerror = () => {};
+
+        try {
+            await client.connect(transport);
+            const inbound = recordInbound(transport);
+
+            // The 2025 vertical, byte-shape checks included.
+            expect(client.getNegotiatedProtocolVersion()).toBe(LATEST_PROTOCOL_VERSION);
+            const tools = await client.listTools();
+            expect(tools.tools.map(tool => tool.name)).toEqual(['echo']);
+            const result = await client.callTool({ name: 'echo', arguments: { text: 'over the real pipe' } });
+            expect(result.content).toEqual([{ type: 'text', text: 'over the real pipe' }]);
+            expect(JSON.stringify(inbound)).not.toContain('resultType');
+
+            // Era-gate negative on the SAME connection: a legacy-classified
+            // server/discover answers a plain −32601 with zero 2026 vocabulary.
+            const gate = await rawRequest(transport, inbound, {
+                jsonrpc: '2.0',
+                id: 'raw-gate-1',
+                method: 'server/discover',
+                params: {}
+            });
+            const error = (gate as { error: { code: number; message: string; data?: unknown } }).error;
+            expect(error.code).toBe(-32_601);
+            expect(error.message).toBe('Method not found');
+            expect(error.data).toBeUndefined();
+            const serialized = JSON.stringify(error).toLowerCase();
+            for (const term of FORBIDDEN_2026_VOCABULARY) {
+                expect(serialized).not.toContain(term.toLowerCase());
+            }
+        } finally {
+            await client.close();
+        }
+    });
+
+    it('modern vertical: the auto-negotiating client reaches 2026-07-28 via server/discover on the pipe and both eras serve on one connection', async () => {
+        const transport = spawnFixtureTransport();
+        const outbound = recordOutbound(transport);
+        const client = new Client({ name: 'modern-pipe-client', version: '1.0.0' }, { versionNegotiation: { mode: 'auto' } });
+        client.onerror = () => {};
+
+        try {
+            await client.connect(transport);
+            const inbound = recordInbound(transport);
+
+            // 2026 negotiated via discover on the pipe — no initialize was ever written.
+            expect(client.getNegotiatedProtocolVersion()).toBe(MODERN);
+            expect(outbound.some(message => (message as { method?: string }).method === 'initialize')).toBe(false);
+            expect((outbound[0] as { method?: string }).method).toBe('server/discover');
+
+            // Modern vertical: list → call, every request carrying the per-request envelope.
+            // (Attaching it explicitly is the documented stop-gap until automatic
+            // per-request envelope emission lands client-side.)
+            const envelope = {
+                [PROTOCOL_VERSION_META_KEY]: MODERN,
+                [CLIENT_INFO_META_KEY]: { name: 'modern-pipe-client', version: '1.0.0' },
+                [CLIENT_CAPABILITIES_META_KEY]: {}
+            };
+            // The list leg is asserted at the wire level: the 2026 wire schema
+            // for cacheable list results requires the ttlMs/cacheScope stamps,
+            // whose server-side stamping ships with the result-stamping
+            // milestone — the client-side typed decode of tools/list on the
+            // modern era completes once that lands.
+            const modernList = await rawRequest(transport, inbound, {
+                jsonrpc: '2.0',
+                id: 'raw-modern-list',
+                method: 'tools/list',
+                params: { _meta: envelope }
+            });
+            const modernListResult = (modernList as { result?: { tools?: Array<{ name: string }>; resultType?: string } }).result;
+            expect(modernListResult?.tools?.map(tool => tool.name)).toEqual(['echo']);
+            expect(modernListResult?.resultType).toBe('complete');
+
+            const result = await client.request({
+                method: 'tools/call',
+                params: { name: 'echo', arguments: { text: 'modern leg' }, _meta: envelope }
+            });
+            expect(result.content).toEqual([{ type: 'text', text: 'modern leg' }]);
+
+            // Both eras concurrently on ONE connection: a raw legacy (envelope-less)
+            // request on the same pipe is served on the 2025 era…
+            const legacyList = await rawRequest(transport, inbound, {
+                jsonrpc: '2.0',
+                id: 'raw-legacy-list',
+                method: 'tools/list',
+                params: {}
+            });
+            const legacyResult = (legacyList as { result?: { tools?: Array<{ name: string }>; resultType?: string } }).result;
+            expect(legacyResult?.tools?.map(tool => tool.name)).toEqual(['echo']);
+            expect(legacyResult?.resultType).toBeUndefined();
+
+            // …while the era-gate negative holds on the same connection too.
+            const gate = await rawRequest(transport, inbound, {
+                jsonrpc: '2.0',
+                id: 'raw-gate-2',
+                method: 'subscriptions/listen',
+                params: {}
+            });
+            const error = (gate as { error: { code: number; message: string; data?: unknown } }).error;
+            expect(error.code).toBe(-32_601);
+            expect(error.message).toBe('Method not found');
+            expect(error.data).toBeUndefined();
+        } finally {
+            await client.close();
+        }
+    });
+});


### PR DESCRIPTION

Adds the stdio/long-lived-connection half of dual-era serving: `ServerOptions.eraSupport` with a `'legacy'` default that preserves today's behavior exactly, per-message era selection on dual-era connections via a protocol-layer classification consult, the era gate that keeps 2026-only methods invisible to 2025-era traffic, era-keyed direction enforcement, and a runnable dual-era stdio example with real child-process e2e coverage.

## Motivation and Context
The 2026-07-28 draft revision can already be served over HTTP per request (`createMcpHandler`). stdio servers are different: they are hand-constructed, long-lived, and bound to one connection — so serving the new revision there has to be a per-message decision on the same pipe, and it has to be impossible to change what an existing server puts on the wire just by upgrading the SDK.

- **`ServerOptions.eraSupport: 'legacy' | 'dual-era' | 'modern'`** (default `'legacy'`). The default changes nothing: no `server/discover`, no new advertisement, byte-identical 2025 serving. `'dual-era'` serves both eras on one connection, classifying each message by the per-request `_meta` envelope (`initialize` and claim-less messages are 2025-era; envelope-carrying messages are 2026-era) — one option, transport unchanged. `'modern'` is strict 2026-only: requests without the envelope (including `initialize`) get the unsupported-protocol-version error with the supported list.
- **A 2026-era revision in `supportedProtocolVersions` now requires the declaration**: on a default instance it throws a `TypeError` at construction instead of silently installing the discover handler.
- **Protocol-layer classification consult**: a new protected `Protocol._classifyInbound` hook, consulted only when the transport did not classify a message (an HTTP-edge classification always wins). The server override classifies per message on declared instances; the base implementation returns `undefined`, leaving every existing dispatch path untouched.
- **Era gate on long-lived connections**: methods that exist in only one era stay invisible to the other — a 2025-era request for `server/discover` (or any 2026-only method) answers the same plain `-32601` a 2025 server sends, with nothing in the message or data revealing the modern registry; a 2026-era request for a removed method answers `-32601` too, and outbound requests die locally with a typed error when the era does not define them.
- **Directionality**: the 2026 era has no server→client JSON-RPC request channel. A `'modern'` server cannot emit sampling/elicitation/roots wire requests; a dual-era server still can toward the 2025-era clients it serves; and a client whose connection negotiated a modern era drops inbound requests instead of answering them (on stdio the client must never write responses).
- **Accessors on dual-era instances**: `getClientCapabilities()` / `getClientVersion()` / `getNegotiatedProtocolVersion()` keep their `initialize`-scoped semantics and are never backfilled from 2026-era requests (mixed-era interleaving makes instance-level backfill racy); handlers read per-request identity from `ctx.mcpReq.envelope`. Documented in the migration guide.
- **Demo + e2e**: `examples/server/src/dualEraStdio.ts` (the opt-in is the single option; the transport line is unchanged) with a two-legged client example, plus an integration suite that spawns the same server shape as a real child process and drives the 2025 vertical, the 2026 vertical negotiated via `server/discover` on the pipe, and the era-gate negative on one connection. Stdio has no conformance harness, so this SDK e2e coverage is its referee.

## How Has This Been Tested?
- New unit suites for the per-message era predicate (including the rule that classification keys on the reserved protocol-version `_meta` key, never bare `_meta`), the classification consult (edge classification always wins; the base path is unchanged; per-message era on dual-era instances; strict-instance handoff; the drop arm), `eraSupport` construction/serving semantics, the long-lived era gate with a dedicated zero-2026-vocabulary leak test, a scripted-2025 golden pin on a default server, the client-side inbound-request drop, and a merged first-contact fixture corpus for the probe classifier (probe edges plus the wire shapes deployed 2025 servers actually answer).
- A real child-process stdio integration suite covering both eras and the era gate on one pipe, plus the runnable examples.
- Full repo gates: typecheck, lint, build, docs build, every package suite, integration, the full e2e matrix, and the conformance suites against the published referee with no expected-failures changes.

## Breaking Changes
One deliberate, narrow break (changeset + migration entry): constructing a `Server`/`McpServer` with a 2026-era revision in `supportedProtocolVersions` without declaring `eraSupport` now throws a `TypeError` (previously it silently installed the `server/discover` handler). Servers that do not opt in are byte-identical to before, and the default version list is unaffected.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
- The classification consult is deliberately the only change to the protocol dispatch file; everything era-specific lives in the role classes and the existing classification pure module.
- Typed client-side decoding of cacheable list results (e.g. `tools/list`) on the 2026 era completes once result stamping supplies the required cache fields; until then the modern list leg is exercised at the wire level and the example uses `tools/call`.