### PR TITLE
docs: point readers (and their LLMs) at the markdown renditions

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -53,6 +53,17 @@ export default defineConfig({
     buildEnd(siteConfig) {
         generateLlmsArtifacts(docsDir, siteConfig.outDir, siteUrl);
     },
+    transformPageData(pageData) {
+        // Every guide page has a markdown rendition next to its HTML (llms.ts);
+        // advertise it to tools via a rel=alternate link. The API reference has none.
+        if (!pageData.relativePath.startsWith('api/')) {
+            pageData.frontmatter.head ??= [];
+            pageData.frontmatter.head.push([
+                'link',
+                { rel: 'alternate', type: 'text/markdown', href: `${siteUrl}/${pageData.relativePath}` }
+            ]);
+        }
+    },
     themeConfig: {
         nav: [
             { text: 'Get started', link: '/get-started/first-server', activeMatch: '^/get-started/' },

--- a/docs/.vitepress/theme/MarkdownSource.vue
+++ b/docs/.vitepress/theme/MarkdownSource.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+import { useData, withBase } from 'vitepress';
+import { computed } from 'vue';
+
+// Every guide page has a markdown rendition generated next to its HTML (see
+// ../llms.ts); the generated API reference does not.
+const { page } = useData();
+const mdPath = computed(() => (page.value.relativePath.startsWith('api/') ? undefined : withBase(`/${page.value.relativePath}`)));
+</script>
+
+<template>
+    <div v-if="mdPath" class="markdown-source">
+        Are you an LLM (or feeding one)? This page as
+        <a :href="mdPath" target="_self">markdown</a> · <a :href="withBase('/llms.txt')" target="_self">llms.txt</a> ·
+        <a :href="withBase('/llms-full.txt')" target="_self">llms-full.txt</a>
+    </div>
+</template>

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -171,3 +171,20 @@
     text-decoration: underline;
     margin-left: 4px;
 }
+
+/* --------------------------------------------------- markdown-source footer */
+
+.markdown-source {
+    margin-bottom: 16px;
+    padding-top: 16px;
+    border-top: 1px solid var(--vp-c-divider);
+    color: var(--vp-c-text-3);
+    font-size: 12px;
+    line-height: 1.5;
+}
+
+.markdown-source a {
+    color: var(--vp-c-text-2);
+    text-decoration: underline;
+    font-weight: 400;
+}

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -3,13 +3,15 @@ import DefaultTheme from 'vitepress/theme';
 import { h } from 'vue';
 
 import Banner from './Banner.vue';
+import MarkdownSource from './MarkdownSource.vue';
 import './custom.css';
 
 export default {
     extends: DefaultTheme,
     Layout() {
         return h(DefaultTheme.Layout, null, {
-            'layout-top': () => h(Banner)
+            'layout-top': () => h(Banner),
+            'doc-footer-before': () => h(MarkdownSource)
         });
     }
 } satisfies Theme;


### PR DESCRIPTION
Makes the markdown renditions discoverable from the HTML site. Every guide page gets a muted footer line above the prev/next cards — "Are you an LLM (or feeding one)? This page as markdown · llms.txt · llms-full.txt" — and a `<link rel="alternate" type="text/markdown">` in its head pointing at its own `.md` rendition.

## Motivation and Context

#2407 added llms.txt and per-page markdown renditions, but nothing on the HTML site mentions them — an agent (or a person about to paste docs into a chat) landing on a page from search has no way to find the markdown twin. The footer line covers humans and agents reading the page; the head link is the machine-standard pointer for tools that look for one.

The API reference pages have no renditions, so they get neither.

## How Has This Been Tested?

`pnpm docs:build` green (0 dead links). Rendered output verified: the footer line and head link present on guide pages with the correct per-page URL, both absent on API pages. `target="_self"` keeps the SPA router from intercepting the non-HTML links (same fix as the version banners in #2396).

## Breaking Changes

None.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
