### PR TITLE
test(conformance): bump referee to 0.2.0-alpha.7; drop server-sse-polling from baseline (conformance#366)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1728,8 +1728,8 @@ importers:
         specifier: workspace:^
         version: link:../../packages/client
       '@modelcontextprotocol/conformance':
-        specifier: 0.2.0-alpha.6
-        version: 0.2.0-alpha.6(@cfworker/json-schema@4.1.1)
+        specifier: 0.2.0-alpha.7
+        version: 0.2.0-alpha.7(@cfworker/json-schema@4.1.1)
       '@modelcontextprotocol/core':
         specifier: workspace:^
         version: link:../../packages/core
@@ -2740,8 +2740,8 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
-  '@modelcontextprotocol/conformance@0.2.0-alpha.6':
-    resolution: {integrity: sha512-LIP5AQiPqKWndgcTvryyrffm6UT9kwu7lKBmnHkKGQeYu3/thCeVf+jgNCrR0xNs4Fw44f48I9GH1E+BrVbdZQ==}
+  '@modelcontextprotocol/conformance@0.2.0-alpha.7':
+    resolution: {integrity: sha512-S3usVyTWdEqvJpyGnXAz6Uj4yboBwT44lrmMqaQtxKcw4PK8H5XfdH5NQqNmDl9/zQbk4oDxtXqzUyGqTbEDzg==}
     hasBin: true
 
   '@modelcontextprotocol/sdk@1.29.0':
@@ -6630,7 +6630,7 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@modelcontextprotocol/conformance@0.2.0-alpha.6(@cfworker/json-schema@4.1.1)':
+  '@modelcontextprotocol/conformance@0.2.0-alpha.7(@cfworker/json-schema@4.1.1)':
     dependencies:
       '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
       '@octokit/rest': 22.0.1

--- a/test/conformance/expected-failures.yaml
+++ b/test/conformance/expected-failures.yaml
@@ -2,7 +2,7 @@
 # CI exits 0 if only these fail, exits 1 on unexpected failures or stale entries.
 #
 # Baseline established against the published @modelcontextprotocol/conformance
-# release pinned in package.json (0.2.0-alpha.6). Newer conformance releases
+# release pinned in package.json (0.2.0-alpha.7). Newer conformance releases
 # are adopted by deliberately bumping the package.json pin and reconciling
 # this file in the same change.
 #
@@ -24,7 +24,7 @@ client: []
 
 server:
     # --- SEP-2663 (io.modelcontextprotocol/tasks) — server SDK does not implement the tasks extension ---
-    # Extension-tagged scenarios; selected only by `--suite all` (the alpha.6 referee
+    # Extension-tagged scenarios; selected only by `--suite all` (the alpha.7 referee
     # has no server-side `--suite extensions`). The active/draft/2026 legs never select
     # them, so they cannot flag these entries as stale. `tasks-status-notifications` is
     # intentionally absent: the referee SKIPs it unconditionally (harness rewrite pending
@@ -39,8 +39,3 @@ server:
     - tasks-dispatch-and-envelope
     - tasks-required-task-error
     - tasks-mrtr-composition
-    # --- conformance#256 server-sse-polling — referee-side pending scenario ---
-    # SHOULD-level checks emit WARNING (priming event + retry field) which the baseline
-    # checker treats as failure. Selected only by `--suite all`; on hold pending
-    # conformance#366 (referee sends 2025-03-26 while testing a 2025-11-25 feature; SDK correctly version-gates priming).
-    - server-sse-polling

--- a/test/conformance/package.json
+++ b/test/conformance/package.json
@@ -41,7 +41,7 @@
         "test:conformance:all": "pnpm run test:conformance:client:all && pnpm run test:conformance:server:all"
     },
     "devDependencies": {
-        "@modelcontextprotocol/conformance": "0.2.0-alpha.6",
+        "@modelcontextprotocol/conformance": "0.2.0-alpha.7",
         "@modelcontextprotocol/client": "workspace:^",
         "@modelcontextprotocol/server": "workspace:^",
         "@modelcontextprotocol/core": "workspace:^",


### PR DESCRIPTION
Bump the conformance referee pin to `0.2.0-alpha.7` and reconcile baselines.

## Motivation and Context
alpha.7 carries conformance#366 (server-sse-polling now negotiates `2025-11-25` for the priming/retry SHOULD checks). With it, `server-sse-polling` passes 3/3 against the SDK.

## How Has This Been Tested?
All 6 conformance legs exit 0: `server` 42/0, `server:draft` 81/0, `server:extensions` 136 pass / 27 expected (tasks-*), `server:2026` 110/0, `client:all` 438/0, `client:2026` 374/0.

## Breaking Changes
None.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added or updated documentation as needed

## Additional context
- `server-sse-polling` removed from `expected-failures.yaml` (now passes).
- `tasks-status-notifications` still referee-side SKIP at alpha.7; comment updated.
- All 9 `tasks-*` baseline entries unchanged.
