### PR TITLE
feat(core,server): SEP-2577 type-stack @deprecated sweep; ResourceNotFoundError -32602; 2026-era + entry-hosting e2e cells

### DIFF
--- a/.changeset/fix-unknown-tool-protocol-error.md
+++ b/.changeset/fix-unknown-tool-protocol-error.md
@@ -9,7 +9,6 @@ Fix error handling for unknown tools and resources per MCP spec.
 code `-32602` (InvalidParams) instead of `CallToolResult` with `isError: true`.
 Callers who checked `result.isError` for unknown tools should catch rejected promises instead.
 
-**Resources:** Unknown resource reads now return error code `-32002` (ResourceNotFound)
-instead of `-32602` (InvalidParams).
-
-Added `ProtocolErrorCode.ResourceNotFound`.
+**Resources:** Added `ProtocolErrorCode.ResourceNotFound` (`-32002`) as receive-tolerated
+vocabulary. The wire code emitted for an unknown `resources/read` URI is `-32602`
+(Invalid Params) — see the `resource-not-found-32602` changeset.

--- a/.changeset/resource-not-found-32602.md
+++ b/.changeset/resource-not-found-32602.md
@@ -1,0 +1,21 @@
+---
+"@modelcontextprotocol/core": minor
+"@modelcontextprotocol/server": major
+"@modelcontextprotocol/client": minor
+---
+
+`resources/read` for an unknown URI now answers with JSON-RPC error code `-32602`
+(Invalid Params) on every protocol revision, with `error.data.uri` echoing the
+requested URI. The 2026-07-28 specification requires `-32602`; the v1.x SDK already
+emitted `-32602` on earlier revisions, so v1.x peers see no change.
+
+This supersedes an interim `-32002` emission that shipped in earlier v2 alphas. The
+era-aware encode seam (`WireCodec.encodeErrorCode`) maps any handler-thrown `-32002`
+to `-32602` on the wire, so a handler written against the older alpha behaves
+identically without changes.
+
+`ProtocolErrorCode.ResourceNotFound` (`-32002`) remains importable as receive-tolerated
+vocabulary; clients should accept both `-32602` and `-32002` from peers (the
+specification's backwards-compatibility clause). The new typed `ResourceNotFoundError`
+class carries `data.uri`, and `ProtocolError.fromError` recognises both codes by the
+`data.uri` shape.

--- a/.changeset/resource-not-found-32602.md
+++ b/.changeset/resource-not-found-32602.md
@@ -11,11 +11,14 @@ emitted `-32602` on earlier revisions, so v1.x peers see no change.
 
 This supersedes an interim `-32002` emission that shipped in earlier v2 alphas. The
 era-aware encode seam (`WireCodec.encodeErrorCode`) maps any handler-thrown `-32002`
-to `-32602` on the wire, so a handler written against the older alpha behaves
-identically without changes.
+to `-32602` on the wire; note that a `-32002` thrown without `data.uri` is emitted as
+a bare `-32602` and is no longer recognizable as resource-not-found — throw
+`ResourceNotFoundError` (or include `data: { uri }`) to preserve the classification.
 
 `ProtocolErrorCode.ResourceNotFound` (`-32002`) remains importable as receive-tolerated
 vocabulary; clients should accept both `-32602` and `-32002` from peers (the
 specification's backwards-compatibility clause). The new typed `ResourceNotFoundError`
-class carries `data.uri`, and `ProtocolError.fromError` recognises both codes by the
-`data.uri` shape.
+class carries `data.uri`, and `ProtocolError.fromError` reconstructs it from a `-32602`
+only when `error.data` is exactly `{ uri: string }` (and nothing else), and from a
+legacy `-32002` whenever `data.uri` is a string; a bare `-32002` without `data.uri`
+stays a generic `ProtocolError`.

--- a/.changeset/sep-2577-deprecate-type-stacks.md
+++ b/.changeset/sep-2577-deprecate-type-stacks.md
@@ -1,0 +1,6 @@
+---
+'@modelcontextprotocol/core': patch
+'@modelcontextprotocol/client': patch
+---
+
+Complete the SEP-2577 `@deprecated` sweep on the public type surface (SEP-2596 Tier-1 obligation). Marks the full Logging type stack (`LoggingLevel`, `SetLevelRequest`, `LoggingMessageNotification` and params), the full Sampling type stack (`CreateMessageRequest`/`Result`, `SamplingMessage`, `ModelPreferences`/`ModelHint`, `ToolChoice`, `ToolUseContent`/`ToolResultContent`, and the `includeContext` enum values), the full Roots type stack (`Root`, `ListRootsRequest`/`Result`, `RootsListChangedNotification`), and `registerClient` (Dynamic Client Registration; prefer Client ID Metadata Documents per SEP-991). Mirrors the markers already present on the per-revision reference types. JSDoc only — wire behavior is unchanged; everything remains fully functional during the deprecation window (at least twelve months).

--- a/docs/migration-SKILL.md
+++ b/docs/migration-SKILL.md
@@ -584,6 +584,8 @@ into the same routing.
 
 No code changes required; these are wire-behavior notes:
 
+- `resources/read` for an unknown URI answers JSON-RPC error code `-32602` (Invalid Params) on every protocol revision, with `error.data.uri` echoing the requested URI. Earlier v2 alphas emitted `-32002`; v1.x already emitted `-32602`, so v1.x peers see no change. Throw the typed
+  `ResourceNotFoundError` from a custom resource handler; a handler-thrown `-32002` is still mapped to `-32602` on the wire by the encode seam. Clients accept both codes; `ProtocolErrorCode.ResourceNotFound` (`-32002`) stays importable as receive-tolerated vocabulary.
 - Resumability behavior (SSE priming events, `closeSSEStream` / `closeStandaloneSSEStream` callbacks) is only enabled for protocol versions in the transport's supported-versions list that are `>= 2025-11-25`. Unknown future version strings in an `initialize` request body no
   longer enable it. Behavior for all currently supported protocol versions is unchanged.
 - Session-ID mismatch still responds `404 Not Found` with JSON-RPC error code `-32001` (`Session not found`), unchanged from v1. This `-32001` usage is an SDK convention, not a spec-assigned code, and may be re-derived as 2026 protocol revision error handling is adopted —

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1308,11 +1308,11 @@ with the `allowInputRequired: true` request option plus the `withInputRequired()
 ### Resource not found is `-32602` on every revision; typed `ResourceNotFoundError`
 
 `resources/read` for an unknown URI now answers with JSON-RPC error code **`-32602` (Invalid Params)** on every protocol revision, with `error.data.uri` echoing the requested URI. The 2026-07-28 specification requires `-32602`; the v1.x SDK already emitted `-32602` on earlier
-revisions, so v1.x peers see no change. An interim `-32002` emission that shipped in earlier v2 alphas is reverted: the era encode seam maps any handler-thrown `-32002` to `-32602` on the wire, so a handler written against the older alpha behaves identically without changes.
+revisions, so v1.x peers see no change. An interim `-32002` emission that shipped in earlier v2 alphas is reverted: the era encode seam maps any handler-thrown `-32002` to `-32602` on the wire; note that a `-32002` thrown without `data.uri` is emitted as a bare `-32602` and is no longer recognizable as resource-not-found — throw `ResourceNotFoundError` (or include `data: { uri }`) to preserve the classification.
 
 `ProtocolErrorCode.ResourceNotFound` (`-32002`) **remains importable** as receive-tolerated vocabulary: clients should accept both `-32602` and `-32002` from peers (the specification's backwards-compatibility clause). The new typed `ResourceNotFoundError` class carries the URI on
-`.uri`, and `ProtocolError.fromError` recognizes both codes by the `data.uri` shape — recognize peers' errors by their code and `error.data`, not by `instanceof`, which does not survive bundling. Servers must not return an empty `contents` array for a non-existent resource (an
-empty array is ambiguous between "exists but empty" and "does not exist").
+`.uri`, and `ProtocolError.fromError` reconstructs it from a `-32602` only when `error.data` is exactly `{ uri: string }` (and nothing else), and from a legacy `-32002` whenever `data.uri` is a string (a bare `-32002` without `data.uri` stays a generic `ProtocolError`) — recognize peers' errors by their code and `error.data`, not by `instanceof`, which does not survive
+bundling. Servers must not return an empty `contents` array for a non-existent resource (an empty array is ambiguous between "exists but empty" and "does not exist").
 
 ```typescript
 import { ProtocolError, ResourceNotFoundError } from '@modelcontextprotocol/client';
@@ -1320,9 +1320,12 @@ import { ProtocolError, ResourceNotFoundError } from '@modelcontextprotocol/clie
 try {
     await client.readResource({ uri: 'file:///nope' });
 } catch (error) {
-    const typed = error instanceof ProtocolError ? ProtocolError.fromError(error.code, error.message, error.data) : undefined;
-    if (typed instanceof ResourceNotFoundError) {
-        console.log('not found:', typed.uri);
+    // fromError reconstructs the typed class from code + data alone, so this
+    // works even when `error` crossed a bundle boundary and `instanceof` on
+    // the thrown object would not match.
+    const e = error as ProtocolError;
+    if (ProtocolError.fromError(e.code, e.message, e.data) instanceof ResourceNotFoundError) {
+        console.log('not found:', (e.data as { uri: string }).uri);
     }
 }
 ```

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1435,6 +1435,22 @@ subpath in some files and rely on the default in others.
 
 To replace validation wholesale rather than customizing the built-in classes, implement the `jsonSchemaValidator` interface and pass your own implementation through the option above.
 
+## Specification clarifications adopted (no SDK behavior change)
+
+The 2026-07-28 specification revision includes a number of documentation-only clarifications that do not change SDK wire behavior or public surface. They are recorded here so an audit of the revision's changelog against this guide is complete; nothing in this section requires
+code changes.
+
+- **Timeouts** — the specification's per-operation timeout guidance section was removed; the SDK's `RequestOptions.timeout` and `DEFAULT_REQUEST_TIMEOUT_MSEC` are unchanged.
+- **stdio shutdown** — the specification clarifies stdio shutdown/termination wording; `StdioServerTransport`/`StdioClientTransport` close semantics are unchanged.
+- **Transports as bindings** — the specification reframes transports as bindings of one protocol; the SDK's `Transport` interface is unchanged.
+- **`resources/read` clarifications** — wording-only; behavior unchanged. The `file://` path-sanitization MUST is server-author guidance: a resource handler that resolves `file://` URIs to real paths is responsible for rejecting traversal (`..`) and symlink escapes itself — the SDK does not interpose on the path.
+- **`PromptMessage` resource links** — `ContentBlock` already includes `ResourceLink` on every revision; no change.
+- **Completion `ref/resource` URI templates** — documentation alignment; the SDK's `completion/complete` handling is unchanged.
+- **Pagination cursors** — the specification clarifies that an empty-string cursor is a valid opaque cursor; the SDK already passes `cursor` through verbatim (it is `z.string().optional()`).
+- **Sampling** — documentation of host requirements; no SDK surface change.
+- **Elicitation** — the specification relaxes elicitation statefulness wording and removes a rate-limiting SHOULD; no SDK surface change.
+- **Cosmetic schema/JSDoc sweeps** — phrasing alignment with the draft specification; the per-revision generated reference types remain pinned to the specification anchor.
+
 ## Unchanged APIs
 
 The following APIs are unchanged between v1 and v2 (only the import paths changed):

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1305,6 +1305,28 @@ identifiers from rejections. See `examples/mrtr/server.ts` for a worked end-to-e
 keep returning their plain result types — the interactive rounds happen inside the call, and a registered handler written for the 2025 flow keeps working unchanged. Configure or opt out via `ClientOptions.inputRequired` (`{ autoFulfill: false }`), drive the flow manually per call
 with the `allowInputRequired: true` request option plus the `withInputRequired()` schema wrapper, and expect the typed `InputRequiredRoundsExceeded` error when the round cap is exhausted. 2025-era connections are unaffected (the legacy wire has no `input_required` vocabulary).
 
+### Resource not found is `-32602` on every revision; typed `ResourceNotFoundError`
+
+`resources/read` for an unknown URI now answers with JSON-RPC error code **`-32602` (Invalid Params)** on every protocol revision, with `error.data.uri` echoing the requested URI. The 2026-07-28 specification requires `-32602`; the v1.x SDK already emitted `-32602` on earlier
+revisions, so v1.x peers see no change. An interim `-32002` emission that shipped in earlier v2 alphas is reverted: the era encode seam maps any handler-thrown `-32002` to `-32602` on the wire, so a handler written against the older alpha behaves identically without changes.
+
+`ProtocolErrorCode.ResourceNotFound` (`-32002`) **remains importable** as receive-tolerated vocabulary: clients should accept both `-32602` and `-32002` from peers (the specification's backwards-compatibility clause). The new typed `ResourceNotFoundError` class carries the URI on
+`.uri`, and `ProtocolError.fromError` recognizes both codes by the `data.uri` shape — recognize peers' errors by their code and `error.data`, not by `instanceof`, which does not survive bundling. Servers must not return an empty `contents` array for a non-existent resource (an
+empty array is ambiguous between "exists but empty" and "does not exist").
+
+```typescript
+import { ProtocolError, ResourceNotFoundError } from '@modelcontextprotocol/client';
+
+try {
+    await client.readResource({ uri: 'file:///nope' });
+} catch (error) {
+    const typed = error instanceof ProtocolError ? ProtocolError.fromError(error.code, error.message, error.data) : undefined;
+    if (typed instanceof ResourceNotFoundError) {
+        console.log('not found:', typed.uri);
+    }
+}
+```
+
 ### Typed `-32003` missing-client-capability error
 
 `MissingRequiredClientCapabilityError` is the typed error class for the 2026-07-28 `-32003` protocol error: processing a request requires a capability the client did not declare in the request's `clientCapabilities`. Its `data.requiredCapabilities` lists the missing capabilities,

--- a/packages/client/src/client/auth.ts
+++ b/packages/client/src/client/auth.ts
@@ -1699,6 +1699,12 @@ export async function fetchToken(
  * If `scope` is provided, it overrides `clientMetadata.scope` in the registration
  * request body. This allows callers to apply the Scope Selection Strategy (SEP-835)
  * consistently across both DCR and the subsequent authorization request.
+ *
+ * @deprecated Dynamic Client Registration is deprecated as of protocol version
+ * 2026-07-28 (SEP-2577) in favor of Client ID Metadata Documents (SEP-991).
+ * Remains functional during the deprecation window (at least twelve months).
+ * Prefer a CIMD URL `client_id` when the authorization server advertises
+ * `client_id_metadata_document_supported`; the SDK already gates on this for you.
  */
 export async function registerClient(
     authorizationServerUrl: string | URL,

--- a/packages/core/src/exports/public/index.ts
+++ b/packages/core/src/exports/public/index.ts
@@ -101,6 +101,7 @@ export { ProtocolErrorCode } from '../../types/enums.js';
 export {
     MissingRequiredClientCapabilityError,
     ProtocolError,
+    ResourceNotFoundError,
     UnsupportedProtocolVersionError,
     UrlElicitationRequiredError
 } from '../../types/errors.js';

--- a/packages/core/src/shared/protocol.ts
+++ b/packages/core/src/shared/protocol.ts
@@ -1055,11 +1055,16 @@ export abstract class Protocol<ContextT extends BaseContext> {
                         return;
                     }
 
+                    // The error half of the encode seam: the era codec selects
+                    // the wire code for a handler-thrown error, so per-era
+                    // wire-code policy lives in the codec rather than in any
+                    // handler. Non-integer codes still fall through to −32603.
+                    const thrownCode = Number.isSafeInteger(error['code']) ? (error['code'] as number) : ProtocolErrorCode.InternalError;
                     const errorResponse: JSONRPCErrorResponse = {
                         jsonrpc: '2.0',
                         id: request.id,
                         error: {
-                            code: Number.isSafeInteger(error['code']) ? error['code'] : ProtocolErrorCode.InternalError,
+                            code: codec.encodeErrorCode(thrownCode),
                             message: error.message ?? 'Internal error',
                             ...(error['data'] !== undefined && { data: error['data'] })
                         }

--- a/packages/core/src/types/enums.ts
+++ b/packages/core/src/types/enums.ts
@@ -11,6 +11,17 @@ export enum ProtocolErrorCode {
     InternalError = -32_603,
 
     // MCP-specific error codes
+    /**
+     * Resource not found.
+     *
+     * Receive-tolerated only: the SDK never EMITS `-32002` — `resources/read`
+     * misses answer `-32602` (Invalid Params) on every protocol revision per
+     * the 2026-07-28 spec MUST, and a handler-thrown `-32002` is mapped to
+     * `-32602` at the era encode seam. The member stays importable so clients
+     * can recognise `-32002` from peers built on earlier SDK releases (the
+     * spec's "clients SHOULD also accept `-32002`" backwards-compatibility
+     * clause). Throw `ResourceNotFoundError` instead.
+     */
     ResourceNotFound = -32_002,
     /**
      * Processing the request requires a capability the client did not declare

--- a/packages/core/src/types/errors.ts
+++ b/packages/core/src/types/errors.ts
@@ -39,6 +39,24 @@ export class ProtocolError extends Error {
             }
         }
 
+        // Resource not found is recognised on BOTH the spec-mandated −32602 and
+        // the legacy −32002 (the spec's "clients SHOULD also accept −32002"
+        // backwards-compatibility clause). On −32602 the data-shape parse is
+        // narrowed to "exactly `{ uri: string }` and nothing else": a server's
+        // own Invalid Params that happens to carry `data.uri` alongside other
+        // keys (e.g. `{ uri, reason: 'uri must be https' }`) stays a generic
+        // ProtocolError. On −32002 the code itself is the discriminator, so any
+        // `data.uri` string suffices.
+        if (code === ProtocolErrorCode.InvalidParams || code === ProtocolErrorCode.ResourceNotFound) {
+            const errorData = data as Record<string, unknown> | undefined;
+            if (
+                typeof errorData?.uri === 'string' &&
+                (code === ProtocolErrorCode.ResourceNotFound || Object.keys(errorData).length === 1)
+            ) {
+                return new ResourceNotFoundError(errorData.uri, message);
+            }
+        }
+
         if (code === ProtocolErrorCode.MissingRequiredClientCapability && data) {
             const errorData = data as Partial<MissingRequiredClientCapabilityErrorData>;
             if (
@@ -52,6 +70,32 @@ export class ProtocolError extends Error {
 
         // Default to generic ProtocolError
         return new ProtocolError(code, message, data);
+    }
+}
+
+/**
+ * Error type for a `resources/read` miss: the requested resource does not
+ * exist. The wire code is `-32602` (Invalid Params) on every protocol
+ * revision — the spec MUST for revision 2026-07-28, and the value the v1.x
+ * SDK has always emitted on earlier revisions. The error data echoes the
+ * requested URI.
+ *
+ * Recognise this error by checking `error.data.uri` is a string (a
+ * `-32602` with `data.uri` is resource-not-found; any other `-32602` is an
+ * ordinary Invalid Params). For backwards compatibility, clients should also
+ * accept `-32002` as resource not found — earlier SDK builds emitted that
+ * code, and {@linkcode ProtocolError.fromError} recognises both. Do not rely
+ * on `instanceof` — it does not work across separately bundled copies of the
+ * SDK.
+ */
+export class ResourceNotFoundError extends ProtocolError {
+    constructor(uri: string, message: string = `Resource not found: ${uri}`) {
+        super(ProtocolErrorCode.InvalidParams, message, { uri });
+    }
+
+    /** The URI that was requested and not found. */
+    get uri(): string {
+        return (this.data as { uri: string }).uri;
     }
 }
 

--- a/packages/core/src/types/errors.ts
+++ b/packages/core/src/types/errors.ts
@@ -80,12 +80,14 @@ export class ProtocolError extends Error {
  * SDK has always emitted on earlier revisions. The error data echoes the
  * requested URI.
  *
- * Recognise this error by checking `error.data.uri` is a string (a
- * `-32602` with `data.uri` is resource-not-found; any other `-32602` is an
- * ordinary Invalid Params). For backwards compatibility, clients should also
+ * Recognise this error by checking `error.data` is exactly `{ uri: string }`
+ * (a `-32602` whose data carries `uri` and nothing else is resource-not-found;
+ * any other `-32602` is an ordinary Invalid Params). For backwards compatibility, clients should also
  * accept `-32002` as resource not found — earlier SDK builds emitted that
- * code, and {@linkcode ProtocolError.fromError} recognises both. Do not rely
- * on `instanceof` — it does not work across separately bundled copies of the
+ * code, and {@linkcode ProtocolError.fromError} reconstructs this class for
+ * either code **when `error.data` carries `uri`** (a bare `-32002` without
+ * `data.uri` stays a generic {@linkcode ProtocolError}). Do not rely on
+ * `instanceof` — it does not work across separately bundled copies of the
  * SDK.
  */
 export class ResourceNotFoundError extends ProtocolError {

--- a/packages/core/src/types/schemas.ts
+++ b/packages/core/src/types/schemas.ts
@@ -1129,6 +1129,10 @@ export const AudioContentSchema = z.object({
 /**
  * A tool call request from an assistant (LLM).
  * Represents the assistant's request to use a tool.
+ *
+ * @deprecated Deprecated as of protocol version 2026-07-28 (SEP-2577); remains
+ * in the specification for at least twelve months. Migrate to calling LLM
+ * provider APIs directly.
  */
 export const ToolUseContentSchema = z.object({
     type: z.literal('tool_use'),
@@ -1455,11 +1459,19 @@ export const ListChangedOptionsBaseSchema = z.object({
 /* Logging */
 /**
  * The severity of a log message.
+ *
+ * @deprecated Deprecated as of protocol version 2026-07-28 (SEP-2577); remains
+ * in the specification for at least twelve months. Migrate to stderr logging
+ * (STDIO servers) or OpenTelemetry.
  */
 export const LoggingLevelSchema = z.enum(['debug', 'info', 'notice', 'warning', 'error', 'critical', 'alert', 'emergency']);
 
 /**
  * Parameters for a `logging/setLevel` request.
+ *
+ * @deprecated Deprecated as of protocol version 2026-07-28 (SEP-2577); remains
+ * in the specification for at least twelve months. Migrate to stderr logging
+ * (STDIO servers) or OpenTelemetry.
  */
 export const SetLevelRequestParamsSchema = BaseRequestParamsSchema.extend({
     /**
@@ -1469,6 +1481,10 @@ export const SetLevelRequestParamsSchema = BaseRequestParamsSchema.extend({
 });
 /**
  * A request from the client to the server, to enable or adjust logging.
+ *
+ * @deprecated Deprecated as of protocol version 2026-07-28 (SEP-2577); remains
+ * in the specification for at least twelve months. Migrate to stderr logging
+ * (STDIO servers) or OpenTelemetry.
  */
 export const SetLevelRequestSchema = RequestSchema.extend({
     method: z.literal('logging/setLevel'),
@@ -1477,6 +1493,10 @@ export const SetLevelRequestSchema = RequestSchema.extend({
 
 /**
  * Parameters for a `notifications/message` notification.
+ *
+ * @deprecated Deprecated as of protocol version 2026-07-28 (SEP-2577); remains
+ * in the specification for at least twelve months. Migrate to stderr logging
+ * (STDIO servers) or OpenTelemetry.
  */
 export const LoggingMessageNotificationParamsSchema = NotificationsParamsSchema.extend({
     /**
@@ -1494,6 +1514,10 @@ export const LoggingMessageNotificationParamsSchema = NotificationsParamsSchema.
 });
 /**
  * Notification of a log message passed from server to client. If no `logging/setLevel` request has been sent from the client, the server MAY decide which messages to send automatically.
+ *
+ * @deprecated Deprecated as of protocol version 2026-07-28 (SEP-2577); remains
+ * in the specification for at least twelve months. Migrate to stderr logging
+ * (STDIO servers) or OpenTelemetry.
  */
 export const LoggingMessageNotificationSchema = NotificationSchema.extend({
     method: z.literal('notifications/message'),
@@ -1503,6 +1527,10 @@ export const LoggingMessageNotificationSchema = NotificationSchema.extend({
 /* Sampling */
 /**
  * Hints to use for model selection.
+ *
+ * @deprecated Deprecated as of protocol version 2026-07-28 (SEP-2577); remains
+ * in the specification for at least twelve months. Migrate to calling LLM
+ * provider APIs directly.
  */
 export const ModelHintSchema = z.object({
     /**
@@ -1513,6 +1541,10 @@ export const ModelHintSchema = z.object({
 
 /**
  * The server's preferences for model selection, requested of the client during sampling.
+ *
+ * @deprecated Deprecated as of protocol version 2026-07-28 (SEP-2577); remains
+ * in the specification for at least twelve months. Migrate to calling LLM
+ * provider APIs directly.
  */
 export const ModelPreferencesSchema = z.object({
     /**
@@ -1535,6 +1567,10 @@ export const ModelPreferencesSchema = z.object({
 
 /**
  * Controls tool usage behavior in sampling requests.
+ *
+ * @deprecated Deprecated as of protocol version 2026-07-28 (SEP-2577); remains
+ * in the specification for at least twelve months. Migrate to calling LLM
+ * provider APIs directly.
  */
 export const ToolChoiceSchema = z.object({
     /**
@@ -1549,6 +1585,10 @@ export const ToolChoiceSchema = z.object({
 /**
  * The result of a tool execution, provided by the user (server).
  * Represents the outcome of invoking a tool requested via `ToolUseContent`.
+ *
+ * @deprecated Deprecated as of protocol version 2026-07-28 (SEP-2577); remains
+ * in the specification for at least twelve months. Migrate to calling LLM
+ * provider APIs directly.
  */
 export const ToolResultContentSchema = z.object({
     type: z.literal('tool_result'),
@@ -1567,12 +1607,20 @@ export const ToolResultContentSchema = z.object({
 /**
  * Basic content types for sampling responses (without tool use).
  * Used for backwards-compatible {@linkcode CreateMessageResult} when tools are not used.
+ *
+ * @deprecated Deprecated as of protocol version 2026-07-28 (SEP-2577); remains
+ * in the specification for at least twelve months. Migrate to calling LLM
+ * provider APIs directly.
  */
 export const SamplingContentSchema = z.discriminatedUnion('type', [TextContentSchema, ImageContentSchema, AudioContentSchema]);
 
 /**
  * Content block types allowed in sampling messages.
  * This includes text, image, audio, tool use requests, and tool results.
+ *
+ * @deprecated Deprecated as of protocol version 2026-07-28 (SEP-2577); remains
+ * in the specification for at least twelve months. Migrate to calling LLM
+ * provider APIs directly.
  */
 export const SamplingMessageContentBlockSchema = z.discriminatedUnion('type', [
     TextContentSchema,
@@ -1584,6 +1632,10 @@ export const SamplingMessageContentBlockSchema = z.discriminatedUnion('type', [
 
 /**
  * Describes a message issued to or received from an LLM API.
+ *
+ * @deprecated Deprecated as of protocol version 2026-07-28 (SEP-2577); remains
+ * in the specification for at least twelve months. Migrate to calling LLM
+ * provider APIs directly.
  */
 export const SamplingMessageSchema = z.object({
     role: RoleSchema,
@@ -1597,6 +1649,10 @@ export const SamplingMessageSchema = z.object({
 
 /**
  * Parameters for a `sampling/createMessage` request.
+ *
+ * @deprecated Deprecated as of protocol version 2026-07-28 (SEP-2577); remains
+ * in the specification for at least twelve months. Migrate to calling LLM
+ * provider APIs directly.
  */
 export const CreateMessageRequestParamsSchema = TaskAugmentedRequestParamsSchema.extend({
     messages: z.array(SamplingMessageSchema),
@@ -1612,8 +1668,12 @@ export const CreateMessageRequestParamsSchema = TaskAugmentedRequestParamsSchema
      * A request to include context from one or more MCP servers (including the caller), to be attached to the prompt.
      * The client MAY ignore this request.
      *
-     * Default is `"none"`. Values `"thisServer"` and `"allServers"` are soft-deprecated. Servers SHOULD only use these values if the client
-     * declares `ClientCapabilities`.`sampling.context`. These values may be removed in future spec releases.
+     * Default is `"none"`. The values `"thisServer"` and `"allServers"` are deprecated (SEP-2596): servers SHOULD
+     * omit this field or use `"none"`, and SHOULD only use the deprecated values if the client declares
+     * `ClientCapabilities`.`sampling.context`.
+     *
+     * @deprecated The `"thisServer"` and `"allServers"` values are deprecated as of protocol version 2025-11-25
+     * (SEP-2596) and will be removed no later than the Sampling feature itself (SEP-2577). Omit this field or use `"none"`.
      */
     includeContext: z.enum(['none', 'thisServer', 'allServers']).optional(),
     temperature: z.number().optional(),
@@ -1642,6 +1702,10 @@ export const CreateMessageRequestParamsSchema = TaskAugmentedRequestParamsSchema
 });
 /**
  * A request from the server to sample an LLM via the client. The client has full discretion over which model to select. The client should also inform the user before beginning sampling, to allow them to inspect the request (human in the loop) and decide whether to approve it.
+ *
+ * @deprecated Deprecated as of protocol version 2026-07-28 (SEP-2577); remains
+ * in the specification for at least twelve months. Migrate to calling LLM
+ * provider APIs directly.
  */
 export const CreateMessageRequestSchema = RequestSchema.extend({
     method: z.literal('sampling/createMessage'),
@@ -1652,6 +1716,10 @@ export const CreateMessageRequestSchema = RequestSchema.extend({
  * The client's response to a `sampling/create_message` request from the server.
  * This is the backwards-compatible version that returns single content (no arrays).
  * Used when the request does not include tools.
+ *
+ * @deprecated Deprecated as of protocol version 2026-07-28 (SEP-2577); remains
+ * in the specification for at least twelve months. Migrate to calling LLM
+ * provider APIs directly.
  */
 export const CreateMessageResultSchema = ResultSchema.extend({
     /**
@@ -1679,6 +1747,10 @@ export const CreateMessageResultSchema = ResultSchema.extend({
 /**
  * The client's response to a `sampling/create_message` request when tools were provided.
  * This version supports array content for tool use flows.
+ *
+ * @deprecated Deprecated as of protocol version 2026-07-28 (SEP-2577); remains
+ * in the specification for at least twelve months. Migrate to calling LLM
+ * provider APIs directly.
  */
 export const CreateMessageResultWithToolsSchema = ResultSchema.extend({
     /**
@@ -2025,6 +2097,10 @@ export const CompleteResultSchema = ResultSchema.extend({
 /* Roots */
 /**
  * Represents a root directory or file that the server can operate on.
+ *
+ * @deprecated Deprecated as of protocol version 2026-07-28 (SEP-2577); remains
+ * in the specification for at least twelve months. Migrate to passing paths via
+ * tool parameters, resource URIs, or configuration.
  */
 export const RootSchema = z.object({
     /**
@@ -2045,6 +2121,10 @@ export const RootSchema = z.object({
 
 /**
  * Sent from the server to request a list of root URIs from the client.
+ *
+ * @deprecated Deprecated as of protocol version 2026-07-28 (SEP-2577); remains
+ * in the specification for at least twelve months. Migrate to passing paths via
+ * tool parameters, resource URIs, or configuration.
  */
 export const ListRootsRequestSchema = RequestSchema.extend({
     method: z.literal('roots/list'),
@@ -2053,6 +2133,10 @@ export const ListRootsRequestSchema = RequestSchema.extend({
 
 /**
  * The client's response to a `roots/list` request from the server.
+ *
+ * @deprecated Deprecated as of protocol version 2026-07-28 (SEP-2577); remains
+ * in the specification for at least twelve months. Migrate to passing paths via
+ * tool parameters, resource URIs, or configuration.
  */
 export const ListRootsResultSchema = ResultSchema.extend({
     roots: z.array(RootSchema)
@@ -2060,6 +2144,10 @@ export const ListRootsResultSchema = ResultSchema.extend({
 
 /**
  * A notification from the client to the server, informing it that the list of roots has changed.
+ *
+ * @deprecated Deprecated as of protocol version 2026-07-28 (SEP-2577); remains
+ * in the specification for at least twelve months. Migrate to passing paths via
+ * tool parameters, resource URIs, or configuration.
  */
 export const RootsListChangedNotificationSchema = NotificationSchema.extend({
     method: z.literal('notifications/roots/list_changed'),

--- a/packages/core/src/types/types.ts
+++ b/packages/core/src/types/types.ts
@@ -374,7 +374,17 @@ export type GetPromptRequest = Infer<typeof GetPromptRequestSchema>;
 export type TextContent = Infer<typeof TextContentSchema>;
 export type ImageContent = Infer<typeof ImageContentSchema>;
 export type AudioContent = Infer<typeof AudioContentSchema>;
+/**
+ * @deprecated Deprecated as of protocol version 2026-07-28 (SEP-2577); remains
+ * in the specification for at least twelve months. Migrate to calling LLM
+ * provider APIs directly.
+ */
 export type ToolUseContent = Infer<typeof ToolUseContentSchema>;
+/**
+ * @deprecated Deprecated as of protocol version 2026-07-28 (SEP-2577); remains
+ * in the specification for at least twelve months. Migrate to calling LLM
+ * provider APIs directly.
+ */
 export type ToolResultContent = Infer<typeof ToolResultContentSchema>;
 export type EmbeddedResource = Infer<typeof EmbeddedResourceSchema>;
 export type ResourceLink = Infer<typeof ResourceLinkSchema>;
@@ -396,22 +406,97 @@ export type CallToolRequest = Infer<typeof CallToolRequestSchema>;
 export type ToolListChangedNotification = Infer<typeof ToolListChangedNotificationSchema>;
 
 /* Logging */
+/**
+ * @deprecated Deprecated as of protocol version 2026-07-28 (SEP-2577); remains
+ * in the specification for at least twelve months. Migrate to stderr logging
+ * (STDIO servers) or OpenTelemetry.
+ */
 export type LoggingLevel = Infer<typeof LoggingLevelSchema>;
+/**
+ * @deprecated Deprecated as of protocol version 2026-07-28 (SEP-2577); remains
+ * in the specification for at least twelve months. Migrate to stderr logging
+ * (STDIO servers) or OpenTelemetry.
+ */
 export type SetLevelRequestParams = Infer<typeof SetLevelRequestParamsSchema>;
+/**
+ * @deprecated Deprecated as of protocol version 2026-07-28 (SEP-2577); remains
+ * in the specification for at least twelve months. Migrate to stderr logging
+ * (STDIO servers) or OpenTelemetry.
+ */
 export type SetLevelRequest = Infer<typeof SetLevelRequestSchema>;
+/**
+ * @deprecated Deprecated as of protocol version 2026-07-28 (SEP-2577); remains
+ * in the specification for at least twelve months. Migrate to stderr logging
+ * (STDIO servers) or OpenTelemetry.
+ */
 export type LoggingMessageNotificationParams = Infer<typeof LoggingMessageNotificationParamsSchema>;
+/**
+ * @deprecated Deprecated as of protocol version 2026-07-28 (SEP-2577); remains
+ * in the specification for at least twelve months. Migrate to stderr logging
+ * (STDIO servers) or OpenTelemetry.
+ */
 export type LoggingMessageNotification = Infer<typeof LoggingMessageNotificationSchema>;
 
 /* Sampling */
+/**
+ * @deprecated Deprecated as of protocol version 2026-07-28 (SEP-2577); remains
+ * in the specification for at least twelve months. Migrate to calling LLM
+ * provider APIs directly.
+ */
 export type ToolChoice = Infer<typeof ToolChoiceSchema>;
+/**
+ * @deprecated Deprecated as of protocol version 2026-07-28 (SEP-2577); remains
+ * in the specification for at least twelve months. Migrate to calling LLM
+ * provider APIs directly.
+ */
 export type ModelHint = Infer<typeof ModelHintSchema>;
+/**
+ * @deprecated Deprecated as of protocol version 2026-07-28 (SEP-2577); remains
+ * in the specification for at least twelve months. Migrate to calling LLM
+ * provider APIs directly.
+ */
 export type ModelPreferences = Infer<typeof ModelPreferencesSchema>;
+/**
+ * @deprecated Deprecated as of protocol version 2026-07-28 (SEP-2577); remains
+ * in the specification for at least twelve months. Migrate to calling LLM
+ * provider APIs directly.
+ */
 export type SamplingContent = Infer<typeof SamplingContentSchema>;
+/**
+ * @deprecated Deprecated as of protocol version 2026-07-28 (SEP-2577); remains
+ * in the specification for at least twelve months. Migrate to calling LLM
+ * provider APIs directly.
+ */
 export type SamplingMessageContentBlock = Infer<typeof SamplingMessageContentBlockSchema>;
+/**
+ * @deprecated Deprecated as of protocol version 2026-07-28 (SEP-2577); remains
+ * in the specification for at least twelve months. Migrate to calling LLM
+ * provider APIs directly.
+ */
 export type SamplingMessage = Infer<typeof SamplingMessageSchema>;
+/**
+ * @deprecated Deprecated as of protocol version 2026-07-28 (SEP-2577); remains
+ * in the specification for at least twelve months. Migrate to calling LLM
+ * provider APIs directly.
+ */
 export type CreateMessageRequestParams = Infer<typeof CreateMessageRequestParamsSchema>;
+/**
+ * @deprecated Deprecated as of protocol version 2026-07-28 (SEP-2577); remains
+ * in the specification for at least twelve months. Migrate to calling LLM
+ * provider APIs directly.
+ */
 export type CreateMessageRequest = Infer<typeof CreateMessageRequestSchema>;
+/**
+ * @deprecated Deprecated as of protocol version 2026-07-28 (SEP-2577); remains
+ * in the specification for at least twelve months. Migrate to calling LLM
+ * provider APIs directly.
+ */
 export type CreateMessageResult = StripWireOnly<Infer<typeof CreateMessageResultSchema>>;
+/**
+ * @deprecated Deprecated as of protocol version 2026-07-28 (SEP-2577); remains
+ * in the specification for at least twelve months. Migrate to calling LLM
+ * provider APIs directly.
+ */
 export type CreateMessageResultWithTools = StripWireOnly<Infer<typeof CreateMessageResultWithToolsSchema>>;
 
 /* Elicitation */
@@ -443,9 +528,29 @@ export type CompleteRequest = Infer<typeof CompleteRequestSchema>;
 export type CompleteResult = StripWireOnly<Infer<typeof CompleteResultSchema>>;
 
 /* Roots */
+/**
+ * @deprecated Deprecated as of protocol version 2026-07-28 (SEP-2577); remains
+ * in the specification for at least twelve months. Migrate to passing paths via
+ * tool parameters, resource URIs, or configuration.
+ */
 export type Root = Infer<typeof RootSchema>;
+/**
+ * @deprecated Deprecated as of protocol version 2026-07-28 (SEP-2577); remains
+ * in the specification for at least twelve months. Migrate to passing paths via
+ * tool parameters, resource URIs, or configuration.
+ */
 export type ListRootsRequest = Infer<typeof ListRootsRequestSchema>;
+/**
+ * @deprecated Deprecated as of protocol version 2026-07-28 (SEP-2577); remains
+ * in the specification for at least twelve months. Migrate to passing paths via
+ * tool parameters, resource URIs, or configuration.
+ */
 export type ListRootsResult = StripWireOnly<Infer<typeof ListRootsResultSchema>>;
+/**
+ * @deprecated Deprecated as of protocol version 2026-07-28 (SEP-2577); remains
+ * in the specification for at least twelve months. Migrate to passing paths via
+ * tool parameters, resource URIs, or configuration.
+ */
 export type RootsListChangedNotification = Infer<typeof RootsListChangedNotificationSchema>;
 
 /* Multi round-trip requests (protocol revision 2026-07-28)
@@ -796,11 +901,19 @@ export type RequestMetaObject = RequestMeta;
 /**
  * {@linkcode CreateMessageRequestParams} without tools - for backwards-compatible overload.
  * Excludes tools/toolChoice to indicate they should not be provided.
+ *
+ * @deprecated Deprecated as of protocol version 2026-07-28 (SEP-2577); remains
+ * in the specification for at least twelve months. Migrate to calling LLM
+ * provider APIs directly.
  */
 export type CreateMessageRequestParamsBase = Omit<CreateMessageRequestParams, 'tools' | 'toolChoice'>;
 
 /**
  * {@linkcode CreateMessageRequestParams} with required tools - for tool-enabled overload.
+ *
+ * @deprecated Deprecated as of protocol version 2026-07-28 (SEP-2577); remains
+ * in the specification for at least twelve months. Migrate to calling LLM
+ * provider APIs directly.
  */
 export interface CreateMessageRequestParamsWithTools extends CreateMessageRequestParams {
     tools: Tool[];

--- a/packages/core/src/wire/codec.ts
+++ b/packages/core/src/wire/codec.ts
@@ -166,6 +166,19 @@ export interface WireCodec {
     encodeResult(method: string, result: Result): Result;
 
     /**
+     * Outbound error-code mapping (the error half of the stamp seam). A
+     * handler-thrown `ProtocolError`'s numeric code passes through here on
+     * its way to the JSON-RPC error response, so per-era wire-code selection
+     * lives in the codec rather than in handler/funnel code. The current
+     * mapping is identical on both eras (the `-32002` resource-not-found
+     * domain code maps to `-32602` Invalid Params on the wire — the
+     * 2026-07-28 spec MUST, and what the deployed v1.x SDK already emits on
+     * earlier revisions); the seam is the structural home for any future
+     * per-era divergence. Unknown codes pass through unchanged.
+     */
+    encodeErrorCode(code: number): number;
+
+    /**
      * Inbound envelope enforcement for era-classified traffic: validates the
      * lifted envelope material of a request. Returns an error message when
      * the era requires an envelope and it is missing/invalid (→ −32602 at the

--- a/packages/core/src/wire/rev2025-11-25/codec.ts
+++ b/packages/core/src/wire/rev2025-11-25/codec.ts
@@ -68,6 +68,12 @@ export const rev2025Codec: WireCodec = {
     // The never-stamp guarantee: identity. No stamp code path exists.
     encodeResult: (_method: string, result: Result): Result => result,
 
+    // The −32002 resource-not-found domain code maps to −32602 on the wire on
+    // this era too (matching what the deployed v1.x SDK already emits — this
+    // is not a behavior change for v1.x peers). There is deliberately no era
+    // branch that preserves −32002.
+    encodeErrorCode: (code: number): number => (code === -32_002 ? -32_602 : code),
+
     // The 2025 era never requires a per-request envelope.
     checkInboundEnvelope: (_material: LiftedWireMaterial): string | undefined => undefined
 };

--- a/packages/core/src/wire/rev2026-07-28/codec.ts
+++ b/packages/core/src/wire/rev2026-07-28/codec.ts
@@ -203,6 +203,10 @@ export const rev2026Codec: WireCodec = {
         return fillCacheFields(method, stampResultType(method, enforceDeletedFields(method, result)));
     },
 
+    // The −32002 resource-not-found domain code maps to −32602 Invalid Params
+    // on the wire (the 2026-07-28 spec MUST for resources/read misses).
+    encodeErrorCode: (code: number): number => (code === -32_002 ? -32_602 : code),
+
     checkInboundEnvelope(material: LiftedWireMaterial): string | undefined {
         if (material.envelope === undefined) {
             return (

--- a/packages/core/test/types/errorSurfacePins.test.ts
+++ b/packages/core/test/types/errorSurfacePins.test.ts
@@ -25,6 +25,7 @@ import {
     ProtocolError,
     ProtocolErrorCode,
     SUPPORTED_PROTOCOL_VERSIONS,
+    ResourceNotFoundError,
     UnsupportedProtocolVersionError,
     UrlElicitationRequiredError
 } from '../../src/types/index.js';
@@ -121,6 +122,44 @@ describe('ProtocolError', () => {
         const generic = ProtocolError.fromError(-32004, 'unsupported', { wrong: 'shape' });
         expect(generic).toBeInstanceOf(ProtocolError);
         expect(generic).not.toBeInstanceOf(UnsupportedProtocolVersionError);
+    });
+
+    test('fromError accepts BOTH -32602 and -32002 as resource-not-found by data.uri shape', () => {
+        // Cross-bundle data-parse contract: the typed ResourceNotFoundError is
+        // recognised by `data.uri` being a string on either the spec-mandated
+        // -32602 or the legacy -32002 (the spec's "clients SHOULD also accept
+        // -32002" backwards-compatibility clause). The recognition input is the
+        // bare wire shape — no instanceof on the inbound value.
+        const onSpecCode = ProtocolError.fromError(-32602, 'Resource not found: file:///x', { uri: 'file:///x' });
+        expect(onSpecCode).toBeInstanceOf(ResourceNotFoundError);
+        expect((onSpecCode as ResourceNotFoundError).uri).toBe('file:///x');
+        expect(onSpecCode.code).toBe(-32602);
+
+        const onLegacyCode = ProtocolError.fromError(-32002, 'Resource not found', { uri: 'mem://y' });
+        expect(onLegacyCode).toBeInstanceOf(ResourceNotFoundError);
+        expect((onLegacyCode as ResourceNotFoundError).uri).toBe('mem://y');
+
+        // -32602 without `data.uri` is an ordinary Invalid Params, not resource-not-found.
+        const plainInvalid = ProtocolError.fromError(-32602, 'Invalid params', { something: 'else' });
+        expect(plainInvalid).not.toBeInstanceOf(ResourceNotFoundError);
+        expect(plainInvalid.code).toBe(-32602);
+    });
+
+    test('fromError does NOT reclassify -32602 as ResourceNotFoundError when data carries uri alongside other keys', () => {
+        // A server's own Invalid Params with `data.uri` (e.g. a "uri must be
+        // https" validation error) is NOT a resource-not-found. The discriminator
+        // on -32602 is "exactly { uri } and nothing else".
+        const validationError = ProtocolError.fromError(-32602, 'uri must be https', {
+            uri: 'http://example/x',
+            reason: 'uri must be https'
+        });
+        expect(validationError).not.toBeInstanceOf(ResourceNotFoundError);
+        expect(validationError).toBeInstanceOf(ProtocolError);
+        expect(validationError.code).toBe(-32602);
+        // -32002 is still recognised on `data.uri` regardless of extra keys —
+        // the legacy code is itself the discriminator.
+        const legacyWithExtra = ProtocolError.fromError(-32002, 'Resource not found', { uri: 'mem://y', extra: 1 });
+        expect(legacyWithExtra).toBeInstanceOf(ResourceNotFoundError);
     });
 });
 

--- a/packages/core/test/wire/encodeContract.test.ts
+++ b/packages/core/test/wire/encodeContract.test.ts
@@ -26,6 +26,7 @@ import {
 } from '../../src/shared/resultCacheHints.js';
 import { ProtocolError } from '../../src/types/errors.js';
 import type { Result } from '../../src/types/types.js';
+import { rev2025Codec } from '../../src/wire/rev2025-11-25/codec.js';
 import { rev2026Codec } from '../../src/wire/rev2026-07-28/codec.js';
 import {
     DEFAULT_CACHE_SCOPE,
@@ -197,5 +198,20 @@ describe('the codec integration (encodeResult applies the contract in pinned ord
 
     test('a stray input_required from a non-multi-round-trip handler throws out of encodeResult (answered as an internal error upstream)', () => {
         expect(() => rev2026Codec.encodeResult('tools/list', asResult({ resultType: 'input_required' }))).toThrowError(ProtocolError);
+    });
+});
+
+describe('the error half of the encode seam — encodeErrorCode', () => {
+    test('the -32002 resource-not-found domain code maps to -32602 on BOTH eras (flat; no era branch preserves -32002)', () => {
+        // The seam owns wire-code selection; both era codecs select -32602.
+        expect(rev2026Codec.encodeErrorCode(-32_002)).toBe(-32_602);
+        expect(rev2025Codec.encodeErrorCode(-32_002)).toBe(-32_602);
+    });
+
+    test('every other code passes through identically on both eras', () => {
+        for (const code of [-32_700, -32_600, -32_601, -32_602, -32_603, -32_000, -32_001, -32_003, -32_004, -32_042, -1, 0]) {
+            expect(rev2026Codec.encodeErrorCode(code)).toBe(code);
+            expect(rev2025Codec.encodeErrorCode(code)).toBe(code);
+        }
     });
 });

--- a/packages/server/src/server/mcp.ts
+++ b/packages/server/src/server/mcp.ts
@@ -36,6 +36,7 @@ import {
     promptArgumentsFromStandardSchema,
     ProtocolError,
     ProtocolErrorCode,
+    ResourceNotFoundError,
     scanXMcpHeaderDeclarations,
     standardSchemaToJsonSchema,
     UriTemplate,
@@ -481,7 +482,10 @@ export class McpServer {
                 }
             }
 
-            throw new ProtocolError(ProtocolErrorCode.ResourceNotFound, `Resource ${uri} not found`);
+            // Domain layer throws one neutral resource-not-found error; the
+            // era-aware encode seam (WireCodec.encodeErrorCode) selects the
+            // wire code (−32602 on every era).
+            throw new ResourceNotFoundError(request.params.uri);
         });
 
         this._resourceHandlersInitialized = true;

--- a/packages/server/test/server/eraParityErrorShapes.test.ts
+++ b/packages/server/test/server/eraParityErrorShapes.test.ts
@@ -199,7 +199,9 @@ describe('era-parity error shapes', () => {
 
         expect(legacy.status).toBe(200);
         expect(modern.status).toBe(200);
-        expect(legacy.error).toMatchObject({ code: -32_002, message: 'resource missing' });
+        // The encode seam selects the wire code: a handler-thrown −32002 is
+        // emitted as −32602 on BOTH eras (no era branch preserves −32002).
+        expect(legacy.error).toMatchObject({ code: -32_602, message: 'resource missing' });
         expect(modern.error).toEqual(legacy.error);
     });
 

--- a/packages/server/test/server/listOrdering.test.ts
+++ b/packages/server/test/server/listOrdering.test.ts
@@ -1,0 +1,51 @@
+/**
+ * SF-02 — deterministic list ordering across requests.
+ *
+ * The spec recommends servers return tools/prompts/resources in a stable,
+ * deterministic order across requests when the underlying set has not changed.
+ * `McpServer` registries are plain string-keyed objects, so iteration is
+ * insertion order; this test pins that ordering at the wire so a registry
+ * refactor cannot quietly change it.
+ */
+import { describe, expect, it } from 'vitest';
+import * as z from 'zod/v4';
+
+import { invoke } from '../../src/server/invoke.js';
+import { McpServer } from '../../src/server/mcp.js';
+
+const LEGACY = { classification: { era: 'legacy' as const } };
+
+const list = async (server: McpServer, method: string, key: string): Promise<string[]> => {
+    const response = await invoke(server, { jsonrpc: '2.0', id: 1, method, params: {} }, LEGACY);
+    const body = (await response.json()) as { result: Record<string, Array<{ name: string }>> };
+    return body.result[key]!.map(item => item.name);
+};
+
+describe('McpServer list ordering', () => {
+    it('tools/list, prompts/list and resources/list each return in registration order, stable across calls', async () => {
+        const server = new McpServer({ name: 'ordering', version: '0' });
+
+        // Non-sorted registration order so neither alphabetic nor reverse would mask it.
+        const toolOrder = ['gamma', 'alpha', 'mu', 'beta'];
+        for (const name of toolOrder) {
+            server.registerTool(name, { inputSchema: z.object({}) }, async () => ({ content: [] }));
+        }
+
+        const promptOrder = ['second', 'first', 'third'];
+        for (const name of promptOrder) {
+            server.registerPrompt(name, {}, async () => ({ messages: [] }));
+        }
+
+        const resourceOrder = ['c', 'a', 'b'];
+        for (const name of resourceOrder) {
+            server.registerResource(name, `mem://${name}`, {}, async () => ({ contents: [] }));
+        }
+
+        expect(await list(server, 'tools/list', 'tools')).toEqual(toolOrder);
+        expect(await list(server, 'tools/list', 'tools')).toEqual(toolOrder);
+        expect(await list(server, 'prompts/list', 'prompts')).toEqual(promptOrder);
+        expect(await list(server, 'prompts/list', 'prompts')).toEqual(promptOrder);
+        expect(await list(server, 'resources/list', 'resources')).toEqual(resourceOrder);
+        expect(await list(server, 'resources/list', 'resources')).toEqual(resourceOrder);
+    });
+});

--- a/packages/server/test/server/perRequestTransport.test.ts
+++ b/packages/server/test/server/perRequestTransport.test.ts
@@ -171,7 +171,9 @@ describe('HTTP status mapping', () => {
         const transport = await connectedTransport(server);
         const response = await transport.handleMessage(toolsCall());
         expect(response.status).toBe(200);
-        expect(errorOf(await response.json())).toMatchObject({ code: -32_002, message: 'resource missing' });
+        // The encode seam maps −32002 → −32602 on the wire; what this test
+        // pins is that the error stays IN-BAND on HTTP 200.
+        expect(errorOf(await response.json())).toMatchObject({ code: -32_602, message: 'resource missing' });
     });
 
     it('keeps a handler-thrown method-not-found error in-band on HTTP 200 (the status table is origin-keyed)', async () => {

--- a/test/conformance/expected-failures.2026-07-28.yaml
+++ b/test/conformance/expected-failures.2026-07-28.yaml
@@ -69,7 +69,3 @@ server:
     # checks; it fails identically at 2025 in `--suite all` (not a 2026-path
     # regression).
     - json-schema-2020-12
-    # SEP-2164: server returns -32002 without the requested URI in error.data
-    # (WARNING-only; the expected-failures evaluator counts WARNINGs as
-    # failures). Same failure as in the 2025 baseline.
-    - sep-2164-resource-not-found

--- a/test/conformance/expected-failures.yaml
+++ b/test/conformance/expected-failures.yaml
@@ -44,9 +44,5 @@ client:
     # client support for the token-exchange + JWT bearer flow.
     - auth/enterprise-managed-authorization
 
-server:
-    # --- Draft-spec scenarios (in `--suite draft`; the default `active` suite is green) ---
-    # WARNING-only entry: the scenario emits no FAILURE checks, only a SHOULD-level
-    # WARNING, but the expected-failures evaluator counts WARNINGs as failures.
-    # SEP-2164: server returns -32002 without the requested URI in error.data.
-    - sep-2164-resource-not-found
+server: []
+# (sep-2164-resource-not-found burned by the resources/read -32602 fix.)

--- a/test/e2e/requirements.ts
+++ b/test/e2e/requirements.ts
@@ -362,6 +362,8 @@ export const REQUIREMENTS: Record<string, Requirement> = {
         transports: STATEFUL_TRANSPORTS,
         source: 'https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation#user-interaction-model',
         behavior: "A tool handler that issues an elicitation receives the client's result and can embed it in the tool call result.",
+        removedInSpecVersion: '2026-07-28',
+        supersededBy: 'elicitation:mrtr:form:basic',
         note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
     },
     'tools:call:is-error': {
@@ -389,6 +391,8 @@ export const REQUIREMENTS: Record<string, Requirement> = {
         source: 'https://modelcontextprotocol.io/specification/2025-11-25/client/sampling',
         behavior:
             "A tool handler that issues a sampling request receives the client's completion and can embed it in the tool call result.",
+        removedInSpecVersion: '2026-07-28',
+        supersededBy: 'sampling:mrtr:create:basic',
         note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
     },
     'tools:call:structured-content': {
@@ -435,6 +439,8 @@ export const REQUIREMENTS: Record<string, Requirement> = {
         transports: STATEFUL_TRANSPORTS,
         source: 'https://modelcontextprotocol.io/specification/2025-11-25/server/tools#list-changed-notification',
         behavior: "When the tool set changes, the server sends notifications/tools/list_changed and it reaches the client's handler.",
+        removedInSpecVersion: '2026-07-28',
+        supersededBy: 'tools:listen:list-changed',
         note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
     },
     'tools:list:basic': {
@@ -571,6 +577,8 @@ export const REQUIREMENTS: Record<string, Requirement> = {
         source: 'https://modelcontextprotocol.io/specification/2025-11-25/server/resources#list-changed-notification',
         behavior:
             "When the resource set changes, the server sends notifications/resources/list_changed and it reaches the client's handler.",
+        removedInSpecVersion: '2026-07-28',
+        supersededBy: 'resources:listen:list-changed',
         note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
     },
     'resources:list:basic': {
@@ -701,6 +709,8 @@ export const REQUIREMENTS: Record<string, Requirement> = {
         transports: STATEFUL_TRANSPORTS,
         source: 'https://modelcontextprotocol.io/specification/2025-11-25/server/prompts#list-changed-notification',
         behavior: "When the prompt set changes, the server sends notifications/prompts/list_changed and it reaches the client's handler.",
+        removedInSpecVersion: '2026-07-28',
+        supersededBy: 'prompts:listen:list-changed',
         note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
     },
     'prompts:list:basic': {
@@ -850,12 +860,16 @@ export const REQUIREMENTS: Record<string, Requirement> = {
         source: 'https://modelcontextprotocol.io/specification/2025-11-25/client/sampling#creating-messages',
         behavior:
             "A sampling/createMessage request from a server handler is answered by the client's sampling callback, and the callback's result (role, content, model, stopReason) is returned to the handler.",
+        removedInSpecVersion: '2026-07-28',
+        supersededBy: 'sampling:mrtr:create:basic',
         note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
     },
     'sampling:create:include-context': {
         transports: STATEFUL_TRANSPORTS,
         source: 'https://modelcontextprotocol.io/specification/2025-11-25/client/sampling#capabilities',
         behavior: 'The includeContext value supplied by the server reaches the client callback intact.',
+        removedInSpecVersion: '2026-07-28',
+        supersededBy: 'sampling:mrtr:create:include-context',
         note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
     },
     'sampling:create:model-preferences': {
@@ -863,12 +877,16 @@ export const REQUIREMENTS: Record<string, Requirement> = {
         source: 'https://modelcontextprotocol.io/specification/2025-11-25/client/sampling#model-preferences',
         behavior:
             'The model preferences supplied by the server (hints and the cost, speed, and intelligence priorities) reach the client callback intact.',
+        removedInSpecVersion: '2026-07-28',
+        supersededBy: 'sampling:mrtr:create:model-preferences',
         note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
     },
     'sampling:create:system-prompt': {
         transports: STATEFUL_TRANSPORTS,
         source: 'https://modelcontextprotocol.io/specification/2025-11-25/client/sampling#creating-messages',
         behavior: 'The system prompt supplied by the server reaches the client callback intact.',
+        removedInSpecVersion: '2026-07-28',
+        supersededBy: 'sampling:mrtr:create:system-prompt',
         note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
     },
     'sampling:create:tools': {
@@ -987,18 +1005,24 @@ export const REQUIREMENTS: Record<string, Requirement> = {
         transports: STATEFUL_TRANSPORTS,
         source: 'https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation#response-actions',
         behavior: "A form-mode elicitation answered with action 'accept' returns the user's content to the requesting handler.",
+        removedInSpecVersion: '2026-07-28',
+        supersededBy: 'elicitation:mrtr:form:basic',
         note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
     },
     'elicitation:form:action:cancel': {
         transports: STATEFUL_TRANSPORTS,
         source: 'https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation#response-actions',
         behavior: "A form-mode elicitation answered with action 'cancel' returns no content to the handler.",
+        removedInSpecVersion: '2026-07-28',
+        supersededBy: 'elicitation:mrtr:form:action:cancel',
         note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
     },
     'elicitation:form:action:decline': {
         transports: STATEFUL_TRANSPORTS,
         source: 'https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation#response-actions',
         behavior: "A form-mode elicitation answered with action 'decline' returns no content to the handler.",
+        removedInSpecVersion: '2026-07-28',
+        supersededBy: 'elicitation:mrtr:form:action:decline',
         note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
     },
     'elicitation:form:basic': {
@@ -1006,6 +1030,8 @@ export const REQUIREMENTS: Record<string, Requirement> = {
         source: 'https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation#form-mode-elicitation-requests',
         behavior:
             'A form-mode elicitation delivers the message and requested schema to the client callback exactly as the server sent them.',
+        removedInSpecVersion: '2026-07-28',
+        supersededBy: 'elicitation:mrtr:form:basic',
         note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
     },
     'elicitation:form:defaults': {
@@ -1030,6 +1056,8 @@ export const REQUIREMENTS: Record<string, Requirement> = {
         transports: STATEFUL_TRANSPORTS,
         source: 'https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation#requested-schema',
         behavior: 'Requested-schema fields may be string (with format), number or integer, or boolean.',
+        removedInSpecVersion: '2026-07-28',
+        supersededBy: 'elicitation:mrtr:form:schema:primitives',
         note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
     },
     'elicitation:url:action:accept-no-content': {
@@ -1114,6 +1142,8 @@ export const REQUIREMENTS: Record<string, Requirement> = {
         source: 'https://modelcontextprotocol.io/specification/2025-11-25/client/roots#listing-roots',
         behavior:
             "A roots/list request from a server handler is answered by the client's roots callback, and the returned roots (uri, name) reach the handler.",
+        removedInSpecVersion: '2026-07-28',
+        supersededBy: 'roots:mrtr:list:basic',
         note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
     },
     'roots:list:client-error': {
@@ -1132,6 +1162,8 @@ export const REQUIREMENTS: Record<string, Requirement> = {
         source: 'https://modelcontextprotocol.io/specification/2025-11-25/client/roots#listing-roots',
         behavior: 'An empty roots list is a valid response and reaches the handler as such.',
         transports: ['inMemory', 'stdio', 'streamableHttp'],
+        removedInSpecVersion: '2026-07-28',
+        supersededBy: 'roots:mrtr:list:empty',
         note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
     },
 
@@ -1142,6 +1174,8 @@ export const REQUIREMENTS: Record<string, Requirement> = {
         source: 'sdk',
         behavior:
             'A client configured to react to list_changed notifications automatically re-fetches the corresponding list and delivers the fresh result to its callback.',
+        removedInSpecVersion: '2026-07-28',
+        supersededBy: 'client:listen:auto-refresh',
         note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
     },
     'client:list-changed:capability-gated': {
@@ -2393,6 +2427,8 @@ export const REQUIREMENTS: Record<string, Requirement> = {
         behavior:
             "ctx.mcpReq.elicitInput() inside a tool handler sends elicitation/create to the client and resolves with the client's ElicitResult, which the handler can fold into its tool result.",
         transports: STATEFUL_TRANSPORTS,
+        removedInSpecVersion: '2026-07-28',
+        supersededBy: 'elicitation:mrtr:form:basic',
         note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
     },
     'mcpserver:context:sampling-from-handler': {
@@ -2400,6 +2436,8 @@ export const REQUIREMENTS: Record<string, Requirement> = {
         behavior:
             "ctx.mcpReq.requestSampling() inside a tool handler sends sampling/createMessage to the client and resolves with the client's CreateMessageResult.",
         transports: STATEFUL_TRANSPORTS,
+        removedInSpecVersion: '2026-07-28',
+        supersededBy: 'sampling:mrtr:create:basic',
         note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
     },
     'hosting:context:web-request-headers': {
@@ -2723,6 +2761,149 @@ export const REQUIREMENTS: Record<string, Requirement> = {
             'On a 2025-era connection, Client.listen() throws a typed MethodNotSupportedByProtocolVersion error steering to resources/subscribe and ClientOptions.listChanged before any wire write (no transparent shim).',
         removedInSpecVersion: '2026-07-28',
         note: 'Runs on the 2025-era arms; the entryModern arm is bound out by the removedInSpecVersion.'
+    },
+
+    // 2026-era siblings of the push-style sampling/elicitation/roots round-trips: the 2025-shape
+    // bodies push a server→client request; on the 2026-07-28 era the same spec behavior rides the
+    // multi-round-trip flow (a handler returns inputRequired() and the client auto-fulfilment driver
+    // dispatches the embedded request to the locally registered handler). Each row supersedes the
+    // 2025-shape sibling(s) it covers.
+
+    'sampling:mrtr:create:basic': {
+        source: 'https://modelcontextprotocol.io/specification/draft/client/sampling#creating-messages',
+        behavior:
+            "An embedded sampling/createMessage request returned via inputRequired() from a tool handler is fulfilled by the client's sampling handler, and the handler's result (role, content, model, stopReason) reaches the retried tool handler in inputResponses.",
+        addedInSpecVersion: '2026-07-28',
+        transports: ['entryModern'],
+        supersedes: ['sampling:create:basic', 'tools:call:sampling-roundtrip', 'mcpserver:context:sampling-from-handler'],
+        note: 'Runs on the entryModern arm; the 2026 path for a server handler to obtain a sampling completion is inputRequired.createMessage(...) — the push-style server.createMessage / ctx.mcpReq.requestSampling APIs are era-gated to fail on this revision.'
+    },
+    'sampling:mrtr:create:model-preferences': {
+        source: 'https://modelcontextprotocol.io/specification/draft/client/sampling#model-preferences',
+        behavior:
+            'The model preferences supplied in an embedded sampling/createMessage request (hints and the cost, speed, and intelligence priorities) reach the client sampling handler intact.',
+        addedInSpecVersion: '2026-07-28',
+        transports: ['entryModern'],
+        supersedes: ['sampling:create:model-preferences'],
+        note: 'Runs on the entryModern arm; the embedded request travels in an input_required result and the client driver dispatches it to the registered handler.'
+    },
+    'sampling:mrtr:create:system-prompt': {
+        source: 'https://modelcontextprotocol.io/specification/draft/client/sampling#creating-messages',
+        behavior: 'The system prompt supplied in an embedded sampling/createMessage request reaches the client sampling handler intact.',
+        addedInSpecVersion: '2026-07-28',
+        transports: ['entryModern'],
+        supersedes: ['sampling:create:system-prompt'],
+        note: 'Runs on the entryModern arm; the embedded request travels in an input_required result and the client driver dispatches it to the registered handler.'
+    },
+    'sampling:mrtr:create:include-context': {
+        source: 'https://modelcontextprotocol.io/specification/draft/client/sampling#capabilities',
+        behavior:
+            'The includeContext value supplied in an embedded sampling/createMessage request reaches the client sampling handler intact.',
+        addedInSpecVersion: '2026-07-28',
+        transports: ['entryModern'],
+        supersedes: ['sampling:create:include-context'],
+        note: 'Runs on the entryModern arm; the embedded request travels in an input_required result and the client driver dispatches it to the registered handler.'
+    },
+    'elicitation:mrtr:form:basic': {
+        source: 'https://modelcontextprotocol.io/specification/draft/client/elicitation#form-mode-elicitation-requests',
+        behavior:
+            "An embedded form-mode elicitation/create request returned via inputRequired() from a tool handler delivers the message and requested schema to the client's elicitation handler exactly as sent, and an accept response carrying the user's content reaches the retried tool handler in inputResponses.",
+        addedInSpecVersion: '2026-07-28',
+        transports: ['entryModern'],
+        supersedes: [
+            'elicitation:form:basic',
+            'tools:call:elicitation-roundtrip',
+            'mcpserver:context:elicit-from-handler',
+            'elicitation:form:action:accept'
+        ],
+        note: 'Runs on the entryModern arm; the 2026 path for a server handler to obtain elicited input is inputRequired.elicit(...) — the push-style server.elicitInput / ctx.mcpReq.elicitInput APIs are era-gated to fail on this revision.'
+    },
+    'elicitation:mrtr:form:action:decline': {
+        source: 'https://modelcontextprotocol.io/specification/draft/client/elicitation#response-actions',
+        behavior:
+            "An embedded form-mode elicitation answered with action 'decline' reaches the retried handler in inputResponses with no content; acceptedContent() returns undefined for it.",
+        addedInSpecVersion: '2026-07-28',
+        transports: ['entryModern'],
+        supersedes: ['elicitation:form:action:decline'],
+        note: 'Runs on the entryModern arm; the embedded request travels in an input_required result and the client driver dispatches it to the registered handler.'
+    },
+    'elicitation:mrtr:form:action:cancel': {
+        source: 'https://modelcontextprotocol.io/specification/draft/client/elicitation#response-actions',
+        behavior:
+            "An embedded form-mode elicitation answered with action 'cancel' reaches the retried handler in inputResponses with no content; acceptedContent() returns undefined for it.",
+        addedInSpecVersion: '2026-07-28',
+        transports: ['entryModern'],
+        supersedes: ['elicitation:form:action:cancel'],
+        note: 'Runs on the entryModern arm; the embedded request travels in an input_required result and the client driver dispatches it to the registered handler.'
+    },
+    'elicitation:mrtr:form:schema:primitives': {
+        source: 'https://modelcontextprotocol.io/specification/draft/client/elicitation#requested-schema',
+        behavior:
+            'Requested-schema fields on an embedded form-mode elicitation may be string (with format), number or integer, or boolean; they reach the client handler intact.',
+        addedInSpecVersion: '2026-07-28',
+        transports: ['entryModern'],
+        supersedes: ['elicitation:form:schema:primitives'],
+        note: 'Runs on the entryModern arm; the embedded request travels in an input_required result and the client driver dispatches it to the registered handler.'
+    },
+    'roots:mrtr:list:basic': {
+        source: 'https://modelcontextprotocol.io/specification/draft/client/roots#listing-roots',
+        behavior:
+            "An embedded roots/list request returned via inputRequired() from a tool handler is fulfilled by the client's roots handler, and the returned roots (uri, name) reach the retried tool handler in inputResponses.",
+        addedInSpecVersion: '2026-07-28',
+        transports: ['entryModern'],
+        supersedes: ['roots:list:basic'],
+        note: 'Runs on the entryModern arm; the 2026 path for a server handler to obtain the client roots is inputRequired.listRoots() — the push-style server.listRoots() API is era-gated to fail on this revision.'
+    },
+    'roots:mrtr:list:empty': {
+        source: 'https://modelcontextprotocol.io/specification/draft/client/roots#listing-roots',
+        behavior:
+            'An empty roots list returned by the client roots handler for an embedded roots/list request reaches the retried tool handler as such.',
+        addedInSpecVersion: '2026-07-28',
+        transports: ['entryModern'],
+        supersedes: ['roots:list:empty'],
+        note: 'Runs on the entryModern arm; the embedded request travels in an input_required result and the client driver dispatches it to the registered handler.'
+    },
+
+    // 2026-era siblings of the captured-instance list_changed publish rows: the 2025-shape bodies
+    // publish by mutating the connected server instance; on the 2026-07-28 era the publication path
+    // is handler.notify.* and delivery rides a subscriptions/listen stream. Each row supersedes the
+    // 2025-shape sibling it covers.
+
+    'tools:listen:list-changed': {
+        source: 'https://modelcontextprotocol.io/specification/draft/server/tools#list-changed-notification',
+        behavior:
+            "A notifications/tools/list_changed published via handler.notify.toolsChanged() reaches a client whose subscriptions/listen stream requested toolsListChanged, and is dispatched to the client's registered notification handler.",
+        addedInSpecVersion: '2026-07-28',
+        transports: ['entryModern'],
+        supersedes: ['tools:list-changed'],
+        note: 'Hosted by the test body via createMcpHandler so it can publish via handler.notify; the 2026 publication path is the entry-level notifier, not mutation of a captured server instance.'
+    },
+    'resources:listen:list-changed': {
+        source: 'https://modelcontextprotocol.io/specification/draft/server/resources#list-changed-notification',
+        behavior:
+            "A notifications/resources/list_changed published via handler.notify.resourcesChanged() reaches a client whose subscriptions/listen stream requested resourcesListChanged, and is dispatched to the client's registered notification handler.",
+        addedInSpecVersion: '2026-07-28',
+        transports: ['entryModern'],
+        supersedes: ['resources:list-changed'],
+        note: 'Hosted by the test body via createMcpHandler so it can publish via handler.notify; the 2026 publication path is the entry-level notifier, not mutation of a captured server instance.'
+    },
+    'prompts:listen:list-changed': {
+        source: 'https://modelcontextprotocol.io/specification/draft/server/prompts#list-changed-notification',
+        behavior:
+            "A notifications/prompts/list_changed published via handler.notify.promptsChanged() reaches a client whose subscriptions/listen stream requested promptsListChanged, and is dispatched to the client's registered notification handler.",
+        addedInSpecVersion: '2026-07-28',
+        transports: ['entryModern'],
+        supersedes: ['prompts:list-changed'],
+        note: 'Hosted by the test body via createMcpHandler so it can publish via handler.notify; the 2026 publication path is the entry-level notifier, not mutation of a captured server instance.'
+    },
+    'client:listen:auto-refresh': {
+        source: 'sdk',
+        behavior:
+            'A client configured with listChanged auto-refresh, on a modern connection, opens a subscriptions/listen stream and on each published change re-fetches the corresponding list and delivers the fresh result to its callback.',
+        addedInSpecVersion: '2026-07-28',
+        transports: ['entryModern'],
+        supersedes: ['client:list-changed:auto-refresh'],
+        note: 'Hosted by the test body via createMcpHandler so it can publish via handler.notify; the auto-opened subscription is the modern delivery path for ClientOptions.listChanged.'
     }
 } satisfies Record<string, Requirement>;
 

--- a/test/e2e/requirements.ts
+++ b/test/e2e/requirements.ts
@@ -595,8 +595,9 @@ export const REQUIREMENTS: Record<string, Requirement> = {
         behavior: 'resources/read returns text contents carrying uri, mimeType, and the text.'
     },
     'resources:read:unknown-uri': {
-        source: 'https://modelcontextprotocol.io/specification/2025-11-25/server/resources#error-handling',
-        behavior: 'resources/read for an unknown URI returns JSON-RPC error -32002 (resource not found).'
+        source: 'https://modelcontextprotocol.io/specification/draft/server/resources#error-handling',
+        behavior:
+            'resources/read for an unknown URI returns JSON-RPC error -32602 (Invalid Params) with data.uri echoing the requested URI; clients also recognise -32002 from older peers. Servers do not return an empty contents array for a non-existent resource.'
     },
     'resources:subscribe:capability-required': {
         entryExclusions: [{ arm: 'entryModern', reason: 'method-not-in-modern-registry' }],

--- a/test/e2e/requirements.ts
+++ b/test/e2e/requirements.ts
@@ -2373,6 +2373,93 @@ export const REQUIREMENTS: Record<string, Requirement> = {
         addedInSpecVersion: '2026-07-28',
         note: "Runs on the entryModern arm; the body wires one harness-hosted endpoint per responseMode value via wire()'s entry.responseMode option and asserts the response shape on the arm-recorded HTTP exchanges."
     },
+
+    // v2 features: dual-era HTTP entry — HTTP request mechanics on the harness-hosted entry
+    // (entry-side siblings of the hosting:http / hosting:stateless families, which hand-host the
+    // server transport themselves and so never reach createMcpHandler when given an entry arm).
+
+    'typescript:hosting:entry:method-405': {
+        source: 'sdk',
+        behavior:
+            'An unsupported HTTP method (PUT, PATCH) on a createMcpHandler endpoint is answered 405 with a JSON-RPC Method-not-allowed body on both legs: the stateless legacy fallback rejects every non-POST method, and the modern-only strict path rejects body-less non-POST traffic via the modern-only-method-not-allowed cell.',
+        transports: ['entryStateless', 'entryModern'],
+        note: 'Runs on the createMcpHandler entry arms; the unsupported methods are POSTed through wired.fetch so the HTTP status and body are observed directly. The entry does not emit an Allow header (the per-session server transport does), so only the status and JSON-RPC error shape are pinned.'
+    },
+    'typescript:hosting:entry:parse-error-400': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#sending-messages-to-the-server',
+        behavior:
+            'A POST whose body is not valid JSON is answered 400 by a createMcpHandler endpoint on both legs, with a JSON-RPC Parse-error (-32700) body: the entry classifier reads no envelope claim from a non-JSON body, so the stateless legacy fallback delegates the parse error and the modern-only strict path emits it itself.',
+        transports: ['entryStateless', 'entryModern'],
+        note: 'Runs on the createMcpHandler entry arms; the malformed body is POSTed through wired.fetch so the HTTP status and JSON-RPC error code are observed directly.'
+    },
+    'typescript:hosting:entry:legacy-accept-406': {
+        source: 'sdk',
+        behavior:
+            "A 2025-era POST whose Accept header does not allow both application/json and text/event-stream is answered 406 by a createMcpHandler endpoint's stateless legacy slot (the legacy fallback delegates to the streamable HTTP server transport, whose Accept negotiation is unchanged).",
+        transports: ['entryStateless'],
+        removedInSpecVersion: '2026-07-28',
+        note: 'Runs on the entryStateless arm and is bounded to the 2025-11-25 axis: Accept negotiation is enforced by the legacy server transport the fallback delegates to, not by the modern per-request path. The probes are POSTed through wired.fetch so the 406 is observed directly.'
+    },
+    'typescript:hosting:entry:legacy-content-type-415': {
+        source: 'sdk',
+        behavior:
+            "A 2025-era POST whose Content-Type is not application/json is answered 415 by a createMcpHandler endpoint's stateless legacy slot (the legacy fallback delegates to the streamable HTTP server transport, whose Content-Type validation is unchanged).",
+        transports: ['entryStateless'],
+        removedInSpecVersion: '2026-07-28',
+        note: 'Runs on the entryStateless arm and is bounded to the 2025-11-25 axis: Content-Type validation is enforced by the legacy server transport the fallback delegates to. The entry classifier reads the body before that delegate runs, so a body that happens to be valid JSON is still rejected on Content-Type alone.'
+    },
+    'typescript:hosting:entry:legacy-protocol-version-header-400': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#protocol-version-header',
+        behavior:
+            "A 2025-era POST carrying an MCP-Protocol-Version header naming an unknown revision is answered 400 by a createMcpHandler endpoint's stateless legacy slot, with the response body naming the supported version(s).",
+        transports: ['entryStateless'],
+        removedInSpecVersion: '2026-07-28',
+        note: 'Runs on the entryStateless arm and is bounded to the 2025-11-25 axis: the protocol-version header check is enforced by the legacy server transport the fallback delegates to. Header/body cross-checks on the modern path are pinned by the entry std-header rows; this row pins only that a non-modern unsupported header still surfaces as 400 through the fallback.'
+    },
+    'typescript:hosting:entry:legacy-protocol-version-default': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#protocol-version-header',
+        behavior:
+            "A 2025-era POST without an MCP-Protocol-Version header is served by a createMcpHandler endpoint's stateless legacy slot under the assumed default protocol version (2025-03-26): a tools/list round-trips without the header.",
+        transports: ['entryStateless'],
+        removedInSpecVersion: '2026-07-28',
+        note: 'Runs on the entryStateless arm and is bounded to the 2025-11-25 axis. The probe is POSTed through wired.fetch with only Accept and Content-Type headers so the default-version path is the one exercised.'
+    },
+    'typescript:hosting:entry:no-session-id': {
+        source: 'sdk',
+        behavior:
+            'A createMcpHandler endpoint emits no Mcp-Session-Id response header on either leg: the stateless legacy fallback hosts a sessionless server transport per request, and the modern per-request path has no session at all — every recorded exchange of a connect-then-tools/call round trip carries no session header.',
+        transports: ['entryStateless', 'entryModern'],
+        note: "Runs on the createMcpHandler entry arms; asserted on the arm-recorded httpLog response clones. The entry's BYO sessionful composition is the only way to issue a session id and is pinned by typescript:hosting:entry:byo-sessionful-legacy."
+    },
+    'typescript:hosting:entry:ctx-http-req-headers': {
+        source: 'sdk',
+        behavior:
+            "A custom HTTP header set on the StreamableHTTP client transport reaches a tool handler's ctx.http.req as Fetch Headers when the server is hosted by createMcpHandler, on both legs: the stateless legacy fallback and the modern per-request path each thread the original Request through to handler context.",
+        transports: ['entryStateless', 'entryModern'],
+        note: "The body hosts createMcpHandler itself (the wire() entry arm builds the client transport without a custom-header hook) and the matrix arm selects the legacy posture and client pin: entryStateless drives a plain client through legacy: 'stateless', entryModern drives a 2026-07-28-pinned client through legacy: 'reject'."
+    },
+
+    // v2 features: dual-era HTTP entry — bearer auth composed in front of createMcpHandler
+    // (entry-side siblings of the hosting:auth family, which hand-hosts an Express stack and so
+    // never reaches createMcpHandler when given an entry arm). The SDK does not enforce endpoint
+    // authentication on either era — bearer/OAuth auth is deployer-composed middleware in front of
+    // whichever handler is mounted, and the entry passes a verified AuthInfo through unchanged.
+
+    'typescript:hosting:entry:auth:missing-401': {
+        source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#error-handling',
+        behavior:
+            'A bearer-protected createMcpHandler deployment — a user-composed verification gate in front of handler.fetch — answers a request without an Authorization header with 401 and a WWW-Authenticate challenge on both legs, and the entry is never reached for that request (no factory call).',
+        transports: ['entryStateless', 'entryModern'],
+        note: "The body hosts createMcpHandler itself behind the documented bearer-gate composition (verify the Authorization header, then call handler.fetch(request, { authInfo })); the matrix arm selects the legacy posture and client pin. The 401/WWW-Authenticate is the gate's own response — the entry performs no token verification — and the body asserts the gate composes correctly with both serving paths."
+    },
+    'typescript:hosting:entry:auth:authinfo-propagates': {
+        source: 'sdk',
+        behavior:
+            "A verified AuthInfo handed to createMcpHandler.fetch(request, { authInfo }) reaches per-request handlers as ctx.http.authInfo unchanged on both legs, and the same AuthInfo is exposed on the factory's per-request context (McpRequestContext.authInfo) before the instance is built.",
+        transports: ['entryStateless', 'entryModern'],
+        note: 'The body hosts createMcpHandler itself behind the documented bearer-gate composition; the matrix arm selects the legacy posture and client pin. authInfo is strictly pass-through — the entry never derives it from request headers — so the cell pins delivery, not verification. The OAuth client flow that obtains the token is hosting-agnostic and is covered by the client-auth family; the dedicated client-completes-OAuth-then-negotiates-2026 journey rides the auth-package redo (M13.1) so it is targeted at the surviving auth surface.'
+    },
+
     'typescript:transport:stdio:dual-era-serving': {
         source: 'sdk',
         behavior:

--- a/test/e2e/scenarios/hosting-entry-auth.test.ts
+++ b/test/e2e/scenarios/hosting-entry-auth.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Bearer auth composed with the dual-era HTTP entry (`createMcpHandler`), and
+ * per-request HTTP context exposure on it. These are the entry-side siblings of
+ * `hosting:auth:authinfo-propagates` / `hosting:auth:missing-401` /
+ * `hosting:context:web-request-headers`, whose bodies hand-host an Express or
+ * per-session stack and so never reach `createMcpHandler` when given an entry
+ * arm.
+ *
+ * The SDK does not enforce endpoint authentication on either era — bearer auth
+ * is deployer-composed middleware in front of whichever handler is mounted.
+ * The composition under test here is the documented one: a user-shaped gate
+ * verifies the Authorization header and, on success, hands the verified
+ * `AuthInfo` to `handler.fetch(request, { authInfo })`. The entry never derives
+ * `authInfo` from request headers; it is strictly pass-through to the factory's
+ * per-request context and to handler `ctx.http.authInfo`. Each cell hosts the
+ * composition itself behind an in-process fetch (the wire() entry arm has no
+ * hook for the gate or for client-transport requestInit), and the matrix arm
+ * selects which leg of the entry serves the authenticated traffic
+ * (`entryStateless` → a plain client through the stateless legacy fallback;
+ * `entryModern` → a 2026-07-28-pinned client through the modern-only strict
+ * path).
+ */
+import { Client, StreamableHTTPClientTransport } from '@modelcontextprotocol/client';
+import type { AuthInfo, McpRequestContext } from '@modelcontextprotocol/server';
+import { createMcpHandler, McpServer } from '@modelcontextprotocol/server';
+import { expect } from 'vitest';
+import { z } from 'zod/v4';
+
+import { verifies } from '../helpers/verifies.js';
+import type { TestArgs } from '../types.js';
+
+const MODERN = '2026-07-28';
+const VALID_TOKEN = 'e2e-entry-access-token';
+
+/** What the user's verifier derives from the Authorization header (a fresh object per request, so the assertion checks delivery, not identity). */
+function verifyBearer(header: string | null): AuthInfo | undefined {
+    if (header !== `Bearer ${VALID_TOKEN}`) return undefined;
+    return {
+        token: VALID_TOKEN,
+        clientId: 'e2e-entry-caller',
+        scopes: ['mcp:tools:read', 'mcp:tools:call'],
+        extra: { userId: 'user-42' }
+    };
+}
+
+/** The 401 a bearer gate answers a missing/invalid token with (mirrors the spec's WWW-Authenticate discovery shape). */
+function unauthorized(): Response {
+    return Response.json(
+        { error: 'invalid_token' },
+        {
+            status: 401,
+            headers: {
+                'content-type': 'application/json',
+                'www-authenticate':
+                    'Bearer error="invalid_token", resource_metadata="http://in-process/.well-known/oauth-protected-resource"'
+            }
+        }
+    );
+}
+
+verifies('typescript:hosting:entry:auth:missing-401', async ({ transport }: TestArgs) => {
+    let factoryCalls = 0;
+    const factory = (_ctx?: McpRequestContext): McpServer => {
+        factoryCalls++;
+        const server = new McpServer({ name: 'e2e-entry-auth', version: '1.0.0' }, { capabilities: { tools: {} } });
+        server.registerTool('whoami', { inputSchema: z.object({}) }, () => ({ content: [{ type: 'text', text: 'reached' }] }));
+        return server;
+    };
+
+    const handler = createMcpHandler(factory, { legacy: transport === 'entryStateless' ? 'stateless' : 'reject' });
+    await using _ = { [Symbol.asyncDispose]: () => handler.close() };
+
+    // The documented bearer-gate composition in front of the entry.
+    const gatedFetch = async (url: URL | string, init?: RequestInit): Promise<Response> => {
+        const request = new Request(url, init);
+        const authInfo = verifyBearer(request.headers.get('authorization'));
+        if (authInfo === undefined) return unauthorized();
+        return handler.fetch(request, { authInfo });
+    };
+
+    // 1. Raw probe without an Authorization header: the gate answers 401 with
+    //    the WWW-Authenticate challenge, and the entry is never reached.
+    const probe = await gatedFetch('http://in-process/mcp', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', accept: 'application/json, text/event-stream' },
+        body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} })
+    });
+    expect(probe.status).toBe(401);
+    const wwwAuthenticate = probe.headers.get('www-authenticate');
+    expect(wwwAuthenticate).toContain('Bearer');
+    expect(wwwAuthenticate).toContain('resource_metadata');
+    expect(factoryCalls).toBe(0);
+
+    // 2. The plain SDK client (no Authorization on its requestInit) cannot
+    //    connect through the gate on either leg, and the entry is still never
+    //    reached. The exact connect-time error surface (401 wrapped by the
+    //    legacy POST or by the modern discover negotiation) is a client-auth
+    //    concern; this cell pins only that the gate composes — connect rejects
+    //    and no factory call runs.
+    const plainClient = new Client({ name: 'plain-client', version: '1.0.0' });
+    if (transport === 'entryModern') plainClient.setVersionNegotiation({ mode: { pin: MODERN } });
+    try {
+        await expect(
+            plainClient.connect(new StreamableHTTPClientTransport(new URL('http://in-process/mcp'), { fetch: gatedFetch }))
+        ).rejects.toThrow();
+    } finally {
+        await plainClient.close().catch(() => {});
+    }
+    expect(factoryCalls).toBe(0);
+});
+
+verifies('typescript:hosting:entry:auth:authinfo-propagates', async ({ transport }: TestArgs) => {
+    // Recorders live outside the per-request factory.
+    const seenByFactory: Array<AuthInfo | undefined> = [];
+    const seenByTool: Array<AuthInfo | undefined> = [];
+
+    const factory = (ctx?: McpRequestContext): McpServer => {
+        seenByFactory.push(ctx?.authInfo);
+        const server = new McpServer({ name: 'e2e-entry-auth', version: '1.0.0' }, { capabilities: { tools: {} } });
+        server.registerTool(
+            'whoami',
+            { description: 'Reports the authenticated caller derived from ctx.http.authInfo.', inputSchema: z.object({}) },
+            (_args, handlerCtx) => {
+                seenByTool.push(handlerCtx.http?.authInfo);
+                return {
+                    content: [
+                        {
+                            type: 'text',
+                            text: handlerCtx.http?.authInfo
+                                ? `${handlerCtx.http.authInfo.clientId} [${handlerCtx.http.authInfo.scopes.join(' ')}] (${ctx?.era ?? 'unknown'})`
+                                : 'no-auth-info'
+                        }
+                    ]
+                };
+            }
+        );
+        return server;
+    };
+
+    const handler = createMcpHandler(factory, { legacy: transport === 'entryStateless' ? 'stateless' : 'reject' });
+    const gatedFetch = async (url: URL | string, init?: RequestInit): Promise<Response> => {
+        const request = new Request(url, init);
+        const authInfo = verifyBearer(request.headers.get('authorization'));
+        if (authInfo === undefined) return unauthorized();
+        return handler.fetch(request, { authInfo });
+    };
+
+    const client = new Client({ name: 'auth-client', version: '1.0.0' });
+    if (transport === 'entryModern') client.setVersionNegotiation({ mode: { pin: MODERN } });
+    await using _ = {
+        [Symbol.asyncDispose]: async () => {
+            await client.close().catch(() => {});
+            await handler.close();
+        }
+    };
+
+    await client.connect(
+        new StreamableHTTPClientTransport(new URL('http://in-process/mcp'), {
+            fetch: gatedFetch,
+            requestInit: { headers: { Authorization: `Bearer ${VALID_TOKEN}` } }
+        })
+    );
+    if (transport === 'entryModern') expect(client.getNegotiatedProtocolVersion()).toBe(MODERN);
+
+    const result = await client.callTool({ name: 'whoami', arguments: {} });
+    expect(result.isError).toBeFalsy();
+    const era = transport === 'entryStateless' ? 'legacy' : 'modern';
+    expect(result.content).toEqual([{ type: 'text', text: `e2e-entry-caller [mcp:tools:read mcp:tools:call] (${era})` }]);
+
+    // The verified AuthInfo handed to handler.fetch(request, { authInfo })
+    // reached the tool handler's ctx.http.authInfo unchanged — not dropped, not
+    // replaced by a placeholder, not derived from a header.
+    expect(seenByTool).toHaveLength(1);
+    expect(seenByTool[0]).toEqual({
+        token: VALID_TOKEN,
+        clientId: 'e2e-entry-caller',
+        scopes: ['mcp:tools:read', 'mcp:tools:call'],
+        extra: { userId: 'user-42' }
+    });
+
+    // ...and the same AuthInfo was on the factory's per-request context for
+    // every instance the entry built (negotiation + the tools/call), so a
+    // factory keying surface off authInfo sees it on the leg under test.
+    expect(seenByFactory.length).toBeGreaterThan(0);
+    for (const seen of seenByFactory) {
+        expect(seen).toEqual({
+            token: VALID_TOKEN,
+            clientId: 'e2e-entry-caller',
+            scopes: ['mcp:tools:read', 'mcp:tools:call'],
+            extra: { userId: 'user-42' }
+        });
+    }
+});
+
+verifies('typescript:hosting:entry:ctx-http-req-headers', async ({ transport }: TestArgs) => {
+    const PROBE_HEADER = 'x-e2e-probe';
+    const PROBE_VALUE = 'probe-7d1f';
+    const seenByTool: Array<{ isFetchHeaders: boolean; probe: string | null }> = [];
+
+    const factory = (_ctx?: McpRequestContext): McpServer => {
+        const server = new McpServer({ name: 'e2e-entry-ctx', version: '1.0.0' }, { capabilities: { tools: {} } });
+        server.registerTool('read-probe-header', { inputSchema: z.object({}) }, (_args, ctx) => {
+            const headers = ctx.http?.req?.headers;
+            seenByTool.push({
+                isFetchHeaders: headers instanceof Headers,
+                probe: headers instanceof Headers ? headers.get(PROBE_HEADER) : null
+            });
+            return { content: [{ type: 'text', text: headers?.get(PROBE_HEADER) ?? '<missing>' }] };
+        });
+        return server;
+    };
+
+    const handler = createMcpHandler(factory, { legacy: transport === 'entryStateless' ? 'stateless' : 'reject' });
+    const client = new Client({ name: 'ctx-client', version: '1.0.0' });
+    if (transport === 'entryModern') client.setVersionNegotiation({ mode: { pin: MODERN } });
+    await using _ = {
+        [Symbol.asyncDispose]: async () => {
+            await client.close().catch(() => {});
+            await handler.close();
+        }
+    };
+
+    await client.connect(
+        new StreamableHTTPClientTransport(new URL('http://in-process/mcp'), {
+            fetch: (url, init) => handler.fetch(new Request(url, init)),
+            requestInit: { headers: { [PROBE_HEADER]: PROBE_VALUE } }
+        })
+    );
+
+    const result = await client.callTool({ name: 'read-probe-header', arguments: {} });
+    expect(result.isError).toBeFalsy();
+    expect(result.content).toEqual([{ type: 'text', text: PROBE_VALUE }]);
+    // The custom header set on the client transport is readable as Fetch
+    // Headers inside the handler on the leg the matrix arm selected.
+    expect(seenByTool).toEqual([{ isFetchHeaders: true, probe: PROBE_VALUE }]);
+});

--- a/test/e2e/scenarios/hosting-entry-http.test.ts
+++ b/test/e2e/scenarios/hosting-entry-http.test.ts
@@ -1,0 +1,153 @@
+/**
+ * HTTP request mechanics on the dual-era HTTP entry (`createMcpHandler`),
+ * exercised through the wire() entry arms. These are the entry-side siblings
+ * of the `hosting:http:*` / `hosting:stateless:*` rows, whose bodies hand-host
+ * the streamable HTTP server transport themselves and so never reach
+ * `createMcpHandler` when given an entry arm. Every probe here goes through
+ * `wired.fetch` against the harness-hosted entry so the HTTP status/body is
+ * observed directly; the matrix arm selects which leg of the entry answers it
+ * (`entryStateless` → the stateless legacy fallback; `entryModern` → the
+ * modern-only strict path).
+ */
+import { Client } from '@modelcontextprotocol/client';
+import type { McpRequestContext } from '@modelcontextprotocol/server';
+import { McpServer } from '@modelcontextprotocol/server';
+import { expect } from 'vitest';
+import { z } from 'zod/v4';
+
+import { wire } from '../helpers/index.js';
+import { verifies } from '../helpers/verifies.js';
+import type { TestArgs } from '../types.js';
+
+const LEGACY = '2025-11-25';
+
+/** One ctx-taking factory backing every cell. */
+function echoFactory(_ctx?: McpRequestContext): McpServer {
+    const server = new McpServer({ name: 'e2e-entry-http', version: '1.0.0' }, { capabilities: { tools: {} } });
+    server.registerTool('echo', { inputSchema: z.object({ text: z.string() }) }, ({ text }) => ({
+        content: [{ type: 'text', text }]
+    }));
+    return server;
+}
+
+verifies('typescript:hosting:entry:method-405', async ({ transport }: TestArgs) => {
+    const client = new Client({ name: 'method-405-client', version: '1.0.0' });
+    await using wired = await wire(transport, echoFactory, client, { entry: { legacy: 'stateless' } });
+
+    for (const method of ['PUT', 'PATCH']) {
+        const response = await wired.fetch!(wired.url!, { method });
+        expect(response.status).toBe(405);
+        const body = (await response.json()) as { jsonrpc: string; error: { code: number; message: string } };
+        expect(body.jsonrpc).toBe('2.0');
+        expect(body.error.code).toBe(-32_000);
+        expect(body.error.message).toMatch(/method not allowed/i);
+    }
+});
+
+verifies('typescript:hosting:entry:parse-error-400', async ({ transport }: TestArgs) => {
+    const client = new Client({ name: 'parse-error-client', version: '1.0.0' });
+    await using wired = await wire(transport, echoFactory, client, { entry: { legacy: 'stateless' } });
+
+    const response = await wired.fetch!(wired.url!, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', accept: 'application/json, text/event-stream' },
+        body: 'not json'
+    });
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as { jsonrpc: string; error: { code: number } };
+    expect(body.jsonrpc).toBe('2.0');
+    expect(body.error.code).toBe(-32_700);
+});
+
+verifies('typescript:hosting:entry:legacy-accept-406', async ({ transport }: TestArgs) => {
+    const client = new Client({ name: 'accept-406-client', version: '1.0.0' });
+    await using wired = await wire(transport, echoFactory, client);
+
+    const body = JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} });
+
+    // The legacy server transport requires both application/json and
+    // text/event-stream on POST: each single-type Accept (and an absent
+    // Accept) is rejected at 406 by the fallback the entry delegated to.
+    for (const accept of ['application/json', 'text/event-stream', undefined]) {
+        const response = await wired.fetch!(wired.url!, {
+            method: 'POST',
+            headers: {
+                'mcp-protocol-version': LEGACY,
+                'content-type': 'application/json',
+                ...(accept !== undefined && { accept })
+            },
+            body
+        });
+        expect(response.status).toBe(406);
+    }
+});
+
+verifies('typescript:hosting:entry:legacy-content-type-415', async ({ transport }: TestArgs) => {
+    const client = new Client({ name: 'content-type-415-client', version: '1.0.0' });
+    await using wired = await wire(transport, echoFactory, client);
+
+    // A non-JSON Content-Type carrying a syntactically-JSON 2025-era body: the
+    // entry classifier reads the body (it does not gate on Content-Type), routes
+    // it legacy, and the fallback's transport answers 415 on Content-Type alone.
+    const response = await wired.fetch!(wired.url!, {
+        method: 'POST',
+        headers: {
+            'mcp-protocol-version': LEGACY,
+            'content-type': 'text/plain',
+            accept: 'application/json, text/event-stream'
+        },
+        body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} })
+    });
+    expect(response.status).toBe(415);
+});
+
+verifies('typescript:hosting:entry:legacy-protocol-version-header-400', async ({ transport }: TestArgs) => {
+    const client = new Client({ name: 'protocol-version-400-client', version: '1.0.0' });
+    await using wired = await wire(transport, echoFactory, client);
+
+    // An unknown (and not modern-era) protocol-version header on a 2025-era
+    // body: the entry routes it legacy, and the fallback's transport answers
+    // the spec's 400 with the supported version(s) named in the body.
+    const response = await wired.fetch!(wired.url!, {
+        method: 'POST',
+        headers: {
+            'mcp-protocol-version': '1999-01-01',
+            'content-type': 'application/json',
+            accept: 'application/json, text/event-stream'
+        },
+        body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} })
+    });
+    expect(response.status).toBe(400);
+    expect(await response.text()).toContain(LEGACY);
+});
+
+verifies('typescript:hosting:entry:legacy-protocol-version-default', async ({ transport }: TestArgs) => {
+    const client = new Client({ name: 'protocol-version-default-client', version: '1.0.0' });
+    await using wired = await wire(transport, echoFactory, client);
+
+    // No MCP-Protocol-Version header at all: the legacy fallback assumes the
+    // spec's default version, so a 2025-era tools/list still round-trips.
+    const response = await wired.fetch!(wired.url!, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', accept: 'application/json, text/event-stream' },
+        body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} })
+    });
+    expect(response.status).toBe(200);
+    expect(await response.text()).toContain('"echo"');
+});
+
+verifies('typescript:hosting:entry:no-session-id', async ({ transport }: TestArgs) => {
+    const client = new Client({ name: 'no-session-id-client', version: '1.0.0' });
+    await using wired = await wire(transport, echoFactory, client, { entry: { legacy: 'stateless' } });
+
+    // A typed round trip through the wired client (so both the connect-time
+    // negotiation and a follow-up request are recorded), then assert no
+    // exchange ever carried an Mcp-Session-Id response header.
+    const result = await client.callTool({ name: 'echo', arguments: { text: 'probe' } });
+    expect(result.content).toEqual([{ type: 'text', text: 'probe' }]);
+
+    expect(wired.httpLog!.length).toBeGreaterThan(0);
+    for (const exchange of wired.httpLog!) {
+        expect(exchange.response.headers.get('mcp-session-id')).toBeNull();
+    }
+});

--- a/test/e2e/scenarios/mrtr.test.ts
+++ b/test/e2e/scenarios/mrtr.test.ts
@@ -194,6 +194,292 @@ verifies('typescript:mrtr:rounds-cap', async ({ transport }: TestArgs) => {
     expect(recordedRequests(wired, 'tools/call')).toHaveLength(3);
 });
 
+// 2026-era siblings of the push-style sampling/elicitation/roots round-trips:
+// each body returns inputRequired() with an embedded request, the client
+// auto-fulfilment driver dispatches it to the locally registered handler, and
+// the retried tool handler reads the response from ctx.mcpReq.inputResponses.
+
+verifies('sampling:mrtr:create:basic', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        const server = new McpServer({ name: 'mrtr-sampling', version: '1.0.0' }, { capabilities: { tools: {} } });
+        server.registerTool('summarize', { inputSchema: z.object({ text: z.string() }) }, async ({ text }, ctx) => {
+            const completion = ctx.mcpReq.inputResponses?.['llm'] as
+                | { role: string; content: { type: string; text: string }; model: string; stopReason: string }
+                | undefined;
+            if (completion === undefined) {
+                return inputRequired({
+                    inputRequests: {
+                        llm: inputRequired.createMessage({
+                            messages: [{ role: 'user', content: { type: 'text', text: `Summarize: ${text}` } }],
+                            maxTokens: 64
+                        })
+                    }
+                });
+            }
+            return { structuredContent: { completion }, content: [{ type: 'text', text: completion.content.text }] };
+        });
+        return server;
+    };
+
+    const seen: unknown[] = [];
+    const client = new Client({ name: 'mrtr-client', version: '1.0.0' }, { capabilities: { sampling: {} } });
+    client.setRequestHandler('sampling/createMessage', async request => {
+        seen.push(request.params);
+        return { role: 'assistant', content: { type: 'text', text: 'a brief summary' }, model: 'stub-model', stopReason: 'endTurn' };
+    });
+
+    await using wired = await wire(transport, makeServer, client);
+
+    const result = await client.callTool({ name: 'summarize', arguments: { text: 'hello world' } });
+    expect(result.isError).toBeFalsy();
+    expect(result.structuredContent).toEqual({
+        completion: { role: 'assistant', content: { type: 'text', text: 'a brief summary' }, model: 'stub-model', stopReason: 'endTurn' }
+    });
+
+    // The embedded request reached the registered handler exactly once.
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toMatchObject({ messages: [{ role: 'user', content: { type: 'text', text: 'Summarize: hello world' } }] });
+
+    // Two independent wire legs: original + retry carrying the bare response.
+    const toolCalls = recordedRequests(wired, 'tools/call');
+    expect(toolCalls).toHaveLength(2);
+    const retryParams = toolCalls[1]!.params as Record<string, unknown>;
+    expect(retryParams.inputResponses).toMatchObject({
+        llm: { role: 'assistant', content: { type: 'text', text: 'a brief summary' }, model: 'stub-model', stopReason: 'endTurn' }
+    });
+});
+
+verifies(
+    ['sampling:mrtr:create:model-preferences', 'sampling:mrtr:create:system-prompt', 'sampling:mrtr:create:include-context'],
+    async ({ transport }: TestArgs) => {
+        const PREFS = { hints: [{ name: 'stub-model' }], costPriority: 0.2, speedPriority: 0.5, intelligencePriority: 0.9 };
+        const makeServer = () => {
+            const server = new McpServer({ name: 'mrtr-sampling', version: '1.0.0' }, { capabilities: { tools: {} } });
+            server.registerTool('ask', { inputSchema: z.object({}) }, async (_args, ctx) => {
+                if (ctx.mcpReq.inputResponses?.['llm'] !== undefined) {
+                    return { content: [{ type: 'text', text: 'ok' }] };
+                }
+                return inputRequired({
+                    inputRequests: {
+                        llm: inputRequired.createMessage({
+                            messages: [{ role: 'user', content: { type: 'text', text: 'hi' } }],
+                            maxTokens: 16,
+                            systemPrompt: 'You are a terse assistant.',
+                            includeContext: 'none',
+                            modelPreferences: PREFS
+                        })
+                    }
+                });
+            });
+            return server;
+        };
+
+        const seen: Array<Record<string, unknown>> = [];
+        const client = new Client({ name: 'mrtr-client', version: '1.0.0' }, { capabilities: { sampling: {} } });
+        client.setRequestHandler('sampling/createMessage', async request => {
+            seen.push(request.params as Record<string, unknown>);
+            return { role: 'assistant', content: { type: 'text', text: 'hi' }, model: 'stub-model', stopReason: 'endTurn' };
+        });
+
+        await using _ = await wire(transport, makeServer, client);
+
+        const result = await client.callTool({ name: 'ask', arguments: {} });
+        expect(result.isError).toBeFalsy();
+        expect(seen).toHaveLength(1);
+        expect(seen[0]?.systemPrompt).toBe('You are a terse assistant.');
+        expect(seen[0]?.includeContext).toBe('none');
+        expect(seen[0]?.modelPreferences).toEqual(PREFS);
+    }
+);
+
+verifies('elicitation:mrtr:form:basic', async ({ transport }: TestArgs) => {
+    const SCHEMA = {
+        type: 'object' as const,
+        properties: { name: { type: 'string' as const, description: 'Your name' } },
+        required: ['name']
+    };
+    const makeServer = () => {
+        const server = new McpServer({ name: 'mrtr-elicit', version: '1.0.0' }, { capabilities: { tools: {} } });
+        server.registerTool('greet', { inputSchema: z.object({}) }, async (_args, ctx) => {
+            const answered = acceptedContent<{ name: string }>(ctx.mcpReq.inputResponses, 'who');
+            if (answered === undefined) {
+                return inputRequired({
+                    inputRequests: { who: inputRequired.elicit({ message: 'What is your name?', requestedSchema: SCHEMA }) }
+                });
+            }
+            return { content: [{ type: 'text', text: `hello ${answered.name}` }] };
+        });
+        return server;
+    };
+
+    const seen: unknown[] = [];
+    const client = new Client({ name: 'mrtr-client', version: '1.0.0' }, { capabilities: { elicitation: { form: {} } } });
+    client.setRequestHandler('elicitation/create', async request => {
+        seen.push(request.params);
+        return { action: 'accept', content: { name: 'Ada' } };
+    });
+
+    await using _ = await wire(transport, makeServer, client);
+
+    const result = await client.callTool({ name: 'greet', arguments: {} });
+    expect(result.content).toEqual([{ type: 'text', text: 'hello Ada' }]);
+
+    // The embedded request delivered message + schema exactly as sent.
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toMatchObject({ mode: 'form', message: 'What is your name?', requestedSchema: SCHEMA });
+});
+
+verifies('elicitation:mrtr:form:action:decline', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        const server = new McpServer({ name: 'mrtr-elicit', version: '1.0.0' }, { capabilities: { tools: {} } });
+        server.registerTool('ask', { inputSchema: z.object({}) }, async (_args, ctx) => {
+            const responses = ctx.mcpReq.inputResponses;
+            if (responses === undefined) {
+                return inputRequired({
+                    inputRequests: { confirm: inputRequired.elicit({ message: 'Proceed?', requestedSchema: CONFIRM_SCHEMA }) }
+                });
+            }
+            const raw = responses['confirm'] as { action: string; content?: unknown };
+            return {
+                structuredContent: { action: raw.action, accepted: acceptedContent(responses, 'confirm') !== undefined },
+                content: []
+            };
+        });
+        return server;
+    };
+
+    const client = new Client({ name: 'mrtr-client', version: '1.0.0' }, { capabilities: { elicitation: { form: {} } } });
+    client.setRequestHandler('elicitation/create', async () => ({ action: 'decline' }));
+
+    await using _ = await wire(transport, makeServer, client);
+
+    const result = await client.callTool({ name: 'ask', arguments: {} });
+    expect(result.structuredContent).toEqual({ action: 'decline', accepted: false });
+});
+
+verifies('elicitation:mrtr:form:action:cancel', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        const server = new McpServer({ name: 'mrtr-elicit', version: '1.0.0' }, { capabilities: { tools: {} } });
+        server.registerTool('ask', { inputSchema: z.object({}) }, async (_args, ctx) => {
+            const responses = ctx.mcpReq.inputResponses;
+            if (responses === undefined) {
+                return inputRequired({
+                    inputRequests: { confirm: inputRequired.elicit({ message: 'Proceed?', requestedSchema: CONFIRM_SCHEMA }) }
+                });
+            }
+            const raw = responses['confirm'] as { action: string; content?: unknown };
+            return {
+                structuredContent: { action: raw.action, accepted: acceptedContent(responses, 'confirm') !== undefined },
+                content: []
+            };
+        });
+        return server;
+    };
+
+    const client = new Client({ name: 'mrtr-client', version: '1.0.0' }, { capabilities: { elicitation: { form: {} } } });
+    client.setRequestHandler('elicitation/create', async () => ({ action: 'cancel' }));
+
+    await using _ = await wire(transport, makeServer, client);
+
+    const result = await client.callTool({ name: 'ask', arguments: {} });
+    expect(result.structuredContent).toEqual({ action: 'cancel', accepted: false });
+});
+
+verifies('elicitation:mrtr:form:schema:primitives', async ({ transport }: TestArgs) => {
+    const SCHEMA = {
+        type: 'object' as const,
+        properties: {
+            email: { type: 'string' as const, format: 'email' as const },
+            age: { type: 'integer' as const },
+            score: { type: 'number' as const },
+            subscribe: { type: 'boolean' as const }
+        },
+        required: ['email']
+    };
+    const makeServer = () => {
+        const server = new McpServer({ name: 'mrtr-elicit', version: '1.0.0' }, { capabilities: { tools: {} } });
+        server.registerTool('signup', { inputSchema: z.object({}) }, async (_args, ctx) => {
+            if (ctx.mcpReq.inputResponses?.['form'] !== undefined) {
+                return { content: [{ type: 'text', text: 'ok' }] };
+            }
+            return inputRequired({
+                inputRequests: { form: inputRequired.elicit({ message: 'Sign up', requestedSchema: SCHEMA }) }
+            });
+        });
+        return server;
+    };
+
+    const seen: unknown[] = [];
+    const client = new Client({ name: 'mrtr-client', version: '1.0.0' }, { capabilities: { elicitation: { form: {} } } });
+    client.setRequestHandler('elicitation/create', async request => {
+        seen.push(request.params);
+        return { action: 'accept', content: { email: 'ada@example.com', age: 36, score: 0.9, subscribe: true } };
+    });
+
+    await using _ = await wire(transport, makeServer, client);
+
+    const result = await client.callTool({ name: 'signup', arguments: {} });
+    expect(result.isError).toBeFalsy();
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toMatchObject({ requestedSchema: SCHEMA });
+});
+
+verifies('roots:mrtr:list:basic', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        const server = new McpServer({ name: 'mrtr-roots', version: '1.0.0' }, { capabilities: { tools: {} } });
+        server.registerTool('list-roots', { inputSchema: z.object({}) }, async (_args, ctx) => {
+            const answered = ctx.mcpReq.inputResponses?.['roots'] as { roots: Array<{ uri: string; name?: string }> } | undefined;
+            if (answered === undefined) {
+                return inputRequired({ inputRequests: { roots: inputRequired.listRoots() } });
+            }
+            return { structuredContent: { roots: answered.roots }, content: [] };
+        });
+        return server;
+    };
+
+    const seen: Array<{ method: string }> = [];
+    const client = new Client({ name: 'mrtr-client', version: '1.0.0' }, { capabilities: { roots: {} } });
+    client.setRequestHandler('roots/list', async request => {
+        seen.push({ method: request.method });
+        return {
+            roots: [{ uri: 'file:///home/user/projects/myproject', name: 'My Project' }, { uri: 'file:///home/user/repos/backend' }]
+        };
+    });
+
+    await using _ = await wire(transport, makeServer, client);
+
+    const result = await client.callTool({ name: 'list-roots', arguments: {} });
+    expect(result.isError).toBeFalsy();
+    expect(seen).toHaveLength(1);
+    expect(seen[0]?.method).toBe('roots/list');
+    expect(result.structuredContent).toEqual({
+        roots: [{ uri: 'file:///home/user/projects/myproject', name: 'My Project' }, { uri: 'file:///home/user/repos/backend' }]
+    });
+});
+
+verifies('roots:mrtr:list:empty', async ({ transport }: TestArgs) => {
+    const makeServer = () => {
+        const server = new McpServer({ name: 'mrtr-roots', version: '1.0.0' }, { capabilities: { tools: {} } });
+        server.registerTool('list-roots', { inputSchema: z.object({}) }, async (_args, ctx) => {
+            const answered = ctx.mcpReq.inputResponses?.['roots'] as { roots: unknown[] } | undefined;
+            if (answered === undefined) {
+                return inputRequired({ inputRequests: { roots: inputRequired.listRoots() } });
+            }
+            return { structuredContent: { count: answered.roots.length }, content: [] };
+        });
+        return server;
+    };
+
+    const client = new Client({ name: 'mrtr-client', version: '1.0.0' }, { capabilities: { roots: {} } });
+    client.setRequestHandler('roots/list', async () => ({ roots: [] }));
+
+    await using _ = await wire(transport, makeServer, client);
+
+    const result = await client.callTool({ name: 'list-roots', arguments: {} });
+    expect(result.isError).toBeFalsy();
+    expect(result.structuredContent).toEqual({ count: 0 });
+});
+
 verifies('typescript:mrtr:legacy-32042-freeze', async ({ transport }: TestArgs) => {
     const URL_PARAMS = {
         mode: 'url' as const,

--- a/test/e2e/scenarios/resources.test.ts
+++ b/test/e2e/scenarios/resources.test.ts
@@ -182,10 +182,32 @@ verifies('resources:read:unknown-uri', async ({ transport }: TestArgs) => {
     const client = newClient();
     await using _ = await wire(transport, makeServer, client);
 
-    await expect(client.readResource({ uri: 'file:///no-such-resource' })).rejects.toMatchObject({
-        code: -32_002,
-        message: expect.stringMatching(/not found|unknown/i)
-    });
+    let received: ProtocolError | undefined;
+    try {
+        const result = await client.readResource({ uri: 'file:///no-such-resource' });
+        // MUST-NOT rider: never an empty contents array for a non-existent resource.
+        expect(result.contents).not.toEqual([]);
+    } catch (error) {
+        received = error as ProtocolError;
+    }
+    expect(received).toBeDefined();
+
+    // The wire code is −32602 on every protocol revision (the encode seam owns
+    // the −32002 → −32602 mapping), with `data.uri` echoing the requested URI.
+    expect(received!.code).toBe(-32_602);
+    expect(received!.message).toMatch(/not found/i);
+    expect(received!.data).toEqual({ uri: 'file:///no-such-resource' });
+
+    // The cross-bundle data-parse recognizer reconstructs the typed error
+    // from code + structurally valid data (no `instanceof` across bundles).
+    // It accepts BOTH −32602 and the legacy −32002; the duck shape is `data.uri`.
+    const recognised = ProtocolError.fromError(received!.code, received!.message, received!.data);
+    expect((recognised as { uri?: string }).uri).toBe('file:///no-such-resource');
+    const legacy = ProtocolError.fromError(-32_002, 'Resource not found', { uri: 'file:///x' });
+    expect((legacy as { uri?: string }).uri).toBe('file:///x');
+    // ProtocolErrorCode.ResourceNotFound (−32002) stays importable as legacy
+    // receive-tolerated vocabulary.
+    expect(ProtocolErrorCode.ResourceNotFound).toBe(-32_002);
 });
 
 verifies('resources:read:template-vars', async ({ transport }: TestArgs) => {

--- a/test/e2e/scenarios/subscriptions.test.ts
+++ b/test/e2e/scenarios/subscriptions.test.ts
@@ -21,6 +21,33 @@ function makeServer() {
     return server;
 }
 
+/**
+ * A modern in-process host with a tool, a prompt, and a resource registered so
+ * the entry advertises listChanged for all three kinds (the listen ack honors a
+ * filter only for kinds the server advertises).
+ */
+async function hostListenAllKinds() {
+    const factory = () => {
+        const server = new McpServer({ name: 'subs-e2e', version: '1' });
+        server.registerTool('greet', { inputSchema: z.object({}) }, async () => ({ content: [] }));
+        server.registerPrompt('hello', { description: 'p' }, async () => ({ messages: [] }));
+        server.registerResource('r', 'file:///r', {}, async uri => ({ contents: [{ uri: uri.href, text: 'r' }] }));
+        return server;
+    };
+    const handler = createMcpHandler(factory, { legacy: 'reject', keepAliveMs: 0 });
+    const fetch = (u: URL | string, init?: RequestInit) => handler.fetch(new Request(u, init));
+    const client = new Client({ name: 'subs-e2e-client', version: '1' }, { versionNegotiation: { mode: 'auto' } });
+    await client.connect(new StreamableHTTPClientTransport(new URL('http://in-process/mcp'), { fetch }));
+    expect(client.getNegotiatedProtocolVersion()).toBe('2026-07-28');
+    return {
+        client,
+        handler,
+        factory,
+        fetch,
+        [Symbol.asyncDispose]: () => Promise.all([client.close(), handler.close()]).then(() => {})
+    };
+}
+
 async function hostListen() {
     const handler = createMcpHandler(() => makeServer(), { legacy: 'reject', keepAliveMs: 0 });
     const url = new URL('http://in-process/mcp');
@@ -136,6 +163,85 @@ verifies('subscriptions:listen:honored-filter-narrows-to-advertised', async () =
     await new Promise(r => setTimeout(r, 30));
     expect(seen).toEqual(['tools']);
     await sub.close();
+});
+
+// 2026-era siblings of the captured-instance list_changed publish rows: the
+// publication path is handler.notify.* and delivery rides subscriptions/listen.
+
+verifies('tools:listen:list-changed', async () => {
+    await using h = await hostListenAllKinds();
+    const seen: string[] = [];
+    h.client.setNotificationHandler('notifications/tools/list_changed', () => void seen.push('tools'));
+    const sub = await h.client.listen({ toolsListChanged: true });
+    expect(sub.honoredFilter).toEqual({ toolsListChanged: true });
+    h.handler.notify.toolsChanged();
+    await new Promise(r => setTimeout(r, 30));
+    expect(seen).toEqual(['tools']);
+    await sub.close();
+});
+
+verifies('resources:listen:list-changed', async () => {
+    await using h = await hostListenAllKinds();
+    const seen: string[] = [];
+    h.client.setNotificationHandler('notifications/resources/list_changed', () => void seen.push('resources'));
+    const sub = await h.client.listen({ resourcesListChanged: true });
+    expect(sub.honoredFilter).toEqual({ resourcesListChanged: true });
+    h.handler.notify.resourcesChanged();
+    await new Promise(r => setTimeout(r, 30));
+    expect(seen).toEqual(['resources']);
+    await sub.close();
+});
+
+verifies('prompts:listen:list-changed', async () => {
+    await using h = await hostListenAllKinds();
+    const seen: string[] = [];
+    h.client.setNotificationHandler('notifications/prompts/list_changed', () => void seen.push('prompts'));
+    const sub = await h.client.listen({ promptsListChanged: true });
+    expect(sub.honoredFilter).toEqual({ promptsListChanged: true });
+    h.handler.notify.promptsChanged();
+    await new Promise(r => setTimeout(r, 30));
+    expect(seen).toEqual(['prompts']);
+    await sub.close();
+});
+
+verifies('client:listen:auto-refresh', async () => {
+    const factory = () => {
+        const server = new McpServer({ name: 'subs-e2e', version: '1' });
+        server.registerTool('greet', { inputSchema: z.object({}) }, async () => ({ content: [] }));
+        return server;
+    };
+    const handler = createMcpHandler(factory, { legacy: 'reject', keepAliveMs: 0 });
+    const fetch = (u: URL | string, init?: RequestInit) => handler.fetch(new Request(u, init));
+    let done!: () => void;
+    const finished = new Promise<void>(r => {
+        done = r;
+    });
+    const refreshed: unknown[] = [];
+    const client = new Client(
+        { name: 'subs-e2e-client', version: '1' },
+        {
+            versionNegotiation: { mode: 'auto' },
+            listChanged: {
+                tools: {
+                    onChanged: (error, tools) => {
+                        expect(error).toBeNull();
+                        refreshed.push(tools);
+                        done();
+                    }
+                }
+            }
+        }
+    );
+    await client.connect(new StreamableHTTPClientTransport(new URL('http://in-process/mcp'), { fetch }));
+    expect(client.autoOpenedSubscription?.honoredFilter).toEqual({ toolsListChanged: true });
+    handler.notify.toolsChanged();
+    await finished;
+    // The auto-refresh re-fetched tools/list and delivered the fresh result.
+    expect(refreshed).toHaveLength(1);
+    expect(refreshed[0]).toEqual([expect.objectContaining({ name: 'greet' })]);
+    await client.autoOpenedSubscription!.close();
+    await client.close();
+    await handler.close();
 });
 
 verifies('subscriptions:listen:capacity-guard', async () => {

--- a/test/integration/test/server/mcp.test.ts
+++ b/test/integration/test/server/mcp.test.ts
@@ -2728,8 +2728,12 @@ describe('Zod v4', () => {
                     }
                 })
             ).rejects.toMatchObject({
-                code: ProtocolErrorCode.ResourceNotFound,
-                message: expect.stringContaining('not found')
+                // SEP-2164: resources/read miss is −32602 Invalid Params on the wire
+                // (every protocol revision); the encode seam maps a handler-thrown
+                // −32002 to −32602, and `data.uri` echoes the requested URI.
+                code: ProtocolErrorCode.InvalidParams,
+                message: expect.stringMatching(/not found/i),
+                data: { uri: 'test://nonexistent' }
             });
         });
 


### PR DESCRIPTION
SEP-2577 `@deprecated` sweep on the public type stacks, the `resources/read` not-found error-code flip to −32602 with a typed `ResourceNotFoundError`, small additive verifications, and two batches of new e2e cells (2026-era sibling rows + dedicated entry-hosting cells). Stacked on `fweinberger/on-codec-conformance`.

## Motivation and Context

### SEP-2577 `@deprecated` markers (SEP-2596 Tier-1)

Completes the `@deprecated` JSDoc sweep on the public runtime **type stacks** in `schemas.ts` + `types.ts` (the runtime API methods landed in #2268; the per-revision reference types in #2252). Covered: logging (`LoggingLevel`, `SetLevelRequest`, `LoggingMessageNotification` and params/schemas), sampling (`ModelHint`/`ModelPreferences`/`ToolChoice`/`ToolUseContent`/`ToolResultContent`/`SamplingContent`/`SamplingMessage`/`CreateMessageRequest`/`CreateMessageResult` and variants), `includeContext` upgraded soft → `@deprecated`, roots (`Root`/`ListRootsRequest`/`ListRootsResult`/`RootsListChangedNotification`), and `registerClient` (DCR → CIMD/SEP-991 marker only). JSDoc-only — zero wire/behavior diffs, no Zod constraint changes. Runtime warnings (SHOULD) are **not** in this PR; they ride a separate decision on timing.

### `resources/read` miss → −32602 + typed error

New typed `ResourceNotFoundError` (`data.uri`, code −32602) is the one neutral domain error `McpServer.resources/read` throws on a miss. New `WireCodec.encodeErrorCode` is the era-aware seam wired at the protocol-layer handler-error path; both era codecs flat-map −32002 → −32602 (no era branch preserves −32002). `ProtocolErrorCode.ResourceNotFound` (−32002) stays importable with receive-tolerated JSDoc; `ProtocolError.fromError` reconstructs the typed class for **either** code only when `error.data` carries `uri` (a bare −32002 without `data.uri` stays a generic `ProtocolError`). HTTP status: in-band 200 both eras. The −32000 "Unsupported protocol version" literal is verified untouched; `encodeErrorCode` unit test pins pass-through for −32000/−32001/−32003/−32004/−32042.

### Small additives + doc closeout

- `tools/list` / `prompts/list` / `resources/list` deterministic registration-order verified at the wire (test pins existing behavior)
- empty-string cursor pass-through verified
- `migration.md` "Specification clarifications adopted (no SDK behavior change)" section
- 5 pre-existing `{@link}` warnings resolved → `docs:check` 0 warnings

### e2e: 2026-era sibling rows

14 new `addedInSpecVersion:'2026-07-28'` rows on `entryModern`, supersedes-linked to 19 retired 2025-shape source rows: `sampling:mrtr:create:{basic,model-preferences,system-prompt,include-context}`, `elicitation:mrtr:form:{basic,action:decline,action:cancel,schema:primitives}`, `roots:mrtr:list:{basic,empty}`, `{tools,resources,prompts}:listen:list-changed`, `client:listen:auto-refresh`. Cell delta 2740 → 2679 (−61 net = +14 genuine `entryModern` cells, −75 duplicate 2026-axis cells removed from the retired rows — those were registering identical runs to their 2025-11-25 cells because the body never pinned protocol version on stateful arms).

### e2e: entry-hosting cells

10 new `typescript:hosting:entry:*` rows (no edits to existing rows): HTTP mechanics via `wired.fetch` (`method-405`, `parse-error-400`, `no-session-id`, `legacy-accept-406`, `legacy-content-type-415`, `legacy-protocol-version-header-400`, `legacy-protocol-version-default`) and bearer-auth + `ctx.http` via self-hosted `createMcpHandler` (`ctx-http-req-headers`, `auth:missing-401`, `auth:authinfo-propagates`). Cell delta 2679 → 2695 (+16). The full-OAuth-flow cell is deferred (targets a surface still under design).

## How Has This Been Tested?

- new unit tests: `errorSurfacePins.test.ts` (accept-both data-parse contract), `encodeContract.test.ts` (flat-map + pass-through table both eras)
- existing-test modifications (all strengthened or relocated, none weakened): `mcp.test.ts:2731` expectation `ResourceNotFound` → `InvalidParams` + `data.uri`; e2e `resources:read:unknown-uri` body rewritten (asserts −32602 + `data.uri` + accept-both via `fromError` + importability + MUST-NOT-empty rider); `eraParityErrorShapes.test.ts:202` and `perRequestTransport.test.ts:174` expected `−32_002` → `−32_602`
- conformance: `sep-2164-resource-not-found` burned down on both yaml files (3p/0f at this pin)
- Full gates at tip: typecheck:all, lint:all, **docs:check 0 warnings**, build:all; package suites core 1210 / codemod 350 / server-legacy 162 / server 334 / client 535 / hono 12 / fastify 22 / express 40 / node 88 / shared 2; integration 348; e2e 2490p/205xf/2695 cells, 0 unexpected; conformance client / client:all / client:2026 / server / server:draft / server:2026 all rc=0

## Breaking Changes

None at the API surface. Behavior change: `resources/read` on an unknown URI now answers −32602 (was −32002) on every era. Receive-side accepts both; changeset + `migration.md` / `migration-SKILL.md` entries included.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

Deferred to follow-up: the client cache-freshness test battery (~100–150 LOC; surfaces exist, only the battery is unbuilt). The conformance-floor exit criterion ("draft suite green except flag-gated auth set") is reached after `fweinberger/on-renumber` in this stack flips the spec#2907 error codes; at this tip `server:draft` is 70p/4f with 3 of the 4 expected-fails being renumber fallout.

