### PR TITLE
docs: @deprecated JSDoc on push-style server→client APIs that throw on 2026-07-28-era requests

### DIFF
--- a/packages/core/src/shared/protocol.ts
+++ b/packages/core/src/shared/protocol.ts
@@ -387,6 +387,11 @@ export type ServerContext = BaseContext & {
 
         /**
          * Send an elicitation request to the client, requesting user input.
+         *
+         * @deprecated Throws on a 2026-07-28-era request — return `inputRequired(...)`
+         * (multi-round-trip) from the handler instead. The 2025 push-style server-to-client request model is
+         * replaced by input_required results in the 2026-07-28 protocol. If your factory serves
+         * both eras, this only works on the legacy path.
          */
         elicitInput: (params: ElicitRequestFormParams | ElicitRequestURLParams, options?: RequestOptions) => Promise<ElicitResult>;
 
@@ -394,8 +399,10 @@ export type ServerContext = BaseContext & {
          * Request LLM sampling from the client.
          *
          * @deprecated Deprecated as of protocol version 2026-07-28 (SEP-2577).
-         * Remains functional during the deprecation window (at least twelve months).
-         * Migrate to calling LLM provider APIs directly.
+         * Throws on a 2026-07-28-era request — return `inputRequired(...)` (multi-round-trip)
+         * from the handler instead, or migrate to calling LLM provider APIs directly. The 2025 push-style
+         * server-to-client request model is replaced by input_required results in the 2026-07-28
+         * protocol. If your factory serves both eras, this only works on the legacy path.
          */
         requestSampling: (
             params: CreateMessageRequest['params'],

--- a/packages/server/src/server/server.ts
+++ b/packages/server/src/server/server.ts
@@ -849,6 +849,12 @@ export class Server extends Protocol<ServerContext> {
         return this._capabilities;
     }
 
+    /**
+     * Sends a `ping` request to the connected client.
+     *
+     * @deprecated The 2026-07-28 protocol removed ping; it throws on a 2026-07-28-era instance.
+     * If your factory serves both eras, this only works on the legacy path.
+     */
     async ping(): Promise<EmptyResult> {
         this._assertPushApiInServedEra('ping');
         return this.request({ method: 'ping' });
@@ -859,8 +865,10 @@ export class Server extends Protocol<ServerContext> {
      * Returns single content block for backwards compatibility.
      *
      * @deprecated Deprecated as of protocol version 2026-07-28 (SEP-2577).
-     * Remains functional during the deprecation window (at least twelve months).
-     * Migrate to calling LLM provider APIs directly.
+     * Throws on a 2026-07-28-era request — use {@link index.inputRequired | inputRequired} (multi-round-trip) instead,
+     * or migrate to calling LLM provider APIs directly. The 2025 push-style server-to-client
+     * request model is replaced by input_required results in the 2026-07-28 protocol. If your
+     * factory serves both eras, this only works on the legacy path.
      */
     async createMessage(params: CreateMessageRequestParamsBase, options?: RequestOptions): Promise<CreateMessageResult>;
 
@@ -869,8 +877,10 @@ export class Server extends Protocol<ServerContext> {
      * Returns content that may be a single block or array (for parallel tool calls).
      *
      * @deprecated Deprecated as of protocol version 2026-07-28 (SEP-2577).
-     * Remains functional during the deprecation window (at least twelve months).
-     * Migrate to calling LLM provider APIs directly.
+     * Throws on a 2026-07-28-era request — use {@link index.inputRequired | inputRequired} (multi-round-trip) instead,
+     * or migrate to calling LLM provider APIs directly. The 2025 push-style server-to-client
+     * request model is replaced by input_required results in the 2026-07-28 protocol. If your
+     * factory serves both eras, this only works on the legacy path.
      */
     async createMessage(params: CreateMessageRequestParamsWithTools, options?: RequestOptions): Promise<CreateMessageResultWithTools>;
 
@@ -879,8 +889,10 @@ export class Server extends Protocol<ServerContext> {
      * When tools may or may not be present, returns the union type.
      *
      * @deprecated Deprecated as of protocol version 2026-07-28 (SEP-2577).
-     * Remains functional during the deprecation window (at least twelve months).
-     * Migrate to calling LLM provider APIs directly.
+     * Throws on a 2026-07-28-era request — use {@link index.inputRequired | inputRequired} (multi-round-trip) instead,
+     * or migrate to calling LLM provider APIs directly. The 2025 push-style server-to-client
+     * request model is replaced by input_required results in the 2026-07-28 protocol. If your
+     * factory serves both eras, this only works on the legacy path.
      */
     async createMessage(
         params: CreateMessageRequest['params'],
@@ -960,6 +972,11 @@ export class Server extends Protocol<ServerContext> {
      * @param params The parameters for the elicitation request.
      * @param options Optional request options.
      * @returns The result of the elicitation request.
+     *
+     * @deprecated Throws on a 2026-07-28-era request — use {@link index.inputRequired | inputRequired} (multi-round-trip)
+     * instead. The 2025 push-style server-to-client request model is replaced by input_required
+     * results in the 2026-07-28 protocol. If your factory serves both eras, this only works on the
+     * legacy path.
      */
     async elicitInput(params: ElicitRequestFormParams | ElicitRequestURLParams, options?: RequestOptions): Promise<ElicitResult> {
         this._assertPushApiInServedEra('elicitation/create');
@@ -1049,8 +1066,10 @@ export class Server extends Protocol<ServerContext> {
      * Requests the list of roots from the client.
      *
      * @deprecated Deprecated as of protocol version 2026-07-28 (SEP-2577).
-     * Remains functional during the deprecation window (at least twelve months).
-     * Migrate to passing paths via tool parameters, resource URIs, or configuration.
+     * Throws on a 2026-07-28-era request — use {@link index.inputRequired | inputRequired} (multi-round-trip) instead,
+     * or migrate to passing paths via tool parameters, resource URIs, or configuration. The 2025
+     * push-style server-to-client request model is replaced by input_required results in the
+     * 2026-07-28 protocol. If your factory serves both eras, this only works on the legacy path.
      */
     async listRoots(params?: ListRootsRequest['params'], options?: RequestOptions): Promise<ListRootsResult> {
         this._assertPushApiInServedEra('roots/list');


### PR DESCRIPTION
Adds `@deprecated` JSDoc to the push-style server→client request APIs (`Server.ping/createMessage/elicitInput/listRoots` and `ctx.mcpReq.elicitInput/requestSampling`) that throw on a 2026-07-28-era instance, steering to `inputRequired()`. JSDoc only — no behavior or type changes.

## Motivation and Context
These methods loud-fail at runtime on 2026-07-28-era requests (`_assertPushApiInServedEra`), but nothing at the type/IDE level signals it. The tag gives strikethrough and a lint-level steer to the multi-round-trip replacement without a breaking type change. The type-level era discriminant is tracked separately.

## Breaking Changes
None — JSDoc only.

## Types of changes
- [x] Documentation update
