### PR TITLE
docs(migration): dual-role instanceof caveat in the Errors section

### DIFF
--- a/docs/migration/upgrade-to-v2.md
+++ b/docs/migration/upgrade-to-v2.md
@@ -560,6 +560,17 @@ Replace the literal with the named code. Loud (`TS2367`) when the compared value
 typed `SdkErrorCode`; silent when the left side is `unknown` or a cast — grep for
 `=== -32000` / `=== -32001`.
 
+**Dual-role processes: `instanceof` does not cross the packages.**
+`@modelcontextprotocol/client` and `@modelcontextprotocol/server` each bundle their own
+copy of these error classes, so in a process that uses both — a gateway, a host, an
+in-process test — an error constructed by one package fails `instanceof` against the
+class imported from the other, silently. When an error may originate from the other
+package, match on stable fields instead of class identity: `error.code` values
+(`SdkErrorCode` strings for SDK errors, numeric JSON-RPC codes for protocol errors,
+`OAuthErrorCode` strings for OAuth errors) plus presence checks like `'status' in e`,
+or reconstruct typed protocol errors with `ProtocolError.fromError(code, message, data)`
+— it exists precisely because `instanceof` does not survive bundle boundaries.
+
 **Constructing the error (test stubs, custom transports).** v1
 `new StreamableHTTPError(code, message)` becomes
 `new SdkHttpError(code, message, data)`: the first argument is now a `SdkErrorCode`


### PR DESCRIPTION
Follow-up to #2382. The Errors section teaches `e instanceof SdkHttpError && e.status === 401`-style classification; in a process that uses both `@modelcontextprotocol/client` and `@modelcontextprotocol/server` (gateway, host, in-process test), each package bundles its own copy of the error classes, so an error constructed by one package fails `instanceof` against the class imported from the other — silently. With the runtime-identity fix (#2384) not proceeding, the guide should say so where the patterns are taught.

## Motivation and Context

Four independent v1→v2 migrations hit silent cross-package `instanceof` misses. This adds one paragraph documenting the limitation and the cross-bundle-safe forms: `error.code` / field-presence matching, and `ProtocolError.fromError` for typed protocol errors.

## How Has This Been Tested?

Docs-only; prettier clean.

## Breaking Changes

None.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed