### PR TITLE
fix(server): reject duplicate in-flight request ids

### DIFF
--- a/packages/server/src/server/streamableHttp.ts
+++ b/packages/server/src/server/streamableHttp.ts
@@ -313,6 +313,18 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
         );
     }
 
+    private findDuplicateRequestId(messages: JSONRPCMessage[]): RequestId | undefined {
+        const requestIds = new Set<RequestId>();
+        for (const message of messages) {
+            if (!isJSONRPCRequest(message)) continue;
+            if (requestIds.has(message.id) || this._requestToStreamMapping.has(message.id)) {
+                return message.id;
+            }
+            requestIds.add(message.id);
+        }
+        return undefined;
+    }
+
     /**
      * Validates request headers for DNS rebinding protection.
      * @returns Error response if validation fails, `undefined` if validation passes.
@@ -697,7 +709,7 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
 
             const request = req;
 
-            let rawMessage;
+            let rawMessage: unknown;
             if (options?.parsedBody === undefined) {
                 try {
                     rawMessage = await req.json();
@@ -772,6 +784,13 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
                     this.onmessage?.(message, { authInfo: options?.authInfo, request });
                 }
                 return new Response(null, { status: 202 });
+            }
+
+            const duplicateRequestId = this.findDuplicateRequestId(messages);
+            if (duplicateRequestId !== undefined) {
+                const error = `Invalid Request: Request id ${String(duplicateRequestId)} is already in flight`;
+                this.onerror?.(new Error(error));
+                return this.createJsonErrorResponse(400, -32_600, error);
             }
 
             // The default behavior is to use SSE streaming

--- a/packages/server/test/server/streamableHttp.test.ts
+++ b/packages/server/test/server/streamableHttp.test.ts
@@ -271,6 +271,52 @@ describe('Zod v4', () => {
                 });
             });
 
+            it('should reject a duplicate in-flight request id before overwriting stream mapping', async () => {
+                let release!: () => void;
+                const gate = new Promise<void>(resolve => {
+                    release = resolve;
+                });
+                mcpServer.registerTool(
+                    'hold',
+                    { description: 'wait before returning', inputSchema: z.object({}) },
+                    async (): Promise<CallToolResult> => {
+                        await gate;
+                        return { content: [{ type: 'text', text: 'done' }] };
+                    }
+                );
+
+                sessionId = await initializeServer();
+
+                const duplicateId = 'duplicate-1';
+                const firstMessage: JSONRPCMessage = {
+                    jsonrpc: '2.0',
+                    method: 'tools/call',
+                    params: { name: 'hold', arguments: {} },
+                    id: duplicateId
+                };
+                const secondMessage: JSONRPCMessage = {
+                    jsonrpc: '2.0',
+                    method: 'tools/list',
+                    params: {},
+                    id: duplicateId
+                };
+
+                let firstResponse: Response | undefined;
+                let secondResponse: Response | undefined;
+                try {
+                    firstResponse = await transport.handleRequest(createRequest('POST', firstMessage, { sessionId }));
+                    secondResponse = await transport.handleRequest(createRequest('POST', secondMessage, { sessionId }));
+
+                    expect(secondResponse.status).toBe(400);
+                    const errorData = await secondResponse.json();
+                    expectErrorResponse(errorData, -32_600, /already in flight/);
+                } finally {
+                    release();
+                    await firstResponse?.body?.cancel().catch(() => {});
+                    await secondResponse?.body?.cancel().catch(() => {});
+                }
+            });
+
             it('should reject requests without a valid session ID', async () => {
                 const request = createRequest('POST', TEST_MESSAGES.toolsList);
                 const response = await transport.handleRequest(request);


### PR DESCRIPTION
Fixes #2433

## Summary
- reject duplicate request ids that are already in flight for Streamable HTTP POST requests
- reject duplicate ids inside the same request batch before registering any stream mapping
- add a regression test for the duplicate in-flight request-id overwrite path

## Verification
- `pnpm --filter @modelcontextprotocol/server test -- packages/server/test/server/streamableHttp.test.ts -t "duplicate in-flight request id"` (red before fix, green after fix)
- `pnpm --filter @modelcontextprotocol/server test -- test/server/streamableHttp.test.ts`
- `pnpm --filter @modelcontextprotocol/server typecheck`
- `pnpm --filter @modelcontextprotocol/server lint`
- pre-push lefthook: build, typecheck, and lint passed