### PR TITLE
fix: harden Standard Schema elicitation conversion

### DIFF
--- a/.changeset/standard-schema-elicitation.md
+++ b/.changeset/standard-schema-elicitation.md
@@ -5,4 +5,4 @@
 ---
 
 Allow form elicitation requests to accept Standard Schema values such as Zod objects for `requestedSchema`. The server converts these schemas to MCP's restricted elicitation JSON Schema before sending and parses accepted content with the original schema before returning typed
-results. Zod string formats that map to MCP's supported `email`, `uri`, `date`, or `date-time` formats are accepted; arbitrary regex patterns remain rejected because form elicitation does not carry JSON Schema `pattern`.
+results. Zod string formats that map to MCP's supported `email`, `uri`, `date`, or `date-time` formats are accepted; arbitrary regex patterns remain rejected because form elicitation does not carry JSON Schema `pattern`. The converted schema's root is held to the spec's shape (`type`, `properties`, `required`, `$schema`): unknown root keywords — such as the `additionalProperties` emitted by `z.strictObject()` — are rejected before sending, and annotation-only root keywords (`title`, `description`) are dropped.

--- a/.changeset/standard-schema-elicitation.md
+++ b/.changeset/standard-schema-elicitation.md
@@ -1,0 +1,7 @@
+---
+'@modelcontextprotocol/core': minor
+'@modelcontextprotocol/server': minor
+---
+
+Allow form elicitation requests to accept Standard Schema values such as Zod objects for `requestedSchema`. The server converts these schemas to MCP's restricted elicitation JSON Schema before sending and parses accepted content with the original schema before returning typed
+results.

--- a/.changeset/standard-schema-elicitation.md
+++ b/.changeset/standard-schema-elicitation.md
@@ -1,6 +1,7 @@
 ---
-'@modelcontextprotocol/core': minor
+'@modelcontextprotocol/core-internal': minor
 '@modelcontextprotocol/server': minor
+'@modelcontextprotocol/client': minor
 ---
 
 Allow form elicitation requests to accept Standard Schema values such as Zod objects for `requestedSchema`. The server converts these schemas to MCP's restricted elicitation JSON Schema before sending and parses accepted content with the original schema before returning typed

--- a/.changeset/standard-schema-elicitation.md
+++ b/.changeset/standard-schema-elicitation.md
@@ -4,4 +4,4 @@
 ---
 
 Allow form elicitation requests to accept Standard Schema values such as Zod objects for `requestedSchema`. The server converts these schemas to MCP's restricted elicitation JSON Schema before sending and parses accepted content with the original schema before returning typed
-results.
+results. Zod string formats that map to MCP's supported `email`, `uri`, `date`, or `date-time` formats are accepted; arbitrary regex patterns remain rejected because form elicitation does not carry JSON Schema `pattern`.

