### PR TITLE
docs: turn the version banners into working cross-site links

### DIFF
--- a/docs/.vitepress/theme/Banner.vue
+++ b/docs/.vitepress/theme/Banner.vue
@@ -1,6 +1,5 @@
 <template>
     <div class="version-banner">
-        You are viewing the in-development v2 documentation. The stable v1 docs are at
-        <a href="https://ts.sdk.modelcontextprotocol.io/">ts.sdk.modelcontextprotocol.io</a>.
+        Looking for the <a href="https://ts.sdk.modelcontextprotocol.io/" target="_self">v1 documentation</a>?
     </div>
 </template>

--- a/docs/v1/.vitepress/theme/Banner.vue
+++ b/docs/v1/.vitepress/theme/Banner.vue
@@ -1,6 +1,5 @@
 <template>
     <div class="version-banner">
-        You are viewing the v1.x documentation. The in-development v2 docs are at
-        <a href="https://ts.sdk.modelcontextprotocol.io/v2/">/v2/</a>.
+        Looking for the <a href="https://ts.sdk.modelcontextprotocol.io/v2/" target="_self">v2 beta documentation</a>?
     </div>
 </template>


### PR DESCRIPTION
The version banners on both doc sites linked the sibling site with a plain same-origin anchor. The VitePress client-side router intercepts same-origin links and resolves them inside the current site — which has no such page — so clicking either banner rendered a client-side 404 (a hard reload then loaded the right site). This adds `target="_self"`, which the router does not intercept, and rewords both banners.

## Motivation and Context

Live defect on ts.sdk.modelcontextprotocol.io after #2395: the banner cross-links 404 in both directions until the page is reloaded.

## How Has This Been Tested?

- Root cause confirmed in the shipped router (`vitepress/dist/client/app/router.js` skips links with a `target` attribute).
- `pnpm docs:build` green; the rendered banner anchor carries `target="_self"` and the new copy.

## Breaking Changes

None — docs site only.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

Banner copy is now "Looking for the **v1 documentation**?" on the v2 site and "Looking for the **v2 beta documentation**?" on the v1 site, with the destination as the underlined link.
