### PR TITLE
docs: name the current site in both version banners and add a beta callout to the landing page

### DIFF
--- a/docs/.vitepress/theme/Banner.vue
+++ b/docs/.vitepress/theme/Banner.vue
@@ -1,5 +1,6 @@
 <template>
     <div class="version-banner">
-        Looking for the <a href="https://ts.sdk.modelcontextprotocol.io/" target="_self">v1 documentation</a>?
+        This is the documentation for the v2 beta — looking for the
+        <a href="https://ts.sdk.modelcontextprotocol.io/" target="_self">v1 documentation</a>?
     </div>
 </template>

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,9 +1,12 @@
 ---
-status: calibration
 shape: landing
 ---
 
 # MCP TypeScript SDK
+
+::: info v2 beta
+This is the documentation for **v2** of the SDK, currently in **beta**: the API is settling but can still change before the stable release alongside the [2026-07-28 spec](https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/). [Tell us what you find](https://github.com/modelcontextprotocol/typescript-sdk/issues/new?template=v2-feedback.yml) — and if you need the stable v1, its documentation is at [ts.sdk.modelcontextprotocol.io](https://ts.sdk.modelcontextprotocol.io/).
+:::
 
 The **Model Context Protocol** (MCP) is an open standard that connects AI applications to the systems where your data and tools live. You write a **server** that exposes tools, resources, and prompts; any MCP **host** — Claude Code, VS Code, Cursor, your own application — connects to it and lets a model use them. The protocol is defined by [the MCP specification](https://modelcontextprotocol.io/specification/latest); this SDK is its TypeScript implementation, on Node.js, Bun, and Deno.
 

--- a/docs/v1/.vitepress/theme/Banner.vue
+++ b/docs/v1/.vitepress/theme/Banner.vue
@@ -1,5 +1,6 @@
 <template>
     <div class="version-banner">
-        Looking for the <a href="https://ts.sdk.modelcontextprotocol.io/v2/" target="_self">v2 beta documentation</a>?
+        This is the documentation for v1.x — looking for the
+        <a href="https://ts.sdk.modelcontextprotocol.io/v2/" target="_self">v2 beta documentation</a>?
     </div>
 </template>


### PR DESCRIPTION
Two small presentation changes to the v2 docs site, following the Python SDK docs.

## Motivation and Context

The site banner only said where the reader could go ("Looking for the v1 documentation?") without saying where they are; the landing page had no version-status callout. Both are standard on the Python SDK docs site.

- The banner now reads: "This is the documentation for the v2 beta — looking for the v1 documentation?"
- The landing page opens with a `v2 beta` info callout under the title: status, the spec the API tracks, a link to the v2 feedback issue form, and the v1 documentation link.

## How Has This Been Tested?

`pnpm docs:build` (0 dead links, 0 typedoc warnings) and the rendered output inspected.

## Breaking Changes

None.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

Also removes a stale drafting-status frontmatter key from the landing page.
