### PR TITLE
Fix import ordering in client auth

### DIFF
--- a/packages/client/src/client/auth.ts
+++ b/packages/client/src/client/auth.ts
@@ -15,7 +15,6 @@ import type {
 import {
     brandedHasInstance,
     checkResourceAllowed,
-    stampErrorBrands,
     LATEST_PROTOCOL_VERSION,
     OAuthClientInformationFullSchema,
     OAuthError,
@@ -25,7 +24,8 @@ import {
     OAuthProtectedResourceMetadataSchema,
     OAuthTokensSchema,
     OpenIdProviderDiscoveryMetadataSchema,
-    resourceUrlFromServerUrl
+    resourceUrlFromServerUrl,
+    stampErrorBrands
 } from '@modelcontextprotocol/core-internal';
 import pkceChallenge from 'pkce-challenge';
 


### PR DESCRIPTION
Lint autofix: `stampErrorBrands` sits out of order in the `client/auth.ts` import list. #2384 and #2422 each passed CI individually, but their combination trips `simple-import-sort` on main — any freshly-branched PR now inherits the warning. Two-line reorder, no behavior change.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally