### PR TITLE
fix(client): fire onerror only once when the standalone GET stream fails

### DIFF
--- a/.changeset/single-onerror-standalone-get.md
+++ b/.changeset/single-onerror-standalone-get.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/client': patch
+---
+
+`StreamableHTTPClientTransport` no longer reports the same standalone GET failure to `onerror` twice, including when `close()` aborts an in-flight stream.

--- a/packages/client/src/client/streamableHttp.ts
+++ b/packages/client/src/client/streamableHttp.ts
@@ -519,12 +519,6 @@ export class StreamableHTTPClientTransport implements Transport {
 
     private async _startOrAuthSse(options: StartSSEOptions, isAuthRetry = false, stepUpRetries = 0): Promise<void> {
         const { resumptionToken, requestSignal } = options;
-        // Same guard as `_handleSseStream`: a resurrected listen stream (the
-        // POST-SSE → GET reconnect path threads `requestSignal` through
-        // `StartSSEOptions`) must honour the per-request abort exactly as the
-        // original POST did — both as a fetch signal and as a "do not surface
-        // onerror" gate.
-        const isIntentionalAbort = (): boolean => this._abortController?.signal.aborted === true || requestSignal?.aborted === true;
 
         try {
             // Try to open an initial SSE stream with GET to listen for server messages
@@ -629,10 +623,7 @@ export class StreamableHTTPClientTransport implements Transport {
 
             this._handleSseStream(response.body, options, true);
         } catch (error) {
-            if (!isIntentionalAbort()) {
-                this.onerror?.(error as Error);
-            }
-            throw error;
+            throw error as Error;
         }
     }
 
@@ -1242,9 +1233,14 @@ export class StreamableHTTPClientTransport implements Transport {
      * @param options Optional callback to receive new resumption tokens
      */
     async resumeStream(lastEventId: string, options?: { onresumptiontoken?: (token: string) => void }): Promise<void> {
-        await this._startOrAuthSse({
-            resumptionToken: lastEventId,
-            onresumptiontoken: options?.onresumptiontoken
-        });
+        try {
+            await this._startOrAuthSse({
+                resumptionToken: lastEventId,
+                onresumptiontoken: options?.onresumptiontoken
+            });
+        } catch (error) {
+            this.onerror?.(error as Error);
+            throw error;
+        }
     }
 }

--- a/packages/client/test/client/streamableHttp.test.ts
+++ b/packages/client/test/client/streamableHttp.test.ts
@@ -7,6 +7,23 @@ import { UnauthorizedError } from '../../src/client/auth';
 import type { ReconnectionScheduler, StartSSEOptions, StreamableHTTPReconnectionOptions } from '../../src/client/streamableHttp';
 import { StreamableHTTPClientTransport } from '../../src/client/streamableHttp';
 
+function captureTransportErrors(transport: StreamableHTTPClientTransport): { errors: Error[]; firstError: Promise<Error> } {
+    const errors: Error[] = [];
+    let resolveFirstError!: (error: Error) => void;
+    const firstError = new Promise<Error>(resolve => {
+        resolveFirstError = resolve;
+    });
+
+    transport.onerror = error => {
+        errors.push(error);
+        if (errors.length === 1) {
+            resolveFirstError(error);
+        }
+    };
+
+    return { errors, firstError };
+}
+
 describe('StreamableHTTPClientTransport', () => {
     let transport: StreamableHTTPClientTransport;
     let mockAuthProvider: Mocked<OAuthClientProvider>;
@@ -465,6 +482,110 @@ describe('StreamableHTTPClientTransport', () => {
                 params: {}
             })
         );
+    });
+
+    it('should fire onerror only once when the standalone GET stream fails to open', async () => {
+        const { errors, firstError } = captureTransportErrors(transport);
+
+        const fetchMock = globalThis.fetch as Mock;
+        fetchMock.mockResolvedValueOnce({
+            ok: true,
+            status: 202,
+            headers: new Headers()
+        });
+        fetchMock.mockResolvedValueOnce({
+            ok: false,
+            status: 500,
+            statusText: 'Internal Server Error',
+            text: () => Promise.resolve(''),
+            headers: new Headers()
+        });
+
+        await transport.start();
+        await transport.send({ jsonrpc: '2.0', method: 'notifications/initialized', params: {} } as JSONRPCMessage);
+
+        const error = await firstError;
+        await Promise.resolve();
+
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+        expect(errors).toHaveLength(1);
+        expect(error.message).toContain('Failed to open SSE stream');
+    });
+
+    it('should fire onerror only once when close() aborts an in-flight standalone GET request', async () => {
+        const { errors, firstError } = captureTransportErrors(transport);
+        let markGetStarted!: () => void;
+        const getStarted = new Promise<void>(resolve => {
+            markGetStarted = resolve;
+        });
+
+        const fetchMock = globalThis.fetch as Mock;
+        fetchMock.mockResolvedValueOnce({
+            ok: true,
+            status: 202,
+            headers: new Headers()
+        });
+        fetchMock.mockImplementationOnce(
+            (_url, init: RequestInit) =>
+                new Promise((_resolve, reject) => {
+                    markGetStarted();
+                    init.signal?.addEventListener('abort', () => reject(init.signal?.reason), { once: true });
+                })
+        );
+
+        await transport.start();
+        await transport.send({ jsonrpc: '2.0', method: 'notifications/initialized', params: {} } as JSONRPCMessage);
+
+        await getStarted;
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+
+        await transport.close();
+        await firstError;
+        await Promise.resolve();
+
+        expect(errors).toHaveLength(1);
+    });
+
+    it('should fire onerror once and reject when resumeStream fails', async () => {
+        const { errors } = captureTransportErrors(transport);
+
+        const fetchMock = globalThis.fetch as Mock;
+        fetchMock.mockResolvedValueOnce({
+            ok: false,
+            status: 500,
+            statusText: 'Internal Server Error',
+            text: () => Promise.resolve(''),
+            headers: new Headers()
+        });
+
+        await transport.start();
+        await expect(transport.resumeStream('event-123')).rejects.toThrow('Failed to open SSE stream');
+
+        expect(errors).toHaveLength(1);
+        expect(errors[0]?.message).toContain('Failed to open SSE stream');
+    });
+
+    it('should fire onerror only once when a resumption GET fails', async () => {
+        const { errors, firstError } = captureTransportErrors(transport);
+
+        const fetchMock = globalThis.fetch as Mock;
+        fetchMock.mockResolvedValueOnce({
+            ok: false,
+            status: 500,
+            statusText: 'Internal Server Error',
+            text: () => Promise.resolve(''),
+            headers: new Headers()
+        });
+
+        await transport.start();
+        await transport.send({ jsonrpc: '2.0', method: 'test', params: {}, id: 'request-1' }, { resumptionToken: 'event-123' });
+
+        const error = await firstError;
+        await Promise.resolve();
+
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(errors).toHaveLength(1);
+        expect(error.message).toContain('Failed to open SSE stream');
     });
 
     it('should handle multiple concurrent SSE streams', async () => {


### PR DESCRIPTION
Ports #880 to v2, following the maintainer request in #868. Fixes #868.

## Motivation and Context

`_startOrAuthSse` reported a failure through `onerror` and then rethrew it. The standalone GET and reconnection call sites caught that same rejection and reported it again, so one stream failure could produce two callbacks.

The helper now only propagates failures. Each call site that owns a stream reports the failure once. `resumeStream()` keeps its existing contract: the returned promise rejects and `onerror` is called once. The 401/403 authentication retry path continues to return through the recursive call without taking error ownership.

## How Has This Been Tested?

Four event-driven regressions cover:

- a failed standalone GET;
- `close()` aborting an in-flight standalone GET;
- `resumeStream()` rejection plus one `onerror` callback;
- a failed resumption GET started by `_send`.

The focused transport tests pass with 73 tests. The full client suite passes with 801 tests, and the repository's non-e2e package matrix, `check:all`, `build:all`, documentation build, distribution type smoke test, and changeset check also pass.

## Breaking Changes

None.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
