### PR TITLE
feat: add injectable SDK logger

### DIFF
--- a/.changeset/injectable-sdk-logger.md
+++ b/.changeset/injectable-sdk-logger.md
@@ -1,0 +1,7 @@
+---
+'@modelcontextprotocol/core': minor
+'@modelcontextprotocol/client': minor
+'@modelcontextprotocol/server': minor
+---
+
+Add a `logger` protocol option so client and server SDK diagnostics can be routed through user-provided logging.

--- a/.changeset/injectable-sdk-logger.md
+++ b/.changeset/injectable-sdk-logger.md
@@ -1,5 +1,5 @@
 ---
-'@modelcontextprotocol/core': minor
+'@modelcontextprotocol/core-internal': minor
 '@modelcontextprotocol/client': minor
 '@modelcontextprotocol/server': minor
 ---

--- a/docs/servers/logging-progress-cancellation.md
+++ b/docs/servers/logging-progress-cancellation.md
@@ -71,6 +71,25 @@ Only the result comes back:
 
 `progress` must increase on every notification for the same token; `total` and `message` are optional.
 
+## Route SDK diagnostics
+
+Pass `logger` to route local warnings and debug messages from SDK internals. On stdio, send every level to stderr so diagnostics never enter the JSON-RPC channel.
+
+```ts source="../../examples/guides/servers/logging-progress-cancellation.examples.ts#sdkLogger_stderr"
+const sdkLogger = {
+    debug: (...args: unknown[]) => console.error('[debug]', ...args),
+    info: (...args: unknown[]) => console.error('[info]', ...args),
+    warn: (...args: unknown[]) => console.error('[warn]', ...args),
+    error: (...args: unknown[]) => console.error('[error]', ...args)
+};
+
+const diagnosticServer = new McpServer({ name: 'file-processor', version: '1.0.0' }, { logger: sdkLogger });
+```
+
+The same option works on `Client` and low-level `Server`; `createMcpHandler` also accepts it for handler diagnostics. Every method is optional, and an omitted method discards diagnostics at that level. The default is `console`.
+
+This logger stays local to the process. It does not send MCP `notifications/message`; use `ctx.mcpReq.log` for that deprecated protocol feature.
+
 ## Log to the client
 
 ::: warning Deprecated — SEP-2577
@@ -201,5 +220,6 @@ Resolve an identifier against a fixed list, as `fetch-source` does. A tool that 
 
 - Every handler receives a context as its second argument; the request-scoped helpers live on `ctx.mcpReq`.
 - `ctx.mcpReq.notify` sends `notifications/progress` when the request carried a `progressToken`; `progress` must increase on each one.
+- The `logger` option routes local SDK diagnostics; it is separate from MCP protocol logging.
 - `ctx.mcpReq.log(level, data)` sends `notifications/message` once the `logging` capability is declared; MCP logging is deprecated (SEP-2577).
 - `ctx.mcpReq.signal` aborts on cancellation and disconnect — check it in long loops and forward it to your own I/O.

--- a/examples/guides/servers/logging-progress-cancellation.examples.ts
+++ b/examples/guides/servers/logging-progress-cancellation.examples.ts
@@ -20,6 +20,19 @@ import * as z from 'zod/v4';
 const server = new McpServer({ name: 'file-processor', version: '1.0.0' }, { capabilities: { logging: {} } });
 //#endregion logging_capability
 