--- a/packages/core-internal/src/exports/public/index.ts
+++ b/packages/core-internal/src/exports/public/index.ts
@@ -46,6 +46,8 @@ export { getDisplayName } from '../../shared/metadataUtils';
 export type {
     BaseContext,
     ClientContext,
+    ElicitInputFormParams,
+    ElicitInputResult,
     NotificationOptions,
     ProgressCallback,
     ProtocolOptions,

--- a/packages/core-internal/src/index.ts
+++ b/packages/core-internal/src/index.ts
@@ -4,6 +4,7 @@ export * from './errors/sdkErrors';
 export * from './shared/auth';
 export * from './shared/authUtils';
 export * from './shared/clientCapabilityRequirements';
+export * from './shared/elicitation';
 export * from './shared/envelope';
 export * from './shared/inboundClassification';
 export * from './shared/inputRequired';

--- a/packages/core-internal/src/shared/elicitation.ts
+++ b/packages/core-internal/src/shared/elicitation.ts
@@ -82,6 +82,12 @@ function isRedundantFormatPattern(original: Record<string, unknown>, parsed: Rec
     return ZOD_REDUNDANT_FORMAT_PATTERNS.get(parsed.format)?.has(original.pattern) === true;
 }
 
+const ANNOTATION_ONLY_JSON_SCHEMA_KEYWORDS = new Set(['$comment', 'deprecated', 'examples', 'readOnly', 'writeOnly']);
+
+function isAnnotationOnlyJsonSchemaKeyword(key: string): boolean {
+    return ANNOTATION_ONLY_JSON_SCHEMA_KEYWORDS.has(key) || key.startsWith('x-');
+}
+
 function findStrippedJsonSchemaPaths(original: unknown, parsed: unknown, path = ''): string[] {
     if (Array.isArray(original) && Array.isArray(parsed)) {
         return original.flatMap((item, index) => findStrippedJsonSchemaPaths(item, parsed[index], `${path}[${index}]`));
@@ -94,7 +100,7 @@ function findStrippedJsonSchemaPaths(original: unknown, parsed: unknown, path = 
     return Object.entries(original).flatMap(([key, value]) => {
         const childPath = path ? `${path}.${key}` : key;
         if (!Object.prototype.hasOwnProperty.call(parsed, key)) {
-            if (isRedundantFormatPattern(original, parsed, key)) {
+            if (isRedundantFormatPattern(original, parsed, key) || isAnnotationOnlyJsonSchemaKeyword(key)) {
                 return [];
             }
             return [childPath];

--- a/packages/core-internal/src/shared/elicitation.ts
+++ b/packages/core-internal/src/shared/elicitation.ts
@@ -6,7 +6,7 @@ import { ElicitRequestFormParamsSchema } from '../types/schemas';
 import type { ElicitRequestFormParams } from '../types/types';
 import { parseSchema } from '../util/schema';
 import type { StandardSchemaWithJSON } from '../util/standardSchema';
-import { standardSchemaToJsonSchema } from '../util/standardSchema';
+import { isStandardSchema, standardSchemaToJsonSchema } from '../util/standardSchema';
 import type { ElicitInputFormParams } from './protocol';
 
 export type NormalizedElicitInputFormParams = {
@@ -154,7 +154,12 @@ function findStrippedJsonSchemaPaths(original: unknown, parsed: unknown, path = 
 function isElicitInputSchema(
     schema: ElicitRequestFormParams['requestedSchema'] | StandardSchemaWithJSON
 ): schema is StandardSchemaWithJSON {
-    return typeof schema === 'object' && schema !== null && '~standard' in schema;
+    // isStandardSchema, not a plain '~standard' key probe: ArkType schemas are functions
+    // (a typeof-object check routes them, unconverted, to the raw branch), and a plain JSON
+    // schema containing a literal '~standard' key — wire-legal via the catchall — must stay
+    // on the raw branch. Not isStandardSchemaWithJSON: gating on `~standard.jsonSchema` here
+    // would front-run standardSchemaToJsonSchema's zod 4.0/4.1 fallback (see zodCompat.ts).
+    return isStandardSchema(schema);
 }
 
 function convertStandardElicitationSchema(standardSchema: StandardSchemaWithJSON): Record<string, unknown> {

--- a/packages/core-internal/src/shared/elicitation.ts
+++ b/packages/core-internal/src/shared/elicitation.ts
@@ -1,3 +1,5 @@
+import * as z from 'zod/v4';
+
 import { ProtocolErrorCode } from '../types/enums';
 import { ProtocolError } from '../types/errors';
 import { ElicitRequestFormParamsSchema } from '../types/schemas';
@@ -16,52 +18,66 @@ function isJsonObject(value: unknown): value is Record<string, unknown> {
     return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
-const ZOD_ISO_DATE_PATTERN = String.raw`(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))`;
-const ZOD_ISO_TIME_PREFIX = String.raw`(?:[01]\d|2[0-3]):[0-5]\d`;
-const ZOD_ISO_OFFSET_PATTERN = String.raw`([+-](?:[01]\d|2[0-3]):[0-5]\d)`;
+// A `pattern` emitted beside a supported `format` is redundant — zod realizes every format
+// check as a regex — and is dropped so the wire schema stays within the elicitation subset.
+// The reference patterns are derived from the installed zod at runtime rather than vendored
+// as string literals: zod's format regexes change across in-range releases, so a vendored
+// copy would start rejecting schemas produced by any newer zod while CI (lockfile-pinned)
+// stays green. A pattern the installed zod would not emit for that format — e.g. a
+// customized `z.email({ pattern })` — still rejects, because the wire schema cannot carry it.
+// Residual limitation: if the app resolves a second zod copy whose regexes differ from this
+// package's resolved zod, its emissions won't match the reference and reject (fail closed);
+// zod is a peer dependency precisely so installs dedupe to one copy.
+// Derivation is cheap (a handful of toJSONSchema calls) and only runs when a stripped
+// `pattern` sits beside a matching `format`, so no caching.
 
-const ZOD_REDUNDANT_FORMAT_PATTERNS: ReadonlyMap<string, ReadonlySet<string>> = new Map([
-    ['email', new Set([String.raw`^(?!\.)(?!.*\.\.)([A-Za-z0-9_'+\-\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\-]*\.)+[A-Za-z]{2,}$`])],
-    [
-        'date',
-        new Set([
-            String.raw`^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))$`
-        ])
-    ]
-]);
-
-const ZOD_DATETIME_ZONE_SUFFIXES = [
-    String.raw`(?:Z)`,
-    String.raw`(?:Z|)`,
-    String.raw`(?:Z|${ZOD_ISO_OFFSET_PATTERN})`,
-    String.raw`(?:Z||${ZOD_ISO_OFFSET_PATTERN})`
-] as const;
-
-function escapeRegExpLiteral(value: string): string {
-    return value.replaceAll(/[.*+?^${}()|[\]\\]/g, match => `\\${match}`);
+function zodEmittedPattern(schema: z.ZodType): string | undefined {
+    // Conversion options must stay in lockstep with standardSchemaToJsonSchema (which
+    // produced the pattern under comparison via `~standard.jsonSchema.input`).
+    const jsonSchema = z.toJSONSchema(schema, { target: 'draft-2020-12', io: 'input' }) as Record<string, unknown>;
+    return typeof jsonSchema.pattern === 'string' ? jsonSchema.pattern : undefined;
 }
 
-const ZOD_PRECISION_TIME_PATTERN = new RegExp(String.raw`^${escapeRegExpLiteral(String.raw`${ZOD_ISO_TIME_PREFIX}:[0-5]\d\.\d{`)}\d+\}$`);
+const DATETIME_FRACTION_DIGITS = /\\\.\\d\{(\d+)\}/;
 
-function isZodIsoDatetimePattern(pattern: string): boolean {
-    const prefix = `^${ZOD_ISO_DATE_PATTERN}T(?:`;
-    if (!pattern.startsWith(prefix) || !pattern.endsWith(')$')) {
-        return false;
+function datetimeReferenceSchemas(pattern: string): z.ZodType[] {
+    // The emitted pattern depends on the authoring options (offset/local/precision); the
+    // fraction-digit count recovered from the pattern under test keeps the candidate set
+    // finite. Duplicate candidates are fine — the result feeds a Set.
+    const fractionDigits = DATETIME_FRACTION_DIGITS.exec(pattern);
+    const precisions: Array<number | undefined> = [undefined, -1, 0];
+    if (fractionDigits) {
+        precisions.push(Number(fractionDigits[1]));
     }
-
-    const innerPattern = pattern.slice(prefix.length, -2);
-    const zoneSuffix = ZOD_DATETIME_ZONE_SUFFIXES.find(suffix => innerPattern.endsWith(suffix));
-    if (!zoneSuffix) {
-        return false;
-    }
-
-    const timePattern = innerPattern.slice(0, -zoneSuffix.length);
-    return (
-        timePattern === String.raw`${ZOD_ISO_TIME_PREFIX}` ||
-        timePattern === String.raw`${ZOD_ISO_TIME_PREFIX}:[0-5]\d` ||
-        timePattern === String.raw`${ZOD_ISO_TIME_PREFIX}(?::[0-5]\d(?:\.\d+)?)?` ||
-        ZOD_PRECISION_TIME_PATTERN.test(timePattern)
+    return [false, true].flatMap(local =>
+        [false, true].flatMap(offset => precisions.map(precision => z.iso.datetime({ local, offset, precision })))
     );
+}
+
+function referencePatternsForFormat(format: string, pattern: string): ReadonlySet<string> {
+    let referenceSchemas: z.ZodType[];
+    switch (format) {
+        case 'email': {
+            referenceSchemas = [z.email()];
+            break;
+        }
+        case 'uri': {
+            referenceSchemas = [z.url()];
+            break;
+        }
+        case 'date': {
+            referenceSchemas = [z.iso.date()];
+            break;
+        }
+        case 'date-time': {
+            referenceSchemas = datetimeReferenceSchemas(pattern);
+            break;
+        }
+        default: {
+            referenceSchemas = [];
+        }
+    }
+    return new Set(referenceSchemas.map(schema => zodEmittedPattern(schema)).filter((emitted): emitted is string => emitted !== undefined));
 }
 
 function isRedundantFormatPattern(original: Record<string, unknown>, parsed: Record<string, unknown>, key: string): boolean {
@@ -75,17 +91,43 @@ function isRedundantFormatPattern(original: Record<string, unknown>, parsed: Rec
         return false;
     }
 
-    if (parsed.format === 'date-time') {
-        return isZodIsoDatetimePattern(original.pattern);
-    }
-
-    return ZOD_REDUNDANT_FORMAT_PATTERNS.get(parsed.format)?.has(original.pattern) === true;
+    return referencePatternsForFormat(parsed.format, original.pattern).has(original.pattern);
 }
 
 const ANNOTATION_ONLY_JSON_SCHEMA_KEYWORDS = new Set(['$comment', 'deprecated', 'examples', 'readOnly', 'writeOnly']);
 
 function isAnnotationOnlyJsonSchemaKeyword(key: string): boolean {
     return ANNOTATION_ONLY_JSON_SCHEMA_KEYWORDS.has(key) || key.startsWith('x-');
+}
+
+// The spec declares a closed shape for the `requestedSchema` root: `$schema`, `type`,
+// `properties` and `required` only. The wire schema cannot enforce that (its root is a
+// catchall so hand-authored extensions stay wire-legal), and the stripped-keys diff below
+// never fires for root keys the catchall retains — so converted Standard Schemas are pruned
+// here: annotation-only root keywords are dropped, anything else unknown rejects (e.g.
+// `z.strictObject()` emits a root `additionalProperties: false`). The keyword set is derived
+// from the wire schema so it tracks spec revisions; `$schema` is spec-declared but absent
+// from the wire schema's declared keys (the catchall admits it).
+const ELICITATION_ROOT_KEYWORDS = new Set(['$schema', ...Object.keys(ElicitRequestFormParamsSchema.shape.requestedSchema.shape)]);
+const ROOT_ANNOTATION_KEYWORDS = new Set(['title', 'description']);
+
+function pruneElicitationSchemaRoot(schema: Record<string, unknown>): Record<string, unknown> {
+    const requestedSchema: Record<string, unknown> = {};
+    const unsupportedKeys: string[] = [];
+    for (const [key, value] of Object.entries(schema)) {
+        if (ELICITATION_ROOT_KEYWORDS.has(key)) {
+            requestedSchema[key] = value;
+        } else if (!ROOT_ANNOTATION_KEYWORDS.has(key) && !isAnnotationOnlyJsonSchemaKeyword(key)) {
+            unsupportedKeys.push(key);
+        }
+    }
+    if (unsupportedKeys.length > 0) {
+        throw new ProtocolError(
+            ProtocolErrorCode.InvalidParams,
+            `Elicitation requestedSchema contains unsupported JSON Schema keyword(s) after Standard Schema conversion: ${unsupportedKeys.join(', ')}`
+        );
+    }
+    return requestedSchema;
 }
 
 function findStrippedJsonSchemaPaths(original: unknown, parsed: unknown, path = ''): string[] {
@@ -137,7 +179,7 @@ export function normalizeElicitInputFormParams(
         const standardSchema = formParams.requestedSchema;
         const normalizedParams = {
             ...formParams,
-            requestedSchema: convertStandardElicitationSchema(standardSchema)
+            requestedSchema: pruneElicitationSchemaRoot(convertStandardElicitationSchema(standardSchema))
         };
         const parsedParams = parseSchema(ElicitRequestFormParamsSchema, normalizedParams);
         if (!parsedParams.success) {

--- a/packages/core-internal/src/shared/elicitation.ts
+++ b/packages/core-internal/src/shared/elicitation.ts
@@ -1,11 +1,11 @@
-import type { ElicitInputFormParams, ElicitRequestFormParams, StandardSchemaWithJSON } from '@modelcontextprotocol/core-internal';
-import {
-    ElicitRequestFormParamsSchema,
-    parseSchema,
-    ProtocolError,
-    ProtocolErrorCode,
-    standardSchemaToJsonSchema
-} from '@modelcontextprotocol/core-internal';
+import { ProtocolErrorCode } from '../types/enums';
+import { ProtocolError } from '../types/errors';
+import { ElicitRequestFormParamsSchema } from '../types/schemas';
+import type { ElicitRequestFormParams } from '../types/types';
+import { parseSchema } from '../util/schema';
+import type { StandardSchemaWithJSON } from '../util/standardSchema';
+import { standardSchemaToJsonSchema } from '../util/standardSchema';
+import type { ElicitInputFormParams } from './protocol';
 
 export type NormalizedElicitInputFormParams = {
     params: ElicitRequestFormParams;
@@ -109,6 +109,18 @@ function isElicitInputSchema(
     return typeof schema === 'object' && schema !== null && '~standard' in schema;
 }
 
+function convertStandardElicitationSchema(standardSchema: StandardSchemaWithJSON): Record<string, unknown> {
+    try {
+        return standardSchemaToJsonSchema(standardSchema, 'input');
+    } catch (error) {
+        const detail = error instanceof Error ? error.message : String(error);
+        throw new ProtocolError(
+            ProtocolErrorCode.InvalidParams,
+            `Elicitation requestedSchema must describe an object with flat primitive properties: ${detail}`
+        );
+    }
+}
+
 export function normalizeElicitInputFormParams(
     params: ElicitRequestFormParams | ElicitInputFormParams<StandardSchemaWithJSON>
 ): NormalizedElicitInputFormParams {
@@ -119,7 +131,7 @@ export function normalizeElicitInputFormParams(
         const standardSchema = formParams.requestedSchema;
         const normalizedParams = {
             ...formParams,
-            requestedSchema: standardSchemaToJsonSchema(standardSchema, 'input')
+            requestedSchema: convertStandardElicitationSchema(standardSchema)
         };
         const parsedParams = parseSchema(ElicitRequestFormParamsSchema, normalizedParams);
         if (!parsedParams.success) {

--- a/packages/core-internal/src/shared/inputRequired.ts
+++ b/packages/core-internal/src/shared/inputRequired.ts
@@ -30,7 +30,9 @@ import type {
     InputResponses,
     Root
 } from '../types/types';
-import type { StandardSchemaV1 } from '../util/standardSchema';
+import type { StandardSchemaV1, StandardSchemaWithJSON } from '../util/standardSchema';
+import { normalizeElicitInputFormParams } from './elicitation';
+import type { ElicitInputFormParams } from './protocol';
 
 /** The shape accepted by {@linkcode inputRequired}. */
 export interface InputRequiredSpec {
@@ -56,6 +58,9 @@ interface InputRequiredBuilder {
      * that fails verification. The SDK does not do this for you.
      */
     (spec: InputRequiredSpec): InputRequiredResult;
+
+    /** Builds an embedded form-mode elicitation request (`elicitation/create`). */
+    elicit<Schema extends StandardSchemaWithJSON>(params: Omit<ElicitInputFormParams<Schema>, 'mode'> & { mode?: 'form' }): InputRequest;
 
     /** Builds an embedded form-mode elicitation request (`elicitation/create`). */
     elicit(params: Omit<ElicitRequestFormParams, 'mode'> & { mode?: 'form' }): InputRequest;
@@ -118,8 +123,15 @@ function buildInputRequired(spec: InputRequiredSpec): InputRequiredResult {
  * ```
  */
 export const inputRequired: InputRequiredBuilder = Object.assign(buildInputRequired, {
-    elicit(params: Omit<ElicitRequestFormParams, 'mode'> & { mode?: 'form' }): InputRequest {
-        return { method: 'elicitation/create', params: { ...params, mode: 'form' } };
+    elicit(
+        params:
+            | (Omit<ElicitRequestFormParams, 'mode'> & { mode?: 'form' })
+            | (Omit<ElicitInputFormParams<StandardSchemaWithJSON>, 'mode'> & { mode?: 'form' })
+    ): InputRequest {
+        const { params: normalizedParams } = normalizeElicitInputFormParams(
+            params as ElicitRequestFormParams | ElicitInputFormParams<StandardSchemaWithJSON>
+        );
+        return { method: 'elicitation/create', params: normalizedParams };
     },
     elicitUrl(params: Omit<ElicitRequestURLParams, 'mode' | 'elicitationId'>): InputRequest {
         // The neutral ElicitRequestURLParams keeps `elicitationId` (it is required on the

--- a/packages/core-internal/src/shared/inputRequired.ts
+++ b/packages/core-internal/src/shared/inputRequired.ts
@@ -17,6 +17,7 @@
  * discriminator, and hand-built result literals are equally legal — the
  * server seam re-checks the at-least-one rule for them.
  */
+import { ProtocolError } from '../types/errors';
 import { isInputRequiredResult } from '../types/guards';
 import type {
     CreateMessageRequestParams,
@@ -128,10 +129,17 @@ export const inputRequired: InputRequiredBuilder = Object.assign(buildInputRequi
             | (Omit<ElicitRequestFormParams, 'mode'> & { mode?: 'form' })
             | (Omit<ElicitInputFormParams<StandardSchemaWithJSON>, 'mode'> & { mode?: 'form' })
     ): InputRequest {
-        const { params: normalizedParams } = normalizeElicitInputFormParams(
-            params as ElicitRequestFormParams | ElicitInputFormParams<StandardSchemaWithJSON>
-        );
-        return { method: 'elicitation/create', params: normalizedParams };
+        try {
+            const { params: normalizedParams } = normalizeElicitInputFormParams(
+                params as ElicitRequestFormParams | ElicitInputFormParams<StandardSchemaWithJSON>
+            );
+            return { method: 'elicitation/create', params: normalizedParams };
+        } catch (error) {
+            // Authoring mistakes in the builder surface as TypeError, matching inputRequired()
+            // itself; a ProtocolError escaping a prompts/get or resources/read handler would
+            // reach the client as InvalidParams on its own request.
+            throw error instanceof ProtocolError ? new TypeError(error.message, { cause: error }) : error;
+        }
     },
     elicitUrl(params: Omit<ElicitRequestURLParams, 'mode' | 'elicitationId'>): InputRequest {
         // The neutral ElicitRequestURLParams keeps `elicitationId` (it is required on the

--- a/packages/core-internal/src/shared/protocol.ts
+++ b/packages/core-internal/src/shared/protocol.ts
@@ -45,7 +45,7 @@ import {
     ProtocolErrorCode,
     SUPPORTED_PROTOCOL_VERSIONS
 } from '../types/index';
-import type { StandardSchemaV1 } from '../util/standardSchema';
+import type { StandardSchemaV1, StandardSchemaWithJSON } from '../util/standardSchema';
 import { isStandardSchema, validateStandardSchema } from '../util/standardSchema';
 import { bootstrapOutboundCodec } from '../wire/bootstrap';
 import type { LiftedWireMaterial, WireCodec } from '../wire/codec';
@@ -444,6 +444,18 @@ export type BaseContext = {
     };
 };
 
+export type ElicitInputFormParams<Schema extends StandardSchemaWithJSON = StandardSchemaWithJSON> = Omit<
+    ElicitRequestFormParams,
+    'requestedSchema'
+> & {
+    requestedSchema: Schema;
+};
+
+export type ElicitInputResult<Schema extends StandardSchemaWithJSON> = Result & {
+    action: ElicitResult['action'];
+    content?: StandardSchemaWithJSON.InferOutput<Schema>;
+};
+
 /**
  * Context provided to server-side request handlers, extending {@linkcode BaseContext} with server-specific fields.
  */
@@ -467,7 +479,13 @@ export type ServerContext = BaseContext & {
          * replaced by input_required results in the 2026-07-28 protocol. If your factory serves
          * both eras, this only works on the legacy path.
          */
-        elicitInput: (params: ElicitRequestFormParams | ElicitRequestURLParams, options?: RequestOptions) => Promise<ElicitResult>;
+        elicitInput: {
+            <Schema extends StandardSchemaWithJSON>(
+                params: ElicitInputFormParams<Schema>,
+                options?: RequestOptions
+            ): Promise<ElicitInputResult<Schema>>;
+            (params: ElicitRequestFormParams | ElicitRequestURLParams, options?: RequestOptions): Promise<ElicitResult>;
+        };
 
         /**
          * Request LLM sampling from the client.

--- a/packages/core-internal/test/shared/elicitation.test.ts
+++ b/packages/core-internal/test/shared/elicitation.test.ts
@@ -19,6 +19,51 @@ function schemaFromJson(jsonSchema: Record<string, unknown>): StandardSchemaWith
     } satisfies StandardSchemaWithJSON;
 }
 
+describe('normalizeElicitInputFormParams schema detection', () => {
+    test('converts function-typed Standard Schemas (ArkType-style)', () => {
+        const jsonSchema = {
+            type: 'object',
+            properties: { name: { type: 'string' } },
+            required: ['name']
+        };
+        const functionSchema = Object.assign(() => {}, {
+            '~standard': {
+                version: 1 as const,
+                vendor: 'test',
+                validate: (value: unknown) => ({ value }),
+                jsonSchema: {
+                    input: () => jsonSchema,
+                    output: () => ({})
+                }
+            }
+        });
+
+        const { params, standardSchema } = normalizeElicitInputFormParams({
+            message: 'Name?',
+            requestedSchema: functionSchema as unknown as StandardSchemaWithJSON
+        });
+
+        expect(standardSchema).toBe(functionSchema);
+        expect(params.requestedSchema).toEqual(jsonSchema);
+    });
+
+    test('routes a plain JSON schema containing a literal "~standard" key to the raw branch', () => {
+        const rawSchema = {
+            type: 'object' as const,
+            properties: { name: { type: 'string' as const } },
+            '~standard': 'extension-data'
+        };
+
+        const { params, standardSchema } = normalizeElicitInputFormParams({
+            message: 'Name?',
+            requestedSchema: rawSchema as never
+        });
+
+        expect(standardSchema).toBeUndefined();
+        expect(params.requestedSchema).toBe(rawSchema);
+    });
+});
+
 describe('normalizeElicitInputFormParams root keywords', () => {
     test('keeps the spec-declared root keys including $schema', () => {
         const { params } = normalizeElicitInputFormParams({

--- a/packages/core-internal/test/shared/elicitation.test.ts
+++ b/packages/core-internal/test/shared/elicitation.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, test } from 'vitest';
+import * as z from 'zod/v4';
+
+import { normalizeElicitInputFormParams } from '../../src/shared/elicitation';
+import { ProtocolError } from '../../src/types/errors';
+import type { StandardSchemaWithJSON } from '../../src/util/standardSchema';
+
+function schemaFromJson(jsonSchema: Record<string, unknown>): StandardSchemaWithJSON {
+    return {
+        '~standard': {
+            version: 1,
+            vendor: 'test',
+            validate: (value: unknown) => ({ value }),
+            jsonSchema: {
+                input: () => jsonSchema,
+                output: () => ({})
+            }
+        }
+    } satisfies StandardSchemaWithJSON;
+}
+
+describe('normalizeElicitInputFormParams root keywords', () => {
+    test('keeps the spec-declared root keys including $schema', () => {
+        const { params } = normalizeElicitInputFormParams({
+            message: 'Name?',
+            requestedSchema: z.object({ name: z.string() })
+        });
+
+        expect(params.requestedSchema).toEqual({
+            $schema: 'https://json-schema.org/draft/2020-12/schema',
+            type: 'object',
+            properties: { name: { type: 'string' } },
+            required: ['name']
+        });
+    });
+
+    test('drops annotation-only root keywords', () => {
+        const { params } = normalizeElicitInputFormParams({
+            message: 'Name?',
+            requestedSchema: z.object({ name: z.string() }).meta({ title: 'User', description: 'User info', 'x-ui-hint': 'compact' })
+        });
+
+        expect(params.requestedSchema).toEqual({
+            $schema: 'https://json-schema.org/draft/2020-12/schema',
+            type: 'object',
+            properties: { name: { type: 'string' } },
+            required: ['name']
+        });
+    });
+
+    test.each([
+        ['z.strictObject emits additionalProperties: false', z.strictObject({ name: z.string() }), /additionalProperties/],
+        ['z.looseObject emits additionalProperties: {}', z.looseObject({ name: z.string() }), /additionalProperties/],
+        [
+            'catchall emits a nested schema under additionalProperties',
+            z.object({ name: z.string() }).catchall(z.object({ x: z.string() })),
+            /additionalProperties/
+        ],
+        ['a root default cannot ride the wire', z.object({ name: z.string() }).default({ name: 'x' }), /default/],
+        [
+            'a custom schema emitting $defs',
+            schemaFromJson({
+                $defs: { Name: { type: 'string' } },
+                type: 'object',
+                properties: { name: { $ref: '#/$defs/Name' } },
+                required: ['name']
+            }),
+            /\$defs/
+        ]
+    ])('rejects unsupported root keywords: %s', (_label, requestedSchema, message) => {
+        const params = { message: 'Name?', requestedSchema } as Parameters<typeof normalizeElicitInputFormParams>[0];
+        const act = () => normalizeElicitInputFormParams(params);
+        expect(act).toThrow(ProtocolError);
+        expect(act).toThrow(/unsupported JSON Schema keyword\(s\)/);
+        expect(act).toThrow(message);
+    });
+});
+
+describe('normalizeElicitInputFormParams redundant format patterns', () => {
+    test.each([
+        ['z.email()', z.email(), 'email'],
+        ['z.url()', z.url(), 'uri'],
+        ['z.iso.date()', z.iso.date(), 'date'],
+        ['z.iso.datetime()', z.iso.datetime(), 'date-time'],
+        ['z.iso.datetime({ offset: true })', z.iso.datetime({ offset: true }), 'date-time'],
+        ['z.iso.datetime({ local: true })', z.iso.datetime({ local: true }), 'date-time'],
+        ['z.iso.datetime({ precision: -1 })', z.iso.datetime({ precision: -1 }), 'date-time'],
+        ['z.iso.datetime({ precision: 0 })', z.iso.datetime({ precision: 0 }), 'date-time'],
+        ['z.iso.datetime({ precision: 3, offset: true })', z.iso.datetime({ precision: 3, offset: true }), 'date-time']
+    ])('accepts %s and strips the zod-emitted pattern', (_label, fieldSchema, format) => {
+        const { params } = normalizeElicitInputFormParams({
+            message: 'Value?',
+            requestedSchema: z.object({ value: fieldSchema })
+        });
+
+        const valueSchema = (params.requestedSchema.properties as Record<string, Record<string, unknown>>).value!;
+        expect(valueSchema.format).toBe(format);
+        expect(valueSchema.pattern).toBeUndefined();
+    });
+
+    test('accepts exactly the pattern the installed zod emits for a format', () => {
+        const emittedPattern = (z.toJSONSchema(z.email(), { target: 'draft-2020-12', io: 'input' }) as Record<string, unknown>)
+            .pattern as string;
+        const { params } = normalizeElicitInputFormParams({
+            message: 'Email?',
+            requestedSchema: schemaFromJson({
+                type: 'object',
+                properties: { email: { type: 'string', format: 'email', pattern: emittedPattern } },
+                required: ['email']
+            })
+        });
+
+        const emailSchema = (params.requestedSchema.properties as Record<string, Record<string, unknown>>).email!;
+        expect(emailSchema.format).toBe('email');
+        expect(emailSchema.pattern).toBeUndefined();
+    });
+
+    test.each([
+        ['a customized email pattern', z.object({ email: z.email({ pattern: /@corp\.com$/ }) }), /properties\.email\.pattern/],
+        [
+            'a pattern the installed zod would not emit for the format',
+            schemaFromJson({
+                type: 'object',
+                properties: { email: { type: 'string', format: 'email', pattern: '^different$' } },
+                required: ['email']
+            }),
+            /properties\.email\.pattern/
+        ],
+        ['a pattern without a supported format', z.object({ code: z.string().regex(/^[A-Z]{3}$/) }), /properties\.code\.pattern/]
+    ])('rejects %s', (_label, requestedSchema, message) => {
+        const params = { message: 'Value?', requestedSchema } as Parameters<typeof normalizeElicitInputFormParams>[0];
+        const act = () => normalizeElicitInputFormParams(params);
+        expect(act).toThrow(ProtocolError);
+        expect(act).toThrow(message);
+    });
+});

--- a/packages/core-internal/test/shared/inputRequired.test.ts
+++ b/packages/core-internal/test/shared/inputRequired.test.ts
@@ -8,7 +8,6 @@ import { describe, expect, test } from 'vitest';
 import * as z from 'zod/v4';
 
 import { acceptedContent, inputRequired, withInputRequired } from '../../src/shared/inputRequired';
-import { ProtocolError } from '../../src/types/errors';
 import { isInputRequiredResult } from '../../src/types/guards';
 import { validateStandardSchema } from '../../src/util/standardSchema';
 
@@ -103,19 +102,34 @@ describe('inputRequired() builder', () => {
         });
     });
 
-    test('elicit rejects non-object Standard Schema roots as invalid elicitation params', () => {
+    test('elicit rejects non-object Standard Schema roots as a TypeError', () => {
         expect(() =>
             inputRequired.elicit({
                 message: 'Name?',
                 requestedSchema: z.string()
             })
-        ).toThrow(ProtocolError);
+        ).toThrow(TypeError);
         expect(() =>
             inputRequired.elicit({
                 message: 'Name?',
                 requestedSchema: z.string()
             })
         ).toThrow(/Elicitation requestedSchema must describe an object/);
+    });
+
+    test('elicit rejects schemas outside the elicitation subset as a TypeError', () => {
+        expect(() =>
+            inputRequired.elicit({
+                message: 'Name?',
+                requestedSchema: z.strictObject({ name: z.string() })
+            })
+        ).toThrow(TypeError);
+        expect(() =>
+            inputRequired.elicit({
+                message: 'Name?',
+                requestedSchema: z.strictObject({ name: z.string() })
+            })
+        ).toThrow(/unsupported JSON Schema keyword\(s\).*additionalProperties/);
     });
 });
 

--- a/packages/core-internal/test/shared/inputRequired.test.ts
+++ b/packages/core-internal/test/shared/inputRequired.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, test } from 'vitest';
 import * as z from 'zod/v4';
 
 import { acceptedContent, inputRequired, withInputRequired } from '../../src/shared/inputRequired';
+import { ProtocolError } from '../../src/types/errors';
 import { isInputRequiredResult } from '../../src/types/guards';
 import { validateStandardSchema } from '../../src/util/standardSchema';
 
@@ -50,6 +51,42 @@ describe('inputRequired() builder', () => {
             params: { messages: [{ role: 'user', content: { type: 'text', text: 'hi' } }], maxTokens: 5 }
         });
         expect(inputRequired.listRoots()).toEqual({ method: 'roots/list' });
+    });
+
+    test('elicit converts Standard Schema requestedSchema to elicitation JSON Schema', () => {
+        const request = inputRequired.elicit({
+            message: 'Email?',
+            requestedSchema: z.object({ email: z.email() })
+        });
+
+        expect(request).toEqual({
+            method: 'elicitation/create',
+            params: {
+                mode: 'form',
+                message: 'Email?',
+                requestedSchema: {
+                    $schema: 'https://json-schema.org/draft/2020-12/schema',
+                    type: 'object',
+                    properties: { email: { type: 'string', format: 'email' } },
+                    required: ['email']
+                }
+            }
+        });
+    });
+
+    test('elicit rejects non-object Standard Schema roots as invalid elicitation params', () => {
+        expect(() =>
+            inputRequired.elicit({
+                message: 'Name?',
+                requestedSchema: z.string()
+            })
+        ).toThrow(ProtocolError);
+        expect(() =>
+            inputRequired.elicit({
+                message: 'Name?',
+                requestedSchema: z.string()
+            })
+        ).toThrow(/Elicitation requestedSchema must describe an object/);
     });
 });
 

--- a/packages/core-internal/test/shared/inputRequired.test.ts
+++ b/packages/core-internal/test/shared/inputRequired.test.ts
@@ -74,6 +74,35 @@ describe('inputRequired() builder', () => {
         });
     });
 
+    test('elicit drops annotation-only metadata from Standard Schema properties', () => {
+        const request = inputRequired.elicit({
+            message: 'Name?',
+            requestedSchema: z.object({
+                name: z.string().meta({
+                    title: 'Name',
+                    examples: ['Ada Lovelace'],
+                    deprecated: false,
+                    readOnly: true,
+                    'x-ui-order': 1
+                })
+            })
+        });
+
+        expect(request).toEqual({
+            method: 'elicitation/create',
+            params: {
+                mode: 'form',
+                message: 'Name?',
+                requestedSchema: {
+                    $schema: 'https://json-schema.org/draft/2020-12/schema',
+                    type: 'object',
+                    properties: { name: { type: 'string', title: 'Name' } },
+                    required: ['name']
+                }
+            }
+        });
+    });
+
     test('elicit rejects non-object Standard Schema roots as invalid elicitation params', () => {
         expect(() =>
             inputRequired.elicit({

--- a/packages/server/src/server/elicitation.ts
+++ b/packages/server/src/server/elicitation.ts
@@ -1,0 +1,106 @@
+import type { ElicitInputFormParams, ElicitRequestFormParams, StandardSchemaWithJSON } from '@modelcontextprotocol/core-internal';
+import {
+    ElicitRequestFormParamsSchema,
+    parseSchema,
+    ProtocolError,
+    ProtocolErrorCode,
+    standardSchemaToJsonSchema
+} from '@modelcontextprotocol/core-internal';
+
+export type NormalizedElicitInputFormParams = {
+    params: ElicitRequestFormParams;
+    standardSchema?: StandardSchemaWithJSON;
+};
+
+function isJsonObject(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+const ZOD_REDUNDANT_FORMAT_PATTERNS: ReadonlyMap<string, ReadonlySet<string>> = new Map([
+    ['email', new Set([String.raw`^(?!\.)(?!.*\.\.)([A-Za-z0-9_'+\-\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\-]*\.)+[A-Za-z]{2,}$`])],
+    [
+        'date',
+        new Set([
+            String.raw`^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))$`
+        ])
+    ],
+    [
+        'date-time',
+        new Set([
+            String.raw`^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$`
+        ])
+    ]
+]);
+
+function isRedundantFormatPattern(original: Record<string, unknown>, parsed: Record<string, unknown>, key: string): boolean {
+    if (
+        key !== 'pattern' ||
+        typeof original.pattern !== 'string' ||
+        parsed.type !== 'string' ||
+        typeof parsed.format !== 'string' ||
+        original.format !== parsed.format
+    ) {
+        return false;
+    }
+
+    return ZOD_REDUNDANT_FORMAT_PATTERNS.get(parsed.format)?.has(original.pattern) === true;
+}
+
+function findStrippedJsonSchemaPaths(original: unknown, parsed: unknown, path = ''): string[] {
+    if (Array.isArray(original) && Array.isArray(parsed)) {
+        return original.flatMap((item, index) => findStrippedJsonSchemaPaths(item, parsed[index], `${path}[${index}]`));
+    }
+
+    if (!isJsonObject(original) || !isJsonObject(parsed)) {
+        return [];
+    }
+
+    return Object.entries(original).flatMap(([key, value]) => {
+        const childPath = path ? `${path}.${key}` : key;
+        if (!Object.prototype.hasOwnProperty.call(parsed, key)) {
+            if (isRedundantFormatPattern(original, parsed, key)) {
+                return [];
+            }
+            return [childPath];
+        }
+        return findStrippedJsonSchemaPaths(value, parsed[key], childPath);
+    });
+}
+
+function isElicitInputSchema(
+    schema: ElicitRequestFormParams['requestedSchema'] | StandardSchemaWithJSON
+): schema is StandardSchemaWithJSON {
+    return typeof schema === 'object' && schema !== null && '~standard' in schema;
+}
+
+export function normalizeElicitInputFormParams(
+    params: ElicitRequestFormParams | ElicitInputFormParams<StandardSchemaWithJSON>
+): NormalizedElicitInputFormParams {
+    const formParams =
+        params.mode === 'form' ? (params as ElicitRequestFormParams) : { ...(params as ElicitRequestFormParams), mode: 'form' as const };
+
+    if (isElicitInputSchema(formParams.requestedSchema)) {
+        const standardSchema = formParams.requestedSchema;
+        const normalizedParams = {
+            ...formParams,
+            requestedSchema: standardSchemaToJsonSchema(standardSchema, 'input')
+        };
+        const parsedParams = parseSchema(ElicitRequestFormParamsSchema, normalizedParams);
+        if (!parsedParams.success) {
+            throw new ProtocolError(
+                ProtocolErrorCode.InvalidParams,
+                `Elicitation requestedSchema only supports flat primitive properties (string, number, integer, boolean, and string enums): ${parsedParams.error.message}`
+            );
+        }
+        const strippedSchemaPaths = findStrippedJsonSchemaPaths(normalizedParams.requestedSchema, parsedParams.data.requestedSchema);
+        if (strippedSchemaPaths.length > 0) {
+            throw new ProtocolError(
+                ProtocolErrorCode.InvalidParams,
+                `Elicitation requestedSchema contains unsupported JSON Schema keyword(s) after Standard Schema conversion: ${strippedSchemaPaths.join(', ')}`
+            );
+        }
+        return { params: parsedParams.data, standardSchema };
+    }
+
+    return { params: formParams };
+}

--- a/packages/server/src/server/elicitation.ts
+++ b/packages/server/src/server/elicitation.ts
@@ -16,6 +16,10 @@ function isJsonObject(value: unknown): value is Record<string, unknown> {
     return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
+const ZOD_ISO_DATE_PATTERN = String.raw`(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))`;
+const ZOD_ISO_TIME_PREFIX = String.raw`(?:[01]\d|2[0-3]):[0-5]\d`;
+const ZOD_ISO_OFFSET_PATTERN = String.raw`([+-](?:[01]\d|2[0-3]):[0-5]\d)`;
+
 const ZOD_REDUNDANT_FORMAT_PATTERNS: ReadonlyMap<string, ReadonlySet<string>> = new Map([
     ['email', new Set([String.raw`^(?!\.)(?!.*\.\.)([A-Za-z0-9_'+\-\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\-]*\.)+[A-Za-z]{2,}$`])],
     [
@@ -23,14 +27,42 @@ const ZOD_REDUNDANT_FORMAT_PATTERNS: ReadonlyMap<string, ReadonlySet<string>> = 
         new Set([
             String.raw`^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))$`
         ])
-    ],
-    [
-        'date-time',
-        new Set([
-            String.raw`^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$`
-        ])
     ]
 ]);
+
+const ZOD_DATETIME_ZONE_SUFFIXES = [
+    String.raw`(?:Z)`,
+    String.raw`(?:Z|)`,
+    String.raw`(?:Z|${ZOD_ISO_OFFSET_PATTERN})`,
+    String.raw`(?:Z||${ZOD_ISO_OFFSET_PATTERN})`
+] as const;
+
+function escapeRegExpLiteral(value: string): string {
+    return value.replaceAll(/[.*+?^${}()|[\]\\]/g, match => `\\${match}`);
+}
+
+const ZOD_PRECISION_TIME_PATTERN = new RegExp(String.raw`^${escapeRegExpLiteral(String.raw`${ZOD_ISO_TIME_PREFIX}:[0-5]\d\.\d{`)}\d+\}$`);
+
+function isZodIsoDatetimePattern(pattern: string): boolean {
+    const prefix = `^${ZOD_ISO_DATE_PATTERN}T(?:`;
+    if (!pattern.startsWith(prefix) || !pattern.endsWith(')$')) {
+        return false;
+    }
+
+    const innerPattern = pattern.slice(prefix.length, -2);
+    const zoneSuffix = ZOD_DATETIME_ZONE_SUFFIXES.find(suffix => innerPattern.endsWith(suffix));
+    if (!zoneSuffix) {
+        return false;
+    }
+
+    const timePattern = innerPattern.slice(0, -zoneSuffix.length);
+    return (
+        timePattern === String.raw`${ZOD_ISO_TIME_PREFIX}` ||
+        timePattern === String.raw`${ZOD_ISO_TIME_PREFIX}:[0-5]\d` ||
+        timePattern === String.raw`${ZOD_ISO_TIME_PREFIX}(?::[0-5]\d(?:\.\d+)?)?` ||
+        ZOD_PRECISION_TIME_PATTERN.test(timePattern)
+    );
+}
 
 function isRedundantFormatPattern(original: Record<string, unknown>, parsed: Record<string, unknown>, key: string): boolean {
     if (
@@ -41,6 +73,10 @@ function isRedundantFormatPattern(original: Record<string, unknown>, parsed: Rec
         original.format !== parsed.format
     ) {
         return false;
+    }
+
+    if (parsed.format === 'date-time') {
+        return isZodIsoDatetimePattern(original.pattern);
     }
 
     return ZOD_REDUNDANT_FORMAT_PATTERNS.get(parsed.format)?.has(original.pattern) === true;

--- a/packages/server/src/server/server.ts
+++ b/packages/server/src/server/server.ts
@@ -1136,6 +1136,18 @@ export class Server extends Protocol<ServerContext> {
         params: ElicitInputFormParams<Schema>,
         options?: RequestOptions
     ): Promise<ElicitInputResult<Schema>>;
+    /**
+     * Creates an elicitation request for the given parameters.
+     * For backwards compatibility, `mode` may be omitted for form requests and will default to `"form"`.
+     * @param params The parameters for the elicitation request.
+     * @param options Optional request options.
+     * @returns The result of the elicitation request.
+     *
+     * @deprecated Throws on a 2026-07-28-era request — use {@link index.inputRequired | inputRequired} (multi-round-trip)
+     * instead. The 2025 push-style server-to-client request model is replaced by input_required
+     * results in the 2026-07-28 protocol. If your factory serves both eras, this only works on the
+     * legacy path.
+     */
     async elicitInput(params: ElicitRequestFormParams | ElicitRequestURLParams, options?: RequestOptions): Promise<ElicitResult>;
     async elicitInput(
         params: ElicitRequestFormParams | ElicitRequestURLParams | ElicitInputFormParams<StandardSchemaWithJSON>,

--- a/packages/server/src/server/server.ts
+++ b/packages/server/src/server/server.ts
@@ -10,6 +10,8 @@ import type {
     CreateMessageResult,
     CreateMessageResultWithTools,
     DiscoverResult,
+    ElicitInputFormParams,
+    ElicitInputResult,
     ElicitRequestFormParams,
     ElicitRequestURLParams,
     ElicitResult,
@@ -34,6 +36,7 @@ import type {
     Result,
     ServerCapabilities,
     ServerContext,
+    StandardSchemaWithJSON,
     ToolResultContent,
     ToolUseContent
 } from '@modelcontextprotocol/core-internal';
@@ -58,6 +61,7 @@ import {
     ProtocolErrorCode,
     SdkError,
     SdkErrorCode,
+    standardSchemaToJsonSchema,
     withRequestStateValue
 } from '@modelcontextprotocol/core-internal';
 import { DefaultJsonSchemaValidator } from '@modelcontextprotocol/server/_shims';
@@ -1127,7 +1131,15 @@ export class Server extends Protocol<ServerContext> {
      * results in the 2026-07-28 protocol. If your factory serves both eras, this only works on the
      * legacy path.
      */
-    async elicitInput(params: ElicitRequestFormParams | ElicitRequestURLParams, options?: RequestOptions): Promise<ElicitResult> {
+    async elicitInput<Schema extends StandardSchemaWithJSON>(
+        params: ElicitInputFormParams<Schema>,
+        options?: RequestOptions
+    ): Promise<ElicitInputResult<Schema>>;
+    async elicitInput(params: ElicitRequestFormParams | ElicitRequestURLParams, options?: RequestOptions): Promise<ElicitResult>;
+    async elicitInput(
+        params: ElicitRequestFormParams | ElicitRequestURLParams | ElicitInputFormParams<StandardSchemaWithJSON>,
+        options?: RequestOptions
+    ): Promise<ElicitResult | ElicitInputResult<StandardSchemaWithJSON>> {
         this._assertPushApiInServedEra('elicitation/create');
         const mode = (params.mode ?? 'form') as 'form' | 'url';
 
@@ -1158,7 +1170,7 @@ export class Server extends Protocol<ServerContext> {
      * `acceptedContent` overload and can re-ask).
      */
     private async _sendElicitationLeg(
-        params: ElicitRequestFormParams | ElicitRequestURLParams,
+        params: ElicitRequestFormParams | ElicitRequestURLParams | ElicitInputFormParams<StandardSchemaWithJSON>,
         options?: RequestOptions,
         behavior?: { validateAcceptedContent: boolean }
     ): Promise<ElicitResult> {
@@ -1173,8 +1185,9 @@ export class Server extends Protocol<ServerContext> {
                 return this.request({ method: 'elicitation/create', params: urlParams }, options);
             }
             case 'form': {
-                const formParams: ElicitRequestFormParams =
-                    params.mode === 'form' ? (params as ElicitRequestFormParams) : { ...(params as ElicitRequestFormParams), mode: 'form' };
+                const formParams = this.normalizeElicitInputFormParams(
+                    params as ElicitRequestFormParams | ElicitInputFormParams<StandardSchemaWithJSON>
+                );
 
                 const result = await this.request({ method: 'elicitation/create', params: formParams }, options);
 
@@ -1202,6 +1215,33 @@ export class Server extends Protocol<ServerContext> {
                 return result;
             }
         }
+    }
+
+    private normalizeElicitInputFormParams(
+        params: ElicitRequestFormParams | ElicitInputFormParams<StandardSchemaWithJSON>
+    ): ElicitRequestFormParams {
+        const formParams =
+            params.mode === 'form'
+                ? (params as ElicitRequestFormParams)
+                : { ...(params as ElicitRequestFormParams), mode: 'form' as const };
+
+        if (this.isElicitInputSchema(formParams.requestedSchema)) {
+            return {
+                ...formParams,
+                requestedSchema: standardSchemaToJsonSchema(
+                    formParams.requestedSchema,
+                    'input'
+                ) as ElicitRequestFormParams['requestedSchema']
+            };
+        }
+
+        return formParams;
+    }
+
+    private isElicitInputSchema(
+        schema: ElicitRequestFormParams['requestedSchema'] | StandardSchemaWithJSON
+    ): schema is StandardSchemaWithJSON {
+        return typeof schema === 'object' && schema !== null && '~standard' in schema;
     }
 
     /**

--- a/packages/server/src/server/server.ts
+++ b/packages/server/src/server/server.ts
@@ -55,6 +55,7 @@ import {
     missingClientCapabilities,
     MissingRequiredClientCapabilityError,
     modernProtocolVersions,
+    normalizeElicitInputFormParams,
     parseSchema,
     Protocol,
     ProtocolError,
@@ -66,7 +67,6 @@ import {
 } from '@modelcontextprotocol/core-internal';
 import { DefaultJsonSchemaValidator } from '@modelcontextprotocol/server/_shims';
 
-import { normalizeElicitInputFormParams } from './elicitation';
 import { coerceEmbeddedInputRequest, LegacyInputRequiredShim, resolveLegacyShimOptions } from './legacyInputRequiredShim';
 
 /**

--- a/packages/server/src/server/server.ts
+++ b/packages/server/src/server/server.ts
@@ -1249,7 +1249,7 @@ export class Server extends Protocol<ServerContext> {
             if (!parsedParams.success) {
                 throw new ProtocolError(
                     ProtocolErrorCode.InvalidParams,
-                    'Elicitation requestedSchema only supports flat primitive properties (string, number, integer, boolean, and string enums).'
+                    `Elicitation requestedSchema only supports flat primitive properties (string, number, integer, boolean, and string enums): ${parsedParams.error.message}`
                 );
             }
             return { params: parsedParams.data, standardSchema };

--- a/packages/server/src/server/server.ts
+++ b/packages/server/src/server/server.ts
@@ -51,7 +51,6 @@ import {
     legacyProtocolVersions,
     LOG_LEVEL_META_KEY,
     LoggingLevelSchema,
-    ElicitRequestFormParamsSchema,
     mergeCapabilities,
     missingClientCapabilities,
     MissingRequiredClientCapabilityError,
@@ -62,12 +61,12 @@ import {
     ProtocolErrorCode,
     SdkError,
     SdkErrorCode,
-    standardSchemaToJsonSchema,
     validateStandardSchema,
     withRequestStateValue
 } from '@modelcontextprotocol/core-internal';
 import { DefaultJsonSchemaValidator } from '@modelcontextprotocol/server/_shims';
 
+import { normalizeElicitInputFormParams } from './elicitation';
 import { coerceEmbeddedInputRequest, LegacyInputRequiredShim, resolveLegacyShimOptions } from './legacyInputRequiredShim';
 
 /**
@@ -242,44 +241,6 @@ export function seedClientIdentityFromEnvelope(server: Server, identity: PerRequ
  */
 export function installModernOnlyHandlers(server: Server, servedModernVersions: readonly string[]): void {
     installDiscoverHandler(server, servedModernVersions);
-}
-
-function isJsonObject(value: unknown): value is Record<string, unknown> {
-    return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
-
-const ELICITATION_STRING_FORMATS = new Set(['email', 'uri', 'date', 'date-time']);
-
-function isSupportedFormatPattern(original: Record<string, unknown>, parsed: Record<string, unknown>, key: string): boolean {
-    return (
-        key === 'pattern' &&
-        typeof original.pattern === 'string' &&
-        parsed.type === 'string' &&
-        typeof parsed.format === 'string' &&
-        original.format === parsed.format &&
-        ELICITATION_STRING_FORMATS.has(parsed.format)
-    );
-}
-
-function findStrippedJsonSchemaPaths(original: unknown, parsed: unknown, path = ''): string[] {
-    if (Array.isArray(original) && Array.isArray(parsed)) {
-        return original.flatMap((item, index) => findStrippedJsonSchemaPaths(item, parsed[index], `${path}[${index}]`));
-    }
-
-    if (!isJsonObject(original) || !isJsonObject(parsed)) {
-        return [];
-    }
-
-    return Object.entries(original).flatMap(([key, value]) => {
-        const childPath = path ? `${path}.${key}` : key;
-        if (!Object.prototype.hasOwnProperty.call(parsed, key)) {
-            if (isSupportedFormatPattern(original, parsed, key)) {
-                return [];
-            }
-            return [childPath];
-        }
-        return findStrippedJsonSchemaPaths(value, parsed[key], childPath);
-    });
 }
 
 /**
@@ -1225,7 +1186,7 @@ export class Server extends Protocol<ServerContext> {
                 return this.request({ method: 'elicitation/create', params: urlParams }, options);
             }
             case 'form': {
-                const { params: formParams, standardSchema } = this.normalizeElicitInputFormParams(
+                const { params: formParams, standardSchema } = normalizeElicitInputFormParams(
                     params as ElicitRequestFormParams | ElicitInputFormParams<StandardSchemaWithJSON>
                 );
 
@@ -1266,47 +1227,6 @@ export class Server extends Protocol<ServerContext> {
                 return result;
             }
         }
-    }
-
-    private normalizeElicitInputFormParams(params: ElicitRequestFormParams | ElicitInputFormParams<StandardSchemaWithJSON>): {
-        params: ElicitRequestFormParams;
-        standardSchema?: StandardSchemaWithJSON;
-    } {
-        const formParams =
-            params.mode === 'form'
-                ? (params as ElicitRequestFormParams)
-                : { ...(params as ElicitRequestFormParams), mode: 'form' as const };
-
-        if (this.isElicitInputSchema(formParams.requestedSchema)) {
-            const standardSchema = formParams.requestedSchema;
-            const normalizedParams = {
-                ...formParams,
-                requestedSchema: standardSchemaToJsonSchema(standardSchema, 'input')
-            };
-            const parsedParams = parseSchema(ElicitRequestFormParamsSchema, normalizedParams);
-            if (!parsedParams.success) {
-                throw new ProtocolError(
-                    ProtocolErrorCode.InvalidParams,
-                    `Elicitation requestedSchema only supports flat primitive properties (string, number, integer, boolean, and string enums): ${parsedParams.error.message}`
-                );
-            }
-            const strippedSchemaPaths = findStrippedJsonSchemaPaths(normalizedParams.requestedSchema, parsedParams.data.requestedSchema);
-            if (strippedSchemaPaths.length > 0) {
-                throw new ProtocolError(
-                    ProtocolErrorCode.InvalidParams,
-                    `Elicitation requestedSchema contains unsupported JSON Schema keyword(s) after Standard Schema conversion: ${strippedSchemaPaths.join(', ')}`
-                );
-            }
-            return { params: parsedParams.data, standardSchema };
-        }
-
-        return { params: formParams };
-    }
-
-    private isElicitInputSchema(
-        schema: ElicitRequestFormParams['requestedSchema'] | StandardSchemaWithJSON
-    ): schema is StandardSchemaWithJSON {
-        return typeof schema === 'object' && schema !== null && '~standard' in schema;
     }
 
     /**

--- a/packages/server/src/server/server.ts
+++ b/packages/server/src/server/server.ts
@@ -248,6 +248,19 @@ function isJsonObject(value: unknown): value is Record<string, unknown> {
     return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
+const ELICITATION_STRING_FORMATS = new Set(['email', 'uri', 'date', 'date-time']);
+
+function isSupportedFormatPattern(original: Record<string, unknown>, parsed: Record<string, unknown>, key: string): boolean {
+    return (
+        key === 'pattern' &&
+        typeof original.pattern === 'string' &&
+        parsed.type === 'string' &&
+        typeof parsed.format === 'string' &&
+        original.format === parsed.format &&
+        ELICITATION_STRING_FORMATS.has(parsed.format)
+    );
+}
+
 function findStrippedJsonSchemaPaths(original: unknown, parsed: unknown, path = ''): string[] {
     if (Array.isArray(original) && Array.isArray(parsed)) {
         return original.flatMap((item, index) => findStrippedJsonSchemaPaths(item, parsed[index], `${path}[${index}]`));
@@ -260,6 +273,9 @@ function findStrippedJsonSchemaPaths(original: unknown, parsed: unknown, path = 
     return Object.entries(original).flatMap(([key, value]) => {
         const childPath = path ? `${path}.${key}` : key;
         if (!Object.prototype.hasOwnProperty.call(parsed, key)) {
+            if (isSupportedFormatPattern(original, parsed, key)) {
+                return [];
+            }
             return [childPath];
         }
         return findStrippedJsonSchemaPaths(value, parsed[key], childPath);

--- a/packages/server/src/server/server.ts
+++ b/packages/server/src/server/server.ts
@@ -405,7 +405,7 @@ export class Server extends Protocol<ServerContext> {
                     // session-wide stream to deliver it on.
                     return ctx.mcpReq.notify({ method: 'notifications/message', params: { level, data, logger } });
                 },
-                elicitInput: (params, options) => this.elicitInput(params, options),
+                elicitInput: this.elicitInput.bind(this) as ServerContext['mcpReq']['elicitInput'],
                 requestSampling: (params, options) => this.createMessage(params, options)
             },
             http: hasHttpInfo
@@ -1174,7 +1174,7 @@ export class Server extends Protocol<ServerContext> {
         params: ElicitRequestFormParams | ElicitRequestURLParams | ElicitInputFormParams<StandardSchemaWithJSON>,
         options?: RequestOptions,
         behavior?: { validateAcceptedContent: boolean }
-    ): Promise<ElicitResult> {
+    ): Promise<ElicitResult | ElicitInputResult<StandardSchemaWithJSON>> {
         const mode = (params.mode ?? 'form') as 'form' | 'url';
         const validateAcceptedContent = behavior?.validateAcceptedContent ?? true;
 

--- a/packages/server/src/server/server.ts
+++ b/packages/server/src/server/server.ts
@@ -51,6 +51,7 @@ import {
     legacyProtocolVersions,
     LOG_LEVEL_META_KEY,
     LoggingLevelSchema,
+    ElicitRequestFormParamsSchema,
     mergeCapabilities,
     missingClientCapabilities,
     MissingRequiredClientCapabilityError,
@@ -62,6 +63,7 @@ import {
     SdkError,
     SdkErrorCode,
     standardSchemaToJsonSchema,
+    validateStandardSchema,
     withRequestStateValue
 } from '@modelcontextprotocol/core-internal';
 import { DefaultJsonSchemaValidator } from '@modelcontextprotocol/server/_shims';
@@ -1185,31 +1187,42 @@ export class Server extends Protocol<ServerContext> {
                 return this.request({ method: 'elicitation/create', params: urlParams }, options);
             }
             case 'form': {
-                const formParams = this.normalizeElicitInputFormParams(
+                const { params: formParams, standardSchema } = this.normalizeElicitInputFormParams(
                     params as ElicitRequestFormParams | ElicitInputFormParams<StandardSchemaWithJSON>
                 );
 
                 const result = await this.request({ method: 'elicitation/create', params: formParams }, options);
 
-                if (validateAcceptedContent && result.action === 'accept' && result.content && formParams.requestedSchema) {
-                    try {
-                        const validator = this._jsonSchemaValidator.getValidator(formParams.requestedSchema as JsonSchemaType);
-                        const validationResult = validator(result.content);
-
-                        if (!validationResult.valid) {
+                if (validateAcceptedContent && result.action === 'accept' && result.content !== undefined && formParams.requestedSchema) {
+                    if (standardSchema) {
+                        const parsedContent = await validateStandardSchema(standardSchema, result.content);
+                        if (!parsedContent.success) {
                             throw new ProtocolError(
                                 ProtocolErrorCode.InvalidParams,
-                                `Elicitation response content does not match requested schema: ${validationResult.errorMessage}`
+                                `Elicitation response content does not match requested schema: ${parsedContent.error}`
                             );
                         }
-                    } catch (error) {
-                        if (error instanceof ProtocolError) {
-                            throw error;
+                        return { ...result, content: parsedContent.data };
+                    } else {
+                        try {
+                            const validator = this._jsonSchemaValidator.getValidator(formParams.requestedSchema as JsonSchemaType);
+                            const validationResult = validator(result.content);
+
+                            if (!validationResult.valid) {
+                                throw new ProtocolError(
+                                    ProtocolErrorCode.InvalidParams,
+                                    `Elicitation response content does not match requested schema: ${validationResult.errorMessage}`
+                                );
+                            }
+                        } catch (error) {
+                            if (error instanceof ProtocolError) {
+                                throw error;
+                            }
+                            throw new ProtocolError(
+                                ProtocolErrorCode.InternalError,
+                                `Error validating elicitation response: ${error instanceof Error ? error.message : String(error)}`
+                            );
                         }
-                        throw new ProtocolError(
-                            ProtocolErrorCode.InternalError,
-                            `Error validating elicitation response: ${error instanceof Error ? error.message : String(error)}`
-                        );
                     }
                 }
                 return result;
@@ -1217,25 +1230,32 @@ export class Server extends Protocol<ServerContext> {
         }
     }
 
-    private normalizeElicitInputFormParams(
-        params: ElicitRequestFormParams | ElicitInputFormParams<StandardSchemaWithJSON>
-    ): ElicitRequestFormParams {
+    private normalizeElicitInputFormParams(params: ElicitRequestFormParams | ElicitInputFormParams<StandardSchemaWithJSON>): {
+        params: ElicitRequestFormParams;
+        standardSchema?: StandardSchemaWithJSON;
+    } {
         const formParams =
             params.mode === 'form'
                 ? (params as ElicitRequestFormParams)
                 : { ...(params as ElicitRequestFormParams), mode: 'form' as const };
 
         if (this.isElicitInputSchema(formParams.requestedSchema)) {
-            return {
+            const standardSchema = formParams.requestedSchema;
+            const normalizedParams = {
                 ...formParams,
-                requestedSchema: standardSchemaToJsonSchema(
-                    formParams.requestedSchema,
-                    'input'
-                ) as ElicitRequestFormParams['requestedSchema']
+                requestedSchema: standardSchemaToJsonSchema(standardSchema, 'input')
             };
+            const parsedParams = parseSchema(ElicitRequestFormParamsSchema, normalizedParams);
+            if (!parsedParams.success) {
+                throw new ProtocolError(
+                    ProtocolErrorCode.InvalidParams,
+                    'Elicitation requestedSchema only supports flat primitive properties (string, number, integer, boolean, and string enums).'
+                );
+            }
+            return { params: parsedParams.data, standardSchema };
         }
 
-        return formParams;
+        return { params: formParams };
     }
 
     private isElicitInputSchema(

--- a/packages/server/src/server/server.ts
+++ b/packages/server/src/server/server.ts
@@ -244,6 +244,28 @@ export function installModernOnlyHandlers(server: Server, servedModernVersions: 
     installDiscoverHandler(server, servedModernVersions);
 }
 
+function isJsonObject(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function findStrippedJsonSchemaPaths(original: unknown, parsed: unknown, path = ''): string[] {
+    if (Array.isArray(original) && Array.isArray(parsed)) {
+        return original.flatMap((item, index) => findStrippedJsonSchemaPaths(item, parsed[index], `${path}[${index}]`));
+    }
+
+    if (!isJsonObject(original) || !isJsonObject(parsed)) {
+        return [];
+    }
+
+    return Object.entries(original).flatMap(([key, value]) => {
+        const childPath = path ? `${path}.${key}` : key;
+        if (!Object.prototype.hasOwnProperty.call(parsed, key)) {
+            return [childPath];
+        }
+        return findStrippedJsonSchemaPaths(value, parsed[key], childPath);
+    });
+}
+
 /**
  * An MCP server on top of a pluggable transport.
  *
@@ -1250,6 +1272,13 @@ export class Server extends Protocol<ServerContext> {
                 throw new ProtocolError(
                     ProtocolErrorCode.InvalidParams,
                     `Elicitation requestedSchema only supports flat primitive properties (string, number, integer, boolean, and string enums): ${parsedParams.error.message}`
+                );
+            }
+            const strippedSchemaPaths = findStrippedJsonSchemaPaths(normalizedParams.requestedSchema, parsedParams.data.requestedSchema);
+            if (strippedSchemaPaths.length > 0) {
+                throw new ProtocolError(
+                    ProtocolErrorCode.InvalidParams,
+                    `Elicitation requestedSchema contains unsupported JSON Schema keyword(s) after Standard Schema conversion: ${strippedSchemaPaths.join(', ')}`
                 );
             }
             return { params: parsedParams.data, standardSchema };

--- a/packages/server/test/server/jsonSchemaValidatorOverride.test.ts
+++ b/packages/server/test/server/jsonSchemaValidatorOverride.test.ts
@@ -210,6 +210,16 @@ describe('server JSON Schema validator overrides', () => {
         ).rejects.toThrow(/flat primitive properties/);
         expect(sawElicitationRequest).toBe(false);
 
+        await expect(
+            server.elicitInput({
+                message: 'What is your ID?',
+                requestedSchema: z.object({
+                    id: z.string().uuid()
+                })
+            })
+        ).rejects.toThrow(/format/);
+        expect(sawElicitationRequest).toBe(false);
+
         await server.close();
         await clientTransport.close();
     });

--- a/packages/server/test/server/jsonSchemaValidatorOverride.test.ts
+++ b/packages/server/test/server/jsonSchemaValidatorOverride.test.ts
@@ -135,7 +135,7 @@ describe('server JSON Schema validator overrides', () => {
 
         const schema = z.object({
             count: z.coerce.number().min(1).meta({ title: 'Registration Count', description: 'Number of registrations to process' }),
-            email: z.string().email().meta({ title: 'Email', description: 'Email address' }),
+            email: z.email().meta({ title: 'Email', description: 'Email address' }),
             startsAt: z.iso.datetime({ offset: true }).meta({ title: 'Start Time' }),
             newsletter: z.boolean().default(false)
         });

--- a/packages/server/test/server/jsonSchemaValidatorOverride.test.ts
+++ b/packages/server/test/server/jsonSchemaValidatorOverride.test.ts
@@ -1,5 +1,7 @@
 import type { JsonSchemaType, JsonSchemaValidatorResult, jsonSchemaValidator } from '@modelcontextprotocol/core-internal';
 import { InMemoryTransport, LATEST_PROTOCOL_VERSION } from '@modelcontextprotocol/core-internal';
+import { expectTypeOf } from 'vitest';
+import * as z from 'zod/v4';
 import { fromJsonSchema } from '../../src/fromJsonSchema';
 import { Server } from '../../src/server/server';
 
@@ -75,6 +77,74 @@ describe('server JSON Schema validator overrides', () => {
             }
         ]);
         expect(validator.values).toEqual([{ name: 123 }]);
+
+        await server.close();
+        await clientTransport.close();
+    });
+
+    test('Server elicitInput accepts a Standard Schema requestedSchema', async () => {
+        const validator = new RecordingValidator();
+        const server = new Server(
+            { name: 'test-server', version: '1.0.0' },
+            {
+                capabilities: {},
+                jsonSchemaValidator: validator
+            }
+        );
+
+        const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+        await server.connect(serverTransport);
+        await clientTransport.start();
+
+        const initializeResponse = new Promise(resolve => {
+            clientTransport.onmessage = message => resolve(message);
+        });
+        await clientTransport.send({
+            jsonrpc: '2.0',
+            id: 1,
+            method: 'initialize',
+            params: {
+                protocolVersion: LATEST_PROTOCOL_VERSION,
+                capabilities: { elicitation: { form: {} } },
+                clientInfo: { name: 'test-client', version: '1.0.0' }
+            }
+        });
+        await initializeResponse;
+
+        let requestedSchema: JsonSchemaType | undefined;
+        clientTransport.onmessage = async message => {
+            if ('method' in message && 'id' in message && message.method === 'elicitation/create' && message.params) {
+                requestedSchema = message.params.requestedSchema as JsonSchemaType;
+                await clientTransport.send({
+                    jsonrpc: '2.0',
+                    id: message.id,
+                    result: { action: 'accept', content: { name: 'Ada Lovelace' } }
+                });
+            }
+        };
+
+        const schema = z.object({
+            name: z.string().describe('Full name'),
+            subscribe: z.boolean().optional()
+        });
+
+        const result = await server.elicitInput({
+            message: 'What is your name?',
+            requestedSchema: schema
+        });
+
+        expectTypeOf(result.content).toEqualTypeOf<{ name: string; subscribe?: boolean | undefined } | undefined>();
+        expect(result).toEqual({ action: 'accept', content: { name: 'Ada Lovelace' } });
+        expect(requestedSchema).toMatchObject({
+            type: 'object',
+            properties: {
+                name: { type: 'string', description: 'Full name' },
+                subscribe: { type: 'boolean' }
+            },
+            required: ['name']
+        });
+        expect(validator.schemas).toEqual([requestedSchema]);
+        expect(validator.values).toEqual([{ name: 'Ada Lovelace' }]);
 
         await server.close();
         await clientTransport.close();

--- a/packages/server/test/server/jsonSchemaValidatorOverride.test.ts
+++ b/packages/server/test/server/jsonSchemaValidatorOverride.test.ts
@@ -124,13 +124,14 @@ describe('server JSON Schema validator overrides', () => {
                 await clientTransport.send({
                     jsonrpc: '2.0',
                     id: message.id,
-                    result: { action: 'accept', content: { count: '5' } }
+                    result: { action: 'accept', content: { count: '5', email: 'user@example.com' } }
                 });
             }
         };
 
         const schema = z.object({
             count: z.coerce.number().min(1).meta({ title: 'Registration Count', description: 'Number of registrations to process' }),
+            email: z.string().email().meta({ title: 'Email', description: 'Email address' }),
             newsletter: z.boolean().default(false)
         });
 
@@ -142,8 +143,8 @@ describe('server JSON Schema validator overrides', () => {
         const result = await server.elicitInput(params);
 
         expectTypeOf(result).toMatchTypeOf<ElicitInputResult<typeof schema>>();
-        expectTypeOf(result.content).toEqualTypeOf<{ count: number; newsletter: boolean } | undefined>();
-        expect(result).toEqual({ action: 'accept', content: { count: 5, newsletter: false } });
+        expectTypeOf(result.content).toEqualTypeOf<{ count: number; email: string; newsletter: boolean } | undefined>();
+        expect(result).toEqual({ action: 'accept', content: { count: 5, email: 'user@example.com', newsletter: false } });
         expect(requestedSchema).toMatchObject({
             type: 'object',
             properties: {
@@ -153,10 +154,18 @@ describe('server JSON Schema validator overrides', () => {
                     title: 'Registration Count',
                     description: 'Number of registrations to process'
                 },
+                email: {
+                    type: 'string',
+                    format: 'email',
+                    title: 'Email',
+                    description: 'Email address'
+                },
                 newsletter: { type: 'boolean', default: false }
             },
-            required: ['count']
+            required: ['count', 'email']
         });
+        const emailSchema = (requestedSchema!.properties as Record<string, Record<string, unknown>>).email!;
+        expect(emailSchema.pattern).toBeUndefined();
         expect(validator.schemas).toEqual([]);
         expect(validator.values).toEqual([]);
 

--- a/packages/server/test/server/jsonSchemaValidatorOverride.test.ts
+++ b/packages/server/test/server/jsonSchemaValidatorOverride.test.ts
@@ -220,6 +220,36 @@ describe('server JSON Schema validator overrides', () => {
         ).rejects.toThrow(/format/);
         expect(sawElicitationRequest).toBe(false);
 
+        await expect(
+            server.elicitInput({
+                message: 'What is your code?',
+                requestedSchema: z.object({
+                    code: z.string().regex(/^[A-Z]{3}$/)
+                })
+            })
+        ).rejects.toThrow(/properties\.code\.pattern/);
+        expect(sawElicitationRequest).toBe(false);
+
+        await expect(
+            server.elicitInput({
+                message: 'How many?',
+                requestedSchema: z.object({
+                    count: z.number().multipleOf(2)
+                })
+            })
+        ).rejects.toThrow(/properties\.count\.multipleOf/);
+        expect(sawElicitationRequest).toBe(false);
+
+        await expect(
+            server.elicitInput({
+                message: 'How many?',
+                requestedSchema: z.object({
+                    count: z.number().gt(0)
+                })
+            })
+        ).rejects.toThrow(/properties\.count\.exclusiveMinimum/);
+        expect(sawElicitationRequest).toBe(false);
+
         await server.close();
         await clientTransport.close();
     });

--- a/packages/server/test/server/jsonSchemaValidatorOverride.test.ts
+++ b/packages/server/test/server/jsonSchemaValidatorOverride.test.ts
@@ -6,6 +6,7 @@ import type {
     ElicitInputResult,
     JsonSchemaType,
     JsonSchemaValidatorResult,
+    StandardSchemaWithJSON,
     jsonSchemaValidator
 } from '../../src/index';
 import { fromJsonSchema } from '../../src/fromJsonSchema';
@@ -124,7 +125,10 @@ describe('server JSON Schema validator overrides', () => {
                 await clientTransport.send({
                     jsonrpc: '2.0',
                     id: message.id,
-                    result: { action: 'accept', content: { count: '5', email: 'user@example.com' } }
+                    result: {
+                        action: 'accept',
+                        content: { count: '5', email: 'user@example.com', startsAt: '2026-01-02T03:04:05+01:00' }
+                    }
                 });
             }
         };
@@ -132,6 +136,7 @@ describe('server JSON Schema validator overrides', () => {
         const schema = z.object({
             count: z.coerce.number().min(1).meta({ title: 'Registration Count', description: 'Number of registrations to process' }),
             email: z.string().email().meta({ title: 'Email', description: 'Email address' }),
+            startsAt: z.iso.datetime({ offset: true }).meta({ title: 'Start Time' }),
             newsletter: z.boolean().default(false)
         });
 
@@ -143,8 +148,11 @@ describe('server JSON Schema validator overrides', () => {
         const result = await server.elicitInput(params);
 
         expectTypeOf(result).toMatchTypeOf<ElicitInputResult<typeof schema>>();
-        expectTypeOf(result.content).toEqualTypeOf<{ count: number; email: string; newsletter: boolean } | undefined>();
-        expect(result).toEqual({ action: 'accept', content: { count: 5, email: 'user@example.com', newsletter: false } });
+        expectTypeOf(result.content).toEqualTypeOf<{ count: number; email: string; startsAt: string; newsletter: boolean } | undefined>();
+        expect(result).toEqual({
+            action: 'accept',
+            content: { count: 5, email: 'user@example.com', startsAt: '2026-01-02T03:04:05+01:00', newsletter: false }
+        });
         expect(requestedSchema).toMatchObject({
             type: 'object',
             properties: {
@@ -160,12 +168,19 @@ describe('server JSON Schema validator overrides', () => {
                     title: 'Email',
                     description: 'Email address'
                 },
+                startsAt: {
+                    type: 'string',
+                    format: 'date-time',
+                    title: 'Start Time'
+                },
                 newsletter: { type: 'boolean', default: false }
             },
-            required: ['count', 'email']
+            required: ['count', 'email', 'startsAt']
         });
         const emailSchema = (requestedSchema!.properties as Record<string, Record<string, unknown>>).email!;
         expect(emailSchema.pattern).toBeUndefined();
+        const startsAtSchema = (requestedSchema!.properties as Record<string, Record<string, unknown>>).startsAt!;
+        expect(startsAtSchema.pattern).toBeUndefined();
         expect(validator.schemas).toEqual([]);
         expect(validator.values).toEqual([]);
 
@@ -247,6 +262,36 @@ describe('server JSON Schema validator overrides', () => {
                 })
             })
         ).rejects.toThrow(/properties\.email\.pattern/);
+        expect(sawElicitationRequest).toBe(false);
+
+        const customDateTimePatternSchema = {
+            '~standard': {
+                version: 1,
+                vendor: 'test',
+                validate: (value: unknown) => ({ value }),
+                jsonSchema: {
+                    input: () => ({
+                        type: 'object',
+                        properties: {
+                            startsAt: {
+                                type: 'string',
+                                format: 'date-time',
+                                pattern: '2026'
+                            }
+                        },
+                        required: ['startsAt']
+                    }),
+                    output: () => ({})
+                }
+            }
+        } satisfies StandardSchemaWithJSON;
+
+        await expect(
+            server.elicitInput({
+                message: 'When should we start?',
+                requestedSchema: customDateTimePatternSchema
+            })
+        ).rejects.toThrow(/properties\.startsAt\.pattern/);
         expect(sawElicitationRequest).toBe(false);
 
         await expect(

--- a/packages/server/test/server/jsonSchemaValidatorOverride.test.ts
+++ b/packages/server/test/server/jsonSchemaValidatorOverride.test.ts
@@ -130,7 +130,7 @@ describe('server JSON Schema validator overrides', () => {
         };
 
         const schema = z.object({
-            count: z.coerce.number().min(1),
+            count: z.coerce.number().min(1).meta({ title: 'Registration Count', description: 'Number of registrations to process' }),
             newsletter: z.boolean().default(false)
         });
 
@@ -147,7 +147,12 @@ describe('server JSON Schema validator overrides', () => {
         expect(requestedSchema).toMatchObject({
             type: 'object',
             properties: {
-                count: { type: 'number', minimum: 1 },
+                count: {
+                    type: 'number',
+                    minimum: 1,
+                    title: 'Registration Count',
+                    description: 'Number of registrations to process'
+                },
                 newsletter: { type: 'boolean', default: false }
             },
             required: ['count']

--- a/packages/server/test/server/jsonSchemaValidatorOverride.test.ts
+++ b/packages/server/test/server/jsonSchemaValidatorOverride.test.ts
@@ -1,7 +1,13 @@
-import type { JsonSchemaType, JsonSchemaValidatorResult, jsonSchemaValidator } from '@modelcontextprotocol/core-internal';
 import { InMemoryTransport, LATEST_PROTOCOL_VERSION } from '@modelcontextprotocol/core-internal';
 import { expectTypeOf } from 'vitest';
 import * as z from 'zod/v4';
+import type {
+    ElicitInputFormParams,
+    ElicitInputResult,
+    JsonSchemaType,
+    JsonSchemaValidatorResult,
+    jsonSchemaValidator
+} from '../../src/index';
 import { fromJsonSchema } from '../../src/fromJsonSchema';
 import { Server } from '../../src/server/server';
 
@@ -118,33 +124,86 @@ describe('server JSON Schema validator overrides', () => {
                 await clientTransport.send({
                     jsonrpc: '2.0',
                     id: message.id,
-                    result: { action: 'accept', content: { name: 'Ada Lovelace' } }
+                    result: { action: 'accept', content: { count: '5' } }
                 });
             }
         };
 
         const schema = z.object({
-            name: z.string().describe('Full name'),
-            subscribe: z.boolean().optional()
+            count: z.coerce.number().min(1),
+            newsletter: z.boolean().default(false)
         });
 
-        const result = await server.elicitInput({
-            message: 'What is your name?',
+        const params = {
+            message: 'How many registrations?',
             requestedSchema: schema
-        });
+        } satisfies ElicitInputFormParams<typeof schema>;
 
-        expectTypeOf(result.content).toEqualTypeOf<{ name: string; subscribe?: boolean | undefined } | undefined>();
-        expect(result).toEqual({ action: 'accept', content: { name: 'Ada Lovelace' } });
+        const result = await server.elicitInput(params);
+
+        expectTypeOf(result).toMatchTypeOf<ElicitInputResult<typeof schema>>();
+        expectTypeOf(result.content).toEqualTypeOf<{ count: number; newsletter: boolean } | undefined>();
+        expect(result).toEqual({ action: 'accept', content: { count: 5, newsletter: false } });
         expect(requestedSchema).toMatchObject({
             type: 'object',
             properties: {
-                name: { type: 'string', description: 'Full name' },
-                subscribe: { type: 'boolean' }
+                count: { type: 'number', minimum: 1 },
+                newsletter: { type: 'boolean', default: false }
             },
-            required: ['name']
+            required: ['count']
         });
-        expect(validator.schemas).toEqual([requestedSchema]);
-        expect(validator.values).toEqual([{ name: 'Ada Lovelace' }]);
+        expect(validator.schemas).toEqual([]);
+        expect(validator.values).toEqual([]);
+
+        await server.close();
+        await clientTransport.close();
+    });
+
+    test('Server elicitInput rejects Standard Schemas outside the elicitation subset before sending', async () => {
+        const server = new Server({ name: 'test-server', version: '1.0.0' }, { capabilities: {} });
+
+        const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+        await server.connect(serverTransport);
+        await clientTransport.start();
+
+        const initializeResponse = new Promise(resolve => {
+            clientTransport.onmessage = message => resolve(message);
+        });
+        await clientTransport.send({
+            jsonrpc: '2.0',
+            id: 1,
+            method: 'initialize',
+            params: {
+                protocolVersion: LATEST_PROTOCOL_VERSION,
+                capabilities: { elicitation: { form: {} } },
+                clientInfo: { name: 'test-client', version: '1.0.0' }
+            }
+        });
+        await initializeResponse;
+
+        let sawElicitationRequest = false;
+        clientTransport.onmessage = async message => {
+            if ('method' in message && 'id' in message && message.method === 'elicitation/create') {
+                sawElicitationRequest = true;
+                await clientTransport.send({
+                    jsonrpc: '2.0',
+                    id: message.id,
+                    result: { action: 'decline' }
+                });
+            }
+        };
+
+        await expect(
+            server.elicitInput({
+                message: 'Where should we ship it?',
+                requestedSchema: z.object({
+                    address: z.object({
+                        city: z.string()
+                    })
+                })
+            })
+        ).rejects.toThrow(/flat primitive properties/);
+        expect(sawElicitationRequest).toBe(false);
 
         await server.close();
         await clientTransport.close();

--- a/packages/server/test/server/jsonSchemaValidatorOverride.test.ts
+++ b/packages/server/test/server/jsonSchemaValidatorOverride.test.ts
@@ -241,6 +241,16 @@ describe('server JSON Schema validator overrides', () => {
 
         await expect(
             server.elicitInput({
+                message: 'What is your email?',
+                requestedSchema: z.object({
+                    email: z.email({ pattern: /@corp\.com$/ })
+                })
+            })
+        ).rejects.toThrow(/properties\.email\.pattern/);
+        expect(sawElicitationRequest).toBe(false);
+
+        await expect(
+            server.elicitInput({
                 message: 'How many?',
                 requestedSchema: z.object({
                     count: z.number().multipleOf(2)

--- a/packages/server/test/server/jsonSchemaValidatorOverride.test.ts
+++ b/packages/server/test/server/jsonSchemaValidatorOverride.test.ts
@@ -306,6 +306,16 @@ describe('server JSON Schema validator overrides', () => {
 
         await expect(
             server.elicitInput({
+                message: 'What is your name?',
+                requestedSchema: z.strictObject({
+                    name: z.string()
+                })
+            })
+        ).rejects.toThrow(/unsupported JSON Schema keyword\(s\).*additionalProperties/);
+        expect(sawElicitationRequest).toBe(false);
+
+        await expect(
+            server.elicitInput({
                 message: 'How many?',
                 requestedSchema: z.object({
                     count: z.number().gt(0)


### PR DESCRIPTION

Follow-up hardening for the Standard Schema elicitation support — four contained fixes, sent as a PR onto your branch so you can review and merge it into #2369 directly. No changes to the API shape or the overall design, which look right.

## Motivation and Context

**1. Unknown root-level keywords passed the flat-primitive gate onto the wire.**
The gate works by parsing with `ElicitRequestFormParamsSchema` and diffing for stripped keys — but that schema's `requestedSchema` root is `.catchall(z.unknown())`, so unknown root keys are never stripped and the diff can't fire for them. Concretely, `z.strictObject(...)` shipped `additionalProperties: false` in the outgoing request, `.catchall(z.object(...))` shipped a nested schema, and a custom Standard Schema could ship `$defs`. The spec declares a closed root shape for `requestedSchema` (`$schema`/`type`/`properties`/`required`), so the fix whitelists the root after conversion — the keyword set is derived from the wire schema so it tracks spec revisions, `$schema` stays (it's spec-declared and zod emits it on every conversion), annotation-only root keywords (`title`/`description` from `.meta()`) are dropped, and anything else throws the existing "unsupported JSON Schema keyword(s)" error before sending.

One deliberate trade-off to flag: root `title`/`description` are now silently dropped rather than sent or rejected — the spec root shape doesn't declare them, so forwarding risks strict-client rejections, and throwing on `.describe()` felt hostile. Happy to change that if you see it differently.

**2. The vendored zod regexes were a time bomb against the `^4.2.0` peer range.**
`ZOD_ISO_DATE_PATTERN` and friends were byte-copies of what one zod version emits. zod is a peer at `^4.2.0`: if a future in-range zod tweaked any of those regexes, previously-working `z.email()` / `z.iso.datetime()` elicitations would start throwing at user runtime while lockfile-pinned CI stayed green. The reference patterns are now derived from the installed zod at runtime (`z.toJSONSchema(z.email(), ...)` etc., with the date-time option space enumerated from the pattern under test), so the converter and the reference can't drift apart. Behavior is unchanged — I checked the new derivation against the old matcher's full accepted set under zod 4.3.6 and they're equivalent in both directions, and your customized-pattern rejection tests (`z.email({ pattern })`, the hand-built date-time case) pass untouched.

Residual limitation worth knowing: if an app resolves *two* zod copies whose regexes differ, the mismatch rejects (fail closed). That's much rarer than the single-copy upgrade the vendored approach broke on, and zod being a peer dep is exactly what makes installs dedupe.

**3. Function-typed Standard Schemas (ArkType) were misrouted past conversion.**
The schema-detection guard required `typeof schema === 'object'`, but ArkType schemas are functions — they satisfied the typed overload, then fell through to the raw branch: no conversion, no flat-primitive gate, and the arktype-internal object shipped as `requestedSchema`. The guard now delegates to `isStandardSchema`, which accepts functions and actually verifies `~standard.validate` (and is the guard `normalizeRawShapeSchema` already uses for this routing decision — gating on `~standard.jsonSchema` would front-run the zod 4.0/4.1 fallback). This also fixes the reverse misroute: a plain JSON `requestedSchema` containing a literal `"~standard"` key — wire-legal via the catchall — was routed into conversion and threw; it now stays on the raw branch.

**4. `inputRequired.elicit` now throws `TypeError` on unsupported schemas.**
`inputRequired()` throws `TypeError` for authoring mistakes, but `elicit` with an unsupported schema threw `ProtocolError(InvalidParams)` — inside a `prompts/get` or `resources/read` handler that reaches the client as `-32602` on *its own* request, when the defect is server-side. The builder now rewraps as `TypeError` (with the original error as `cause`). `elicitInput` keeps throwing `ProtocolError`, where it maps to the outgoing request.

## How Has This Been Tested?

- New `packages/core-internal/test/shared/elicitation.test.ts` unit-testing `normalizeElicitInputFormParams` directly: root-keyword rejections (`strictObject`, `looseObject`, `catchall`, root `default`, `$defs`), `$schema`/annotation handling, the format acceptance matrix (`z.email()`, `z.url()`, `z.iso.date()`, all `z.iso.datetime` variants incl. precision −1/0/3), customized-pattern rejections, an installed-zod equivalence case, and the schema-detection cases (function-typed schema converts; literal `"~standard"` key stays raw).
- A server-level `strictObject` case asserting the request throws before anything reaches the client.
- Existing suites pass unmodified except the two builder tests updated for the `TypeError` contract (1,328 core-internal + 381 server tests green).
- Manually drove a real `Server` over `InMemoryTransport` through the public package exports: observed the wire `requestedSchema` (formats kept, no patterns, clean root; a function schema converts rather than shipping vendor internals), the typed/coerced result, pre-send rejections, and the builder error type.

## Breaking Changes

None released — this adjusts behavior introduced on this branch. Two in-branch behavior changes: schemas emitting unknown root keywords now reject instead of leaking them onto the wire, and `inputRequired.elicit` authoring errors are `TypeError` instead of `ProtocolError`. The changeset is updated to describe the root handling.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

The root-keyword set is derived from `ElicitRequestFormParamsSchema`'s declared shape plus `$schema`, so a future spec revision that adds a root key only needs the schema change. One behavior note on the guard fix: an object carrying a `~standard` key that is *not* a valid Standard Schema (no `validate` function) now passes through the raw branch onto the wire instead of throwing a vendor error — matching how the same object behaves without this feature. Not touched here (can follow up separately): JSDoc for the new public types/overloads, enum and response-failure test coverage, and the response-validation asymmetry between `elicitInput` and `inputRequired.elicit` + `acceptedContent`.
