### PR TITLE
ci: declare read-only GITHUB_TOKEN permissions on the examples workflow

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -8,6 +8,9 @@ on:
     pull_request:
     workflow_dispatch:
 
+permissions:
+    contents: read
+
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
     cancel-in-progress: true


### PR DESCRIPTION
Adds an explicit `permissions: contents: read` block to `.github/workflows/examples.yml` (CodeQL flagged the missing block on the integration tally PR). The examples job only checks out and runs `pnpm`, so read-only is sufficient and does not affect the job.