+// "Route SDK diagnostics" — keep local SDK output off the stdio protocol channel.
+//#region sdkLogger_stderr
+const sdkLogger = {
+    debug: (...args: unknown[]) => console.error('[debug]', ...args),
+    info: (...args: unknown[]) => console.error('[info]', ...args),
+    warn: (...args: unknown[]) => console.error('[warn]', ...args),
+    error: (...args: unknown[]) => console.error('[error]', ...args)
+};
+
+const diagnosticServer = new McpServer({ name: 'file-processor', version: '1.0.0' }, { logger: sdkLogger });
+//#endregion sdkLogger_stderr
+void diagnosticServer;
+
 // "Report progress from a handler" — the page's lead block.
 //#region registerTool_progress
 server.registerTool(

--- a/packages/client/src/client/client.ts
+++ b/packages/client/src/client/client.ts
@@ -2442,7 +2442,9 @@ export class Client extends Protocol<ClientContext> {
         const filtered = result.tools.filter(tool => {
             const scan = scanXMcpHeaderDeclarations(tool.inputSchema);
             if (!scan.valid) {
-                console.warn(`[mcp-sdk] excluding tool '${tool.name}' from tools/list: invalid x-mcp-header declaration — ${scan.reason}`);
+                this._logger.warn?.(
+                    `[mcp-sdk] excluding tool '${tool.name}' from tools/list: invalid x-mcp-header declaration — ${scan.reason}`
+                );
                 return false;
             }
             return true;

--- a/packages/client/src/client/client.ts
+++ b/packages/client/src/client/client.ts
@@ -1500,7 +1500,7 @@ export class Client extends Protocol<ClientContext> {
     async listPrompts(params?: ListPromptsRequest['params'], options?: CacheableRequestOptions): Promise<ListPromptsResult> {
         if (!this._serverCapabilities?.prompts && !this._enforceStrictCapabilities) {
             // Respect capability negotiation: server does not support prompts
-            console.debug('Client.listPrompts() called but server does not advertise prompts capability - returning empty list');
+            this._logger.debug?.('Client.listPrompts() called but server does not advertise prompts capability - returning empty list');
             return { prompts: [] };
         }
         if (params?.cursor !== undefined) {
@@ -1540,7 +1540,7 @@ export class Client extends Protocol<ClientContext> {
     async listResources(params?: ListResourcesRequest['params'], options?: CacheableRequestOptions): Promise<ListResourcesResult> {
         if (!this._serverCapabilities?.resources && !this._enforceStrictCapabilities) {
             // Respect capability negotiation: server does not support resources
-            console.debug('Client.listResources() called but server does not advertise resources capability - returning empty list');
+            this._logger.debug?.('Client.listResources() called but server does not advertise resources capability - returning empty list');
             return { resources: [] };
         }
         if (params?.cursor !== undefined) {
@@ -1571,7 +1571,7 @@ export class Client extends Protocol<ClientContext> {
     ): Promise<ListResourceTemplatesResult> {
         if (!this._serverCapabilities?.resources && !this._enforceStrictCapabilities) {
             // Respect capability negotiation: server does not support resources
-            console.debug(
+            this._logger.debug?.(
                 'Client.listResourceTemplates() called but server does not advertise resources capability - returning empty list'
             );
             return { resourceTemplates: [] };
@@ -2395,7 +2395,7 @@ export class Client extends Protocol<ClientContext> {
     async listTools(params?: ListToolsRequest['params'], options?: CacheableRequestOptions): Promise<ListToolsResult> {
         if (!this._serverCapabilities?.tools && !this._enforceStrictCapabilities) {
             // Respect capability negotiation: server does not support tools
-            console.debug('Client.listTools() called but server does not advertise tools capability - returning empty list');
+            this._logger.debug?.('Client.listTools() called but server does not advertise tools capability - returning empty list');
             return { tools: [] };
         }
         if (params?.cursor !== undefined) {

--- a/packages/client/test/client/logger.test.ts
+++ b/packages/client/test/client/logger.test.ts
@@ -1,4 +1,4 @@
-import { InMemoryTransport, LATEST_PROTOCOL_VERSION } from '@modelcontextprotocol/core';
+import { InMemoryTransport, LATEST_PROTOCOL_VERSION } from '@modelcontextprotocol/core-internal';
 import { describe, expect, it, vi } from 'vitest';
 import { Client } from '../../src/client/client';
 

--- a/packages/client/test/client/logger.test.ts
+++ b/packages/client/test/client/logger.test.ts
@@ -1,6 +1,9 @@
+import type { JSONRPCRequest, Tool } from '@modelcontextprotocol/core-internal';
 import { InMemoryTransport, LATEST_PROTOCOL_VERSION } from '@modelcontextprotocol/core-internal';
 import { describe, expect, it, vi } from 'vitest';
 import { Client } from '../../src/client/client';
+
+const MODERN = '2026-07-28';
 
 describe('Client logger option', () => {
     it('routes SDK diagnostics to the configured logger', async () => {
@@ -32,6 +35,61 @@ describe('Client logger option', () => {
         expect(consoleDebug).not.toHaveBeenCalled();
 
         consoleDebug.mockRestore();
+        await client.close();
+        await clientTransport.close();
+        await serverTransport.close();
+    });
+
+    it('routes invalid x-mcp-header tool exclusion warnings to the configured logger', async () => {
+        const warn = vi.fn();
+        const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const client = new Client(
+            { name: 'test-client', version: '1.0.0' },
+            { logger: { warn }, versionNegotiation: { mode: { pin: MODERN } } }
+        );
+        const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+        const invalidTool: Tool = {
+            name: 'bad-tool',
+            inputSchema: { type: 'object', properties: { data: { type: 'object', 'x-mcp-header': 'Data' } } }
+        };
+
+        serverTransport.onmessage = async message => {
+            const request = message as JSONRPCRequest;
+            if (request.id === undefined) return;
+
+            if (request.method === 'server/discover') {
+                await serverTransport.send({
+                    jsonrpc: '2.0',
+                    id: request.id,
+                    result: {
+                        resultType: 'complete',
+                        supportedVersions: [MODERN],
+                        capabilities: { tools: {} },
+                        serverInfo: { name: 'test-server', version: '1.0.0' }
+                    }
+                });
+            } else if (request.method === 'tools/list') {
+                await serverTransport.send({
+                    jsonrpc: '2.0',
+                    id: request.id,
+                    result: {
+                        resultType: 'complete',
+                        ttlMs: 60_000,
+                        cacheScope: 'public',
+                        tools: [invalidTool]
+                    }
+                });
+            }
+        };
+
+        await Promise.all([client.connect(clientTransport), serverTransport.start()]);
+
+        const result = await client.listTools();
+        expect(result.tools).toEqual([]);
+        expect(warn).toHaveBeenCalledWith(expect.stringContaining("excluding tool 'bad-tool'"));
+        expect(consoleWarn).not.toHaveBeenCalled();
+
+        consoleWarn.mockRestore();
         await client.close();
         await clientTransport.close();
         await serverTransport.close();

--- a/packages/client/test/client/logger.test.ts
+++ b/packages/client/test/client/logger.test.ts
@@ -1,0 +1,39 @@
+import { InMemoryTransport, LATEST_PROTOCOL_VERSION } from '@modelcontextprotocol/core';
+import { describe, expect, it, vi } from 'vitest';
+import { Client } from '../../src/client/client';
+
+describe('Client logger option', () => {
+    it('routes SDK diagnostics to the configured logger', async () => {
+        const debug = vi.fn();
+        const consoleDebug = vi.spyOn(console, 'debug').mockImplementation(() => {});
+        const client = new Client({ name: 'test-client', version: '1.0.0' }, { logger: { debug } });
+        const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+        serverTransport.onmessage = async message => {
+            if ('method' in message && 'id' in message && message.method === 'initialize') {
+                await serverTransport.send({
+                    jsonrpc: '2.0',
+                    id: message.id,
+                    result: {
+                        protocolVersion: LATEST_PROTOCOL_VERSION,
+                        capabilities: {},
+                        serverInfo: { name: 'test-server', version: '1.0.0' }
+                    }
+                });
+            }
+        };
+
+        await Promise.all([client.connect(clientTransport), serverTransport.start()]);
+
+        await expect(client.listTools()).resolves.toEqual({ tools: [] });
+        expect(debug).toHaveBeenCalledWith(
+            'Client.listTools() called but server does not advertise tools capability - returning empty list'
+        );
+        expect(consoleDebug).not.toHaveBeenCalled();
+
+        consoleDebug.mockRestore();
+        await client.close();
+        await clientTransport.close();
+        await serverTransport.close();
+    });
+});

--- a/packages/core-internal/src/exports/public/index.ts
+++ b/packages/core-internal/src/exports/public/index.ts
@@ -42,6 +42,9 @@ export { checkResourceAllowed, resourceUrlFromServerUrl } from '../../shared/aut
 // Metadata utilities
 export { getDisplayName } from '../../shared/metadataUtils';
 
+// Logging
+export type { SdkLogger } from '../../shared/logger';
+
 // Protocol types (NOT the Protocol class itself or mergeCapabilities)
 export type {
     BaseContext,

--- a/packages/core-internal/src/index.ts
+++ b/packages/core-internal/src/index.ts
@@ -9,6 +9,7 @@ export * from './shared/inboundClassification';
 export * from './shared/inputRequired';
 export * from './shared/inputRequiredDriver';
 export * from './shared/inputRequiredEngine';
+export * from './shared/logger';
 export * from './shared/mcpParamHeaders';
 export * from './shared/metadataUtils';
 export * from './shared/protocol';

--- a/packages/core-internal/src/shared/logger.ts
+++ b/packages/core-internal/src/shared/logger.ts
@@ -1,5 +1,9 @@
 /**
- * Logger used by SDK internals for diagnostics.
+ * Console-compatible sink for local SDK diagnostics.
+ *
+ * This is separate from MCP protocol logging (`notifications/message`). Every method is
+ * optional; diagnostics at an omitted level are discarded. Pass an adapter around a
+ * structured logger when its methods do not already accept console-style arguments.
  */
 export type SdkLogger = {
     debug?: (...args: unknown[]) => void;

--- a/packages/core-internal/src/shared/logger.ts
+++ b/packages/core-internal/src/shared/logger.ts
@@ -1,0 +1,9 @@
+/**
+ * Logger used by SDK internals for diagnostics.
+ */
+export type SdkLogger = {
+    debug?: (...args: unknown[]) => void;
+    info?: (...args: unknown[]) => void;
+    warn?: (...args: unknown[]) => void;
+    error?: (...args: unknown[]) => void;
+};

--- a/packages/core-internal/src/shared/protocol.ts
+++ b/packages/core-internal/src/shared/protocol.ts
@@ -90,7 +90,8 @@ export type ProtocolOptions = {
     debouncedNotificationMethods?: string[];
 
     /**
-     * Logger used by SDK internals for warnings and diagnostic messages.
+     * Console-compatible sink for local SDK diagnostics. This does not affect MCP protocol
+     * logging (`notifications/message`). Omitted methods discard diagnostics at that level.
      *
      * @default console
      */

--- a/packages/core-internal/src/shared/protocol.ts
+++ b/packages/core-internal/src/shared/protocol.ts
@@ -51,6 +51,7 @@ import { bootstrapOutboundCodec } from '../wire/bootstrap';
 import type { LiftedWireMaterial, WireCodec } from '../wire/codec';
 import { classifiedWireEra, codecForVersion, isSpecNotificationMethod, isSpecRequestMethod, MODERN_WIRE_REVISION } from '../wire/codec';
 import { manualInputRequiredValue, partitionInputResponses } from './inputRequiredEngine';
+import type { SdkLogger } from './logger';
 import type { Transport, TransportSendOptions } from './transport';
 
 /**
@@ -87,6 +88,13 @@ export type ProtocolOptions = {
      * e.g., `['notifications/tools/list_changed']`
      */
     debouncedNotificationMethods?: string[];
+
+    /**
+     * Logger used by SDK internals for warnings and diagnostic messages.
+     *
+     * @default console
+     */
+    logger?: SdkLogger;
 };
 
 /**
@@ -580,6 +588,7 @@ export abstract class Protocol<ContextT extends BaseContext> {
     }
 
     protected _supportedProtocolVersions: string[];
+    protected _logger: SdkLogger;
 
     /**
      * Callback for when the connection is closed for any reason.
@@ -607,6 +616,7 @@ export abstract class Protocol<ContextT extends BaseContext> {
 
     constructor(private _options?: ProtocolOptions) {
         this._supportedProtocolVersions = _options?.supportedProtocolVersions ?? SUPPORTED_PROTOCOL_VERSIONS;
+        this._logger = _options?.logger ?? console;
 
         this.setNotificationHandler('notifications/cancelled', notification => {
             this._oncancel(notification);

--- a/packages/core-internal/src/shared/toolNameValidation.ts
+++ b/packages/core-internal/src/shared/toolNameValidation.ts
@@ -10,6 +10,8 @@
  * @see {@link https://github.com/modelcontextprotocol/modelcontextprotocol/issues/986 | SEP-986: Specify Format for Tool Names}
  */
 
+import type { SdkLogger } from './logger';
+
 /**
  * Regular expression for valid tool names according to SEP-986 specification
  */
@@ -86,16 +88,17 @@ export function validateToolName(name: string): {
  * Issues warnings for non-conforming tool names
  * @param name - The tool name that triggered the warnings
  * @param warnings - Array of warning messages
+ * @param logger - Logger to emit warnings through
  */
-export function issueToolNameWarning(name: string, warnings: string[]): void {
+export function issueToolNameWarning(name: string, warnings: string[], logger: SdkLogger = console): void {
     if (warnings.length > 0) {
-        console.warn(`Tool name validation warning for "${name}":`);
+        logger.warn?.(`Tool name validation warning for "${name}":`);
         for (const warning of warnings) {
-            console.warn(`  - ${warning}`);
+            logger.warn?.(`  - ${warning}`);
         }
-        console.warn('Tool registration will proceed, but this may cause compatibility issues.');
-        console.warn('Consider updating the tool name to conform to the MCP tool naming standard.');
-        console.warn(
+        logger.warn?.('Tool registration will proceed, but this may cause compatibility issues.');
+        logger.warn?.('Consider updating the tool name to conform to the MCP tool naming standard.');
+        logger.warn?.(
             'See SEP: Specify Format for Tool Names (https://github.com/modelcontextprotocol/modelcontextprotocol/issues/986) for more details.'
         );
     }
@@ -104,13 +107,14 @@ export function issueToolNameWarning(name: string, warnings: string[]): void {
 /**
  * Validates a tool name and issues warnings for non-conforming names
  * @param name - The tool name to validate
+ * @param logger - Logger to emit warnings through
  * @returns `true` if the name is valid, `false` otherwise
  */
-export function validateAndWarnToolName(name: string): boolean {
+export function validateAndWarnToolName(name: string, logger?: SdkLogger): boolean {
     const result = validateToolName(name);
 
     // Always issue warnings for any validation issues (both invalid names and warnings)
-    issueToolNameWarning(name, result.warnings);
+    issueToolNameWarning(name, result.warnings, logger);
 
     return result.isValid;
 }

--- a/packages/core-internal/src/util/standardSchema.ts
+++ b/packages/core-internal/src/util/standardSchema.ts
@@ -8,6 +8,8 @@
 
 import * as z from 'zod/v4';
 
+import type { SdkLogger } from '../shared/logger';
+
 // Standard Schema interfaces — vendored from https://standardschema.dev (spec v1, Jan 2025)
 
 export interface StandardTypedV1<Input = unknown, Output = Input> {
@@ -175,7 +177,11 @@ let warnedZodFallback = false;
  * `io: 'output'` a non-object root is returned as-is; the `"object"` default is
  * applied only when the root is provably object-shaped.
  */
-export function standardSchemaToJsonSchema(schema: StandardJSONSchemaV1, io: 'input' | 'output' = 'input'): Record<string, unknown> {
+export function standardSchemaToJsonSchema(
+    schema: StandardJSONSchemaV1,
+    io: 'input' | 'output' = 'input',
+    logger: SdkLogger = console
+): Record<string, unknown> {
     const std = schema['~standard'];
     let result: Record<string, unknown>;
     if (std.jsonSchema) {
@@ -193,7 +199,7 @@ export function standardSchemaToJsonSchema(schema: StandardJSONSchemaV1, io: 'in
         }
         if (!warnedZodFallback) {
             warnedZodFallback = true;
-            console.warn(
+            logger.warn?.(
                 '[mcp-sdk] Your zod version does not implement `~standard.jsonSchema` (added in zod 4.2.0). ' +
                     'Falling back to z.toJSONSchema(). Upgrade to zod >=4.2.0 to silence this warning.'
             );

--- a/packages/core-internal/src/util/standardSchema.ts
+++ b/packages/core-internal/src/util/standardSchema.ts
@@ -284,9 +284,10 @@ export async function validateStandardSchema<T extends StandardSchemaV1>(
 // Prompt argument extraction
 
 export function promptArgumentsFromStandardSchema(
-    schema: StandardJSONSchemaV1
+    schema: StandardJSONSchemaV1,
+    logger: SdkLogger = console
 ): Array<{ name: string; description?: string; required: boolean }> {
-    const jsonSchema = standardSchemaToJsonSchema(schema, 'input');
+    const jsonSchema = standardSchemaToJsonSchema(schema, 'input', logger);
     const properties = (jsonSchema.properties as Record<string, { description?: string }>) || {};
     const required = (jsonSchema.required as string[]) || [];
 

--- a/packages/core-internal/test/util/standardSchema.zodFallback.test.ts
+++ b/packages/core-internal/test/util/standardSchema.zodFallback.test.ts
@@ -6,7 +6,8 @@ type SchemaArg = Parameters<typeof standardSchemaToJsonSchema>[0];
 
 describe('standardSchemaToJsonSchema — zod fallback paths', () => {
     it('falls back to z.toJSONSchema for zod 4.0–4.1 (vendor=zod, no ~standard.jsonSchema, has _zod)', () => {
-        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const warn = vi.fn();
+        const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
         const real = z.object({ a: z.string() });
         // Simulate zod 4.0–4.1: shadow `~standard` on the real instance with `jsonSchema` removed.
         // Keeps the rest of the zod 4 object (including `_zod`) intact so z.toJSONSchema can introspect it.
@@ -14,12 +15,13 @@ describe('standardSchemaToJsonSchema — zod fallback paths', () => {
         void _drop;
         Object.defineProperty(real, '~standard', { value: { ...stdNoJson, vendor: 'zod' }, configurable: true });
 
-        const result = standardSchemaToJsonSchema(real as unknown as SchemaArg);
+        const result = standardSchemaToJsonSchema(real as unknown as SchemaArg, 'input', { warn });
         expect(result.type).toBe('object');
         expect((result.properties as unknown as Record<string, unknown>)?.a).toBeDefined();
         expect(warn).toHaveBeenCalledOnce();
         expect(warn.mock.calls[0]?.[0]).toContain('zod 4.2.0');
-        warn.mockRestore();
+        expect(consoleWarn).not.toHaveBeenCalled();
+        consoleWarn.mockRestore();
     });
 
     it('throws a clear error for zod 3 (vendor=zod, no ~standard.jsonSchema, no _zod)', () => {

--- a/packages/server/src/server/createMcpHandler.ts
+++ b/packages/server/src/server/createMcpHandler.ts
@@ -34,7 +34,8 @@ import type {
     InboundLadderRejection,
     InboundLegacyRoute,
     InboundModernRoute,
-    RequestId
+    RequestId,
+    SdkLogger
 } from '@modelcontextprotocol/core-internal';
 import {
     classifyInboundRequest,
@@ -162,6 +163,8 @@ export interface CreateMcpHandlerOptions {
     legacy?: 'stateless' | 'reject';
     /** Callback for out-of-band errors and rejected requests (reporting only; it never alters the response). */
     onerror?: (error: Error) => void;
+    /** Logger used for SDK diagnostics emitted by the HTTP handler. Defaults to `console`. */
+    logger?: SdkLogger;
     /**
      * Response shaping for modern (2026-07-28) request exchanges:
      *
@@ -581,7 +584,7 @@ export async function isLegacyRequest(request: Request, parsedBody?: unknown): P
  * request headers.
  */
 export function createMcpHandler(factory: McpServerFactory, options: CreateMcpHandlerOptions = {}): McpHttpHandler {
-    const { legacy, onerror, responseMode } = options;
+    const { legacy, onerror, responseMode, logger = console } = options;
 
     // Construction-time guard for JavaScript callers passing a handler as the
     // legacy value: the option only selects a posture ('stateless' | 'reject').
@@ -614,8 +617,7 @@ export function createMcpHandler(factory: McpServerFactory, options: CreateMcpHa
         onerror: reportError
     });
     if (responseMode === 'json') {
-        // eslint-disable-next-line no-console
-        console.warn(
+        logger.warn?.(
             "responseMode: 'json' drops mid-call notifications. subscriptions/listen streams are always served over SSE regardless; " +
                 'other notifications emitted before a result are dropped.'
         );

--- a/packages/server/src/server/mcp.ts
+++ b/packages/server/src/server/mcp.ts
@@ -832,7 +832,7 @@ export class McpServer {
                 this._toolInputSchemaJson[name] = json;
                 const scan = scanXMcpHeaderDeclarations(json);
                 if (!scan.valid) {
-                    this._logger.warn(
+                    this._logger.warn?.(
                         `[mcp-sdk] tool '${name}' carries an invalid x-mcp-header declaration and will be excluded by ` +
                             `conforming Streamable HTTP clients: ${scan.reason}`
                     );
@@ -1332,10 +1332,7 @@ const EMPTY_OBJECT_JSON_SCHEMA = {
  * `tools/list` emits (and that the 2025 codec's `encodeResult('tools/list', …)` may wrap). A conversion
  * failure yields `undefined` so the failure surfaces where it always has (`tools/list`).
  */
-function convertOutputSchemaJson(
-    outputSchema: StandardSchemaWithJSON | undefined,
-    logger: SdkLogger
-): Record<string, unknown> | undefined {
+function convertOutputSchemaJson(outputSchema: StandardSchemaWithJSON | undefined, logger: SdkLogger): Record<string, unknown> | undefined {
     if (outputSchema === undefined) return undefined;
     try {
         return standardSchemaToJsonSchema(outputSchema, 'output', logger);

--- a/packages/server/src/server/mcp.ts
+++ b/packages/server/src/server/mcp.ts
@@ -19,6 +19,7 @@ import type {
     Resource,
     ResourceTemplateReference,
     Result,
+    SdkLogger,
     ServerContext,
     StandardSchemaWithJSON,
     Tool,
@@ -75,6 +76,8 @@ export class McpServer {
     } = {};
     private _registeredTools: { [name: string]: RegisteredTool } = {};
     private _registeredPrompts: { [name: string]: RegisteredPrompt } = {};
+    private readonly _logger: SdkLogger;
+
     /**
      * Per-tool JSON-converted `inputSchema`, memoized so the SEP-2243
      * registration-time scan and the pre-dispatch validation step share one
@@ -106,7 +109,7 @@ export class McpServer {
         // A successful re-derive is memoized so the per-request-factory
         // `createMcpHandler` model does not re-convert on every call.
         try {
-            const json = standardSchemaToJsonSchema(tool.inputSchema, 'input');
+            const json = standardSchemaToJsonSchema(tool.inputSchema, 'input', this._logger);
             this._toolInputSchemaJson[name] = json;
             return json;
         } catch {
@@ -115,6 +118,7 @@ export class McpServer {
     }
 
     constructor(serverInfo: Implementation, options?: ServerOptions) {
+        this._logger = options?.logger ?? console;
         this.server = new Server(serverInfo, options);
 
         // Per the MCP spec, a server that declares a primitive capability MUST respond to its
@@ -186,7 +190,7 @@ export class McpServer {
                             title: tool.title,
                             description: tool.description,
                             inputSchema: tool.inputSchema
-                                ? (standardSchemaToJsonSchema(tool.inputSchema, 'input') as Tool['inputSchema'])
+                                ? (standardSchemaToJsonSchema(tool.inputSchema, 'input', this._logger) as Tool['inputSchema'])
                                 : EMPTY_OBJECT_JSON_SCHEMA,
                             annotations: tool.annotations,
                             icons: tool.icons,
@@ -199,7 +203,11 @@ export class McpServer {
                             // `{type:'object',properties:{result:<natural>},required:['result']}` toward
                             // 2025-era clients) lives in the 2025 wire codec's `encodeResult('tools/list', …)`
                             // — this handler is era-blind and emits the natural converted schema.
-                            toolDefinition.outputSchema = standardSchemaToJsonSchema(tool.outputSchema, 'output') as Tool['outputSchema'];
+                            toolDefinition.outputSchema = standardSchemaToJsonSchema(
+                                tool.outputSchema,
+                                'output',
+                                this._logger
+                            ) as Tool['outputSchema'];
                         }
 
                         return toolDefinition;
@@ -807,7 +815,7 @@ export class McpServer {
         handler: AnyToolHandler<StandardSchemaWithJSON | undefined>
     ): RegisteredTool {
         // Validate tool name according to SEP specification
-        validateAndWarnToolName(name);
+        validateAndWarnToolName(name, this._logger);
 
         // SEP-2243 registration-time declaration-validity check (additive: warn,
         // never throw — clients enforce by exclusion, servers by header
@@ -820,11 +828,11 @@ export class McpServer {
         // the "warn, never throw" contract.
         if (inputSchema !== undefined) {
             try {
-                const json = standardSchemaToJsonSchema(inputSchema, 'input');
+                const json = standardSchemaToJsonSchema(inputSchema, 'input', this._logger);
                 this._toolInputSchemaJson[name] = json;
                 const scan = scanXMcpHeaderDeclarations(json);
                 if (!scan.valid) {
-                    console.warn(
+                    this._logger.warn(
                         `[mcp-sdk] tool '${name}' carries an invalid x-mcp-header declaration and will be excluded by ` +
                             `conforming Streamable HTTP clients: ${scan.reason}`
                     );
@@ -844,7 +852,7 @@ export class McpServer {
             description,
             inputSchema,
             outputSchema,
-            outputSchemaJson: convertOutputSchemaJson(outputSchema),
+            outputSchemaJson: convertOutputSchemaJson(outputSchema, this._logger),
             annotations,
             icons,
             execution,
@@ -862,7 +870,7 @@ export class McpServer {
                 // `_toolInputSchemaJson` slot rather than the original.
                 if (updates.name !== undefined && updates.name !== name) {
                     if (typeof updates.name === 'string') {
-                        validateAndWarnToolName(updates.name);
+                        validateAndWarnToolName(updates.name, this._logger);
                     }
                     delete this._registeredTools[name];
                     delete this._toolInputSchemaJson[name];
@@ -899,7 +907,7 @@ export class McpServer {
 
                 if (updates.outputSchema !== undefined) {
                     registeredTool.outputSchema = updates.outputSchema;
-                    registeredTool.outputSchemaJson = convertOutputSchemaJson(updates.outputSchema);
+                    registeredTool.outputSchemaJson = convertOutputSchemaJson(updates.outputSchema, this._logger);
                 }
                 if (updates.annotations !== undefined) registeredTool.annotations = updates.annotations;
                 if (updates.icons !== undefined) registeredTool.icons = updates.icons;
@@ -1324,10 +1332,13 @@ const EMPTY_OBJECT_JSON_SCHEMA = {
  * `tools/list` emits (and that the 2025 codec's `encodeResult('tools/list', …)` may wrap). A conversion
  * failure yields `undefined` so the failure surfaces where it always has (`tools/list`).
  */
-function convertOutputSchemaJson(outputSchema: StandardSchemaWithJSON | undefined): Record<string, unknown> | undefined {
+function convertOutputSchemaJson(
+    outputSchema: StandardSchemaWithJSON | undefined,
+    logger: SdkLogger
+): Record<string, unknown> | undefined {
     if (outputSchema === undefined) return undefined;
     try {
-        return standardSchemaToJsonSchema(outputSchema, 'output');
+        return standardSchemaToJsonSchema(outputSchema, 'output', logger);
     } catch {
         return undefined;
     }

--- a/packages/server/src/server/mcp.ts
+++ b/packages/server/src/server/mcp.ts
@@ -541,7 +541,7 @@ export class McpServer {
                             name,
                             title: prompt.title,
                             description: prompt.description,
-                            arguments: prompt.argsSchema ? promptArgumentsFromStandardSchema(prompt.argsSchema) : undefined,
+                            arguments: prompt.argsSchema ? promptArgumentsFromStandardSchema(prompt.argsSchema, this._logger) : undefined,
                             icons: prompt.icons,
                             _meta: prompt._meta
                         };

--- a/packages/server/test/server/createMcpHandler.test.ts
+++ b/packages/server/test/server/createMcpHandler.test.ts
@@ -761,6 +761,21 @@ describe('createMcpHandler — responseMode', () => {
         expect(text).toContain('json only');
     });
 
+    it("routes the responseMode: 'json' warning to the configured logger", () => {
+        const { factory } = testFactory();
+        const warn = vi.fn();
+        const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+        try {
+            createMcpHandler(factory, { responseMode: 'json', logger: { warn } });
+        } finally {
+            consoleWarn.mockRestore();
+        }
+
+        expect(warn).toHaveBeenCalledWith(expect.stringContaining("responseMode: 'json' drops mid-call notifications"));
+        expect(consoleWarn).not.toHaveBeenCalled();
+    });
+
     it("responseMode: 'sse' streams even when the handler emits nothing before its result", async () => {
         const { factory } = testFactory();
         const handler = createMcpHandler(factory, { responseMode: 'sse' });

--- a/packages/server/test/server/mcp.compat.test.ts
+++ b/packages/server/test/server/mcp.compat.test.ts
@@ -91,6 +91,51 @@ describe('registerTool/registerPrompt accept raw Zod shape (auto-wrapped)', () =
         expect(isStandardSchema(prompts['p']?.argsSchema)).toBe(true);
     });
 
+    it('routes prompt argsSchema conversion warnings to the configured logger', async () => {
+        const warn = vi.fn();
+        const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const server = new McpServer({ name: 't', version: '1.0.0' }, { logger: { warn } });
+
+        const argsSchema = z.object({ topic: z.string() });
+        const { jsonSchema: _drop, ...stdNoJson } = argsSchema['~standard'] as unknown as Record<string, unknown>;
+        void _drop;
+        Object.defineProperty(argsSchema, '~standard', { value: { ...stdNoJson, vendor: 'zod' }, configurable: true });
+
+        server.registerPrompt('p', { argsSchema }, async ({ topic }) => ({
+            messages: [{ role: 'user' as const, content: { type: 'text' as const, text: topic } }]
+        }));
+
+        const [client, srv] = InMemoryTransport.createLinkedPair();
+        try {
+            await server.connect(srv);
+            await client.start();
+
+            const responses: JSONRPCMessage[] = [];
+            client.onmessage = m => responses.push(m);
+
+            await client.send({
+                jsonrpc: '2.0',
+                id: 1,
+                method: 'initialize',
+                params: {
+                    protocolVersion: LATEST_PROTOCOL_VERSION,
+                    capabilities: {},
+                    clientInfo: { name: 'c', version: '1.0.0' }
+                }
+            } as JSONRPCMessage);
+            await client.send({ jsonrpc: '2.0', method: 'notifications/initialized' } as JSONRPCMessage);
+            await client.send({ jsonrpc: '2.0', id: 2, method: 'prompts/list' } as JSONRPCMessage);
+
+            await vi.waitFor(() => expect(responses.some(r => 'id' in r && r.id === 2)).toBe(true));
+
+            expect(warn).toHaveBeenCalledWith(expect.stringContaining('zod 4.2.0'));
+            expect(consoleWarn).not.toHaveBeenCalled();
+        } finally {
+            consoleWarn.mockRestore();
+            await server.close();
+        }
+    });
+
     it('callback receives validated, typed args end-to-end via tools/call', async () => {
         const server = new McpServer({ name: 't', version: '1.0.0' });
 

--- a/packages/server/test/server/mcp.compat.test.ts
+++ b/packages/server/test/server/mcp.compat.test.ts
@@ -7,6 +7,20 @@ import type { InferRawShape } from '../../src/server/mcp';
 import { completable } from '../../src/server/completable';
 
 describe('registerTool/registerPrompt accept raw Zod shape (auto-wrapped)', () => {
+    it('routes tool-name warnings to the configured logger', () => {
+        const warn = vi.fn();
+        const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const server = new McpServer({ name: 't', version: '1.0.0' }, { logger: { warn } });
+
+        server.registerTool('bad tool', {}, async () => ({
+            content: [{ type: 'text' as const, text: 'ok' }]
+        }));
+
+        expect(warn).toHaveBeenCalledWith('Tool name validation warning for "bad tool":');
+        expect(consoleWarn).not.toHaveBeenCalled();
+        consoleWarn.mockRestore();
+    });
+
     it('registerTool accepts a raw shape for inputSchema and auto-wraps it', () => {
         const server = new McpServer({ name: 't', version: '1.0.0' });
 


### PR DESCRIPTION
## Summary
- add a `logger` protocol option shared by Client, Server, and McpServer
- expose the same diagnostics sink on `createMcpHandler`
- route client capability diagnostics, tool-name warnings, x-mcp-header warnings, and Standard Schema fallback warnings through the configured logger
- export the `SdkLogger` type and add focused coverage and documentation

Fixes #1262

## API decision

`SdkLogger` is intentionally a minimal, console-compatible diagnostics sink with optional `debug`, `info`, `warn`, and `error` methods. It does not adopt RFC 5424 levels or filtering: these are local SDK diagnostics, not MCP protocol logging, and level policy belongs to the application's logger. Console, Pino, and Winston can be passed directly or through a small adapter.

Omitting a method discards diagnostics at that level. Omitting `logger` preserves the current `console` behavior. For stdio servers, the documentation shows routing every level to stderr so diagnostics cannot enter the JSON-RPC channel.

## Tests
- `pnpm sync:snippets --check`
- `pnpm --filter @modelcontextprotocol/examples typecheck`
- `pnpm --filter @modelcontextprotocol/client test -- test/client/logger.test.ts`
- `pnpm --filter @modelcontextprotocol/core-internal test -- test/util/standardSchema.zodFallback.test.ts`
- `pnpm --filter @modelcontextprotocol/server test -- test/server/createMcpHandler.test.ts test/server/mcp.compat.test.ts`
- `pnpm --filter @modelcontextprotocol/core-internal --filter @modelcontextprotocol/client --filter @modelcontextprotocol/server typecheck`
- `pnpm --filter @modelcontextprotocol/client --filter @modelcontextprotocol/server build`
- `node scripts/smoke-dist-types.mjs`
- pre-push `typecheck:all`, `build:all`, and `lint:all`
