### PR TITLE
fix(middleware): stop bundling workspace type graphs into .d.ts (avoids dts-gen OOM)

### DIFF
--- a/packages/middleware/express/tsdown.config.ts
+++ b/packages/middleware/express/tsdown.config.ts
@@ -12,11 +12,11 @@ export default defineConfig({
     shims: true,
     dts: {
         resolver: 'tsc',
+        // Keep workspace deps as external imports in the bundled .d.ts instead of
+        // inlining their type graph — see ../node/tsdown.config.ts for the rationale.
         compilerOptions: {
-            baseUrl: '.',
-            paths: {
-                '@modelcontextprotocol/server': ['../server/src/index.ts']
-            }
+            paths: {},
+            preserveSymlinks: true
         }
     }
 });

--- a/packages/middleware/fastify/tsdown.config.ts
+++ b/packages/middleware/fastify/tsdown.config.ts
@@ -12,11 +12,11 @@ export default defineConfig({
     shims: true,
     dts: {
         resolver: 'tsc',
+        // Keep workspace deps as external imports in the bundled .d.ts instead of
+        // inlining their type graph — see ../node/tsdown.config.ts for the rationale.
         compilerOptions: {
-            baseUrl: '.',
-            paths: {
-                '@modelcontextprotocol/server': ['../server/src/index.ts']
-            }
+            paths: {},
+            preserveSymlinks: true
         }
     }
 });

--- a/packages/middleware/hono/tsdown.config.ts
+++ b/packages/middleware/hono/tsdown.config.ts
@@ -12,11 +12,11 @@ export default defineConfig({
     shims: true,
     dts: {
         resolver: 'tsc',
+        // Keep workspace deps as external imports in the bundled .d.ts instead of
+        // inlining their type graph — see ../node/tsdown.config.ts for the rationale.
         compilerOptions: {
-            baseUrl: '.',
-            paths: {
-                '@modelcontextprotocol/server': ['../server/src/index.ts']
-            }
+            paths: {},
+            preserveSymlinks: true
         }
     }
 });

--- a/packages/middleware/node/src/streamableHttp.ts
+++ b/packages/middleware/node/src/streamableHttp.ts
@@ -10,8 +10,14 @@
 import type { IncomingMessage, ServerResponse } from 'node:http';
 
 import { getRequestListener } from '@hono/node-server';
-import type { AuthInfo, JSONRPCMessage, MessageExtraInfo, RequestId, Transport } from '@modelcontextprotocol/core';
-import type { WebStandardStreamableHTTPServerTransportOptions } from '@modelcontextprotocol/server';
+import type {
+    AuthInfo,
+    JSONRPCMessage,
+    MessageExtraInfo,
+    RequestId,
+    Transport,
+    WebStandardStreamableHTTPServerTransportOptions
+} from '@modelcontextprotocol/server';
 import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/server';
 
 /**

--- a/packages/middleware/node/tsdown.config.ts
+++ b/packages/middleware/node/tsdown.config.ts
@@ -21,12 +21,17 @@ export default defineConfig({
     //    Bundles d.ts files into a single output
     dts: {
         resolver: 'tsc',
-        // override just for DTS generation:
+        // The dev tsconfig.json maps @modelcontextprotocol/* to workspace source via
+        // `paths` so typecheck/IDE work without a prior build. For declaration emit we
+        // need the opposite: resolve workspace deps through node_modules and keep them
+        // as *external* imports in the bundled .d.ts (server is a peerDependency, so
+        // consumers already have its types). `paths: {}` disables the dev source
+        // mappings; `preserveSymlinks` keeps `node_modules` in the resolved path so
+        // rolldown-plugin-dts recognises the dep as external instead of inlining the
+        // whole upstream type graph (which OOMs once core's surface gets large enough).
         compilerOptions: {
-            baseUrl: '.',
-            paths: {
-                '@modelcontextprotocol/core': ['../core/src/index.ts']
-            }
+            paths: {},
+            preserveSymlinks: true
         }
     }
 });

--- a/packages/middleware/node/tsdown.config.ts
+++ b/packages/middleware/node/tsdown.config.ts
@@ -29,6 +29,12 @@ export default defineConfig({
         // mappings; `preserveSymlinks` keeps `node_modules` in the resolved path so
         // rolldown-plugin-dts recognises the dep as external instead of inlining the
         // whole upstream type graph (which OOMs once core's surface gets large enough).
+        //
+        // TODO: drop this override once tsdown pulls rolldown-plugin-dts >=0.21.0
+        // (sxzz/rolldown-plugin-dts@03998d41 honours rolldown `external` before the
+        // node_modules path test). Bumping also requires reworking the `dts.resolve`
+        // usage in packages/{server,client}/tsdown.config.ts — that option was removed
+        // in the same release.
         compilerOptions: {
             paths: {},
             preserveSymlinks: true


### PR DESCRIPTION
The four `packages/middleware/*` tsdown builds were inlining the entire `@modelcontextprotocol/server` (and transitively `core`) type graph into their bundled `.d.mts` instead of emitting an external `import` for the peer dependency. On `main` this is ~14s and a 540 KB sourcemap for `@modelcontextprotocol/node` (a ~200-line wrapper); once `core`'s public type surface grows past a fairly low threshold the dts step OOMs at the default Node heap.

## Motivation and Context

`rolldown-plugin-dts` (the dts bundler tsdown uses) decides external-vs-bundle by testing the resolved path for `node_modules`. With pnpm workspace symlinks the realpath is `packages/server/...` — no `node_modules` in it — so the peer dep is treated as local source and inlined. The dev `tsconfig.json` `paths` (which map `@modelcontextprotocol/*` to workspace source for IDE/typecheck) compound this by routing the resolver straight at source files. The explicit `dts.compilerOptions.paths` overrides that were already in these configs were dead — wrong relative depth — so they never did anything.

This is fixed upstream in `rolldown-plugin-dts@0.21.0` (sxzz/rolldown-plugin-dts@03998d41), which honours rolldown's `external` resolution before the `node_modules` path test. We're pinned one minor behind via `tsdown: ^0.18.0`. Bumping tsdown is the right long-term fix but the same upstream release also removed the `dts.resolve` option that `packages/{server,client}/tsdown.config.ts` rely on, so the bump is a separate, larger change — TODO left in `packages/middleware/node/tsdown.config.ts`.

## How Has This Been Tested?

- `@modelcontextprotocol/node` build: 14s → 0.8s; `dist/index.d.mts` 22.77 KB → 4.90 KB (sourcemap 539 KB → 0.37 KB). Output now starts with `import { AuthInfo, JSONRPCMessage, MessageExtraInfo, RequestId, Transport, WebStandardStreamableHTTPServerTransportOptions } from "@modelcontextprotocol/server"`.
- `hono` / `fastify` `dist/index.d.mts` are byte-identical to `main` (they only import from their framework peer); `express` differs only by replacing inlined server types with the external import.
- JS bundle (`dist/index.mjs`) is byte-identical for all four — the change is scoped to `dts.compilerOptions`.
- Consumer typecheck against built dist: `NodeStreamableHTTPServerTransport` is assignable to `Transport` from `@modelcontextprotocol/server` and accepted by `McpServer.connect()`.
- Verified the OOM no longer reproduces on a branch with a larger `core` type surface that previously crashed with `node::OOMErrorHandler` / exit 134.
- `pnpm typecheck:all`, `pnpm build:all`, middleware test suites (126 tests) all pass.

## Breaking Changes

None. `@modelcontextprotocol/server` is already a required `peerDependency` of every middleware package, so the external type import resolves for all existing consumers.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

- Also retargets `packages/middleware/node/src/streamableHttp.ts`'s type-only import from the private `@modelcontextprotocol/core` package to `@modelcontextprotocol/server`, which re-exports the same five types via `core/public`. Middleware packages should only depend on their declared peer dep.
- Because the peer dep is externalised by path-match before its types are read, middleware dts emit does **not** require `packages/server/dist` to exist — output is byte-identical with it absent, so there is no new build-order constraint.
- Follow-up: bump `tsdown` (pulls `rolldown-plugin-dts >=0.21.0`) and drop this override; rework the `dts.resolve: ['ajv', 'ajv-formats']` usage in server/client at the same time.