### PR TITLE
fix(packaging): remove root declarations for subpath-only validators

### DIFF
--- a/.changeset/root-validator-declarations.md
+++ b/.changeset/root-validator-declarations.md
@@ -1,0 +1,6 @@
+---
+'@modelcontextprotocol/server': patch
+'@modelcontextprotocol/client': patch
+---
+
+Remove subpath-only JSON Schema validator provider classes from the root declaration barrels. `AjvJsonSchemaValidator`, `CfWorkerJsonSchemaValidator`, and `CfWorkerSchemaDraft` remain available from the explicit `validators/ajv` and `validators/cf-worker` subpaths, matching the runtime export surface and avoiding CJS declarations that compile and then resolve to `undefined` at runtime.

--- a/packages/client/test/client/barrelClean.test.ts
+++ b/packages/client/test/client/barrelClean.test.ts
@@ -10,6 +10,7 @@ const distDir = join(pkgDir, 'dist');
 const NODE_ONLY = /\b(child_process|cross-spawn|node:stream|node:child_process)\b/;
 // Anchored at start-of-line so JSDoc-example `from 'ajv'` strings in vendored chunks don't match.
 const VALIDATOR_BACKEND_IMPORT = /^import[^\n]*?from\s+["'](?:ajv|ajv-formats|@cfworker\/json-schema)["']/m;
+const ROOT_VALIDATOR_PROVIDER_EXPORTS = /\b(?:AjvJsonSchemaValidator|CfWorkerJsonSchemaValidator|CfWorkerSchemaDraft)\b/;
 
 function chunkImportsOf(entryPath: string): string[] {
     const visited = new Set<string>();
@@ -65,6 +66,12 @@ describe('@modelcontextprotocol/client root entry is browser-safe', () => {
                     expect.objectContaining({ content: expect.stringMatching(VALIDATOR_BACKEND_IMPORT) })
                 );
             }
+        }
+    });
+
+    test('root declarations do not advertise subpath-only validator providers', () => {
+        for (const declaration of ['index.d.mts', 'index.d.cts']) {
+            expect(readFileSync(join(distDir, declaration), 'utf8')).not.toMatch(ROOT_VALIDATOR_PROVIDER_EXPORTS);
         }
     });
 });

--- a/packages/core-internal/src/exports/public/index.ts
+++ b/packages/core-internal/src/exports/public/index.ts
@@ -131,10 +131,8 @@ export {
 export type { SpecTypeName, SpecTypes } from '../../types/specTypeSchema';
 export { isSpecType, specTypeSchemas } from '../../types/specTypeSchema';
 export type { StandardSchemaV1, StandardSchemaV1Sync, StandardSchemaWithJSON } from '../../util/standardSchema';
-// Validator providers are type-only here — import the runtime classes from the explicit
-// `@modelcontextprotocol/{client,server}/validators/{ajv,cf-worker}` subpaths to customise.
-export type { AjvJsonSchemaValidator } from '../../validators/ajvProvider';
-export type { CfWorkerJsonSchemaValidator, CfWorkerSchemaDraft } from '../../validators/cfWorkerProvider';
+// Validator provider classes are subpath-only so root entries stay runtime-neutral.
+// Import them from `@modelcontextprotocol/{client,server}/validators/{ajv,cf-worker}`.
 // fromJsonSchema is intentionally NOT exported here — the server and client packages
 // provide runtime-aware wrappers that default to the appropriate validator via _shims.
 export type { JsonSchemaType, JsonSchemaValidator, jsonSchemaValidator, JsonSchemaValidatorResult } from '../../validators/types';

--- a/packages/server/test/server/barrelClean.test.ts
+++ b/packages/server/test/server/barrelClean.test.ts
@@ -10,6 +10,7 @@ const distDir = join(pkgDir, 'dist');
 const NODE_ONLY = /\b(child_process|cross-spawn|node:stream|node:child_process)\b/;
 // Anchored at start-of-line so JSDoc-example `from 'ajv'` strings in vendored chunks don't match.
 const VALIDATOR_BACKEND_IMPORT = /^import[^\n]*?from\s+["'](?:ajv|ajv-formats|@cfworker\/json-schema)["']/m;
+const ROOT_VALIDATOR_PROVIDER_EXPORTS = /\b(?:AjvJsonSchemaValidator|CfWorkerJsonSchemaValidator|CfWorkerSchemaDraft)\b/;
 
 function chunkImportsOf(entryPath: string): string[] {
     const visited = new Set<string>();
@@ -66,6 +67,12 @@ describe('@modelcontextprotocol/server root entry is browser-safe', () => {
                     expect.objectContaining({ content: expect.stringMatching(VALIDATOR_BACKEND_IMPORT) })
                 );
             }
+        }
+    });
+
+    test('root declarations do not advertise subpath-only validator providers', () => {
+        for (const declaration of ['index.d.mts', 'index.d.cts']) {
+            expect(readFileSync(join(distDir, declaration), 'utf8')).not.toMatch(ROOT_VALIDATOR_PROVIDER_EXPORTS);
         }
     });
 });

