### PR TITLE
test(e2e): audit transport-restricted requirements for the entry arms; admit two and harden entryModern

### DIFF
--- a/test/e2e/helpers/index.ts
+++ b/test/e2e/helpers/index.ts
@@ -164,6 +164,7 @@ export async function wire(
                 clientTx = attachModernEnvelope(clientTx);
             }
             await client.connect(sniffTransport(clientTx, 'client', sniff));
+            if (transport === 'entryModern') assertModernNegotiation(client);
             return {
                 fetch,
                 url,
@@ -352,14 +353,32 @@ function pinModernNegotiation(client: Client): void {
 }
 
 /**
+ * Fail fast if an entryModern connection did not actually negotiate the
+ * 2026-07-28 revision. Every cell on the arm asserts modern-path behavior, so
+ * a broken negotiation pin (or a regression in the discover negotiation) would
+ * otherwise surface as hundreds of unrelated downstream assertion failures;
+ * this turns it into one attributable arm-level error right after connect.
+ */
+function assertModernNegotiation(client: Client): void {
+    const negotiated = client.getNegotiatedProtocolVersion();
+    if (negotiated !== MODERN_REVISION) {
+        throw new Error(
+            `entryModern arm: expected the connection to negotiate protocol version ${MODERN_REVISION}, but it negotiated ${negotiated ?? 'no version'}`
+        );
+    }
+}
+
+/**
  * The per-request `_meta` envelope stop-gap for the entryModern arm: the
  * negotiating client only attaches the envelope to its `server/discover` probe
  * today (automatic per-request emission is a client-side follow-up), so the
  * harness re-attaches the same envelope to every later request and notification
  * the scenario's typed calls put on the wire. The envelope is captured from the
- * probe itself, so it always matches what the client actually claimed; messages
- * that already carry a protocol-version claim (the probe, or a scenario's
- * explicitly enveloped request) pass through untouched.
+ * latest enveloped message the client sent (normally the probe), so it always
+ * matches the most recent claim the client actually made — a connection that
+ * renegotiated would not keep stamping a stale version; messages that already
+ * carry a protocol-version claim (the probe, or a scenario's explicitly
+ * enveloped request) pass through untouched.
  *
  * Applied beneath the wire sniffer and `tapWire`, so recorded traffic shows the
  * messages exactly as the scenario sent them while the wire carries the
@@ -374,7 +393,7 @@ function attachModernEnvelope<T extends SdkTransport>(transport: T): T {
             const params = (message.params ?? {}) as { _meta?: Record<string, unknown> };
             const meta = params._meta;
             if (meta?.[PROTOCOL_VERSION_META_KEY] !== undefined) {
-                envelope ??= {
+                envelope = {
                     [PROTOCOL_VERSION_META_KEY]: meta[PROTOCOL_VERSION_META_KEY],
                     [CLIENT_INFO_META_KEY]: meta[CLIENT_INFO_META_KEY],
                     [CLIENT_CAPABILITIES_META_KEY]: meta[CLIENT_CAPABILITIES_META_KEY]

--- a/test/e2e/requirements.ts
+++ b/test/e2e/requirements.ts
@@ -2145,11 +2145,11 @@ export const REQUIREMENTS: Record<string, Requirement> = {
         note: 'This is an HTTP-specific flow requiring session management; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
     },
     'flow:tool-result:resource-link-follow': {
-        transports: STATEFUL_TRANSPORTS,
+        transports: [...STATEFUL_TRANSPORTS, 'entryStateless', 'entryModern'],
         source: 'https://modelcontextprotocol.io/specification/2025-11-25/server/tools#resource-links',
         behavior:
             'A resource_link returned by a tool call can be followed with resources/read on the linked URI to retrieve the referenced contents.',
-        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
+        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these. The createMcpHandler entry arms are included: the body is plain client→server request/response (a tools/call, then a resources/read against the same statically-registered factory), so the per-request entry serves it on both eras.'
     },
     'flow:proxy:forward-tools-resources': {
         transports: ['inMemory', 'streamableHttp'],
@@ -2367,8 +2367,8 @@ export const REQUIREMENTS: Record<string, Requirement> = {
         source: 'sdk',
         behavior:
             'A notification handler registered for a non-spec method with a params schema receives schema-validated custom notifications sent by the remote side.',
-        transports: STATEFUL_TRANSPORTS,
-        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
+        transports: [...STATEFUL_TRANSPORTS, 'entryStateless', 'entryModern'],
+        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these. The createMcpHandler entry arms are included: the server→client heartbeats are emitted during the tools/call exchange (ctx.mcpReq.notify) and observed after it completes, and the client→server heartbeat is a plain notification handled by the per-request instance, so the entry arms serve the body on both eras.'
     },
     'typescript:method-string-handlers:result-type-inference': {
         entryExclusions: [{ arm: 'entryModern', reason: 'method-not-in-modern-registry' }],


### PR DESCRIPTION
Audits every transport-restricted requirement in the e2e manifest for applicability to the createMcpHandler entry arms, admits the two whose bodies the per-request entry can already serve, and hardens the entryModern arm against negotiation/envelope drift.

## Motivation and Context
The entry arms added in #2309 opt in every requirement without an explicit `transports` restriction; the ~240 rows that carry one were authored before the entry existed and never reach the arms. This pass reviews each of them so that nothing is skipped silently: requirements the per-request entry can serve today are admitted, and the rest are confirmed as blocked on missing entry features (server→client requests, sessions/standalone streams) or as genuinely transport-specific.

- **Two requirements join the entry arms** (+4 cells, all green): `flow:tool-result:resource-link-follow` and `custom-methods:notification-handler`. Both bodies need only request-scoped delivery, so the per-request entry serves them unmodified on both eras; their notes explain the inclusion. No scenario body was changed and no knownFailure or exclusion was added.
- **The rest stay restricted on purpose.** Server→client request flows (sampling, elicitation, roots), subscription/list-changed/standalone-stream behaviors, session lifecycle and resumability, and persistent-instance state cannot be expressed on a per-request entry yet; transport-class internals, framework adapters, and stdio/SSE-specific mechanics never will be. The OAuth/auth scenarios stay restricted for a different reason: their bodies host their own servers and auth stacks, so labelling them with an entry arm would not exercise the entry — authenticated serving through `createMcpHandler` needs dedicated entry-side scenarios, which this review calls out as follow-up coverage alongside the other generic HTTP-mechanics behaviors that deserve dedicated entry-side cells later (several already have them).
- **entryModern arm hardening.** The arm now asserts immediately after connect that the connection actually negotiated 2026-07-28, so a broken negotiation pin produces one attributable arm-level failure instead of hundreds of downstream ones; and the per-request envelope shim now captures from the latest enveloped message rather than the first, so a renegotiated connection could not keep claiming a stale version.

## How Has This Been Tested?
Full e2e matrix before/after on the same machine: 2536 passed / 205 expected-fail / 2741 cells → 2540 / 205 / 2745, zero unexpected failures in both runs. Package typecheck and lint for the e2e workspace are green. No package source, examples, or conformance changes.

## Breaking Changes
None — test-only.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Test/coverage change (no runtime behavior change)

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
One candidate that looked admissible analytically — logging emitted via the request context (`ctx.mcpReq.log`) while the handler is still running — stays restricted, and the reason is sharper than a missing delivery channel: those notifications are emitted without a `relatedRequestId`, and the per-request transport drops messages that are not related to the single in-flight request, so handler-context logs are never delivered when serving through `createMcpHandler`. Request-related notifications and progress do ride the in-flight exchange (which is why those cells pass on the entry arms). Whether handler-context logging should be emitted as request-related on per-request serving is left as an explicit follow-up rather than changed here.
