### PR TITLE
chore: add missing changesets for CommonJS builds and codemod iterations

### DIFF
--- a/.changeset/cjs-dual-builds.md
+++ b/.changeset/cjs-dual-builds.md
@@ -1,0 +1,13 @@
+---
+'@modelcontextprotocol/server': minor
+'@modelcontextprotocol/client': minor
+'@modelcontextprotocol/core': minor
+'@modelcontextprotocol/server-legacy': minor
+'@modelcontextprotocol/codemod': minor
+'@modelcontextprotocol/express': minor
+'@modelcontextprotocol/hono': minor
+'@modelcontextprotocol/fastify': minor
+'@modelcontextprotocol/node': minor
+---
+
+Ship CommonJS builds alongside ESM for all v2 packages, so `require()` consumers and CJS-only toolchains can use the SDK without a bundler shim.

--- a/.changeset/codemod-iterations-5.md
+++ b/.changeset/codemod-iterations-5.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/codemod': patch
+---
+
+v1-to-v2 migration fixes from continued real-world migrations (codemod iterations 5).


### PR DESCRIPTION
The CommonJS dual-build change and codemod iterations 5 merged without changesets, so the release automation has nothing to version. This adds the two missing changesets; on merge the Version Packages PR regenerates for the next beta.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed