### PR TITLE
test(integration): stop the cloudflare workers test from rewriting workspace dist mid-suite

### DIFF
--- a/test/integration/test/server/cloudflareWorkers.test.ts
+++ b/test/integration/test/server/cloudflareWorkers.test.ts
@@ -40,6 +40,63 @@ const WRANGLER_BIN = (() => {
     return path.resolve(path.dirname(pkgPath), bin);
 })();
 
+/**
+ * Create an installable tarball of `@modelcontextprotocol/server` without mutating the workspace.
+ *
+ * Running `pnpm pack` inside `packages/server` is not an option here: its `prepack` hook rebuilds
+ * the package in place (tsdown with `clean: true`), deleting and rewriting `packages/server/dist`
+ * while the rest of the test run is still going. Anything that node-resolves the workspace
+ * packages at that moment — most notably suites that spawn child processes importing
+ * `@modelcontextprotocol/server` — sees a half-written dist and fails. Instead, the bundle is
+ * built into a staging directory under the test's temp dir and the tarball is created from that
+ * staging copy, so shared, node-resolvable state never changes while tests are running.
+ *
+ * Returns the tarball's file name; the tarball itself is written into `tempDir`.
+ */
+function packServerPackage(tempDir: string): string {
+    const serverPkgPath = path.resolve(__dirname, '../../../../packages/server');
+    const stagingDir = path.join(tempDir, 'package-staging');
+    fs.mkdirSync(stagingDir, { recursive: true });
+
+    // Build the publishable bundle with its output redirected away from the workspace's
+    // packages/server/dist (the CLI flag overrides `outDir` from tsdown.config.ts).
+    execSync(`pnpm exec tsdown --out-dir "${path.join(stagingDir, 'dist')}"`, {
+        cwd: serverPkgPath,
+        stdio: 'pipe',
+        timeout: 60_000
+    });
+
+    // Write a publish-shaped manifest into the staging dir: drop lifecycle scripts and
+    // devDependencies, and resolve pnpm-only `catalog:`/`workspace:` specifiers to the versions
+    // installed in the workspace — the same substitution `pnpm pack` performs when publishing.
+    const manifest = JSON.parse(fs.readFileSync(path.join(serverPkgPath, 'package.json'), 'utf8')) as {
+        scripts?: unknown;
+        devDependencies?: unknown;
+        dependencies?: Record<string, string>;
+    };
+    delete manifest.scripts;
+    delete manifest.devDependencies;
+    const dependencies = manifest.dependencies ?? {};
+    for (const [name, spec] of Object.entries(dependencies)) {
+        if (spec.startsWith('catalog:') || spec.startsWith('workspace:')) {
+            const installed = JSON.parse(fs.readFileSync(path.join(serverPkgPath, 'node_modules', name, 'package.json'), 'utf8')) as {
+                version: string;
+            };
+            dependencies[name] = installed.version;
+        }
+    }
+    fs.writeFileSync(path.join(stagingDir, 'package.json'), JSON.stringify(manifest, null, 2));
+
+    // Pack the staging copy. The staged manifest carries no scripts, so this is a pure tar step;
+    // npm is used because the staging dir lives outside the pnpm workspace.
+    const packOutput = execSync(`npm pack --pack-destination "${tempDir}"`, {
+        cwd: stagingDir,
+        encoding: 'utf8',
+        timeout: 60_000
+    });
+    return path.basename(packOutput.trim().split('\n').pop()!);
+}
+
 /** Ask the kernel for a currently-free port instead of hardcoding one. */
 async function getFreePort(): Promise<number> {
     return new Promise((resolve, reject) => {
@@ -212,14 +269,9 @@ describe('Cloudflare Workers compatibility (no nodejs_compat)', () => {
         };
 
         try {
-            // Pack server package
-            const serverPkgPath = path.resolve(__dirname, '../../../../packages/server');
-            const packOutput = execSync(`pnpm pack --pack-destination "${tempDir}"`, {
-                cwd: serverPkgPath,
-                encoding: 'utf8',
-                timeout: 60_000
-            });
-            const tarballName = path.basename(packOutput.trim().split('\n').pop()!);
+            // Pack the server package into the temp dir without touching the workspace's own
+            // dist/ — see packServerPackage for why the plain `pnpm pack` route is unsafe here.
+            const tarballName = packServerPackage(tempDir);
 
             // Write package.json
             const pkgJson = {


### PR DESCRIPTION

---

Stops the Cloudflare Workers integration test from rebuilding `packages/server/dist` in place
while tests are running. Follow-up to #2296 (workerd process leak), which is unchanged.

## Motivation and Context

The test packs `@modelcontextprotocol/server` with `pnpm pack`, and the package's `prepack`
hook rebuilds it in place (tsdown with `clean: true`), deleting and rewriting
`packages/server/dist` mid-run. Test files in this repo resolve the workspace packages from
source, so nothing fails today — but any suite that spawns child processes which resolve
`@modelcontextprotocol/server` through normal node resolution (the package `exports` point at
`dist/`) races against that clean+rewrite and can see a missing or half-written dist. Tests
shouldn't mutate shared, node-resolvable state at runtime.

The bundle is now built into a staging directory under the test's temp dir
(`tsdown --out-dir`), a publish-shaped manifest is written there (`catalog:`/`workspace:`
specifiers resolved to installed versions, scripts dropped), and the tarball is created from
that staging copy. The workspace's own `dist/` is never touched.

## How Has This Been Tested?

- `test/server/cloudflareWorkers.test.ts` alone and the full `test/integration` suite
  (14 files / 327 tests) pass locally.
- Verified all workspace `dist/` files are byte-identical (sha256 + mtimes) before and after
  the suite; previously the run rewrote `packages/server/dist`.
- Verified no leftover workerd processes after the run (behavior from #2296 preserved).

## Breaking Changes

None — test infrastructure only.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

The test still builds exactly what it packs and still exercises the packed package in
`wrangler dev` without nodejs_compat; only where the build output and tarball land has
changed. The helper calls `tsdown` directly so it can redirect the output directory — if the
server package ever changes bundlers, this line needs the matching update.

---
