### PR TITLE
fix(packaging): expose Ajv from CJS validator subpaths

### DIFF
--- a/.changeset/cjs-ajv-validator-subpath.md
+++ b/.changeset/cjs-ajv-validator-subpath.md
@@ -1,0 +1,6 @@
+---
+'@modelcontextprotocol/server': patch
+'@modelcontextprotocol/client': patch
+---
+
+Fix the CommonJS `validators/ajv` subpath so reading the exported `Ajv` class no longer throws `ReferenceError: import_ajv is not defined`. The subpath now re-exports the bundled provider's concrete `Ajv` value in CJS output, matching the existing ESM behavior.

--- a/packages/client/test/client/barrelClean.test.ts
+++ b/packages/client/test/client/barrelClean.test.ts
@@ -1,5 +1,6 @@
 import { execFileSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -7,6 +8,7 @@ import { beforeAll, describe, expect, test } from 'vitest';
 
 const pkgDir = join(dirname(fileURLToPath(import.meta.url)), '../..');
 const distDir = join(pkgDir, 'dist');
+const requireDist = createRequire(join(pkgDir, 'package.json'));
 const NODE_ONLY = /\b(child_process|cross-spawn|node:stream|node:child_process)\b/;
 // Anchored at start-of-line so JSDoc-example `from 'ajv'` strings in vendored chunks don't match.
 const VALIDATOR_BACKEND_IMPORT = /^import[^\n]*?from\s+["'](?:ajv|ajv-formats|@cfworker\/json-schema)["']/m;
@@ -66,5 +68,16 @@ describe('@modelcontextprotocol/client root entry is browser-safe', () => {
                 );
             }
         }
+    });
+
+    test('CJS AJV validator subpath exposes Ajv at runtime', () => {
+        const { Ajv, AjvJsonSchemaValidator, addFormats } = requireDist(
+            './dist/validators/ajv.cjs'
+        ) as typeof import('../../src/validators/ajv');
+
+        const ajv = new Ajv({ strict: false, allErrors: true });
+        addFormats(ajv);
+
+        expect(new AjvJsonSchemaValidator(ajv)).toBeInstanceOf(AjvJsonSchemaValidator);
     });
 });

--- a/packages/core-internal/src/validators/ajvProvider.ts
+++ b/packages/core-internal/src/validators/ajvProvider.ts
@@ -2,6 +2,7 @@
  * AJV-based JSON Schema validator provider
  */
 
+import { Ajv as Draft7Ajv } from 'ajv';
 import { Ajv2020 } from 'ajv/dist/2020.js';
 import _addFormats from 'ajv-formats';
 
@@ -31,6 +32,7 @@ interface AjvValidateFunction {
     errors?: any;
 }
 
+/** `ajv-formats` default export, normalised through the CJS/ESM interop wrapper. */
 const addFormats = _addFormats as unknown as typeof _addFormats.default;
 
 function createDefaultAjvInstance(): AjvLike {
@@ -152,6 +154,6 @@ export class AjvJsonSchemaValidator implements jsonSchemaValidator {
  * declaration bundling — see #2339). To construct a custom 2020-12 instance, add `ajv` to your own
  * dependencies (matching the SDK's pinned version) and `import { Ajv2020 } from 'ajv/dist/2020.js'`.
  */
-export { Ajv } from 'ajv';
-/** `ajv-formats` default export, normalised through the CJS/ESM interop wrapper. */
-export { addFormats };
+const Ajv = Draft7Ajv;
+
+export { addFormats, Ajv };

--- a/packages/server/test/server/barrelClean.test.ts
+++ b/packages/server/test/server/barrelClean.test.ts
@@ -1,5 +1,6 @@
 import { execFileSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -7,6 +8,7 @@ import { beforeAll, describe, expect, test } from 'vitest';
 
 const pkgDir = join(dirname(fileURLToPath(import.meta.url)), '../..');
 const distDir = join(pkgDir, 'dist');
+const requireDist = createRequire(join(pkgDir, 'package.json'));
 const NODE_ONLY = /\b(child_process|cross-spawn|node:stream|node:child_process)\b/;
 // Anchored at start-of-line so JSDoc-example `from 'ajv'` strings in vendored chunks don't match.
 const VALIDATOR_BACKEND_IMPORT = /^import[^\n]*?from\s+["'](?:ajv|ajv-formats|@cfworker\/json-schema)["']/m;
@@ -67,5 +69,16 @@ describe('@modelcontextprotocol/server root entry is browser-safe', () => {
                 );
             }
         }
+    });
+
+    test('CJS AJV validator subpath exposes Ajv at runtime', () => {
+        const { Ajv, AjvJsonSchemaValidator, addFormats } = requireDist(
+            './dist/validators/ajv.cjs'
+        ) as typeof import('../../src/validators/ajv');
+
+        const ajv = new Ajv({ strict: false, allErrors: true });
+        addFormats(ajv);
+
+        expect(new AjvJsonSchemaValidator(ajv)).toBeInstanceOf(AjvJsonSchemaValidator);
     });
 });


### PR DESCRIPTION
## Summary

Fixes the CommonJS `validators/ajv` subpath export for both `@modelcontextprotocol/server` and `@modelcontextprotocol/client`. In CommonJS consumers, reading `Ajv` from either AJV validator subpath currently throws `ReferenceError: import_ajv is not defined`.

The CJS build was preserving `Ajv` as a live getter but leaving it pointed at an ESM-only local alias (`import_ajv`). Exporting `Ajv` as a concrete local value from the provider makes the generated CJS subpath re-export `require_ajvProvider.Ajv`, matching the actual CJS provider module.

Adds regression coverage through the existing dist/barrel tests by requiring the built CJS validator subpath and constructing `Ajv`, `addFormats`, and `AjvJsonSchemaValidator`.

Fixes #2430.

## Verification

- `pnpm --filter @modelcontextprotocol/server --filter @modelcontextprotocol/client build`
- `node -e "const m = require('./packages/server/dist/validators/ajv.cjs'); new m.Ajv({ strict: false })"`
- `node -e "const m = require('./packages/client/dist/validators/ajv.cjs'); new m.Ajv({ strict: false })"`
- `pnpm --filter @modelcontextprotocol/server test -- test/server/barrelClean.test.ts`
- `pnpm --filter @modelcontextprotocol/client test -- test/client/barrelClean.test.ts`
- `pnpm --filter @modelcontextprotocol/core-internal test -- test/validators/validators.test.ts`
- `node scripts/smoke-dist-types.mjs`
- `git diff --check`
