### PR TITLE
test(e2e): hosting-entry-http arm-posture fix; widen method-405 probe set

### DIFF
--- a/test/e2e/requirements.ts
+++ b/test/e2e/requirements.ts
@@ -2381,9 +2381,9 @@ export const REQUIREMENTS: Record<string, Requirement> = {
     'typescript:hosting:entry:method-405': {
         source: 'sdk',
         behavior:
-            'An unsupported HTTP method (PUT, PATCH) on a createMcpHandler endpoint is answered 405 with a JSON-RPC Method-not-allowed body on both legs: the stateless legacy fallback rejects every non-POST method, and the modern-only strict path rejects body-less non-POST traffic via the modern-only-method-not-allowed cell.',
+            'A non-POST HTTP method (GET, DELETE, PUT, PATCH) on a createMcpHandler endpoint is answered 405 with a JSON-RPC Method-not-allowed body on both legs: the stateless legacy fallback rejects every non-POST method, and the modern-only strict path rejects body-less non-POST traffic via the modern-only-method-not-allowed cell.',
         transports: ['entryStateless', 'entryModern'],
-        note: 'Runs on the createMcpHandler entry arms; the unsupported methods are POSTed through wired.fetch so the HTTP status and body are observed directly. The entry does not emit an Allow header (the per-session server transport does), so only the status and JSON-RPC error shape are pinned.'
+        note: 'Runs on the createMcpHandler entry arms; each non-POST method is sent through wired.fetch so the HTTP status and body are observed directly. The entry does not emit an Allow header (the per-session server transport does), so only the status and JSON-RPC error shape are pinned.'
     },
     'typescript:hosting:entry:parse-error-400': {
         source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#sending-messages-to-the-server',

--- a/test/e2e/scenarios/hosting-entry-http.test.ts
+++ b/test/e2e/scenarios/hosting-entry-http.test.ts
@@ -32,9 +32,11 @@ function echoFactory(_ctx?: McpRequestContext): McpServer {
 
 verifies('typescript:hosting:entry:method-405', async ({ transport }: TestArgs) => {
     const client = new Client({ name: 'method-405-client', version: '1.0.0' });
-    await using wired = await wire(transport, echoFactory, client, { entry: { legacy: 'stateless' } });
+    // No `entry` override: the arm posture (`stateless` on entryStateless,
+    // `reject` on entryModern) is the configuration under test.
+    await using wired = await wire(transport, echoFactory, client);
 
-    for (const method of ['PUT', 'PATCH']) {
+    for (const method of ['GET', 'DELETE', 'PUT', 'PATCH']) {
         const response = await wired.fetch!(wired.url!, { method });
         expect(response.status).toBe(405);
         const body = (await response.json()) as { jsonrpc: string; error: { code: number; message: string } };
@@ -46,7 +48,7 @@ verifies('typescript:hosting:entry:method-405', async ({ transport }: TestArgs) 
 
 verifies('typescript:hosting:entry:parse-error-400', async ({ transport }: TestArgs) => {
     const client = new Client({ name: 'parse-error-client', version: '1.0.0' });
-    await using wired = await wire(transport, echoFactory, client, { entry: { legacy: 'stateless' } });
+    await using wired = await wire(transport, echoFactory, client);
 
     const response = await wired.fetch!(wired.url!, {
         method: 'POST',
@@ -138,7 +140,7 @@ verifies('typescript:hosting:entry:legacy-protocol-version-default', async ({ tr
 
 verifies('typescript:hosting:entry:no-session-id', async ({ transport }: TestArgs) => {
     const client = new Client({ name: 'no-session-id-client', version: '1.0.0' });
-    await using wired = await wire(transport, echoFactory, client, { entry: { legacy: 'stateless' } });
+    await using wired = await wire(transport, echoFactory, client);
 
     // A typed round trip through the wired client (so both the connect-time
     // negotiation and a follow-up request are recorded), then assert no

--- a/test/e2e/scenarios/hosting-entry.test.ts
+++ b/test/e2e/scenarios/hosting-entry.test.ts
@@ -123,7 +123,7 @@ verifies('typescript:hosting:entry:strict-rejects-legacy', async ({ transport }:
 
 verifies('typescript:hosting:entry:notification-202', async ({ transport }: TestArgs) => {
     const client = new Client({ name: 'notify-client', version: '1.0.0' });
-    await using wired = await wire(transport, greetFactory, client, { entry: { legacy: 'stateless' } });
+    await using wired = await wire(transport, greetFactory, client);
 
     // 2025 leg: an envelope-less notification rides the legacy stateless slot.
     // 2026 leg: the notification carries the per-request envelope and a method


### PR DESCRIPTION
Fixes the arm-posture override in the `hosting-entry-http` e2e scenarios introduced in `fweinberger/on-m12` and widens the `method-405` probe set. Stacked on `fweinberger/on-m12`.

## Motivation and Context

`method-405` / `parse-error-400` / `no-session-id` were passing `wire(..., { entry: { legacy: 'stateless' } })`; the helper spreads `sniff.entry` **after** the arm posture, so on `entryModern` the handler ran `legacy: 'stateless'` instead of `'reject'` — the `entryModern` cells were config-duplicates of `entryStateless`.

Fix: drop the override entirely. The arm posture (`'stateless'` on `entryStateless`, `'reject'` on `entryModern`) is exactly what each cell should test; the override was redundant on one arm and wrong on the other. Verified the modern-strict path answers identically for these probes (non-POST → 405/−32000; non-JSON POST → 400/−32700; no `Mcp-Session-Id` emitted).

Also widens the `method-405` probe loop `['PUT','PATCH']` → `['GET','DELETE','PUT','PATCH']` (both legs answer 405/−32000/"Method not allowed." for every non-POST method) and rewords the `requirements.ts` note to match.

## How Has This Been Tested?

- `hosting-entry-http.test.ts` 10/10
- e2e full matrix: 2695 cells (unchanged), 2484p/205xf — the 6 `scenarios/stdio.test.ts` spawn fails are pre-existing at the base and unrelated (sandbox artifacts)
- typecheck, lint

## Breaking Changes

None. Test-only.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

This branch also carries an empty marker commit (`951baaae5`) — no SDK changes; can be dropped on squash.