--- a/scripts/smoke-dist-types.mjs
+++ b/scripts/smoke-dist-types.mjs
@@ -14,7 +14,7 @@ try {
         path.join(dir, 'consumer.ts'),
         [
             "import { Client } from '@modelcontextprotocol/client';",
-            "import type { AjvJsonSchemaValidator as ClientAjv } from '@modelcontextprotocol/client';",
+            "import type { JsonSchemaValidator as ClientJsonSchemaValidator } from '@modelcontextprotocol/client';",
             "import { AjvJsonSchemaValidator } from '@modelcontextprotocol/client/validators/ajv';",
             "import { CfWorkerJsonSchemaValidator as ClientCf } from '@modelcontextprotocol/client/validators/cf-worker';",
             "import { StdioClientTransport } from '@modelcontextprotocol/client/stdio';",
@@ -24,7 +24,7 @@ try {
             "import { StdioServerTransport } from '@modelcontextprotocol/server/stdio';",
             "export const c = new Client({ name: 'smoke', version: '1.0.0' });",
             "export const s = new McpServer({ name: 'smoke', version: '1.0.0' });",
-            'export type T = ClientAjv;',
+            'export type T = ClientJsonSchemaValidator<unknown>;',
             'export { AjvJsonSchemaValidator, ServerAjv, ClientCf, ServerCf, StdioClientTransport, StdioServerTransport };',
             ''
         ].join('\n')


### PR DESCRIPTION
## Summary

Removes `AjvJsonSchemaValidator`, `CfWorkerJsonSchemaValidator`, and `CfWorkerSchemaDraft` from the client/server root declaration barrels.

Those validator provider classes are documented and exported through the explicit validator subpaths:

- `@modelcontextprotocol/{client,server}/validators/ajv`
- `@modelcontextprotocol/{client,server}/validators/cf-worker`

The package root does not export them at runtime, but the CJS declarations were advertising them from the root. That let CJS TypeScript consumers compile code that imported the provider classes from `@modelcontextprotocol/{client,server}`, only for the values to resolve to `undefined` at runtime.

This keeps the root entries runtime-neutral and makes the declarations match the runtime export surface.

Fixes #2391.

## Verification

- `pnpm --filter @modelcontextprotocol/server --filter @modelcontextprotocol/client build`
- `pnpm --filter @modelcontextprotocol/server test -- test/server/barrelClean.test.ts`
- `pnpm --filter @modelcontextprotocol/client test -- test/client/barrelClean.test.ts`
- `node scripts/smoke-dist-types.mjs`
- CJS `.cts` repros for root validator-provider imports now fail at type-check time instead of compiling and resolving `undefined`
- `git diff --check`
