### PR TITLE
Era-scoped protocol version constants; send negotiated version on OAuth discovery

### DIFF
--- a/.changeset/auth-discovery-negotiated-version.md
+++ b/.changeset/auth-discovery-negotiated-version.md
@@ -1,0 +1,11 @@
+---
+'@modelcontextprotocol/client': patch
+---
+
+Send the connection's negotiated protocol version in the `MCP-Protocol-Version`
+header on OAuth metadata discovery requests. Previously every discovery request
+advertised the latest legacy revision regardless of what the connection had
+negotiated. `AuthOptions` and `discoverOAuthServerInfo` gain an optional
+`protocolVersion`; the Streamable HTTP and SSE transports pass their negotiated
+version automatically. When unset (auth before any handshake), discovery still
+falls back to `LATEST_LEGACY_PROTOCOL_VERSION` — unchanged prior behavior.

--- a/.changeset/era-scoped-version-constants.md
+++ b/.changeset/era-scoped-version-constants.md
@@ -1,0 +1,12 @@
+---
+'@modelcontextprotocol/client': patch
+'@modelcontextprotocol/server': patch
+'@modelcontextprotocol/codemod': patch
+---
+
+Rename `LATEST_PROTOCOL_VERSION` → `LATEST_LEGACY_PROTOCOL_VERSION` and
+`SUPPORTED_PROTOCOL_VERSIONS` → `SUPPORTED_LEGACY_PROTOCOL_VERSIONS` (values
+unchanged) so the constants name their era, and make `isModernProtocolVersion`
+and `FIRST_MODERN_PROTOCOL_VERSION` public. The old names remain as
+`@deprecated` aliases until 2.0.0 GA; the v1→v2 codemod applies the rename.
+See the [Protocol versions guide](https://ts.sdk.modelcontextprotocol.io/v2/protocol-versions#the-constants-are-era-scoped).

--- a/docs/migration/upgrade-to-v2.md
+++ b/docs/migration/upgrade-to-v2.md
@@ -1444,6 +1444,16 @@ handling (no `additionalProperties: false` by default; passthrough objects emit
 Golden tests, transcript pins, and strict client-side validators of your advertised
 tool list need re-baselining — the new shapes are spec-conformant.
 
+**Protocol-version constants name their era.** `LATEST_PROTOCOL_VERSION` and
+`SUPPORTED_PROTOCOL_VERSIONS` are renamed to `LATEST_LEGACY_PROTOCOL_VERSION` and
+`SUPPORTED_LEGACY_PROTOCOL_VERSIONS` (same values): they hold only legacy revisions —
+the ones negotiated via the `initialize` handshake — never the 2026-07-28+ revisions,
+which negotiate exclusively via `server/discover`. The codemod applies the rename; the
+old names remain as `@deprecated` aliases until 2.0.0 GA. To classify the revision a
+connection actually landed on, use the newly public `isModernProtocolVersion(version)`
+(or `Client.getProtocolEra()`) — see
+[Protocol versions](../protocol-versions.md#the-constants-are-era-scoped).
+
 ### Behavioral changes
 
 These are runtime-behavior changes that may affect tests and assertions; no source
@@ -1514,7 +1524,7 @@ rewrite required unless noted.
   entries when it has any (otherwise the SDK's default modern set); a `{ pin }` is
   honored as given and is not checked against the list (see
   [support-2026-07-28.md](./support-2026-07-28.md#client-side-versionnegotiation)).
-  v1 had no public equivalent (`SUPPORTED_PROTOCOL_VERSIONS` was a fixed constant) —
+  v1 had no public equivalent (v1's `SUPPORTED_PROTOCOL_VERSIONS` was a fixed constant) —
   replace any workaround that patched the offered version with this option.
 - **Also unchanged: HTTP 405 tolerances.** A `405` answering the standalone GET stream
   open is benign (the client proceeds without the stream), and a `405` answering the

--- a/docs/protocol-versions.md
+++ b/docs/protocol-versions.md
@@ -74,6 +74,39 @@ The rejection is a typed, local `SdkError` — nothing reaches the server beyond
 ERA_NEGOTIATION_FAILED: Version negotiation failed: the server did not offer pinned protocol version 2026-07-28 via server/discover (no fallback in pin mode)
 ```
 
+## The constants are era-scoped
+
+The exported version constants name their era, because each era has its own list:
+`LATEST_LEGACY_PROTOCOL_VERSION` (`'2025-11-25'`) is the revision `initialize` offers
+by default, and `SUPPORTED_LEGACY_PROTOCOL_VERSIONS` is the full `initialize`
+negotiation list. Neither ever contains a 2026-07-28+ revision — modern revisions are
+negotiated only via `server/discover`, so "latest" here means *latest legacy*, not the
+newest revision the SDK speaks. To classify the revision a connection actually landed
+on, use `isModernProtocolVersion` (or ask `getProtocolEra()` directly):
+
+```ts source="../examples/guides/protocolVersions.examples.ts#isModernProtocolVersion_classify"
+import { isModernProtocolVersion, LATEST_LEGACY_PROTOCOL_VERSION } from '@modelcontextprotocol/client';
+
+console.log(`initialize offers: ${LATEST_LEGACY_PROTOCOL_VERSION}`);
+
+for (const connection of [fallback, client]) {
+    const version = connection.getNegotiatedProtocolVersion();
+    if (version) console.log(`${version} → ${isModernProtocolVersion(version) ? 'modern' : 'legacy'}`);
+}
+```
+
+The `'auto'` client from above landed on the modern era; the fallback client landed on
+legacy — the constant never changes, only the negotiated outcome does:
+
+```
+initialize offers: 2025-11-25
+2025-11-25 → legacy
+2026-07-28 → modern
+```
+
+The pre-rename names (`LATEST_PROTOCOL_VERSION`, `SUPPORTED_PROTOCOL_VERSIONS`) remain
+as deprecated aliases until 2.0.0 GA.
+
 ## Understand the probe
 
 `probe` bounds the `server/discover` round trip that `'auto'` and a pin run before anything else.

--- a/examples/custom-version/server.ts
+++ b/examples/custom-version/server.ts
@@ -7,11 +7,11 @@ import { createServer } from 'node:http';
 
 import { parseExampleArgs } from '@mcp-examples/shared';
 import { toNodeHandler } from '@modelcontextprotocol/node';
-import { createMcpHandler, McpServer, SUPPORTED_PROTOCOL_VERSIONS } from '@modelcontextprotocol/server';
+import { createMcpHandler, McpServer, SUPPORTED_LEGACY_PROTOCOL_VERSIONS } from '@modelcontextprotocol/server';
 import { serveStdio } from '@modelcontextprotocol/server/stdio';
 
 // Add support for a newer protocol version (first in list is fallback).
-const CUSTOM_VERSIONS = ['2026-01-01', ...SUPPORTED_PROTOCOL_VERSIONS];
+const CUSTOM_VERSIONS = ['2026-01-01', ...SUPPORTED_LEGACY_PROTOCOL_VERSIONS];
 
 function buildServer(): McpServer {
     const server = new McpServer(

--- a/examples/guides/protocolVersions.examples.ts
+++ b/examples/guides/protocolVersions.examples.ts
@@ -79,6 +79,19 @@ await fallback.connect(new StreamableHTTPClientTransport(new URL('http://localho
 console.log(fallback.getProtocolEra());
 //#endregion versionNegotiation_fallback
 
+// ## The constants are era-scoped — names carry the initialize/discover split.
+
+//#region isModernProtocolVersion_classify
+import { isModernProtocolVersion, LATEST_LEGACY_PROTOCOL_VERSION } from '@modelcontextprotocol/client';
+
+console.log(`initialize offers: ${LATEST_LEGACY_PROTOCOL_VERSION}`);
+
+for (const connection of [fallback, client]) {
+    const version = connection.getNegotiatedProtocolVersion();
+    if (version) console.log(`${version} → ${isModernProtocolVersion(version) ? 'modern' : 'legacy'}`);
+}
+//#endregion isModernProtocolVersion_classify
+
 // ## Pin an era — a pin never falls back; against a 2025-only server it rejects.
 
 //#region versionNegotiation_pin

--- a/packages/client/src/client/auth.ts
+++ b/packages/client/src/client/auth.ts
@@ -14,7 +14,7 @@ import type {
 } from '@modelcontextprotocol/core-internal';
 import {
     checkResourceAllowed,
-    LATEST_PROTOCOL_VERSION,
+    LATEST_LEGACY_PROTOCOL_VERSION,
     OAuthClientInformationFullSchema,
     OAuthError,
     OAuthErrorCode,
@@ -53,6 +53,12 @@ export interface UnauthorizedContext {
     serverUrl: URL;
     /** Fetch function configured with the transport's `requestInit`, for making auth requests. */
     fetchFn: FetchLike;
+    /**
+     * The protocol version negotiated on the connection, if any — forwarded to
+     * {@linkcode auth} so metadata discovery advertises what the connection
+     * actually speaks. See {@linkcode AuthOptions.protocolVersion}.
+     */
+    protocolVersion?: string;
 }
 
 /**
@@ -182,6 +188,7 @@ export async function handleOAuthUnauthorized(
         serverUrl: ctx.serverUrl,
         resourceMetadataUrl,
         scope,
+        protocolVersion: ctx.protocolVersion,
         fetchFn: ctx.fetchFn,
         ...extraAuthOptions
     });
@@ -629,7 +636,7 @@ export async function resolveAuthorizationCallbackParams(
     iss: string | undefined,
     provider: OAuthClientProvider,
     serverUrl: string | URL,
-    opts?: { fetchFn?: FetchLike; resourceMetadataUrl?: URL }
+    opts?: { fetchFn?: FetchLike; resourceMetadataUrl?: URL; protocolVersion?: string }
 ): Promise<{ authorizationCode: string; iss: string | undefined }> {
     if (typeof codeOrParams === 'string') {
         return { authorizationCode: codeOrParams, iss };
@@ -923,6 +930,14 @@ export interface AuthOptions {
     scope?: string;
     /** Explicit `resource_metadata` URL from a `WWW-Authenticate` challenge. */
     resourceMetadataUrl?: URL;
+    /**
+     * The protocol version negotiated on the connection, sent as the
+     * `MCP-Protocol-Version` header on metadata discovery requests. The SDK
+     * transports pass their negotiated version automatically; when unset (e.g.
+     * auth runs before any handshake), discovery falls back to
+     * {@linkcode LATEST_LEGACY_PROTOCOL_VERSION}.
+     */
+    protocolVersion?: string;
     /** Custom `fetch` implementation. */
     fetchFn?: FetchLike;
     /**
@@ -1026,6 +1041,7 @@ async function authInternal(
         iss,
         scope,
         resourceMetadataUrl,
+        protocolVersion,
         fetchFn,
         skipIssuerMetadataValidation,
         forceReauthorization
@@ -1058,6 +1074,7 @@ async function authInternal(
             cachedState.authorizationServerMetadata ??
             (await discoverAuthorizationServerMetadata(authorizationServerUrl, {
                 fetchFn,
+                protocolVersion,
                 skipIssuerValidation: skipIssuerMetadataValidation
             }));
 
@@ -1066,7 +1083,7 @@ async function authInternal(
             try {
                 resourceMetadata = await discoverOAuthProtectedResourceMetadata(
                     serverUrl,
-                    { resourceMetadataUrl: effectiveResourceMetadataUrl },
+                    { resourceMetadataUrl: effectiveResourceMetadataUrl, protocolVersion },
                     fetchFn
                 );
             } catch (error) {
@@ -1092,6 +1109,7 @@ async function authInternal(
         // Full discovery via RFC 9728
         const serverInfo = await discoverOAuthServerInfo(serverUrl, {
             resourceMetadataUrl: effectiveResourceMetadataUrl,
+            protocolVersion,
             fetchFn,
             skipIssuerMetadataValidation
         });
@@ -1596,7 +1614,7 @@ async function discoverMetadataWithFallback(
     opts?: { protocolVersion?: string; metadataUrl?: string | URL; metadataServerUrl?: string | URL }
 ): Promise<Response | undefined> {
     const issuer = new URL(serverUrl);
-    const protocolVersion = opts?.protocolVersion ?? LATEST_PROTOCOL_VERSION;
+    const protocolVersion = opts?.protocolVersion ?? LATEST_LEGACY_PROTOCOL_VERSION;
 
     let url: URL;
     if (opts?.metadataUrl) {
@@ -1647,7 +1665,7 @@ export async function discoverOAuthMetadata(
     if (typeof authorizationServerUrl === 'string') {
         authorizationServerUrl = new URL(authorizationServerUrl);
     }
-    protocolVersion ??= LATEST_PROTOCOL_VERSION;
+    protocolVersion ??= LATEST_LEGACY_PROTOCOL_VERSION;
 
     const response = await discoverMetadataWithFallback(authorizationServerUrl, 'oauth-authorization-server', fetchFn, {
         protocolVersion,
@@ -1749,7 +1767,7 @@ export function buildDiscoveryUrls(authorizationServerUrl: string | URL): { url:
  *
  * @param options - Configuration options
  * @param options.fetchFn - Optional fetch function for making HTTP requests, defaults to global fetch
- * @param options.protocolVersion - MCP protocol version to use, defaults to {@linkcode LATEST_PROTOCOL_VERSION}
+ * @param options.protocolVersion - MCP protocol version to use, defaults to {@linkcode LATEST_LEGACY_PROTOCOL_VERSION}
  * @param options.skipIssuerValidation - Skip the RFC 8414 §3.3 `issuer` echo check. **Security-weakening.**
  * @returns Promise resolving to authorization server metadata, or undefined if discovery fails
  * @throws {IssuerMismatchError} when the metadata's `issuer` does not match `authorizationServerUrl`
@@ -1758,7 +1776,7 @@ export async function discoverAuthorizationServerMetadata(
     authorizationServerUrl: string | URL,
     {
         fetchFn = fetch,
-        protocolVersion = LATEST_PROTOCOL_VERSION,
+        protocolVersion = LATEST_LEGACY_PROTOCOL_VERSION,
         skipIssuerValidation = false
     }: {
         fetchFn?: FetchLike;
@@ -1865,6 +1883,7 @@ export interface OAuthServerInfo {
  * @param serverUrl - The MCP resource server URL
  * @param opts - Optional configuration
  * @param opts.resourceMetadataUrl - Override URL for the protected resource metadata endpoint
+ * @param opts.protocolVersion - Negotiated MCP protocol version for the `MCP-Protocol-Version` discovery header
  * @param opts.fetchFn - Custom fetch function for HTTP requests
  * @returns Authorization server URL, metadata, and resource metadata (if available)
  */
@@ -1872,6 +1891,8 @@ export async function discoverOAuthServerInfo(
     serverUrl: string | URL,
     opts?: {
         resourceMetadataUrl?: URL;
+        /** See {@linkcode AuthOptions.protocolVersion}. */
+        protocolVersion?: string;
         fetchFn?: FetchLike;
         /**
          * Forwarded to {@linkcode discoverAuthorizationServerMetadata} as
@@ -1886,7 +1907,7 @@ export async function discoverOAuthServerInfo(
     try {
         resourceMetadata = await discoverOAuthProtectedResourceMetadata(
             serverUrl,
-            { resourceMetadataUrl: opts?.resourceMetadataUrl },
+            { resourceMetadataUrl: opts?.resourceMetadataUrl, protocolVersion: opts?.protocolVersion },
             opts?.fetchFn
         );
         if (resourceMetadata.authorization_servers && resourceMetadata.authorization_servers.length > 0) {
@@ -1910,6 +1931,7 @@ export async function discoverOAuthServerInfo(
 
     const authorizationServerMetadata = await discoverAuthorizationServerMetadata(authorizationServerUrl, {
         fetchFn: opts?.fetchFn,
+        protocolVersion: opts?.protocolVersion,
         skipIssuerValidation: opts?.skipIssuerMetadataValidation
     });
 

--- a/packages/client/src/client/middleware.ts
+++ b/packages/client/src/client/middleware.ts
@@ -61,10 +61,15 @@ export const withOAuth =
                     // Use provided baseUrl or extract from request URL
                     const serverUrl = baseUrl || (typeof input === 'string' ? new URL(input).origin : input.origin);
 
+                    // If the wrapped request already declared a protocol version (an MCP
+                    // transport sets the header after negotiation), discovery advertises it too.
+                    const protocolVersion = new Headers(init?.headers).get('mcp-protocol-version') ?? undefined;
+
                     const result = await auth(provider, {
                         serverUrl,
                         resourceMetadataUrl,
                         scope,
+                        protocolVersion,
                         fetchFn: next
                     });
 

--- a/packages/client/src/client/sse.ts
+++ b/packages/client/src/client/sse.ts
@@ -10,7 +10,7 @@ import {
 import type { ErrorEvent, EventSourceInit } from 'eventsource';
 import { EventSource } from 'eventsource';
 
-import type { AuthProvider, OAuthClientProvider } from './auth';
+import type { AuthProvider, OAuthClientProvider, UnauthorizedContext } from './auth';
 import {
     adaptOAuthProvider,
     auth,
@@ -129,6 +129,20 @@ export class SSEClientTransport implements Transport {
 
     private _last401Response?: Response;
 
+    /**
+     * The one place that assembles the 401 context — every `onUnauthorized`
+     * call site goes through here so the negotiated protocol version cannot be
+     * forgotten at an individual site.
+     */
+    private _unauthorizedContext(response: Response): UnauthorizedContext {
+        return {
+            response,
+            serverUrl: this._url,
+            fetchFn: this._fetchWithInit,
+            protocolVersion: this._protocolVersion
+        };
+    }
+
     private async _commonHeaders(): Promise<Headers> {
         const headers: RequestInit['headers'] & Record<string, string> = {};
         const token = await this._authProvider?.token();
@@ -180,7 +194,7 @@ export class SSEClientTransport implements Transport {
                         const response = this._last401Response;
                         this._last401Response = undefined;
                         this._eventSource?.close();
-                        this._authProvider.onUnauthorized({ response, serverUrl: this._url, fetchFn: this._fetchWithInit }).then(
+                        this._authProvider.onUnauthorized(this._unauthorizedContext(response)).then(
                             // onUnauthorized succeeded → retry fresh. Its onerror handles its own onerror?.() + reject.
                             () => this._startOrAuth().then(resolve, reject),
                             // onUnauthorized failed → not yet reported.
@@ -280,7 +294,7 @@ export class SSEClientTransport implements Transport {
             iss,
             this._oauthProvider,
             this._url,
-            { fetchFn: this._fetchWithInit, resourceMetadataUrl: this._resourceMetadataUrl }
+            { fetchFn: this._fetchWithInit, resourceMetadataUrl: this._resourceMetadataUrl, protocolVersion: this._protocolVersion }
         );
 
         const result = await auth(this._oauthProvider, {
@@ -289,6 +303,7 @@ export class SSEClientTransport implements Transport {
             iss: issParam,
             resourceMetadataUrl: this._resourceMetadataUrl,
             scope: this._scope,
+            protocolVersion: this._protocolVersion,
             fetchFn: this._fetchWithInit,
             skipIssuerMetadataValidation: this._skipIssuerMetadataValidation
         });
@@ -333,11 +348,7 @@ export class SSEClientTransport implements Transport {
                     }
 
                     if (this._authProvider.onUnauthorized && !isAuthRetry) {
-                        await this._authProvider.onUnauthorized({
-                            response,
-                            serverUrl: this._url,
-                            fetchFn: this._fetchWithInit
-                        });
+                        await this._authProvider.onUnauthorized(this._unauthorizedContext(response));
                         await response.text?.().catch(() => {});
                         // Purposely _not_ awaited, so we don't call onerror twice
                         return this._send(message, true);

--- a/packages/client/src/client/streamableHttp.ts
+++ b/packages/client/src/client/streamableHttp.ts
@@ -18,7 +18,7 @@ import {
 } from '@modelcontextprotocol/core-internal';
 import { EventSourceParserStream } from 'eventsource-parser/stream';
 
-import type { AuthProvider, OAuthClientProvider } from './auth';
+import type { AuthProvider, OAuthClientProvider, UnauthorizedContext } from './auth';
 import {
     adaptOAuthProvider,
     auth,
@@ -413,9 +413,24 @@ export class StreamableHTTPClientTransport implements Transport {
             resourceMetadataUrl: this._resourceMetadataUrl,
             scope: unionScope,
             forceReauthorization,
+            protocolVersion: this._protocolVersion,
             fetchFn: this._fetchWithInit,
             skipIssuerMetadataValidation: this._skipIssuerMetadataValidation
         });
+    }
+
+    /**
+     * The one place that assembles the 401 context — every `onUnauthorized`
+     * call site goes through here so the negotiated protocol version cannot be
+     * forgotten at an individual site.
+     */
+    private _unauthorizedContext(response: Response): UnauthorizedContext {
+        return {
+            response,
+            serverUrl: this._url,
+            fetchFn: this._fetchWithInit,
+            protocolVersion: this._protocolVersion
+        };
     }
 
     private async _commonHeaders(): Promise<Headers> {
@@ -541,11 +556,7 @@ export class StreamableHTTPClientTransport implements Transport {
                     }
 
                     if (this._authProvider.onUnauthorized && !isAuthRetry) {
-                        await this._authProvider.onUnauthorized({
-                            response,
-                            serverUrl: this._url,
-                            fetchFn: this._fetchWithInit
-                        });
+                        await this._authProvider.onUnauthorized(this._unauthorizedContext(response));
                         await response.text?.().catch(() => {});
                         // Purposely _not_ awaited, so we don't call onerror twice
                         return this._startOrAuthSse(options, true, stepUpRetries);
@@ -862,7 +873,7 @@ export class StreamableHTTPClientTransport implements Transport {
             iss,
             this._oauthProvider,
             this._url,
-            { fetchFn: this._fetchWithInit, resourceMetadataUrl: this._resourceMetadataUrl }
+            { fetchFn: this._fetchWithInit, resourceMetadataUrl: this._resourceMetadataUrl, protocolVersion: this._protocolVersion }
         );
 
         const result = await auth(this._oauthProvider, {
@@ -871,6 +882,7 @@ export class StreamableHTTPClientTransport implements Transport {
             iss: issParam,
             resourceMetadataUrl: this._resourceMetadataUrl,
             scope: this._scope,
+            protocolVersion: this._protocolVersion,
             fetchFn: this._fetchWithInit,
             skipIssuerMetadataValidation: this._skipIssuerMetadataValidation
         });
@@ -990,11 +1002,7 @@ export class StreamableHTTPClientTransport implements Transport {
                     }
 
                     if (this._authProvider.onUnauthorized && !isAuthRetry) {
-                        await this._authProvider.onUnauthorized({
-                            response,
-                            serverUrl: this._url,
-                            fetchFn: this._fetchWithInit
-                        });
+                        await this._authProvider.onUnauthorized(this._unauthorizedContext(response));
                         await response.text?.().catch(() => {});
                         // Purposely _not_ awaited, so we don't call onerror twice
                         return this._send(message, options, true, stepUpRetries);

--- a/packages/client/test/client/auth.test.ts
+++ b/packages/client/test/client/auth.test.ts
@@ -6,7 +6,7 @@ import type {
     StoredOAuthClientInformation,
     StoredOAuthTokens
 } from '@modelcontextprotocol/core-internal';
-import { LATEST_PROTOCOL_VERSION, OAuthError, OAuthErrorCode } from '@modelcontextprotocol/core-internal';
+import { LATEST_LEGACY_PROTOCOL_VERSION, OAuthError, OAuthErrorCode } from '@modelcontextprotocol/core-internal';
 import type { Mock } from 'vitest';
 import { expect, vi } from 'vitest';
 
@@ -25,6 +25,7 @@ import {
     discoverOAuthServerInfo,
     exchangeAuthorization,
     extractWWWAuthenticateParams,
+    handleOAuthUnauthorized,
     InsecureTokenEndpointError,
     isHttpsUrl,
     isStrictScopeSuperset,
@@ -401,14 +402,14 @@ describe('OAuth Authorization', () => {
                 const [firstUrl, firstOptions] = calls[0]!;
                 expect(firstUrl.toString()).toBe('https://resource.example.com/.well-known/oauth-protected-resource/path/name');
                 expect(firstOptions.headers).toEqual({
-                    'MCP-Protocol-Version': LATEST_PROTOCOL_VERSION
+                    'MCP-Protocol-Version': LATEST_LEGACY_PROTOCOL_VERSION
                 });
 
                 // Second call should be root fallback
                 const [secondUrl, secondOptions] = calls[1]!;
                 expect(secondUrl.toString()).toBe('https://resource.example.com/.well-known/oauth-protected-resource');
                 expect(secondOptions.headers).toEqual({
-                    'MCP-Protocol-Version': LATEST_PROTOCOL_VERSION
+                    'MCP-Protocol-Version': LATEST_LEGACY_PROTOCOL_VERSION
                 });
             }
         );
@@ -530,7 +531,7 @@ describe('OAuth Authorization', () => {
             const [lastUrl, lastOptions] = calls[2]!;
             expect(lastUrl.toString()).toBe('https://resource.example.com/.well-known/oauth-protected-resource');
             expect(lastOptions.headers).toEqual({
-                'MCP-Protocol-Version': LATEST_PROTOCOL_VERSION
+                'MCP-Protocol-Version': LATEST_LEGACY_PROTOCOL_VERSION
             });
         });
 
@@ -575,7 +576,7 @@ describe('OAuth Authorization', () => {
             const [url, options] = customFetch.mock.calls[0]!;
             expect(url.toString()).toBe('https://resource.example.com/.well-known/oauth-protected-resource');
             expect(options.headers).toEqual({
-                'MCP-Protocol-Version': LATEST_PROTOCOL_VERSION
+                'MCP-Protocol-Version': LATEST_LEGACY_PROTOCOL_VERSION
             });
         });
     });
@@ -604,7 +605,7 @@ describe('OAuth Authorization', () => {
             const [url, options] = calls[0]!;
             expect(url.toString()).toBe('https://auth.example.com/.well-known/oauth-authorization-server');
             expect(options.headers).toEqual({
-                'MCP-Protocol-Version': LATEST_PROTOCOL_VERSION
+                'MCP-Protocol-Version': LATEST_LEGACY_PROTOCOL_VERSION
             });
         });
 
@@ -622,7 +623,7 @@ describe('OAuth Authorization', () => {
             const [url, options] = calls[0]!;
             expect(url.toString()).toBe('https://auth.example.com/.well-known/oauth-authorization-server/path/name');
             expect(options.headers).toEqual({
-                'MCP-Protocol-Version': LATEST_PROTOCOL_VERSION
+                'MCP-Protocol-Version': LATEST_LEGACY_PROTOCOL_VERSION
             });
         });
 
@@ -650,14 +651,14 @@ describe('OAuth Authorization', () => {
             const [firstUrl, firstOptions] = calls[0]!;
             expect(firstUrl.toString()).toBe('https://auth.example.com/.well-known/oauth-authorization-server/path/name');
             expect(firstOptions.headers).toEqual({
-                'MCP-Protocol-Version': LATEST_PROTOCOL_VERSION
+                'MCP-Protocol-Version': LATEST_LEGACY_PROTOCOL_VERSION
             });
 
             // Second call should be root fallback
             const [secondUrl, secondOptions] = calls[1]!;
             expect(secondUrl.toString()).toBe('https://auth.example.com/.well-known/oauth-authorization-server');
             expect(secondOptions.headers).toEqual({
-                'MCP-Protocol-Version': LATEST_PROTOCOL_VERSION
+                'MCP-Protocol-Version': LATEST_LEGACY_PROTOCOL_VERSION
             });
         });
 
@@ -743,7 +744,7 @@ describe('OAuth Authorization', () => {
             const [lastUrl, lastOptions] = calls[2]!;
             expect(lastUrl.toString()).toBe('https://auth.example.com/.well-known/oauth-authorization-server');
             expect(lastOptions.headers).toEqual({
-                'MCP-Protocol-Version': LATEST_PROTOCOL_VERSION
+                'MCP-Protocol-Version': LATEST_LEGACY_PROTOCOL_VERSION
             });
         });
 
@@ -906,7 +907,7 @@ describe('OAuth Authorization', () => {
             const [url, options] = customFetch.mock.calls[0]!;
             expect(url.toString()).toBe('https://auth.example.com/.well-known/oauth-authorization-server');
             expect(options.headers).toEqual({
-                'MCP-Protocol-Version': LATEST_PROTOCOL_VERSION
+                'MCP-Protocol-Version': LATEST_LEGACY_PROTOCOL_VERSION
             });
         });
     });
@@ -2602,6 +2603,93 @@ describe('OAuth Authorization', () => {
             vi.clearAllMocks();
         });
 
+        describe('protocolVersion threading into discovery', () => {
+            const discoveryHeaders = (): Record<string, string>[] =>
+                mockFetch.mock.calls
+                    .filter(([url]) => url.toString().includes('/.well-known/'))
+                    .map(([, options]) => options?.headers as Record<string, string>);
+
+            const expectDiscoveryVersion = (version: string) => {
+                const headers = discoveryHeaders();
+                expect(headers.length).toBeGreaterThan(0);
+                for (const h of headers) {
+                    expect(h).toMatchObject({ 'MCP-Protocol-Version': version });
+                }
+            };
+
+            const provider: OAuthClientProvider = {
+                ...mockProvider,
+                clientInformation: vi.fn().mockResolvedValue({ client_id: 'client-id' }),
+                tokens: vi.fn().mockResolvedValue(undefined)
+            };
+
+            beforeEach(() => {
+                mockFetch.mockImplementation(url => {
+                    const urlString = url.toString();
+                    if (urlString.includes('/.well-known/oauth-protected-resource')) {
+                        return Promise.resolve({
+                            ok: true,
+                            status: 200,
+                            json: async () => ({
+                                resource: 'https://api.example.com/mcp-server',
+                                authorization_servers: ['https://auth.example.com']
+                            })
+                        });
+                    }
+                    if (urlString.includes('/.well-known/oauth-authorization-server')) {
+                        return Promise.resolve({
+                            ok: true,
+                            status: 200,
+                            json: async () => ({
+                                issuer: 'https://auth.example.com',
+                                authorization_endpoint: 'https://auth.example.com/authorize',
+                                token_endpoint: 'https://auth.example.com/token',
+                                response_types_supported: ['code'],
+                                code_challenge_methods_supported: ['S256']
+                            })
+                        });
+                    }
+                    return Promise.reject(new Error(`Unexpected fetch call: ${urlString}`));
+                });
+            });
+
+            it('sends the negotiated protocolVersion on every discovery request', async () => {
+                // The transports thread the connection's negotiated version through
+                // AuthOptions: discovery advertises what the connection actually speaks.
+                const result = await auth(provider, {
+                    serverUrl: 'https://api.example.com/mcp-server',
+                    protocolVersion: '2025-03-26'
+                });
+                expect(result).toBe('REDIRECT');
+                expectDiscoveryVersion('2025-03-26');
+            });
+
+            it('defaults to the latest legacy revision when no version was negotiated', async () => {
+                await auth(provider, { serverUrl: 'https://api.example.com/mcp-server' });
+                expectDiscoveryVersion(LATEST_LEGACY_PROTOCOL_VERSION);
+            });
+
+            it("forwards UnauthorizedContext.protocolVersion on the transports' 401 path", async () => {
+                const challenge = new Response(null, {
+                    status: 401,
+                    headers: {
+                        'WWW-Authenticate': 'Bearer resource_metadata="https://api.example.com/.well-known/oauth-protected-resource"'
+                    }
+                });
+                // REDIRECT surfaces as UnauthorizedError from handleOAuthUnauthorized —
+                // by then every discovery request has already gone out.
+                await expect(
+                    handleOAuthUnauthorized(provider, {
+                        response: challenge,
+                        serverUrl: new URL('https://api.example.com/mcp-server'),
+                        fetchFn: mockFetch,
+                        protocolVersion: '2025-06-18'
+                    })
+                ).rejects.toThrow(UnauthorizedError);
+                expectDiscoveryVersion('2025-06-18');
+            });
+        });
+
         it('performs client_credentials with private_key_jwt when provider has addClientAuthentication', async () => {
             // Arrange: metadata discovery for PRM and AS
             mockFetch.mockImplementation(url => {
@@ -3897,7 +3985,7 @@ describe('OAuth Authorization', () => {
             expect(options.headers).toMatchObject({
                 'user-agent': 'MyApp/1.0',
                 'x-custom-header': 'test-value',
-                'MCP-Protocol-Version': LATEST_PROTOCOL_VERSION
+                'MCP-Protocol-Version': LATEST_LEGACY_PROTOCOL_VERSION
             });
         });
 
@@ -3935,7 +4023,7 @@ describe('OAuth Authorization', () => {
             expect(options.headers).toMatchObject({
                 Accept: 'application/json', // Auth-specific value wins
                 'user-agent': 'MyApp/1.0', // Base value preserved
-                'MCP-Protocol-Version': LATEST_PROTOCOL_VERSION
+                'MCP-Protocol-Version': LATEST_LEGACY_PROTOCOL_VERSION
             });
         });
 

--- a/packages/client/test/client/envelopeAutoEmission.test.ts
+++ b/packages/client/test/client/envelopeAutoEmission.test.ts
@@ -11,7 +11,7 @@ import {
     CLIENT_CAPABILITIES_META_KEY,
     CLIENT_INFO_META_KEY,
     InMemoryTransport,
-    LATEST_PROTOCOL_VERSION,
+    LATEST_LEGACY_PROTOCOL_VERSION,
     PROTOCOL_VERSION_META_KEY
 } from '@modelcontextprotocol/core-internal';
 import { describe, expect, it } from 'vitest';
@@ -60,7 +60,7 @@ async function scriptedServerSide(era: 'modern' | 'legacy', answerToolsList = tr
                 jsonrpc: '2.0',
                 id: request.id,
                 result: {
-                    protocolVersion: LATEST_PROTOCOL_VERSION,
+                    protocolVersion: LATEST_LEGACY_PROTOCOL_VERSION,
                     capabilities: { tools: {} },
                     serverInfo: { name: 'scripted-legacy-server', version: '1.0.0' }
                 }

--- a/packages/client/test/client/jsonSchemaValidatorOverride.test.ts
+++ b/packages/client/test/client/jsonSchemaValidatorOverride.test.ts
@@ -1,5 +1,5 @@
 import type { JSONRPCMessage, JsonSchemaType, JsonSchemaValidatorResult, jsonSchemaValidator } from '@modelcontextprotocol/core-internal';
-import { InMemoryTransport, LATEST_PROTOCOL_VERSION } from '@modelcontextprotocol/core-internal';
+import { InMemoryTransport, LATEST_LEGACY_PROTOCOL_VERSION } from '@modelcontextprotocol/core-internal';
 import { Client } from '../../src/client/client';
 import { fromJsonSchema } from '../../src/fromJsonSchema';
 
@@ -24,7 +24,7 @@ async function connectInitializedClient(client: Client) {
                 jsonrpc: '2.0',
                 id: message.id,
                 result: {
-                    protocolVersion: LATEST_PROTOCOL_VERSION,
+                    protocolVersion: LATEST_LEGACY_PROTOCOL_VERSION,
                     capabilities: { tools: {} },
                     serverInfo: { name: 'test-server', version: '1.0.0' }
                 }
@@ -132,7 +132,7 @@ describe('client JSON Schema validator overrides', () => {
                         jsonrpc: '2.0',
                         id: message.id,
                         result: {
-                            protocolVersion: LATEST_PROTOCOL_VERSION,
+                            protocolVersion: LATEST_LEGACY_PROTOCOL_VERSION,
                             capabilities: { tools: {} },
                             serverInfo: { name: 'test-server', version: '1.0.0' }
                         }

--- a/packages/client/test/client/listen.test.ts
+++ b/packages/client/test/client/listen.test.ts
@@ -9,7 +9,7 @@
 import type { JSONRPCMessage, JSONRPCNotification } from '@modelcontextprotocol/core-internal';
 import {
     InMemoryTransport,
-    LATEST_PROTOCOL_VERSION,
+    LATEST_LEGACY_PROTOCOL_VERSION,
     PROTOCOL_VERSION_META_KEY,
     SdkError,
     SdkErrorCode,
@@ -93,7 +93,7 @@ describe('Client.listen()', () => {
                 void serverTx.send({
                     jsonrpc: '2.0',
                     id: req.id,
-                    result: { protocolVersion: LATEST_PROTOCOL_VERSION, capabilities: {}, serverInfo: { name: 's', version: '1' } }
+                    result: { protocolVersion: LATEST_LEGACY_PROTOCOL_VERSION, capabilities: {}, serverInfo: { name: 's', version: '1' } }
                 });
             }
         };

--- a/packages/client/test/client/modernEraInboundDrop.test.ts
+++ b/packages/client/test/client/modernEraInboundDrop.test.ts
@@ -7,7 +7,7 @@
  * methods it has no handler for).
  */
 import type { JSONRPCMessage } from '@modelcontextprotocol/core-internal';
-import { InMemoryTransport, LATEST_PROTOCOL_VERSION } from '@modelcontextprotocol/core-internal';
+import { InMemoryTransport, LATEST_LEGACY_PROTOCOL_VERSION } from '@modelcontextprotocol/core-internal';
 import { describe, expect, it } from 'vitest';
 
 import { Client } from '../../src/client/client';
@@ -53,7 +53,7 @@ async function scriptedServerSide(eras: 'modern' | 'legacy') {
                 jsonrpc: '2.0',
                 id: request.id,
                 result: {
-                    protocolVersion: LATEST_PROTOCOL_VERSION,
+                    protocolVersion: LATEST_LEGACY_PROTOCOL_VERSION,
                     capabilities: {},
                     serverInfo: { name: 'scripted-legacy-server', version: '1.0.0' }
                 }
@@ -130,7 +130,7 @@ describe('client inbound-drop on modern-era connections (TS-01)', () => {
         const { clientTx, serverTx, written } = await scriptedServerSide('legacy');
         const client = new Client({ name: 'legacy-client', version: '1.0.0' }, { versionNegotiation: { mode: 'auto' } });
         await client.connect(clientTx);
-        expect(client.getNegotiatedProtocolVersion()).toBe(LATEST_PROTOCOL_VERSION);
+        expect(client.getNegotiatedProtocolVersion()).toBe(LATEST_LEGACY_PROTOCOL_VERSION);
 
         await serverTx.send({ jsonrpc: '2.0', id: 'legacy-1', method: 'roots/list', params: {} });
         await flush();

--- a/packages/client/test/client/probeFixtureCorpus.test.ts
+++ b/packages/client/test/client/probeFixtureCorpus.test.ts
@@ -19,7 +19,7 @@
  * probe wire shape (string id, `server/discover` first, never a real request).
  */
 import type { JSONRPCMessage, Transport } from '@modelcontextprotocol/core-internal';
-import { LATEST_PROTOCOL_VERSION, PROTOCOL_VERSION_META_KEY } from '@modelcontextprotocol/core-internal';
+import { LATEST_LEGACY_PROTOCOL_VERSION, PROTOCOL_VERSION_META_KEY } from '@modelcontextprotocol/core-internal';
 import { describe, expect, it } from 'vitest';
 
 import { Client } from '../../src/client/client';
@@ -123,7 +123,7 @@ const CORPUS: CorpusRow[] = [
             kind: 'rpc-error',
             code: -32_022,
             message: 'Unsupported protocol version',
-            data: { supported: [MODERN, LATEST_PROTOCOL_VERSION], requested: '2027-01-01' }
+            data: { supported: [MODERN, LATEST_LEGACY_PROTOCOL_VERSION], requested: '2027-01-01' }
         },
         expected: 'corrective'
     },
@@ -138,7 +138,7 @@ const CORPUS: CorpusRow[] = [
             kind: 'rpc-error',
             code: -32_022,
             message: 'Unsupported protocol version',
-            data: { supported: [LATEST_PROTOCOL_VERSION], requested: MODERN }
+            data: { supported: [LATEST_LEGACY_PROTOCOL_VERSION], requested: MODERN }
         },
         expected: 'legacy'
     },

--- a/packages/client/test/client/streamableHttp.test.ts
+++ b/packages/client/test/client/streamableHttp.test.ts
@@ -793,6 +793,45 @@ describe('StreamableHTTPClientTransport', () => {
         expect(mockAuthProvider.redirectToAuthorization.mock.calls).toHaveLength(1);
     });
 
+    it('sends the negotiated protocol version on OAuth discovery requests after a 401', async () => {
+        const message: JSONRPCMessage = {
+            jsonrpc: '2.0',
+            method: 'test',
+            params: {},
+            id: 'test-id'
+        };
+
+        // Simulate an established connection: the negotiated version must reach
+        // every discovery request the 401 triggers (via UnauthorizedContext).
+        transport.setProtocolVersion('2025-03-26');
+
+        (globalThis.fetch as Mock)
+            .mockResolvedValueOnce({
+                ok: false,
+                status: 401,
+                statusText: 'Unauthorized',
+                headers: new Headers(),
+                text: async () => {
+                    throw 'dont read my body';
+                }
+            })
+            .mockResolvedValue({
+                ok: false,
+                status: 404,
+                text: async () => {
+                    throw 'dont read my body';
+                }
+            });
+
+        await expect(transport.send(message)).rejects.toThrow(UnauthorizedError);
+
+        const discoveryCalls = (globalThis.fetch as Mock).mock.calls.filter(([url]) => url.toString().includes('/.well-known/'));
+        expect(discoveryCalls.length).toBeGreaterThan(0);
+        for (const [, init] of discoveryCalls) {
+            expect(new Headers(init?.headers).get('mcp-protocol-version')).toBe('2025-03-26');
+        }
+    });
+
     it('silently refreshes and retries when a POST returns 401 invalid_token', async () => {
         const message: JSONRPCMessage = {
             jsonrpc: '2.0',

--- a/packages/codemod/src/migrations/v1-to-v2/mappings/symbolMap.ts
+++ b/packages/codemod/src/migrations/v1-to-v2/mappings/symbolMap.ts
@@ -14,7 +14,10 @@ export const SIMPLE_RENAMES: Record<string, string> = {
     JSONRPCResponse: 'JSONRPCResultResponse',
     JSONRPCResponseSchema: 'JSONRPCResultResponseSchema',
     ResourceReference: 'ResourceTemplateReference',
-    ResourceReferenceSchema: 'ResourceTemplateReferenceSchema'
+    ResourceReferenceSchema: 'ResourceTemplateReferenceSchema',
+    // Era-scoped rename — see docs/migration/upgrade-to-v2.md (Types & schemas).
+    LATEST_PROTOCOL_VERSION: 'LATEST_LEGACY_PROTOCOL_VERSION',
+    SUPPORTED_PROTOCOL_VERSIONS: 'SUPPORTED_LEGACY_PROTOCOL_VERSIONS'
 };
 
 export const ERROR_CODE_SDK_MEMBERS = new Set(['RequestTimeout', 'ConnectionClosed']);

--- a/packages/core-internal/src/exports/public/index.ts
+++ b/packages/core-internal/src/exports/public/index.ts
@@ -83,6 +83,7 @@ export {
     INVALID_PARAMS,
     INVALID_REQUEST,
     JSONRPC_VERSION,
+    LATEST_LEGACY_PROTOCOL_VERSION,
     LATEST_PROTOCOL_VERSION,
     LOG_LEVEL_META_KEY,
     METHOD_NOT_FOUND,
@@ -90,13 +91,18 @@ export {
     PROTOCOL_VERSION_META_KEY,
     RELATED_TASK_META_KEY,
     SUBSCRIPTION_ID_META_KEY,
+    SUPPORTED_LEGACY_PROTOCOL_VERSIONS,
     SUPPORTED_PROTOCOL_VERSIONS,
     TRACEPARENT_META_KEY,
     TRACESTATE_META_KEY
 } from '../../types/constants';
 
-// Protocol-era helpers
+// Protocol-era helpers: the era vocabulary plus the classifier for interpreting
+// a negotiated version string (e.g. from `Client.getNegotiatedProtocolVersion()`).
+// The era-scoped supported-version *lists* stay era-local: the legacy list is
+// exported above; the modern list is internal to negotiation.
 export type { ProtocolEra } from '../../shared/protocolEras';
+export { FIRST_MODERN_PROTOCOL_VERSION, isModernProtocolVersion } from '../../shared/protocolEras';
 
 // Enums
 export { ProtocolErrorCode } from '../../types/enums';

--- a/packages/core-internal/src/shared/protocol.ts
+++ b/packages/core-internal/src/shared/protocol.ts
@@ -43,7 +43,7 @@ import {
     PROTOCOL_VERSION_META_KEY,
     ProtocolError,
     ProtocolErrorCode,
-    SUPPORTED_PROTOCOL_VERSIONS
+    SUPPORTED_LEGACY_PROTOCOL_VERSIONS
 } from '../types/index';
 import type { StandardSchemaV1 } from '../util/standardSchema';
 import { isStandardSchema, validateStandardSchema } from '../util/standardSchema';
@@ -68,7 +68,7 @@ export type ProtocolOptions = {
      * the server counter-offers it); 2026-era entries are only ever selected via
      * `server/discover`. Passed to transport during {@linkcode Protocol.connect | connect()}.
      *
-     * @default {@linkcode SUPPORTED_PROTOCOL_VERSIONS}
+     * @default {@linkcode SUPPORTED_LEGACY_PROTOCOL_VERSIONS}
      */
     supportedProtocolVersions?: string[];
 
@@ -606,7 +606,7 @@ export abstract class Protocol<ContextT extends BaseContext> {
     fallbackNotificationHandler?: (notification: Notification) => Promise<void>;
 
     constructor(private _options?: ProtocolOptions) {
-        this._supportedProtocolVersions = _options?.supportedProtocolVersions ?? SUPPORTED_PROTOCOL_VERSIONS;
+        this._supportedProtocolVersions = _options?.supportedProtocolVersions ?? SUPPORTED_LEGACY_PROTOCOL_VERSIONS;
 
         this.setNotificationHandler('notifications/cancelled', notification => {
             this._oncancel(notification);

--- a/packages/core-internal/src/shared/protocolEras.ts
+++ b/packages/core-internal/src/shared/protocolEras.ts
@@ -26,13 +26,20 @@ export const FIRST_MODERN_PROTOCOL_VERSION = '2026-07-28';
 
 /**
  * Modern-era protocol revisions this SDK can negotiate via `server/discover`.
- * Deliberately separate from {@linkcode SUPPORTED_PROTOCOL_VERSIONS} (the legacy
+ * Deliberately separate from {@linkcode SUPPORTED_LEGACY_PROTOCOL_VERSIONS} (the legacy
  * `initialize` list), so adding a revision here can never leak a modern version
  * string into a 2025-era handshake. Internal — not part of the public API surface.
  */
 export const SUPPORTED_MODERN_PROTOCOL_VERSIONS = [FIRST_MODERN_PROTOCOL_VERSION];
 
-/** Whether the given protocol revision belongs to the modern (2026-07-28+) era. */
+/**
+ * Whether the given protocol revision belongs to the modern (2026-07-28+) era.
+ *
+ * Public: pair with `Client.getNegotiatedProtocolVersion()` to classify the
+ * revision a connection landed on. Assumes the ISO-date revision identifiers
+ * the protocol defines — a non-date string (e.g. `'draft'`) is not
+ * classifiable and compares lexicographically like any other string.
+ */
 export function isModernProtocolVersion(version: string): boolean {
     return version >= FIRST_MODERN_PROTOCOL_VERSION;
 }

--- a/packages/core-internal/src/types/constants.ts
+++ b/packages/core-internal/src/types/constants.ts
@@ -1,6 +1,46 @@
-export const LATEST_PROTOCOL_VERSION = '2025-11-25';
+/*
+ * Protocol revision constants for the legacy (pre-2026-07-28) era.
+ *
+ * The wire protocol splits into two eras (see `shared/protocolEras.ts`): legacy
+ * revisions are negotiated via the `initialize` handshake; modern revisions
+ * (2026-07-28 and later) are negotiated exclusively via `server/discover`. The
+ * constants below are legacy-era facts only — a modern revision never appears
+ * in them, so an `initialize` exchange can never offer or accept one.
+ */
+
+/**
+ * The most recent legacy-era protocol revision — the version a client offers
+ * in the `initialize` handshake by default.
+ *
+ * This is deliberately not the newest revision the SDK speaks: 2026-07-28 and
+ * later revisions belong to the modern era, negotiated exclusively via
+ * `server/discover` (opt in through the client's `versionNegotiation` option).
+ * Use `isModernProtocolVersion` to classify a negotiated version string.
+ */
+export const LATEST_LEGACY_PROTOCOL_VERSION = '2025-11-25';
+
+/**
+ * The legacy revision assumed for an HTTP request that carries no
+ * `MCP-Protocol-Version` header — the last revision released before the
+ * header existed.
+ */
 export const DEFAULT_NEGOTIATED_PROTOCOL_VERSION = '2025-03-26';
-export const SUPPORTED_PROTOCOL_VERSIONS = [LATEST_PROTOCOL_VERSION, '2025-06-18', '2025-03-26', '2024-11-05', '2024-10-07'];
+
+/**
+ * The legacy-era protocol revisions this SDK can negotiate via the
+ * `initialize` handshake, newest first.
+ *
+ * Deliberately excludes modern (2026-07-28+) revisions — those are negotiated
+ * only via `server/discover`, so they must never appear in an `initialize`
+ * offer, accept, or counter-offer.
+ */
+export const SUPPORTED_LEGACY_PROTOCOL_VERSIONS = [LATEST_LEGACY_PROTOCOL_VERSION, '2025-06-18', '2025-03-26', '2024-11-05', '2024-10-07'];
+
+/** @deprecated Renamed to {@linkcode LATEST_LEGACY_PROTOCOL_VERSION}; alias removed at 2.0.0 GA. */
+export const LATEST_PROTOCOL_VERSION = LATEST_LEGACY_PROTOCOL_VERSION;
+
+/** @deprecated Renamed to {@linkcode SUPPORTED_LEGACY_PROTOCOL_VERSIONS}; alias removed at 2.0.0 GA. */
+export const SUPPORTED_PROTOCOL_VERSIONS = SUPPORTED_LEGACY_PROTOCOL_VERSIONS;
 
 /**
  * `_meta` key associating a message with a 2025-11-25 task.

--- a/packages/core-internal/src/wire/codec.ts
+++ b/packages/core-internal/src/wire/codec.ts
@@ -289,7 +289,7 @@ export interface WireCodec {
 /**
  * Era resolution, many-to-one (Q1-SD1): every modern-era revision
  * (`>= 2026-07-28`) → the 2026-era codec; every legacy revision (the five
- * `SUPPORTED_PROTOCOL_VERSIONS`) and `undefined`/unknown → the 2025-era
+ * `SUPPORTED_LEGACY_PROTOCOL_VERSIONS`) and `undefined`/unknown → the 2025-era
  * codec (the DV-13 default posture — hand-constructed instances and
  * unclassified traffic are legacy-era). This is the same era predicate the
  * rest of the SDK uses ({@link isModernProtocolVersion}); a pinned modern

--- a/packages/core-internal/test/shared/protocolEras.test.ts
+++ b/packages/core-internal/test/shared/protocolEras.test.ts
@@ -7,15 +7,15 @@ import {
     modernProtocolVersions,
     SUPPORTED_MODERN_PROTOCOL_VERSIONS
 } from '../../src/shared/protocolEras';
-import { LATEST_PROTOCOL_VERSION, SUPPORTED_PROTOCOL_VERSIONS } from '../../src/types/constants';
+import { LATEST_LEGACY_PROTOCOL_VERSION, SUPPORTED_LEGACY_PROTOCOL_VERSIONS } from '../../src/types/constants';
 
 describe('protocol era helpers', () => {
     test('every released (legacy-list) version is classified legacy', () => {
-        for (const version of SUPPORTED_PROTOCOL_VERSIONS) {
+        for (const version of SUPPORTED_LEGACY_PROTOCOL_VERSIONS) {
             expect(isModernProtocolVersion(version)).toBe(false);
         }
-        expect(legacyProtocolVersions(SUPPORTED_PROTOCOL_VERSIONS)).toEqual(SUPPORTED_PROTOCOL_VERSIONS);
-        expect(modernProtocolVersions(SUPPORTED_PROTOCOL_VERSIONS)).toEqual([]);
+        expect(legacyProtocolVersions(SUPPORTED_LEGACY_PROTOCOL_VERSIONS)).toEqual(SUPPORTED_LEGACY_PROTOCOL_VERSIONS);
+        expect(modernProtocolVersions(SUPPORTED_LEGACY_PROTOCOL_VERSIONS)).toEqual([]);
     });
 
     test('the 2026-07-28 revision and later are classified modern', () => {
@@ -25,17 +25,17 @@ describe('protocol era helpers', () => {
     });
 
     test('subsetting preserves the list preference order', () => {
-        const mixed = ['2026-07-28', LATEST_PROTOCOL_VERSION, '2025-06-18'];
+        const mixed = ['2026-07-28', LATEST_LEGACY_PROTOCOL_VERSION, '2025-06-18'];
         expect(modernProtocolVersions(mixed)).toEqual(['2026-07-28']);
-        expect(legacyProtocolVersions(mixed)).toEqual([LATEST_PROTOCOL_VERSION, '2025-06-18']);
+        expect(legacyProtocolVersions(mixed)).toEqual([LATEST_LEGACY_PROTOCOL_VERSION, '2025-06-18']);
     });
 
     test('era-disjoint constants: the modern list never feeds the legacy initialize list', () => {
         // Ordering guard (counter-offer leak, server.ts counter-offer site): the
-        // legacy SUPPORTED_PROTOCOL_VERSIONS constant must not contain modern
+        // legacy SUPPORTED_LEGACY_PROTOCOL_VERSIONS constant must not contain modern
         // revisions; modern negotiation reads SUPPORTED_MODERN_PROTOCOL_VERSIONS,
         // which must contain only modern revisions.
-        expect(SUPPORTED_PROTOCOL_VERSIONS.some(isModernProtocolVersion)).toBe(false);
+        expect(SUPPORTED_LEGACY_PROTOCOL_VERSIONS.some(isModernProtocolVersion)).toBe(false);
         expect(SUPPORTED_MODERN_PROTOCOL_VERSIONS.every(isModernProtocolVersion)).toBe(true);
     });
 });

--- a/packages/core-internal/test/types.test.ts
+++ b/packages/core-internal/test/types.test.ts
@@ -14,14 +14,14 @@ import {
     DiscoverResultSchema,
     ElicitRequestFormParamsSchema,
     EmptyResultSchema,
-    LATEST_PROTOCOL_VERSION,
+    LATEST_LEGACY_PROTOCOL_VERSION,
     LOG_LEVEL_META_KEY,
     PromptMessageSchema,
     PROTOCOL_VERSION_META_KEY,
     ResourceLinkSchema,
     ResultSchema,
     SamplingMessageSchema,
-    SUPPORTED_PROTOCOL_VERSIONS,
+    SUPPORTED_LEGACY_PROTOCOL_VERSIONS,
     ToolChoiceSchema,
     ToolResultContentSchema,
     ToolSchema,
@@ -36,17 +36,17 @@ import { RequestMetaEnvelopeSchema } from '../src/wire/rev2026-07-28/schemas';
 
 describe('Types', () => {
     test('should have correct latest protocol version', () => {
-        expect(LATEST_PROTOCOL_VERSION).toBeDefined();
-        expect(LATEST_PROTOCOL_VERSION).toBe('2025-11-25');
+        expect(LATEST_LEGACY_PROTOCOL_VERSION).toBeDefined();
+        expect(LATEST_LEGACY_PROTOCOL_VERSION).toBe('2025-11-25');
     });
     test('should have correct supported protocol versions', () => {
-        expect(SUPPORTED_PROTOCOL_VERSIONS).toBeDefined();
-        expect(SUPPORTED_PROTOCOL_VERSIONS).toBeInstanceOf(Array);
-        expect(SUPPORTED_PROTOCOL_VERSIONS).toContain(LATEST_PROTOCOL_VERSION);
-        expect(SUPPORTED_PROTOCOL_VERSIONS).toContain('2025-06-18');
-        expect(SUPPORTED_PROTOCOL_VERSIONS).toContain('2025-03-26');
-        expect(SUPPORTED_PROTOCOL_VERSIONS).toContain('2024-11-05');
-        expect(SUPPORTED_PROTOCOL_VERSIONS).toContain('2024-10-07');
+        expect(SUPPORTED_LEGACY_PROTOCOL_VERSIONS).toBeDefined();
+        expect(SUPPORTED_LEGACY_PROTOCOL_VERSIONS).toBeInstanceOf(Array);
+        expect(SUPPORTED_LEGACY_PROTOCOL_VERSIONS).toContain(LATEST_LEGACY_PROTOCOL_VERSION);
+        expect(SUPPORTED_LEGACY_PROTOCOL_VERSIONS).toContain('2025-06-18');
+        expect(SUPPORTED_LEGACY_PROTOCOL_VERSIONS).toContain('2025-03-26');
+        expect(SUPPORTED_LEGACY_PROTOCOL_VERSIONS).toContain('2024-11-05');
+        expect(SUPPORTED_LEGACY_PROTOCOL_VERSIONS).toContain('2024-10-07');
     });
 
     describe('ResourceLink', () => {

--- a/packages/core-internal/test/types/errorSurfacePins.test.ts
+++ b/packages/core-internal/test/types/errorSurfacePins.test.ts
@@ -19,16 +19,17 @@ import {
     INVALID_PARAMS,
     INVALID_REQUEST,
     JSONRPC_VERSION,
-    LATEST_PROTOCOL_VERSION,
+    LATEST_LEGACY_PROTOCOL_VERSION,
     METHOD_NOT_FOUND,
     PARSE_ERROR,
     ProtocolError,
     ProtocolErrorCode,
-    SUPPORTED_PROTOCOL_VERSIONS,
+    SUPPORTED_LEGACY_PROTOCOL_VERSIONS,
     ResourceNotFoundError,
     UnsupportedProtocolVersionError,
     UrlElicitationRequiredError
 } from '../../src/types/index';
+import { FIRST_MODERN_PROTOCOL_VERSION, isModernProtocolVersion } from '../../src/shared/protocolEras';
 import { STDIO_DEFAULT_MAX_BUFFER_SIZE } from '../../src/shared/stdio';
 
 describe('ProtocolErrorCode', () => {
@@ -187,11 +188,26 @@ describe('protocol version constants', () => {
     test('values and membership are frozen', () => {
         // The supported list is pinned by exact value (not just membership) so a
         // naive LATEST bump that silently drops a previous version goes red here.
-        expect(LATEST_PROTOCOL_VERSION).toBe('2025-11-25');
+        expect(LATEST_LEGACY_PROTOCOL_VERSION).toBe('2025-11-25');
         expect(DEFAULT_NEGOTIATED_PROTOCOL_VERSION).toBe('2025-03-26');
-        expect(SUPPORTED_PROTOCOL_VERSIONS).toEqual(['2025-11-25', '2025-06-18', '2025-03-26', '2024-11-05', '2024-10-07']);
-        expect(SUPPORTED_PROTOCOL_VERSIONS).toContain(LATEST_PROTOCOL_VERSION);
-        expect(SUPPORTED_PROTOCOL_VERSIONS).toContain(DEFAULT_NEGOTIATED_PROTOCOL_VERSION);
+        expect(SUPPORTED_LEGACY_PROTOCOL_VERSIONS).toEqual(['2025-11-25', '2025-06-18', '2025-03-26', '2024-11-05', '2024-10-07']);
+        expect(SUPPORTED_LEGACY_PROTOCOL_VERSIONS).toContain(LATEST_LEGACY_PROTOCOL_VERSION);
+        expect(SUPPORTED_LEGACY_PROTOCOL_VERSIONS).toContain(DEFAULT_NEGOTIATED_PROTOCOL_VERSION);
+    });
+
+    test('the era surface is public, and the pre-rename names remain aliases until 2.0.0 GA', async () => {
+        // Users interpreting getNegotiatedProtocolVersion() need the classifier,
+        // not just the ProtocolEra type — pin the public barrel's era surface,
+        // including the deprecated aliases (identity, not just equality: the
+        // supported list is the same array object). Era-disjointness of the
+        // legacy list is pinned in shared/protocolEras.test.ts.
+        const publicBarrel = await import('../../src/exports/public/index');
+        expect(publicBarrel.isModernProtocolVersion).toBe(isModernProtocolVersion);
+        expect(publicBarrel.FIRST_MODERN_PROTOCOL_VERSION).toBe(FIRST_MODERN_PROTOCOL_VERSION);
+        expect(publicBarrel.LATEST_LEGACY_PROTOCOL_VERSION).toBe(LATEST_LEGACY_PROTOCOL_VERSION);
+        expect(publicBarrel.SUPPORTED_LEGACY_PROTOCOL_VERSIONS).toBe(SUPPORTED_LEGACY_PROTOCOL_VERSIONS);
+        expect(publicBarrel.LATEST_PROTOCOL_VERSION).toBe(LATEST_LEGACY_PROTOCOL_VERSION);
+        expect(publicBarrel.SUPPORTED_PROTOCOL_VERSIONS).toBe(SUPPORTED_LEGACY_PROTOCOL_VERSIONS);
     });
 });
 

--- a/packages/server/src/server/server.ts
+++ b/packages/server/src/server/server.ts
@@ -44,7 +44,7 @@ import {
     codecForVersion,
     isInputRequiredResult,
     isModernProtocolVersion,
-    LATEST_PROTOCOL_VERSION,
+    LATEST_LEGACY_PROTOCOL_VERSION,
     legacyProtocolVersions,
     LOG_LEVEL_META_KEY,
     LoggingLevelSchema,
@@ -637,7 +637,7 @@ export class Server extends Protocol<ServerContext> {
                 throw new ProtocolError(
                     ProtocolErrorCode.InternalError,
                     `Handler for ${method} returned an input-required result, but this request is served on protocol revision ` +
-                        `${this._negotiatedProtocolVersion ?? LATEST_PROTOCOL_VERSION}, which has no input_required vocabulary`
+                        `${this._negotiatedProtocolVersion ?? LATEST_LEGACY_PROTOCOL_VERSION}, which has no input_required vocabulary`
                 );
             }
             // Write-once handlers served to deployed 2025 clients.
@@ -888,7 +888,7 @@ export class Server extends Protocol<ServerContext> {
         const legacyVersions = legacyProtocolVersions(this._supportedProtocolVersions);
         const protocolVersion = legacyVersions.includes(requestedVersion)
             ? requestedVersion
-            : (legacyVersions[0] ?? LATEST_PROTOCOL_VERSION);
+            : (legacyVersions[0] ?? LATEST_LEGACY_PROTOCOL_VERSION);
 
         // The negotiated version is the instance's connection state — it IS
         // the wire-era selection for everything this instance sends and

--- a/packages/server/src/server/streamableHttp.ts
+++ b/packages/server/src/server/streamableHttp.ts
@@ -15,7 +15,7 @@ import {
     isJSONRPCRequest,
     isJSONRPCResultResponse,
     JSONRPCMessageSchema,
-    SUPPORTED_PROTOCOL_VERSIONS
+    SUPPORTED_LEGACY_PROTOCOL_VERSIONS
 } from '@modelcontextprotocol/core-internal';
 
 export type StreamId = string;
@@ -155,7 +155,7 @@ export interface WebStandardStreamableHTTPServerTransportOptions {
      * `supportedProtocolVersions` to the transport, so you typically don't need
      * to set this option directly.
      *
-     * @default {@linkcode SUPPORTED_PROTOCOL_VERSIONS}
+     * @default {@linkcode SUPPORTED_LEGACY_PROTOCOL_VERSIONS}
      */
     supportedProtocolVersions?: string[];
 }
@@ -262,7 +262,7 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
         this._allowedOrigins = options.allowedOrigins;
         this._enableDnsRebindingProtection = options.enableDnsRebindingProtection ?? false;
         this._retryInterval = options.retryInterval;
-        this._supportedProtocolVersions = options.supportedProtocolVersions ?? SUPPORTED_PROTOCOL_VERSIONS;
+        this._supportedProtocolVersions = options.supportedProtocolVersions ?? SUPPORTED_LEGACY_PROTOCOL_VERSIONS;
     }
 
     /**

--- a/packages/server/test/server/createMcpHandlerStatelessLiteral.test.ts
+++ b/packages/server/test/server/createMcpHandlerStatelessLiteral.test.ts
@@ -8,9 +8,9 @@
  * go-sdk substring dependency) is the same one the standalone transport test
  * pins. This twin asserts the bytes hold on the sugar path itself: HTTP 400,
  * code -32000, and the literal substring `Unsupported protocol version`, with
- * the supported-versions suffix derived from `SUPPORTED_PROTOCOL_VERSIONS`.
+ * the supported-versions suffix derived from `SUPPORTED_LEGACY_PROTOCOL_VERSIONS`.
  */
-import { SUPPORTED_PROTOCOL_VERSIONS } from '@modelcontextprotocol/core-internal';
+import { SUPPORTED_LEGACY_PROTOCOL_VERSIONS } from '@modelcontextprotocol/core-internal';
 import { describe, expect, it } from 'vitest';
 import * as z from 'zod/v4';
 
@@ -67,7 +67,7 @@ describe('createMcpHandler legacy:"stateless" — unsupported protocol version w
         expect(body.id).toBeNull();
         expect(body.error.code).toBe(-32_000);
         expect(body.error.message).toBe(
-            `Bad Request: Unsupported protocol version: 2024-01-01 (supported versions: ${SUPPORTED_PROTOCOL_VERSIONS.join(', ')})`
+            `Bad Request: Unsupported protocol version: 2024-01-01 (supported versions: ${SUPPORTED_LEGACY_PROTOCOL_VERSIONS.join(', ')})`
         );
     });
 

--- a/packages/server/test/server/discover.test.ts
+++ b/packages/server/test/server/discover.test.ts
@@ -28,10 +28,10 @@ import {
     InMemoryTransport,
     isJSONRPCErrorResponse,
     isJSONRPCResultResponse,
-    LATEST_PROTOCOL_VERSION,
+    LATEST_LEGACY_PROTOCOL_VERSION,
     PROTOCOL_VERSION_META_KEY,
     setNegotiatedProtocolVersion,
-    SUPPORTED_PROTOCOL_VERSIONS
+    SUPPORTED_LEGACY_PROTOCOL_VERSIONS
 } from '@modelcontextprotocol/core-internal';
 import { describe, expect, it } from 'vitest';
 
@@ -39,7 +39,7 @@ import { discoverAdvertisedCapabilities, Server } from '../../src/server/server'
 
 const MODERN = '2026-07-28';
 /** A supported list spanning both eras — what the constant becomes after a future bump. */
-const DUAL_ERA_VERSIONS = [MODERN, ...SUPPORTED_PROTOCOL_VERSIONS];
+const DUAL_ERA_VERSIONS = [MODERN, ...SUPPORTED_LEGACY_PROTOCOL_VERSIONS];
 
 async function sendRaw(server: Server, request: JSONRPCRequest, options?: { markModern?: boolean }): Promise<JSONRPCMessage> {
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
@@ -166,7 +166,7 @@ describe('discover advertisement constraints', () => {
 
         // The legacy initialize advertisement still carries the full capability set.
         const server = new Server({ name: 'test', version: '1.0.0' }, { capabilities, supportedProtocolVersions: DUAL_ERA_VERSIONS });
-        const response = await sendRaw(server, initializeRequest(LATEST_PROTOCOL_VERSION));
+        const response = await sendRaw(server, initializeRequest(LATEST_LEGACY_PROTOCOL_VERSION));
         if (!isJSONRPCResultResponse(response)) throw new Error('expected result');
         const result = InitializeResultSchema.parse(response.result);
         expect(result.capabilities.tools).toEqual({ listChanged: true });
@@ -184,7 +184,7 @@ describe('era-aware counter-offer ordering (the guard that precedes any constant
         // supportedProtocolVersions[0] is the modern revision here — the
         // counter-offer must NOT be it: a fallback initialize never meets a
         // leaked 2026 string at this site.
-        expect(result.protocolVersion).toBe(LATEST_PROTOCOL_VERSION);
+        expect(result.protocolVersion).toBe(LATEST_LEGACY_PROTOCOL_VERSION);
         expect(result.protocolVersion).not.toBe(MODERN);
         await server.close();
     });
@@ -194,8 +194,8 @@ describe('era-aware counter-offer ordering (the guard that precedes any constant
         const response = await sendRaw(server, initializeRequest(MODERN));
         if (!isJSONRPCResultResponse(response)) throw new Error('expected result');
         const result = InitializeResultSchema.parse(response.result);
-        expect(result.protocolVersion).toBe(LATEST_PROTOCOL_VERSION);
-        expect(server.getNegotiatedProtocolVersion()).toBe(LATEST_PROTOCOL_VERSION);
+        expect(result.protocolVersion).toBe(LATEST_LEGACY_PROTOCOL_VERSION);
+        expect(server.getNegotiatedProtocolVersion()).toBe(LATEST_LEGACY_PROTOCOL_VERSION);
         await server.close();
     });
 
@@ -204,7 +204,7 @@ describe('era-aware counter-offer ordering (the guard that precedes any constant
         const response = await sendRaw(server, initializeRequest('1999-01-01'));
         if (!isJSONRPCResultResponse(response)) throw new Error('expected result');
         const result = InitializeResultSchema.parse(response.result);
-        expect(result.protocolVersion).toBe(SUPPORTED_PROTOCOL_VERSIONS[0]);
+        expect(result.protocolVersion).toBe(SUPPORTED_LEGACY_PROTOCOL_VERSIONS[0]);
         await server.close();
     });
 });

--- a/packages/server/test/server/inputRequired.test.ts
+++ b/packages/server/test/server/inputRequired.test.ts
@@ -33,7 +33,7 @@ import {
     CLIENT_INFO_META_KEY,
     InMemoryTransport,
     inputRequired,
-    LATEST_PROTOCOL_VERSION,
+    LATEST_LEGACY_PROTOCOL_VERSION,
     PROTOCOL_VERSION_META_KEY,
     setNegotiatedProtocolVersion,
     UrlElicitationRequiredError
@@ -105,7 +105,7 @@ const legacyInitialize = (id: number): JSONRPCRequest => ({
     jsonrpc: '2.0',
     id,
     method: 'initialize',
-    params: { protocolVersion: LATEST_PROTOCOL_VERSION, capabilities: {}, clientInfo: { name: 'legacy-client', version: '1.0.0' } }
+    params: { protocolVersion: LATEST_LEGACY_PROTOCOL_VERSION, capabilities: {}, clientInfo: { name: 'legacy-client', version: '1.0.0' } }
 });
 
 function resultOf(message: JSONRPCMessage): Record<string, unknown> {

--- a/packages/server/test/server/jsonSchemaValidatorOverride.test.ts
+++ b/packages/server/test/server/jsonSchemaValidatorOverride.test.ts
@@ -1,5 +1,5 @@
 import type { JsonSchemaType, JsonSchemaValidatorResult, jsonSchemaValidator } from '@modelcontextprotocol/core-internal';
-import { InMemoryTransport, LATEST_PROTOCOL_VERSION } from '@modelcontextprotocol/core-internal';
+import { InMemoryTransport, LATEST_LEGACY_PROTOCOL_VERSION } from '@modelcontextprotocol/core-internal';
 import { fromJsonSchema } from '../../src/fromJsonSchema';
 import { Server } from '../../src/server/server';
 
@@ -39,7 +39,7 @@ describe('server JSON Schema validator overrides', () => {
             id: 1,
             method: 'initialize',
             params: {
-                protocolVersion: LATEST_PROTOCOL_VERSION,
+                protocolVersion: LATEST_LEGACY_PROTOCOL_VERSION,
                 capabilities: { elicitation: { form: {} } },
                 clientInfo: { name: 'test-client', version: '1.0.0' }
             }

--- a/packages/server/test/server/legacyDefaultServing.test.ts
+++ b/packages/server/test/server/legacyDefaultServing.test.ts
@@ -12,7 +12,7 @@ import {
     InMemoryTransport,
     isJSONRPCErrorResponse,
     isJSONRPCResultResponse,
-    LATEST_PROTOCOL_VERSION
+    LATEST_LEGACY_PROTOCOL_VERSION
 } from '@modelcontextprotocol/core-internal';
 import { describe, expect, it } from 'vitest';
 import * as z from 'zod/v4';
@@ -59,7 +59,7 @@ const initializeRequest = (id: number): JSONRPCRequest => ({
     jsonrpc: '2.0',
     id,
     method: 'initialize',
-    params: { protocolVersion: LATEST_PROTOCOL_VERSION, capabilities: {}, clientInfo: { name: 'legacy-client', version: '1.0.0' } }
+    params: { protocolVersion: LATEST_LEGACY_PROTOCOL_VERSION, capabilities: {}, clientInfo: { name: 'legacy-client', version: '1.0.0' } }
 });
 
 describe('Q10-L2: a hand-constructed server on 2025 traffic', () => {
@@ -71,7 +71,7 @@ describe('Q10-L2: a hand-constructed server on 2025 traffic', () => {
         expect(isJSONRPCResultResponse(init)).toBe(true);
         if (isJSONRPCResultResponse(init)) {
             expect(init.result).toEqual({
-                protocolVersion: LATEST_PROTOCOL_VERSION,
+                protocolVersion: LATEST_LEGACY_PROTOCOL_VERSION,
                 capabilities: { tools: { listChanged: true } },
                 serverInfo: { name: 'legacy-default-test-server', version: '1.0.0' },
                 instructions: 'test instructions'

--- a/packages/server/test/server/legacyShimHarness.ts
+++ b/packages/server/test/server/legacyShimHarness.ts
@@ -14,7 +14,7 @@ import type {
     JSONRPCResultResponse,
     RequestId
 } from '@modelcontextprotocol/core-internal';
-import { InMemoryTransport, LATEST_PROTOCOL_VERSION } from '@modelcontextprotocol/core-internal';
+import { InMemoryTransport, LATEST_LEGACY_PROTOCOL_VERSION } from '@modelcontextprotocol/core-internal';
 
 import type { McpServer } from '../../src/server/mcp';
 import type { Server } from '../../src/server/server';
@@ -27,7 +27,7 @@ export const legacyInitialize = (id: number, capabilities: Record<string, unknow
     jsonrpc: '2.0',
     id,
     method: 'initialize',
-    params: { protocolVersion: LATEST_PROTOCOL_VERSION, capabilities, clientInfo: { name: 'legacy-client', version: '1.0.0' } }
+    params: { protocolVersion: LATEST_LEGACY_PROTOCOL_VERSION, capabilities, clientInfo: { name: 'legacy-client', version: '1.0.0' } }
 });
 
 export function resultOf(message: JSONRPCMessage): Record<string, unknown> {

--- a/packages/server/test/server/lowLevelLegacyWrap.test.ts
+++ b/packages/server/test/server/lowLevelLegacyWrap.test.ts
@@ -8,7 +8,7 @@
  * the wrap — the only era branch is the codec.
  */
 import type { JSONRPCMessage, JSONRPCNotification, JSONRPCRequest } from '@modelcontextprotocol/core-internal';
-import { InMemoryTransport, isJSONRPCResultResponse, LATEST_PROTOCOL_VERSION } from '@modelcontextprotocol/core-internal';
+import { InMemoryTransport, isJSONRPCResultResponse, LATEST_LEGACY_PROTOCOL_VERSION } from '@modelcontextprotocol/core-internal';
 import { describe, expect, it } from 'vitest';
 
 import { Server } from '../../src/server/server';
@@ -39,7 +39,7 @@ const initializeRequest = (id: number): JSONRPCRequest => ({
     jsonrpc: '2.0',
     id,
     method: 'initialize',
-    params: { protocolVersion: LATEST_PROTOCOL_VERSION, capabilities: {}, clientInfo: { name: 'legacy-client', version: '1.0.0' } }
+    params: { protocolVersion: LATEST_LEGACY_PROTOCOL_VERSION, capabilities: {}, clientInfo: { name: 'legacy-client', version: '1.0.0' } }
 });
 
 describe('SEP-2106: the 2025 wire codec owns the legacy {result:…} wrap (low-level Server)', () => {

--- a/packages/server/test/server/mcp.compat.test.ts
+++ b/packages/server/test/server/mcp.compat.test.ts
@@ -1,5 +1,5 @@
 import type { JSONRPCMessage } from '@modelcontextprotocol/core-internal';
-import { InMemoryTransport, isStandardSchema, LATEST_PROTOCOL_VERSION } from '@modelcontextprotocol/core-internal';
+import { InMemoryTransport, isStandardSchema, LATEST_LEGACY_PROTOCOL_VERSION } from '@modelcontextprotocol/core-internal';
 import { describe, expect, expectTypeOf, it, vi } from 'vitest';
 import * as z from 'zod/v4';
 import { McpServer } from '../../src/index';
@@ -98,7 +98,7 @@ describe('registerTool/registerPrompt accept raw Zod shape (auto-wrapped)', () =
             id: 1,
             method: 'initialize',
             params: {
-                protocolVersion: LATEST_PROTOCOL_VERSION,
+                protocolVersion: LATEST_LEGACY_PROTOCOL_VERSION,
                 capabilities: {},
                 clientInfo: { name: 'c', version: '1.0.0' }
             }

--- a/packages/server/test/server/mcp.icons.test.ts
+++ b/packages/server/test/server/mcp.icons.test.ts
@@ -1,5 +1,5 @@
 import type { Icon, JSONRPCMessage } from '@modelcontextprotocol/core-internal';
-import { InMemoryTransport, LATEST_PROTOCOL_VERSION } from '@modelcontextprotocol/core-internal';
+import { InMemoryTransport, LATEST_LEGACY_PROTOCOL_VERSION } from '@modelcontextprotocol/core-internal';
 import { describe, expect, it, vi } from 'vitest';
 import { McpServer, ResourceTemplate } from '../../src/index';
 
@@ -25,7 +25,7 @@ async function initializeAndRequest(server: McpServer, request: { method: string
         id: 1,
         method: 'initialize',
         params: {
-            protocolVersion: LATEST_PROTOCOL_VERSION,
+            protocolVersion: LATEST_LEGACY_PROTOCOL_VERSION,
             capabilities: {},
             clientInfo: { name: 'c', version: '1.0.0' }
         }
@@ -52,7 +52,7 @@ async function getInitializeResult(server: McpServer): Promise<Record<string, un
         id: 1,
         method: 'initialize',
         params: {
-            protocolVersion: LATEST_PROTOCOL_VERSION,
+            protocolVersion: LATEST_LEGACY_PROTOCOL_VERSION,
             capabilities: {},
             clientInfo: { name: 'c', version: '1.0.0' }
         }

--- a/packages/server/test/server/serveStdio.test.ts
+++ b/packages/server/test/server/serveStdio.test.ts
@@ -35,7 +35,7 @@ import {
     inputRequired,
     isJSONRPCErrorResponse,
     isJSONRPCResultResponse,
-    LATEST_PROTOCOL_VERSION,
+    LATEST_LEGACY_PROTOCOL_VERSION,
     PROTOCOL_VERSION_META_KEY,
     SdkError,
     SdkErrorCode
@@ -60,7 +60,7 @@ const envelope = (overrides?: Record<string, unknown>) => ({
     ...overrides
 });
 
-const initializeRequest = (id: number | string, requestedVersion = LATEST_PROTOCOL_VERSION): JSONRPCRequest => ({
+const initializeRequest = (id: number | string, requestedVersion = LATEST_LEGACY_PROTOCOL_VERSION): JSONRPCRequest => ({
     jsonrpc: '2.0',
     id,
     method: 'initialize',
@@ -139,7 +139,7 @@ describe('legacy opening (default legacy: serve)', () => {
         expect(isJSONRPCResultResponse(init)).toBe(true);
         if (isJSONRPCResultResponse(init)) {
             expect(init.result).toEqual({
-                protocolVersion: LATEST_PROTOCOL_VERSION,
+                protocolVersion: LATEST_LEGACY_PROTOCOL_VERSION,
                 capabilities: { tools: { listChanged: true } },
                 serverInfo: { name: 'serve-stdio-test-server', version: '1.0.0' },
                 instructions: 'serve-stdio test instructions'
@@ -246,7 +246,7 @@ describe('modern opening', () => {
             expect(init.error.code).toBe(-32_022);
             const data = init.error.data as { supported?: string[]; requested?: string };
             expect(data.supported).toContain(MODERN);
-            expect(data.requested).toBe(LATEST_PROTOCOL_VERSION);
+            expect(data.requested).toBe(LATEST_LEGACY_PROTOCOL_VERSION);
         }
 
         await handle.close();
@@ -293,7 +293,7 @@ describe('server/discover probe window', () => {
         const init = await request(initializeRequest(2));
         expect(isJSONRPCResultResponse(init)).toBe(true);
         if (isJSONRPCResultResponse(init)) {
-            expect((init.result as { protocolVersion?: string }).protocolVersion).toBe(LATEST_PROTOCOL_VERSION);
+            expect((init.result as { protocolVersion?: string }).protocolVersion).toBe(LATEST_LEGACY_PROTOCOL_VERSION);
         }
 
         // The optimistic modern instance was discarded; the legacy session is
@@ -327,7 +327,7 @@ describe('server/discover probe window', () => {
         }
         expect(isJSONRPCResultResponse(init)).toBe(true);
         if (isJSONRPCResultResponse(init)) {
-            expect((init.result as { protocolVersion?: string }).protocolVersion).toBe(LATEST_PROTOCOL_VERSION);
+            expect((init.result as { protocolVersion?: string }).protocolVersion).toBe(LATEST_LEGACY_PROTOCOL_VERSION);
         }
         // The probe answer reached the wire before the fallback's handshake answer.
         expect(inbound.indexOf(discover)).toBeLessThan(inbound.indexOf(init));
@@ -362,7 +362,7 @@ describe('server/discover probe window', () => {
         const init = await request(initializeRequest(3));
         expect(isJSONRPCResultResponse(init)).toBe(true);
         if (isJSONRPCResultResponse(init)) {
-            expect((init.result as { protocolVersion?: string }).protocolVersion).toBe(LATEST_PROTOCOL_VERSION);
+            expect((init.result as { protocolVersion?: string }).protocolVersion).toBe(LATEST_LEGACY_PROTOCOL_VERSION);
         }
         expect(eras).toEqual(['modern', 'legacy']);
         expect(closed[0]).toBe(true);
@@ -391,7 +391,7 @@ describe('server/discover probe window', () => {
         const init = await request(initializeRequest(2));
         expect(isJSONRPCResultResponse(init)).toBe(true);
         if (isJSONRPCResultResponse(init)) {
-            expect((init.result as { protocolVersion?: string }).protocolVersion).toBe(LATEST_PROTOCOL_VERSION);
+            expect((init.result as { protocolVersion?: string }).protocolVersion).toBe(LATEST_LEGACY_PROTOCOL_VERSION);
         }
 
         // The fallback handshake was served by a fresh legacy instance and
@@ -422,7 +422,7 @@ describe('server/discover probe window', () => {
         const init = await request(initializeRequest(2));
         expect(isJSONRPCResultResponse(init)).toBe(true);
         if (isJSONRPCResultResponse(init)) {
-            expect((init.result as { protocolVersion?: string }).protocolVersion).toBe(LATEST_PROTOCOL_VERSION);
+            expect((init.result as { protocolVersion?: string }).protocolVersion).toBe(LATEST_LEGACY_PROTOCOL_VERSION);
         }
 
         // The probe instance was discarded and the fallback is served end to
@@ -503,7 +503,7 @@ describe("legacy: 'reject'", () => {
             expect(init.error.code).toBe(-32_022);
             const data = init.error.data as { supported?: string[]; requested?: string };
             expect(data.supported).toContain(MODERN);
-            expect(data.requested).toBe(LATEST_PROTOCOL_VERSION);
+            expect(data.requested).toBe(LATEST_LEGACY_PROTOCOL_VERSION);
         }
         expect(eras).toEqual([]);
 
@@ -848,7 +848,7 @@ describe('legacy input_required shim through the stdio entry', () => {
             id: 1,
             method: 'initialize',
             params: {
-                protocolVersion: LATEST_PROTOCOL_VERSION,
+                protocolVersion: LATEST_LEGACY_PROTOCOL_VERSION,
                 capabilities: { elicitation: { form: {} } },
                 clientInfo: { name: 'legacy-client', version: '1.0.0' }
             }

--- a/packages/server/test/server/server.test.ts
+++ b/packages/server/test/server/server.test.ts
@@ -3,8 +3,8 @@ import {
     InitializeResultSchema,
     InMemoryTransport,
     isJSONRPCResultResponse,
-    LATEST_PROTOCOL_VERSION,
-    SUPPORTED_PROTOCOL_VERSIONS
+    LATEST_LEGACY_PROTOCOL_VERSION,
+    SUPPORTED_LEGACY_PROTOCOL_VERSIONS
 } from '@modelcontextprotocol/core-internal';
 import { Server } from '../../src/server/server';
 
@@ -72,7 +72,7 @@ describe('Server', () => {
                 id: 1,
                 method: 'initialize',
                 params: {
-                    protocolVersion: LATEST_PROTOCOL_VERSION,
+                    protocolVersion: LATEST_LEGACY_PROTOCOL_VERSION,
                     capabilities: {},
                     clientInfo: { name: 'test-client', version: '1.0.0' }
                 }
@@ -80,7 +80,7 @@ describe('Server', () => {
 
             await responsePromise;
 
-            expect(setProtocolVersion).toHaveBeenCalledWith(LATEST_PROTOCOL_VERSION);
+            expect(setProtocolVersion).toHaveBeenCalledWith(LATEST_LEGACY_PROTOCOL_VERSION);
 
             await server.close();
         });
@@ -96,16 +96,16 @@ describe('Server', () => {
         it('returns the requested version after initialize when the server supports it', async () => {
             const server = new Server({ name: 'test', version: '1.0.0' }, { capabilities: {} });
 
-            const respondedVersion = await initializeServer(server, LATEST_PROTOCOL_VERSION);
+            const respondedVersion = await initializeServer(server, LATEST_LEGACY_PROTOCOL_VERSION);
 
-            expect(respondedVersion).toBe(LATEST_PROTOCOL_VERSION);
-            expect(server.getNegotiatedProtocolVersion()).toBe(LATEST_PROTOCOL_VERSION);
+            expect(respondedVersion).toBe(LATEST_LEGACY_PROTOCOL_VERSION);
+            expect(server.getNegotiatedProtocolVersion()).toBe(LATEST_LEGACY_PROTOCOL_VERSION);
 
             await server.close();
         });
 
         it('returns the older version when the client requests an older supported version', async () => {
-            expect(SUPPORTED_PROTOCOL_VERSIONS).toContain(OLDER_SUPPORTED_VERSION);
+            expect(SUPPORTED_LEGACY_PROTOCOL_VERSIONS).toContain(OLDER_SUPPORTED_VERSION);
             const server = new Server({ name: 'test', version: '1.0.0' }, { capabilities: {} });
 
             const respondedVersion = await initializeServer(server, OLDER_SUPPORTED_VERSION);
@@ -117,15 +117,15 @@ describe('Server', () => {
         });
 
         it('returns the fallback version when the client requests an unsupported version', async () => {
-            expect(SUPPORTED_PROTOCOL_VERSIONS).not.toContain(UNSUPPORTED_VERSION);
+            expect(SUPPORTED_LEGACY_PROTOCOL_VERSIONS).not.toContain(UNSUPPORTED_VERSION);
             const server = new Server({ name: 'test', version: '1.0.0' }, { capabilities: {} });
 
             const respondedVersion = await initializeServer(server, UNSUPPORTED_VERSION);
 
             // The server falls back to its latest supported version and the getter reflects
             // the version it actually responded with, not the one the client asked for.
-            expect(respondedVersion).toBe(LATEST_PROTOCOL_VERSION);
-            expect(server.getNegotiatedProtocolVersion()).toBe(LATEST_PROTOCOL_VERSION);
+            expect(respondedVersion).toBe(LATEST_LEGACY_PROTOCOL_VERSION);
+            expect(server.getNegotiatedProtocolVersion()).toBe(LATEST_LEGACY_PROTOCOL_VERSION);
 
             await server.close();
         });
@@ -141,14 +141,14 @@ describe('Server', () => {
             // counter-offer can never name it. The dual-era list arms live in
             // discover.test.ts ("era-aware counter-offer ordering").
             const DRAFT_REVISION = '2026-07-28';
-            expect(SUPPORTED_PROTOCOL_VERSIONS).not.toContain(DRAFT_REVISION);
+            expect(SUPPORTED_LEGACY_PROTOCOL_VERSIONS).not.toContain(DRAFT_REVISION);
             const server = new Server({ name: 'test', version: '1.0.0' }, { capabilities: {} });
 
             const respondedVersion = await initializeServer(server, DRAFT_REVISION);
 
-            expect(respondedVersion).toBe(LATEST_PROTOCOL_VERSION);
+            expect(respondedVersion).toBe(LATEST_LEGACY_PROTOCOL_VERSION);
             expect(respondedVersion).not.toBe(DRAFT_REVISION);
-            expect(server.getNegotiatedProtocolVersion()).toBe(LATEST_PROTOCOL_VERSION);
+            expect(server.getNegotiatedProtocolVersion()).toBe(LATEST_LEGACY_PROTOCOL_VERSION);
 
             await server.close();
         });
@@ -176,7 +176,7 @@ describe('Server', () => {
                 id: 1,
                 method: 'initialize',
                 params: {
-                    protocolVersion: LATEST_PROTOCOL_VERSION,
+                    protocolVersion: LATEST_LEGACY_PROTOCOL_VERSION,
                     capabilities: {},
                     clientInfo: { name: 'test-client', version: '1.0.0' }
                 }

--- a/packages/server/test/server/streamableHttpUnsupportedVersionLiteral.test.ts
+++ b/packages/server/test/server/streamableHttpUnsupportedVersionLiteral.test.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'node:crypto';
 
 import type { JSONRPCMessage } from '@modelcontextprotocol/core-internal';
-import { SUPPORTED_PROTOCOL_VERSIONS } from '@modelcontextprotocol/core-internal';
+import { SUPPORTED_LEGACY_PROTOCOL_VERSIONS } from '@modelcontextprotocol/core-internal';
 
 import { McpServer } from '../../src/server/mcp';
 import { WebStandardStreamableHTTPServerTransport } from '../../src/server/streamableHttp';
@@ -19,7 +19,7 @@ import { WebStandardStreamableHTTPServerTransport } from '../../src/server/strea
  * refactors of the transport internals.
  *
  * The rest of the message (prefix, echoed version, supported-versions list)
- * is asserted against a string derived from `SUPPORTED_PROTOCOL_VERSIONS`
+ * is asserted against a string derived from `SUPPORTED_LEGACY_PROTOCOL_VERSIONS`
  * rather than a frozen byte literal, so these tests survive additions to the
  * supported-versions list while still catching any rewording.
  */
@@ -106,7 +106,7 @@ describe('Unsupported protocol version - wire literal continuity', () => {
             expect(body.id).toBeNull();
             expect(body.error.code).toBe(-32_000);
             expect(body.error.message).toBe(
-                `Bad Request: Unsupported protocol version: 2099-01-01 (supported versions: ${SUPPORTED_PROTOCOL_VERSIONS.join(', ')})`
+                `Bad Request: Unsupported protocol version: 2099-01-01 (supported versions: ${SUPPORTED_LEGACY_PROTOCOL_VERSIONS.join(', ')})`
             );
         } finally {
             await transport.close();

--- a/test/e2e/helpers/wire-sniffer.test.ts
+++ b/test/e2e/helpers/wire-sniffer.test.ts
@@ -1,4 +1,4 @@
-import { LATEST_PROTOCOL_VERSION } from '@modelcontextprotocol/server';
+import { LATEST_LEGACY_PROTOCOL_VERSION } from '@modelcontextprotocol/server';
 import { describe, expect, it } from 'vitest';
 
 import { assertWireMessage } from './wire-sniffer';
@@ -16,7 +16,11 @@ describe('assertWireMessage', () => {
     it('accepts a valid client initialize request', () => {
         expect(() =>
             assertWireMessage(
-                req('initialize', { protocolVersion: LATEST_PROTOCOL_VERSION, capabilities: {}, clientInfo: { name: 'c', version: '0' } }),
+                req('initialize', {
+                    protocolVersion: LATEST_LEGACY_PROTOCOL_VERSION,
+                    capabilities: {},
+                    clientInfo: { name: 'c', version: '0' }
+                }),
                 'client'
             )
         ).not.toThrow();

--- a/test/e2e/scenarios/client-auth.test.ts
+++ b/test/e2e/scenarios/client-auth.test.ts
@@ -51,7 +51,7 @@ import type {
     StoredOAuthClientInformation,
     StoredOAuthTokens
 } from '@modelcontextprotocol/server';
-import { LATEST_PROTOCOL_VERSION, McpServer } from '@modelcontextprotocol/server';
+import { LATEST_LEGACY_PROTOCOL_VERSION, McpServer } from '@modelcontextprotocol/server';
 import { importSPKI, jwtVerify } from 'jose';
 import { expect, vi } from 'vitest';
 import { z } from 'zod/v4';
@@ -1269,7 +1269,11 @@ verifies('client-auth:prm-discovery:fallback-order', async (_args: TestArgs) => 
         return new Response('Not Found', { status: 404 });
     };
 
-    const result = await discoverOAuthProtectedResourceMetadata(MCP_URL, { protocolVersion: LATEST_PROTOCOL_VERSION }, discoveryFetch);
+    const result = await discoverOAuthProtectedResourceMetadata(
+        MCP_URL,
+        { protocolVersion: LATEST_LEGACY_PROTOCOL_VERSION },
+        discoveryFetch
+    );
     expect(result).toMatchObject(prmMetadata);
     expect(discoveryCalls[0]).toBe('/.well-known/oauth-protected-resource/mcp');
 });
@@ -1574,7 +1578,7 @@ verifies('client-auth:low-level:discover-and-exchange', async (_args: TestArgs) 
     const clientInformation = { client_id: 'low-level-public-client' };
     const redirectUri = 'http://localhost:3000/callback';
 
-    const prm = await discoverOAuthProtectedResourceMetadata(MCP_URL, { protocolVersion: LATEST_PROTOCOL_VERSION }, discoveryFetch);
+    const prm = await discoverOAuthProtectedResourceMetadata(MCP_URL, { protocolVersion: LATEST_LEGACY_PROTOCOL_VERSION }, discoveryFetch);
     expect(prm.resource).toBe(RESOURCE);
     expect(prm.authorization_servers).toContain(ISSUER);
 
@@ -1582,7 +1586,7 @@ verifies('client-auth:low-level:discover-and-exchange', async (_args: TestArgs) 
     if (!authorizationServer) throw new Error('protected resource metadata did not list an authorization server');
 
     const asMetadata = await discoverAuthorizationServerMetadata(authorizationServer, {
-        protocolVersion: LATEST_PROTOCOL_VERSION,
+        protocolVersion: LATEST_LEGACY_PROTOCOL_VERSION,
         fetchFn: discoveryFetch
     });
     if (!asMetadata) throw new Error('authorization server metadata discovery returned undefined');

--- a/test/e2e/scenarios/hosting-express.test.ts
+++ b/test/e2e/scenarios/hosting-express.test.ts
@@ -24,7 +24,7 @@ import { Client, StreamableHTTPClientTransport } from '@modelcontextprotocol/cli
 import { createMcpExpressApp, mcpAuthMetadataRouter, requireBearerAuth } from '@modelcontextprotocol/express';
 import { NodeStreamableHTTPServerTransport } from '@modelcontextprotocol/node';
 import type { OAuthMetadata } from '@modelcontextprotocol/server';
-import { LATEST_PROTOCOL_VERSION, McpServer, OAuthError, OAuthErrorCode } from '@modelcontextprotocol/server';
+import { LATEST_LEGACY_PROTOCOL_VERSION, McpServer, OAuthError, OAuthErrorCode } from '@modelcontextprotocol/server';
 import type { AuthorizationParams, OAuthServerProvider } from '@modelcontextprotocol/server-legacy';
 import { mcpAuthRouter } from '@modelcontextprotocol/server-legacy';
 import type { Express, RequestHandler } from 'express';
@@ -544,7 +544,7 @@ verifies('hosting:express:adapter-host-header-validation', async ({ protocolVers
         // Control: the identical request with the real localhost Host reaches the transport and initializes normally.
         // The negotiated version follows initialize semantics: a 2026-era request is answered with the latest legacy
         // version (2026-era revisions are never negotiated via initialize); legacy requests are echoed back.
-        const negotiatedVersion = protocolVersion >= '2026-07-28' ? LATEST_PROTOCOL_VERSION : protocolVersion;
+        const negotiatedVersion = protocolVersion >= '2026-07-28' ? LATEST_LEGACY_PROTOCOL_VERSION : protocolVersion;
         const allowed = await postWithHost(new URL('/mcp', baseUrl), `127.0.0.1:${baseUrl.port}`, initializeBody);
         expect(allowed.status).toBe(200);
         const allowedJson: unknown = JSON.parse(allowed.body);

--- a/test/e2e/scenarios/hosting-http.test.ts
+++ b/test/e2e/scenarios/hosting-http.test.ts
@@ -14,7 +14,7 @@
 import { randomUUID } from 'node:crypto';
 
 import type { JSONRPCMessage } from '@modelcontextprotocol/server';
-import { LATEST_PROTOCOL_VERSION, McpServer, WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/server';
+import { LATEST_LEGACY_PROTOCOL_VERSION, McpServer, WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/server';
 import { expect, vi } from 'vitest';
 import { z } from 'zod/v4';
 
@@ -36,7 +36,11 @@ const initializeBody = (clientInfo?: { name: string; version: string }) =>
         jsonrpc: '2.0',
         id: 1,
         method: 'initialize',
-        params: { protocolVersion: LATEST_PROTOCOL_VERSION, capabilities: {}, clientInfo: clientInfo ?? { name: 'probe', version: '0' } }
+        params: {
+            protocolVersion: LATEST_LEGACY_PROTOCOL_VERSION,
+            capabilities: {},
+            clientInfo: clientInfo ?? { name: 'probe', version: '0' }
+        }
     });
 
 function sseTap(body: ReadableStream<Uint8Array>) {
@@ -80,7 +84,7 @@ verifies('hosting:http:accept-406', async (_args: TestArgs) => {
     const { handleRequest, close } = hostPerSession(echoServer);
 
     try {
-        const base = { 'mcp-protocol-version': LATEST_PROTOCOL_VERSION };
+        const base = { 'mcp-protocol-version': LATEST_LEGACY_PROTOCOL_VERSION };
         const body = JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} });
 
         const initRes = await handleRequest(
@@ -139,7 +143,7 @@ verifies('hosting:http:batch', async (_args: TestArgs) => {
 
     try {
         const headers = {
-            'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+            'mcp-protocol-version': LATEST_LEGACY_PROTOCOL_VERSION,
             'content-type': 'application/json',
             accept: 'application/json, text/event-stream'
         };
@@ -186,7 +190,7 @@ verifies('hosting:http:content-type-415', async (_args: TestArgs) => {
             new Request('http://in-process/mcp', {
                 method: 'POST',
                 headers: {
-                    'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+                    'mcp-protocol-version': LATEST_LEGACY_PROTOCOL_VERSION,
                     'content-type': 'text/plain',
                     accept: 'application/json, text/event-stream'
                 },
@@ -221,7 +225,7 @@ verifies('hosting:http:disconnect-not-cancel', async (_args: TestArgs) => {
             new Request('http://in-process/mcp', {
                 method: 'POST',
                 headers: {
-                    'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+                    'mcp-protocol-version': LATEST_LEGACY_PROTOCOL_VERSION,
                     'content-type': 'application/json',
                     accept: 'application/json, text/event-stream'
                 },
@@ -234,7 +238,7 @@ verifies('hosting:http:disconnect-not-cancel', async (_args: TestArgs) => {
             new Request('http://in-process/mcp', {
                 method: 'POST',
                 headers: {
-                    'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+                    'mcp-protocol-version': LATEST_LEGACY_PROTOCOL_VERSION,
                     'mcp-session-id': sessionId!,
                     'content-type': 'application/json',
                     accept: 'application/json, text/event-stream'
@@ -278,7 +282,7 @@ verifies('hosting:http:dns-rebinding', async (_args: TestArgs) => {
 
     try {
         const headers = {
-            'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+            'mcp-protocol-version': LATEST_LEGACY_PROTOCOL_VERSION,
             'content-type': 'application/json',
             accept: 'application/json, text/event-stream'
         };
@@ -335,7 +339,7 @@ verifies('hosting:http:json-response-mode', async (_args: TestArgs) => {
             new Request('http://in-process/mcp', {
                 method: 'POST',
                 headers: {
-                    'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+                    'mcp-protocol-version': LATEST_LEGACY_PROTOCOL_VERSION,
                     'content-type': 'application/json',
                     accept: 'application/json, text/event-stream'
                 },
@@ -360,7 +364,7 @@ verifies('hosting:http:method-405', async (_args: TestArgs) => {
     try {
         for (const method of ['PUT', 'PATCH']) {
             const res = await tx.handleRequest(
-                new Request('http://in-process/mcp', { method, headers: { 'mcp-protocol-version': LATEST_PROTOCOL_VERSION } })
+                new Request('http://in-process/mcp', { method, headers: { 'mcp-protocol-version': LATEST_LEGACY_PROTOCOL_VERSION } })
             );
             expect(res.status).toBe(405);
             expect(res.headers.get('allow')).toBe('GET, POST, DELETE');
@@ -392,7 +396,7 @@ verifies('hosting:http:no-broadcast', async (_args: TestArgs) => {
             new Request('http://in-process/mcp', {
                 method: 'POST',
                 headers: {
-                    'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+                    'mcp-protocol-version': LATEST_LEGACY_PROTOCOL_VERSION,
                     'content-type': 'application/json',
                     accept: 'application/json, text/event-stream'
                 },
@@ -404,7 +408,11 @@ verifies('hosting:http:no-broadcast', async (_args: TestArgs) => {
         const sse = await handleRequest(
             new Request('http://in-process/mcp', {
                 method: 'GET',
-                headers: { accept: 'text/event-stream', 'mcp-protocol-version': LATEST_PROTOCOL_VERSION, 'mcp-session-id': sessionId }
+                headers: {
+                    accept: 'text/event-stream',
+                    'mcp-protocol-version': LATEST_LEGACY_PROTOCOL_VERSION,
+                    'mcp-session-id': sessionId
+                }
             })
         );
         expect(sse.status).toBe(200);
@@ -415,7 +423,7 @@ verifies('hosting:http:no-broadcast', async (_args: TestArgs) => {
             new Request('http://in-process/mcp', {
                 method: 'POST',
                 headers: {
-                    'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+                    'mcp-protocol-version': LATEST_LEGACY_PROTOCOL_VERSION,
                     'mcp-session-id': sessionId,
                     'content-type': 'application/json',
                     accept: 'application/json, text/event-stream'
@@ -477,7 +485,7 @@ verifies('hosting:http:notifications-202', async (_args: TestArgs) => {
             new Request('http://in-process/mcp', {
                 method: 'POST',
                 headers: {
-                    'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+                    'mcp-protocol-version': LATEST_LEGACY_PROTOCOL_VERSION,
                     'content-type': 'application/json',
                     accept: 'application/json, text/event-stream'
                 },
@@ -490,7 +498,7 @@ verifies('hosting:http:notifications-202', async (_args: TestArgs) => {
             new Request('http://in-process/mcp', {
                 method: 'POST',
                 headers: {
-                    'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+                    'mcp-protocol-version': LATEST_LEGACY_PROTOCOL_VERSION,
                     'mcp-session-id': sessionId,
                     'content-type': 'application/json',
                     accept: 'application/json, text/event-stream'
@@ -513,7 +521,7 @@ verifies('hosting:http:onerror', async (_args: TestArgs) => {
 
     try {
         const accept = 'application/json, text/event-stream';
-        const base = { 'mcp-protocol-version': LATEST_PROTOCOL_VERSION };
+        const base = { 'mcp-protocol-version': LATEST_LEGACY_PROTOCOL_VERSION };
         const init = await tx.handleRequest(
             new Request('http://in-process/mcp', {
                 method: 'POST',
@@ -592,7 +600,7 @@ verifies('hosting:http:parse-error-400', async (_args: TestArgs) => {
             new Request('http://in-process/mcp', {
                 method: 'POST',
                 headers: {
-                    'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+                    'mcp-protocol-version': LATEST_LEGACY_PROTOCOL_VERSION,
                     'content-type': 'application/json',
                     accept: 'application/json, text/event-stream'
                 },
@@ -616,7 +624,7 @@ verifies('hosting:http:protocol-version-400', async (_args: TestArgs) => {
             new Request('http://in-process/mcp', {
                 method: 'POST',
                 headers: {
-                    'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+                    'mcp-protocol-version': LATEST_LEGACY_PROTOCOL_VERSION,
                     'content-type': 'application/json',
                     accept: 'application/json, text/event-stream'
                 },
@@ -642,7 +650,7 @@ verifies('hosting:http:protocol-version-400', async (_args: TestArgs) => {
 
         expect(unsupported.status).toBe(400);
         const text = await unsupported.text();
-        expect(text).toContain(LATEST_PROTOCOL_VERSION);
+        expect(text).toContain(LATEST_LEGACY_PROTOCOL_VERSION);
     } finally {
         await close();
     }
@@ -656,7 +664,7 @@ verifies('hosting:http:protocol-version-default', async (_args: TestArgs) => {
             new Request('http://in-process/mcp', {
                 method: 'POST',
                 headers: {
-                    'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+                    'mcp-protocol-version': LATEST_LEGACY_PROTOCOL_VERSION,
                     'content-type': 'application/json',
                     accept: 'application/json, text/event-stream'
                 },
@@ -707,7 +715,7 @@ verifies('hosting:http:response-same-connection', async (_args: TestArgs) => {
             new Request('http://in-process/mcp', {
                 method: 'POST',
                 headers: {
-                    'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+                    'mcp-protocol-version': LATEST_LEGACY_PROTOCOL_VERSION,
                     'content-type': 'application/json',
                     accept: 'application/json, text/event-stream'
                 },
@@ -720,7 +728,11 @@ verifies('hosting:http:response-same-connection', async (_args: TestArgs) => {
         const sse = await handleRequest(
             new Request('http://in-process/mcp', {
                 method: 'GET',
-                headers: { accept: 'text/event-stream', 'mcp-protocol-version': LATEST_PROTOCOL_VERSION, 'mcp-session-id': sessionId }
+                headers: {
+                    accept: 'text/event-stream',
+                    'mcp-protocol-version': LATEST_LEGACY_PROTOCOL_VERSION,
+                    'mcp-session-id': sessionId
+                }
             })
         );
         expect(sse.status).toBe(200);
@@ -730,7 +742,7 @@ verifies('hosting:http:response-same-connection', async (_args: TestArgs) => {
             new Request('http://in-process/mcp', {
                 method: 'POST',
                 headers: {
-                    'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+                    'mcp-protocol-version': LATEST_LEGACY_PROTOCOL_VERSION,
                     'mcp-session-id': sessionId,
                     'content-type': 'application/json',
                     accept: 'application/json, text/event-stream'
@@ -774,7 +786,7 @@ verifies('hosting:http:second-sse-rejected', async (_args: TestArgs) => {
             new Request('http://in-process/mcp', {
                 method: 'POST',
                 headers: {
-                    'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+                    'mcp-protocol-version': LATEST_LEGACY_PROTOCOL_VERSION,
                     'content-type': 'application/json',
                     accept: 'application/json, text/event-stream'
                 },
@@ -786,7 +798,11 @@ verifies('hosting:http:second-sse-rejected', async (_args: TestArgs) => {
         const sse1 = await handleRequest(
             new Request('http://in-process/mcp', {
                 method: 'GET',
-                headers: { accept: 'text/event-stream', 'mcp-protocol-version': LATEST_PROTOCOL_VERSION, 'mcp-session-id': sessionId }
+                headers: {
+                    accept: 'text/event-stream',
+                    'mcp-protocol-version': LATEST_LEGACY_PROTOCOL_VERSION,
+                    'mcp-session-id': sessionId
+                }
             })
         );
         expect(sse1.status).toBe(200);
@@ -797,7 +813,11 @@ verifies('hosting:http:second-sse-rejected', async (_args: TestArgs) => {
             const sse2 = await handleRequest(
                 new Request('http://in-process/mcp', {
                     method: 'GET',
-                    headers: { accept: 'text/event-stream', 'mcp-protocol-version': LATEST_PROTOCOL_VERSION, 'mcp-session-id': sessionId }
+                    headers: {
+                        accept: 'text/event-stream',
+                        'mcp-protocol-version': LATEST_LEGACY_PROTOCOL_VERSION,
+                        'mcp-session-id': sessionId
+                    }
                 })
             );
             expect(sse2.status).toBe(409);
@@ -807,7 +827,7 @@ verifies('hosting:http:second-sse-rejected', async (_args: TestArgs) => {
                 new Request('http://in-process/mcp', {
                     method: 'POST',
                     headers: {
-                        'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+                        'mcp-protocol-version': LATEST_LEGACY_PROTOCOL_VERSION,
                         'mcp-session-id': sessionId,
                         'content-type': 'application/json',
                         accept: 'application/json, text/event-stream'
@@ -844,7 +864,7 @@ verifies('hosting:http:sse-close-after-response', async (_args: TestArgs) => {
             new Request('http://in-process/mcp', {
                 method: 'POST',
                 headers: {
-                    'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+                    'mcp-protocol-version': LATEST_LEGACY_PROTOCOL_VERSION,
                     'content-type': 'application/json',
                     accept: 'application/json, text/event-stream'
                 },
@@ -857,7 +877,7 @@ verifies('hosting:http:sse-close-after-response', async (_args: TestArgs) => {
             new Request('http://in-process/mcp', {
                 method: 'POST',
                 headers: {
-                    'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+                    'mcp-protocol-version': LATEST_LEGACY_PROTOCOL_VERSION,
                     'mcp-session-id': sessionId,
                     'content-type': 'application/json',
                     accept: 'application/json, text/event-stream'
@@ -915,7 +935,7 @@ verifies('hosting:http:standalone-sse', async (_args: TestArgs) => {
             new Request('http://in-process/mcp', {
                 method: 'POST',
                 headers: {
-                    'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+                    'mcp-protocol-version': LATEST_LEGACY_PROTOCOL_VERSION,
                     'content-type': 'application/json',
                     accept: 'application/json, text/event-stream'
                 },
@@ -927,7 +947,11 @@ verifies('hosting:http:standalone-sse', async (_args: TestArgs) => {
         const sse = await handleRequest(
             new Request('http://in-process/mcp', {
                 method: 'GET',
-                headers: { accept: 'text/event-stream', 'mcp-protocol-version': LATEST_PROTOCOL_VERSION, 'mcp-session-id': sessionId }
+                headers: {
+                    accept: 'text/event-stream',
+                    'mcp-protocol-version': LATEST_LEGACY_PROTOCOL_VERSION,
+                    'mcp-session-id': sessionId
+                }
             })
         );
         expect(sse.status).toBe(200);
@@ -968,7 +992,7 @@ verifies('hosting:http:standalone-sse-no-response', async (_args: TestArgs) => {
             new Request('http://in-process/mcp', {
                 method: 'POST',
                 headers: {
-                    'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+                    'mcp-protocol-version': LATEST_LEGACY_PROTOCOL_VERSION,
                     'content-type': 'application/json',
                     accept: 'application/json, text/event-stream'
                 },
@@ -980,7 +1004,11 @@ verifies('hosting:http:standalone-sse-no-response', async (_args: TestArgs) => {
         const sse = await handleRequest(
             new Request('http://in-process/mcp', {
                 method: 'GET',
-                headers: { accept: 'text/event-stream', 'mcp-protocol-version': LATEST_PROTOCOL_VERSION, 'mcp-session-id': sessionId }
+                headers: {
+                    accept: 'text/event-stream',
+                    'mcp-protocol-version': LATEST_LEGACY_PROTOCOL_VERSION,
+                    'mcp-session-id': sessionId
+                }
             })
         );
         expect(sse.status).toBe(200);
@@ -1022,7 +1050,7 @@ verifies('hosting:http:send-no-listener-noop', async (_args: TestArgs) => {
             new Request('http://in-process/mcp', {
                 method: 'POST',
                 headers: {
-                    'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+                    'mcp-protocol-version': LATEST_LEGACY_PROTOCOL_VERSION,
                     'content-type': 'application/json',
                     accept: 'application/json, text/event-stream'
                 },

--- a/test/e2e/scenarios/hosting-resume.test.ts
+++ b/test/e2e/scenarios/hosting-resume.test.ts
@@ -8,7 +8,7 @@
 
 import { Client, StreamableHTTPClientTransport } from '@modelcontextprotocol/client';
 import type { EventId, EventStore, JSONRPCMessage, StreamId } from '@modelcontextprotocol/server';
-import { LATEST_PROTOCOL_VERSION, McpServer, parseJSONRPCMessage } from '@modelcontextprotocol/server';
+import { LATEST_LEGACY_PROTOCOL_VERSION, McpServer, parseJSONRPCMessage } from '@modelcontextprotocol/server';
 import { expect, vi } from 'vitest';
 import { z } from 'zod/v4';
 
@@ -32,7 +32,7 @@ async function completeHandshake(
             id: 0,
             method: 'initialize',
             params: {
-                protocolVersion: LATEST_PROTOCOL_VERSION,
+                protocolVersion: LATEST_LEGACY_PROTOCOL_VERSION,
                 capabilities,
                 clientInfo: { name: 'test', version: '0' }
             }
@@ -46,7 +46,7 @@ async function completeHandshake(
 
     await initRes.body?.cancel();
 
-    const baseHeaders = { 'mcp-session-id': sessionId, 'mcp-protocol-version': LATEST_PROTOCOL_VERSION };
+    const baseHeaders = { 'mcp-session-id': sessionId, 'mcp-protocol-version': LATEST_LEGACY_PROTOCOL_VERSION };
 
     const notifRes = await fetch(url, {
         method: 'POST',

--- a/test/e2e/scenarios/hosting-session.test.ts
+++ b/test/e2e/scenarios/hosting-session.test.ts
@@ -13,7 +13,7 @@ import { randomUUID } from 'node:crypto';
 
 import { Client, StreamableHTTPClientTransport } from '@modelcontextprotocol/client';
 import { NodeStreamableHTTPServerTransport } from '@modelcontextprotocol/node';
-import { LATEST_PROTOCOL_VERSION, McpServer, WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/server';
+import { LATEST_LEGACY_PROTOCOL_VERSION, McpServer, WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/server';
 import cors from 'cors';
 import express from 'express';
 import { expect, vi } from 'vitest';
@@ -51,7 +51,7 @@ verifies('hosting:session:create', async (_args: TestArgs) => {
             new Request(url, {
                 method: 'POST',
                 headers: {
-                    'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+                    'mcp-protocol-version': LATEST_LEGACY_PROTOCOL_VERSION,
                     'content-type': 'application/json',
                     accept: 'application/json, text/event-stream'
                 },
@@ -59,7 +59,7 @@ verifies('hosting:session:create', async (_args: TestArgs) => {
                     jsonrpc: '2.0',
                     id: 1,
                     method: 'initialize',
-                    params: { protocolVersion: LATEST_PROTOCOL_VERSION, capabilities: {}, clientInfo: { name: 'c', version: '0' } }
+                    params: { protocolVersion: LATEST_LEGACY_PROTOCOL_VERSION, capabilities: {}, clientInfo: { name: 'c', version: '0' } }
                 })
             })
         );
@@ -96,7 +96,7 @@ verifies('hosting:session:cors-expose', async (_args: TestArgs) => {
             method: 'POST',
             headers: {
                 origin: browserOrigin,
-                'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+                'mcp-protocol-version': LATEST_LEGACY_PROTOCOL_VERSION,
                 'content-type': 'application/json',
                 accept: 'application/json, text/event-stream'
             },
@@ -104,7 +104,7 @@ verifies('hosting:session:cors-expose', async (_args: TestArgs) => {
                 jsonrpc: '2.0',
                 id: 1,
                 method: 'initialize',
-                params: { protocolVersion: LATEST_PROTOCOL_VERSION, capabilities: {}, clientInfo: { name: 'c', version: '0' } }
+                params: { protocolVersion: LATEST_LEGACY_PROTOCOL_VERSION, capabilities: {}, clientInfo: { name: 'c', version: '0' } }
             })
         });
 
@@ -161,7 +161,7 @@ verifies('hosting:session:unknown-id', async (_args: TestArgs) => {
                     jsonrpc: '2.0',
                     id: 1,
                     method: 'initialize',
-                    params: { protocolVersion: LATEST_PROTOCOL_VERSION, capabilities: {}, clientInfo: { name: 'c', version: '0' } }
+                    params: { protocolVersion: LATEST_LEGACY_PROTOCOL_VERSION, capabilities: {}, clientInfo: { name: 'c', version: '0' } }
                 })
             })
         );
@@ -170,7 +170,7 @@ verifies('hosting:session:unknown-id', async (_args: TestArgs) => {
         const unknownId = randomUUID();
         const headers = {
             'mcp-session-id': unknownId,
-            'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+            'mcp-protocol-version': LATEST_LEGACY_PROTOCOL_VERSION,
             'content-type': 'application/json',
             accept: 'application/json, text/event-stream'
         };
@@ -200,7 +200,7 @@ verifies('hosting:session:missing-id', async (_args: TestArgs) => {
     await server.connect(tx);
     const url = new URL('http://in-process/mcp');
     const headers = {
-        'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+        'mcp-protocol-version': LATEST_LEGACY_PROTOCOL_VERSION,
         'content-type': 'application/json',
         accept: 'application/json, text/event-stream'
     };
@@ -214,7 +214,7 @@ verifies('hosting:session:missing-id', async (_args: TestArgs) => {
                     jsonrpc: '2.0',
                     id: 1,
                     method: 'initialize',
-                    params: { protocolVersion: LATEST_PROTOCOL_VERSION, capabilities: {}, clientInfo: { name: 'c', version: '0' } }
+                    params: { protocolVersion: LATEST_LEGACY_PROTOCOL_VERSION, capabilities: {}, clientInfo: { name: 'c', version: '0' } }
                 })
             })
         );
@@ -268,7 +268,7 @@ verifies('hosting:session:delete', async (_args: TestArgs) => {
 
     const url = new URL('http://in-process/mcp');
     const headers = {
-        'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+        'mcp-protocol-version': LATEST_LEGACY_PROTOCOL_VERSION,
         'content-type': 'application/json',
         accept: 'application/json, text/event-stream'
     };
@@ -282,7 +282,7 @@ verifies('hosting:session:delete', async (_args: TestArgs) => {
                     jsonrpc: '2.0',
                     id: 1,
                     method: 'initialize',
-                    params: { protocolVersion: LATEST_PROTOCOL_VERSION, capabilities: {}, clientInfo: { name: 'c', version: '0' } }
+                    params: { protocolVersion: LATEST_LEGACY_PROTOCOL_VERSION, capabilities: {}, clientInfo: { name: 'c', version: '0' } }
                 })
             })
         );
@@ -304,7 +304,7 @@ verifies('hosting:session:delete', async (_args: TestArgs) => {
         const deleteRes = await handle(
             new Request(url, {
                 method: 'DELETE',
-                headers: { 'mcp-protocol-version': LATEST_PROTOCOL_VERSION, 'mcp-session-id': sessionId }
+                headers: { 'mcp-protocol-version': LATEST_LEGACY_PROTOCOL_VERSION, 'mcp-session-id': sessionId }
             })
         );
         expect(deleteRes.status).toBe(200);
@@ -330,7 +330,7 @@ verifies('hosting:session:post-termination-404', async (_args: TestArgs) => {
     const { handleRequest, close } = hostPerSession(echoServer);
     const url = new URL('http://in-process/mcp');
     const headers = {
-        'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+        'mcp-protocol-version': LATEST_LEGACY_PROTOCOL_VERSION,
         'content-type': 'application/json',
         accept: 'application/json, text/event-stream'
     };
@@ -344,7 +344,7 @@ verifies('hosting:session:post-termination-404', async (_args: TestArgs) => {
                     jsonrpc: '2.0',
                     id: 1,
                     method: 'initialize',
-                    params: { protocolVersion: LATEST_PROTOCOL_VERSION, capabilities: {}, clientInfo: { name: 'c', version: '0' } }
+                    params: { protocolVersion: LATEST_LEGACY_PROTOCOL_VERSION, capabilities: {}, clientInfo: { name: 'c', version: '0' } }
                 })
             })
         );
@@ -365,7 +365,7 @@ verifies('hosting:session:post-termination-404', async (_args: TestArgs) => {
         const deleteRes = await handleRequest(
             new Request(url, {
                 method: 'DELETE',
-                headers: { 'mcp-protocol-version': LATEST_PROTOCOL_VERSION, 'mcp-session-id': sessionId }
+                headers: { 'mcp-protocol-version': LATEST_LEGACY_PROTOCOL_VERSION, 'mcp-session-id': sessionId }
             })
         );
         expect(deleteRes.status).toBe(200);
@@ -405,7 +405,7 @@ verifies('hosting:session:id-charset', async (_args: TestArgs) => {
                 new Request(url, {
                     method: 'POST',
                     headers: {
-                        'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+                        'mcp-protocol-version': LATEST_LEGACY_PROTOCOL_VERSION,
                         'content-type': 'application/json',
                         accept: 'application/json, text/event-stream'
                     },
@@ -413,7 +413,11 @@ verifies('hosting:session:id-charset', async (_args: TestArgs) => {
                         jsonrpc: '2.0',
                         id: 1,
                         method: 'initialize',
-                        params: { protocolVersion: LATEST_PROTOCOL_VERSION, capabilities: {}, clientInfo: { name: 'c', version: '0' } }
+                        params: {
+                            protocolVersion: LATEST_LEGACY_PROTOCOL_VERSION,
+                            capabilities: {},
+                            clientInfo: { name: 'c', version: '0' }
+                        }
                     })
                 })
             );
@@ -442,7 +446,7 @@ verifies('hosting:session:reinitialize', async (_args: TestArgs) => {
     const initReq = new Request(url, {
         method: 'POST',
         headers: {
-            'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+            'mcp-protocol-version': LATEST_LEGACY_PROTOCOL_VERSION,
             'content-type': 'application/json',
             accept: 'application/json, text/event-stream'
         },
@@ -450,7 +454,7 @@ verifies('hosting:session:reinitialize', async (_args: TestArgs) => {
             jsonrpc: '2.0',
             id: 1,
             method: 'initialize',
-            params: { protocolVersion: LATEST_PROTOCOL_VERSION, capabilities: {}, clientInfo: { name: 'c', version: '0' } }
+            params: { protocolVersion: LATEST_LEGACY_PROTOCOL_VERSION, capabilities: {}, clientInfo: { name: 'c', version: '0' } }
         })
     });
 
@@ -464,7 +468,7 @@ verifies('hosting:session:reinitialize', async (_args: TestArgs) => {
             method: 'POST',
             headers: {
                 'mcp-session-id': sessionId,
-                'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+                'mcp-protocol-version': LATEST_LEGACY_PROTOCOL_VERSION,
                 'content-type': 'application/json',
                 accept: 'application/json, text/event-stream'
             },
@@ -472,7 +476,7 @@ verifies('hosting:session:reinitialize', async (_args: TestArgs) => {
                 jsonrpc: '2.0',
                 id: 2,
                 method: 'initialize',
-                params: { protocolVersion: LATEST_PROTOCOL_VERSION, capabilities: {}, clientInfo: { name: 'c', version: '0' } }
+                params: { protocolVersion: LATEST_LEGACY_PROTOCOL_VERSION, capabilities: {}, clientInfo: { name: 'c', version: '0' } }
             })
         });
 
@@ -530,7 +534,7 @@ verifies('hosting:session:isolation', async (_args: TestArgs) => {
         const deleteRes = await host.handleRequest(
             new Request(url, {
                 method: 'DELETE',
-                headers: { 'mcp-protocol-version': LATEST_PROTOCOL_VERSION, 'mcp-session-id': sessionIdB }
+                headers: { 'mcp-protocol-version': LATEST_LEGACY_PROTOCOL_VERSION, 'mcp-session-id': sessionIdB }
             })
         );
         expect(deleteRes.status).toBe(200);
@@ -543,7 +547,7 @@ verifies('hosting:session:isolation', async (_args: TestArgs) => {
                 method: 'POST',
                 headers: {
                     'mcp-session-id': sessionIdB,
-                    'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+                    'mcp-protocol-version': LATEST_LEGACY_PROTOCOL_VERSION,
                     'content-type': 'application/json',
                     accept: 'application/json, text/event-stream'
                 },
@@ -564,7 +568,7 @@ verifies('hosting:stateless:no-session-id', async (_args: TestArgs) => {
     const req = new Request(url, {
         method: 'POST',
         headers: {
-            'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+            'mcp-protocol-version': LATEST_LEGACY_PROTOCOL_VERSION,
             'content-type': 'application/json',
             accept: 'application/json, text/event-stream'
         },
@@ -572,7 +576,7 @@ verifies('hosting:stateless:no-session-id', async (_args: TestArgs) => {
             jsonrpc: '2.0',
             id: 1,
             method: 'initialize',
-            params: { protocolVersion: LATEST_PROTOCOL_VERSION, capabilities: {}, clientInfo: { name: 'c', version: '0' } }
+            params: { protocolVersion: LATEST_LEGACY_PROTOCOL_VERSION, capabilities: {}, clientInfo: { name: 'c', version: '0' } }
         })
     });
 
@@ -632,13 +636,13 @@ verifies('hosting:stateless:get-delete-405', async (_args: TestArgs) => {
     const getRes = await handleStateless(
         new Request(url, {
             method: 'GET',
-            headers: { 'mcp-protocol-version': LATEST_PROTOCOL_VERSION, accept: 'text/event-stream' }
+            headers: { 'mcp-protocol-version': LATEST_LEGACY_PROTOCOL_VERSION, accept: 'text/event-stream' }
         })
     );
     expect(getRes.status).toBe(405);
 
     const deleteRes = await handleStateless(
-        new Request(url, { method: 'DELETE', headers: { 'mcp-protocol-version': LATEST_PROTOCOL_VERSION } })
+        new Request(url, { method: 'DELETE', headers: { 'mcp-protocol-version': LATEST_LEGACY_PROTOCOL_VERSION } })
     );
     expect(deleteRes.status).toBe(405);
 });
@@ -698,7 +702,7 @@ verifies('hosting:stateless:no-reuse', async (_args: TestArgs) => {
             new Request(url, {
                 method: 'POST',
                 headers: {
-                    'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+                    'mcp-protocol-version': LATEST_LEGACY_PROTOCOL_VERSION,
                     'content-type': 'application/json',
                     accept: 'application/json, text/event-stream'
                 },
@@ -706,7 +710,7 @@ verifies('hosting:stateless:no-reuse', async (_args: TestArgs) => {
                     jsonrpc: '2.0',
                     id: 1,
                     method: 'initialize',
-                    params: { protocolVersion: LATEST_PROTOCOL_VERSION, capabilities: {}, clientInfo: { name: 'c', version: '0' } }
+                    params: { protocolVersion: LATEST_LEGACY_PROTOCOL_VERSION, capabilities: {}, clientInfo: { name: 'c', version: '0' } }
                 })
             })
         );
@@ -715,7 +719,7 @@ verifies('hosting:stateless:no-reuse', async (_args: TestArgs) => {
         const secondReq = new Request(url, {
             method: 'POST',
             headers: {
-                'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+                'mcp-protocol-version': LATEST_LEGACY_PROTOCOL_VERSION,
                 'content-type': 'application/json',
                 accept: 'application/json, text/event-stream'
             },
@@ -831,7 +835,7 @@ verifies('hosting:session:delete-cancels-inflight', async (_args: TestArgs) => {
     const host = hostPerSession(makeServer);
     const url = new URL('http://in-process/mcp');
     const headers = {
-        'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
+        'mcp-protocol-version': LATEST_LEGACY_PROTOCOL_VERSION,
         'content-type': 'application/json',
         accept: 'application/json, text/event-stream'
     };
@@ -845,7 +849,7 @@ verifies('hosting:session:delete-cancels-inflight', async (_args: TestArgs) => {
                     jsonrpc: '2.0',
                     id: 1,
                     method: 'initialize',
-                    params: { protocolVersion: LATEST_PROTOCOL_VERSION, capabilities: {}, clientInfo: { name: 'c', version: '0' } }
+                    params: { protocolVersion: LATEST_LEGACY_PROTOCOL_VERSION, capabilities: {}, clientInfo: { name: 'c', version: '0' } }
                 })
             })
         );
@@ -880,7 +884,7 @@ verifies('hosting:session:delete-cancels-inflight', async (_args: TestArgs) => {
         const deleteRes = await host.handleRequest(
             new Request(url, {
                 method: 'DELETE',
-                headers: { 'mcp-protocol-version': LATEST_PROTOCOL_VERSION, 'mcp-session-id': sessionId }
+                headers: { 'mcp-protocol-version': LATEST_LEGACY_PROTOCOL_VERSION, 'mcp-session-id': sessionId }
             })
         );
         expect(deleteRes.status).toBe(200);

--- a/test/e2e/scenarios/lifecycle.test.ts
+++ b/test/e2e/scenarios/lifecycle.test.ts
@@ -22,12 +22,12 @@ import {
     isJSONRPCNotification,
     isJSONRPCRequest,
     isJSONRPCResultResponse,
-    LATEST_PROTOCOL_VERSION,
+    LATEST_LEGACY_PROTOCOL_VERSION,
     McpServer,
     SdkError,
     SdkErrorCode,
     Server,
-    SUPPORTED_PROTOCOL_VERSIONS
+    SUPPORTED_LEGACY_PROTOCOL_VERSIONS
 } from '@modelcontextprotocol/server';
 import { expect } from 'vitest';
 import { z } from 'zod/v4';
@@ -37,8 +37,8 @@ import { verifies } from '../helpers/verifies';
 import type { TestArgs } from '../types';
 
 function olderSupportedVersion(): string {
-    const older = SUPPORTED_PROTOCOL_VERSIONS.find(v => v !== LATEST_PROTOCOL_VERSION);
-    if (older === undefined) throw new Error('expected SUPPORTED_PROTOCOL_VERSIONS to include a version other than the latest');
+    const older = SUPPORTED_LEGACY_PROTOCOL_VERSIONS.find(v => v !== LATEST_LEGACY_PROTOCOL_VERSION);
+    if (older === undefined) throw new Error('expected SUPPORTED_LEGACY_PROTOCOL_VERSIONS to include a version other than the latest');
     return older;
 }
 
@@ -125,7 +125,7 @@ verifies('lifecycle:initialize:basic', async ({ transport }: TestArgs) => {
     expect(initReqs).toHaveLength(1);
     const initParams = initReqs[0];
     if (!initParams) throw new Error('expected the server to receive exactly one initialize request');
-    expect(initParams.protocolVersion).toBe(LATEST_PROTOCOL_VERSION);
+    expect(initParams.protocolVersion).toBe(LATEST_LEGACY_PROTOCOL_VERSION);
     expect(initParams.clientInfo).toEqual({ name: 'lifecycle-client', version: '0.0.0' });
     expect(initParams.capabilities).toEqual({ roots: {} });
 
@@ -225,7 +225,7 @@ verifies('lifecycle:ping', async ({ transport }: TestArgs) => {
 
 verifies('lifecycle:version:match', async ({ transport }: TestArgs) => {
     const initReqs: InitializeRequest['params'][] = [];
-    const makeServer = () => recordingInitServer(LATEST_PROTOCOL_VERSION, initReqs);
+    const makeServer = () => recordingInitServer(LATEST_LEGACY_PROTOCOL_VERSION, initReqs);
     const client = minimalClient();
 
     await using _ = await wire(transport, makeServer, client);
@@ -233,7 +233,7 @@ verifies('lifecycle:version:match', async ({ transport }: TestArgs) => {
     expect(initReqs).toHaveLength(1);
     const initParams = initReqs[0];
     if (!initParams) throw new Error('expected the server to receive exactly one initialize request');
-    expect(initParams.protocolVersion).toBe(LATEST_PROTOCOL_VERSION);
+    expect(initParams.protocolVersion).toBe(LATEST_LEGACY_PROTOCOL_VERSION);
 
     // Connect succeeded at the matched version: server state is populated.
     expect(client.getServerCapabilities()).toEqual({});
@@ -254,8 +254,8 @@ verifies('lifecycle:version:downgrade', async ({ transport }: TestArgs) => {
     expect(initReqs).toHaveLength(1);
     const initParams = initReqs[0];
     if (!initParams) throw new Error('expected the server to receive exactly one initialize request');
-    expect(initParams.protocolVersion).toBe(LATEST_PROTOCOL_VERSION);
-    expect(OLDER_SUPPORTED_VERSION).not.toBe(LATEST_PROTOCOL_VERSION);
+    expect(initParams.protocolVersion).toBe(LATEST_LEGACY_PROTOCOL_VERSION);
+    expect(OLDER_SUPPORTED_VERSION).not.toBe(LATEST_LEGACY_PROTOCOL_VERSION);
     expect(client.getServerCapabilities()).toEqual({});
     expect(client.getServerVersion()).toEqual({ name: 's', version: '0' });
 });
@@ -269,7 +269,7 @@ verifies('lifecycle:version:server-fallback-latest', async ({ transport }: TestA
             : message
     );
 
-    expect(SUPPORTED_PROTOCOL_VERSIONS).not.toContain(BOGUS_VERSION);
+    expect(SUPPORTED_LEGACY_PROTOCOL_VERSIONS).not.toContain(BOGUS_VERSION);
 
     await using _ = await wire(transport, minimalServer, client);
 
@@ -284,7 +284,7 @@ verifies('lifecycle:version:server-fallback-latest', async ({ transport }: TestA
         e => e.direction === 'server-to-client' && isJSONRPCResultResponse(e.message) && e.message.id === initRequestId
     );
     if (!initResponse || !isJSONRPCResultResponse(initResponse.message)) throw new Error('expected a result for the initialize request');
-    expect(initResponse.message.result.protocolVersion).toBe(LATEST_PROTOCOL_VERSION);
+    expect(initResponse.message.result.protocolVersion).toBe(LATEST_LEGACY_PROTOCOL_VERSION);
 
     // The client accepted the fallback version: initialization completed and server state is populated.
     expect(client.getServerVersion()).toEqual({ name: 'minimal-server', version: '0.0.0' });
@@ -498,7 +498,7 @@ verifies('lifecycle:version:custom-supported-versions', async ({ transport }: Te
     const makeServer = () =>
         new McpServer(
             { name: 'custom-versions-server', version: '0.0.0' },
-            { supportedProtocolVersions: [LATEST_PROTOCOL_VERSION, OLDER_SUPPORTED_VERSION] }
+            { supportedProtocolVersions: [LATEST_LEGACY_PROTOCOL_VERSION, OLDER_SUPPORTED_VERSION] }
         );
     const client = new Client(
         { name: 'custom-versions-client', version: '0.0.0' },
@@ -531,11 +531,11 @@ verifies('lifecycle:version:custom-supported-versions', async ({ transport }: Te
 verifies('lifecycle:version:no-overlap-rejects', async ({ transport }: TestArgs) => {
     // The server only negotiates the latest version while the client only accepts the older one — no overlap.
     const makeServer = () =>
-        new McpServer({ name: 'no-overlap-server', version: '0.0.0' }, { supportedProtocolVersions: [LATEST_PROTOCOL_VERSION] });
+        new McpServer({ name: 'no-overlap-server', version: '0.0.0' }, { supportedProtocolVersions: [LATEST_LEGACY_PROTOCOL_VERSION] });
     const client = new Client({ name: 'no-overlap-client', version: '0.0.0' }, { supportedProtocolVersions: [OLDER_SUPPORTED_VERSION] });
 
     await expect(wire(transport, makeServer, client)).rejects.toThrow(
-        `Server's protocol version is not supported: ${LATEST_PROTOCOL_VERSION}`
+        `Server's protocol version is not supported: ${LATEST_LEGACY_PROTOCOL_VERSION}`
     );
 
     // The connection was never established: initialization state stays empty. (Transport closure itself is lifecycle:version:reject-unsupported's contract.)

--- a/test/e2e/scenarios/raw-result-type.test.ts
+++ b/test/e2e/scenarios/raw-result-type.test.ts
@@ -23,7 +23,7 @@
  */
 import { Client, SdkError, SdkErrorCode, StreamableHTTPClientTransport } from '@modelcontextprotocol/client';
 import type { JSONRPCRequest } from '@modelcontextprotocol/server';
-import { InMemoryTransport, LATEST_PROTOCOL_VERSION } from '@modelcontextprotocol/server';
+import { InMemoryTransport, LATEST_LEGACY_PROTOCOL_VERSION } from '@modelcontextprotocol/server';
 import { expect } from 'vitest';
 
 import { verifies } from '../helpers/verifies';
@@ -54,7 +54,8 @@ function initializeResult(requestedVersion: string) {
 function makeResponder(toolCallBody: unknown) {
     return function respondTo(request: JSONRPCRequest): unknown {
         if (request.method === 'initialize') {
-            const requested = (request.params as { protocolVersion?: string } | undefined)?.protocolVersion ?? LATEST_PROTOCOL_VERSION;
+            const requested =
+                (request.params as { protocolVersion?: string } | undefined)?.protocolVersion ?? LATEST_LEGACY_PROTOCOL_VERSION;
             return initializeResult(requested);
         }
         if (request.method === 'server/discover') {

--- a/test/e2e/scenarios/transport-http.test.ts
+++ b/test/e2e/scenarios/transport-http.test.ts
@@ -21,9 +21,9 @@ import { randomUUID } from 'node:crypto';
 import { Client, SdkHttpError, StreamableHTTPClientTransport } from '@modelcontextprotocol/client';
 import { JSONRPCRequestSchema } from '@modelcontextprotocol/core-internal';
 import {
-    LATEST_PROTOCOL_VERSION,
+    LATEST_LEGACY_PROTOCOL_VERSION,
     McpServer,
-    SUPPORTED_PROTOCOL_VERSIONS,
+    SUPPORTED_LEGACY_PROTOCOL_VERSIONS,
     WebStandardStreamableHTTPServerTransport
 } from '@modelcontextprotocol/server';
 import { expect, vi } from 'vitest';
@@ -44,7 +44,7 @@ function echoServer(): McpServer {
     return s;
 }
 
-const OLDER_VERSION = SUPPORTED_PROTOCOL_VERSIONS.find(v => v !== LATEST_PROTOCOL_VERSION);
+const OLDER_VERSION = SUPPORTED_LEGACY_PROTOCOL_VERSIONS.find(v => v !== LATEST_LEGACY_PROTOCOL_VERSION);
 
 interface RecordedRequest {
     method: string;
@@ -125,7 +125,7 @@ verifies('typescript:client-transport:http:protocol-version-stored', async (_arg
 
         await client.connect(transport);
 
-        expect(transport.protocolVersion).toBe(LATEST_PROTOCOL_VERSION);
+        expect(transport.protocolVersion).toBe(LATEST_LEGACY_PROTOCOL_VERSION);
 
         await client.close();
         await transport.close();
@@ -138,7 +138,7 @@ verifies('client-transport:http:protocol-version-header', async (_args: TestArgs
     const records: RecordedRequest[] = [];
 
     expect(OLDER_VERSION).toBeDefined();
-    expect(OLDER_VERSION).not.toBe(LATEST_PROTOCOL_VERSION);
+    expect(OLDER_VERSION).not.toBe(LATEST_LEGACY_PROTOCOL_VERSION);
     const olderVersion = defined(OLDER_VERSION, 'older supported protocol version');
 
     // The server only supports an older spec version, so initialize negotiates the connection down to it

--- a/test/e2e/scenarios/transport-raw.test.ts
+++ b/test/e2e/scenarios/transport-raw.test.ts
@@ -21,7 +21,7 @@ import {
     CallToolResultSchema,
     InitializeResultSchema,
     JSONRPCResultResponseSchema,
-    LATEST_PROTOCOL_VERSION
+    LATEST_LEGACY_PROTOCOL_VERSION
 } from '@modelcontextprotocol/core-internal';
 import type { JSONRPCMessage, JSONRPCNotification, JSONRPCRequest } from '@modelcontextprotocol/server';
 import { InMemoryTransport, McpServer } from '@modelcontextprotocol/server';
@@ -58,7 +58,7 @@ const INITIALIZED_NOTIFICATION: JSONRPCNotification = { jsonrpc: '2.0', method: 
  * request.
  */
 function expectedNegotiatedVersion(requested: string): string {
-    return requested >= '2026-07-28' ? LATEST_PROTOCOL_VERSION : requested;
+    return requested >= '2026-07-28' ? LATEST_LEGACY_PROTOCOL_VERSION : requested;
 }
 
 /** Hand-built tools/call request for the echo tool exposed by both real servers used below. */

--- a/test/integration/test/client/client.test.ts
+++ b/test/integration/test/client/client.test.ts
@@ -2,12 +2,12 @@ import { Client, getSupportedElicitationModes } from '@modelcontextprotocol/clie
 import type { Prompt, Resource, Tool, Transport } from '@modelcontextprotocol/core-internal';
 import {
     InMemoryTransport,
-    LATEST_PROTOCOL_VERSION,
+    LATEST_LEGACY_PROTOCOL_VERSION,
     ProtocolErrorCode,
     SdkError,
     SdkErrorCode,
     setNegotiatedProtocolVersion,
-    SUPPORTED_PROTOCOL_VERSIONS
+    SUPPORTED_LEGACY_PROTOCOL_VERSIONS
 } from '@modelcontextprotocol/core-internal';
 import { McpServer, Server } from '@modelcontextprotocol/server';
 
@@ -24,7 +24,7 @@ test('should initialize with matching protocol version', async () => {
                     jsonrpc: '2.0',
                     id: message.id,
                     result: {
-                        protocolVersion: LATEST_PROTOCOL_VERSION,
+                        protocolVersion: LATEST_LEGACY_PROTOCOL_VERSION,
                         capabilities: {},
                         serverInfo: {
                             name: 'test',
@@ -57,7 +57,7 @@ test('should initialize with matching protocol version', async () => {
         expect.objectContaining({
             method: 'initialize',
             params: expect.objectContaining({
-                protocolVersion: LATEST_PROTOCOL_VERSION
+                protocolVersion: LATEST_LEGACY_PROTOCOL_VERSION
             })
         }),
         expect.objectContaining({
@@ -73,7 +73,7 @@ test('should initialize with matching protocol version', async () => {
  * Test: Initialize with Supported Older Protocol Version
  */
 test('should initialize with supported older protocol version', async () => {
-    const OLD_VERSION = SUPPORTED_PROTOCOL_VERSIONS[1];
+    const OLD_VERSION = SUPPORTED_LEGACY_PROTOCOL_VERSIONS[1];
     const clientTransport: Transport = {
         start: vi.fn().mockResolvedValue(undefined),
         close: vi.fn().mockResolvedValue(undefined),
@@ -135,7 +135,7 @@ test('should restore negotiated protocol version on transport when reconnecting 
                     jsonrpc: '2.0',
                     id: message.id,
                     result: {
-                        protocolVersion: LATEST_PROTOCOL_VERSION,
+                        protocolVersion: LATEST_LEGACY_PROTOCOL_VERSION,
                         capabilities: {},
                         serverInfo: { name: 'test', version: '1.0' }
                     }
@@ -149,8 +149,8 @@ test('should restore negotiated protocol version on transport when reconnecting 
     await client.connect(initialTransport);
 
     // Initial handshake should have set the protocol version on the transport
-    expect(setProtocolVersion).toHaveBeenCalledWith(LATEST_PROTOCOL_VERSION);
-    expect(client.getNegotiatedProtocolVersion()).toBe(LATEST_PROTOCOL_VERSION);
+    expect(setProtocolVersion).toHaveBeenCalledWith(LATEST_LEGACY_PROTOCOL_VERSION);
+    expect(client.getNegotiatedProtocolVersion()).toBe(LATEST_LEGACY_PROTOCOL_VERSION);
 
     // Now simulate reconnection: new transport with a pre-existing sessionId.
     // connect() will early-return without re-initializing, but MUST restore the protocol version
@@ -169,7 +169,7 @@ test('should restore negotiated protocol version on transport when reconnecting 
     // No initialize request should have been sent (sessionId was set)
     expect(reconnectTransport.send).not.toHaveBeenCalledWith(expect.objectContaining({ method: 'initialize' }), expect.anything());
     // But the protocol version MUST have been restored onto the new transport
-    expect(reconnectSetProtocolVersion).toHaveBeenCalledWith(LATEST_PROTOCOL_VERSION);
+    expect(reconnectSetProtocolVersion).toHaveBeenCalledWith(LATEST_LEGACY_PROTOCOL_VERSION);
 });
 
 /***
@@ -185,7 +185,7 @@ test('should restore negotiated protocol version on transport when reconnecting 
  */
 test('should run a fresh initialize handshake after close() when the previous connection negotiated the modern era', async () => {
     const MODERN_REVISION = '2026-07-28';
-    const supportedProtocolVersions = [MODERN_REVISION, ...SUPPORTED_PROTOCOL_VERSIONS];
+    const supportedProtocolVersions = [MODERN_REVISION, ...SUPPORTED_LEGACY_PROTOCOL_VERSIONS];
 
     const connectModern = async (client: Client) => {
         const server = new Server({ name: 'modern server', version: '1.0' }, { capabilities: {}, supportedProtocolVersions });
@@ -225,7 +225,7 @@ test('should run a fresh initialize handshake after close() when the previous co
     // a leftover modern negotiated version would kill `initialize` locally (it is physically
     // absent from the modern registry).
     await connectLegacy(client);
-    expect(client.getNegotiatedProtocolVersion()).toBe(LATEST_PROTOCOL_VERSION);
+    expect(client.getNegotiatedProtocolVersion()).toBe(LATEST_LEGACY_PROTOCOL_VERSION);
 
     await client.close();
 });
@@ -277,7 +277,7 @@ test('should reject unsupported protocol version', async () => {
  * Test: Connect New Client to Old Supported Server Version
  */
 test('should connect new client to old, supported server version', async () => {
-    const OLD_VERSION = SUPPORTED_PROTOCOL_VERSIONS[1];
+    const OLD_VERSION = SUPPORTED_LEGACY_PROTOCOL_VERSIONS[1];
     const server = new Server(
         {
             name: 'test server',
@@ -352,7 +352,7 @@ test('should negotiate version when client is old, and newer server supports its
     );
 
     server.setRequestHandler('initialize', _request => ({
-        protocolVersion: LATEST_PROTOCOL_VERSION,
+        protocolVersion: LATEST_LEGACY_PROTOCOL_VERSION,
         capabilities: {
             resources: {},
             tools: {}
@@ -471,7 +471,7 @@ test('should respect server capabilities', async () => {
     );
 
     server.setRequestHandler('initialize', _request => ({
-        protocolVersion: LATEST_PROTOCOL_VERSION,
+        protocolVersion: LATEST_LEGACY_PROTOCOL_VERSION,
         capabilities: {
             resources: {},
             tools: {}
@@ -549,7 +549,7 @@ test('should return empty lists for missing capabilities by default', async () =
     );
 
     server.setRequestHandler('initialize', _request => ({
-        protocolVersion: LATEST_PROTOCOL_VERSION,
+        protocolVersion: LATEST_LEGACY_PROTOCOL_VERSION,
         capabilities: {
             tools: {}
         },
@@ -880,7 +880,7 @@ test('should reject form-mode elicitation when client only supports URL mode', a
                     jsonrpc: '2.0',
                     id: messageId,
                     result: {
-                        protocolVersion: LATEST_PROTOCOL_VERSION,
+                        protocolVersion: LATEST_LEGACY_PROTOCOL_VERSION,
                         capabilities: {},
                         serverInfo: {
                             name: 'test-server',
@@ -1022,7 +1022,7 @@ test('should reject URL-mode elicitation when client only supports form mode', a
                     jsonrpc: '2.0',
                     id: messageId,
                     result: {
-                        protocolVersion: LATEST_PROTOCOL_VERSION,
+                        protocolVersion: LATEST_LEGACY_PROTOCOL_VERSION,
                         capabilities: {},
                         serverInfo: {
                             name: 'test-server',

--- a/test/integration/test/client/discoverRoundtrip.test.ts
+++ b/test/integration/test/client/discoverRoundtrip.test.ts
@@ -14,7 +14,12 @@ import type { Server as HttpServer } from 'node:http';
 import { createServer } from 'node:http';
 
 import { Client, StreamableHTTPClientTransport } from '@modelcontextprotocol/client';
-import { SdkError, SdkErrorCode, setNegotiatedProtocolVersion, SUPPORTED_PROTOCOL_VERSIONS } from '@modelcontextprotocol/core-internal';
+import {
+    SdkError,
+    SdkErrorCode,
+    setNegotiatedProtocolVersion,
+    SUPPORTED_LEGACY_PROTOCOL_VERSIONS
+} from '@modelcontextprotocol/core-internal';
 import { NodeStreamableHTTPServerTransport } from '@modelcontextprotocol/node';
 import { McpServer } from '@modelcontextprotocol/server';
 import { listenOnRandomPort } from '@modelcontextprotocol/test-helpers';
@@ -22,7 +27,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import * as z from 'zod/v4';
 
 const MODERN = '2026-07-28';
-const DUAL_ERA_VERSIONS = [MODERN, ...SUPPORTED_PROTOCOL_VERSIONS];
+const DUAL_ERA_VERSIONS = [MODERN, ...SUPPORTED_LEGACY_PROTOCOL_VERSIONS];
 
 function recordingFetch() {
     const bodies: string[] = [];

--- a/test/integration/test/server.test.ts
+++ b/test/integration/test/server.test.ts
@@ -12,10 +12,10 @@ import type {
 } from '@modelcontextprotocol/core-internal';
 import {
     InMemoryTransport,
-    LATEST_PROTOCOL_VERSION,
+    LATEST_LEGACY_PROTOCOL_VERSION,
     SdkError,
     SdkErrorCode,
-    SUPPORTED_PROTOCOL_VERSIONS
+    SUPPORTED_LEGACY_PROTOCOL_VERSIONS
 } from '@modelcontextprotocol/core-internal';
 import { createMcpExpressApp } from '@modelcontextprotocol/express';
 import { McpServer, Server } from '@modelcontextprotocol/server';
@@ -90,7 +90,7 @@ test('should accept latest protocol version', async () => {
         send: vi.fn().mockImplementation(message => {
             if (message.id === 1 && message.result) {
                 expect(message.result).toEqual({
-                    protocolVersion: LATEST_PROTOCOL_VERSION,
+                    protocolVersion: LATEST_LEGACY_PROTOCOL_VERSION,
                     capabilities: expect.any(Object),
                     serverInfo: {
                         name: 'test server',
@@ -128,7 +128,7 @@ test('should accept latest protocol version', async () => {
         id: 1,
         method: 'initialize',
         params: {
-            protocolVersion: LATEST_PROTOCOL_VERSION,
+            protocolVersion: LATEST_LEGACY_PROTOCOL_VERSION,
             capabilities: {},
             clientInfo: {
                 name: 'test client',
@@ -141,7 +141,7 @@ test('should accept latest protocol version', async () => {
 });
 
 test('should accept supported older protocol version', async () => {
-    const OLD_VERSION = SUPPORTED_PROTOCOL_VERSIONS[1];
+    const OLD_VERSION = SUPPORTED_LEGACY_PROTOCOL_VERSIONS[1];
     let sendPromiseResolve: (value: unknown) => void;
     const sendPromise = new Promise(resolve => {
         sendPromiseResolve = resolve;
@@ -213,7 +213,7 @@ test('should handle unsupported protocol version', async () => {
         send: vi.fn().mockImplementation(message => {
             if (message.id === 1 && message.result) {
                 expect(message.result).toEqual({
-                    protocolVersion: LATEST_PROTOCOL_VERSION,
+                    protocolVersion: LATEST_LEGACY_PROTOCOL_VERSION,
                     capabilities: expect.any(Object),
                     serverInfo: {
                         name: 'test server',

--- a/test/integration/test/server/dualEraStdio.test.ts
+++ b/test/integration/test/server/dualEraStdio.test.ts
@@ -25,7 +25,7 @@ import type { JSONRPCMessage } from '@modelcontextprotocol/core-internal';
 import {
     CLIENT_CAPABILITIES_META_KEY,
     CLIENT_INFO_META_KEY,
-    LATEST_PROTOCOL_VERSION,
+    LATEST_LEGACY_PROTOCOL_VERSION,
     PROTOCOL_VERSION_META_KEY
 } from '@modelcontextprotocol/core-internal';
 import { describe, expect, it, vi } from 'vitest';
@@ -100,7 +100,7 @@ describe('serveStdio over a real child-process pipe (one connection per spawned 
             const inbound = recordInbound(transport);
 
             // The 2025 vertical, byte-shape checks included.
-            expect(client.getNegotiatedProtocolVersion()).toBe(LATEST_PROTOCOL_VERSION);
+            expect(client.getNegotiatedProtocolVersion()).toBe(LATEST_LEGACY_PROTOCOL_VERSION);
             const tools = await client.listTools();
             expect(tools.tools.map(tool => tool.name)).toEqual(['echo']);
             const result = await client.callTool({ name: 'echo', arguments: { text: 'over the real pipe' } });
@@ -167,7 +167,7 @@ describe('serveStdio over a real child-process pipe (one connection per spawned 
                 jsonrpc: '2.0',
                 id: 'raw-late-initialize',
                 method: 'initialize',
-                params: { protocolVersion: LATEST_PROTOCOL_VERSION, capabilities: {}, clientInfo: { name: 'late', version: '0' } }
+                params: { protocolVersion: LATEST_LEGACY_PROTOCOL_VERSION, capabilities: {}, clientInfo: { name: 'late', version: '0' } }
             });
             const lateError = (lateInitialize as { error: { code: number; data?: { supported?: string[] } } }).error;
             expect(lateError.code).toBe(-32_022);
@@ -204,13 +204,13 @@ describe('serveStdio over a real child-process pipe (one connection per spawned 
                 id: 'fallback-init',
                 method: 'initialize',
                 params: {
-                    protocolVersion: LATEST_PROTOCOL_VERSION,
+                    protocolVersion: LATEST_LEGACY_PROTOCOL_VERSION,
                     capabilities: {},
                     clientInfo: { name: 'fallback-pipe-client', version: '1.0.0' }
                 }
             });
             const initResult = (init as { result?: { protocolVersion?: string } }).result;
-            expect(initResult?.protocolVersion).toBe(LATEST_PROTOCOL_VERSION);
+            expect(initResult?.protocolVersion).toBe(LATEST_LEGACY_PROTOCOL_VERSION);
             expect(JSON.stringify(init)).not.toContain('resultType');
 
             await transport.send({ jsonrpc: '2.0', method: 'notifications/initialized' });

--- a/test/integration/test/stateManagementStreamableHttp.test.ts
+++ b/test/integration/test/stateManagementStreamableHttp.test.ts
@@ -4,7 +4,7 @@ import { createServer } from 'node:http';
 
 import { Client, StreamableHTTPClientTransport } from '@modelcontextprotocol/client';
 import { NodeStreamableHTTPServerTransport } from '@modelcontextprotocol/node';
-import { LATEST_PROTOCOL_VERSION, McpServer } from '@modelcontextprotocol/server';
+import { LATEST_LEGACY_PROTOCOL_VERSION, McpServer } from '@modelcontextprotocol/server';
 import { listenOnRandomPort } from '@modelcontextprotocol/test-helpers';
 import * as z from 'zod/v4';
 
@@ -220,7 +220,7 @@ describe('Zod v4', () => {
                 await client.connect(transport);
 
                 // Verify protocol version is set after connecting
-                expect(transport.protocolVersion).toBe(LATEST_PROTOCOL_VERSION);
+                expect(transport.protocolVersion).toBe(LATEST_LEGACY_PROTOCOL_VERSION);
 
                 // Clean up
                 await transport.close();


### PR DESCRIPTION
Follow-up to the confusion in #2410: `LATEST_PROTOCOL_VERSION = '2025-11-25'` reads as "the SDK doesn't speak 2026-07-28", when it actually means "the latest revision `initialize` can negotiate". This PR makes the era scoping visible in the names, and fixes OAuth discovery ignoring the negotiated version.

## Motivation and Context

The SDK deliberately splits protocol revisions into two eras: legacy revisions negotiate via `initialize`, modern revisions (2026-07-28+) exclusively via `server/discover`. The public constants predate that split and misstate their scope:

- `LATEST_PROTOCOL_VERSION` is not the latest revision the SDK speaks — it's the latest *legacy* one. #2410's reporter dug it out of the bundle and concluded 2026-07-28 support was missing.
- `SUPPORTED_PROTOCOL_VERSIONS` is not all supported versions — it's the `initialize` list.
- Neither had TSDoc; the era rationale was documented only on an internal constant.
- The `ProtocolEra` type is public but the classifier for it wasn't — you could get `getNegotiatedProtocolVersion()` and the type, but not `isModernProtocolVersion` to connect them.

Separately (second commit): OAuth metadata discovery always sent `MCP-Protocol-Version: 2025-11-25`, regardless of what the connection negotiated. The discovery functions already accepted a `protocolVersion` — nothing threaded the transport's negotiated version into them.

Changes:

1. **Rename with aliases**: `LATEST_LEGACY_PROTOCOL_VERSION`, `SUPPORTED_LEGACY_PROTOCOL_VERSIONS`; old names stay as `@deprecated` aliases until 2.0.0 GA. Codemod mapping added, TSDoc on all three constants, new docs section in `protocol-versions.md` (with a runnable snippet), migration-guide note, behavior-surface pins extended (alias identity, era purity of the legacy list, public-barrel surface).
2. **Export the era classifier**: `isModernProtocolVersion` and `FIRST_MODERN_PROTOCOL_VERSION` join the public barrel. The modern *list* stays internal to negotiation.
3. **Thread the negotiated version into auth**: `AuthOptions.protocolVersion` and `UnauthorizedContext.protocolVersion` (also on `discoverOAuthServerInfo` and `resolveAuthorizationCallbackParams`), passed automatically by the Streamable HTTP and SSE transports on the 401 path, step-up, `finishAuth`, and by `withOAuth` (which reads the wrapped request's own `mcp-protocol-version` header). Each transport assembles the 401 context in one private `_unauthorizedContext()` builder so a future call site can't silently forget the field. Pre-handshake auth still defaults to the latest legacy revision, so existing flows are unchanged.

## How Has This Been Tested?

- New pin in `errorSurfacePins.test.ts`: the public barrel exports the era surface, and the deprecated aliases stay identical (same array object) to the new names. Era-disjointness of the legacy list was already pinned in `protocolEras.test.ts`.
- New client tests: `auth()` sends the threaded version on every discovery request and falls back to the latest legacy revision when none is passed; `handleOAuthUnauthorized` forwards `UnauthorizedContext.protocolVersion`; and a transport-level test drives `StreamableHTTPClientTransport` through set-version → 401 → discovery and asserts the header on the actual discovery requests.
- Full `core-internal`, `client`, `server`, and `codemod` suites pass locally; `sync:snippets` is clean; the docs example (`protocolVersions.examples.ts`, including the new region) executes against live in-process servers.
- Verified end-to-end against a local mock AS: a real `StreamableHTTPClientTransport` hitting 401 sends `MCP-Protocol-Version: <negotiated>` on both `.well-known` requests, and the pre-handshake default is unchanged.

## Breaking Changes

None while the beta is open: the old constant names remain exported as `@deprecated` aliases with identical values. Removing the aliases is planned for 2.0.0 GA (tracked in the migration guide). The OAuth header change is behavioral: discovery now advertises the negotiated version instead of unconditionally claiming `2025-11-25` — strictly more accurate, and unchanged when auth runs before a handshake.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

Known follow-ups deliberately left out to keep the diff reviewable:

- The codemod's namespace-import branch (`import * as types from …; types.LATEST_PROTOCOL_VERSION`) applies neither `SIMPLE_RENAMES` nor a diagnostic — pre-existing for all simple renames, but these two entries fail *silently* at GA (the aliases keep them compiling until then). Worth a diagnostic before the aliases drop.
- `crossAppAccess`'s IdP metadata discovery still uses the default version (its assertion ctx has no channel for the negotiated one).
- The `mcp-protocol-version` header name is a raw string in ~9 files; a shared constant next to `PROTOCOL_VERSION_META_KEY` would fit the existing pattern.
- The two `export *` wildcards at the package indexes (client/server → `core-internal/public`) are how the aliases flow out today; converting them to named export lists per the repo convention is a separate change.
- `isModernProtocolVersion` assumes ISO-date revision identifiers (documented on the export); a custom non-date version string like `'draft'` is not classifiable.

Draft: opening this for discussion of the naming (`LEGACY` qualifier vs alternatives) before polishing.
