### PR TITLE
feat(client): SEP-2468 RFC 9207 iss + RFC 8414 §3.3 issuer-echo validation

### DIFF
--- a/.changeset/auth-iss-validation.md
+++ b/.changeset/auth-iss-validation.md
@@ -1,0 +1,6 @@
+---
+"@modelcontextprotocol/core": minor
+"@modelcontextprotocol/client": minor
+---
+
+Implement RFC 9207 / RFC 8414 §3.3 OAuth issuer validation (SEP-2468). `discoverAuthorizationServerMetadata()` now rejects metadata whose `issuer` does not match the discovery URL (opt out via `skipIssuerValidation` / `AuthOptions.skipIssuerMetadataValidation` — security-weakening). `auth()`, `exchangeAuthorization()`, `fetchToken()`, and `transport.finishAuth(code, iss?)` now validate the authorization-callback `iss` against the recorded issuer before redeeming the code; new `IssuerMismatchError` and `validateAuthorizationResponseIssuer()` are exported.

--- a/docs/client.md
+++ b/docs/client.md
@@ -192,8 +192,8 @@ Server only implements `client_secret_basic`/`client_secret_post`, so there is n
 ### Full OAuth with user authorization
 
 For user-facing applications, implement the {@linkcode @modelcontextprotocol/client!client/auth.OAuthClientProvider | OAuthClientProvider} interface to handle the full authorization code flow (redirects, code verifiers, token storage, dynamic client registration). The {@linkcode
-@modelcontextprotocol/client!client/client.Client#connect | connect()} call will throw {@linkcode @modelcontextprotocol/client!client/auth.UnauthorizedError | UnauthorizedError} when authorization is needed — catch it, complete the browser flow, call {@linkcode
-@modelcontextprotocol/client!client/streamableHttp.StreamableHTTPClientTransport#finishAuth | transport.finishAuth(code)}, and reconnect.
+@modelcontextprotocol/client!client/client.Client#connect | connect()} call will throw {@linkcode @modelcontextprotocol/client!client/auth.UnauthorizedError | UnauthorizedError} when authorization is needed — catch it, complete the browser flow, pass the redirect URL's query to {@linkcode
+@modelcontextprotocol/client!client/streamableHttp.StreamableHTTPClientTransport#finishAuth | transport.finishAuth(url.searchParams)} (so the SDK can validate the RFC 9207 `iss` parameter), and reconnect.
 
 For a complete working OAuth flow, see [`simpleOAuthClient.ts`](https://github.com/modelcontextprotocol/typescript-sdk/blob/main/examples/oauth/simpleOAuthClient.ts) and
 [`simpleOAuthClientProvider.ts`](https://github.com/modelcontextprotocol/typescript-sdk/blob/main/examples/oauth/simpleOAuthClientProvider.ts).

--- a/docs/migration-SKILL.md
+++ b/docs/migration-SKILL.md
@@ -579,6 +579,10 @@ Output-schema validator compilation is now lazy (first `callTool()` against the 
 New (no v1 equivalent): `Client.connect(transport, { prior: DiscoverResult })` — zero-round-trip connect (2026-07-28+ only; throws `EraNegotiationFailed` otherwise). Probe once, persist `client.getDiscoverResult()` (`JSON.stringify`), feed to every worker. New exported type:
 `ConnectOptions` (extends `RequestOptions` with `prior?: DiscoverResult`).
 
+OAuth callback handling: pass the callback URL's `URLSearchParams` to `transport.finishAuth(url.searchParams)` (or pass `iss` alongside `authorizationCode` to `auth()` / `finishAuth(code, iss)`). The SDK now validates `iss` per RFC 9207: a mismatched `iss` throws `IssuerMismatchError` regardless of advertised support; a missing `iss` throws only when the AS advertised `authorization_response_iss_parameter_supported: true`. Do not surface `error_description` / `error_uri` from a callback that failed this check.
+
+`discoverAuthorizationServerMetadata()` now rejects metadata whose `issuer` does not exactly match the URL it was fetched for (RFC 8414 §3.3), throwing `IssuerMismatchError`. Pass `skipIssuerMetadataValidation: true` on `AuthOptions` (or `skipIssuerValidation: true` on the helper) only as a temporary workaround for a known-misconfigured AS.
+
 No code changes required; wire-behavior note: on a 2026-07-28 Streamable HTTP connection, aborting an in-flight client request (caller `signal` / timeout) closes that request's SSE response stream as the spec cancellation signal — `notifications/cancelled` is no longer POSTed
 there. 2025-era connections and stdio at any era still send `notifications/cancelled`. Custom `Transport` implementations that open one underlying request per outbound message and honor `TransportSendOptions.requestSignal` may declare `readonly hasPerRequestStream = true` to opt
 into the same routing.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1564,9 +1564,28 @@ The inline options object on `auth()` is now the named `AuthOptions` type, expor
 
 New TypeScript-only aliases `StoredOAuthTokens` and `StoredOAuthClientInformation` add an optional `issuer?: string` field on top of the wire types and are used as the parameter/return types of `tokens()` / `saveTokens()` and `clientInformation()` / `saveClientInformation()`. The `issuer` field is **not** part of the RFC 6749/7591 wire responses and is intentionally absent from `OAuthTokensSchema` / `OAuthClientInformationSchema` so an authorization server cannot populate it; once the SEP-2352 behavior change lands the SDK will stamp it onto credentials before calling `saveTokens` / `saveClientInformation`. Provider implementations should round-trip it unchanged. The field is currently inert.
 
+### Authorization-server mix-up defense (RFC 9207 / RFC 8414 §3.3)
+
+**Action required for hosts handling OAuth callbacks.**
+
+`transport.finishAuth()` and `auth()` now validate the `iss` parameter from the authorization callback against the issuer recorded from the authorization server's validated metadata (RFC 9207). A **mismatched** `iss` is rejected with `IssuerMismatchError` before the code is exchanged regardless of what the AS advertised; a **missing** `iss` is rejected only when the AS advertised `authorization_response_iss_parameter_supported: true`.
+
+**You must** pass the callback URL's query parameters to the SDK so it can read `iss` alongside `code`:
+
+```typescript
+const url = new URL(callbackUrl);
+await transport.finishAuth(url.searchParams); // SDK reads `code` + `iss`
+```
+
+`transport.finishAuth(code, iss)` remains supported for back-compat. If you bypass `auth()` and call `exchangeAuthorization()` / `fetchToken()` directly, pass `iss` in the options bag — the same validation runs there.
+
+**You must not** display or act on `error`, `error_description`, or `error_uri` from the callback URL when `IssuerMismatchError` is thrown — those values are attacker-controlled in a mix-up attack.
+
+`discoverAuthorizationServerMetadata()` now rejects metadata whose `issuer` does not exactly match the URL it was fetched for (RFC 8414 §3.3). If you connect to a known-misconfigured AS, set `skipIssuerMetadataValidation: true` on `StreamableHTTPClientTransportOptions` / `SSEClientTransportOptions` (or on `AuthOptions` if you call `auth()` directly, or `skipIssuerValidation: true` on the low-level helper) — **this weakens the mix-up defense and should be treated as a temporary workaround.** It suppresses only the metadata-echo check; the callback-`iss` validation always runs (and degrades to a no-op only when `iss` is absent and the AS does not advertise support).
+
 ### Conformance obligations for `OAuthClientProvider` implementers
 
-<!-- Filled in as the SEP-2468/2352/2350/837/2207 behavior PRs land. -->
+<!-- Filled in as the SEP-2352/2350/837/2207 behavior PRs land. -->
 
 ## Using an LLM to migrate your code
 

--- a/examples/oauth/README.md
+++ b/examples/oauth/README.md
@@ -5,7 +5,7 @@ The **authorization-code** OAuth grant — the interactive "user signs in and ap
 - `server.ts` — `setupAuthServer` (the better-auth/OIDC demo Authorization Server from `@mcp-examples/shared`) on `:PORT+1`, and a `createMcpHandler` Resource Server behind `requireBearerAuth({ verifier: demoTokenVerifier })` on `:PORT/mcp`, advertising the AS via
   `createProtectedResourceMetadataRouter` (RFC 9728). DEMO ONLY — the AS auto-signs-in a fixed user, and with `OAUTH_DEMO_AUTO_CONSENT=1` it also auto-approves the consent screen.
 - `client.ts` — **CI-runnable headless flow.** Drives the same SDK auth machinery as the browser client, but instead of `open()`ing the authorization URL it follows the 302 chain itself with `fetch(..., { redirect: 'manual' })` (the demo AS's auto-sign-in + auto-consent collapse
-  every interactive step into a redirect), reads the `code` off the final `Location` header, calls `transport.finishAuth(code)`, reconnects, and asserts `ctx.authInfo` round-trips. This is what the harness runs.
+  every interactive step into a redirect), reads the callback query off the final `Location` header, calls `transport.finishAuth(url.searchParams)` (so the SDK reads `code` + `iss` per RFC 9207), reconnects, and asserts `ctx.authInfo` round-trips. This is what the harness runs.
 - `simpleOAuthClient.ts` + `simpleOAuthClientProvider.ts` — **manual real-browser flow.** Full authorization-code flow against any OAuth-protected MCP server: opens the browser, runs a local callback server on `:8090`, exchanges the code, then drops into a small `list`/`call`
   REPL. Run this when you want to see the consent page.
 - `dualModeAuth.ts` — two auth patterns through the one `authProvider` option: host-managed bearer token vs a built-in `OAuthClientProvider`.

--- a/examples/oauth/client.ts
+++ b/examples/oauth/client.ts
@@ -48,7 +48,7 @@ const CALLBACK_URL = 'http://127.0.0.1:8090/callback';
  * would, and the demo AS's auto-sign-in + `autoConsent` collapse every
  * interactive step into a 302.
  */
-async function followAuthorizationRedirects(authorizationUrl: URL): Promise<string> {
+async function followAuthorizationRedirects(authorizationUrl: URL): Promise<URLSearchParams> {
     let next = authorizationUrl.href;
     // Crude cookie jar — enough for a single-origin demo AS.
     const jar = new Map<string, string>();
@@ -76,7 +76,7 @@ async function followAuthorizationRedirects(authorizationUrl: URL): Promise<stri
             const error = resolved.searchParams.get('error');
             if (error) throw new Error(`AS returned error on callback: ${error} ${resolved.searchParams.get('error_description') ?? ''}`);
             if (!code) throw new Error(`callback redirect missing ?code: ${resolved.href}`);
-            return code;
+            return resolved.searchParams;
         }
         next = resolved.href;
     }
@@ -121,14 +121,16 @@ runClient('oauth', async () => {
 
     // ---- 2. Follow the authorization URL headlessly ---------------------------
     // (the browser-and-user stand-in; see `followAuthorizationRedirects`).
-    const code = await followAuthorizationRedirects(capturedAuthorizationUrl!);
+    const callbackParams = await followAuthorizationRedirects(capturedAuthorizationUrl!);
 
     // ---- 3. Exchange the code for tokens --------------------------------------
-    // In the browser flow the local callback server hands this `code` to
-    // `transport.finishAuth`; we read it off the `Location` header instead. The
-    // SDK now POSTs `grant_type=authorization_code` (+ PKCE `code_verifier`) to
-    // the AS `/token` endpoint and saves the tokens on `provider`.
-    await firstTransport.finishAuth(code);
+    // In the browser flow the local callback server hands the redirect query to
+    // `transport.finishAuth`; we read it off the final `Location` header instead.
+    // The SDK reads `code` + `iss` (RFC 9207) from the params, validates `iss`
+    // against the recorded issuer, then POSTs `grant_type=authorization_code`
+    // (+ PKCE `code_verifier`) to the AS `/token` endpoint and saves the tokens
+    // on `provider`.
+    await firstTransport.finishAuth(callbackParams);
     const tokens = provider.tokens();
     check.ok(tokens?.access_token, 'token exchange should have yielded an access_token');
     check.equal(tokens?.token_type, 'Bearer');

--- a/examples/oauth/simpleOAuthClient.ts
+++ b/examples/oauth/simpleOAuthClient.ts
@@ -77,8 +77,8 @@ class InteractiveOAuthClient {
     /**
      * Starts a temporary HTTP server to receive the OAuth callback
      */
-    private async waitForOAuthCallback(): Promise<string> {
-        return new Promise<string>((resolve, reject) => {
+    private async waitForOAuthCallback(): Promise<URLSearchParams> {
+        return new Promise<URLSearchParams>((resolve, reject) => {
             const server = createServer((req, res) => {
                 // Ignore favicon requests
                 if (req.url === '/favicon.ico') {
@@ -105,7 +105,8 @@ class InteractiveOAuthClient {
             </html>
           `);
 
-                    resolve(code);
+                    // Hand back the whole query — finishAuth() reads `code` + `iss` (RFC 9207) itself.
+                    resolve(parsedUrl.searchParams);
                     setTimeout(() => server.close(), 3000);
                 } else if (error) {
                     console.log(`❌ Authorization error: ${error}`);
@@ -148,10 +149,11 @@ class InteractiveOAuthClient {
         } catch (error) {
             if (error instanceof UnauthorizedError) {
                 console.log('🔐 OAuth required - waiting for authorization...');
-                const callbackPromise = this.waitForOAuthCallback();
-                const authCode = await callbackPromise;
-                await transport.finishAuth(authCode);
-                console.log('🔐 Authorization code received:', authCode);
+                const callbackParams = await this.waitForOAuthCallback();
+                // Pass the whole callback query — the SDK extracts `code` and validates
+                // `iss` against the recorded issuer (RFC 9207) before exchanging the code.
+                await transport.finishAuth(callbackParams);
+                console.log('🔐 Authorization code received:', callbackParams.get('code'));
                 console.log('🔌 Reconnecting with authenticated transport...');
                 await this.attemptConnection(oauthProvider);
             } else {

--- a/packages/client/src/client/auth.ts
+++ b/packages/client/src/client/auth.ts
@@ -27,6 +27,11 @@ import {
 } from '@modelcontextprotocol/core';
 import pkceChallenge from 'pkce-challenge';
 
+import { IssuerMismatchError } from './authErrors.js';
+
+// Re-exported for back-compat — the canonical home is ./authErrors.js.
+export { IssuerMismatchError } from './authErrors.js';
+
 /**
  * Function type for adding client authentication to token requests.
  */
@@ -118,13 +123,18 @@ export function isOAuthClientProvider(provider: AuthProvider | OAuthClientProvid
  * `WWW-Authenticate` parameters from the 401 response and runs {@linkcode auth}.
  * Used by {@linkcode adaptOAuthProvider} to bridge `OAuthClientProvider` to `AuthProvider`.
  */
-export async function handleOAuthUnauthorized(provider: OAuthClientProvider, ctx: UnauthorizedContext): Promise<void> {
+export async function handleOAuthUnauthorized(
+    provider: OAuthClientProvider,
+    ctx: UnauthorizedContext,
+    extraAuthOptions?: Pick<AuthOptions, 'skipIssuerMetadataValidation'>
+): Promise<void> {
     const { resourceMetadataUrl, scope } = extractWWWAuthenticateParams(ctx.response);
     const result = await auth(provider, {
         serverUrl: ctx.serverUrl,
         resourceMetadataUrl,
         scope,
-        fetchFn: ctx.fetchFn
+        fetchFn: ctx.fetchFn,
+        ...extraAuthOptions
     });
     if (result !== 'AUTHORIZED') {
         throw new UnauthorizedError();
@@ -137,13 +147,16 @@ export async function handleOAuthUnauthorized(provider: OAuthClientProvider, ctx
  * the adapted provider for `_commonHeaders()` and 401 handling, while keeping the
  * original `OAuthClientProvider` for OAuth-specific paths (`finishAuth()`, 403 upscoping).
  */
-export function adaptOAuthProvider(provider: OAuthClientProvider): AuthProvider {
+export function adaptOAuthProvider(
+    provider: OAuthClientProvider,
+    extraAuthOptions?: Pick<AuthOptions, 'skipIssuerMetadataValidation'>
+): AuthProvider {
     return {
         token: async () => {
             const tokens = await provider.tokens();
             return tokens?.access_token;
         },
-        onUnauthorized: async ctx => handleOAuthUnauthorized(provider, ctx)
+        onUnauthorized: async ctx => handleOAuthUnauthorized(provider, ctx, extraAuthOptions)
     };
 }
 
@@ -412,6 +425,67 @@ export class UnauthorizedError extends Error {
     }
 }
 
+/**
+ * Validates the `iss` parameter from an authorization response against the
+ * issuer recorded from the authorization server's validated metadata, per
+ * RFC 9207 §2.4 and the MCP specification's four-row decision table.
+ *
+ * | `issParameterSupported` | `iss`   | Action                                           |
+ * | ----------------------- | ------- | ------------------------------------------------ |
+ * | `true`                  | present | compare; throw {@linkcode IssuerMismatchError} on mismatch |
+ * | `true`                  | absent  | throw {@linkcode IssuerMismatchError}            |
+ * | `false`                 | present | compare; throw {@linkcode IssuerMismatchError} on mismatch |
+ * | `false`                 | absent  | proceed (no-op)                                  |
+ *
+ * Comparison is **simple string equality** (RFC 3986 §6.2.1). Scheme/host case
+ * folding, default-port elision, trailing-slash, and percent-encoding
+ * normalization are explicitly **not** applied — any difference is a mismatch.
+ *
+ * When `expectedIssuer` is `undefined` (no validated metadata document exists),
+ * the check has no authentic baseline and degenerates to a no-op.
+ *
+ * @throws {IssuerMismatchError} with `kind: 'authorization_response'`
+ */
+/**
+ * Reads RFC 9207's `authorization_response_iss_parameter_supported` from
+ * authorization-server metadata. Only a literal `true` counts as advertised;
+ * absent, `false`, or a non-boolean wire value (coerced to `undefined` by the
+ * schema) means not advertised.
+ */
+function isIssParameterSupported(metadata: AuthorizationServerMetadata | undefined): boolean {
+    return metadata?.authorization_response_iss_parameter_supported === true;
+}
+
+export function validateAuthorizationResponseIssuer({
+    iss,
+    expectedIssuer,
+    issParameterSupported
+}: {
+    /** The form-urldecoded `iss` query parameter from the authorization callback, or `undefined` if absent. */
+    iss: string | undefined;
+    /** The `issuer` value from the authorization server's validated metadata document. */
+    expectedIssuer: string | undefined;
+    /** Whether the metadata advertised `authorization_response_iss_parameter_supported: true`. */
+    issParameterSupported: boolean;
+}): void {
+    if (expectedIssuer === undefined) {
+        // No validated metadata document → no recorded issuer → no comparison (table row 4).
+        return;
+    }
+    if (iss === undefined) {
+        if (issParameterSupported) {
+            // Row 2: AS advertised that it always sends `iss`; absence is a stripped-parameter attack indicator.
+            throw new IssuerMismatchError('authorization_response', expectedIssuer, undefined);
+        }
+        // Row 4: not advertised, not present → proceed.
+        return;
+    }
+    // Rows 1 & 3: present → compare with simple string comparison only.
+    if (iss !== expectedIssuer) {
+        throw new IssuerMismatchError('authorization_response', expectedIssuer, iss);
+    }
+}
+
 export type ClientAuthMethod = 'client_secret_basic' | 'client_secret_post' | 'none';
 
 function isClientAuthMethod(method: string): method is ClientAuthMethod {
@@ -582,8 +656,10 @@ export interface AuthOptions {
     /**
      * The form-urldecoded `iss` query parameter from the authorization callback,
      * if present. Passed through to RFC 9207 §2.4 issuer validation alongside
-     * `authorizationCode`. The validation behavior is wired up in a follow-up
-     * change; this field is currently inert.
+     * `authorizationCode`. Validated against the recorded issuer per RFC 9207
+     * §2.4 before the code is redeemed — see
+     * {@linkcode validateAuthorizationResponseIssuer} and the migration guide's
+     * *Authorization-server mix-up defense* section.
      */
     iss?: string;
     /** Scope to request; computed by Scope Selection Strategy when omitted. */
@@ -595,9 +671,7 @@ export interface AuthOptions {
     /**
      * Opt-out for the RFC 8414 §3.3 issuer-echo check during authorization
      * server discovery. Disabling it is **security-weakening** and intended only
-     * for authorization servers known to publish a mismatched `issuer`. The
-     * check itself is wired up in a follow-up change; this flag is currently
-     * inert.
+     * for authorization servers known to publish a mismatched `issuer`.
      *
      * @default false
      */
@@ -664,7 +738,7 @@ export function determineScope(options: {
 
 async function authInternal(
     provider: OAuthClientProvider,
-    { serverUrl, authorizationCode, scope, resourceMetadataUrl, fetchFn }: AuthOptions
+    { serverUrl, authorizationCode, iss, scope, resourceMetadataUrl, fetchFn, skipIssuerMetadataValidation }: AuthOptions
 ): Promise<AuthResult> {
     // Check if the provider has cached discovery state to skip discovery
     const cachedState = await provider.discoveryState?.();
@@ -685,7 +759,11 @@ async function authInternal(
         authorizationServerUrl = cachedState.authorizationServerUrl;
         resourceMetadata = cachedState.resourceMetadata;
         metadata =
-            cachedState.authorizationServerMetadata ?? (await discoverAuthorizationServerMetadata(authorizationServerUrl, { fetchFn }));
+            cachedState.authorizationServerMetadata ??
+            (await discoverAuthorizationServerMetadata(authorizationServerUrl, {
+                fetchFn,
+                skipIssuerValidation: skipIssuerMetadataValidation
+            }));
 
         // If resource metadata wasn't cached, try to fetch it for selectResourceURL
         if (!resourceMetadata) {
@@ -716,7 +794,11 @@ async function authInternal(
         }
     } else {
         // Full discovery via RFC 9728
-        const serverInfo = await discoverOAuthServerInfo(serverUrl, { resourceMetadataUrl: effectiveResourceMetadataUrl, fetchFn });
+        const serverInfo = await discoverOAuthServerInfo(serverUrl, {
+            resourceMetadataUrl: effectiveResourceMetadataUrl,
+            fetchFn,
+            skipIssuerMetadataValidation
+        });
         authorizationServerUrl = serverInfo.authorizationServerUrl;
         metadata = serverInfo.authorizationServerMetadata;
         resourceMetadata = serverInfo.resourceMetadata;
@@ -799,10 +881,22 @@ async function authInternal(
 
     // Exchange authorization code for tokens, or fetch tokens directly for non-interactive flows
     if (authorizationCode !== undefined || nonInteractiveFlow) {
+        // RFC 9207: validate the callback `iss` against the recorded issuer before the
+        // authorization code is sent to any token endpoint. Non-interactive flows have no
+        // authorization response, so the gate is keyed on `authorizationCode`.
+        if (authorizationCode !== undefined) {
+            validateAuthorizationResponseIssuer({
+                iss,
+                expectedIssuer: metadata?.issuer,
+                issParameterSupported: isIssParameterSupported(metadata)
+            });
+        }
+
         const tokens = await fetchToken(provider, authorizationServerUrl, {
             metadata,
             resource,
             authorizationCode,
+            iss,
             scope: resolvedScope,
             fetchFn
         });
@@ -1269,19 +1363,29 @@ export function buildDiscoveryUrls(authorizationServerUrl: string | URL): { url:
  * @param authorizationServerUrl - The authorization server URL obtained from the MCP Server's
  *                                 protected resource metadata, or the MCP server's URL if the
  *                                 metadata was not found.
+ * The returned metadata's `issuer` is validated against `authorizationServerUrl`
+ * per RFC 8414 §3.3 (and OIDC Discovery §4.3): if they differ the metadata is
+ * **rejected** with {@linkcode IssuerMismatchError} and not returned. Set
+ * `skipIssuerValidation: true` to suppress this check — **security-weakening**,
+ * intended only for known-misconfigured authorization servers.
+ *
  * @param options - Configuration options
  * @param options.fetchFn - Optional fetch function for making HTTP requests, defaults to global fetch
  * @param options.protocolVersion - MCP protocol version to use, defaults to {@linkcode LATEST_PROTOCOL_VERSION}
+ * @param options.skipIssuerValidation - Skip the RFC 8414 §3.3 `issuer` echo check. **Security-weakening.**
  * @returns Promise resolving to authorization server metadata, or undefined if discovery fails
+ * @throws {IssuerMismatchError} when the metadata's `issuer` does not match `authorizationServerUrl`
  */
 export async function discoverAuthorizationServerMetadata(
     authorizationServerUrl: string | URL,
     {
         fetchFn = fetch,
-        protocolVersion = LATEST_PROTOCOL_VERSION
+        protocolVersion = LATEST_PROTOCOL_VERSION,
+        skipIssuerValidation = false
     }: {
         fetchFn?: FetchLike;
         protocolVersion?: string;
+        skipIssuerValidation?: boolean;
     } = {}
 ): Promise<AuthorizationServerMetadata | undefined> {
     const headers = {
@@ -1315,9 +1419,29 @@ export async function discoverAuthorizationServerMetadata(
         }
 
         // Parse and validate based on type
-        return type === 'oauth'
-            ? OAuthMetadataSchema.parse(await response.json())
-            : OpenIdProviderDiscoveryMetadataSchema.parse(await response.json());
+        const parsed =
+            type === 'oauth'
+                ? OAuthMetadataSchema.parse(await response.json())
+                : OpenIdProviderDiscoveryMetadataSchema.parse(await response.json());
+
+        if (!skipIssuerValidation) {
+            // RFC 8414 §3.3 / OIDC Discovery §4.3: the `issuer` value in the document MUST be
+            // identical to the issuer identifier used to construct the well-known URL. Compare
+            // against the raw input string — callers pass the exact issuer string the AS published.
+            const expectedIssuer = typeof authorizationServerUrl === 'string' ? authorizationServerUrl : authorizationServerUrl.href;
+            // One narrow tolerance: the SDK's own legacy-fallback path synthesizes the AS URL via
+            // `String(new URL('/', serverUrl))`, which always carries a trailing `/`. That value is
+            // SDK-generated (not attacker-controlled), so accept the slash-only difference here.
+            // The tolerance is one-directional and end-anchored — a different host or path is still
+            // a mismatch.
+            const matches =
+                parsed.issuer === expectedIssuer || (expectedIssuer.endsWith('/') && parsed.issuer === expectedIssuer.slice(0, -1));
+            if (!matches) {
+                throw new IssuerMismatchError('metadata', expectedIssuer, parsed.issuer);
+            }
+        }
+
+        return parsed;
     }
 
     return undefined;
@@ -1371,6 +1495,11 @@ export async function discoverOAuthServerInfo(
     opts?: {
         resourceMetadataUrl?: URL;
         fetchFn?: FetchLike;
+        /**
+         * Forwarded to {@linkcode discoverAuthorizationServerMetadata} as
+         * `skipIssuerValidation`. **Security-weakening** — see {@linkcode AuthOptions.skipIssuerMetadataValidation}.
+         */
+        skipIssuerMetadataValidation?: boolean;
     }
 ): Promise<OAuthServerInfo> {
     let resourceMetadata: OAuthProtectedResourceMetadata | undefined;
@@ -1401,7 +1530,10 @@ export async function discoverOAuthServerInfo(
         authorizationServerUrl = String(new URL('/', serverUrl));
     }
 
-    const authorizationServerMetadata = await discoverAuthorizationServerMetadata(authorizationServerUrl, { fetchFn: opts?.fetchFn });
+    const authorizationServerMetadata = await discoverAuthorizationServerMetadata(authorizationServerUrl, {
+        fetchFn: opts?.fetchFn,
+        skipIssuerValidation: opts?.skipIssuerMetadataValidation
+    });
 
     return {
         authorizationServerUrl,
@@ -1589,6 +1721,7 @@ export async function exchangeAuthorization(
         metadata,
         clientInformation,
         authorizationCode,
+        iss,
         codeVerifier,
         redirectUri,
         resource,
@@ -1598,6 +1731,12 @@ export async function exchangeAuthorization(
         metadata?: AuthorizationServerMetadata;
         clientInformation: OAuthClientInformationMixed;
         authorizationCode: string;
+        /**
+         * The form-urldecoded `iss` query parameter from the authorization callback.
+         * Validated per RFC 9207 §2.4 against `metadata.issuer` before the code is
+         * redeemed; see {@linkcode validateAuthorizationResponseIssuer}.
+         */
+        iss?: string;
         codeVerifier: string;
         redirectUri: string | URL;
         resource?: URL;
@@ -1605,6 +1744,12 @@ export async function exchangeAuthorization(
         fetchFn?: FetchLike;
     }
 ): Promise<OAuthTokens> {
+    validateAuthorizationResponseIssuer({
+        iss,
+        expectedIssuer: metadata?.issuer,
+        issParameterSupported: isIssParameterSupported(metadata)
+    });
+
     const tokenRequestParams = prepareAuthorizationCodeRequest(authorizationCode, codeVerifier, redirectUri);
 
     return executeTokenRequest(authorizationServerUrl, {
@@ -1699,6 +1844,7 @@ export async function fetchToken(
         metadata,
         resource,
         authorizationCode,
+        iss,
         scope,
         fetchFn
     }: {
@@ -1706,11 +1852,25 @@ export async function fetchToken(
         resource?: URL;
         /** Authorization code for the default `authorization_code` grant flow */
         authorizationCode?: string;
+        /**
+         * The form-urldecoded `iss` query parameter from the authorization callback.
+         * Validated per RFC 9207 §2.4 when `authorizationCode` is present;
+         * see {@linkcode validateAuthorizationResponseIssuer}.
+         */
+        iss?: string;
         /** Optional scope parameter from auth() options */
         scope?: string;
         fetchFn?: FetchLike;
     } = {}
 ): Promise<OAuthTokens> {
+    if (authorizationCode !== undefined) {
+        validateAuthorizationResponseIssuer({
+            iss,
+            expectedIssuer: metadata?.issuer,
+            issParameterSupported: isIssParameterSupported(metadata)
+        });
+    }
+
     // Prefer scope from options, fallback to provider.clientMetadata.scope
     const effectiveScope = scope ?? provider.clientMetadata.scope;
 

--- a/packages/client/src/client/authErrors.ts
+++ b/packages/client/src/client/authErrors.ts
@@ -22,3 +22,40 @@ export class OAuthClientFlowError extends Error {
         this.name = new.target.name;
     }
 }
+
+/**
+ * Thrown when an authorization-server issuer identifier fails validation.
+ *
+ * Two checks raise this error, distinguished by {@linkcode IssuerMismatchError.kind | kind}:
+ * - `'metadata'` — the `issuer` in fetched authorization-server metadata does
+ *   not match the issuer identifier the well-known URL was constructed from
+ *   (RFC 8414 §3.3 / OpenID Connect Discovery §4.3).
+ * - `'authorization_response'` — the `iss` parameter on the authorization
+ *   callback failed RFC 9207 §2.4 validation against the recorded issuer.
+ *
+ * Intentionally does **not** extend `OAuthError`: the `auth()`
+ * orchestrator's `OAuthError` retry block must not swallow this — a mix-up
+ * indication is fatal for the flow, not a retryable credential problem.
+ *
+ * On the `'authorization_response'` path the {@linkcode IssuerMismatchError.received | received}
+ * value is attacker-controllable in a mix-up attack; callers **MUST NOT** display
+ * it (or any `error`/`error_description`/`error_uri` from the same callback) to
+ * end users. The values are JSON-encoded in the message to neutralize log-injection.
+ */
+export class IssuerMismatchError extends OAuthClientFlowError {
+    /** Which check failed — metadata echo (RFC 8414 §3.3) or authorization-response `iss` (RFC 9207). */
+    readonly kind: 'metadata' | 'authorization_response';
+    /** The issuer the client expected (from validated metadata / discovery input). */
+    readonly expected: string | undefined;
+    /** The issuer value that was received. Attacker-controllable on the `'authorization_response'` path. */
+    readonly received: string | undefined;
+
+    constructor(kind: 'metadata' | 'authorization_response', expected: string | undefined, received: string | undefined) {
+        const where = kind === 'metadata' ? 'authorization server metadata (RFC 8414 §3.3)' : 'authorization response (RFC 9207)';
+        // JSON-stringify embedded values so attacker-supplied control characters cannot forge log lines.
+        super(`Issuer mismatch in ${where}: expected ${JSON.stringify(expected)}, received ${JSON.stringify(received)}`);
+        this.kind = kind;
+        this.expected = expected;
+        this.received = received;
+    }
+}

--- a/packages/client/src/client/sse.ts
+++ b/packages/client/src/client/sse.ts
@@ -45,6 +45,15 @@ export type SSEClientTransportOptions = {
     authProvider?: AuthProvider | OAuthClientProvider;
 
     /**
+     * Opt-out for the RFC 8414 §3.3 issuer-echo check during authorization-server
+     * metadata discovery. **Security-weakening** — see
+     * {@linkcode index.AuthOptions.skipIssuerMetadataValidation | AuthOptions.skipIssuerMetadataValidation}.
+     * Only honoured when {@linkcode SSEClientTransportOptions.authProvider | authProvider}
+     * is an `OAuthClientProvider`.
+     */
+    skipIssuerMetadataValidation?: boolean;
+
+    /**
      * Customizes the initial SSE request to the server (the request that begins the stream).
      *
      * NOTE: Setting this property will prevent an `Authorization` header from
@@ -81,6 +90,7 @@ export class SSEClientTransport implements Transport {
     private _requestInit?: RequestInit;
     private _authProvider?: AuthProvider;
     private _oauthProvider?: OAuthClientProvider;
+    private _skipIssuerMetadataValidation?: boolean;
     private _fetch?: FetchLike;
     private _fetchWithInit: FetchLike;
     private _protocolVersion?: string;
@@ -95,9 +105,12 @@ export class SSEClientTransport implements Transport {
         this._scope = undefined;
         this._eventSourceInit = opts?.eventSourceInit;
         this._requestInit = opts?.requestInit;
+        this._skipIssuerMetadataValidation = opts?.skipIssuerMetadataValidation;
         if (isOAuthClientProvider(opts?.authProvider)) {
             this._oauthProvider = opts.authProvider;
-            this._authProvider = adaptOAuthProvider(opts.authProvider);
+            this._authProvider = adaptOAuthProvider(opts.authProvider, {
+                skipIssuerMetadataValidation: opts.skipIssuerMetadataValidation
+            });
         } else {
             this._authProvider = opts?.authProvider;
         }
@@ -228,18 +241,46 @@ export class SSEClientTransport implements Transport {
 
     /**
      * Call this method after the user has finished authorizing via their user agent and is redirected back to the MCP client application. This will exchange the authorization code for an access token, enabling the next connection attempt to successfully auth.
+     *
+     * Prefer passing the callback URL's `searchParams` directly — the SDK extracts
+     * `code` and `iss` (and validates `iss` per RFC 9207) for you. The `(code, iss?)`
+     * positional form remains supported for back-compat.
+     *
+     * @param callbackParams - The `URLSearchParams` from the authorization callback URL
+     *   (e.g. `new URL(callbackUrl).searchParams`). `code` and `iss` are read from it.
      */
-    async finishAuth(authorizationCode: string): Promise<void> {
+    async finishAuth(callbackParams: URLSearchParams): Promise<void>;
+    /**
+     * @param authorizationCode - The `code` query parameter from the authorization callback URL.
+     * @param iss - The form-urldecoded `iss` query parameter from the same callback URL, if
+     *   present. Validated per RFC 9207 against the recorded issuer before the code is redeemed.
+     */
+    async finishAuth(authorizationCode: string, iss?: string): Promise<void>;
+    async finishAuth(codeOrParams: string | URLSearchParams, iss?: string): Promise<void> {
         if (!this._oauthProvider) {
             throw new UnauthorizedError('finishAuth requires an OAuthClientProvider');
+        }
+
+        let authorizationCode: string;
+        if (codeOrParams instanceof URLSearchParams) {
+            const code = codeOrParams.get('code');
+            if (!code) {
+                throw new UnauthorizedError('Authorization callback is missing the "code" parameter');
+            }
+            authorizationCode = code;
+            iss = codeOrParams.get('iss') ?? undefined;
+        } else {
+            authorizationCode = codeOrParams;
         }
 
         const result = await auth(this._oauthProvider, {
             serverUrl: this._url,
             authorizationCode,
+            iss,
             resourceMetadataUrl: this._resourceMetadataUrl,
             scope: this._scope,
-            fetchFn: this._fetchWithInit
+            fetchFn: this._fetchWithInit,
+            skipIssuerMetadataValidation: this._skipIssuerMetadataValidation
         });
         if (result !== 'AUTHORIZED') {
             throw new UnauthorizedError('Failed to authorize');

--- a/packages/client/src/client/streamableHttp.ts
+++ b/packages/client/src/client/streamableHttp.ts
@@ -20,6 +20,8 @@ import { EventSourceParserStream } from 'eventsource-parser/stream';
 
 import type { AuthProvider, OAuthClientProvider } from './auth.js';
 import { adaptOAuthProvider, auth, extractWWWAuthenticateParams, isOAuthClientProvider, UnauthorizedError } from './auth.js';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- referenced via {@linkcode} in finishAuth JSDoc
+import type { IssuerMismatchError } from './authErrors.js';
 
 // Default reconnection options for StreamableHTTP connections
 const DEFAULT_STREAMABLE_HTTP_RECONNECTION_OPTIONS: StreamableHTTPReconnectionOptions = {
@@ -150,6 +152,15 @@ export type StreamableHTTPClientTransportOptions = {
     authProvider?: AuthProvider | OAuthClientProvider;
 
     /**
+     * Opt-out for the RFC 8414 §3.3 issuer-echo check during authorization-server
+     * metadata discovery. **Security-weakening** — see
+     * {@linkcode index.AuthOptions.skipIssuerMetadataValidation | AuthOptions.skipIssuerMetadataValidation}.
+     * Only honoured when {@linkcode StreamableHTTPClientTransportOptions.authProvider | authProvider}
+     * is an `OAuthClientProvider`.
+     */
+    skipIssuerMetadataValidation?: boolean;
+
+    /**
      * Customizes HTTP requests to the server.
      */
     requestInit?: RequestInit;
@@ -251,6 +262,7 @@ export class StreamableHTTPClientTransport implements Transport {
     private _requestInit?: RequestInit;
     private _authProvider?: AuthProvider;
     private _oauthProvider?: OAuthClientProvider;
+    private _skipIssuerMetadataValidation?: boolean;
     private _fetch?: FetchLike;
     private _fetchWithInit: FetchLike;
     private _sessionId?: string;
@@ -278,9 +290,12 @@ export class StreamableHTTPClientTransport implements Transport {
         this._resourceMetadataUrl = undefined;
         this._scope = undefined;
         this._requestInit = opts?.requestInit;
+        this._skipIssuerMetadataValidation = opts?.skipIssuerMetadataValidation;
         if (isOAuthClientProvider(opts?.authProvider)) {
             this._oauthProvider = opts.authProvider;
-            this._authProvider = adaptOAuthProvider(opts.authProvider);
+            this._authProvider = adaptOAuthProvider(opts.authProvider, {
+                skipIssuerMetadataValidation: opts.skipIssuerMetadataValidation
+            });
         } else {
             this._authProvider = opts?.authProvider;
         }
@@ -686,18 +701,48 @@ export class StreamableHTTPClientTransport implements Transport {
 
     /**
      * Call this method after the user has finished authorizing via their user agent and is redirected back to the MCP client application. This will exchange the authorization code for an access token, enabling the next connection attempt to successfully auth.
+     *
+     * Prefer passing the callback URL's `searchParams` directly — the SDK extracts
+     * `code` and `iss` (and validates `iss` per RFC 9207) for you. The `(code, iss?)`
+     * positional form remains supported for back-compat.
+     *
+     * @param callbackParams - The `URLSearchParams` from the authorization callback URL
+     *   (e.g. `new URL(callbackUrl).searchParams`). `code` and `iss` are read from it.
      */
-    async finishAuth(authorizationCode: string): Promise<void> {
+    async finishAuth(callbackParams: URLSearchParams): Promise<void>;
+    /**
+     * @param authorizationCode - The `code` query parameter from the authorization callback URL.
+     * @param iss - The form-urldecoded `iss` query parameter from the same callback URL, if
+     *   present. Validated per RFC 9207 against the recorded issuer before the code is redeemed.
+     *   When the authorization server advertises `authorization_response_iss_parameter_supported: true`,
+     *   omitting this causes the exchange to be **rejected** with {@linkcode IssuerMismatchError}.
+     */
+    async finishAuth(authorizationCode: string, iss?: string): Promise<void>;
+    async finishAuth(codeOrParams: string | URLSearchParams, iss?: string): Promise<void> {
         if (!this._oauthProvider) {
             throw new UnauthorizedError('finishAuth requires an OAuthClientProvider');
+        }
+
+        let authorizationCode: string;
+        if (codeOrParams instanceof URLSearchParams) {
+            const code = codeOrParams.get('code');
+            if (!code) {
+                throw new UnauthorizedError('Authorization callback is missing the "code" parameter');
+            }
+            authorizationCode = code;
+            iss = codeOrParams.get('iss') ?? undefined;
+        } else {
+            authorizationCode = codeOrParams;
         }
 
         const result = await auth(this._oauthProvider, {
             serverUrl: this._url,
             authorizationCode,
+            iss,
             resourceMetadataUrl: this._resourceMetadataUrl,
             scope: this._scope,
-            fetchFn: this._fetchWithInit
+            fetchFn: this._fetchWithInit,
+            skipIssuerMetadataValidation: this._skipIssuerMetadataValidation
         });
         if (result !== 'AUTHORIZED') {
             throw new UnauthorizedError('Failed to authorize');
@@ -862,7 +907,8 @@ export class StreamableHTTPClientTransport implements Transport {
                             serverUrl: this._url,
                             resourceMetadataUrl: this._resourceMetadataUrl,
                             scope: this._scope,
-                            fetchFn: this._fetchWithInit
+                            fetchFn: this._fetchWithInit,
+                            skipIssuerMetadataValidation: this._skipIssuerMetadataValidation
                         });
 
                         if (result !== 'AUTHORIZED') {

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -37,9 +37,10 @@ export {
     selectResourceURL,
     startAuthorization,
     UnauthorizedError,
+    validateAuthorizationResponseIssuer,
     validateClientMetadataUrl
 } from './client/auth.js';
-export { OAuthClientFlowError } from './client/authErrors.js';
+export { IssuerMismatchError, OAuthClientFlowError } from './client/authErrors.js';
 export type {
     AssertionCallback,
     ClientCredentialsProviderOptions,

--- a/packages/client/test/client/auth.test.ts
+++ b/packages/client/test/client/auth.test.ts
@@ -15,10 +15,12 @@ import {
     exchangeAuthorization,
     extractWWWAuthenticateParams,
     isHttpsUrl,
+    IssuerMismatchError,
     refreshAuthorization,
     registerClient,
     selectClientAuthMethod,
     startAuthorization,
+    validateAuthorizationResponseIssuer,
     validateClientMetadataUrl
 } from '../../src/client/auth.js';
 import { createPrivateKeyJwtAuth } from '../../src/client/authExtensions.js';
@@ -883,6 +885,7 @@ describe('OAuth Authorization', () => {
         };
 
         it('tries URLs in order and returns first successful metadata', async () => {
+            const tenantOidcMetadata = { ...validOpenIdMetadata, issuer: 'https://auth.example.com/tenant1' };
             // First OAuth URL (path before well-known) fails with 404
             mockFetch.mockResolvedValueOnce({
                 ok: false,
@@ -893,12 +896,12 @@ describe('OAuth Authorization', () => {
             mockFetch.mockResolvedValueOnce({
                 ok: true,
                 status: 200,
-                json: async () => validOpenIdMetadata
+                json: async () => tenantOidcMetadata
             });
 
             const metadata = await discoverAuthorizationServerMetadata('https://auth.example.com/tenant1');
 
-            expect(metadata).toEqual(validOpenIdMetadata);
+            expect(metadata).toEqual(tenantOidcMetadata);
 
             // Verify it tried the URLs in the correct order
             const calls = mockFetch.mock.calls;
@@ -919,9 +922,26 @@ describe('OAuth Authorization', () => {
                 json: async () => validOpenIdMetadata
             });
 
-            const metadata = await discoverAuthorizationServerMetadata('https://mcp.example.com');
+            const metadata = await discoverAuthorizationServerMetadata('https://auth.example.com');
 
             expect(metadata).toEqual(validOpenIdMetadata);
+        });
+
+        it('preserves authorization_response_iss_parameter_supported through OIDC discovery parse', async () => {
+            // OAuth well-known 404s; OIDC well-known returns metadata advertising RFC 9207 support.
+            // Regression-guard: OpenIdProviderDiscoveryMetadataSchema is a plain z.object(), so the
+            // field must be declared on the underlying schemas or it gets stripped — making the
+            // RFC 9207 §2.4 advertised-but-missing reject inert on the OIDC-only discovery path.
+            mockFetch.mockResolvedValueOnce({ ok: false, status: 404 });
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                status: 200,
+                json: async () => ({ ...validOpenIdMetadata, authorization_response_iss_parameter_supported: true })
+            });
+
+            const metadata = await discoverAuthorizationServerMetadata('https://auth.example.com');
+
+            expect(metadata?.authorization_response_iss_parameter_supported).toBe(true);
         });
 
         it('continues on 502 and tries next URL', async () => {
@@ -1049,6 +1069,133 @@ describe('OAuth Authorization', () => {
 
             // Only one call — no CORS retry attempted in non-browser environments
             expect(mockFetch).toHaveBeenCalledTimes(1);
+        });
+
+        describe('RFC 8414 §3.3 issuer-echo validation', () => {
+            it('rejects metadata whose issuer does not match the discovery input', async () => {
+                mockFetch.mockResolvedValueOnce({
+                    ok: true,
+                    status: 200,
+                    json: async () => ({ ...validOAuthMetadata, issuer: 'https://honest.example.com' })
+                });
+
+                const err = await discoverAuthorizationServerMetadata('https://attacker.example.com').catch(e => e);
+                expect(err).toBeInstanceOf(IssuerMismatchError);
+                expect(err).not.toBeInstanceOf(OAuthError);
+                expect(err.kind).toBe('metadata');
+                expect(err.expected).toBe('https://attacker.example.com');
+                expect(err.received).toBe('https://honest.example.com');
+            });
+
+            it('rejects when metadata issuer matches a different tenant on the same host', async () => {
+                mockFetch.mockResolvedValueOnce({
+                    ok: true,
+                    status: 200,
+                    json: async () => ({ ...validOAuthMetadata, issuer: 'https://auth.example.com/tenant2' })
+                });
+
+                await expect(discoverAuthorizationServerMetadata('https://auth.example.com/tenant1')).rejects.toThrow(IssuerMismatchError);
+            });
+
+            it('accepts when issuer matches the discovery input exactly', async () => {
+                mockFetch.mockResolvedValueOnce({
+                    ok: true,
+                    status: 200,
+                    json: async () => validOAuthMetadata
+                });
+
+                await expect(discoverAuthorizationServerMetadata('https://auth.example.com')).resolves.toEqual(validOAuthMetadata);
+            });
+
+            it('tolerates a trailing slash on the SDK-synthesized discovery input only', async () => {
+                // The legacy-fallback path synthesizes `String(new URL('/', serverUrl))` which always ends in `/`.
+                mockFetch.mockResolvedValueOnce({
+                    ok: true,
+                    status: 200,
+                    json: async () => validOAuthMetadata // issuer: 'https://auth.example.com'
+                });
+                await expect(discoverAuthorizationServerMetadata('https://auth.example.com/')).resolves.toEqual(validOAuthMetadata);
+
+                // The tolerance is one-directional: a slash on the *received* side is still a mismatch.
+                mockFetch.mockResolvedValueOnce({
+                    ok: true,
+                    status: 200,
+                    json: async () => ({ ...validOAuthMetadata, issuer: 'https://auth.example.com/' })
+                });
+                await expect(discoverAuthorizationServerMetadata('https://auth.example.com')).rejects.toThrow(IssuerMismatchError);
+            });
+
+            it('skipIssuerValidation suppresses the check', async () => {
+                mockFetch.mockResolvedValueOnce({
+                    ok: true,
+                    status: 200,
+                    json: async () => ({ ...validOAuthMetadata, issuer: 'https://honest.example.com' })
+                });
+
+                await expect(
+                    discoverAuthorizationServerMetadata('https://attacker.example.com', { skipIssuerValidation: true })
+                ).resolves.toMatchObject({ issuer: 'https://honest.example.com' });
+            });
+        });
+    });
+
+    describe('validateAuthorizationResponseIssuer', () => {
+        const expectedIssuer = 'https://auth.example.com';
+
+        // The spec's four-row decision table.
+        it.each([
+            { label: 'row 1: supported + present + match → proceed', supported: true, iss: expectedIssuer, throws: false },
+            { label: 'row 1: supported + present + mismatch → reject', supported: true, iss: 'https://attacker.example', throws: true },
+            { label: 'row 2: supported + absent → reject', supported: true, iss: undefined, throws: true },
+            { label: 'row 3: not advertised + present + match → proceed', supported: false, iss: expectedIssuer, throws: false },
+            {
+                label: 'row 3: not advertised + present + mismatch → reject',
+                supported: false,
+                iss: 'https://attacker.example',
+                throws: true
+            },
+            { label: 'row 4: not advertised + absent → proceed', supported: false, iss: undefined, throws: false }
+        ])('$label', ({ supported, iss, throws }) => {
+            const run = () => validateAuthorizationResponseIssuer({ iss, expectedIssuer, issParameterSupported: supported });
+            if (throws) {
+                expect(run).toThrow(IssuerMismatchError);
+                try {
+                    run();
+                } catch (e) {
+                    expect((e as IssuerMismatchError).kind).toBe('authorization_response');
+                }
+            } else {
+                expect(run).not.toThrow();
+            }
+        });
+
+        // Forbidden normalizations: every one of these MUST be a mismatch even though
+        // the values are URL-equivalent under RFC 3986 §6.2.2-6.2.3.
+        it.each([
+            { label: 'scheme case', iss: 'HTTPS://auth.example.com' },
+            { label: 'host case', iss: 'https://AUTH.example.com' },
+            { label: 'default port elision', iss: 'https://auth.example.com:443' },
+            { label: 'trailing slash', iss: 'https://auth.example.com/' },
+            { label: 'percent-encoding', iss: 'https://auth.example.co%6D' }
+        ])('rejects on $label difference (no normalization applied)', ({ iss }) => {
+            expect(() => validateAuthorizationResponseIssuer({ iss, expectedIssuer, issParameterSupported: true })).toThrow(
+                IssuerMismatchError
+            );
+        });
+
+        it('no-ops when there is no recorded issuer (no validated metadata)', () => {
+            expect(() =>
+                validateAuthorizationResponseIssuer({ iss: 'https://anything', expectedIssuer: undefined, issParameterSupported: true })
+            ).not.toThrow();
+            expect(() =>
+                validateAuthorizationResponseIssuer({ iss: undefined, expectedIssuer: undefined, issParameterSupported: true })
+            ).not.toThrow();
+        });
+
+        it('IssuerMismatchError JSON-encodes received value (log-injection guard)', () => {
+            const err = new IssuerMismatchError('authorization_response', expectedIssuer, 'https://a\nINFO: forged');
+            expect(err.message).not.toContain('\nINFO');
+            expect(err.message).toContain(String.raw`https://a\nINFO: forged`);
         });
     });
 
@@ -2277,7 +2424,7 @@ describe('OAuth Authorization', () => {
                         ok: true,
                         status: 200,
                         json: async () => ({
-                            issuer: 'https://auth.example.com',
+                            issuer: 'https://resource.example.com',
                             authorization_endpoint: 'https://auth.example.com/authorize',
                             token_endpoint: 'https://auth.example.com/token',
                             registration_endpoint: 'https://auth.example.com/register',
@@ -2730,7 +2877,7 @@ describe('OAuth Authorization', () => {
                         ok: true,
                         status: 200,
                         json: async () => ({
-                            issuer: 'https://auth.example.com',
+                            issuer: 'https://api.example.com',
                             authorization_endpoint: 'https://auth.example.com/authorize',
                             token_endpoint: 'https://auth.example.com/token',
                             response_types_supported: ['code'],
@@ -2786,7 +2933,7 @@ describe('OAuth Authorization', () => {
                         ok: true,
                         status: 200,
                         json: async () => ({
-                            issuer: 'https://auth.example.com',
+                            issuer: 'https://api.example.com',
                             authorization_endpoint: 'https://auth.example.com/authorize',
                             token_endpoint: 'https://auth.example.com/token',
                             response_types_supported: ['code'],
@@ -2850,7 +2997,7 @@ describe('OAuth Authorization', () => {
                         ok: true,
                         status: 200,
                         json: async () => ({
-                            issuer: 'https://auth.example.com',
+                            issuer: 'https://api.example.com',
                             authorization_endpoint: 'https://auth.example.com/authorize',
                             token_endpoint: 'https://auth.example.com/token',
                             response_types_supported: ['code'],

--- a/packages/client/test/client/sse.test.ts
+++ b/packages/client/test/client/sse.test.ts
@@ -45,12 +45,14 @@ describe('SSEClientTransport', () => {
                 res.writeHead(200, {
                     'Content-Type': 'application/json'
                 });
+                // RFC 8414 §3.3: issuer must match the URL the metadata was fetched from.
+                const self = `http://${req.headers.host}`;
                 res.end(
                     JSON.stringify({
-                        issuer: 'https://auth.example.com',
-                        authorization_endpoint: 'https://auth.example.com/authorize',
-                        token_endpoint: 'https://auth.example.com/token',
-                        registration_endpoint: 'https://auth.example.com/register',
+                        issuer: self,
+                        authorization_endpoint: `${self}/authorize`,
+                        token_endpoint: `${self}/token`,
+                        registration_endpoint: `${self}/register`,
                         response_types_supported: ['code'],
                         code_challenge_methods_supported: ['S256']
                     })

--- a/packages/core/src/shared/auth.ts
+++ b/packages/core/src/shared/auth.ts
@@ -66,7 +66,9 @@ export const OAuthMetadataSchema = z.looseObject({
     introspection_endpoint_auth_methods_supported: z.array(z.string()).optional(),
     introspection_endpoint_auth_signing_alg_values_supported: z.array(z.string()).optional(),
     code_challenge_methods_supported: z.array(z.string()).optional(),
-    client_id_metadata_document_supported: z.boolean().optional()
+    client_id_metadata_document_supported: z.boolean().optional(),
+    // eslint-disable-next-line unicorn/prefer-top-level-await -- Zod .catch(), not a Promise chain
+    authorization_response_iss_parameter_supported: z.boolean().optional().catch(undefined)
 });
 
 /**
@@ -110,7 +112,9 @@ export const OpenIdProviderMetadataSchema = z.looseObject({
     require_request_uri_registration: z.boolean().optional(),
     op_policy_uri: SafeUrlSchema.optional(),
     op_tos_uri: SafeUrlSchema.optional(),
-    client_id_metadata_document_supported: z.boolean().optional()
+    client_id_metadata_document_supported: z.boolean().optional(),
+    // eslint-disable-next-line unicorn/prefer-top-level-await -- Zod .catch(), not a Promise chain
+    authorization_response_iss_parameter_supported: z.boolean().optional().catch(undefined)
 });
 
 /**

--- a/test/conformance/expected-failures.2026-07-28.yaml
+++ b/test/conformance/expected-failures.2026-07-28.yaml
@@ -52,14 +52,16 @@ client:
     - auth/scope-retry-limit
 
     # --- Same gaps as the 2025 baseline (fail identically when forced to 2026-07-28) ---
-    # SEP-2468 (authorization response iss parameter): not implemented in the client.
+    # SEP-2468 iss-* scenarios: the SEP-2468 check itself PASSES — these stay
+    # listed because the referee bundles a SEP-837 `application_type` DCR check
+    # into the same scenario. Burn alongside PR-B (SEP-837 heuristic-default).
+    # `auth/metadata-issuer-mismatch` burns (rejected before DCR).
     - auth/iss-supported
     - auth/iss-not-advertised
     - auth/iss-supported-missing
     - auth/iss-wrong-issuer
     - auth/iss-unexpected
     - auth/iss-normalized
-    - auth/metadata-issuer-mismatch
     # SEP-2352 (authorization server migration): client does not re-register
     # when PRM authorization_servers changes.
     - auth/authorization-server-migration

--- a/test/conformance/expected-failures.yaml
+++ b/test/conformance/expected-failures.yaml
@@ -19,17 +19,27 @@
 
 client:
     # --- Draft-spec scenarios (in `--suite draft`, also part of `--suite all`) ---
-    # SEP-2468 (authorization response iss parameter): not implemented in the client.
+    # SEP-2468 (authorization response iss parameter): the SEP-2468 check itself
+    # PASSES — these stay listed because the referee's createAuthServer also
+    # asserts SEP-837 `application_type` on the same DCR request, which fails
+    # until PR-B (SEP-837 heuristic-default) lands. Burn these alongside PR-B.
     - auth/iss-supported
     - auth/iss-not-advertised
     - auth/iss-supported-missing
     - auth/iss-wrong-issuer
     - auth/iss-unexpected
     - auth/iss-normalized
-    - auth/metadata-issuer-mismatch
+    # `auth/metadata-issuer-mismatch` (the seventh SEP-2468 cell) burns: the SDK
+    # rejects the mismatched metadata before DCR, so the SEP-837 check never fires.
     # SEP-2352 (authorization server migration): client does not re-register when
     # PRM authorization_servers changes.
     - auth/authorization-server-migration
+    # SEP-2468 RFC 9207 `iss` validation is now default-ON. The referee's
+    # 2025-03-26 backcompat mock emits a callback `iss` with a `/oauth` path
+    # component that does not match its own metadata `issuer` (conformance#359
+    # fixed the metadata side; the callback `iss` is a follow-up). The SDK
+    # correctly rejects per RFC 9207 §2.4. Scenario is `removedIn: 2025-06-18`.
+    - auth/2025-03-26-oauth-metadata-backcompat
     # SEP-837 (application_type during DCR): the check only fires on draft-version
     # runs; this draft scenario is the one place the client still hits it.
     - auth/offline-access-not-supported

--- a/test/conformance/src/everythingClient.ts
+++ b/test/conformance/src/everythingClient.ts
@@ -425,7 +425,19 @@ registerScenarios(
         'auth/token-endpoint-auth-post',
         'auth/token-endpoint-auth-none',
         'auth/offline-access-scope',
-        'auth/offline-access-not-supported'
+        'auth/offline-access-not-supported',
+        // SEP-2468 (RFC 9207 iss / RFC 8414 §3.3 issuer-echo). The well-behaved
+        // client captures `iss` from the authorization redirect and passes it to
+        // `auth()`; the SDK validates internally. Positive scenarios proceed to
+        // the token endpoint; negative scenarios throw `IssuerMismatchError` and
+        // the process exits with an error (the referee sets `allowClientError`).
+        'auth/iss-supported',
+        'auth/iss-not-advertised',
+        'auth/iss-supported-missing',
+        'auth/iss-wrong-issuer',
+        'auth/iss-unexpected',
+        'auth/iss-normalized',
+        'auth/metadata-issuer-mismatch'
     ],
     runAuthClient
 );

--- a/test/conformance/src/helpers/conformanceOAuthProvider.ts
+++ b/test/conformance/src/helpers/conformanceOAuthProvider.ts
@@ -11,6 +11,7 @@ export class ConformanceOAuthProvider implements OAuthClientProvider {
     private _tokens?: OAuthTokens;
     private _codeVerifier?: string;
     private _authCode?: string;
+    private _iss?: string;
     private _authCodePromise?: Promise<string>;
 
     constructor(
@@ -58,6 +59,8 @@ export class ConformanceOAuthProvider implements OAuthClientProvider {
             if (location) {
                 const redirectUrl = new URL(location);
                 const code = redirectUrl.searchParams.get('code');
+                // RFC 9207: capture `iss` alongside `code` for validation before token exchange.
+                this._iss = redirectUrl.searchParams.get('iss') ?? undefined;
                 if (code) {
                     this._authCode = code;
                     return;
@@ -78,6 +81,11 @@ export class ConformanceOAuthProvider implements OAuthClientProvider {
             return this._authCode;
         }
         throw new Error('No authorization code');
+    }
+
+    /** The `iss` parameter captured from the authorization callback (RFC 9207), or `undefined` if absent. */
+    getIss(): string | undefined {
+        return this._iss;
     }
 
     saveCodeVerifier(codeVerifier: string): void {

--- a/test/conformance/src/helpers/withOAuthRetry.ts
+++ b/test/conformance/src/helpers/withOAuthRetry.ts
@@ -25,6 +25,7 @@ export const handle401 = async (
         // await provider.waitForCallback();
 
         const authorizationCode = await provider.getAuthCode();
+        const iss = provider.getIss();
 
         // TODO: this retry logic should be incorporated into the typescript SDK
         result = await auth(provider, {
@@ -32,6 +33,7 @@ export const handle401 = async (
             resourceMetadataUrl,
             scope,
             authorizationCode,
+            iss,
             fetchFn: next
         });
         if (result !== 'AUTHORIZED') {

--- a/test/e2e/requirements.ts
+++ b/test/e2e/requirements.ts
@@ -2178,12 +2178,55 @@ export const REQUIREMENTS: Record<string, Requirement> = {
         behavior:
             'The client rejects authorization-server metadata whose issuer does not match the URL the metadata was retrieved from (RFC 8414 section 3.3).',
         transports: ['streamableHttp'],
-        note: 'This exercises the HTTP hosting/auth layer and OAuth client; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.',
-        knownFailures: [
-            {
-                note: 'discoverAuthorizationServerMetadata never validates that the returned issuer matches the authorization-server URL the metadata was fetched from (RFC 8414 section 3.3), so spoofed-issuer metadata is accepted and the OAuth flow proceeds to registration and redirect.'
-            }
-        ]
+        note: 'This exercises the HTTP hosting/auth layer and OAuth client; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'client-auth:iss:match': {
+        addedInSpecVersion: '2026-07-28',
+        source: 'https://modelcontextprotocol.io/specification/draft/basic/authorization#authorization-response-issuer-validation',
+        behavior:
+            "When the authorization callback's iss exactly matches the issuer recorded from validated AS metadata, finishAuth() proceeds to redeem the authorization code (RFC 9207 §2.4, table row 1).",
+        transports: ['streamableHttp'],
+        note: 'This exercises the HTTP hosting/auth layer and OAuth client; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'client-auth:iss:mismatch-reject': {
+        addedInSpecVersion: '2026-07-28',
+        source: 'https://modelcontextprotocol.io/specification/draft/basic/authorization#authorization-response-issuer-validation',
+        behavior:
+            "When the authorization callback's iss differs from the recorded issuer, the client throws IssuerMismatchError (kind 'authorization_response') and does not transmit the authorization code to any token endpoint.",
+        transports: ['streamableHttp'],
+        note: 'This exercises the HTTP hosting/auth layer and OAuth client; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'client-auth:iss:supported-missing-reject': {
+        addedInSpecVersion: '2026-07-28',
+        source: 'https://modelcontextprotocol.io/specification/draft/basic/authorization#authorization-response-issuer-validation',
+        behavior:
+            'When the AS metadata advertises authorization_response_iss_parameter_supported: true and the callback carries no iss, the client throws IssuerMismatchError before redeeming the code (table row 2).',
+        transports: ['streamableHttp'],
+        note: 'This exercises the HTTP hosting/auth layer and OAuth client; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'client-auth:iss:unadvertised-proceed': {
+        addedInSpecVersion: '2026-07-28',
+        source: 'https://modelcontextprotocol.io/specification/draft/basic/authorization#authorization-response-issuer-validation',
+        behavior:
+            'When the AS metadata does not advertise authorization_response_iss_parameter_supported and the callback carries no iss, the client proceeds with the code exchange (table row 4).',
+        transports: ['streamableHttp'],
+        note: 'This exercises the HTTP hosting/auth layer and OAuth client; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'client-auth:iss:no-normalize': {
+        addedInSpecVersion: '2026-07-28',
+        source: 'https://modelcontextprotocol.io/specification/draft/basic/authorization#authorization-response-issuer-validation',
+        behavior:
+            'iss comparison is simple string comparison only — scheme/host case folding, default-port elision, trailing-slash, and percent-encoding normalization are NOT applied; any such difference is rejected as a mismatch.',
+        transports: ['streamableHttp'],
+        note: 'This exercises the HTTP hosting/auth layer and OAuth client; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
+    },
+    'client-auth:iss:opt-out': {
+        addedInSpecVersion: '2026-07-28',
+        source: 'sdk',
+        behavior:
+            'AuthOptions.skipIssuerMetadataValidation: true suppresses only the RFC 8414 §3.3 metadata-issuer-echo check (AU-02) — it does not relax the RFC 9207 callback-iss validation, which continues to reject mismatches.',
+        transports: ['streamableHttp'],
+        note: 'This exercises the HTTP hosting/auth layer and OAuth client; the matrix transport arg is ignored, so it runs as a single streamableHttp-labelled cell to avoid duplicate runs.'
     },
     'client-auth:prm-discovery:no-prm-fallback': {
         source: 'sdk',

--- a/test/e2e/scenarios/client-auth.test.ts
+++ b/test/e2e/scenarios/client-auth.test.ts
@@ -18,6 +18,7 @@ import {
     discoverAuthorizationServerMetadata,
     discoverOAuthProtectedResourceMetadata,
     exchangeAuthorization,
+    IssuerMismatchError,
     OAuthError,
     OAuthErrorCode,
     PrivateKeyJwtProvider,
@@ -29,6 +30,7 @@ import {
     StaticPrivateKeyJwtProvider,
     StreamableHTTPClientTransport,
     UnauthorizedError,
+    validateAuthorizationResponseIssuer,
     withLogging,
     withOAuth
 } from '@modelcontextprotocol/client';
@@ -519,7 +521,11 @@ verifies('client-auth:as-metadata-discovery:issuer-validation', async (_args: Te
     const transport = new StreamableHTTPClientTransport(new URL(MCP_URL), { authProvider: provider, fetch: combinedFetch });
 
     try {
-        await expect(client.connect(transport)).rejects.toThrow(/issuer/i);
+        const err: unknown = await client.connect(transport).catch((error: unknown) => error);
+        expect(err).toBeInstanceOf(IssuerMismatchError);
+        expect((err as IssuerMismatchError).kind).toBe('metadata');
+        // Intentionally not an OAuthError — the auth() retry block must not swallow it.
+        expect(err).not.toBeInstanceOf(OAuthError);
 
         // The mismatched metadata is rejected before registering, redirecting the user, or requesting tokens.
         expect(as.registerCalls).toHaveLength(0);
@@ -529,6 +535,112 @@ verifies('client-auth:as-metadata-discovery:issuer-validation', async (_args: Te
         await client.close();
         await mcpHost.close();
     }
+});
+
+/**
+ * Runs the redirect leg of the OAuth flow against a mock AS configured with `asMetadata`, then
+ * calls `transport.finishAuth(code, iss)`. Returns the thrown error (or undefined on success)
+ * and the recorded token-endpoint calls so the caller can assert whether the code went on the wire.
+ */
+async function runFinishAuthScenario(asMetadata: Partial<AuthorizationServerMetadata>, iss: string | undefined) {
+    const as = createMockAuthorizationServer({ asMetadata, tokenResponses: [{ access_token: 'iss-flow-token', token_type: 'Bearer' }] });
+    const provider = new RecordingOAuthClientProvider();
+    const mcpHost = createAuthenticatedHost('iss-flow-token');
+    const combinedFetch = createCombinedFetch({ as, mcpHost, validToken: 'iss-flow-token' });
+
+    const transport = new StreamableHTTPClientTransport(new URL(MCP_URL), { authProvider: provider, fetch: combinedFetch });
+    const client = new Client({ name: 'c', version: '0' });
+    try {
+        // First connect → 401 → discovery → REDIRECT.
+        await expect(client.connect(transport)).rejects.toThrow(UnauthorizedError);
+        expect(provider.redirectedTo).toHaveLength(1);
+
+        let thrown: unknown;
+        try {
+            await transport.finishAuth('granted-code', iss);
+        } catch (error) {
+            thrown = error;
+        }
+        return { thrown, tokenCalls: as.tokenCalls, provider };
+    } finally {
+        await client.close();
+        await mcpHost.close();
+    }
+}
+
+verifies('client-auth:iss:match', async (_args: TestArgs) => {
+    const { thrown, tokenCalls, provider } = await runFinishAuthScenario({ authorization_response_iss_parameter_supported: true }, ISSUER);
+    expect(thrown).toBeUndefined();
+    expect(tokenCalls).toHaveLength(1);
+    expect(defined(tokenCalls[0], 'token call').body.get('code')).toBe('granted-code');
+    expect(provider.saved.tokens?.access_token).toBe('iss-flow-token');
+});
+
+verifies('client-auth:iss:mismatch-reject', async (_args: TestArgs) => {
+    const { thrown, tokenCalls } = await runFinishAuthScenario(
+        { authorization_response_iss_parameter_supported: true },
+        'https://attacker.example.com'
+    );
+    expect(thrown).toBeInstanceOf(IssuerMismatchError);
+    expect((thrown as IssuerMismatchError).kind).toBe('authorization_response');
+    expect((thrown as IssuerMismatchError).expected).toBe(ISSUER);
+    // The authorization code never reaches a token endpoint.
+    expect(tokenCalls).toHaveLength(0);
+});
+
+verifies('client-auth:iss:supported-missing-reject', async (_args: TestArgs) => {
+    const { thrown, tokenCalls } = await runFinishAuthScenario({ authorization_response_iss_parameter_supported: true }, undefined);
+    expect(thrown).toBeInstanceOf(IssuerMismatchError);
+    expect((thrown as IssuerMismatchError).received).toBeUndefined();
+    expect(tokenCalls).toHaveLength(0);
+});
+
+verifies('client-auth:iss:unadvertised-proceed', async (_args: TestArgs) => {
+    // Row 4: not advertised + iss absent → the exchange proceeds. Also covers row 3 (not advertised
+    // + iss present → still compared) by additionally asserting the same scenario rejects a wrong iss.
+    const proceed = await runFinishAuthScenario({}, undefined);
+    expect(proceed.thrown).toBeUndefined();
+    expect(proceed.tokenCalls).toHaveLength(1);
+
+    const reject = await runFinishAuthScenario({}, 'https://attacker.example.com');
+    expect(reject.thrown).toBeInstanceOf(IssuerMismatchError);
+    expect(reject.tokenCalls).toHaveLength(0);
+});
+
+verifies('client-auth:iss:no-normalize', async (_args: TestArgs) => {
+    // Each value is URL-equivalent to ISSUER under RFC 3986 §6.2.2-6.2.3 normalization, but
+    // RFC 9207 mandates simple string comparison — every one MUST be rejected.
+    for (const iss of [ISSUER.toUpperCase(), `${ISSUER}/`, `${ISSUER}:443`, ISSUER.replace('https', 'HTTPS')]) {
+        expect(() => validateAuthorizationResponseIssuer({ iss, expectedIssuer: ISSUER, issParameterSupported: true })).toThrow(
+            IssuerMismatchError
+        );
+    }
+
+    // And end-to-end through finishAuth(): a trailing-slash difference is a real reject.
+    const { thrown, tokenCalls } = await runFinishAuthScenario({ authorization_response_iss_parameter_supported: true }, `${ISSUER}/`);
+    expect(thrown).toBeInstanceOf(IssuerMismatchError);
+    expect(tokenCalls).toHaveLength(0);
+});
+
+verifies('client-auth:iss:opt-out', async (_args: TestArgs) => {
+    // skipIssuerMetadataValidation suppresses AU-02 (metadata echo): mismatched-issuer metadata is accepted.
+    const as = createMockAuthorizationServer({ asMetadata: { issuer: 'https://misconfigured.example.com' } });
+    const fetchFn = (url: URL | string, init?: RequestInit) => as.handleRequest(new Request(url, init));
+    const provider = new RecordingOAuthClientProvider();
+    await auth(provider, { serverUrl: MCP_URL, skipIssuerMetadataValidation: true, fetchFn });
+    expect(provider.redirectedTo).toHaveLength(1);
+
+    // It does NOT suppress AU-01 (callback iss): a mismatched iss is still rejected before token exchange.
+    await expect(
+        auth(provider, {
+            serverUrl: MCP_URL,
+            authorizationCode: 'granted-code',
+            iss: 'https://attacker.example.com',
+            skipIssuerMetadataValidation: true,
+            fetchFn
+        })
+    ).rejects.toThrow(IssuerMismatchError);
+    expect(as.tokenCalls).toHaveLength(0);
 });
 
 verifies('client-auth:bearer-header:every-request', async (_args: TestArgs) => {
@@ -921,8 +1033,10 @@ verifies('client-auth:prm-discovery:fallback-order', async (_args: TestArgs) => 
 
 verifies('client-auth:prm-discovery:no-prm-fallback', async (_args: TestArgs) => {
     const VALID = 'legacy-fallback-token';
+    // RFC 8414 §3.3: metadata fetched at the MCP origin must claim that origin as its issuer.
     const as = createMockAuthorizationServer({
         noPRMDiscovery: true,
+        asMetadata: { issuer: new URL(MCP_URL).origin },
         tokenResponses: [{ access_token: VALID, token_type: 'Bearer' }]
     });
     const provider = new RecordingOAuthClientProvider({ clientInformation: { client_id: 'legacy-fallback-client' } });


### PR DESCRIPTION

`9beb2b1d2`

<!-- brief summary -->
Implements the OAuth mix-up defenses, default-ON: RFC 8414 §3.3 metadata `issuer` echo validation in `discoverAuthorizationServerMetadata()`, RFC 9207 `iss` validation before token exchange in `authInternal`/`exchangeAuthorization`/`fetchToken`, and `finishAuth(code, iss?)` on both HTTP transports. New exported `IssuerMismatchError {kind: 'metadata' | 'authorization_response'}` and pure helper `validateAuthorizationResponseIssuer()`.

### Motivation and Context
SEP-2468 ([modelcontextprotocol/modelcontextprotocol#2468](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2468), spec wording in [#2646](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2646)).

Normative sentences implemented:

> After retrieving a metadata document, MCP clients **MUST** validate it as required by RFC8414 Section 3.3 …: the `issuer` value in the document **MUST** be identical to the issuer identifier used to construct the well-known URL. If they differ, the client **MUST NOT** use the metadata.
> — `basic/authorization/authorization-server-discovery.mdx`

> On receiving the authorization response, MCP clients **MUST** apply the validation in RFC9207 Section 2.4 before transmitting the authorization code to any token endpoint.
> — `basic/authorization/index.mdx`

> After decoding the `iss` value … clients **MUST NOT** apply scheme or host case folding, default-port elision, trailing-slash, or percent-encoding normalization … before comparison.
> — `basic/authorization/index.mdx`

> If issuer validation fails, the client **MUST** treat the response as invalid and abort the authorization flow.
> — SEP-2468

The validator implements the spec's 4-row decision table with exact `===` comparison (no `URL` construction). `IssuerMismatchError` extends `Error` (not `OAuthError`) so the existing `auth()` retry/invalidate catch does not swallow it; its message JSON-encodes received/expected to guard against log injection from attacker-controlled `iss`.

### How Has This Been Tested?
- Unit: `validateAuthorizationResponseIssuer` table-driven over all 4 rows + each forbidden normalization (`packages/client/test/client/auth.test.ts`).
- E2E: `client-auth:iss:{match, mismatch-reject, supported-missing-reject, unadvertised-proceed, no-normalize, opt-out}` requirement rows; `as-metadata-discovery:issuer-validation` flips from knownFailure to pass.
- Conformance: `auth/metadata-issuer-mismatch` burns; the 6 `auth/iss-*` cells pass the SEP-2468 check (they stay listed until PR 3 because the referee bundles a SEP-837 `application_type` check into the same scenarios).
- Existing-test fixtures aligned to RFC 8414 §3.3 (issuer values only; the tests assert other behavior).

### Breaking Changes
**Yes — new default-on rejection paths.**
- `discoverAuthorizationServerMetadata()` now throws `IssuerMismatchError{kind:'metadata'}` when the metadata `issuer` does not echo the well-known URL it was fetched from. Hosts whose AS serves a non-echoing issuer (a latent RFC 8414 §3.3 violation) will fail at discovery; the documented escape hatch is `skipIssuerMetadataValidation: true` (suppresses AU-02 only, not the runtime `iss` check).
- `auth()`/`finishAuth()` now reject the authorization response when the AS advertised `authorization_response_iss_parameter_supported: true` but the host did not pass `iss`. Hosts must extract `iss` from the callback URL alongside `code` and pass it to `finishAuth(code, iss)`. ASes that do not advertise support are unaffected.

Both are spec MUSTs; per the gating frame in DECISIONS.md Q4 they ship default-on with a named opt-out, not opt-in.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

### Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

### Additional context
- `skipIssuerMetadataValidation` suppresses **only** the metadata echo check (AU-02), never the runtime `iss` check (AU-01) — AU-01 already degrades safely via decision-table rows 3/4 when the AS doesn't advertise support.
- One-directional trailing-slash tolerance is applied **only** to the SDK-synthesized legacy-fallback URL (SDK-generated, not attacker-controlled).
- `auth/2025-03-26-oauth-metadata-backcompat` is newly listed in the 2025 baseline because the deprecated referee mock serves a §3.3-violating issuer; that scenario is `removedIn: 2025-06-18` and the mock is fixed by conformance#359 (adopted in PR 7).

---

