### PR TITLE
fix: hide validator provider types from root declarations

### DIFF
--- a/.changeset/fix-validator-root-types.md
+++ b/.changeset/fix-validator-root-types.md
@@ -1,0 +1,6 @@
+---
+"@modelcontextprotocol/client": patch
+"@modelcontextprotocol/server": patch
+---
+
+Remove root type declarations for validator provider classes and draft types that are only exported from the `validators/ajv` and `validators/cf-worker` subpaths.

--- a/packages/client/test/client/barrelClean.test.ts
+++ b/packages/client/test/client/barrelClean.test.ts
@@ -27,6 +27,10 @@ function chunkImportsOf(entryPath: string): string[] {
     return [...visited];
 }
 
+function rootDeclarationFiles(): string[] {
+    return ['index.d.mts', 'index.d.cts'].map(file => join(distDir, file)).filter(existsSync);
+}
+
 describe('@modelcontextprotocol/client root entry is browser-safe', () => {
     beforeAll(() => {
         if (!existsSync(join(distDir, 'index.mjs')) || !existsSync(join(distDir, 'stdio.mjs'))) {
@@ -66,5 +70,21 @@ describe('@modelcontextprotocol/client root entry is browser-safe', () => {
                 );
             }
         }
+    });
+
+    test('root declarations do not advertise validator provider types', () => {
+        const declarations = rootDeclarationFiles();
+        expect(declarations.length).toBeGreaterThan(0);
+
+        for (const declaration of declarations) {
+            expect({ declaration, content: readFileSync(declaration, 'utf8') }).not.toEqual(
+                expect.objectContaining({
+                    content: expect.stringMatching(/\b(AjvJsonSchemaValidator|CfWorkerJsonSchemaValidator|CfWorkerSchemaDraft)\b/)
+                })
+            );
+        }
+
+        expect(readFileSync(join(distDir, 'validators', 'ajv.d.mts'), 'utf8')).toMatch(/\bAjvJsonSchemaValidator\b/);
+        expect(readFileSync(join(distDir, 'validators', 'cfWorker.d.mts'), 'utf8')).toMatch(/\bCfWorkerJsonSchemaValidator\b/);
     });
 });

--- a/packages/core-internal/src/exports/public/index.ts
+++ b/packages/core-internal/src/exports/public/index.ts
@@ -131,10 +131,8 @@ export {
 export type { SpecTypeName, SpecTypes } from '../../types/specTypeSchema';
 export { isSpecType, specTypeSchemas } from '../../types/specTypeSchema';
 export type { StandardSchemaV1, StandardSchemaV1Sync, StandardSchemaWithJSON } from '../../util/standardSchema';
-// Validator providers are type-only here — import the runtime classes from the explicit
-// `@modelcontextprotocol/{client,server}/validators/{ajv,cf-worker}` subpaths to customise.
-export type { AjvJsonSchemaValidator } from '../../validators/ajvProvider';
-export type { CfWorkerJsonSchemaValidator, CfWorkerSchemaDraft } from '../../validators/cfWorkerProvider';
+// Validator provider classes and draft types are intentionally only exposed
+// from the explicit `@modelcontextprotocol/{client,server}/validators/{ajv,cf-worker}` subpaths.
 // fromJsonSchema is intentionally NOT exported here — the server and client packages
 // provide runtime-aware wrappers that default to the appropriate validator via _shims.
 export type { JsonSchemaType, JsonSchemaValidator, jsonSchemaValidator, JsonSchemaValidatorResult } from '../../validators/types';

--- a/packages/server/test/server/barrelClean.test.ts
+++ b/packages/server/test/server/barrelClean.test.ts
@@ -27,6 +27,10 @@ function chunkImportsOf(entryPath: string): string[] {
     return [...visited];
 }
 
+function rootDeclarationFiles(): string[] {
+    return ['index.d.mts', 'index.d.cts'].map(file => join(distDir, file)).filter(existsSync);
+}
+
 describe('@modelcontextprotocol/server root entry is browser-safe', () => {
     beforeAll(() => {
         if (!existsSync(join(distDir, 'index.mjs')) || !existsSync(join(distDir, 'stdio.mjs'))) {
@@ -67,5 +71,21 @@ describe('@modelcontextprotocol/server root entry is browser-safe', () => {
                 );
             }
         }
+    });
+
+    test('root declarations do not advertise validator provider types', () => {
+        const declarations = rootDeclarationFiles();
+        expect(declarations.length).toBeGreaterThan(0);
+
+        for (const declaration of declarations) {
+            expect({ declaration, content: readFileSync(declaration, 'utf8') }).not.toEqual(
+                expect.objectContaining({
+                    content: expect.stringMatching(/\b(AjvJsonSchemaValidator|CfWorkerJsonSchemaValidator|CfWorkerSchemaDraft)\b/)
+                })
+            );
+        }
+
+        expect(readFileSync(join(distDir, 'validators', 'ajv.d.mts'), 'utf8')).toMatch(/\bAjvJsonSchemaValidator\b/);
+        expect(readFileSync(join(distDir, 'validators', 'cfWorker.d.mts'), 'utf8')).toMatch(/\bCfWorkerJsonSchemaValidator\b/);
     });
 });


### PR DESCRIPTION
## Summary
- remove validator provider class/draft type re-exports from the shared public root barrel
- keep validator provider types available from the explicit `validators/ajv` and `validators/cf-worker` subpaths
- add client/server barrel-clean regression coverage for both ESM and CJS root declarations

Fixes #2391.

## Validation
- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm --filter @modelcontextprotocol/client build`
- `corepack pnpm --filter @modelcontextprotocol/server build`
- `corepack pnpm --dir packages/client exec vitest run test/client/barrelClean.test.ts`
- `corepack pnpm --dir packages/server exec vitest run test/server/barrelClean.test.ts`
- `corepack pnpm --filter @modelcontextprotocol/client typecheck`
- `corepack pnpm --filter @modelcontextprotocol/server typecheck`
- `git diff --check`