### PR TITLE
feat(examples): deploy todos-server to Cloudflare Workers with OAuth and a live board

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ results/
 
 # Ignore local lefthook configuration
 lefthook-local.yml
+
+# Wrangler local dev cache (examples/todos-server worker entry)
+.wrangler/

--- a/.prettierignore
+++ b/.prettierignore
@@ -28,3 +28,4 @@ packages/codemod/batch-test/results
 # Quickstart examples uses 2-space indent to match ecosystem conventions
 examples/client-quickstart/
 examples/server-quickstart/
+.wrangler/

--- a/docs/.vitepress/nav.ts
+++ b/docs/.vitepress/nav.ts
@@ -42,6 +42,7 @@ export const guideSidebar: DefaultTheme.SidebarItem[] = [
             { text: 'Web-standard runtimes', link: '/serving/web-standard' },
             { text: 'Sessions, state, scaling', link: '/serving/sessions-state-scaling' },
             { text: 'Authorization', link: '/serving/authorization' },
+            { text: 'External authorization servers', link: '/serving/external-authorization-servers' },
             { text: 'Legacy clients', link: '/serving/legacy-clients' }
         ]
     },

--- a/docs/serving/authorization.md
+++ b/docs/serving/authorization.md
@@ -5,7 +5,7 @@ description: 'Require a bearer token on a server you run: verification, protecte
 
 # Require authorization
 
-Protecting a server you run → this page. Signing a user in from a client you build → [Authenticate a user with OAuth](../clients/oauth.md). No user present → [Authenticate without a user](../clients/machine-auth.md).
+Protecting a server you run → this page. Where the Authorization Server itself comes from → [Bring your own Authorization Server](./external-authorization-servers.md). Signing a user in from a client you build → [Authenticate a user with OAuth](../clients/oauth.md). No user present → [Authenticate without a user](../clients/machine-auth.md).
 
 ## Require a bearer token
 
@@ -40,7 +40,7 @@ app.all('/mcp', auth, (req, res) => void node(req, res, req.body));
 A request with a missing, malformed, or expired token gets `401` with the OAuth error code `invalid_token`. A valid token missing one of `requiredScopes` gets `403` with `insufficient_scope`. Both responses carry a `WWW-Authenticate: Bearer …` challenge whose `resource_metadata` parameter is the URL you passed — that challenge is what starts a client's OAuth flow.
 
 ::: info Coming from v1?
-The Authorization Server helpers (`mcpAuthRouter`, `ProxyOAuthServerProvider`, …) are frozen in `@modelcontextprotocol/server-legacy/auth`. Use a dedicated identity provider for new servers; this page only covers the resource-server half.
+The Authorization Server helpers (`mcpAuthRouter`, `ProxyOAuthServerProvider`, …) are frozen in `@modelcontextprotocol/server-legacy/auth`. Use a dedicated identity provider for new servers — [Bring your own Authorization Server](./external-authorization-servers.md) covers that half; this page covers the resource-server half.
 :::
 
 ## Require a bearer token on a web-standard host

--- a/docs/serving/external-authorization-servers.md
+++ b/docs/serving/external-authorization-servers.md
@@ -32,7 +32,7 @@ async function serveVerified(request: Request, props: GrantProps): Promise<Respo
 }
 ```
 
-Every tool and resource handler now reads the identity as `ctx.authInfo`, and token expiry and revocation are enforced by the provider on each request — your code never sees an invalid token. One contract to know: fronting providers typically hand your handler only what was stored when the grant was approved, so embed everything `AuthInfo` needs (client id, scopes) into the grant at consent time.
+Every tool and resource handler now reads the identity as `ctx.http.authInfo`, and token expiry and revocation are enforced by the provider on each request — your code never sees an invalid token. One contract to know: fronting providers typically hand your handler only what was stored when the grant was approved, so embed everything `AuthInfo` needs (client id, scopes) into the grant at consent time.
 
 ::: info Running reference
 The [`todos-server` example](https://github.com/modelcontextprotocol/typescript-sdk/tree/main/examples/todos-server) deploys this style on Cloudflare Workers: `workers-oauth-provider` owns the endpoints, both discovery documents, dynamic client registration and Client ID Metadata Documents, and KV-backed grants — the app supplies a consent step and the `propsToAuthInfo` mapping (`oauth.ts`), and serves anonymous and token-authorized tiers side by side.
@@ -61,7 +61,7 @@ async function fetchHandler(request: Request): Promise<Response> {
 }
 ```
 
-A request with a missing, malformed, or expired token gets the `401` challenge; a valid one reaches handlers with `ctx.authInfo` populated from your verifier. [Require authorization](./authorization.md) covers the rest of this style's surface: the challenge contents, publishing protected resource metadata that names your external issuer, and per-tool scopes.
+A request with a missing, malformed, or expired token gets the `401` challenge; a valid one reaches handlers with `ctx.http.authInfo` populated from your verifier. [Require authorization](./authorization.md) covers the rest of this style's surface: the challenge contents, publishing protected resource metadata that names your external issuer, and per-tool scopes.
 
 ## Choosing a style
 

--- a/docs/serving/external-authorization-servers.md
+++ b/docs/serving/external-authorization-servers.md
@@ -1,0 +1,76 @@
+---
+shape: how-to
+description: Integrate an MCP server with an Authorization Server you bring — a platform provider, an auth framework, or your IdP.
+---
+
+# Bring your own Authorization Server
+
+Protecting a server with a token gate → [Require authorization](./authorization.md). Signing a user in from a client → [Authenticate a user with OAuth](../clients/oauth.md). This page covers the other half of the deployment: where the Authorization Server itself comes from, and how the SDK connects to it.
+
+The SDK ships the Resource Server pieces only — verification, challenges, discovery — and no Authorization Server, deliberately: token issuance, consent, and client registration belong to dedicated systems. The AS you bring is typically your platform's (Cloudflare's [`workers-oauth-provider`](https://github.com/cloudflare/workers-oauth-provider)), an auth framework's (better-auth, in the [`oauth` example](https://github.com/modelcontextprotocol/typescript-sdk/tree/main/examples/oauth)), or your organization's IdP. Two integration styles cover all of them.
+
+## Style A: the Authorization Server fronts your handler
+
+The AS wraps your deployment and verifies every API request before your code runs — `createMcpHandler` performs no verification of its own, so the integration is one option: map the identity the AS hands you into an `AuthInfo` and pass it in.
+
+```ts source="../../examples/guides/serving/external-authorization-servers.examples.ts#styleA_injectAuthInfo"
+// The fronting provider verified the token and hands your handler the identity
+// it stored at grant time (workers-oauth-provider: `ctx.props`). Map it.
+interface GrantProps {
+    clientId: string;
+    scopes: string[];
+}
+
+async function serveVerified(request: Request, props: GrantProps): Promise<Response> {
+    const authInfo: AuthInfo = {
+        token: request.headers.get('authorization')?.replace(/^Bearer /i, '') ?? '',
+        clientId: props.clientId,
+        scopes: props.scopes
+        // No expiresAt: the provider enforces validity on every request.
+    };
+    return handler.fetch(request, { authInfo });
+}
+```
+
+Every tool and resource handler now reads the identity as `ctx.authInfo`, and token expiry and revocation are enforced by the provider on each request — your code never sees an invalid token. One contract to know: fronting providers typically hand your handler only what was stored when the grant was approved, so embed everything `AuthInfo` needs (client id, scopes) into the grant at consent time.
+
+::: info Running reference
+The [`todos-server` example](https://github.com/modelcontextprotocol/typescript-sdk/tree/main/examples/todos-server) deploys this style on Cloudflare Workers: `workers-oauth-provider` owns the endpoints, both discovery documents, dynamic client registration and Client ID Metadata Documents, and KV-backed grants — the app supplies a consent step and the `propsToAuthInfo` mapping (`oauth.ts`), and serves anonymous and token-authorized tiers side by side.
+:::
+
+## Style B: the SDK verifies tokens from an external AS
+
+When the AS is elsewhere — an IdP issuing JWTs, or any issuer reachable for introspection — your server verifies each request itself: implement `OAuthTokenVerifier` against the issuer and put `requireBearerAuth` in front of the handler.
+
+```ts source="../../examples/guides/serving/external-authorization-servers.examples.ts#styleB_externalVerifier"
+// The AS is external (an IdP issuing JWTs): verify each request yourself.
+const verifier: OAuthTokenVerifier = {
+    async verifyAccessToken(token): Promise<AuthInfo> {
+        const payload = await verifyJwtAgainstIssuer(token).catch(() => {
+            throw new OAuthError(OAuthErrorCode.InvalidToken, 'unknown token');
+        });
+        return { token, clientId: payload.sub, scopes: payload.scopes, expiresAt: payload.exp };
+    }
+};
+const gate = requireBearerAuth({ verifier, requiredScopes: ['mcp'] });
+
+async function fetchHandler(request: Request): Promise<Response> {
+    const auth = await gate(request);
+    if (auth instanceof Response) return auth;
+    return handler.fetch(request, { authInfo: auth });
+}
+```
+
+A request with a missing, malformed, or expired token gets the `401` challenge; a valid one reaches handlers with `ctx.authInfo` populated from your verifier. [Require authorization](./authorization.md) covers the rest of this style's surface: the challenge contents, publishing protected resource metadata that names your external issuer, and per-tool scopes.
+
+## Choosing a style
+
+Style A fits when the AS can own your HTTP edge — a platform provider wrapping the worker, or an auth framework mounted in the same app. Style B fits when the AS is a remote system and your server is the edge: nothing fronts you, so you verify. They compose with the same application code either way — the factory receives `authInfo` identically, so switching styles later does not touch your tools.
+
+## Recap
+
+- The SDK is Resource-Server-only by design: bring the Authorization Server from your platform, framework, or IdP.
+- Style A: the AS fronts you and verifies; inject its identity with `handler.fetch(request, { authInfo })`.
+- Style B: the AS is external; verify per request with `OAuthTokenVerifier` + `requireBearerAuth`.
+- Embed what `AuthInfo` needs into the grant at consent time — fronting providers replay only what was stored.
+- The `todos-server` example runs Style A live; the `oauth` example runs an in-process better-auth AS.

--- a/docs/serving/legacy-clients.md
+++ b/docs/serving/legacy-clients.md
@@ -1,6 +1,7 @@
 ---
 shape: how-to
 ---
+
 # Support legacy clients
 
 A **legacy client** speaks a 2025-era protocol revision: it opens with `initialize` and sends no per-request `_meta` envelope. Both serving entry points answer those clients from the same factory that serves modern ones; the `legacy` option decides whether they keep doing it. [Protocol versions](../protocol-versions.md) covers the era model itself.
@@ -87,6 +88,69 @@ The `initialize` the strict handler rejected above now completes the 2025 handsh
 Behind an Express body parser the Node stream is already drained: build the `Request` the predicate takes with `toWebRequest(req, req.body)` from `@modelcontextprotocol/node`.
 :::
 
+## Serve elicitation to 2025-era HTTP clients
+
+Per-request legacy serving has no return path for server→client requests, so a tool that asks for input mid-call answers a **2025-era HTTP client** with an error result instead. The same tool serves its interactive rounds to 2026-07-28 clients as [`input_required` round trips](../servers/input-required.md), and to legacy clients over stdio, where the connection is the session.
+
+Stay on the default posture until the 2025-era HTTP clients you serve need elicitation — [sampling is deprecated](../servers/sampling.md) as of 2026-07-28. To serve those rounds, mint a session for the legacy `initialize`: one transport connected to one instance from your factory, with every request that carries its `Mcp-Session-Id` routed back to that pair.
+
+```ts source="../../examples/guides/serving/legacy-clients.examples.ts#isLegacyRequest_sessions"
+import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/server';
+
+const handler = createMcpHandler(buildServer);
+const sessions = new Map<string, WebStandardStreamableHTTPServerTransport>();
+
+async function serveWithSessions(request: Request): Promise<Response> {
+    // Session traffic goes to the transport that owns the session.
+    const sessionId = request.headers.get('mcp-session-id');
+    if (sessionId !== null) {
+        const transport = sessions.get(sessionId);
+        if (!transport) return new Response('Unknown or expired session', { status: 404 });
+        return transport.handleRequest(request);
+    }
+
+    // A legacy `initialize` opens a session: its own transport, its own instance.
+    const body: unknown =
+        request.method === 'POST'
+            ? await request
+                  .clone()
+                  .json()
+                  .catch(() => {})
+            : undefined;
+    const looksLikeInitialize = typeof body === 'object' && body !== null && 'method' in body && body.method === 'initialize';
+    if (looksLikeInitialize && (await isLegacyRequest(request, body))) {
+        const transport = new WebStandardStreamableHTTPServerTransport({
+            sessionIdGenerator: () => crypto.randomUUID(),
+            onsessioninitialized: id => {
+                sessions.set(id, transport);
+            }
+        });
+        // Set before connect: the server chains an onclose that is already on the transport.
+        transport.onclose = () => {
+            if (transport.sessionId !== undefined) sessions.delete(transport.sessionId);
+        };
+        await buildServer().connect(transport);
+        const response = await transport.handleRequest(request);
+        // A refused handshake mints no session: close, or the pair leaks until process exit.
+        if (transport.sessionId === undefined) await transport.close();
+        return response;
+    }
+
+    // Everything else — modern traffic and legacy one-shots — rides the entry.
+    return handler.fetch(request, body === undefined ? undefined : { parsedBody: body });
+}
+```
+
+`isLegacyRequest` decides whether the request is legacy at all; the `method` peek only narrows which legacy requests open a session. An `initialize` that carries the modern envelope (or names a modern revision in its `MCP-Protocol-Version` header) belongs to the modern path's validation ladder, and a bare method sniff would mint it a 2025 session instead. The already-parsed body goes to the predicate as its second argument, which skips the predicate's internal body clone.
+
+One transport is one session, and the transport's `onclose` — set before `connect`, which chains it — is where the registry entry dies. Never share a transport or a server instance across sessions.
+
+::: tip
+Bound the registry: cap concurrent sessions and evict idle ones — an unauthenticated `initialize` is all it takes to allocate a transport and a server instance. [`todos-server/worker.ts`](https://github.com/modelcontextprotocol/typescript-sdk/blob/main/examples/todos-server/worker.ts) does both and runs this exact hybrid on Cloudflare Workers, with the registry in a per-visitor Durable Object.
+:::
+
+Unknown session ids answer `404` and the client re-initializes; `DELETE` tears the session down through that same `onclose`. [Sessions, state, and scaling](./sessions-state-scaling.md) covers the lifecycle, resumability, and scaling; the [`cli-client`](https://github.com/modelcontextprotocol/typescript-sdk/blob/main/examples/cli-client/README.md) e2e drives elicitation rounds over exactly this hybrid.
+
 ## Know where SSE went
 
 The v2 server never serves the HTTP+SSE transport. An SSE server moving to v2 moves to Streamable HTTP — `createMcpHandler` above — as part of the [v2 upgrade](../migration/upgrade-to-v2.md).
@@ -99,4 +163,5 @@ The client side keeps `SSEClientTransport`, so a v2 `Client` still reaches old S
 - The default HTTP posture is per request and stateless: legacy `GET` and `DELETE` session operations answer `405`.
 - `serveStdio` decides the era once per connection; its default is `'serve'`.
 - `isLegacyRequest` in front of a strict handler keeps an existing sessionful 2025 deployment serving its clients.
+- The default posture answers 2025-era HTTP clients per request, with no channel for server-initiated messages; a session minted for the legacy `initialize` — classified by `isLegacyRequest`, never a method sniff — restores elicitation.
 - The v2 server never serves SSE; the frozen v1 transport is `@modelcontextprotocol/server-legacy/sse`, and the client keeps `SSEClientTransport`.

--- a/docs/serving/sessions-state-scaling.md
+++ b/docs/serving/sessions-state-scaling.md
@@ -1,6 +1,7 @@
 ---
 shape: how-to
 ---
+
 # Sessions, state, and scaling
 
 `createMcpHandler` builds a fresh server instance from your factory for every HTTP request and holds nothing between requests, so a v2 server is stateless and scales horizontally by default — [Serve over HTTP](./http.md) is the whole setup. Read on if you run a sessionful 2025-era deployment, need a dropped stream to resume, or push change notifications across nodes.
@@ -89,6 +90,8 @@ When the connection drops, the client reconnects with the last event id it recei
 The stateless default is the scaling story: every node builds a fresh instance from the same factory and holds nothing between requests, so put the nodes behind any load balancer — no session affinity, nothing to share, nothing to configure.
 
 Sessionful 2025-era nodes hold their sessions in process memory, so they scale two ways. **Persistent storage**: keep `sessionIdGenerator` and point every node at the same `eventStore`, so a dropped stream is resumable from any node that shares the store. **Local state with message routing**: keep per-node sessions and send each session's traffic to the node that owns it — load-balancer affinity, or pub/sub routing between nodes.
+
+A serverless deployment keeps local state with an object per client instead of a node per client. [`todos-server/worker.ts`](https://github.com/modelcontextprotocol/typescript-sdk/blob/main/examples/todos-server/worker.ts) pins each visitor's board and sessions in one Cloudflare Durable Object and embeds the object's own id in the session ids it mints, so whichever edge isolate receives a request forwards it to the object that owns the session.
 
 One thing still crosses nodes on a stateless deployment: `subscriptions/listen`. Its streams deliver the change events published on the handler's **`ServerEventBus`** ([Notifications](../servers/notifications.md)), and the default bus is in-process — `handler.notify.toolsChanged()` on node A never reaches a subscriber whose stream node B holds. Implement `ServerEventBus` over your pub/sub (`publish(event)` forwards to the broker; `subscribe(listener)` registers for events arriving from it) and hand one to every node's `createMcpHandler`.
 

--- a/docs/serving/web-standard.md
+++ b/docs/serving/web-standard.md
@@ -1,6 +1,7 @@
 ---
 shape: how-to
 ---
+
 # Serve on web-standard runtimes
 
 ```sh
@@ -28,6 +29,16 @@ export default handler;
 
 The deployed worker answers MCP requests on every path, with no Node adapter and no body middleware. The factory runs once per request, so a fresh `McpServer` serves every call: [Serve over HTTP](./http.md#understand-the-per-request-factory) covers that model.
 
+::: warning Cloudflare Workers: cancellation needs a compatibility flag
+On Workers, `request.signal` never fires unless the deployment sets the `enable_request_signal` compatibility flag — client disconnects are invisible to the isolate, so 2026-07-28 cancellation (a client cancels by closing the request's response stream) silently does nothing and long-running tools plough on. Add the flag in `wrangler.toml`:
+
+```toml
+compatibility_flags = ["enable_request_signal"]
+```
+
+With it set, the SDK's per-request serving aborts the handler's `ctx.mcpReq.signal` when the client goes away — including across a Durable Object hop, as long as the forwarded `Request` derives from the original. Node deployments need nothing: the adapter wires socket close to the same signal.
+:::
+
 ## Protect against DNS rebinding
 
 The handler performs no `Host` or `Origin` validation, and on a bare fetch-native runtime there is no app factory to arm it for you. Put the framework-agnostic response helpers in front of `fetch`.
@@ -37,8 +48,7 @@ import { hostHeaderValidationResponse, originValidationResponse } from '@modelco
 
 const guarded = {
     async fetch(request: Request): Promise<Response> {
-        const rejected =
-            hostHeaderValidationResponse(request, ['api.example.com']) ?? originValidationResponse(request, ['app.example.com']);
+        const rejected = hostHeaderValidationResponse(request, ['api.example.com']) ?? originValidationResponse(request, ['app.example.com']);
         return rejected ?? handler.fetch(request);
     }
 };

--- a/docs/serving/web-standard.md
+++ b/docs/serving/web-standard.md
@@ -48,7 +48,8 @@ import { hostHeaderValidationResponse, originValidationResponse } from '@modelco
 
 const guarded = {
     async fetch(request: Request): Promise<Response> {
-        const rejected = hostHeaderValidationResponse(request, ['api.example.com']) ?? originValidationResponse(request, ['app.example.com']);
+        const rejected =
+            hostHeaderValidationResponse(request, ['api.example.com']) ?? originValidationResponse(request, ['app.example.com']);
         return rejected ?? handler.fetch(request);
     }
 };

--- a/examples/cli-client/README.md
+++ b/examples/cli-client/README.md
@@ -48,7 +48,7 @@ pnpm --filter @mcp-examples/todos-server start:http
 ANTHROPIC_API_KEY=sk-… pnpm --filter @mcp-examples/cli-client start -- --server http://127.0.0.1:3000/mcp --provider anthropic
 ```
 
-The status line shows what was negotiated — `connected to "todos" (2026-07-28, 8 tools, 2 resources, 2 prompts)`. Add `--legacy` in terminal B to force the 2025-era handshake against the same server and watch the legacy arms of every feature run instead (`connected to "todos" (2025-11-25, …)`). To hold the connection to one exact revision, use `--protocol-version 2025-06-18` (or any supported revision) — the connection fails rather than settle on anything else.
+The status line shows what was negotiated — `connected to "todos" (2026-07-28, 9 tools, 2 resources, 2 prompts)`. Add `--legacy` in terminal B to force the 2025-era handshake against the same server and watch the legacy arms of every feature run instead (`connected to "todos" (2025-11-25, …)`). To hold the connection to one exact revision, use `--protocol-version 2025-06-18` (or any supported revision) — the connection fails rather than settle on anything else.
 
 A tour that touches everything, in one sitting:
 

--- a/examples/cli-client/host/host.ts
+++ b/examples/cli-client/host/host.ts
@@ -158,6 +158,13 @@ export class McpHost {
                 this.ui.status(
                     `connected to "${name}" (${server.protocolVersion}, ${server.tools.length} tools, ${server.resources.length + server.resourceTemplates.length} resources, ${server.prompts.length} prompts)`
                 );
+                // Instructions are the server's own onboarding text — surface them so the
+                // human sees links and hints without having to ask the model for them.
+                // note() wraps; status() clips to one line and would swallow long URLs.
+                const instructions = server.client.getInstructions();
+                if (instructions) {
+                    this.ui.note(`"${name}" says: ${instructions.length > 600 ? `${instructions.slice(0, 600)}…` : instructions}`);
+                }
             } catch (error) {
                 this.ui.status(`failed to connect to "${name}": ${error instanceof Error ? error.message : String(error)}`);
             }

--- a/examples/cli-client/host/ui.ts
+++ b/examples/cli-client/host/ui.ts
@@ -162,10 +162,12 @@ export class ReadlineUI implements HostUI {
     }
 
     note(text: string): void {
-        // Things that became part of the conversation but aren't prose (attached resources).
+        // Things that became part of the conversation but aren't prose (attached
+        // resources, server onboarding text). Unlike status chatter these may carry
+        // links the user needs whole, so they soft-wrap instead of clipping.
         this.clearSpinnerLine();
         this.closeAttentionBlock();
-        console.log(paint('36', this.clipToWidth(`  ▍ ${stripAnsi(text)}`)));
+        console.log(paint('36', `  ▍ ${stripAnsi(text)}`));
         this.afterMeta = true;
     }
 

--- a/examples/eslint.config.mjs
+++ b/examples/eslint.config.mjs
@@ -8,7 +8,13 @@ export default [
         // The nested workspace packages (shared, *-quickstart) are linted by their own configs.
         // The one-way "@mcp-examples/shared must not import from stories" rule lives in
         // shared/eslint.config.mjs so it fires under that package's own lint.
-        ignores: ['shared/**', 'server-quickstart/**', 'client-quickstart/**']
+        ignores: ['shared/**', 'server-quickstart/**', 'client-quickstart/**', '**/.wrangler/**']
+    },
+    {
+        // The Workers runtime module exists only inside workerd; wrangler resolves it at
+        // deploy time and workerEnv.d.ts declares it for the typechecker.
+        files: ['todos-server/worker.ts'],
+        rules: { 'import/no-unresolved': ['error', { ignore: ['^cloudflare:'] }] }
     },
     {
         files: ['**/*.{ts,tsx,js,jsx,mts,cts}'],

--- a/examples/eslint.config.mjs
+++ b/examples/eslint.config.mjs
@@ -17,19 +17,6 @@ export default [
         rules: { 'import/no-unresolved': ['error', { ignore: ['^cloudflare:'] }] }
     },
     {
-        // Browser page scripts shipped as Text modules (inlined into HTML at render).
-        files: ['**/*.client.js'],
-        languageOptions: {
-            globals: {
-                document: 'readonly',
-                location: 'readonly',
-                EventSource: 'readonly',
-                URLSearchParams: 'readonly',
-                setTimeout: 'readonly'
-            }
-        }
-    },
-    {
         files: ['**/*.{ts,tsx,js,jsx,mts,cts}'],
         rules: {
             // Examples write to stdout/stderr deliberately.

--- a/examples/eslint.config.mjs
+++ b/examples/eslint.config.mjs
@@ -17,6 +17,19 @@ export default [
         rules: { 'import/no-unresolved': ['error', { ignore: ['^cloudflare:'] }] }
     },
     {
+        // Browser page scripts shipped as Text modules (inlined into HTML at render).
+        files: ['**/*.client.js'],
+        languageOptions: {
+            globals: {
+                document: 'readonly',
+                location: 'readonly',
+                EventSource: 'readonly',
+                URLSearchParams: 'readonly',
+                setTimeout: 'readonly'
+            }
+        }
+    },
+    {
         files: ['**/*.{ts,tsx,js,jsx,mts,cts}'],
         rules: {
             // Examples write to stdout/stderr deliberately.

--- a/examples/guides/serving/external-authorization-servers.examples.ts
+++ b/examples/guides/serving/external-authorization-servers.examples.ts
@@ -1,0 +1,60 @@
+// docs: typecheck-only
+/**
+ * Companion example for `docs/serving/external-authorization-servers.md`.
+ *
+ * Every `ts` fence on that page is synced from a `//#region` in this file
+ * (`pnpm sync:snippets --check`). Both styles need a live Authorization
+ * Server to exercise, so this file only typechecks:
+ *
+ *     pnpm --filter @modelcontextprotocol/examples typecheck
+ *
+ * @module
+ */
+import type { AuthInfo, McpHttpHandler, OAuthTokenVerifier } from '@modelcontextprotocol/server';
+import { createMcpHandler, McpServer, OAuthError, OAuthErrorCode, requireBearerAuth } from '@modelcontextprotocol/server';
+
+declare function buildServer(): McpServer;
+declare function verifyJwtAgainstIssuer(token: string): Promise<{ sub: string; scopes: string[]; exp: number }>;
+
+const handler: McpHttpHandler = createMcpHandler(buildServer);
+
+//#region styleA_injectAuthInfo
+// The fronting provider verified the token and hands your handler the identity
+// it stored at grant time (workers-oauth-provider: `ctx.props`). Map it.
+interface GrantProps {
+    clientId: string;
+    scopes: string[];
+}
+
+async function serveVerified(request: Request, props: GrantProps): Promise<Response> {
+    const authInfo: AuthInfo = {
+        token: request.headers.get('authorization')?.replace(/^Bearer /i, '') ?? '',
+        clientId: props.clientId,
+        scopes: props.scopes
+        // No expiresAt: the provider enforces validity on every request.
+    };
+    return handler.fetch(request, { authInfo });
+}
+//#endregion styleA_injectAuthInfo
+
+//#region styleB_externalVerifier
+// The AS is external (an IdP issuing JWTs): verify each request yourself.
+const verifier: OAuthTokenVerifier = {
+    async verifyAccessToken(token): Promise<AuthInfo> {
+        const payload = await verifyJwtAgainstIssuer(token).catch(() => {
+            throw new OAuthError(OAuthErrorCode.InvalidToken, 'unknown token');
+        });
+        return { token, clientId: payload.sub, scopes: payload.scopes, expiresAt: payload.exp };
+    }
+};
+const gate = requireBearerAuth({ verifier, requiredScopes: ['mcp'] });
+
+async function fetchHandler(request: Request): Promise<Response> {
+    const auth = await gate(request);
+    if (auth instanceof Response) return auth;
+    return handler.fetch(request, { authInfo: auth });
+}
+//#endregion styleB_externalVerifier
+
+void serveVerified;
+void fetchHandler;

--- a/examples/guides/serving/legacy-clients.examples.ts
+++ b/examples/guides/serving/legacy-clients.examples.ts
@@ -57,6 +57,57 @@ async function serve(request: Request): Promise<Response> {
 //#endregion isLegacyRequest_route
 
 // ---------------------------------------------------------------------------
+// "Serve elicitation to 2025-era HTTP clients"
+// ---------------------------------------------------------------------------
+
+//#region isLegacyRequest_sessions
+import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/server';
+
+const handler = createMcpHandler(buildServer);
+const sessions = new Map<string, WebStandardStreamableHTTPServerTransport>();
+
+async function serveWithSessions(request: Request): Promise<Response> {
+    // Session traffic goes to the transport that owns the session.
+    const sessionId = request.headers.get('mcp-session-id');
+    if (sessionId !== null) {
+        const transport = sessions.get(sessionId);
+        if (!transport) return new Response('Unknown or expired session', { status: 404 });
+        return transport.handleRequest(request);
+    }
+
+    // A legacy `initialize` opens a session: its own transport, its own instance.
+    const body: unknown =
+        request.method === 'POST'
+            ? await request
+                  .clone()
+                  .json()
+                  .catch(() => {})
+            : undefined;
+    const looksLikeInitialize = typeof body === 'object' && body !== null && 'method' in body && body.method === 'initialize';
+    if (looksLikeInitialize && (await isLegacyRequest(request, body))) {
+        const transport = new WebStandardStreamableHTTPServerTransport({
+            sessionIdGenerator: () => crypto.randomUUID(),
+            onsessioninitialized: id => {
+                sessions.set(id, transport);
+            }
+        });
+        // Set before connect: the server chains an onclose that is already on the transport.
+        transport.onclose = () => {
+            if (transport.sessionId !== undefined) sessions.delete(transport.sessionId);
+        };
+        await buildServer().connect(transport);
+        const response = await transport.handleRequest(request);
+        // A refused handshake mints no session: close, or the pair leaks until process exit.
+        if (transport.sessionId === undefined) await transport.close();
+        return response;
+    }
+
+    // Everything else — modern traffic and legacy one-shots — rides the entry.
+    return handler.fetch(request, body === undefined ? undefined : { parsedBody: body });
+}
+//#endregion isLegacyRequest_sessions
+
+// ---------------------------------------------------------------------------
 // Harness (not shown on the page). A 2025-era client opens with a claim-less
 // `initialize` POST; build that request twice and send it to the strict
 // handler, then through the `isLegacyRequest` branch. The page quotes both
@@ -104,4 +155,66 @@ if (served.status !== 200 || initialized.result.protocolVersion !== '2025-06-18'
     throw new Error(`expected the legacy leg to complete the 2025 handshake, got ${served.status} ${JSON.stringify(initialized)}`);
 }
 
+// "Serve elicitation to 2025-era HTTP clients" — the hybrid mints a session for
+// the legacy handshake, routes session traffic to the pinned instance, leaves
+// everything else (including a modern-envelope `initialize`) to the entry, and
+// tears the session down on DELETE.
+const opened = await serveWithSessions(legacyInitialize());
+await opened.text();
+const sessionId = opened.headers.get('mcp-session-id');
+console.log(opened.status, sessionId === null ? 'no session' : 'Mcp-Session-Id minted');
+
+const overSession = (init: RequestInit): Request =>
+    new Request('http://localhost/mcp', {
+        ...init,
+        headers: {
+            'content-type': 'application/json',
+            accept: 'application/json, text/event-stream',
+            'mcp-session-id': sessionId ?? ''
+        }
+    });
+const acked = await serveWithSessions(
+    overSession({ method: 'POST', body: JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' }) })
+);
+await acked.text();
+const pinged = await serveWithSessions(overSession({ method: 'POST', body: JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'ping' }) }));
+const pingedBody = await pinged.text();
+console.log(pinged.status);
+
+const modernInitialize = new Request('http://localhost/mcp', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', accept: 'application/json, text/event-stream', 'mcp-protocol-version': '2026-07-28' },
+    body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 3,
+        method: 'initialize',
+        params: {
+            _meta: {
+                'io.modelcontextprotocol/protocolVersion': '2026-07-28',
+                'io.modelcontextprotocol/clientInfo': { name: 'modern-host', version: '1.0.0' },
+                'io.modelcontextprotocol/clientCapabilities': {}
+            }
+        }
+    })
+});
+const answeredByEntry = await serveWithSessions(modernInitialize);
+await answeredByEntry.text();
+const closed = await serveWithSessions(overSession({ method: 'DELETE' }));
+await closed.text();
+
+// Self-verification for the sessions section.
+if (opened.status !== 200 || sessionId === null) {
+    throw new Error(`expected the legacy initialize to mint a session, got ${opened.status} ${String(sessionId)}`);
+}
+if (acked.status !== 202 || pinged.status !== 200 || !pingedBody.includes('"result"')) {
+    throw new Error(`expected the session to serve the follow-up, got ${acked.status} then ${pinged.status} ${pingedBody.slice(0, 200)}`);
+}
+if (answeredByEntry.headers.get('mcp-session-id') !== null) {
+    throw new Error('expected a modern-envelope initialize to be answered by the entry, not given a 2025 session');
+}
+if (sessions.size !== 0) {
+    throw new Error(`expected DELETE to tear the session down, ${sessions.size} left (DELETE answered ${closed.status})`);
+}
+
 await strict.close();
+await handler.close();

--- a/examples/todos-server/README.md
+++ b/examples/todos-server/README.md
@@ -31,7 +31,7 @@ pnpm --filter @mcp-examples/cli-client start -- --server http://127.0.0.1:3000/m
 pnpm --filter @mcp-examples/cli-client start -- --server http://127.0.0.1:3000/mcp --legacy
 ```
 
-The client's status line shows what was negotiated: `connected to "todos" (2026-07-28, 8 tools, …)` vs `(2025-11-25, …)`.
+The client's status line shows what was negotiated: `connected to "todos" (2026-07-28, 9 tools, …)` vs `(2025-11-25, …)`.
 
 You don't need the HTTP step for a quick look — running `cli-client` with no arguments spawns this server over stdio automatically.
 

--- a/examples/todos-server/README.md
+++ b/examples/todos-server/README.md
@@ -59,6 +59,7 @@ Any other `mcpServers`-style host can spawn it too:
 | Subscriptions              | the board                                              | `resources/subscribe`/`unsubscribe` handlers for 2025-era clients; `subscriptions/listen` routing for 2026-07-28; every mutation notifies                                 |
 | list_changed               | every mutation                                         | resource list + resource updated notifications, delivered correctly over stdio and per-request HTTP                                                                       |
 | Prompts + completions      | `plan-my-day`, `seed-board`                            | `completable()` argument values (project names, themes) wired to `completion/complete`                                                                                    |
+| OAuth tiers                | `whoami` (todos.ts)                                    | Reports `ctx.authInfo`: the verified grant (client + scopes) or the anonymous tier, plus where to watch the board live.                                                   |
 
 The two protocol eras differ in how interactive conversations travel: on 2025-era connections the wire carries _pushed_ `elicitation/create` / `sampling/createMessage` requests; on 2026-07-28 the server returns `input_required` results and the client retries the call with the answers. The interactive tools (`brainstorm_tasks`, `clear_done`, `prioritize`) are written **once** in the `input_required` style — on 2025-era connections the SDK's default-on legacy shim performs the push-style round trips for them, so there is no era branch in any handler. (For a side-by-side of the two wire styles written by hand, see `examples/elicitation`.)
 
@@ -74,12 +75,17 @@ One serving-mode caveat: over **HTTP with a 2025-era client**, `createMcpHandler
 ## Layout
 
 ```text
-server.ts    transport entry (Node): serveStdio by default, createMcpHandler + node adapter behind --http
-worker.ts    transport entry (Cloudflare Workers): the hosted demo — createMcpHandler's web-standard
-             fetch behind a per-visitor Durable Object, plus the landing page (index.html) at /
-todos.ts     the application: state, tools, resources, prompts, subscriptions — every feature above.
-             createTodosApp() gives a host its own board: a buildServer factory, snapshot/restore for
-             persistence, and subscribeInstance for hosts that pin long-lived instances to a bus
+server.ts        transport entry (Node): serveStdio by default, createMcpHandler + node adapter behind --http
+worker.ts        transport entry (Cloudflare Workers): the hosted demo — one door to a per-visitor board
+                 Durable Object (serveBoard), the OAuth provider wrapper, and the pages
+todos.ts         the application: state, tools, resources, prompts, subscriptions — every feature above.
+                 createTodosApp() gives a host its own board: a buildServer factory, snapshot/restore for
+                 persistence, and subscribeInstance for hosts that pin long-lived instances to a bus
+oauth.ts         the OAuth glue: propsToAuthInfo (grant props → AuthInfo), the no-account consent page,
+                 and the viewer-session lifecycle for the live board view
+board.html       the /board live view page; its script ships as board.client.js so the lint gates see it
+index.html       the landing page at /
+e2e/verify.ts    probes a running worker: the dance, tier security, the live view, the pages
 ```
 
 ## Live board view (Cloudflare Workers deployment)
@@ -144,7 +150,7 @@ address, or by an `X-Todos-Board` header when the client sends one) that expires
 
 ```bash
 # from this directory
-npx wrangler dev                                  # local: http://127.0.0.1:8787/mcp
+npx wrangler dev                                  # local: http://127.0.0.1:8850/mcp
 npx wrangler deploy                               # deploys to <name>.<account>.workers.dev
 openssl rand -base64 48 | npx wrangler secret put REQUEST_STATE_SECRET
 ```

--- a/examples/todos-server/README.md
+++ b/examples/todos-server/README.md
@@ -109,6 +109,9 @@ pnpm --filter @mcp-examples/todos-server verify                                 
 pnpm --filter @mcp-examples/todos-server verify -- --base https://your.deploy    # a live deployment
 ```
 
+Section 9 needs `enable_request_signal` in `wrangler.toml` (see the comment there):
+without it Workers never surfaces client disconnects and cancellation is silently dead.
+
 Stays manual on purpose: the real-browser consent click, a real client's OAuth dance
 (Claude Code / cli-client), and anything involving a third-party platform quirk
 (workers.dev bot protection 403s non-browser user agents; deploys propagate for

--- a/examples/todos-server/README.md
+++ b/examples/todos-server/README.md
@@ -62,7 +62,7 @@ Any other `mcpServers`-style host can spawn it too:
 
 The two protocol eras differ in how interactive conversations travel: on 2025-era connections the wire carries _pushed_ `elicitation/create` / `sampling/createMessage` requests; on 2026-07-28 the server returns `input_required` results and the client retries the call with the answers. The interactive tools (`brainstorm_tasks`, `clear_done`, `prioritize`) are written **once** in the `input_required` style — on 2025-era connections the SDK's default-on legacy shim performs the push-style round trips for them, so there is no era branch in any handler. (For a side-by-side of the two wire styles written by hand, see `examples/elicitation`.)
 
-One serving-mode caveat: over **HTTP with a 2025-era client**, `createMcpHandler`'s default stateless posture has no return path for push-style server→client requests, so the sampling/elicitation tools refuse cleanly on that leg (stdio is unaffected; 2026-07-28 HTTP is unaffected).
+One serving-mode caveat: over **HTTP with a 2025-era client**, `createMcpHandler`'s default stateless posture has no return path for push-style server→client requests, so the sampling/elicitation tools refuse cleanly on that leg (stdio is unaffected; 2026-07-28 HTTP is unaffected). The **Workers entry lifts this**: `worker.ts` answers a 2025-era `initialize` with a real session — a per-session `WebStandardStreamableHTTPServerTransport` connected to a server pinned to that session — so the interactive tools work over HTTP for legacy clients too. Sessions are in-memory (each has its own transport); if the object recycles, the client gets the spec's 404 and re-initializes, and the board itself stays durable.
 
 ## Configuration
 
@@ -74,8 +74,36 @@ One serving-mode caveat: over **HTTP with a 2025-era client**, `createMcpHandler
 ## Layout
 
 ```text
-server.ts   transport entry: serveStdio by default, createMcpHandler + node adapter behind --http
-todos.ts    the application: state, tools, resources, prompts, subscriptions — every feature above
+server.ts    transport entry (Node): serveStdio by default, createMcpHandler + node adapter behind --http
+worker.ts    transport entry (Cloudflare Workers): the hosted demo — createMcpHandler's web-standard
+             fetch behind a per-visitor Durable Object, plus the landing page (index.html) at /
+todos.ts     the application: state, tools, resources, prompts, subscriptions — every feature above.
+             createTodosApp() gives a host its own board: a buildServer factory, snapshot/restore for
+             persistence, and forwardServerEvent for hosts that pin long-lived instances to a bus
 ```
 
-This package is intentionally **server-only**; its end-to-end coverage comes from the [`cli-client`](../cli-client/README.md) scripted e2e, which drives it across stdio + HTTP on both protocol eras in CI.
+## Deploy it (Cloudflare Workers)
+
+`worker.ts` + `wrangler.toml` deploy this server as a public demo: `/` serves the landing page,
+`/mcp` serves MCP, and every visitor gets an isolated, capped board (keyed by connecting
+address, or by an `X-Todos-Board` header when the client sends one) that expires after ~2 h idle.
+
+```bash
+# from this directory
+npx wrangler dev                                  # local: http://127.0.0.1:8787/mcp
+npx wrangler deploy                               # deploys to <name>.<account>.workers.dev
+openssl rand -base64 48 | npx wrangler secret put REQUEST_STATE_SECRET
+```
+
+The secret is optional and the default is usually better here: each board mints a key of its
+own and keeps it in durable storage, so multi-round `input_required` flows survive isolate
+recycling, and a leaked key compromises one board instead of every board. Set the deployment-wide
+secret only when rounds must verify across boards. Boards are
+capped (200 tasks; `MAX_TASKS` var to change). Treat anything on a public board as untrusted
+content: boards are shared with whoever shares the visitor key.
+
+The worker bundles the **built** packages (`dist/`, resolved through each package's exports map so
+the `workerd` shims win — see `tsconfig.worker.json`); after editing `packages/*` sources, run
+`pnpm build:all` before `wrangler dev`, or you'll be serving stale code.
+
+This package is intentionally **server-only**; the Node entry's end-to-end coverage comes from the [`cli-client`](../cli-client/README.md) scripted e2e, which drives `server.ts` across stdio + HTTP on both protocol eras in CI. `worker.ts` is a deploy target, not a CI leg — exercise it with `npx wrangler dev` and the same cli-client pointed at the local URL.

--- a/examples/todos-server/README.md
+++ b/examples/todos-server/README.md
@@ -79,7 +79,7 @@ worker.ts    transport entry (Cloudflare Workers): the hosted demo — createMcp
              fetch behind a per-visitor Durable Object, plus the landing page (index.html) at /
 todos.ts     the application: state, tools, resources, prompts, subscriptions — every feature above.
              createTodosApp() gives a host its own board: a buildServer factory, snapshot/restore for
-             persistence, and forwardServerEvent for hosts that pin long-lived instances to a bus
+             persistence, and subscribeInstance for hosts that pin long-lived instances to a bus
 ```
 
 ## Live board view (Cloudflare Workers deployment)

--- a/examples/todos-server/README.md
+++ b/examples/todos-server/README.md
@@ -82,6 +82,42 @@ todos.ts     the application: state, tools, resources, prompts, subscriptions �
              persistence, and forwardServerEvent for hosts that pin long-lived instances to a bus
 ```
 
+## Live board view (Cloudflare Workers deployment)
+
+`/board?b=<name>` is a read-only live view of a named anonymous board: the page holds an
+SSE stream (`/board/events`) that the board's Durable Object feeds from the same
+`ServerEventBus` every other consumer uses, so tasks appear and complete in real time as
+connected agents work. Without `?b=` it shows your own address-keyed board. OAuth boards
+are not viewable this way — their identity lives only inside the grant.
+
+## OAuth (Cloudflare Workers deployment)
+
+The worker wraps everything in [`@cloudflare/workers-oauth-provider`](https://github.com/cloudflare/workers-oauth-provider):
+the provider is the Authorization Server (authorize/token endpoints, RFC 7591 dynamic client
+registration, Client ID Metadata Documents, and both discovery documents), while the MCP
+handler stays a pure Resource Server consumer. `oauth.ts` holds the whole integration:
+
+- `propsToAuthInfo` — the canonical mapping from the provider's grant `props` to the SDK's
+  `AuthInfo`. The provider attaches only `props` after verifying a token, so `clientId` and
+  `scopes` are embedded at grant time; the raw token comes from the request header;
+  `expiresAt` is omitted because the provider verifies the token on every request that
+  reaches the API route, including session traffic — so expiry and revocation take effect
+  immediately without the app tracking timestamps.
+- `handleAuthorize` — the consent step. This demo has no user accounts: the principal is the
+  board, and approving mints a fresh board id into the grant. A real deployment replaces
+  exactly this step with its own sign-in.
+
+Two tiers share the same board machinery: `/mcp` stays anonymous (address- or header-keyed
+boards), `/oauth/mcp` serves token-authorized boards keyed by the grant (`whoami` shows which
+tier a connection is on). Sessions never cross tiers: an OAuth-minted 2025-era session is
+served only through the provider-verified route — every request re-verifies the token, so
+expiry and revocation cut live sessions off — and a session id is never accepted as a
+credential by itself. Requires the `OAUTH_KV` namespace binding (create your own:
+`wrangler kv namespace create OAUTH_KV`, then replace the id in wrangler.toml) and the
+`global_fetch_strictly_public` compatibility flag, which makes the platform itself guarantee
+CIMD metadata fetches only reach public addresses. Setting the `TODOS_AUTO_CONSENT=1` var
+auto-approves consent for scripted end-to-end runs — never set it on a real deployment.
+
 ## Deploy it (Cloudflare Workers)
 
 `worker.ts` + `wrangler.toml` deploy this server as a public demo: `/` serves the landing page,

--- a/examples/todos-server/README.md
+++ b/examples/todos-server/README.md
@@ -91,6 +91,23 @@ connected agents work. Without `?b=` it shows your grant's board if you approved
 consent in this browser (approval sets an opaque, KV-backed viewer cookie — no token or
 board id ever appears in a URL), falling back to your address-keyed board.
 
+## Verifying a deployment
+
+`e2e/verify.ts` probes a running worker end to end — the OAuth dance (both consent
+modes), the tier-security invariants (a session id is never a credential), board
+isolation between grants, the live view's SSE stream, the pages (including that the
+board script parses), and the authorization error paths:
+
+```sh
+pnpm --filter @mcp-examples/todos-server verify                                  # wrangler dev on :8850
+pnpm --filter @mcp-examples/todos-server verify -- --base https://your.deploy    # a live deployment
+```
+
+Stays manual on purpose: the real-browser consent click, a real client's OAuth dance
+(Claude Code / cli-client), and anything involving a third-party platform quirk
+(workers.dev bot protection 403s non-browser user agents; deploys propagate for
+~30s — re-run rather than chase ghosts).
+
 ## OAuth (Cloudflare Workers deployment)
 
 The worker wraps everything in [`@cloudflare/workers-oauth-provider`](https://github.com/cloudflare/workers-oauth-provider):

--- a/examples/todos-server/README.md
+++ b/examples/todos-server/README.md
@@ -87,8 +87,9 @@ todos.ts     the application: state, tools, resources, prompts, subscriptions �
 `/board?b=<name>` is a read-only live view of a named anonymous board: the page holds an
 SSE stream (`/board/events`) that the board's Durable Object feeds from the same
 `ServerEventBus` every other consumer uses, so tasks appear and complete in real time as
-connected agents work. Without `?b=` it shows your own address-keyed board. OAuth boards
-are not viewable this way — their identity lives only inside the grant.
+connected agents work. Without `?b=` it shows your grant's board if you approved an OAuth
+consent in this browser (approval sets an opaque, KV-backed viewer cookie — no token or
+board id ever appears in a URL), falling back to your address-keyed board.
 
 ## OAuth (Cloudflare Workers deployment)
 

--- a/examples/todos-server/board.client.js
+++ b/examples/todos-server/board.client.js
@@ -1,0 +1,73 @@
+// @ts-check
+// The live board page's script, shipped as its own Text module so the repo's
+// lint/format gates see it (an inline <script> is invisible to them). The
+// worker inlines it into board.html at render time via the __BOARD_SCRIPT__
+// marker. Contract with the worker: /board/events emits one `info` event
+// ({ mode: 'named'|'oauth'|'address', label }) and then a snapshot per change.
+const identity = document.querySelector('#identity');
+const list = document.querySelector('#tasks');
+const empty = document.querySelector('#empty');
+const status = document.querySelector('#status');
+const namedBoard = new URLSearchParams(location.search).get('b');
+// Opened from the consent click, this tab races the approval POST: the
+// viewer cookie for the NEW grant lands with the approve response, which
+// may arrive after this page. #claim defers the first connection so the
+// cookie is in place, instead of resolving to a previous grant's board.
+const claiming = location.hash === '#claim' && !namedBoard;
+let source;
+let retried = false;
+
+function renderInfo(info) {
+    identity.textContent =
+        info.mode === 'oauth'
+            ? `You are OAuthed: this is the private board granted to ${info.label}.`
+            : info.mode === 'named'
+              ? `Shared board "${info.label}" — anyone with this link (and any client sending X-Todos-Board: ${info.label}) sees it.`
+              : 'Your address-keyed board (no OAuth grant, no ?b= name).';
+}
+
+function onSnapshot(event) {
+    const snapshot = JSON.parse(event.data);
+    const tasks = snapshot.tasks ?? [];
+    list.replaceChildren(
+        ...tasks.map(task => {
+            const item = document.createElement('li');
+            item.textContent = `${task.title} (${task.id}, ${task.project}${task.priority ? ', ' + task.priority : ''})`;
+            if (task.status === 'done') item.classList.add('done');
+            return item;
+        })
+    );
+    empty.hidden = tasks.length > 0;
+}
+
+function connect() {
+    source = new EventSource('/board/events' + location.search);
+    source.onopen = () => {
+        status.textContent = 'live';
+    };
+    source.onerror = () => {
+        status.textContent = 'reconnecting…';
+    };
+    source.onmessage = onSnapshot;
+    source.addEventListener('info', event => {
+        const info = JSON.parse(event.data);
+        // Opened straight from consent, the viewer cookie can land a moment
+        // after this page: if we resolved to the address fallback, try once
+        // more before accepting it.
+        if (info.mode === 'address' && !namedBoard && !retried) {
+            retried = true;
+            status.textContent = 'claiming your board…';
+            source.close();
+            setTimeout(connect, 1200);
+            return;
+        }
+        renderInfo(info);
+    });
+}
+if (claiming) {
+    status.textContent = 'claiming your board…';
+    identity.textContent = 'finishing authorization…';
+    setTimeout(connect, 1500);
+} else {
+    connect();
+}

--- a/examples/todos-server/board.client.js
+++ b/examples/todos-server/board.client.js
@@ -33,8 +33,29 @@ function onSnapshot(event) {
     list.replaceChildren(
         ...tasks.map(task => {
             const item = document.createElement('li');
-            item.textContent = `${task.title} (${task.id}, ${task.project}${task.priority ? ', ' + task.priority : ''})`;
-            if (task.status === 'done') item.classList.add('done');
+            item.className = task.status === 'done' ? 'task done' : 'task';
+            const box = document.createElement('input');
+            box.type = 'checkbox';
+            box.checked = task.status === 'done';
+            box.disabled = true;
+            box.tabIndex = -1;
+            const title = document.createElement('span');
+            title.className = 'title';
+            title.textContent = task.title;
+            const meta = document.createElement('span');
+            meta.className = 'meta';
+            const chip = text => {
+                const span = document.createElement('span');
+                span.className = 'chip';
+                span.textContent = text;
+                return span;
+            };
+            meta.append(chip(`project · ${task.project}`));
+            if (task.priority) meta.append(chip(`priority · ${task.priority}`));
+            const id = document.createElement('span');
+            id.textContent = task.id;
+            meta.append(id);
+            item.append(box, title, meta);
             return item;
         })
     );

--- a/examples/todos-server/board.client.js
+++ b/examples/todos-server/board.client.js
@@ -1,4 +1,5 @@
 // @ts-check
+/* global document, location, EventSource, URLSearchParams, setTimeout */
 // The live board page's script, shipped as its own Text module so the repo's
 // lint/format gates see it (an inline <script> is invisible to them). The
 // worker inlines it into board.html at render time via the __BOARD_SCRIPT__
@@ -54,7 +55,7 @@ function connect() {
         // Opened straight from consent, the viewer cookie can land a moment
         // after this page: if we resolved to the address fallback, try once
         // more before accepting it.
-        if (info.mode === 'address' && !namedBoard && !retried) {
+        if (info.mode === 'address' && claiming && !retried) {
             retried = true;
             status.textContent = 'claiming your board…';
             source.close();

--- a/examples/todos-server/board.html
+++ b/examples/todos-server/board.html
@@ -53,7 +53,8 @@
         <p id="status">connecting…</p>
         <script>
             const params = new URLSearchParams(location.search);
-            document.getElementById('board-name').textContent = params.get('b') ?? 'your address-keyed board';
+            document.getElementById('board-name').textContent =
+                params.get('b') ?? 'your board (OAuth grant if you just approved one, else address-keyed)';
             const list = document.getElementById('tasks');
             const empty = document.getElementById('empty');
             const status = document.getElementById('status');

--- a/examples/todos-server/board.html
+++ b/examples/todos-server/board.html
@@ -56,73 +56,7 @@
         <p id="empty" hidden>The board is empty — add a task from a connected client.</p>
         <p id="status">connecting…</p>
         <script>
-            const identity = document.getElementById('identity');
-            const list = document.getElementById('tasks');
-            const empty = document.getElementById('empty');
-            const status = document.getElementById('status');
-            const namedBoard = new URLSearchParams(location.search).get('b');
-            // Opened from the consent click, this tab races the approval POST: the
-            // viewer cookie for the NEW grant lands with the approve response, which
-            // may arrive after this page. #claim defers the first connection so the
-            // cookie is in place, instead of resolving to a previous grant's board.
-            const claiming = location.hash === '#claim' && !namedBoard;
-            let source;
-            let retried = false;
-
-            function renderInfo(info) {
-                identity.textContent =
-                    info.mode === 'oauth'
-                        ? `You are OAuthed: this is the private board granted to ${info.label}.`
-                        : info.mode === 'named'
-                          ? `Shared board "${info.label}" — anyone with this link (and any client sending X-Todos-Board: ${info.label}) sees it.`
-                          : 'Your address-keyed board (no OAuth grant, no ?b= name).';
-            }
-
-            function onSnapshot(event) {
-                const snapshot = JSON.parse(event.data);
-                const tasks = snapshot.tasks ?? [];
-                list.replaceChildren(
-                    ...tasks.map(task => {
-                        const item = document.createElement('li');
-                        item.textContent = `${task.title} (${task.id}, ${task.project}${task.priority ? ', ' + task.priority : ''})`;
-                        if (task.status === 'done') item.classList.add('done');
-                        return item;
-                    })
-                );
-                empty.hidden = tasks.length > 0;
-            }
-
-            function connect() {
-                source = new EventSource('/board/events' + location.search);
-                source.onopen = () => {
-                    status.textContent = 'live';
-                };
-                source.onerror = () => {
-                    status.textContent = 'reconnecting…';
-                };
-                source.onmessage = onSnapshot;
-                source.addEventListener('info', event => {
-                    const info = JSON.parse(event.data);
-                    // Opened straight from consent, the viewer cookie can land a moment
-                    // after this page: if we resolved to the address fallback, try once
-                    // more before accepting it.
-                    if (info.mode === 'address' && !namedBoard && !retried) {
-                        retried = true;
-                        status.textContent = 'claiming your board…';
-                        source.close();
-                        setTimeout(connect, 1200);
-                        return;
-                    }
-                    renderInfo(info);
-                });
-            }
-            if (claiming) {
-                status.textContent = 'claiming your board…';
-                identity.textContent = 'finishing authorization…';
-                setTimeout(connect, 1500);
-            } else {
-                connect();
-            }
+            __BOARD_SCRIPT__;
         </script>
     </body>
 </html>

--- a/examples/todos-server/board.html
+++ b/examples/todos-server/board.html
@@ -20,11 +20,38 @@
                 padding: 0.1rem 0.3rem;
             }
             ul {
-                padding-left: 1.4rem;
+                list-style: none;
+                padding: 0;
+                display: grid;
+                gap: 0.5rem;
             }
-            li.done {
+            li.task {
+                display: flex;
+                align-items: baseline;
+                gap: 0.6rem;
+                border: 1px solid #ddd;
+                border-radius: 6px;
+                padding: 0.5rem 0.75rem;
+            }
+            li.task .title {
+                flex: 1;
+            }
+            li.done .title {
                 color: #888;
                 text-decoration: line-through;
+            }
+            .meta {
+                display: flex;
+                gap: 0.4rem;
+                align-items: baseline;
+                color: #888;
+                font-size: 0.78rem;
+                white-space: nowrap;
+            }
+            .chip {
+                border: 1px solid #ccc;
+                border-radius: 999px;
+                padding: 0 0.5rem;
             }
             #identity {
                 font-weight: 600;
@@ -40,6 +67,12 @@
                 }
                 code {
                     background: #222;
+                }
+                li.task {
+                    border-color: #333;
+                }
+                .chip {
+                    border-color: #444;
                 }
             }
         </style>

--- a/examples/todos-server/board.html
+++ b/examples/todos-server/board.html
@@ -59,23 +59,41 @@
             const list = document.getElementById('tasks');
             const empty = document.getElementById('empty');
             const status = document.getElementById('status');
-            const source = new EventSource('/board/events' + location.search);
-            source.addEventListener('info', event => {
-                const info = JSON.parse(event.data);
-                identity.textContent =
-                    info.mode === 'oauth'
-                        ? `You are OAuthed: this is the private board granted to ${info.label}.`
-                        : info.mode === 'named'
-                          ? `Shared board "${info.label}" — anyone with this link (and any client sending X-Todos-Board: ${info.label}) sees it.`
-                          : 'Your address-keyed board (no OAuth grant, no ?b= name).';
-            });
-            source.onopen = () => {
-                status.textContent = 'live';
+            // Opened from consent, the viewer cookie may land a moment after this page:
+            // EventSource reconnects automatically only on error, so nudge one reconnect
+            // if the first resolution was the address fallback.
+            let source = new EventSource('/board/events' + location.search);
+            let retried = false;
+            const attachInfo = () =>
+                source.addEventListener('info', event => {
+                    const info = JSON.parse(event.data);
+                    if (info.mode === 'address' && !retried && !new URLSearchParams(location.search).get('b')) {
+                        retried = true;
+                        setTimeout(() => {
+                            source.close();
+                            source = new EventSource('/board/events' + location.search);
+                            attachInfo();
+                            attachHandlers();
+                        }, 1500);
+                        return;
+                    }
+                    identity.textContent =
+                        info.mode === 'oauth'
+                            ? `You are OAuthed: this is the private board granted to ${info.label}.`
+                            : info.mode === 'named'
+                              ? `Shared board "${info.label}" — anyone with this link (and any client sending X-Todos-Board: ${info.label}) sees it.`
+                              : 'Your address-keyed board (no OAuth grant, no ?b= name).';
+                });
+            const attachHandlers = () => {
+                source.onopen = () => {
+                    status.textContent = 'live';
+                };
+                source.onerror = () => {
+                    status.textContent = 'reconnecting…';
+                };
+                source.onmessage = onSnapshot;
             };
-            source.onerror = () => {
-                status.textContent = 'reconnecting…';
-            };
-            source.onmessage = event => {
+            const onSnapshot = event => {
                 const snapshot = JSON.parse(event.data);
                 const tasks = snapshot.tasks ?? [];
                 list.replaceChildren(
@@ -88,6 +106,8 @@
                 );
                 empty.hidden = tasks.length > 0;
             };
+            attachInfo();
+            attachHandlers();
         </script>
     </body>
 </html>

--- a/examples/todos-server/board.html
+++ b/examples/todos-server/board.html
@@ -26,6 +26,9 @@
                 color: #888;
                 text-decoration: line-through;
             }
+            #identity {
+                font-weight: 600;
+            }
             #status {
                 color: #888;
                 font-size: 0.85rem;
@@ -42,58 +45,35 @@
         </style>
     </head>
     <body>
-        <h1 id="board-title">Live board</h1>
-        <p id="identity" style="font-weight: 600"></p>
+        <h1>Live board</h1>
+        <p id="identity">resolving whose board this is…</p>
         <p>
-            Updates appear the moment any MCP client changes this board. Point a client at <code>__HOST__/mcp</code> with the
-            <code>X-Todos-Board</code> header set to this board's name (add <code>?b=&lt;name&gt;</code> to this page's URL), then watch
-            tasks land here as the agent works. Boards wipe after ~2 hours idle.
+            Updates appear the moment any MCP client changes this board. Anonymous boards: connect a client to
+            <code>__HOST__/mcp</code> with the <code>X-Todos-Board</code> header and add <code>?b=&lt;name&gt;</code> here. OAuth boards:
+            this page shows your grant's board in the browser where you approved consent. Boards wipe after ~2 hours idle.
         </p>
         <ul id="tasks"></ul>
         <p id="empty" hidden>The board is empty — add a task from a connected client.</p>
         <p id="status">connecting…</p>
         <script>
-            const params = new URLSearchParams(location.search);
-            document.getElementById('board-name').textContent =
-                params.get('b') ?? 'your board (OAuth grant if you just approved one, else address-keyed)';
+            const identity = document.getElementById('identity');
             const list = document.getElementById('tasks');
             const empty = document.getElementById('empty');
             const status = document.getElementById('status');
-            // Opened from consent, the viewer cookie may land a moment after this page:
-            // EventSource reconnects automatically only on error, so nudge one reconnect
-            // if the first resolution was the address fallback.
-            let source = new EventSource('/board/events' + location.search);
+            const namedBoard = new URLSearchParams(location.search).get('b');
+            let source;
             let retried = false;
-            const attachInfo = () =>
-                source.addEventListener('info', event => {
-                    const info = JSON.parse(event.data);
-                    if (info.mode === 'address' && !retried && !new URLSearchParams(location.search).get('b')) {
-                        retried = true;
-                        setTimeout(() => {
-                            source.close();
-                            source = new EventSource('/board/events' + location.search);
-                            attachInfo();
-                            attachHandlers();
-                        }, 1500);
-                        return;
-                    }
-                    identity.textContent =
-                        info.mode === 'oauth'
-                            ? `You are OAuthed: this is the private board granted to ${info.label}.`
-                            : info.mode === 'named'
-                              ? `Shared board "${info.label}" — anyone with this link (and any client sending X-Todos-Board: ${info.label}) sees it.`
-                              : 'Your address-keyed board (no OAuth grant, no ?b= name).';
-                });
-            const attachHandlers = () => {
-                source.onopen = () => {
-                    status.textContent = 'live';
-                };
-                source.onerror = () => {
-                    status.textContent = 'reconnecting…';
-                };
-                source.onmessage = onSnapshot;
-            };
-            const onSnapshot = event => {
+
+            function renderInfo(info) {
+                identity.textContent =
+                    info.mode === 'oauth'
+                        ? `You are OAuthed: this is the private board granted to ${info.label}.`
+                        : info.mode === 'named'
+                          ? `Shared board "${info.label}" — anyone with this link (and any client sending X-Todos-Board: ${info.label}) sees it.`
+                          : 'Your address-keyed board (no OAuth grant, no ?b= name).';
+            }
+
+            function onSnapshot(event) {
                 const snapshot = JSON.parse(event.data);
                 const tasks = snapshot.tasks ?? [];
                 list.replaceChildren(
@@ -105,9 +85,33 @@
                     })
                 );
                 empty.hidden = tasks.length > 0;
-            };
-            attachInfo();
-            attachHandlers();
+            }
+
+            function connect() {
+                source = new EventSource('/board/events' + location.search);
+                source.onopen = () => {
+                    status.textContent = 'live';
+                };
+                source.onerror = () => {
+                    status.textContent = 'reconnecting…';
+                };
+                source.onmessage = onSnapshot;
+                source.addEventListener('info', event => {
+                    const info = JSON.parse(event.data);
+                    // Opened straight from consent, the viewer cookie can land a moment
+                    // after this page: if we resolved to the address fallback, try once
+                    // more before accepting it.
+                    if (info.mode === 'address' && !namedBoard && !retried) {
+                        retried = true;
+                        status.textContent = 'claiming your board…';
+                        source.close();
+                        setTimeout(connect, 1200);
+                        return;
+                    }
+                    renderInfo(info);
+                });
+            }
+            connect();
         </script>
     </body>
 </html>

--- a/examples/todos-server/board.html
+++ b/examples/todos-server/board.html
@@ -61,6 +61,11 @@
             const empty = document.getElementById('empty');
             const status = document.getElementById('status');
             const namedBoard = new URLSearchParams(location.search).get('b');
+            // Opened from the consent click, this tab races the approval POST: the
+            // viewer cookie for the NEW grant lands with the approve response, which
+            // may arrive after this page. #claim defers the first connection so the
+            // cookie is in place, instead of resolving to a previous grant's board.
+            const claiming = location.hash === '#claim' && !namedBoard;
             let source;
             let retried = false;
 
@@ -111,7 +116,13 @@
                     renderInfo(info);
                 });
             }
-            connect();
+            if (claiming) {
+                status.textContent = 'claiming your board…';
+                identity.textContent = 'finishing authorization…';
+                setTimeout(connect, 1500);
+            } else {
+                connect();
+            }
         </script>
     </body>
 </html>

--- a/examples/todos-server/board.html
+++ b/examples/todos-server/board.html
@@ -1,0 +1,82 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>todos — live board</title>
+        <style>
+            body {
+                font-family: system-ui, sans-serif;
+                max-width: 44rem;
+                margin: 3rem auto;
+                padding: 0 1rem;
+                line-height: 1.5;
+            }
+            h1 {
+                font-size: 1.3rem;
+            }
+            code {
+                background: #eee;
+                padding: 0.1rem 0.3rem;
+            }
+            ul {
+                padding-left: 1.4rem;
+            }
+            li.done {
+                color: #888;
+                text-decoration: line-through;
+            }
+            #status {
+                color: #888;
+                font-size: 0.85rem;
+            }
+            @media (prefers-color-scheme: dark) {
+                body {
+                    background: #111;
+                    color: #ddd;
+                }
+                code {
+                    background: #222;
+                }
+            }
+        </style>
+    </head>
+    <body>
+        <h1>Live board: <code id="board-name"></code></h1>
+        <p>
+            Updates appear the moment any MCP client changes this board. Point a client at <code>__HOST__/mcp</code> with the
+            <code>X-Todos-Board</code> header set to this board's name (add <code>?b=&lt;name&gt;</code> to this page's URL), then watch
+            tasks land here as the agent works. Boards wipe after ~2 hours idle.
+        </p>
+        <ul id="tasks"></ul>
+        <p id="empty" hidden>The board is empty — add a task from a connected client.</p>
+        <p id="status">connecting…</p>
+        <script>
+            const params = new URLSearchParams(location.search);
+            document.getElementById('board-name').textContent = params.get('b') ?? 'your address-keyed board';
+            const list = document.getElementById('tasks');
+            const empty = document.getElementById('empty');
+            const status = document.getElementById('status');
+            const source = new EventSource('/board/events' + location.search);
+            source.onopen = () => {
+                status.textContent = 'live';
+            };
+            source.onerror = () => {
+                status.textContent = 'reconnecting…';
+            };
+            source.onmessage = event => {
+                const snapshot = JSON.parse(event.data);
+                const tasks = snapshot.tasks ?? [];
+                list.replaceChildren(
+                    ...tasks.map(task => {
+                        const item = document.createElement('li');
+                        item.textContent = `${task.title} (${task.id}, ${task.project}${task.priority ? ', ' + task.priority : ''})`;
+                        if (task.status === 'done') item.classList.add('done');
+                        return item;
+                    })
+                );
+                empty.hidden = tasks.length > 0;
+            };
+        </script>
+    </body>
+</html>

--- a/examples/todos-server/board.html
+++ b/examples/todos-server/board.html
@@ -42,7 +42,8 @@
         </style>
     </head>
     <body>
-        <h1>Live board: <code id="board-name"></code></h1>
+        <h1 id="board-title">Live board</h1>
+        <p id="identity" style="font-weight: 600"></p>
         <p>
             Updates appear the moment any MCP client changes this board. Point a client at <code>__HOST__/mcp</code> with the
             <code>X-Todos-Board</code> header set to this board's name (add <code>?b=&lt;name&gt;</code> to this page's URL), then watch
@@ -59,6 +60,15 @@
             const empty = document.getElementById('empty');
             const status = document.getElementById('status');
             const source = new EventSource('/board/events' + location.search);
+            source.addEventListener('info', event => {
+                const info = JSON.parse(event.data);
+                identity.textContent =
+                    info.mode === 'oauth'
+                        ? `You are OAuthed: this is the private board granted to ${info.label}.`
+                        : info.mode === 'named'
+                          ? `Shared board "${info.label}" — anyone with this link (and any client sending X-Todos-Board: ${info.label}) sees it.`
+                          : 'Your address-keyed board (no OAuth grant, no ?b= name).';
+            });
             source.onopen = () => {
                 status.textContent = 'live';
             };

--- a/examples/todos-server/e2e/verify.ts
+++ b/examples/todos-server/e2e/verify.ts
@@ -297,4 +297,45 @@ const bareApprove = await fetch(`${BASE}/authorize/approve`, { method: 'POST', r
 check.equal(bareApprove.status, 400);
 console.error('[verify] 8. error paths ok');
 
+// 9. 2026-era cancellation: dropping the request's response stream mid-call MUST
+// stop the tool (draft streamable-http). On Workers this needs the
+// enable_request_signal compatibility flag — this probe is the regression net.
+const cancelBoard = `verify-cancel-${Math.random().toString(36).slice(2, 10)}`;
+const onCancelBoard = (name: string, args: unknown): Promise<Response> =>
+    mcp('/mcp', 'tools/call', name, args, { 'x-todos-board': cancelBoard });
+for (let i = 0; i < 6; i++) await onCancelBoard('add_task', { title: `cancel-target-${i}` });
+const dropController = new AbortController();
+const longCall = fetch(`${BASE}/mcp`, {
+    method: 'POST',
+    headers: {
+        'content-type': 'application/json',
+        accept: 'application/json, text/event-stream',
+        'mcp-protocol-version': '2026-07-28',
+        'mcp-method': 'tools/call',
+        'mcp-name': 'work_through_tasks',
+        'x-todos-board': cancelBoard,
+        ...UA
+    },
+    body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 9,
+        method: 'tools/call',
+        params: { name: 'work_through_tasks', arguments: { secondsPerTask: 2 }, _meta: { ...ENVELOPE, progressToken: 'cancel-probe' } }
+    }),
+    signal: dropController.signal
+});
+const streaming = await longCall;
+check.equal(streaming.status, 200);
+// Consume one frame so the exchange is demonstrably live, then drop the connection.
+const frameReader = streaming.body?.getReader();
+check.ok(frameReader !== undefined);
+await frameReader!.read();
+await new Promise(resolve => setTimeout(resolve, 2500));
+dropController.abort();
+await new Promise(resolve => setTimeout(resolve, 12_000));
+const survivors = await toolText(await onCancelBoard('list_tasks', {}));
+const stillOpen = (survivors.match(/- \[ \]/g) ?? []).length;
+check.ok(stillOpen >= 2);
+console.error(`[verify] 9. cancellation ok (${stillOpen}/6 tasks spared by the mid-call drop)`);
+
 console.error('[verify] all checks passed');

--- a/examples/todos-server/e2e/verify.ts
+++ b/examples/todos-server/e2e/verify.ts
@@ -1,0 +1,293 @@
+/**
+ * Self-verifying probe suite for a running todos-server worker (wrangler dev or a
+ * live deployment). Covers what the unit-less worker cannot: the OAuth dance,
+ * the tier-security invariants (session ids are never credentials), the live
+ * board view, and the pages.
+ *
+ *   pnpm --filter @mcp-examples/todos-server verify                       # against http://127.0.0.1:8850
+ *   pnpm --filter @mcp-examples/todos-server verify -- --base https://…   # against a deployment
+ *
+ * Consent handling auto-detects: a 302 from /authorize means TODOS_AUTO_CONSENT
+ * is set (dev); a 200 renders the real consent form, which the suite completes
+ * with the double-submit nonce like a browser would.
+ */
+import { check } from '@mcp-examples/shared';
+
+const baseIndex = process.argv.indexOf('--base');
+const BASE = baseIndex === -1 ? 'http://127.0.0.1:8850' : (process.argv[baseIndex + 1] ?? '');
+// workers.dev bot protection 403s default non-browser UAs; real MCP clients are unaffected.
+const UA = { 'user-agent': 'todos-e2e-verify/1.0' };
+const ENVELOPE = {
+    'io.modelcontextprotocol/protocolVersion': '2026-07-28',
+    'io.modelcontextprotocol/clientInfo': { name: 'verify', version: '1.0' },
+    'io.modelcontextprotocol/clientCapabilities': {}
+};
+
+function b64url(bytes: Uint8Array): string {
+    return Buffer.from(bytes).toString('base64url');
+}
+
+async function sha256(text: string): Promise<string> {
+    return b64url(new Uint8Array(await crypto.subtle.digest('SHA-256', new TextEncoder().encode(text))));
+}
+
+interface Grant {
+    token: string;
+    clientId: string;
+    viewerCookie?: string;
+}
+
+/** The full authorization-code dance: register, authorize (either consent mode), exchange. */
+async function dance(): Promise<Grant> {
+    const registerResponse = await fetch(`${BASE}/oauth/register`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', ...UA },
+        body: JSON.stringify({
+            client_name: 'e2e-verify',
+            redirect_uris: ['http://127.0.0.1:9999/callback'],
+            grant_types: ['authorization_code'],
+            response_types: ['code'],
+            token_endpoint_auth_method: 'none'
+        })
+    });
+    const registered = (await registerResponse.json()) as { client_id: string };
+
+    const verifier = b64url(crypto.getRandomValues(new Uint8Array(32)));
+    const query = new URLSearchParams({
+        response_type: 'code',
+        client_id: registered.client_id,
+        redirect_uri: 'http://127.0.0.1:9999/callback',
+        scope: 'todos',
+        state: 'verify-state',
+        code_challenge: await sha256(verifier),
+        code_challenge_method: 'S256'
+    });
+    let authorize = await fetch(`${BASE}/authorize?${query.toString()}`, { redirect: 'manual', headers: UA });
+    if (authorize.status === 200) {
+        // Real consent page: complete it the way a browser would.
+        const page = await authorize.text();
+        const nonce = /name="nonce" value="([^"]+)"/.exec(page)?.[1] ?? '';
+        const action = (/action="([^"]+)"/.exec(page)?.[1] ?? '').replaceAll('&amp;', '&');
+        const consentCookie = (authorize.headers.get('set-cookie') ?? '').split(';')[0];
+        check.ok(nonce.length > 0);
+        authorize = await fetch(`${BASE}${action}`, {
+            method: 'POST',
+            redirect: 'manual',
+            headers: { 'content-type': 'application/x-www-form-urlencoded', cookie: consentCookie, ...UA },
+            body: new URLSearchParams({ nonce }).toString()
+        });
+    }
+    check.equal(authorize.status, 302);
+    const viewerCookie = (authorize.headers.get('set-cookie') ?? '').split(';')[0] || undefined;
+    const location = new URL(authorize.headers.get('location') ?? '');
+    check.equal(location.searchParams.get('state'), 'verify-state');
+    const code = location.searchParams.get('code') ?? '';
+
+    const tokenResponse = await fetch(`${BASE}/oauth/token`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/x-www-form-urlencoded', ...UA },
+        body: new URLSearchParams({
+            grant_type: 'authorization_code',
+            code,
+            client_id: registered.client_id,
+            redirect_uri: 'http://127.0.0.1:9999/callback',
+            code_verifier: verifier
+        }).toString()
+    });
+    const token = (await tokenResponse.json()) as { access_token: string };
+    check.ok(token.access_token.length > 0);
+    return { token: token.access_token, clientId: registered.client_id, viewerCookie };
+}
+
+async function mcp(
+    path: string,
+    method: string,
+    name: string | undefined,
+    args: unknown,
+    headers: Record<string, string>
+): Promise<Response> {
+    const params =
+        name === undefined
+            ? { _meta: ENVELOPE }
+            : method === 'tools/call'
+              ? { name, arguments: args, _meta: ENVELOPE }
+              : { _meta: ENVELOPE };
+    return fetch(`${BASE}${path}`, {
+        method: 'POST',
+        headers: {
+            'content-type': 'application/json',
+            accept: 'application/json, text/event-stream',
+            'mcp-protocol-version': '2026-07-28',
+            'mcp-method': method,
+            ...(name === undefined ? {} : { 'mcp-name': name }),
+            ...UA,
+            ...headers
+        },
+        body: JSON.stringify({ jsonrpc: '2.0', id: 1, method, params })
+    });
+}
+
+async function toolText(response: Response): Promise<string> {
+    const raw = await response.text();
+    for (const line of raw.split('\n')) {
+        if (line.startsWith('data: ')) return JSON.stringify(JSON.parse(line.slice(6)));
+    }
+    return raw;
+}
+
+/** Read SSE frames from a stream until the predicate is satisfied or the timeout hits. */
+async function readSse(
+    path: string,
+    headers: Record<string, string>,
+    until: (frames: string[]) => boolean,
+    timeoutMs = 12_000
+): Promise<string[]> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    const frames: string[] = [];
+    try {
+        const response = await fetch(`${BASE}${path}`, { headers: { ...UA, ...headers }, signal: controller.signal });
+        check.equal(response.status, 200);
+        const reader = response.body?.getReader();
+        check.ok(reader !== undefined);
+        const decoder = new TextDecoder();
+        let buffer = '';
+        for (;;) {
+            const { value, done } = await reader!.read();
+            if (done) break;
+            buffer += decoder.decode(value, { stream: true });
+            let index: number;
+            while ((index = buffer.indexOf('\n\n')) !== -1) {
+                frames.push(buffer.slice(0, index));
+                buffer = buffer.slice(index + 2);
+            }
+            if (until(frames)) return frames;
+        }
+    } catch (error) {
+        if (!(error instanceof Error && error.name === 'AbortError')) throw error;
+    } finally {
+        clearTimeout(timer);
+        controller.abort();
+    }
+    return frames;
+}
+
+// ---------------------------------------------------------------------------
+
+console.error(`[verify] target: ${BASE}`);
+
+// 1. Discovery documents are spec-shaped.
+const asResponse = await fetch(`${BASE}/.well-known/oauth-authorization-server`, { headers: UA });
+const asMetadata = (await asResponse.json()) as Record<string, unknown>;
+check.ok((asMetadata.code_challenge_methods_supported as string[]).includes('S256'));
+check.equal(asMetadata.client_id_metadata_document_supported, true);
+const prmResponse = await fetch(`${BASE}/.well-known/oauth-protected-resource/oauth/mcp`, { headers: UA });
+const prm = (await prmResponse.json()) as Record<string, unknown>;
+check.equal(prm.resource, `${BASE}/oauth/mcp`);
+console.error('[verify] 1. discovery ok');
+
+// 2. Unauthenticated → 401 with a resource_metadata challenge.
+const unauth = await mcp('/oauth/mcp', 'tools/list', undefined, {}, {});
+check.equal(unauth.status, 401);
+check.match(unauth.headers.get('www-authenticate') ?? '', /resource_metadata=/);
+console.error('[verify] 2. challenge ok');
+
+// 3. Two grants; boards are isolated; whoami reports the grant.
+const grantA = await dance();
+const grantB = await dance();
+const whoami = await toolText(await mcp('/oauth/mcp', 'tools/call', 'whoami', {}, { authorization: `Bearer ${grantA.token}` }));
+check.match(whoami, /Authenticated via OAuth/);
+await mcp('/oauth/mcp', 'tools/call', 'add_task', { title: 'canary-A' }, { authorization: `Bearer ${grantA.token}` });
+const listB = await toolText(await mcp('/oauth/mcp', 'tools/call', 'list_tasks', {}, { authorization: `Bearer ${grantB.token}` }));
+check.ok(!listB.includes('canary-A'));
+console.error('[verify] 3. grants + isolation ok');
+
+// 4. Tier security: a session id is never a credential.
+const init = await fetch(`${BASE}/oauth/mcp`, {
+    method: 'POST',
+    headers: {
+        'content-type': 'application/json',
+        accept: 'application/json, text/event-stream',
+        authorization: `Bearer ${grantA.token}`,
+        ...UA
+    },
+    body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: { protocolVersion: '2025-06-18', capabilities: {}, clientInfo: { name: 'verify', version: '1.0' } }
+    })
+});
+const sessionId = init.headers.get('mcp-session-id') ?? '';
+check.ok(sessionId.length > 0);
+// Session requests speak the session's negotiated protocol (2025-06-18): a
+// 2026-envelope request on a legacy session is correctly refused.
+const onSession = (path: string, headers: Record<string, string>): Promise<Response> =>
+    fetch(`${BASE}${path}`, {
+        method: 'POST',
+        headers: {
+            'content-type': 'application/json',
+            accept: 'application/json, text/event-stream',
+            'mcp-session-id': sessionId,
+            ...UA,
+            ...headers
+        },
+        body: JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} })
+    });
+const bare = await onSession('/mcp', {});
+check.equal(bare.status, 401);
+const crossGrant = await onSession('/oauth/mcp', { authorization: `Bearer ${grantB.token}` });
+check.equal(crossGrant.status, 404);
+const legit = await onSession('/oauth/mcp', { authorization: `Bearer ${grantA.token}` });
+check.equal(legit.status, 200);
+const viewLeak = await readSse('/board/events', { 'mcp-session-id': sessionId }, frames => frames.some(f => f.startsWith('data: ')), 6000);
+check.ok(!viewLeak.join('').includes('canary-A'));
+console.error('[verify] 4. tier security ok');
+
+// 5. Live board view: named board streams its own changes; identity frame is present.
+const boardId = `verify-${Math.random().toString(36).slice(2, 10)}`;
+// eslint-disable-next-line unicorn/prefer-top-level-await -- deliberately concurrent: the watcher must be listening before the mutation
+const watch = readSse(`/board/events?b=${boardId}`, {}, frames => frames.filter(f => f.startsWith('data: ')).length >= 2);
+await new Promise(resolve => setTimeout(resolve, 1000));
+await mcp('/mcp', 'tools/call', 'add_task', { title: 'seen-live' }, { 'x-todos-board': boardId });
+const frames = await watch;
+check.ok(frames.some(f => f.includes('"mode":"named"')));
+check.ok(frames.some(f => f.includes('seen-live')));
+console.error('[verify] 5. board view ok');
+
+// 6. Viewer cookie from consent resolves to the grant board (skipped without a cookie —
+// the auto-consent 302 carries it too, so it is present in both modes).
+if (grantA.viewerCookie) {
+    const viewer = await readSse('/board/events', { cookie: grantA.viewerCookie }, frames => frames.some(f => f.includes('"mode"')), 6000);
+    check.ok(viewer.some(f => f.includes('"mode":"oauth"')));
+    console.error('[verify] 6. viewer cookie ok');
+} else {
+    console.error('[verify] 6. viewer cookie skipped (no cookie in this consent mode)');
+}
+
+// 7. Pages serve and the board script parses.
+const landing = await fetch(`${BASE}/`, { headers: UA });
+check.equal(landing.status, 200);
+const board = await fetch(`${BASE}/board`, { headers: UA });
+const boardPage = await board.text();
+check.equal(board.status, 200);
+const script = /<script>\n?([\s\S]*?)<\/script>/.exec(boardPage)?.[1] ?? '';
+check.ok(script.length > 100);
+// This catches the shipped-dead-script class: the inline script must PARSE.
+// Compile-only: the constructed function is never invoked, so nothing from the
+// target executes here even if --base pointed somewhere hostile.
+// eslint-disable-next-line @typescript-eslint/no-implied-eval, no-new-func
+new Function(script);
+console.error('[verify] 7. pages ok');
+
+// 8. Authorization error paths answer 400, not exceptions.
+const badClient = await fetch(`${BASE}/authorize?response_type=code&client_id=nonexistent&redirect_uri=https%3A%2F%2Fx%2Fcb`, {
+    redirect: 'manual',
+    headers: UA
+});
+check.ok(badClient.status === 400 || badClient.status === 302);
+const bareApprove = await fetch(`${BASE}/authorize/approve`, { method: 'POST', redirect: 'manual', headers: UA });
+check.equal(bareApprove.status, 400);
+console.error('[verify] 8. error paths ok');
+
+console.error('[verify] all checks passed');

--- a/examples/todos-server/e2e/verify.ts
+++ b/examples/todos-server/e2e/verify.ts
@@ -197,7 +197,10 @@ const grantA = await dance();
 const grantB = await dance();
 const whoami = await toolText(await mcp('/oauth/mcp', 'tools/call', 'whoami', {}, { authorization: `Bearer ${grantA.token}` }));
 check.match(whoami, /Authenticated via OAuth/);
-await mcp('/oauth/mcp', 'tools/call', 'add_task', { title: 'canary-A' }, { authorization: `Bearer ${grantA.token}` });
+const canaryAdd = await toolText(
+    await mcp('/oauth/mcp', 'tools/call', 'add_task', { title: 'canary-A' }, { authorization: `Bearer ${grantA.token}` })
+);
+check.match(canaryAdd, /canary-A/);
 const listB = await toolText(await mcp('/oauth/mcp', 'tools/call', 'list_tasks', {}, { authorization: `Bearer ${grantB.token}` }));
 check.ok(!listB.includes('canary-A'));
 console.error('[verify] 3. grants + isolation ok');
@@ -241,6 +244,8 @@ check.equal(crossGrant.status, 404);
 const legit = await onSession('/oauth/mcp', { authorization: `Bearer ${grantA.token}` });
 check.equal(legit.status, 200);
 const viewLeak = await readSse('/board/events', { 'mcp-session-id': sessionId }, frames => frames.some(f => f.startsWith('data: ')), 6000);
+// The absence of the canary only proves anything over a stream that produced a snapshot.
+check.ok(viewLeak.some(f => f.startsWith('data: ')));
 check.ok(!viewLeak.join('').includes('canary-A'));
 console.error('[verify] 4. tier security ok');
 
@@ -255,15 +260,17 @@ check.ok(frames.some(f => f.includes('"mode":"named"')));
 check.ok(frames.some(f => f.includes('seen-live')));
 console.error('[verify] 5. board view ok');
 
-// 6. Viewer cookie from consent resolves to the grant board (skipped without a cookie —
-// the auto-consent 302 carries it too, so it is present in both modes).
-if (grantA.viewerCookie) {
-    const viewer = await readSse('/board/events', { cookie: grantA.viewerCookie }, frames => frames.some(f => f.includes('"mode"')), 6000);
-    check.ok(viewer.some(f => f.includes('"mode":"oauth"')));
-    console.error('[verify] 6. viewer cookie ok');
-} else {
-    console.error('[verify] 6. viewer cookie skipped (no cookie in this consent mode)');
-}
+// 6. The approve 302 carries the viewer cookie in both consent modes; it must resolve
+// to the grant board.
+check.ok(grantA.viewerCookie !== undefined);
+const viewer = await readSse(
+    '/board/events',
+    { cookie: grantA.viewerCookie ?? '' },
+    frames => frames.some(f => f.includes('"mode"')),
+    6000
+);
+check.ok(viewer.some(f => f.includes('"mode":"oauth"')));
+console.error('[verify] 6. viewer cookie ok');
 
 // 7. Pages serve and the board script parses.
 const landing = await fetch(`${BASE}/`, { headers: UA });
@@ -285,7 +292,7 @@ const badClient = await fetch(`${BASE}/authorize?response_type=code&client_id=no
     redirect: 'manual',
     headers: UA
 });
-check.ok(badClient.status === 400 || badClient.status === 302);
+check.equal(badClient.status, 400);
 const bareApprove = await fetch(`${BASE}/authorize/approve`, { method: 'POST', redirect: 'manual', headers: UA });
 check.equal(bareApprove.status, 400);
 console.error('[verify] 8. error paths ok');

--- a/examples/todos-server/index.html
+++ b/examples/todos-server/index.html
@@ -51,6 +51,18 @@
             an <code>mcpServers</code>-style host config:
         </p>
         <pre>{ "mcpServers": { "todos": { "url": "__HOST__/mcp" } } }</pre>
+        <p>
+            Boards on <code>/mcp</code> are anonymous: keyed by your network address, or by an <code>X-Todos-Board</code> header you choose.
+            For a <strong>private board</strong>, connect to <code>__HOST__/oauth/mcp</code> instead — your client discovers the OAuth
+            endpoints automatically (RFC 9728), registers itself (dynamic registration or a URL-format client id), and walks the
+            authorization-code flow with PKCE. Approving consent creates a fresh board bound to that grant: the token is the board. No
+            accounts; boards still expire after ~2 hours idle.
+        </p>
+        <pre>{ "mcpServers": { "todos": { "url": "__HOST__/oauth/mcp" } } }</pre>
+        <p>
+            Watch a board update live at <code>__HOST__/board?b=&lt;name&gt;</code> while a client connected with
+            <code>X-Todos-Board: &lt;name&gt;</code> works on it.
+        </p>
         <p>Or raw, in the 2026-07-28 wire format (there is no <code>initialize</code> — try <code>server/discover</code>):</p>
         <pre>
 curl -X POST __HOST__/mcp \

--- a/examples/todos-server/index.html
+++ b/examples/todos-server/index.html
@@ -59,9 +59,12 @@
             accounts; boards still expire after ~2 hours idle.
         </p>
         <pre>{ "mcpServers": { "todos": { "url": "__HOST__/oauth/mcp" } } }</pre>
+        <h2>Watch it live</h2>
         <p>
-            Watch a board update live at <code>__HOST__/board?b=&lt;name&gt;</code> while a client connected with
-            <code>X-Todos-Board: &lt;name&gt;</code> works on it.
+            <code>__HOST__/board</code> is a read-only live view: tasks appear and complete in real time as connected agents work. Anonymous
+            boards: open <code>__HOST__/board?b=&lt;name&gt;</code> and connect your client with <code>X-Todos-Board: &lt;name&gt;</code>.
+            OAuth boards: after approving consent, open <code>__HOST__/board</code> in the same browser — it shows your grant's board (no
+            token or board id in any URL).
         </p>
         <p>Or raw, in the 2026-07-28 wire format (there is no <code>initialize</code> — try <code>server/discover</code>):</p>
         <pre>

--- a/examples/todos-server/index.html
+++ b/examples/todos-server/index.html
@@ -1,0 +1,107 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>todos — MCP TypeScript SDK reference server</title>
+        <style>
+            body {
+                font-family: system-ui;
+                max-width: 46em;
+                margin: 3em auto;
+                line-height: 1.55;
+                padding: 0 1em;
+            }
+            code,
+            pre {
+                background: #f3f4f6;
+                border-radius: 4px;
+            }
+            code {
+                padding: 0.1em 0.3em;
+            }
+            pre {
+                padding: 0.8em;
+                overflow-x: auto;
+            }
+            h1 {
+                margin-bottom: 0.2em;
+            }
+            h2 {
+                margin-top: 1.6em;
+            }
+            .muted {
+                color: #6b7280;
+            }
+        </style>
+    </head>
+    <body>
+        <h1>todos</h1>
+        <p class="muted">
+            A live deployment of the MCP TypeScript SDK's reference server,
+            <a href="https://github.com/modelcontextprotocol/typescript-sdk/tree/main/examples/todos-server">examples/todos-server</a>
+            — a small todo board where every server-side MCP feature has a real job: tools, resources, prompts, sampling, elicitation,
+            progress, logging, and subscriptions.
+        </p>
+
+        <h2>Connect</h2>
+        <p>
+            The MCP endpoint is <code>__HOST__/mcp</code> (Streamable HTTP). It serves <strong>both protocol revisions at once</strong> —
+            2026-07-28 and 2025-11-25 are negotiated per connection, so both current hosts and 2.0 SDK clients connect to the same URL. In
+            an <code>mcpServers</code>-style host config:
+        </p>
+        <pre>{ "mcpServers": { "todos": { "url": "__HOST__/mcp" } } }</pre>
+        <p>Or raw, in the 2026-07-28 wire format (there is no <code>initialize</code> — try <code>server/discover</code>):</p>
+        <pre>
+curl -X POST __HOST__/mcp \
+  -H 'content-type: application/json' \
+  -H 'accept: application/json, text/event-stream' \
+  -H 'mcp-protocol-version: 2026-07-28' \
+  -H 'mcp-method: server/discover' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"server/discover","params":{"_meta":{
+    "io.modelcontextprotocol/protocolVersion":"2026-07-28",
+    "io.modelcontextprotocol/clientInfo":{"name":"my-client","version":"1.0"},
+    "io.modelcontextprotocol/clientCapabilities":{}}}}'</pre
+        >
+
+        <h2>What to try</h2>
+        <ul>
+            <li>
+                <code>add_task</code>, <code>list_tasks</code>, <code>complete_task</code> — plain CRUD; <code>add_task</code> returns
+                <code>structuredContent</code> against an output schema.
+            </li>
+            <li>
+                <code>brainstorm_tasks</code> — multi-round <code>input_required</code>: a form, an optional follow-up round, then a
+                sampling round that borrows <em>your</em> model.
+            </li>
+            <li><code>clear_done</code> — elicitation: the server asks you to confirm via a schema-driven form.</li>
+            <li><code>work_through_tasks</code> — paced progress notifications; cancel mid-run and watch it stop early.</li>
+            <li><code>todos://board</code> — a subscribable resource; every mutation announces itself.</li>
+            <li><code>plan-my-day</code> — a prompt with completable arguments.</li>
+        </ul>
+        <p class="muted">
+            All of it works on both revisions: 2026-07-28 clients run the interactive tools as stateless
+            <code>input_required</code> round trips, while 2025-era clients get a real session at <code>initialize</code>
+            (<code>Mcp-Session-Id</code>) with push-style elicitation/sampling over its streams. Sessions are in-memory — if the server
+            recycles, a conformant client just re-initializes; your board is durable either way. Session-less 2025-era requests are still
+            answered statelessly — one-shot calls work, but the interactive tools need the session, so a client that connected before
+            sessions existed here should simply reconnect.
+        </p>
+
+        <h2>Boards</h2>
+        <p>
+            Every visitor gets their own board, keyed by connecting address — or send an
+            <code>X-Todos-Board: any-name</code> header to use a board of your own naming (recommended if your network egress rotates IPs,
+            e.g. CGNAT — otherwise consecutive requests may land on different boards). Boards are capped at 200 tasks and expire about two
+            hours after the last change. <strong>Treat board content as untrusted:</strong> it was written by whoever shares your visitor
+            key. Don't give an agent connected here unattended write authority elsewhere, and don't store anything sensitive.
+        </p>
+
+        <p class="muted">
+            No availability promises — this exists so you can kick the tires of a real 2026-07-28 server without running one. Source:
+            <a href="https://github.com/modelcontextprotocol/typescript-sdk">typescript-sdk</a> ·
+            <a href="https://ts.sdk.modelcontextprotocol.io">SDK docs</a> ·
+            <a href="https://modelcontextprotocol.io">MCP spec</a>
+        </p>
+    </body>
+</html>

--- a/examples/todos-server/oauth.ts
+++ b/examples/todos-server/oauth.ts
@@ -1,0 +1,143 @@
+/**
+ * OAuth glue for the todos worker: `@cloudflare/workers-oauth-provider` is the
+ * Authorization Server (endpoints, token issuance, client registration — both
+ * RFC 7591 dynamic registration and Client ID Metadata Documents), and the
+ * MCP handler stays a pure Resource Server consumer: the provider verifies
+ * tokens on the API route and this module maps the grant's `props` into the
+ * SDK's `AuthInfo`.
+ *
+ * The demo has no user accounts. The principal is the board: approving the
+ * consent screen mints a fresh board id into the grant's props, so the token
+ * IS the board — private, portable, and immune to egress-IP rotation. Real
+ * deployments replace exactly one thing: the consent step authenticates a
+ * user (their IdP) instead of minting an anonymous board.
+ */
+import type { AuthInfo } from '@modelcontextprotocol/server';
+
+/** What `completeAuthorization` stores and every authorized request gets back. */
+export interface TodosGrantProps {
+    boardId: string;
+    clientId: string;
+    scopes: string[];
+}
+
+/**
+ * The canonical mapping from the provider's grant props to the SDK's
+ * `AuthInfo`. The provider attaches only `props` after verifying a token, so
+ * everything `AuthInfo` needs must be embedded at grant time (clientId,
+ * scopes); the raw token comes from the request header. `expiresAt` is omitted
+ * because the provider verifies the token on every request that reaches the
+ * API route — including every request of a 2025-era session, which the worker
+ * refuses unless it arrives through the provider-verified route — so expiry
+ * and revocation cut access without the app tracking timestamps.
+ */
+export function propsToAuthInfo(props: TodosGrantProps, request: Request): AuthInfo {
+    return {
+        token: request.headers.get('authorization')?.replace(/^Bearer /i, '') ?? '',
+        clientId: props.clientId,
+        scopes: props.scopes
+    };
+}
+
+/** The provider helpers the worker uses (subset of OAuthHelpers we touch). */
+export interface OAuthHelpers {
+    parseAuthRequest(request: Request): Promise<{ clientId: string; scope: string[]; state: string; redirectUri: string }>;
+    lookupClient(clientId: string): Promise<{ clientId: string; clientName?: string; redirectUris: string[] } | null>;
+    completeAuthorization(options: {
+        request: unknown;
+        userId: string;
+        metadata: Record<string, unknown>;
+        scope: string[];
+        props: TodosGrantProps;
+    }): Promise<{ redirectTo: string }>;
+}
+
+function escapeHtml(value: string): string {
+    return value.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;').replaceAll('"', '&quot;');
+}
+
+function consentPage(clientName: string, scopes: string[], approveAction: string, nonce: string): string {
+    return `<!doctype html>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Authorize — todos demo</title>
+<body style="font-family: system-ui, sans-serif; max-width: 40rem; margin: 4rem auto; padding: 0 1rem; line-height: 1.5">
+<h1>Authorize ${escapeHtml(clientName)}</h1>
+<p><strong>${escapeHtml(clientName)}</strong> is asking for access with scope
+<code>${escapeHtml(scopes.join(' '))}</code>.</p>
+<p>This demo has no accounts: approving creates a <strong>fresh private todo board</strong>
+bound to this authorization. Whoever holds the resulting token holds the board.
+A real deployment would sign you in here instead.</p>
+<form method="post" action="${escapeHtml(approveAction)}">
+<input type="hidden" name="nonce" value="${escapeHtml(nonce)}">
+<button type="submit" style="font-size: 1.1rem; padding: 0.5rem 1.5rem">Approve</button>
+</form>
+</body>`;
+}
+
+/**
+ * GET /authorize — parse the request, show consent (or auto-approve when the
+ * TODOS_AUTO_CONSENT var is set, which the scripted end-to-end dance uses).
+ * POST /authorize/approve — mint the board and complete the grant.
+ *
+ * The original OAuth query parameters ride along to the approve action so the
+ * provider re-parses them there; the provider itself validates client and
+ * redirect URI on completion. Approval is bound to the rendered consent page
+ * by a double-submit nonce (HttpOnly cookie + hidden field), so a bare POST
+ * can never mint a grant.
+ */
+export async function handleAuthorize(request: Request, provider: OAuthHelpers, autoConsent: boolean): Promise<Response> {
+    const url = new URL(request.url);
+    // Routine client mistakes (unknown client_id, mismatched redirect_uri, disabled
+    // flows) must answer 400, not surface as worker exceptions.
+    let oauthRequest: Awaited<ReturnType<OAuthHelpers['parseAuthRequest']>>;
+    let client: Awaited<ReturnType<OAuthHelpers['lookupClient']>>;
+    try {
+        oauthRequest = await provider.parseAuthRequest(request);
+        client = await provider.lookupClient(oauthRequest.clientId);
+    } catch (error) {
+        console.warn('authorize request rejected:', error);
+        return new Response('Invalid authorization request.\n', { status: 400 });
+    }
+    if (!client) {
+        return new Response('Unknown client.\n', { status: 400 });
+    }
+
+    const approve = async (): Promise<Response> => {
+        const boardId = crypto.randomUUID();
+        const scopes = oauthRequest.scope.length > 0 ? oauthRequest.scope : ['todos'];
+        const { redirectTo } = await provider.completeAuthorization({
+            request: oauthRequest,
+            userId: boardId,
+            metadata: { minted: new Date().toISOString() },
+            scope: scopes,
+            props: { boardId, clientId: oauthRequest.clientId, scopes }
+        });
+        return Response.redirect(redirectTo, 302);
+    };
+
+    // Approval happens ONLY on the dedicated approve action, bound to the consent
+    // page by a double-submit nonce (cookie + hidden field). A POST to /authorize
+    // itself (spec-permitted for the request) renders consent like a GET does.
+    if (url.pathname === '/authorize/approve' && request.method === 'POST') {
+        const form = await request.formData().catch(() => {});
+        const submitted = form?.get('nonce');
+        const cookieNonce = /(?:^|;\s*)todos_consent=([^;]+)/.exec(request.headers.get('cookie') ?? '')?.[1];
+        if (typeof submitted !== 'string' || submitted.length === 0 || submitted !== cookieNonce) {
+            return new Response('Consent expired — reopen the authorization link.\n', { status: 400 });
+        }
+        return approve();
+    }
+    if (autoConsent) {
+        return approve();
+    }
+    const nonce = crypto.randomUUID();
+    const clientName = client.clientName ?? client.clientId;
+    return new Response(consentPage(clientName, oauthRequest.scope, `/authorize/approve?${url.searchParams.toString()}`, nonce), {
+        headers: {
+            'content-type': 'text/html; charset=utf-8',
+            'cache-control': 'no-store',
+            'set-cookie': `todos_consent=${nonce}; Path=/authorize; Max-Age=600; HttpOnly; Secure; SameSite=Lax`
+        }
+    });
+}

--- a/examples/todos-server/oauth.ts
+++ b/examples/todos-server/oauth.ts
@@ -76,10 +76,12 @@ bound to this authorization. Whoever holds the resulting token holds the board.
 A real deployment would sign you in here instead.</p>
 <p>After approving, open <a href="/board">/board</a> in this browser to watch the
 board update live while your client works.</p>
-<form method="post" action="${escapeHtml(approveAction)}">
+<form method="post" action="${escapeHtml(approveAction)}" onsubmit="window.open('/board', '_blank')">
 <input type="hidden" name="nonce" value="${escapeHtml(nonce)}">
-<button type="submit" style="font-size: 1.1rem; padding: 0.5rem 1.5rem">Approve</button>
+<button type="submit" style="font-size: 1.1rem; padding: 0.5rem 1.5rem">Approve &amp; open live board</button>
 </form>
+<p style="color: #666; font-size: 0.9rem">Approving finishes the sign-in in this tab and opens your board's
+live view in a new one (or open <a href="/board" target="_blank">/board</a> yourself afterwards).</p>
 </body>`;
 }
 

--- a/examples/todos-server/oauth.ts
+++ b/examples/todos-server/oauth.ts
@@ -39,6 +39,12 @@ export function propsToAuthInfo(props: TodosGrantProps, request: Request): AuthI
     };
 }
 
+/** Minimal structural slice of the KV namespace the viewer sessions use. */
+export interface ViewerSessionStore {
+    put(key: string, value: string, options?: { expirationTtl?: number }): Promise<void>;
+    get(key: string): Promise<string | null>;
+}
+
 /** The provider helpers the worker uses (subset of OAuthHelpers we touch). */
 export interface OAuthHelpers {
     parseAuthRequest(request: Request): Promise<{ clientId: string; scope: string[]; state: string; redirectUri: string }>;
@@ -68,6 +74,8 @@ function consentPage(clientName: string, scopes: string[], approveAction: string
 <p>This demo has no accounts: approving creates a <strong>fresh private todo board</strong>
 bound to this authorization. Whoever holds the resulting token holds the board.
 A real deployment would sign you in here instead.</p>
+<p>After approving, open <a href="/board">/board</a> in this browser to watch the
+board update live while your client works.</p>
 <form method="post" action="${escapeHtml(approveAction)}">
 <input type="hidden" name="nonce" value="${escapeHtml(nonce)}">
 <button type="submit" style="font-size: 1.1rem; padding: 0.5rem 1.5rem">Approve</button>
@@ -86,7 +94,12 @@ A real deployment would sign you in here instead.</p>
  * by a double-submit nonce (HttpOnly cookie + hidden field), so a bare POST
  * can never mint a grant.
  */
-export async function handleAuthorize(request: Request, provider: OAuthHelpers, autoConsent: boolean): Promise<Response> {
+export async function handleAuthorize(
+    request: Request,
+    provider: OAuthHelpers,
+    autoConsent: boolean,
+    viewerSessions: ViewerSessionStore
+): Promise<Response> {
     const url = new URL(request.url);
     // Routine client mistakes (unknown client_id, mismatched redirect_uri, disabled
     // flows) must answer 400, not surface as worker exceptions.
@@ -113,7 +126,18 @@ export async function handleAuthorize(request: Request, provider: OAuthHelpers, 
             scope: scopes,
             props: { boardId, clientId: oauthRequest.clientId, scopes }
         });
-        return Response.redirect(redirectTo, 302);
+        // The one moment the human is in the browser: claiming the live view rides
+        // the approval. The cookie is an opaque KV-backed session (no token, no board
+        // id in any URL); /board with no ?b= resolves it to this grant's board.
+        const viewerId = crypto.randomUUID();
+        await viewerSessions.put(`viewer:${viewerId}`, JSON.stringify({ boardId }), { expirationTtl: 7200 });
+        return new Response(null, {
+            status: 302,
+            headers: {
+                location: redirectTo,
+                'set-cookie': `todos_viewer=${viewerId}; Path=/board; Max-Age=7200; HttpOnly; Secure; SameSite=Lax`
+            }
+        });
     };
 
     // Approval happens ONLY on the dedicated approve action, bound to the consent

--- a/examples/todos-server/oauth.ts
+++ b/examples/todos-server/oauth.ts
@@ -76,7 +76,7 @@ bound to this authorization. Whoever holds the resulting token holds the board.
 A real deployment would sign you in here instead.</p>
 <p>After approving, open <a href="/board">/board</a> in this browser to watch the
 board update live while your client works.</p>
-<form method="post" action="${escapeHtml(approveAction)}" onsubmit="window.open('/board', '_blank')">
+<form method="post" action="${escapeHtml(approveAction)}" onsubmit="window.open('/board#claim', '_blank')">
 <input type="hidden" name="nonce" value="${escapeHtml(nonce)}">
 <button type="submit" style="font-size: 1.1rem; padding: 0.5rem 1.5rem">Approve &amp; open live board</button>
 </form>

--- a/examples/todos-server/oauth.ts
+++ b/examples/todos-server/oauth.ts
@@ -130,7 +130,11 @@ export async function handleAuthorize(
         // the approval. The cookie is an opaque KV-backed session (no token, no board
         // id in any URL); /board with no ?b= resolves it to this grant's board.
         const viewerId = crypto.randomUUID();
-        await viewerSessions.put(`viewer:${viewerId}`, JSON.stringify({ boardId }), { expirationTtl: 7200 });
+        await viewerSessions.put(
+            `viewer:${viewerId}`,
+            JSON.stringify({ boardId, clientName: client?.clientName ?? oauthRequest.clientId }),
+            { expirationTtl: 7200 }
+        );
         return new Response(null, {
             status: 302,
             headers: {

--- a/examples/todos-server/oauth.ts
+++ b/examples/todos-server/oauth.ts
@@ -12,6 +12,7 @@
  * deployments replace exactly one thing: the consent step authenticates a
  * user (their IdP) instead of minting an anonymous board.
  */
+import type { OAuthHelpers } from '@cloudflare/workers-oauth-provider';
 import type { AuthInfo } from '@modelcontextprotocol/server';
 
 /** What `completeAuthorization` stores and every authorized request gets back. */
@@ -45,17 +46,39 @@ export interface ViewerSessionStore {
     get(key: string): Promise<string | null>;
 }
 
-/** The provider helpers the worker uses (subset of OAuthHelpers we touch). */
-export interface OAuthHelpers {
-    parseAuthRequest(request: Request): Promise<{ clientId: string; scope: string[]; state: string; redirectUri: string }>;
-    lookupClient(clientId: string): Promise<{ clientId: string; clientName?: string; redirectUris: string[] } | null>;
-    completeAuthorization(options: {
-        request: unknown;
-        userId: string;
-        metadata: Record<string, unknown>;
-        scope: string[];
-        props: TodosGrantProps;
-    }): Promise<{ redirectTo: string }>;
+export type { OAuthHelpers } from '@cloudflare/workers-oauth-provider';
+
+/** The one place a cookie value is read: shared by the consent nonce and the viewer session. */
+function cookieValue(name: string, cookieHeader: string | null): string | undefined {
+    return new RegExp(String.raw`(?:^|;\s*)${name}=([^;]+)`).exec(cookieHeader ?? '')?.[1];
+}
+
+const VIEWER_COOKIE = 'todos_viewer';
+const VIEWER_TTL_SECONDS = 7200;
+
+/** What a viewer session records: which board, and who the grant was issued to. */
+export interface ViewerSession {
+    boardId: string;
+    clientName?: string;
+}
+
+/**
+ * Claim the live view for a freshly minted board. Returns the Set-Cookie value;
+ * the whole lifecycle (mint here, resolve below, shared TTL) lives in this file.
+ */
+async function claimViewerSession(store: ViewerSessionStore, session: ViewerSession): Promise<string> {
+    const viewerId = crypto.randomUUID();
+    await store.put(`viewer:${viewerId}`, JSON.stringify(session), { expirationTtl: VIEWER_TTL_SECONDS });
+    return `${VIEWER_COOKIE}=${viewerId}; Path=/board; Max-Age=${VIEWER_TTL_SECONDS}; HttpOnly; Secure; SameSite=Lax`;
+}
+
+/** Resolve a viewer cookie back to its session, or undefined for absent/expired/unknown. */
+export async function resolveViewerBoard(cookieHeader: string | null, store: ViewerSessionStore): Promise<ViewerSession | undefined> {
+    const viewerId = cookieValue(VIEWER_COOKIE, cookieHeader);
+    if (!viewerId) return undefined;
+    const record = await store.get(`viewer:${viewerId}`);
+    if (record === null) return undefined;
+    return JSON.parse(record) as ViewerSession;
 }
 
 function escapeHtml(value: string): string {
@@ -131,19 +154,11 @@ export async function handleAuthorize(
         // The one moment the human is in the browser: claiming the live view rides
         // the approval. The cookie is an opaque KV-backed session (no token, no board
         // id in any URL); /board with no ?b= resolves it to this grant's board.
-        const viewerId = crypto.randomUUID();
-        await viewerSessions.put(
-            `viewer:${viewerId}`,
-            JSON.stringify({ boardId, clientName: client?.clientName ?? oauthRequest.clientId }),
-            { expirationTtl: 7200 }
-        );
-        return new Response(null, {
-            status: 302,
-            headers: {
-                location: redirectTo,
-                'set-cookie': `todos_viewer=${viewerId}; Path=/board; Max-Age=7200; HttpOnly; Secure; SameSite=Lax`
-            }
+        const cookie = await claimViewerSession(viewerSessions, {
+            boardId,
+            clientName: client?.clientName ?? oauthRequest.clientId
         });
+        return new Response(null, { status: 302, headers: { location: redirectTo, 'set-cookie': cookie } });
     };
 
     // Approval happens ONLY on the dedicated approve action, bound to the consent
@@ -152,7 +167,7 @@ export async function handleAuthorize(
     if (url.pathname === '/authorize/approve' && request.method === 'POST') {
         const form = await request.formData().catch(() => {});
         const submitted = form?.get('nonce');
-        const cookieNonce = /(?:^|;\s*)todos_consent=([^;]+)/.exec(request.headers.get('cookie') ?? '')?.[1];
+        const cookieNonce = cookieValue('todos_consent', request.headers.get('cookie'));
         if (typeof submitted !== 'string' || submitted.length === 0 || submitted !== cookieNonce) {
             return new Response('Consent expired — reopen the authorization link.\n', { status: 400 });
         }

--- a/examples/todos-server/package.json
+++ b/examples/todos-server/package.json
@@ -12,6 +12,7 @@
     },
     "dependencies": {
         "@cloudflare/workers-oauth-provider": "0.8.0",
+        "@hono/node-server": "catalog:runtimeServerOnly",
         "@mcp-examples/shared": "workspace:*",
         "@modelcontextprotocol/hono": "workspace:*",
         "@modelcontextprotocol/server": "workspace:*",

--- a/examples/todos-server/package.json
+++ b/examples/todos-server/package.json
@@ -4,7 +4,10 @@
     "type": "module",
     "scripts": {
         "start": "tsx server.ts",
-        "start:http": "tsx server.ts --http"
+        "start:http": "tsx server.ts --http",
+        "dev:worker": "npx --yes wrangler@4.100.0 dev",
+        "deploy:worker": "npx --yes wrangler@4.100.0 deploy",
+        "typecheck:worker": "tsc -p tsconfig.worker.json --noEmit"
     },
     "dependencies": {
         "@hono/node-server": "catalog:runtimeServerOnly",
@@ -17,7 +20,7 @@
         "tsx": "catalog:devTools"
     },
     "example": {
-        "excluded": "server-only package — exercised end-to-end by the examples/cli-client e2e legs",
+        "excluded": "server-only package — the Node entry (server.ts) is exercised end-to-end by the examples/cli-client e2e legs; worker.ts is the Cloudflare deploy entry, driven manually via wrangler dev",
         "shapeExempt": "Reference server, not a single-feature story: no client.ts of its own; the paired host lives in examples/cli-client."
     }
 }

--- a/examples/todos-server/package.json
+++ b/examples/todos-server/package.json
@@ -10,7 +10,7 @@
         "typecheck:worker": "tsc -p tsconfig.worker.json --noEmit"
     },
     "dependencies": {
-        "@hono/node-server": "catalog:runtimeServerOnly",
+        "@cloudflare/workers-oauth-provider": "0.8.0",
         "@mcp-examples/shared": "workspace:*",
         "@modelcontextprotocol/hono": "workspace:*",
         "@modelcontextprotocol/server": "workspace:*",

--- a/examples/todos-server/package.json
+++ b/examples/todos-server/package.json
@@ -18,6 +18,7 @@
         "zod": "catalog:runtimeShared"
     },
     "devDependencies": {
+        "@cloudflare/workers-types": "^4.20260629.1",
         "tsx": "catalog:devTools"
     },
     "example": {

--- a/examples/todos-server/package.json
+++ b/examples/todos-server/package.json
@@ -7,7 +7,8 @@
         "start:http": "tsx server.ts --http",
         "dev:worker": "npx --yes wrangler@4.100.0 dev",
         "deploy:worker": "npx --yes wrangler@4.100.0 deploy",
-        "typecheck:worker": "tsc -p tsconfig.worker.json --noEmit"
+        "typecheck:worker": "tsc -p tsconfig.worker.json --noEmit",
+        "verify": "tsx e2e/verify.ts"
     },
     "dependencies": {
         "@cloudflare/workers-oauth-provider": "0.8.0",

--- a/examples/todos-server/server.ts
+++ b/examples/todos-server/server.ts
@@ -5,28 +5,30 @@
  */
 import { serve } from '@hono/node-server';
 import { parseExampleArgs } from '@mcp-examples/shared';
-import { createMcpHonoApp } from '@modelcontextprotocol/hono';
-import { createMcpHandler } from '@modelcontextprotocol/server';
+import { toNodeHandler } from '@modelcontextprotocol/node';
+import { createMcpHandler, InMemoryServerEventBus } from '@modelcontextprotocol/server';
 import { serveStdio } from '@modelcontextprotocol/server/stdio';
 
-import { buildServer, onBoardChanged, onBoardUpdated } from './todos';
+import { createTodosApp } from './todos';
 
 const { transport, port } = parseExampleArgs();
 
+// One process, one board. The key comes from the environment for real deployments and falls
+// back to a per-process random one for the zero-setup demo (fine: one process serves every
+// round of a multi-round flow).
 if (transport === 'stdio') {
-    void serveStdio(buildServer);
+    // Single connection, no bus: the app announces on the pinned instance and the entry
+    // routes that onto its open subscriptions/listen streams.
+    const app = createTodosApp({ requestStateKey: process.env.REQUEST_STATE_SECRET });
+    void serveStdio(app.buildServer);
     console.error('[todos] serving over stdio');
 } else {
-    const handler = createMcpHandler(buildServer);
-    // Per-request serving has no connection to push notifications down — cross-request
-    // events (the board changing) are published through the handler's notifier instead.
-    onBoardChanged(() => handler.notify.resourcesChanged());
-    onBoardUpdated(uri => handler.notify.resourceUpdated(uri));
-    // `createMcpHonoApp()` binds the endpoint behind localhost host/origin
-    // validation by default, matching the framework factories' defaults.
-    const app = createMcpHonoApp();
-    app.all('/mcp', c => handler.fetch(c.req.raw));
-    serve({ fetch: app.fetch, port, hostname: '127.0.0.1' }, () => {
+    // Per-request serving has no connection to push notifications down — the app announces
+    // on the bus and the handler routes the events onto its subscriptions/listen streams.
+    const bus = new InMemoryServerEventBus();
+    const app = createTodosApp({ requestStateKey: process.env.REQUEST_STATE_SECRET, bus });
+    const handler = createMcpHandler(app.buildServer, { bus });
+    createServer(toNodeHandler(handler)).listen(port, () => {
         console.error(`[todos] listening on http://127.0.0.1:${port}/mcp`);
     });
 }

--- a/examples/todos-server/server.ts
+++ b/examples/todos-server/server.ts
@@ -5,7 +5,7 @@
  */
 import { serve } from '@hono/node-server';
 import { parseExampleArgs } from '@mcp-examples/shared';
-import { toNodeHandler } from '@modelcontextprotocol/node';
+import { createMcpHonoApp } from '@modelcontextprotocol/hono';
 import { createMcpHandler, InMemoryServerEventBus } from '@modelcontextprotocol/server';
 import { serveStdio } from '@modelcontextprotocol/server/stdio';
 
@@ -28,7 +28,11 @@ if (transport === 'stdio') {
     const bus = new InMemoryServerEventBus();
     const app = createTodosApp({ requestStateKey: process.env.REQUEST_STATE_SECRET, bus });
     const handler = createMcpHandler(app.buildServer, { bus });
-    createServer(toNodeHandler(handler)).listen(port, () => {
+    // `createMcpHonoApp()` binds the endpoint behind localhost host/origin
+    // validation by default, matching the framework factories' defaults.
+    const honoApp = createMcpHonoApp();
+    honoApp.all('/mcp', c => handler.fetch(c.req.raw));
+    serve({ fetch: honoApp.fetch, port, hostname: '127.0.0.1' }, () => {
         console.error(`[todos] listening on http://127.0.0.1:${port}/mcp`);
     });
 }

--- a/examples/todos-server/todos.ts
+++ b/examples/todos-server/todos.ts
@@ -741,6 +741,21 @@ export function createTodosApp(options: TodosAppOptions = {}): TodosApp {
         );
 
         server.registerTool(
+            'whoami',
+            { description: 'Show the identity this connection serves: the verified OAuth grant, or the anonymous tier.' },
+            async (): Promise<CallToolResult> => ({
+                content: [
+                    {
+                        type: 'text',
+                        text: reqCtx.authInfo
+                            ? `Authenticated via OAuth: client ${reqCtx.authInfo.clientId ?? 'unknown'}, scopes [${(reqCtx.authInfo.scopes ?? []).join(' ')}]. This board belongs to your grant.`
+                            : 'Anonymous tier: this board is keyed by your network address or the X-Todos-Board header. Authorize via OAuth for a private board.'
+                    }
+                ]
+            })
+        );
+
+        server.registerTool(
             'prioritize',
             { description: 'Rank the open tasks by importance using the LLM connected to the host, and update their priorities' },
             async (ctx): Promise<CallToolResult | InputRequiredResult> => {

--- a/examples/todos-server/todos.ts
+++ b/examples/todos-server/todos.ts
@@ -104,12 +104,12 @@ export interface TodosAppOptions {
      */
     bus?: ServerEventBus;
     /**
-     * Location of a human-viewable live board page — a URL, a path, or a thunk
-     * resolved when a server is built (the worker learns its origin from the first
-     * request). When set, the instructions and `whoami` tell the client where to
-     * send the user to watch the board live. Leave unset for hosts without one.
+     * Thunk producing the URL of a human-viewable live board page, resolved when a
+     * server is built (the worker learns its origin from the first request). When
+     * set, the instructions and `whoami` tell the client where to send the user to
+     * watch the board live. Leave unset for hosts without one.
      */
-    boardViewPath?: string | (() => string);
+    boardViewPath?: () => string;
 }
 
 /** One todo board plus the `buildServer` factory that serves it. */
@@ -312,7 +312,7 @@ export function createTodosApp(options: TodosAppOptions = {}): TodosApp {
     }
 
     function buildServer(reqCtx: McpRequestContext): McpServer {
-        const boardViewPath = typeof options.boardViewPath === 'function' ? options.boardViewPath() : options.boardViewPath;
+        const boardViewPath = options.boardViewPath?.();
         const server = new McpServer(
             { name: 'todos', version: '1.0.0' },
             {
@@ -761,7 +761,9 @@ export function createTodosApp(options: TodosAppOptions = {}): TodosApp {
                         text:
                             (reqCtx.authInfo
                                 ? `Authenticated via OAuth: client ${reqCtx.authInfo.clientId ?? 'unknown'}, scopes [${(reqCtx.authInfo.scopes ?? []).join(' ')}]. This board belongs to your grant.`
-                                : 'Anonymous tier: this board is keyed by your network address or the X-Todos-Board header. Authorize via OAuth for a private board.') +
+                                : boardViewPath
+                                  ? 'Anonymous tier: this board is keyed by your network address or the X-Todos-Board header. Authorize via OAuth for a private board.'
+                                  : 'No OAuth grant on this connection — anonymous tier.') +
                             (boardViewPath
                                 ? reqCtx.authInfo
                                     ? ` The user can watch it live at ${boardViewPath}, in the browser where they approved consent.`

--- a/examples/todos-server/todos.ts
+++ b/examples/todos-server/todos.ts
@@ -287,16 +287,11 @@ export function createTodosApp(options: TodosAppOptions = {}): TodosApp {
     }
 
     // Cross-connection announcements go through the bus, once per change; per-connection
-    // delivery knowledge (that client's subscription set) stays with each instance. The
-    // announcing instance is remembered per EVENT OBJECT, not per moment: object identity
-    // survives asynchronous buses, so echo suppression does not depend on the in-memory
-    // bus's synchronous dispatch.
+    // delivery knowledge (that client's subscription set) stays with each instance.
     const bus = options.bus;
     const connections = new WeakMap<McpServer, { subscribedUris: Set<string> }>();
-    const eventOrigin = new WeakMap<ServerEvent, McpServer>();
 
     function deliverToInstance(target: McpServer, event: ServerEvent): void {
-        if (eventOrigin.get(event) === target) return; // its client heard in-band
         const connection = connections.get(target);
         if (!connection) return;
         if (event.kind === 'resources_list_changed') {
@@ -357,17 +352,22 @@ export function createTodosApp(options: TodosAppOptions = {}): TodosApp {
          * {@linkcode TodosApp.subscribeInstance} — so the announcement is made exactly once.
          */
         const announceBoardChange = async (): Promise<void> => {
-            server.sendResourceListChanged();
-            if (reqCtx.era === 'legacy' ? subscribedUris.has(BOARD_URI) : bus === undefined) {
-                await server.server.sendResourceUpdated({ uri: BOARD_URI }).catch(() => {});
-            }
             if (bus) {
-                const listChanged: ServerEvent = { kind: 'resources_list_changed' };
-                const updated: ServerEvent = { kind: 'resource_updated', uri: BOARD_URI };
-                eventOrigin.set(listChanged, server);
-                eventOrigin.set(updated, server);
-                bus.publish(listChanged);
-                bus.publish(updated);
+                // One delivery path: the bus reaches every connection — pinned
+                // sessions via subscribeInstance, modern clients via their
+                // listen streams — INCLUDING the originating one. Every
+                // sibling SDK (go, csharp, python, java) delivers that echo
+                // too: resources/updated is an idempotent invalidation hint,
+                // not a receipt, so self-exclusion buys nothing and would
+                // need origin tracking that breaks across serializing buses.
+                bus.publish({ kind: 'resources_list_changed' });
+                bus.publish({ kind: 'resource_updated', uri: BOARD_URI });
+                return;
+            }
+            // Bus-less host (stdio): this connection is the only audience.
+            server.sendResourceListChanged();
+            if (subscribedUris.has(BOARD_URI)) {
+                await server.server.sendResourceUpdated({ uri: BOARD_URI }).catch(() => {});
             }
         };
 

--- a/examples/todos-server/todos.ts
+++ b/examples/todos-server/todos.ts
@@ -317,6 +317,9 @@ export function createTodosApp(options: TodosAppOptions = {}): TodosApp {
                 capabilities: { logging: {}, resources: { listChanged: true, subscribe: true } },
                 requestState: { verify: stateCodec.verify },
                 instructions:
+                    (options.boardViewPath
+                        ? `LIVE VIEW: the user can watch this board update in real time at ${options.boardViewPath} — with ?b=<name> when connected via the X-Todos-Board header, or as-is in the browser where they approved OAuth consent. Show them this link when you first respond. `
+                        : '') +
                     'todos is a small project todo board (it starts empty). Use list_tasks to see the board, add_task / add_tasks and complete_task to ' +
                     'change it, prioritize to rank the open tasks, brainstorm_tasks to invent themed example tasks, work_through_tasks to finish every ' +
                     'open task with progress updates, and clear_done to remove finished ones (it asks the user for confirmation). The full board is ' +
@@ -325,10 +328,7 @@ export function createTodosApp(options: TodosAppOptions = {}): TodosApp {
                     'elicitation — then borrows the host model — sampling), 2) ask to prioritize the open tasks (sampling), 3) run the plan-my-day ' +
                     'prompt, 4) attach the todos://board resource as context and ask about it, 5) say "do all my tasks" and watch the progress and ' +
                     'log notifications, 6) ask to clear completed tasks (an elicitation-confirmed bulk delete). Watching the board resource ' +
-                    '(/watch in cli-client) shows live change notifications along the way.' +
-                    (options.boardViewPath
-                        ? ` There is also a human-viewable live page: tell the user they can WATCH this board update in real time by opening ${options.boardViewPath} on this server's origin — with ?b=<name> when connected with the X-Todos-Board header, or plain (no query) in the browser where they approved OAuth consent.`
-                        : '')
+                    '(/watch in cli-client) shows live change notifications along the way.'
             }
         );
 
@@ -762,8 +762,8 @@ export function createTodosApp(options: TodosAppOptions = {}): TodosApp {
                                 : 'Anonymous tier: this board is keyed by your network address or the X-Todos-Board header. Authorize via OAuth for a private board.') +
                             (options.boardViewPath
                                 ? reqCtx.authInfo
-                                    ? ` The user can watch it live at ${options.boardViewPath} on this server's origin, in the browser where they approved consent.`
-                                    : ` The user can watch it live at ${options.boardViewPath}?b=<board-name> on this server's origin (when connected with the X-Todos-Board header).`
+                                    ? ` The user can watch it live at ${options.boardViewPath}, in the browser where they approved consent.`
+                                    : ` The user can watch it live at ${options.boardViewPath}?b=<board-name> (when connected with the X-Todos-Board header).`
                                 : '')
                     }
                 ]

--- a/examples/todos-server/todos.ts
+++ b/examples/todos-server/todos.ts
@@ -5,25 +5,35 @@
  * a job: CRUD tools the model calls from chat, the board and each task exposed as resources,
  * planning/seeding prompts, a sampling-backed `prioritize` tool that borrows the *host's*
  * model, elicitation-confirmed `clear_done` and `brainstorm_tasks`, and logging/progress while
- * it works. State is in-memory and per-process; the point is the wiring, not the persistence.
- * The transport entry point that serves this over stdio / Streamable HTTP is ../server.ts.
+ * it works. State is in-memory and per app instance — `createTodosApp()` returns one board plus
+ * the `buildServer` factory that serves it, so each transport entry owns exactly one board. The
+ * point is the wiring, not the persistence (though `snapshot`/`restore` exist so a hosted
+ * deployment can keep a board across process hops — see ./worker.ts).
+ * The transport entry points are ./server.ts (Node: stdio / Streamable HTTP) and ./worker.ts
+ * (Cloudflare Workers).
  */
 import type {
     CallToolResult,
     ElicitRequestFormParams,
     InputRequiredResult,
     McpRequestContext,
-    ServerContext
+    ServerContext,
+    ServerEvent,
+    ServerEventBus
 } from '@modelcontextprotocol/server';
 import {
     acceptedContent,
     completable,
     createRequestStateCodec,
     inputRequired,
+    inputResponse,
     McpServer,
     ResourceTemplate
 } from '@modelcontextprotocol/server';
 import * as z from 'zod/v4';
+
+/** The one subscribable resource this application serves. */
+const BOARD_URI = 'todos://board';
 
 /**
  * The brainstorm_tasks flow as an explicit state machine: each variant names the round the
@@ -35,33 +45,27 @@ type BrainstormState =
     | { step: 'awaiting-custom-count'; topic: string }
     | { step: 'awaiting-ideas'; topic: string; count: number };
 
-/**
- * HMAC-signs the `requestState` round-tripped through brainstorm_tasks' multi-round flow so a
- * client cannot forge or mutate the carried step/theme/count. The seam runs `verify` before the
- * handler (rejecting tampered state with -32602) and the handler reads the decoded payload via
- * the typed `ctx.mcpReq.requestState<BrainstormState>()` accessor — no second decode.
- * The key comes from the environment for real deployments and falls back to a per-process
- * random one for the zero-setup demo (which is fine because one process serves every round).
- */
-const stateCodec = createRequestStateCodec<BrainstormState>({
-    key: process.env.REQUEST_STATE_SECRET ?? crypto.getRandomValues(new Uint8Array(32))
-});
-
-/** Read the `action` from a raw elicitation `inputResponses` entry (decline/cancel detection). */
-function elicitAction(response: unknown): 'accept' | 'decline' | 'cancel' {
-    const action = typeof response === 'object' && response !== null && 'action' in response ? response.action : undefined;
-    return action === 'accept' || action === 'decline' ? action : 'cancel';
+/** Read the `action` from an elicitation round's response via the SDK's typed reader. */
+function elicitAction(responses: Parameters<typeof inputResponse>[0], key: string): 'accept' | 'decline' | 'cancel' {
+    const view = inputResponse(responses, key);
+    return view.kind === 'elicit' ? view.action : 'cancel';
 }
 
-/** Read the text content from a raw sampling (`createMessage`) `inputResponses` entry. */
-function sampledText(response: unknown): string {
-    const content = typeof response === 'object' && response !== null && 'content' in response ? response.content : undefined;
+/**
+ * Read the text content from a sampling round's response. `inputResponse` types the round as
+ * a sampling result; extracting the text from its content is still by hand — the SDK has no
+ * `sampledText`-style reader yet.
+ */
+function sampledText(responses: Parameters<typeof inputResponse>[0], key: string): string {
+    const view = inputResponse(responses, key);
+    if (view.kind !== 'sampling') return '';
+    const content: unknown = view.result.content;
     return typeof content === 'object' && content !== null && 'type' in content && content.type === 'text' && 'text' in content
         ? String(content.text)
         : '';
 }
 
-interface Task {
+export interface Task {
     id: string;
     title: string;
     project: string;
@@ -71,21 +75,52 @@ interface Task {
     status: 'open' | 'done';
 }
 
-let nextId = 1;
-const tasks = new Map<string, Task>();
-
-function addTask(task: Omit<Task, 'id' | 'status'>): Task {
-    const created: Task = { id: `t${nextId++}`, status: 'open', ...task };
-    tasks.set(created.id, created);
-    return created;
+/** A serializable copy of a board, for hosts that persist boards across process hops. */
+export interface BoardSnapshot {
+    nextId: number;
+    tasks: Task[];
 }
 
-function openTasks(): Task[] {
-    return [...tasks.values()].filter(task => task.status === 'open');
+export interface TodosAppOptions {
+    /**
+     * HMAC key for the signed `requestState` round-tripped through brainstorm_tasks' multi-round
+     * flow (≥ 32 bytes). Provide a stable key whenever more than one app instance may serve the
+     * same conversation (e.g. a redeployed or multi-instance host); unset, the app generates a
+     * per-instance random key — fine whenever a single instance serves the whole flow.
+     */
+    requestStateKey?: string | Uint8Array;
+    /**
+     * Refuse task creation beyond this many tasks (the adding tool returns an error result).
+     * Unset means uncapped — fine for a local demo, not for a public deployment.
+     */
+    maxTasks?: number;
+    /**
+     * The board's change bus. Every mutation announces on it once, and the serving entry
+     * fans the events out: `createMcpHandler({ bus })` routes them onto its
+     * `subscriptions/listen` streams, and a host that pins long-lived instances (sessions)
+     * forwards them with {@linkcode TodosApp.forwardServerEvent}. Unset (stdio, tests), the
+     * app announces only on the connection that made the change — the sole audience a
+     * single-connection transport has.
+     */
+    bus?: ServerEventBus;
 }
 
-function projects(): string[] {
-    return [...new Set([...tasks.values()].map(task => task.project))];
+/** One todo board plus the `buildServer` factory that serves it. */
+export interface TodosApp {
+    buildServer(reqCtx: McpRequestContext): McpServer;
+    /**
+     * Subscribe one long-lived instance to the board's change bus. A host that pins instances
+     * past a single request (./worker.ts's 2025-era sessions) calls this once per instance and
+     * runs the returned unsubscribe when the connection ends. The app applies the etiquette
+     * the host cannot see: the instance that announced a change is skipped (its client heard
+     * in-band), and `resources/updated` goes only to clients that subscribed to the URI.
+     * Without a configured bus this is a no-op.
+     */
+    subscribeInstance(server: McpServer): () => void;
+    /** Copy the board out (deep enough to persist safely while handlers keep mutating). */
+    snapshot(): BoardSnapshot;
+    /** Replace the board with a previously snapshotted one. */
+    restore(snapshot: BoardSnapshot): void;
 }
 
 function describeTask(task: Task): string {
@@ -93,40 +128,10 @@ function describeTask(task: Task): string {
     return `- [${task.status === 'done' ? 'x' : ' '}] ${task.title} (${task.id}, ${task.project}${details ? `; ${details}` : ''})`;
 }
 
-function renderBoard(): string {
-    const done = [...tasks.values()].filter(task => task.status === 'done');
-    return [
-        '# Todo board',
-        '',
-        '## Open',
-        ...openTasks().map(task => describeTask(task)),
-        '',
-        '## Done',
-        ...done.map(task => describeTask(task))
-    ].join('\n');
-}
-
 async function logInfo(ctx: ServerContext, text: string): Promise<void> {
     // Request-tied logging: honours the client's logging/setLevel threshold on 2025-era
     // connections and the per-request logLevel opt-in on 2026-07-28 connections.
     await ctx.mcpReq.log('info', text, 'todos');
-}
-
-/**
- * Over per-request HTTP serving, instance-level notifications have nowhere to go —
- * cross-request events are published through the handler's notifier instead. The transport
- * entry (../server.ts) wires these up for the HTTP branch; over stdio they stay unset and the
- * pinned instance's own notifications are routed by the serving entry.
- */
-let publishBoardChanged: (() => void) | undefined;
-let publishBoardUpdated: ((uri: string) => void) | undefined;
-
-export function onBoardChanged(publish: () => void): void {
-    publishBoardChanged = publish;
-}
-
-export function onBoardUpdated(publish: (uri: string) => void): void {
-    publishBoardUpdated = publish;
 }
 
 async function reportProgress(ctx: ServerContext, progress: number, total: number, message: string): Promise<void> {
@@ -212,463 +217,587 @@ function priorityForRank(rank: number, total: number): Task['priority'] {
     return 'low';
 }
 
-export function buildServer(reqCtx: McpRequestContext): McpServer {
-    const server = new McpServer(
-        { name: 'todos', version: '1.0.0' },
-        {
-            capabilities: { logging: {}, resources: { listChanged: true, subscribe: true } },
-            requestState: { verify: stateCodec.verify },
-            instructions:
-                'todos is a small project todo board (it starts empty). Use list_tasks to see the board, add_task / add_tasks and complete_task to ' +
-                'change it, prioritize to rank the open tasks, brainstorm_tasks to invent themed example tasks, work_through_tasks to finish every ' +
-                'open task with progress updates, and clear_done to remove finished ones (it asks the user for confirmation). The full board is ' +
-                'also available as the todos://board resource, and it can be watched/subscribed to for change notifications. ' +
-                'When the user greets you or asks what to try, suggest this tour: 1) ask to brainstorm tasks (the server asks how many — ' +
-                'elicitation — then borrows the host model — sampling), 2) ask to prioritize the open tasks (sampling), 3) run the plan-my-day ' +
-                'prompt, 4) attach the todos://board resource as context and ask about it, 5) say "do all my tasks" and watch the progress and ' +
-                'log notifications, 6) ask to clear completed tasks (an elicitation-confirmed bulk delete). Watching the board resource ' +
-                '(/watch in cli-client) shows live change notifications along the way.'
-        }
-    );
-
-    // Per-resource subscriptions: 2025-era clients call resources/subscribe (tracked here so
-    // updates only go to subscribers); 2026-07-28 clients use a subscriptions/listen filter and
-    // the serving entry routes the same notification onto it.
-    const subscribedUris = new Set<string>();
-    server.server.setRequestHandler('resources/subscribe', request => {
-        subscribedUris.add(request.params.uri);
-        return {};
-    });
-    server.server.setRequestHandler('resources/unsubscribe', request => {
-        subscribedUris.delete(request.params.uri);
-        return {};
+export function createTodosApp(options: TodosAppOptions = {}): TodosApp {
+    /**
+     * HMAC-signs the `requestState` round-tripped through brainstorm_tasks' multi-round flow so a
+     * client cannot forge or mutate the carried step/theme/count. The seam runs `verify` before the
+     * handler (rejecting tampered state with -32602) and the handler reads the decoded payload via
+     * the typed `ctx.mcpReq.requestState<BrainstormState>()` accessor — no second decode.
+     * The key comes from the options for real deployments and falls back to a per-instance
+     * random one for the zero-setup demo (which is fine because one instance serves every round).
+     */
+    const stateCodec = createRequestStateCodec<BrainstormState>({
+        key: options.requestStateKey ?? crypto.getRandomValues(new Uint8Array(32))
     });
 
-    /** Tell connected clients the board changed: the resource list, and the board resource for watchers. */
-    const announceBoardChange = async (): Promise<void> => {
-        await server.sendResourceListChanged();
-        if (publishBoardUpdated) {
-            // Per-request HTTP serving: cross-request delivery goes through the entry's notifier.
-            publishBoardChanged?.();
-            publishBoardUpdated('todos://board');
-        } else if (reqCtx.era === 'modern' || subscribedUris.has('todos://board')) {
-            // stdio: the serving entry routes this onto open listen subscriptions (2026-07-28);
-            // on 2025-era connections it goes out unsolicited, so only send it to subscribers.
-            await server.server.sendResourceUpdated({ uri: 'todos://board' }).catch(() => {});
+    let nextId = 1;
+    const tasks = new Map<string, Task>();
+
+    /** The error a caller gets when `count` more tasks would not fit; `undefined` when they do. */
+    function boardFullError(count: number): CallToolResult | undefined {
+        if (options.maxTasks === undefined || tasks.size + count <= options.maxTasks) return undefined;
+        return {
+            content: [
+                {
+                    type: 'text',
+                    text: `The board is full (${options.maxTasks} tasks) — complete_task and clear_done free up space.`
+                }
+            ],
+            isError: true
+        };
+    }
+
+    function addTask(task: Omit<Task, 'id' | 'status'>): Task {
+        // Batch callers pre-check with boardFullError so a batch never half-lands; a thrown
+        // overflow still surfaces as a tool error result for anything that skips the check.
+        if (options.maxTasks !== undefined && tasks.size >= options.maxTasks) {
+            throw new Error(`The board is full (${options.maxTasks} tasks) — complete_task and clear_done free up space.`);
         }
-    };
+        const created: Task = { id: `t${nextId++}`, status: 'open', ...task };
+        tasks.set(created.id, created);
+        return created;
+    }
 
-    server.registerResource(
-        'board',
-        'todos://board',
-        { description: 'The whole todo board as markdown', mimeType: 'text/markdown' },
-        async uri => ({ contents: [{ uri: uri.href, mimeType: 'text/markdown', text: renderBoard() }] })
-    );
+    function openTasks(): Task[] {
+        return [...tasks.values()].filter(task => task.status === 'open');
+    }
 
-    server.registerResource(
-        'task',
-        new ResourceTemplate('todos://tasks/{id}', {
-            list: async () => ({
-                resources: [...tasks.values()].map(task => ({
-                    uri: `todos://tasks/${task.id}`,
-                    name: task.title,
-                    mimeType: 'text/markdown'
-                }))
+    function projects(): string[] {
+        return [...new Set([...tasks.values()].map(task => task.project))];
+    }
+
+    function renderBoard(): string {
+        const done = [...tasks.values()].filter(task => task.status === 'done');
+        return [
+            '# Todo board',
+            '',
+            '## Open',
+            ...openTasks().map(task => describeTask(task)),
+            '',
+            '## Done',
+            ...done.map(task => describeTask(task))
+        ].join('\n');
+    }
+
+    // Cross-connection announcements go through the bus, once per change; per-connection
+    // delivery knowledge (that client's subscription set) stays with each instance. The
+    // announcing instance is remembered per EVENT OBJECT, not per moment: object identity
+    // survives asynchronous buses, so echo suppression does not depend on the in-memory
+    // bus's synchronous dispatch.
+    const bus = options.bus;
+    const connections = new WeakMap<McpServer, { subscribedUris: Set<string> }>();
+    const eventOrigin = new WeakMap<ServerEvent, McpServer>();
+
+    function deliverToInstance(target: McpServer, event: ServerEvent): void {
+        if (eventOrigin.get(event) === target) return; // its client heard in-band
+        const connection = connections.get(target);
+        if (!connection) return;
+        if (event.kind === 'resources_list_changed') {
+            target.sendResourceListChanged();
+        } else if (event.kind === 'resource_updated' && connection.subscribedUris.has(event.uri)) {
+            void target.server.sendResourceUpdated({ uri: event.uri }).catch(() => {});
+        }
+    }
+
+    function subscribeInstance(server: McpServer): () => void {
+        if (!bus) return () => {};
+        return bus.subscribe(event => deliverToInstance(server, event));
+    }
+
+    function buildServer(reqCtx: McpRequestContext): McpServer {
+        const server = new McpServer(
+            { name: 'todos', version: '1.0.0' },
+            {
+                capabilities: { logging: {}, resources: { listChanged: true, subscribe: true } },
+                requestState: { verify: stateCodec.verify },
+                instructions:
+                    'todos is a small project todo board (it starts empty). Use list_tasks to see the board, add_task / add_tasks and complete_task to ' +
+                    'change it, prioritize to rank the open tasks, brainstorm_tasks to invent themed example tasks, work_through_tasks to finish every ' +
+                    'open task with progress updates, and clear_done to remove finished ones (it asks the user for confirmation). The full board is ' +
+                    'also available as the todos://board resource, and it can be watched/subscribed to for change notifications. ' +
+                    'When the user greets you or asks what to try, suggest this tour: 1) ask to brainstorm tasks (the server asks how many — ' +
+                    'elicitation — then borrows the host model — sampling), 2) ask to prioritize the open tasks (sampling), 3) run the plan-my-day ' +
+                    'prompt, 4) attach the todos://board resource as context and ask about it, 5) say "do all my tasks" and watch the progress and ' +
+                    'log notifications, 6) ask to clear completed tasks (an elicitation-confirmed bulk delete). Watching the board resource ' +
+                    '(/watch in cli-client) shows live change notifications along the way.'
+            }
+        );
+
+        // Per-resource subscriptions: 2025-era clients call resources/subscribe (tracked per
+        // connection so updates only go to subscribers); 2026-07-28 clients use a
+        // subscriptions/listen filter and the serving entry routes bus events onto it.
+        const subscribedUris = new Set<string>();
+        connections.set(server, { subscribedUris });
+        server.server.setRequestHandler('resources/subscribe', request => {
+            subscribedUris.add(request.params.uri);
+            return {};
+        });
+        server.server.setRequestHandler('resources/unsubscribe', request => {
+            subscribedUris.delete(request.params.uri);
+            return {};
+        });
+
+        /**
+         * Tell every client the board changed. This connection hears it in-band: the resource
+         * list always, the board resource when this client subscribed to it (2025-era) or when
+         * no bus exists to carry it (stdio, where the entry lifts the instance's notification
+         * onto its open subscriptions/listen streams). Every other connection hears it through
+         * the bus — the entry's listen streams directly, pinned instances via
+         * {@linkcode TodosApp.forwardServerEvent} — so the announcement is made exactly once.
+         */
+        const announceBoardChange = async (): Promise<void> => {
+            server.sendResourceListChanged();
+            if (reqCtx.era === 'legacy' ? subscribedUris.has(BOARD_URI) : bus === undefined) {
+                await server.server.sendResourceUpdated({ uri: BOARD_URI }).catch(() => {});
+            }
+            if (bus) {
+                const listChanged: ServerEvent = { kind: 'resources_list_changed' };
+                const updated: ServerEvent = { kind: 'resource_updated', uri: BOARD_URI };
+                eventOrigin.set(listChanged, server);
+                eventOrigin.set(updated, server);
+                bus.publish(listChanged);
+                bus.publish(updated);
+            }
+        };
+
+        server.registerResource(
+            'board',
+            'todos://board',
+            { description: 'The whole todo board as markdown', mimeType: 'text/markdown' },
+            async uri => ({ contents: [{ uri: uri.href, mimeType: 'text/markdown', text: renderBoard() }] })
+        );
+
+        server.registerResource(
+            'task',
+            new ResourceTemplate('todos://tasks/{id}', {
+                list: async () => ({
+                    resources: [...tasks.values()].map(task => ({
+                        uri: `todos://tasks/${task.id}`,
+                        name: task.title,
+                        mimeType: 'text/markdown'
+                    }))
+                }),
+                complete: { id: value => [...tasks.keys()].filter(id => id.startsWith(value)) }
             }),
-            complete: { id: value => [...tasks.keys()].filter(id => id.startsWith(value)) }
-        }),
-        { description: 'A single task by id', mimeType: 'text/markdown' },
-        async (uri, variables) => {
-            const task = tasks.get(String(variables.id));
-            return {
-                contents: [
+            { description: 'A single task by id', mimeType: 'text/markdown' },
+            async (uri, variables) => {
+                const task = tasks.get(String(variables.id));
+                return {
+                    contents: [
+                        {
+                            uri: uri.href,
+                            mimeType: 'text/markdown',
+                            text: task ? describeTask(task) : `No task with id ${String(variables.id)}`
+                        }
+                    ]
+                };
+            }
+        );
+
+        server.registerPrompt(
+            'seed-board',
+            {
+                description: 'Have the assistant invent themed example tasks and add them to the board (via add_tasks)',
+                argsSchema: z.object({
+                    theme: completable(z.string().describe('A theme for the invented tasks'), value =>
+                        [
+                            'space-station maintenance',
+                            'wizard tower chores',
+                            'startup launch week',
+                            "engineer's week in hell",
+                            'robot uprising prep'
+                        ].filter(theme => theme.startsWith(value))
+                    )
+                })
+            },
+            async ({ theme }) => ({
+                messages: [
                     {
-                        uri: uri.href,
-                        mimeType: 'text/markdown',
-                        text: task ? describeTask(task) : `No task with id ${String(variables.id)}`
+                        role: 'user',
+                        content: {
+                            type: 'text',
+                            text: `Invent five short, funny todo tasks for the theme "${theme}" and add them to my board with the add_tasks tool (use "${theme}" as the project). Then show me the board.`
+                        }
                     }
                 ]
-            };
-        }
-    );
-
-    server.registerPrompt(
-        'seed-board',
-        {
-            description: 'Have the assistant invent themed example tasks and add them to the board (via add_tasks)',
-            argsSchema: z.object({
-                theme: completable(z.string().describe('A theme for the invented tasks'), value =>
-                    [
-                        'space-station maintenance',
-                        'wizard tower chores',
-                        'startup launch week',
-                        "engineer's week in hell",
-                        'robot uprising prep'
-                    ].filter(theme => theme.startsWith(value))
-                )
             })
-        },
-        async ({ theme }) => ({
-            messages: [
-                {
-                    role: 'user',
-                    content: {
-                        type: 'text',
-                        text: `Invent five short, funny todo tasks for the theme "${theme}" and add them to my board with the add_tasks tool (use "${theme}" as the project). Then show me the board.`
-                    }
-                }
-            ]
-        })
-    );
+        );
 
-    server.registerPrompt(
-        'plan-my-day',
-        {
-            description: 'Seed a planning conversation around the current board',
-            argsSchema: z.object({
-                focus: completable(z.string().describe('Project to focus on'), value =>
-                    projects().filter(project => project.startsWith(value))
-                )
-            })
-        },
-        async ({ focus }) => ({
-            messages: [
-                { role: 'user', content: { type: 'text', text: `Here is my current todo board:\n\n${renderBoard()}` } },
-                { role: 'assistant', content: { type: 'text', text: 'Got it — I can see your board. What should today look like?' } },
-                {
-                    role: 'user',
-                    content: {
-                        type: 'text',
-                        text: `Plan my day around the "${focus}" project: pick at most three tasks, in order, and say why each one is next.`
-                    }
-                }
-            ]
-        })
-    );
-
-    server.registerTool(
-        'add_task',
-        {
-            description: 'Add a task to the board',
-            inputSchema: z.object({
-                title: z.string().describe('What needs doing'),
-                project: z.string().optional().describe('Project bucket, e.g. "ops"'),
-                priority: z.enum(['high', 'medium', 'low']).optional(),
-                due: z.string().optional().describe('Free-form due date, e.g. "Friday"'),
-                notes: z.string().optional()
-            }),
-            outputSchema: z.object({ id: z.string(), title: z.string(), status: z.enum(['open', 'done']) })
-        },
-        async ({ title, project, priority, due, notes }, ctx) => {
-            const task = addTask({ title, project: project ?? 'inbox', priority, due, notes });
-            await announceBoardChange();
-            await logInfo(ctx, `added ${task.id}: ${task.title}`);
-            return {
-                content: [{ type: 'text', text: `Added ${task.id}: ${describeTask(task)}` }],
-                structuredContent: { id: task.id, title: task.title, status: task.status }
-            };
-        }
-    );
-
-    server.registerTool(
-        'add_tasks',
-        {
-            description: 'Add several tasks to the board at once',
-            inputSchema: z.object({
-                tasks: z
-                    .array(
-                        z.object({
-                            title: z.string(),
-                            project: z.string().optional(),
-                            priority: z.enum(['high', 'medium', 'low']).optional(),
-                            due: z.string().optional(),
-                            notes: z.string().optional()
-                        })
+        server.registerPrompt(
+            'plan-my-day',
+            {
+                description: 'Seed a planning conversation around the current board',
+                argsSchema: z.object({
+                    focus: completable(z.string().describe('Project to focus on'), value =>
+                        projects().filter(project => project.startsWith(value))
                     )
-                    .min(1)
-                    .describe('Tasks to add')
+                })
+            },
+            async ({ focus }) => ({
+                messages: [
+                    { role: 'user', content: { type: 'text', text: `Here is my current todo board:\n\n${renderBoard()}` } },
+                    { role: 'assistant', content: { type: 'text', text: 'Got it — I can see your board. What should today look like?' } },
+                    {
+                        role: 'user',
+                        content: {
+                            type: 'text',
+                            text: `Plan my day around the "${focus}" project: pick at most three tasks, in order, and say why each one is next.`
+                        }
+                    }
+                ]
             })
-        },
-        async ({ tasks: newTasks }, ctx) => {
-            const added: Task[] = [];
-            for (const [index, task] of newTasks.entries()) {
-                // Pretend each insert takes a moment so the host has in-flight progress to render.
-                await new Promise(resolve => setTimeout(resolve, 100));
-                added.push(addTask({ ...task, project: task.project ?? 'inbox' }));
-                await reportProgress(ctx, index + 1, newTasks.length, `added "${task.title}"`);
-            }
-            await announceBoardChange();
-            await logInfo(ctx, `added ${added.length} task(s)`);
-            return {
-                content: [{ type: 'text', text: `Added ${added.length} task(s):\n${added.map(task => describeTask(task)).join('\n')}` }]
-            };
-        }
-    );
+        );
 
-    server.registerTool(
-        'brainstorm_tasks',
-        {
-            description:
-                'Invent short, funny example tasks for a theme and add them to the board — asks the user how many (elicitation), then has the LLM connected to the host invent them (sampling)',
-            inputSchema: z.object({
-                theme: z.string().optional().describe('Theme for the invented tasks (default: "an engineer\'s week in hell")')
-            })
-        },
-        async ({ theme }, ctx): Promise<CallToolResult | InputRequiredResult> => {
-            // The theme can come from the model (tool argument) or from the user (the elicitation
-            // form's theme field, pre-filled with a default); the user's answer wins.
-            const fallbackTopic = theme ?? "an engineer's week in hell";
-            const resolveTopic = (raw: unknown): string => (typeof raw === 'string' && raw.trim().length > 0 ? raw.trim() : fallbackTopic);
-            const countMessage = 'Let me invent some tasks for the board.';
-
-            const finish = async (ideasText: string, wanted: number, topic: string): Promise<CallToolResult> => {
-                const titles = ideasText
-                    .split('\n')
-                    .map(line => line.replace(/^[-*\d.\s]+/, '').trim())
-                    .filter(line => line.length > 0)
-                    .slice(0, wanted);
-                if (titles.length === 0) {
-                    return { content: [{ type: 'text', text: 'The model did not return any task ideas.' }], isError: true };
-                }
-                const added = titles.map(title => addTask({ title, project: topic }));
+        server.registerTool(
+            'add_task',
+            {
+                description: 'Add a task to the board',
+                inputSchema: z.object({
+                    title: z.string().describe('What needs doing'),
+                    project: z.string().optional().describe('Project bucket, e.g. "ops"'),
+                    priority: z.enum(['high', 'medium', 'low']).optional(),
+                    due: z.string().optional().describe('Free-form due date, e.g. "Friday"'),
+                    notes: z.string().optional()
+                }),
+                outputSchema: z.object({ id: z.string(), title: z.string(), status: z.enum(['open', 'done']) })
+            },
+            async ({ title, project, priority, due, notes }, ctx) => {
+                const task = addTask({ title, project: project ?? 'inbox', priority, due, notes });
                 await announceBoardChange();
-                await logInfo(ctx, `brainstormed ${added.length} task(s) for "${topic}"`);
+                await logInfo(ctx, `added ${task.id}: ${task.title}`);
+                return {
+                    content: [{ type: 'text', text: `Added ${task.id}: ${describeTask(task)}` }],
+                    structuredContent: { id: task.id, title: task.title, status: task.status }
+                };
+            }
+        );
+
+        server.registerTool(
+            'add_tasks',
+            {
+                description: 'Add several tasks to the board at once',
+                inputSchema: z.object({
+                    tasks: z
+                        .array(
+                            z.object({
+                                title: z.string(),
+                                project: z.string().optional(),
+                                priority: z.enum(['high', 'medium', 'low']).optional(),
+                                due: z.string().optional(),
+                                notes: z.string().optional()
+                            })
+                        )
+                        .min(1)
+                        .describe('Tasks to add')
+                })
+            },
+            async ({ tasks: newTasks }, ctx) => {
+                const full = boardFullError(newTasks.length);
+                if (full) return full;
+                const added: Task[] = [];
+                for (const [index, task] of newTasks.entries()) {
+                    // Pretend each insert takes a moment so the host has in-flight progress to render.
+                    await new Promise(resolve => setTimeout(resolve, 100));
+                    added.push(addTask({ ...task, project: task.project ?? 'inbox' }));
+                    await reportProgress(ctx, index + 1, newTasks.length, `added "${task.title}"`);
+                }
+                await announceBoardChange();
+                await logInfo(ctx, `added ${added.length} task(s)`);
+                return {
+                    content: [{ type: 'text', text: `Added ${added.length} task(s):\n${added.map(task => describeTask(task)).join('\n')}` }]
+                };
+            }
+        );
+
+        server.registerTool(
+            'brainstorm_tasks',
+            {
+                description:
+                    'Invent short, funny example tasks for a theme and add them to the board — asks the user how many (elicitation), then has the LLM connected to the host invent them (sampling)',
+                inputSchema: z.object({
+                    theme: z.string().optional().describe('Theme for the invented tasks (default: "an engineer\'s week in hell")')
+                })
+            },
+            async ({ theme }, ctx): Promise<CallToolResult | InputRequiredResult> => {
+                // The theme can come from the model (tool argument) or from the user (the elicitation
+                // form's theme field, pre-filled with a default); the user's answer wins.
+                const fallbackTopic = theme ?? "an engineer's week in hell";
+                const resolveTopic = (raw: unknown): string =>
+                    typeof raw === 'string' && raw.trim().length > 0 ? raw.trim() : fallbackTopic;
+                const countMessage = 'Let me invent some tasks for the board.';
+
+                const finish = async (ideasText: string, wanted: number, topic: string): Promise<CallToolResult> => {
+                    const titles = ideasText
+                        .split('\n')
+                        .map(line => line.replace(/^[-*\d.\s]+/, '').trim())
+                        .filter(line => line.length > 0)
+                        .slice(0, wanted);
+                    if (titles.length === 0) {
+                        return { content: [{ type: 'text', text: 'The model did not return any task ideas.' }], isError: true };
+                    }
+                    const full = boardFullError(titles.length);
+                    if (full) return full;
+                    const added = titles.map(title => addTask({ title, project: topic }));
+                    await announceBoardChange();
+                    await logInfo(ctx, `brainstormed ${added.length} task(s) for "${topic}"`);
+                    return {
+                        content: [
+                            {
+                                type: 'text',
+                                text: `Added ${added.length} brainstormed task(s):\n${added.map(task => describeTask(task)).join('\n')}`
+                            }
+                        ]
+                    };
+                };
+                const declined = (action: string): CallToolResult => ({
+                    content: [{ type: 'text', text: `Nothing added (user answered: ${action}).` }]
+                });
+
+                // The whole conversation as a multi-round input_required chain — written ONCE.
+                // The handler is a state machine over BrainstormState — it dispatches on
+                // `state.step` (not on which inputResponses key arrived), so each round knows
+                // exactly which answer to read and which data is in scope. State is HMAC-signed
+                // by stateCodec; the seam verified integrity AND decoded the payload before this
+                // handler ran — the typed accessor returns it. On a 2025-era session the SDK's
+                // legacy shim fulfils each round as real push-style requests; the handler never
+                // branches on the served era.
+                const state = ctx.mcpReq.requestState<BrainstormState>();
+                const askForIdeas = async (count: number, topic: string): Promise<InputRequiredResult> =>
+                    inputRequired({
+                        inputRequests: { ideas: inputRequired.createMessage(buildBrainstormSampling(topic, count)) },
+                        requestState: await stateCodec.mint({ step: 'awaiting-ideas', topic, count }, ctx)
+                    });
+
+                switch (state?.step) {
+                    case undefined: {
+                        // First call: ask for the theme and count.
+                        return inputRequired({
+                            inputRequests: {
+                                count: inputRequired.elicit({ message: countMessage, requestedSchema: BRAINSTORM_COUNT_SCHEMA })
+                            },
+                            requestState: await stateCodec.mint({ step: 'awaiting-count' }, ctx)
+                        });
+                    }
+                    case 'awaiting-count': {
+                        const accepted = acceptedContent<{ count?: string; theme?: string }>(ctx.mcpReq.inputResponses, 'count');
+                        if (accepted === undefined) return declined(elicitAction(ctx.mcpReq.inputResponses, 'count'));
+                        const topic = resolveTopic(accepted.theme);
+                        if (accepted.count === 'custom') {
+                            return inputRequired({
+                                inputRequests: {
+                                    customCount: inputRequired.elicit({
+                                        message: 'How many exactly?',
+                                        requestedSchema: BRAINSTORM_CUSTOM_COUNT_SCHEMA
+                                    })
+                                },
+                                requestState: await stateCodec.mint({ step: 'awaiting-custom-count', topic }, ctx)
+                            });
+                        }
+                        const wanted = parseBrainstormCount(accepted.count);
+                        if (wanted === undefined) return declined('cancel');
+                        return askForIdeas(wanted, topic);
+                    }
+                    case 'awaiting-custom-count': {
+                        const accepted = acceptedContent<{ customCount?: number }>(ctx.mcpReq.inputResponses, 'customCount');
+                        const wanted = parseBrainstormCount(accepted?.customCount);
+                        if (wanted === undefined) return declined(elicitAction(ctx.mcpReq.inputResponses, 'customCount'));
+                        return askForIdeas(wanted, state.topic);
+                    }
+                    case 'awaiting-ideas': {
+                        return finish(sampledText(ctx.mcpReq.inputResponses, 'ideas'), state.count, state.topic);
+                    }
+                }
+            }
+        );
+
+        server.registerTool(
+            'list_tasks',
+            {
+                description: 'List tasks on the board',
+                inputSchema: z.object({
+                    status: z.enum(['open', 'done', 'all']).optional().describe('Which tasks to list (default: open)'),
+                    project: z.string().optional().describe('Only tasks in this project')
+                })
+            },
+            async ({ status, project }) => {
+                const wanted = status ?? 'open';
+                const matching = [...tasks.values()].filter(
+                    task => (wanted === 'all' || task.status === wanted) && (!project || task.project === project)
+                );
                 return {
                     content: [
                         {
                             type: 'text',
-                            text: `Added ${added.length} brainstormed task(s):\n${added.map(task => describeTask(task)).join('\n')}`
+                            text: matching.length === 0 ? 'No matching tasks.' : matching.map(task => describeTask(task)).join('\n')
                         }
                     ]
                 };
-            };
-            const declined = (action: string): CallToolResult => ({
-                content: [{ type: 'text', text: `Nothing added (user answered: ${action}).` }]
-            });
+            }
+        );
 
-            // The whole conversation as a multi-round input_required chain — written ONCE.
-            // The handler is a state machine over BrainstormState — it dispatches on
-            // `state.step` (not on which inputResponses key arrived), so each round knows
-            // exactly which answer to read and which data is in scope. State is HMAC-signed
-            // by stateCodec; the seam verified integrity AND decoded the payload before this
-            // handler ran — the typed accessor returns it. On a 2025-era session the SDK's
-            // legacy shim fulfils each round as real push-style requests; the handler never
-            // branches on the served era.
-            const state = ctx.mcpReq.requestState<BrainstormState>();
-            const askForIdeas = async (count: number, topic: string): Promise<InputRequiredResult> =>
-                inputRequired({
-                    inputRequests: { ideas: inputRequired.createMessage(buildBrainstormSampling(topic, count)) },
-                    requestState: await stateCodec.mint({ step: 'awaiting-ideas', topic, count }, ctx)
-                });
+        server.registerTool(
+            'complete_task',
+            {
+                description: 'Mark a task as done',
+                inputSchema: z.object({ task: z.string().describe('Task id, or part of its title') })
+            },
+            async ({ task: query }, ctx) => {
+                const needle = query.toLowerCase();
+                const task = tasks.get(query) ?? [...tasks.values()].find(candidate => candidate.title.toLowerCase().includes(needle));
+                if (!task) {
+                    return { content: [{ type: 'text', text: `No task matches "${query}".` }], isError: true };
+                }
+                task.status = 'done';
+                await announceBoardChange();
+                await logInfo(ctx, `completed ${task.id}: ${task.title}`);
+                return { content: [{ type: 'text', text: `Marked "${task.title}" (${task.id}) as done.` }] };
+            }
+        );
 
-            switch (state?.step) {
-                case undefined: {
-                    // First call: ask for the theme and count.
+        server.registerTool(
+            'work_through_tasks',
+            {
+                description:
+                    'Work through every open task one by one (simulated, a few seconds each), logging what it is "doing", reporting progress, and marking each as done',
+                inputSchema: z.object({
+                    secondsPerTask: z
+                        .number()
+                        .min(0)
+                        .max(15)
+                        .optional()
+                        .describe('How long to pretend each task takes (default: 3 seconds)')
+                })
+            },
+            async ({ secondsPerTask }, ctx) => {
+                const queue = openTasks();
+                if (queue.length === 0) {
+                    return { content: [{ type: 'text', text: 'Nothing open — the board is already clear.' }] };
+                }
+                const paceMs = (secondsPerTask ?? 3) * 1000;
+                for (const [index, task] of queue.entries()) {
+                    // Honour cancellation: if the client aborted the call (notifications/cancelled),
+                    // stop early instead of ploughing through the rest of the queue.
+                    if (ctx.mcpReq.signal.aborted) {
+                        return {
+                            content: [
+                                {
+                                    type: 'text',
+                                    text: `Stopped early — the request was cancelled after ${index} of ${queue.length} task(s).`
+                                }
+                            ]
+                        };
+                    }
+                    // Narrate the "work" (a log notification per task), pretend it takes a moment so the
+                    // host has live progress to render, then announce the board change for watchers.
+                    await logInfo(ctx, `working on "${task.title}" — ${WORK_QUIPS[index % WORK_QUIPS.length] ?? 'working'}…`);
+                    await new Promise(resolve => setTimeout(resolve, paceMs));
+                    task.status = 'done';
+                    await reportProgress(ctx, index + 1, queue.length, `finished "${task.title}"`);
+                    await announceBoardChange();
+                }
+                await logInfo(ctx, `worked through ${queue.length} open task(s)`);
+                return {
+                    content: [
+                        {
+                            type: 'text',
+                            text: `Worked through ${queue.length} task(s):\n${queue.map(task => `- ${task.title} ✔`).join('\n')}`
+                        }
+                    ]
+                };
+            }
+        );
+
+        server.registerTool(
+            'clear_done',
+            { description: 'Delete every completed task (asks the user to confirm first)' },
+            async (ctx): Promise<CallToolResult | InputRequiredResult> => {
+                const done = [...tasks.values()].filter(task => task.status === 'done');
+                if (done.length === 0) return { content: [{ type: 'text', text: 'No completed tasks to clear.' }] };
+                const message = `Delete ${done.length} completed task(s) from the board?`;
+
+                // A single input_required round, written once for both eras — the first call has
+                // no inputResponses and returns the question; the re-call carries the answer.
+                // (For multi-round flows, dispatch on a discriminated requestState instead — see
+                // brainstorm_tasks.) On 2025-era sessions the SDK's legacy shim asks the question
+                // as a real push-style elicitation.
+                const confirmationView = inputResponse(ctx.mcpReq.inputResponses, 'confirmation');
+                if (confirmationView.kind === 'missing') {
                     return inputRequired({
-                        inputRequests: { count: inputRequired.elicit({ message: countMessage, requestedSchema: BRAINSTORM_COUNT_SCHEMA }) },
-                        requestState: await stateCodec.mint({ step: 'awaiting-count' }, ctx)
+                        inputRequests: { confirmation: inputRequired.elicit({ message, requestedSchema: CLEAR_CONFIRM_SCHEMA }) }
                     });
                 }
-                case 'awaiting-count': {
-                    const response = ctx.mcpReq.inputResponses?.['count'];
-                    const accepted = acceptedContent<{ count?: string; theme?: string }>(ctx.mcpReq.inputResponses, 'count');
-                    if (accepted === undefined) return declined(elicitAction(response));
-                    const topic = resolveTopic(accepted.theme);
-                    if (accepted.count === 'custom') {
-                        return inputRequired({
-                            inputRequests: {
-                                customCount: inputRequired.elicit({
-                                    message: 'How many exactly?',
-                                    requestedSchema: BRAINSTORM_CUSTOM_COUNT_SCHEMA
-                                })
-                            },
-                            requestState: await stateCodec.mint({ step: 'awaiting-custom-count', topic }, ctx)
-                        });
-                    }
-                    const wanted = parseBrainstormCount(accepted.count);
-                    if (wanted === undefined) return declined('cancel');
-                    return askForIdeas(wanted, topic);
-                }
-                case 'awaiting-custom-count': {
-                    const response = ctx.mcpReq.inputResponses?.['customCount'];
-                    const accepted = acceptedContent<{ customCount?: number }>(ctx.mcpReq.inputResponses, 'customCount');
-                    const wanted = parseBrainstormCount(accepted?.customCount);
-                    if (wanted === undefined) return declined(elicitAction(response));
-                    return askForIdeas(wanted, state.topic);
-                }
-                case 'awaiting-ideas': {
-                    return finish(sampledText(ctx.mcpReq.inputResponses?.['ideas']), state.count, state.topic);
-                }
-            }
-        }
-    );
+                const action = confirmationView.kind === 'elicit' ? confirmationView.action : 'cancel';
+                const confirmation = acceptedContent<{ confirm?: boolean }>(ctx.mcpReq.inputResponses, 'confirmation');
 
-    server.registerTool(
-        'list_tasks',
-        {
-            description: 'List tasks on the board',
-            inputSchema: z.object({
-                status: z.enum(['open', 'done', 'all']).optional().describe('Which tasks to list (default: open)'),
-                project: z.string().optional().describe('Only tasks in this project')
-            })
-        },
-        async ({ status, project }) => {
-            const wanted = status ?? 'open';
-            const matching = [...tasks.values()].filter(
-                task => (wanted === 'all' || task.status === wanted) && (!project || task.project === project)
-            );
-            return {
-                content: [
-                    {
-                        type: 'text',
-                        text: matching.length === 0 ? 'No matching tasks.' : matching.map(task => describeTask(task)).join('\n')
-                    }
-                ]
-            };
-        }
-    );
-
-    server.registerTool(
-        'complete_task',
-        {
-            description: 'Mark a task as done',
-            inputSchema: z.object({ task: z.string().describe('Task id, or part of its title') })
-        },
-        async ({ task: query }, ctx) => {
-            const needle = query.toLowerCase();
-            const task = tasks.get(query) ?? [...tasks.values()].find(candidate => candidate.title.toLowerCase().includes(needle));
-            if (!task) {
-                return { content: [{ type: 'text', text: `No task matches "${query}".` }], isError: true };
-            }
-            task.status = 'done';
-            await announceBoardChange();
-            await logInfo(ctx, `completed ${task.id}: ${task.title}`);
-            return { content: [{ type: 'text', text: `Marked "${task.title}" (${task.id}) as done.` }] };
-        }
-    );
-
-    server.registerTool(
-        'work_through_tasks',
-        {
-            description:
-                'Work through every open task one by one (simulated, a few seconds each), logging what it is "doing", reporting progress, and marking each as done',
-            inputSchema: z.object({
-                secondsPerTask: z.number().min(0).max(15).optional().describe('How long to pretend each task takes (default: 3 seconds)')
-            })
-        },
-        async ({ secondsPerTask }, ctx) => {
-            const queue = openTasks();
-            if (queue.length === 0) {
-                return { content: [{ type: 'text', text: 'Nothing open — the board is already clear.' }] };
-            }
-            const paceMs = (secondsPerTask ?? 3) * 1000;
-            for (const [index, task] of queue.entries()) {
-                // Honour cancellation: if the client aborted the call (notifications/cancelled),
-                // stop early instead of ploughing through the rest of the queue.
-                if (ctx.mcpReq.signal.aborted) {
-                    return {
-                        content: [
-                            { type: 'text', text: `Stopped early — the request was cancelled after ${index} of ${queue.length} task(s).` }
-                        ]
-                    };
+                if (confirmation?.confirm !== true) {
+                    // Decline and cancel are answers — report them and stop, never ask again.
+                    return { content: [{ type: 'text', text: `Nothing deleted (user answered: ${action}).` }] };
                 }
-                // Narrate the "work" (a log notification per task), pretend it takes a moment so the
-                // host has live progress to render, then announce the board change for watchers.
-                await logInfo(ctx, `working on "${task.title}" — ${WORK_QUIPS[index % WORK_QUIPS.length] ?? 'working'}…`);
-                await new Promise(resolve => setTimeout(resolve, paceMs));
-                task.status = 'done';
-                await reportProgress(ctx, index + 1, queue.length, `finished "${task.title}"`);
+                for (const task of done) tasks.delete(task.id);
                 await announceBoardChange();
+                await logInfo(ctx, `cleared ${done.length} completed task(s)`);
+                return { content: [{ type: 'text', text: `Deleted ${done.length} completed task(s).` }] };
             }
-            await logInfo(ctx, `worked through ${queue.length} open task(s)`);
-            return {
-                content: [
-                    { type: 'text', text: `Worked through ${queue.length} task(s):\n${queue.map(task => `- ${task.title} ✔`).join('\n')}` }
-                ]
-            };
-        }
-    );
+        );
 
-    server.registerTool(
-        'clear_done',
-        { description: 'Delete every completed task (asks the user to confirm first)' },
-        async (ctx): Promise<CallToolResult | InputRequiredResult> => {
-            const done = [...tasks.values()].filter(task => task.status === 'done');
-            if (done.length === 0) return { content: [{ type: 'text', text: 'No completed tasks to clear.' }] };
-            const message = `Delete ${done.length} completed task(s) from the board?`;
-
-            // A single input_required round, written once for both eras — the first call has
-            // no inputResponses and returns the question; the re-call carries the answer.
-            // (For multi-round flows, dispatch on a discriminated requestState instead — see
-            // brainstorm_tasks.) On 2025-era sessions the SDK's legacy shim asks the question
-            // as a real push-style elicitation.
-            const response = ctx.mcpReq.inputResponses?.['confirmation'];
-            if (response === undefined) {
-                return inputRequired({
-                    inputRequests: { confirmation: inputRequired.elicit({ message, requestedSchema: CLEAR_CONFIRM_SCHEMA }) }
-                });
-            }
-            const action = elicitAction(response);
-            const confirmation = acceptedContent<{ confirm?: boolean }>(ctx.mcpReq.inputResponses, 'confirmation');
-
-            if (confirmation?.confirm !== true) {
-                // Decline and cancel are answers — report them and stop, never ask again.
-                return { content: [{ type: 'text', text: `Nothing deleted (user answered: ${action}).` }] };
-            }
-            for (const task of done) tasks.delete(task.id);
-            await announceBoardChange();
-            await logInfo(ctx, `cleared ${done.length} completed task(s)`);
-            return { content: [{ type: 'text', text: `Deleted ${done.length} completed task(s).` }] };
-        }
-    );
-
-    server.registerTool(
-        'prioritize',
-        { description: 'Rank the open tasks by importance using the LLM connected to the host, and update their priorities' },
-        async (ctx): Promise<CallToolResult | InputRequiredResult> => {
-            const candidates = openTasks();
-            if (candidates.length === 0) return { content: [{ type: 'text', text: 'No open tasks to prioritize.' }] };
-            const samplingRequest = {
-                systemPrompt: 'You prioritize todo lists. Reply with one task title per line, most important first. No commentary.',
-                messages: [
-                    {
-                        role: 'user' as const,
-                        content: {
-                            type: 'text' as const,
-                            text: `Rank these tasks:\n${candidates.map(task => `- ${task.title}`).join('\n')}`
+        server.registerTool(
+            'prioritize',
+            { description: 'Rank the open tasks by importance using the LLM connected to the host, and update their priorities' },
+            async (ctx): Promise<CallToolResult | InputRequiredResult> => {
+                const candidates = openTasks();
+                if (candidates.length === 0) return { content: [{ type: 'text', text: 'No open tasks to prioritize.' }] };
+                const samplingRequest = {
+                    systemPrompt: 'You prioritize todo lists. Reply with one task title per line, most important first. No commentary.',
+                    messages: [
+                        {
+                            role: 'user' as const,
+                            content: {
+                                type: 'text' as const,
+                                text: `Rank these tasks:\n${candidates.map(task => `- ${task.title}`).join('\n')}`
+                            }
                         }
-                    }
-                ],
-                maxTokens: 400
-            };
+                    ],
+                    maxTokens: 400
+                };
 
-            // A single input_required round, written once for both eras (the ranking arrives
-            // on the retried call), so no requestState is needed. For multi-round flows,
-            // dispatch on a discriminated requestState instead — see brainstorm_tasks. On
-            // 2025-era sessions the SDK's legacy shim performs the sampling round trip.
-            const response = ctx.mcpReq.inputResponses?.['ranking'];
-            if (response === undefined) {
-                return inputRequired({ inputRequests: { ranking: inputRequired.createMessage(samplingRequest) } });
-            }
-            const rankingText = sampledText(response);
+                // A single input_required round, written once for both eras (the ranking arrives
+                // on the retried call), so no requestState is needed. For multi-round flows,
+                // dispatch on a discriminated requestState instead — see brainstorm_tasks. On
+                // 2025-era sessions the SDK's legacy shim performs the sampling round trip.
+                if (inputResponse(ctx.mcpReq.inputResponses, 'ranking').kind === 'missing') {
+                    return inputRequired({ inputRequests: { ranking: inputRequired.createMessage(samplingRequest) } });
+                }
+                const rankingText = sampledText(ctx.mcpReq.inputResponses, 'ranking');
 
-            const ranked = applyRanking(rankingText, candidates);
-            for (const [index, task] of ranked.entries()) {
-                task.priority = priorityForRank(index, ranked.length);
+                const ranked = applyRanking(rankingText, candidates);
+                for (const [index, task] of ranked.entries()) {
+                    task.priority = priorityForRank(index, ranked.length);
+                }
+                // Priorities are board-visible state — watchers and list caches must hear about it.
+                await announceBoardChange();
+                await logInfo(ctx, `prioritize: ranked ${ranked.length} open task(s) via the host LLM`);
+                return {
+                    content: [
+                        {
+                            type: 'text',
+                            text: `Re-prioritized ${ranked.length} task(s):\n${ranked.map(task => `- ${task.title} → ${task.priority}`).join('\n')}`
+                        }
+                    ]
+                };
             }
-            // Priorities are board-visible state — watchers and list caches must hear about it.
-            await announceBoardChange();
-            await logInfo(ctx, `prioritize: ranked ${ranked.length} open task(s) via the host LLM`);
-            return {
-                content: [
-                    {
-                        type: 'text',
-                        text: `Re-prioritized ${ranked.length} task(s):\n${ranked.map(task => `- ${task.title} → ${task.priority}`).join('\n')}`
-                    }
-                ]
-            };
+        );
+
+        return server;
+    }
+
+    return {
+        buildServer,
+        subscribeInstance,
+        snapshot: () => structuredClone({ nextId, tasks: [...tasks.values()] }),
+        restore: snapshot => {
+            nextId = snapshot.nextId;
+            tasks.clear();
+            for (const task of structuredClone(snapshot.tasks)) tasks.set(task.id, task);
         }
-    );
-
-    return server;
+    };
 }

--- a/examples/todos-server/todos.ts
+++ b/examples/todos-server/todos.ts
@@ -98,17 +98,18 @@ export interface TodosAppOptions {
      * The board's change bus. Every mutation announces on it once, and the serving entry
      * fans the events out: `createMcpHandler({ bus })` routes them onto its
      * `subscriptions/listen` streams, and a host that pins long-lived instances (sessions)
-     * forwards them with {@linkcode TodosApp.forwardServerEvent}. Unset (stdio, tests), the
+     * subscribes each pinned instance via {@linkcode TodosApp.subscribeInstance}. Unset (stdio, tests), the
      * app announces only on the connection that made the change — the sole audience a
      * single-connection transport has.
      */
     bus?: ServerEventBus;
     /**
-     * Path of a human-viewable live board page on this deployment's origin (e.g. '/board').
-     * When set, the instructions and `whoami` tell the client where to send the user to
-     * watch the board update in real time. Leave unset for hosts without one (stdio).
+     * Location of a human-viewable live board page — a URL, a path, or a thunk
+     * resolved when a server is built (the worker learns its origin from the first
+     * request). When set, the instructions and `whoami` tell the client where to
+     * send the user to watch the board live. Leave unset for hosts without one.
      */
-    boardViewPath?: string;
+    boardViewPath?: string | (() => string);
 }
 
 /** One todo board plus the `buildServer` factory that serves it. */
@@ -311,14 +312,15 @@ export function createTodosApp(options: TodosAppOptions = {}): TodosApp {
     }
 
     function buildServer(reqCtx: McpRequestContext): McpServer {
+        const boardViewPath = typeof options.boardViewPath === 'function' ? options.boardViewPath() : options.boardViewPath;
         const server = new McpServer(
             { name: 'todos', version: '1.0.0' },
             {
                 capabilities: { logging: {}, resources: { listChanged: true, subscribe: true } },
                 requestState: { verify: stateCodec.verify },
                 instructions:
-                    (options.boardViewPath
-                        ? `LIVE VIEW: the user can watch this board update in real time at ${options.boardViewPath} — with ?b=<name> when connected via the X-Todos-Board header, or as-is in the browser where they approved OAuth consent. Show them this link when you first respond. `
+                    (boardViewPath
+                        ? `LIVE VIEW: the user can watch this board update in real time at ${boardViewPath} — with ?b=<name> when connected via the X-Todos-Board header, or as-is in the browser where they approved OAuth consent. Show them this link when you first respond. `
                         : '') +
                     'todos is a small project todo board (it starts empty). Use list_tasks to see the board, add_task / add_tasks and complete_task to ' +
                     'change it, prioritize to rank the open tasks, brainstorm_tasks to invent themed example tasks, work_through_tasks to finish every ' +
@@ -352,7 +354,7 @@ export function createTodosApp(options: TodosAppOptions = {}): TodosApp {
          * no bus exists to carry it (stdio, where the entry lifts the instance's notification
          * onto its open subscriptions/listen streams). Every other connection hears it through
          * the bus — the entry's listen streams directly, pinned instances via
-         * {@linkcode TodosApp.forwardServerEvent} — so the announcement is made exactly once.
+         * {@linkcode TodosApp.subscribeInstance} — so the announcement is made exactly once.
          */
         const announceBoardChange = async (): Promise<void> => {
             server.sendResourceListChanged();
@@ -760,10 +762,10 @@ export function createTodosApp(options: TodosAppOptions = {}): TodosApp {
                             (reqCtx.authInfo
                                 ? `Authenticated via OAuth: client ${reqCtx.authInfo.clientId ?? 'unknown'}, scopes [${(reqCtx.authInfo.scopes ?? []).join(' ')}]. This board belongs to your grant.`
                                 : 'Anonymous tier: this board is keyed by your network address or the X-Todos-Board header. Authorize via OAuth for a private board.') +
-                            (options.boardViewPath
+                            (boardViewPath
                                 ? reqCtx.authInfo
-                                    ? ` The user can watch it live at ${options.boardViewPath}, in the browser where they approved consent.`
-                                    : ` The user can watch it live at ${options.boardViewPath}?b=<board-name> (when connected with the X-Todos-Board header).`
+                                    ? ` The user can watch it live at ${boardViewPath}, in the browser where they approved consent.`
+                                    : ` The user can watch it live at ${boardViewPath}?b=<board-name> (when connected with the X-Todos-Board header).`
                                 : '')
                     }
                 ]

--- a/examples/todos-server/todos.ts
+++ b/examples/todos-server/todos.ts
@@ -103,6 +103,12 @@ export interface TodosAppOptions {
      * single-connection transport has.
      */
     bus?: ServerEventBus;
+    /**
+     * Path of a human-viewable live board page on this deployment's origin (e.g. '/board').
+     * When set, the instructions and `whoami` tell the client where to send the user to
+     * watch the board update in real time. Leave unset for hosts without one (stdio).
+     */
+    boardViewPath?: string;
 }
 
 /** One todo board plus the `buildServer` factory that serves it. */
@@ -319,7 +325,10 @@ export function createTodosApp(options: TodosAppOptions = {}): TodosApp {
                     'elicitation — then borrows the host model — sampling), 2) ask to prioritize the open tasks (sampling), 3) run the plan-my-day ' +
                     'prompt, 4) attach the todos://board resource as context and ask about it, 5) say "do all my tasks" and watch the progress and ' +
                     'log notifications, 6) ask to clear completed tasks (an elicitation-confirmed bulk delete). Watching the board resource ' +
-                    '(/watch in cli-client) shows live change notifications along the way.'
+                    '(/watch in cli-client) shows live change notifications along the way.' +
+                    (options.boardViewPath
+                        ? ` There is also a human-viewable live page: tell the user they can WATCH this board update in real time by opening ${options.boardViewPath} on this server's origin — with ?b=<name> when connected with the X-Todos-Board header, or plain (no query) in the browser where they approved OAuth consent.`
+                        : '')
             }
         );
 
@@ -747,9 +756,15 @@ export function createTodosApp(options: TodosAppOptions = {}): TodosApp {
                 content: [
                     {
                         type: 'text',
-                        text: reqCtx.authInfo
-                            ? `Authenticated via OAuth: client ${reqCtx.authInfo.clientId ?? 'unknown'}, scopes [${(reqCtx.authInfo.scopes ?? []).join(' ')}]. This board belongs to your grant.`
-                            : 'Anonymous tier: this board is keyed by your network address or the X-Todos-Board header. Authorize via OAuth for a private board.'
+                        text:
+                            (reqCtx.authInfo
+                                ? `Authenticated via OAuth: client ${reqCtx.authInfo.clientId ?? 'unknown'}, scopes [${(reqCtx.authInfo.scopes ?? []).join(' ')}]. This board belongs to your grant.`
+                                : 'Anonymous tier: this board is keyed by your network address or the X-Todos-Board header. Authorize via OAuth for a private board.') +
+                            (options.boardViewPath
+                                ? reqCtx.authInfo
+                                    ? ` The user can watch it live at ${options.boardViewPath} on this server's origin, in the browser where they approved consent.`
+                                    : ` The user can watch it live at ${options.boardViewPath}?b=<board-name> on this server's origin (when connected with the X-Todos-Board header).`
+                                : '')
                     }
                 ]
             })

--- a/examples/todos-server/tsconfig.worker.json
+++ b/examples/todos-server/tsconfig.worker.json
@@ -6,7 +6,9 @@
         // Worker bundle must instead resolve through each package's exports map so the
         // `workerd` condition picks the Workers shims. Clearing `paths` restores that.
         "paths": {},
-        "noEmit": true
+        "noEmit": true,
+        "lib": ["ESNext"],
+        "types": ["@cloudflare/workers-types"]
     },
     "include": ["worker.ts", "todos.ts", "workerEnv.d.ts"]
 }

--- a/examples/todos-server/tsconfig.worker.json
+++ b/examples/todos-server/tsconfig.worker.json
@@ -1,0 +1,12 @@
+{
+    "extends": "../tsconfig.json",
+    "compilerOptions": {
+        // Used only by wrangler's bundler (see wrangler.toml). The examples tsconfig maps the
+        // SDK packages to their Node-flavoured sources (src/shimsNode.ts) for in-repo DX; the
+        // Worker bundle must instead resolve through each package's exports map so the
+        // `workerd` condition picks the Workers shims. Clearing `paths` restores that.
+        "paths": {},
+        "noEmit": true
+    },
+    "include": ["worker.ts", "todos.ts", "workerEnv.d.ts"]
+}

--- a/examples/todos-server/worker.ts
+++ b/examples/todos-server/worker.ts
@@ -100,6 +100,8 @@ interface Env {
     OAUTH_PROVIDER: OAuthHelpers;
     /** Set to '1' to auto-approve consent — used by the scripted end-to-end dance. */
     TODOS_AUTO_CONSENT?: string;
+    /** Public origin for user-facing links (wrangler [vars]); unset falls back to a relative path. */
+    PUBLIC_ORIGIN?: string;
 }
 
 /** Internal relay: the API handler forwards verified auth into the board object. */
@@ -135,7 +137,7 @@ export class TodosBoard {
             const requestStateKey = env.REQUEST_STATE_SECRET ?? (await this.loadOrCreateCodecKey());
             const parsedMaxTasks = Number(env.MAX_TASKS);
             const maxTasks = Number.isFinite(parsedMaxTasks) && parsedMaxTasks > 0 ? parsedMaxTasks : DEFAULT_MAX_TASKS;
-            this.app = createTodosApp({ requestStateKey, maxTasks, bus: this.bus, boardViewPath: '/board' });
+            this.app = createTodosApp({ requestStateKey, maxTasks, bus: this.bus, boardViewPath: `${env.PUBLIC_ORIGIN ?? ''}/board` });
             this.handler = createMcpHandler(this.app.buildServer, { bus: this.bus });
             // The durable copy of the board follows the same announcements every client does.
             this.bus.subscribe(event => {

--- a/examples/todos-server/worker.ts
+++ b/examples/todos-server/worker.ts
@@ -488,6 +488,9 @@ const defaultHandler = {
                 viewInfo ??= { mode: 'address', label: 'your network address' };
                 const headers = new Headers(request.headers);
                 headers.delete(AUTH_RELAY_HEADER);
+                // The view route must NEVER route by session id: a stale session id would
+                // override the resolved board and stream a private board without a token.
+                headers.delete('mcp-session-id');
                 headers.set(VIEW_INFO_HEADER, JSON.stringify(viewInfo));
                 return serveBoard(new Request(request, { headers }), env, boardName);
             }

--- a/examples/todos-server/worker.ts
+++ b/examples/todos-server/worker.ts
@@ -1,0 +1,341 @@
+/**
+ * Cloudflare Workers entry point for the "todos" reference server (the application itself
+ * lives in todos.ts; the Node transport entry is ./server.ts). Serves the landing page at `/`
+ * and MCP over Streamable HTTP at `/mcp`.
+ *
+ * Boards are per visitor: each visitor key maps to one Durable Object instance, which owns
+ * that board's memory (hydrated from durable storage on wake, persisted on every change) and
+ * one `ServerEventBus` — the single announce channel every serving mode shares. An alarm
+ * wipes an idle board: this is a demo, boards are ephemeral by design.
+ *
+ * Two serving modes share each board:
+ * - 2026-07-28 (and session-less legacy one-shots) ride `createMcpHandler`'s per-request
+ *   model, exactly like the Node entry; the handler routes bus events onto its
+ *   `subscriptions/listen` streams.
+ * - 2025-era clients that POST `initialize` get a REAL session: a per-session
+ *   `WebStandardStreamableHTTPServerTransport` connected to a server instance pinned to that
+ *   session, so push-style server→client requests (elicitation/sampling — the interactive
+ *   tools) work over HTTP. Each session subscribes its instance to the board's bus
+ *   (`app.forwardServerEvent`), so `resources/subscribe` subscribers hear changes made on any
+ *   connection; the subscription ends with the session. Session ids embed this object's own
+ *   opaque id, and the worker routes session traffic by that prefix, so a session sticks to
+ *   its board even when the client's egress IP rotates mid-session. Sessions are in-memory:
+ *   if the object is evicted, the next request gets the spec's 404 and a conformant client
+ *   re-initializes (the board itself is durable).
+ */
+import type { McpHttpHandler } from '@modelcontextprotocol/server';
+import {
+    classifyInboundRequest,
+    createMcpHandler,
+    InMemoryServerEventBus,
+    WebStandardStreamableHTTPServerTransport
+} from '@modelcontextprotocol/server';
+
+import indexHtml from './index.html';
+import type { BoardSnapshot, TodosApp } from './todos';
+import { createTodosApp } from './todos';
+
+/** How long an untouched board survives before its alarm wipes it. */
+const BOARD_TTL_MS = 2 * 60 * 60 * 1000;
+/** Task-count cap per board unless the MAX_TASKS var overrides it. */
+const DEFAULT_MAX_TASKS = 200;
+/** Concurrent 2025-era sessions allowed per board. */
+const MAX_SESSIONS = 8;
+/** At the cap, sessions idle longer than this are evicted to make room. */
+const SESSION_IDLE_MS = 30 * 60 * 1000;
+/** Durable-storage keys: the board snapshot and the fallback requestState key. */
+const BOARD_KEY = 'board:v2';
+const CODEC_KEY_KEY = 'codecKey';
+
+// Minimal structural types for the Workers runtime surface this file touches, so the example
+// typechecks without adding @cloudflare/workers-types to the workspace. If this entry ever
+// grows beyond them, switch to the real types package instead of extending these.
+interface DurableObjectStub {
+    fetch(request: Request): Promise<Response>;
+}
+interface DurableObjectId {
+    toString(): string;
+}
+interface DurableObjectNamespace {
+    idFromName(name: string): DurableObjectId;
+    /** Throws on anything that is not an id minted by this namespace. */
+    idFromString(id: string): DurableObjectId;
+    get(id: DurableObjectId): DurableObjectStub;
+}
+interface DurableObjectStorage {
+    get<T>(key: string): Promise<T | undefined>;
+    put(key: string, value: unknown): Promise<void>;
+    delete(key: string): Promise<boolean>;
+    getAlarm(): Promise<number | null>;
+    setAlarm(scheduledTimeMs: number): Promise<void>;
+}
+interface DurableObjectState {
+    id: DurableObjectId;
+    storage: DurableObjectStorage;
+    blockConcurrencyWhile(callback: () => Promise<void>): Promise<void>;
+}
+
+interface Env {
+    BOARDS: DurableObjectNamespace;
+    /**
+     * HMAC key for the signed multi-round requestState (wrangler secret put REQUEST_STATE_SECRET).
+     * Optional: without it each board mints its own key and persists it in durable storage, which
+     * keeps multi-round flows verifiable across isolate recycling (rounds always route back to
+     * the same board). A deployment-wide secret still wins when set.
+     */
+    REQUEST_STATE_SECRET?: string;
+    /** Optional override for the per-board task cap (a number as a string; wrangler [vars]). */
+    MAX_TASKS?: string;
+}
+
+/** A live 2025-era session: its transport, and when its client was last heard from. */
+interface LegacySession {
+    transport: WebStandardStreamableHTTPServerTransport;
+    lastSeenMs: number;
+}
+
+/**
+ * One visitor's board. The DO is the unit of coherence: its in-memory app instance serves
+ * every request for this visitor, and the board's bus lives here too, so listen streams and
+ * pinned sessions all hear this board's changes no matter which edge isolate a request hit.
+ */
+export class TodosBoard {
+    private readonly state: DurableObjectState;
+    private readonly sessions = new Map<string, LegacySession>();
+    private readonly bus = new InMemoryServerEventBus();
+    private app!: TodosApp;
+    private handler!: McpHttpHandler;
+
+    constructor(state: DurableObjectState, env: Env) {
+        this.state = state;
+        // Everything the first request needs — the codec key, the app, the hydrated board —
+        // is set up before any event is delivered.
+        void state.blockConcurrencyWhile(async () => {
+            const requestStateKey = env.REQUEST_STATE_SECRET ?? (await this.loadOrCreateCodecKey());
+            const parsedMaxTasks = Number(env.MAX_TASKS);
+            const maxTasks = Number.isFinite(parsedMaxTasks) && parsedMaxTasks > 0 ? parsedMaxTasks : DEFAULT_MAX_TASKS;
+            this.app = createTodosApp({ requestStateKey, maxTasks, bus: this.bus });
+            this.handler = createMcpHandler(this.app.buildServer, { bus: this.bus });
+            // The durable copy of the board follows the same announcements every client does.
+            this.bus.subscribe(event => {
+                if (event.kind === 'resource_updated') void this.persist();
+            });
+            const snapshot = await state.storage.get<BoardSnapshot>(BOARD_KEY);
+            if (snapshot) this.app.restore(snapshot);
+            // Every instantiated object carries a wipe alarm, so even a board that only ever
+            // reads (or a session that never mutates) is cleaned up.
+            if ((await state.storage.getAlarm()) === null) {
+                await state.storage.setAlarm(Date.now() + BOARD_TTL_MS);
+            }
+        });
+    }
+
+    /**
+     * Fallback requestState key, persisted next to the board: multi-round flows must survive
+     * this object being evicted between rounds (a per-instance random key would reject its own
+     * follow-up round with -32602 after any recycle).
+     */
+    private async loadOrCreateCodecKey(): Promise<Uint8Array> {
+        const stored = await this.state.storage.get<Uint8Array>(CODEC_KEY_KEY);
+        if (stored) return stored;
+        const created = crypto.getRandomValues(new Uint8Array(32));
+        await this.state.storage.put(CODEC_KEY_KEY, created);
+        return created;
+    }
+
+    private async persist(): Promise<void> {
+        await this.state.storage.put(BOARD_KEY, this.app.snapshot());
+        // Sliding TTL: every change pushes the wipe out again.
+        await this.state.storage.setAlarm(Date.now() + BOARD_TTL_MS);
+    }
+
+    /**
+     * The TTL alarm: drop the stored board (the codec key stays — in-flight multi-round
+     * requestState must not be invalidated by a wipe), reset the in-memory one in case we stay
+     * resident, and end any sessions still pinned to this object.
+     */
+    async alarm(): Promise<void> {
+        await this.state.storage.delete(BOARD_KEY);
+        this.app.restore({ nextId: 1, tasks: [] });
+        // Live clients hear the wipe like any other change.
+        this.bus.publish({ kind: 'resources_list_changed' });
+        this.bus.publish({ kind: 'resource_updated', uri: 'todos://board' });
+        for (const session of this.sessions.values()) {
+            await session.transport.close().catch(() => {});
+        }
+        // A resident object keeps its cleanup cycle: re-arm for the next window.
+        await this.state.storage.setAlarm(Date.now() + BOARD_TTL_MS);
+    }
+
+    /**
+     * A 2025-era `initialize` opens a session: its own transport (which mints the session id)
+     * connected to a server instance pinned to this session, sharing this board. The SDK's
+     * default-on legacy shim then serves the interactive tools as real push-style rounds over
+     * the session's streams, and the bus subscription below delivers board changes made on any
+     * other connection to this session's `resources/subscribe` subscribers.
+     */
+    private async createSession(request: Request): Promise<Response> {
+        if (this.sessions.size >= MAX_SESSIONS) {
+            // Make room by evicting idle sessions before refusing: an abandoned session
+            // (client gone without DELETE) must not wedge the board at the cap forever.
+            const cutoff = Date.now() - SESSION_IDLE_MS;
+            for (const session of this.sessions.values()) {
+                if (session.lastSeenMs < cutoff) await session.transport.close().catch(() => {});
+            }
+        }
+        if (this.sessions.size >= MAX_SESSIONS) {
+            return Response.json(
+                {
+                    jsonrpc: '2.0',
+                    error: { code: -32_000, message: 'Too many concurrent sessions for this board — retry later.' },
+                    id: null
+                },
+                { status: 429 }
+            );
+        }
+        const prefix = this.state.id.toString();
+        const server = this.app.buildServer({ era: 'legacy' });
+        const transport = new WebStandardStreamableHTTPServerTransport({
+            sessionIdGenerator: () => `${prefix}.${crypto.randomUUID()}`,
+            onsessioninitialized: sessionId => {
+                this.sessions.set(sessionId, { transport, lastSeenMs: Date.now() });
+            }
+        });
+        const unsubscribe = this.app.subscribeInstance(server);
+        // Assigned BEFORE connect: the server chains a transport.onclose that is already set,
+        // so both this teardown and the server's own run when the transport closes.
+        transport.onclose = () => {
+            unsubscribe();
+            if (transport.sessionId !== undefined) this.sessions.delete(transport.sessionId);
+        };
+        await server.connect(transport);
+        const response = await transport.handleRequest(request);
+        if (transport.sessionId === undefined) {
+            // The transport refused the handshake (schema-invalid initialize, bad Accept, …):
+            // no session was minted, so nothing else will ever run the teardown. Close now —
+            // otherwise the bus subscription pins this server as a zombie for the DO's life.
+            await transport.close().catch(() => {});
+        }
+        return response;
+    }
+
+    async fetch(request: Request): Promise<Response> {
+        // Session traffic goes to that session's own transport.
+        const sessionId = request.headers.get('mcp-session-id');
+        if (sessionId !== null) {
+            const session = this.sessions.get(sessionId);
+            if (!session) {
+                // Evicted or expired: the spec's 404 tells the client to re-initialize.
+                return Response.json({ jsonrpc: '2.0', error: { code: -32_001, message: 'Session not found' }, id: null }, { status: 404 });
+            }
+            session.lastSeenMs = Date.now();
+            return session.transport.handleRequest(request);
+        }
+
+        // A session-less legacy `initialize` opens a session; every other request rides the
+        // per-request handler unchanged. The routing decision comes from the entry's own
+        // exported classifier — `reason: 'initialize'` names exactly the legacy handshake,
+        // and never disagrees with createMcpHandler on the edge cells (an `initialize`
+        // carrying a modern envelope claim or a modern MCP-Protocol-Version header belongs
+        // to the modern path). Other legacy cells stay on the stateless handler by design.
+        if (request.method === 'POST') {
+            const body: unknown = await request
+                .clone()
+                .json()
+                .catch(() => {});
+            const outcome = classifyInboundRequest({
+                httpMethod: request.method,
+                protocolVersionHeader: request.headers.get('mcp-protocol-version') ?? undefined,
+                mcpMethodHeader: request.headers.get('mcp-method') ?? undefined,
+                mcpNameHeader: request.headers.get('mcp-name') ?? undefined,
+                body
+            });
+            if (outcome.kind === 'legacy' && outcome.reason === 'initialize') {
+                return this.createSession(request);
+            }
+            return this.handler.fetch(request, body === undefined ? undefined : { parsedBody: body });
+        }
+        return this.handler.fetch(request);
+    }
+}
+
+// The endpoint is public and credential-free, so a wide-open CORS posture is deliberate:
+// browser-based MCP clients (inspectors, playgrounds) can connect straight from the page.
+// Headers go on EVERY response (including errors and the 404) — a browser client can only
+// read a diagnostic that carries them.
+function corsHeaders(request: Request): Record<string, string> {
+    return {
+        'access-control-allow-origin': '*',
+        'access-control-allow-methods': 'GET, POST, DELETE, OPTIONS',
+        // Reflect the requested headers: the '*' wildcard never covers Authorization.
+        'access-control-allow-headers': request.headers.get('access-control-request-headers') ?? '*',
+        'access-control-expose-headers': '*',
+        'access-control-max-age': '86400'
+    };
+}
+
+function withCors(request: Request, response: Response): Response {
+    const headers = new Headers(response.headers);
+    for (const [name, value] of Object.entries(corsHeaders(request))) headers.set(name, value);
+    return new Response(response.body, { status: response.status, statusText: response.statusText, headers });
+}
+
+// The landing page is constant per deployment origin — substitute once per isolate.
+let landingPage: { origin: string; html: string } | undefined;
+function renderLandingPage(origin: string): string {
+    if (landingPage?.origin !== origin) landingPage = { origin, html: indexHtml.replaceAll('__HOST__', origin) };
+    return landingPage.html;
+}
+
+export default {
+    async fetch(request: Request, env: Env): Promise<Response> {
+        const url = new URL(request.url);
+        const response = await (async (): Promise<Response> => {
+            if (request.method === 'OPTIONS') return new Response(null, { status: 204 });
+
+            if (url.pathname === '/mcp') {
+                // Board routing. A session id starts with the id of the object that minted it
+                // (opaque, unguessable, validated by idFromString), so a session survives the
+                // client's egress IP rotating. Everything else routes by the connecting
+                // address, or by the X-Todos-Board header for a board of the client's own
+                // naming — the two namespaced so a header value can never collide with (and
+                // read) somebody's address-keyed board.
+                const sessionId = request.headers.get('mcp-session-id');
+                let id: DurableObjectId | undefined;
+                if (sessionId === null) {
+                    const named = request.headers.get('x-todos-board');
+                    const visitor = named ? `named:${named.slice(0, 128)}` : `ip:${request.headers.get('cf-connecting-ip') ?? 'anonymous'}`;
+                    id = env.BOARDS.idFromName(visitor);
+                } else {
+                    try {
+                        id = env.BOARDS.idFromString(sessionId.split('.')[0] ?? '');
+                    } catch {
+                        return Response.json(
+                            { jsonrpc: '2.0', error: { code: -32_001, message: 'Session not found' }, id: null },
+                            { status: 404 }
+                        );
+                    }
+                }
+                try {
+                    return await env.BOARDS.get(id).fetch(request);
+                } catch (error) {
+                    // Details stay server-side; clients get a stable, generic shape.
+                    console.error('board fetch failed:', error);
+                    return Response.json({ error: 'board unavailable' }, { status: 500 });
+                }
+            }
+
+            if (url.pathname === '/') {
+                return new Response(renderLandingPage(url.origin), {
+                    headers: { 'content-type': 'text/html; charset=utf-8', 'cache-control': 'public, max-age=300' }
+                });
+            }
+
+            return new Response('Not found. The MCP endpoint is /mcp; see / for how to connect.\n', {
+                status: 404,
+                headers: { 'content-type': 'text/plain; charset=utf-8' }
+            });
+        })();
+        return withCors(request, response);
+    }
+};

--- a/examples/todos-server/worker.ts
+++ b/examples/todos-server/worker.ts
@@ -133,7 +133,7 @@ export class TodosBoard {
             const requestStateKey = env.REQUEST_STATE_SECRET ?? (await this.loadOrCreateCodecKey());
             const parsedMaxTasks = Number(env.MAX_TASKS);
             const maxTasks = Number.isFinite(parsedMaxTasks) && parsedMaxTasks > 0 ? parsedMaxTasks : DEFAULT_MAX_TASKS;
-            this.app = createTodosApp({ requestStateKey, maxTasks, bus: this.bus });
+            this.app = createTodosApp({ requestStateKey, maxTasks, bus: this.bus, boardViewPath: '/board' });
             this.handler = createMcpHandler(this.app.buildServer, { bus: this.bus });
             // The durable copy of the board follows the same announcements every client does.
             this.bus.subscribe(event => {

--- a/examples/todos-server/worker.ts
+++ b/examples/todos-server/worker.ts
@@ -1,7 +1,10 @@
 /**
  * Cloudflare Workers entry point for the "todos" reference server (the application itself
- * lives in todos.ts; the Node transport entry is ./server.ts). Serves the landing page at `/`
- * and MCP over Streamable HTTP at `/mcp`.
+ * lives in todos.ts; the Node transport entry is ./server.ts; the OAuth glue in ./oauth.ts).
+ * `@cloudflare/workers-oauth-provider` wraps the worker as the Authorization Server: the
+ * landing page and anonymous `/mcp` ride its defaultHandler unchanged, while `/oauth/mcp`
+ * serves token-authorized boards — the provider verifies, `propsToAuthInfo` maps the grant
+ * into the SDK's `AuthInfo`, and the board IS the grant (no user accounts).
  *
  * Boards are per visitor: each visitor key maps to one Durable Object instance, which owns
  * that board's memory (hydrated from durable storage on wake, persisted on every change) and
@@ -23,15 +26,20 @@
  *   if the object is evicted, the next request gets the spec's 404 and a conformant client
  *   re-initializes (the board itself is durable).
  */
-import type { McpHttpHandler } from '@modelcontextprotocol/server';
+import { OAuthProvider } from '@cloudflare/workers-oauth-provider';
+import type { AuthInfo, McpHttpHandler } from '@modelcontextprotocol/server';
 import {
     classifyInboundRequest,
     createMcpHandler,
     InMemoryServerEventBus,
     WebStandardStreamableHTTPServerTransport
 } from '@modelcontextprotocol/server';
+import { WorkerEntrypoint } from 'cloudflare:workers';
 
+import boardHtml from './board.html';
 import indexHtml from './index.html';
+import type { OAuthHelpers, TodosGrantProps } from './oauth';
+import { handleAuthorize, propsToAuthInfo } from './oauth';
 import type { BoardSnapshot, TodosApp } from './todos';
 import { createTodosApp } from './todos';
 
@@ -86,11 +94,22 @@ interface Env {
     REQUEST_STATE_SECRET?: string;
     /** Optional override for the per-board task cap (a number as a string; wrangler [vars]). */
     MAX_TASKS?: string;
+    /** Grant/token storage for the OAuth provider (wrangler kv namespace). */
+    OAUTH_KV: unknown;
+    /** Injected by the provider: parseAuthRequest/lookupClient/completeAuthorization. */
+    OAUTH_PROVIDER: OAuthHelpers;
+    /** Set to '1' to auto-approve consent — used by the scripted end-to-end dance. */
+    TODOS_AUTO_CONSENT?: string;
 }
 
-/** A live 2025-era session: its transport, and when its client was last heard from. */
+/** Internal relay: the API handler forwards verified auth into the board object. */
+const AUTH_RELAY_HEADER = 'x-todos-authinfo';
+
+/** A live 2025-era session: its transport, tier, and when its client was last heard from. */
 interface LegacySession {
     transport: WebStandardStreamableHTTPServerTransport;
+    /** Minted through the provider-verified route: every request must arrive the same way. */
+    authed: boolean;
     lastSeenMs: number;
 }
 
@@ -174,7 +193,7 @@ export class TodosBoard {
      * the session's streams, and the bus subscription below delivers board changes made on any
      * other connection to this session's `resources/subscribe` subscribers.
      */
-    private async createSession(request: Request): Promise<Response> {
+    private async createSession(request: Request, authInfo?: AuthInfo): Promise<Response> {
         if (this.sessions.size >= MAX_SESSIONS) {
             // Make room by evicting idle sessions before refusing: an abandoned session
             // (client gone without DELETE) must not wedge the board at the cap forever.
@@ -194,11 +213,11 @@ export class TodosBoard {
             );
         }
         const prefix = this.state.id.toString();
-        const server = this.app.buildServer({ era: 'legacy' });
+        const server = this.app.buildServer({ era: 'legacy', ...(authInfo === undefined ? {} : { authInfo }) });
         const transport = new WebStandardStreamableHTTPServerTransport({
             sessionIdGenerator: () => `${prefix}.${crypto.randomUUID()}`,
             onsessioninitialized: sessionId => {
-                this.sessions.set(sessionId, { transport, lastSeenMs: Date.now() });
+                this.sessions.set(sessionId, { transport, authed: authInfo !== undefined, lastSeenMs: Date.now() });
             }
         });
         const unsubscribe = this.app.subscribeInstance(server);
@@ -219,14 +238,70 @@ export class TodosBoard {
         return response;
     }
 
+    /**
+     * A live read-only view of this board: the current snapshot immediately, then a fresh
+     * snapshot on every change, as server-sent events. Just another bus subscriber — the
+     * same seam the durable copy and the pinned sessions use.
+     */
+    private boardEventStream(): Response {
+        const encoder = new TextEncoder();
+        let unsubscribe: (() => void) | undefined;
+        let heartbeat: ReturnType<typeof setInterval> | undefined;
+        const stream = new ReadableStream<Uint8Array>({
+            start: controller => {
+                const send = (): void => {
+                    try {
+                        controller.enqueue(encoder.encode(`data: ${JSON.stringify(this.app.snapshot())}\n\n`));
+                    } catch {
+                        // Stream already closed; the cancel() teardown handles the rest.
+                    }
+                };
+                send();
+                unsubscribe = this.bus.subscribe(event => {
+                    if (event.kind === 'resource_updated') send();
+                });
+                heartbeat = setInterval(() => {
+                    try {
+                        controller.enqueue(encoder.encode(': keepalive\n\n'));
+                    } catch {
+                        /* closed */
+                    }
+                }, 25_000);
+            },
+            cancel: () => {
+                unsubscribe?.();
+                if (heartbeat !== undefined) clearInterval(heartbeat);
+            }
+        });
+        return new Response(stream, {
+            headers: { 'content-type': 'text/event-stream', 'cache-control': 'no-store' }
+        });
+    }
+
     async fetch(request: Request): Promise<Response> {
-        // Session traffic goes to that session's own transport.
+        if (new URL(request.url).pathname === '/board/events') {
+            return this.boardEventStream();
+        }
+        // Verified auth relayed by the API handler (never trusted from clients: the
+        // anonymous route strips this header before the request reaches any board).
+        const relayed = request.headers.get(AUTH_RELAY_HEADER);
+        const authInfo = relayed === null ? undefined : (JSON.parse(relayed) as AuthInfo);
+        // Session traffic goes to that session's own transport — but never across tiers.
+        // An OAuth-minted session must arrive through the provider-verified route on every
+        // request (so token expiry and revocation cut it off), and an anonymous session id
+        // is worthless on the authed route: a session id alone is never a credential.
         const sessionId = request.headers.get('mcp-session-id');
         if (sessionId !== null) {
             const session = this.sessions.get(sessionId);
             if (!session) {
                 // Evicted or expired: the spec's 404 tells the client to re-initialize.
                 return Response.json({ jsonrpc: '2.0', error: { code: -32_001, message: 'Session not found' }, id: null }, { status: 404 });
+            }
+            if (session.authed !== (authInfo !== undefined)) {
+                return Response.json(
+                    { jsonrpc: '2.0', error: { code: -32_001, message: 'Session not found on this endpoint' }, id: null },
+                    { status: session.authed ? 401 : 404 }
+                );
             }
             session.lastSeenMs = Date.now();
             return session.transport.handleRequest(request);
@@ -251,11 +326,11 @@ export class TodosBoard {
                 body
             });
             if (outcome.kind === 'legacy' && outcome.reason === 'initialize') {
-                return this.createSession(request);
+                return this.createSession(request, authInfo);
             }
-            return this.handler.fetch(request, body === undefined ? undefined : { parsedBody: body });
+            return this.handler.fetch(request, { ...(body === undefined ? {} : { parsedBody: body }), authInfo });
         }
-        return this.handler.fetch(request);
+        return this.handler.fetch(request, { authInfo });
     }
 }
 
@@ -287,42 +362,106 @@ function renderLandingPage(origin: string): string {
     return landingPage.html;
 }
 
-export default {
+let boardPage: { origin: string; html: string } | undefined;
+function renderBoardPage(origin: string): string {
+    if (boardPage?.origin !== origin) boardPage = { origin, html: boardHtml.replaceAll('__HOST__', origin) };
+    return boardPage.html;
+}
+
+/**
+ * Route one MCP request to its board. Session ids carry the id of the object that
+ * minted them (opaque, unguessable, validated by idFromString), so a session survives
+ * the client's egress IP rotating; session-less requests route by `fallbackBoardName`.
+ */
+async function serveBoard(request: Request, env: Env, fallbackBoardName: string): Promise<Response> {
+    const sessionId = request.headers.get('mcp-session-id');
+    let id: DurableObjectId | undefined;
+    if (sessionId === null) {
+        id = env.BOARDS.idFromName(fallbackBoardName);
+    } else {
+        try {
+            id = env.BOARDS.idFromString(sessionId.split('.')[0] ?? '');
+        } catch {
+            return Response.json({ jsonrpc: '2.0', error: { code: -32_001, message: 'Session not found' }, id: null }, { status: 404 });
+        }
+    }
+    try {
+        return await env.BOARDS.get(id).fetch(request);
+    } catch (error) {
+        // Details stay server-side; clients get a stable, generic shape.
+        console.error('board fetch failed:', error);
+        return Response.json({ error: 'board unavailable' }, { status: 500 });
+    }
+}
+
+/**
+ * Token-authorized MCP: the provider has already verified the access token and
+ * decrypted the grant's props. The board IS the grant (`auth:<boardId>`), and the
+ * verified identity rides an internal header into the board object, where it
+ * surfaces to tool handlers as `ctx.authInfo`.
+ */
+export class TodosApi extends WorkerEntrypoint<Env> {
+    override async fetch(request: Request): Promise<Response> {
+        const props = (this.ctx as { props?: TodosGrantProps }).props;
+        if (!props?.boardId) {
+            return Response.json({ error: 'invalid grant' }, { status: 403 });
+        }
+        // A presented session id must belong to this grant's own board: the token decides
+        // the board, never the session id (which could otherwise route into another grant).
+        const sessionId = request.headers.get('mcp-session-id');
+        if (sessionId !== null && sessionId.split('.')[0] !== this.env.BOARDS.idFromName(`auth:${props.boardId}`).toString()) {
+            return withCors(
+                request,
+                Response.json({ jsonrpc: '2.0', error: { code: -32_001, message: 'Session not found' }, id: null }, { status: 404 })
+            );
+        }
+        const headers = new Headers(request.headers);
+        headers.set(AUTH_RELAY_HEADER, JSON.stringify(propsToAuthInfo(props, request)));
+        const relayed = new Request(request, { headers });
+        const response = await serveBoard(relayed, this.env, `auth:${props.boardId}`);
+        return withCors(request, response);
+    }
+}
+
+const defaultHandler = {
     async fetch(request: Request, env: Env): Promise<Response> {
         const url = new URL(request.url);
         const response = await (async (): Promise<Response> => {
             if (request.method === 'OPTIONS') return new Response(null, { status: 204 });
 
             if (url.pathname === '/mcp') {
-                // Board routing. A session id starts with the id of the object that minted it
-                // (opaque, unguessable, validated by idFromString), so a session survives the
-                // client's egress IP rotating. Everything else routes by the connecting
-                // address, or by the X-Todos-Board header for a board of the client's own
-                // naming — the two namespaced so a header value can never collide with (and
-                // read) somebody's address-keyed board.
-                const sessionId = request.headers.get('mcp-session-id');
-                let id: DurableObjectId | undefined;
-                if (sessionId === null) {
-                    const named = request.headers.get('x-todos-board');
-                    const visitor = named ? `named:${named.slice(0, 128)}` : `ip:${request.headers.get('cf-connecting-ip') ?? 'anonymous'}`;
-                    id = env.BOARDS.idFromName(visitor);
-                } else {
-                    try {
-                        id = env.BOARDS.idFromString(sessionId.split('.')[0] ?? '');
-                    } catch {
-                        return Response.json(
-                            { jsonrpc: '2.0', error: { code: -32_001, message: 'Session not found' }, id: null },
-                            { status: 404 }
-                        );
-                    }
-                }
-                try {
-                    return await env.BOARDS.get(id).fetch(request);
-                } catch (error) {
-                    // Details stay server-side; clients get a stable, generic shape.
-                    console.error('board fetch failed:', error);
-                    return Response.json({ error: 'board unavailable' }, { status: 500 });
-                }
+                // Anonymous tier, unchanged: boards keyed by the X-Todos-Board header (a
+                // board of the client's own naming) or the connecting address — namespaced
+                // so a header value can never collide with an address-keyed board. The
+                // internal auth-relay header is stripped: only the provider-verified API
+                // route may assert an identity.
+                const headers = new Headers(request.headers);
+                headers.delete(AUTH_RELAY_HEADER);
+                const named = request.headers.get('x-todos-board');
+                const visitor = named ? `named:${named.slice(0, 128)}` : `ip:${request.headers.get('cf-connecting-ip') ?? 'anonymous'}`;
+                return serveBoard(new Request(request, { headers }), env, visitor);
+            }
+
+            if (url.pathname === '/authorize' || url.pathname === '/authorize/approve') {
+                return handleAuthorize(request, env.OAUTH_PROVIDER, env.TODOS_AUTO_CONSENT === '1');
+            }
+
+            if (url.pathname === '/board') {
+                return new Response(renderBoardPage(url.origin), {
+                    headers: { 'content-type': 'text/html; charset=utf-8', 'cache-control': 'public, max-age=300' }
+                });
+            }
+
+            if (url.pathname === '/board/events') {
+                // Read-only live view of anonymous boards: ?b=<name> for a named board,
+                // otherwise the viewer's own address-keyed board. OAuth boards are not
+                // reachable here — their id lives only inside the grant.
+                if (request.method !== 'GET') return new Response(null, { status: 405 });
+                const named = url.searchParams.get('b');
+                const viewer = named ? `named:${named.slice(0, 128)}` : `ip:${request.headers.get('cf-connecting-ip') ?? 'anonymous'}`;
+                const headers = new Headers(request.headers);
+                headers.delete(AUTH_RELAY_HEADER);
+                return serveBoard(new Request(request, { headers }), env, viewer);
             }
 
             if (url.pathname === '/') {
@@ -331,11 +470,47 @@ export default {
                 });
             }
 
-            return new Response('Not found. The MCP endpoint is /mcp; see / for how to connect.\n', {
+            return new Response('Not found. The MCP endpoint is /mcp (anonymous) or /oauth/mcp (OAuth); see / for how to connect.\n', {
                 status: 404,
                 headers: { 'content-type': 'text/plain; charset=utf-8' }
             });
         })();
         return withCors(request, response);
+    }
+};
+
+// The provider owns the OAuth endpoints (authorize/token/register + both discovery
+// documents), verifies tokens on the API route, and passes everything else through
+// to the default handler. CIMD needs the global_fetch_strictly_public compatibility
+// flag (wrangler.toml): the platform itself guarantees metadata fetches only reach
+// public addresses.
+const provider = new OAuthProvider({
+    apiRoute: '/oauth/mcp',
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    apiHandler: TodosApi as any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    defaultHandler: defaultHandler as any,
+    authorizeEndpoint: '/authorize',
+    tokenEndpoint: '/oauth/token',
+    clientRegistrationEndpoint: '/oauth/register',
+    scopesSupported: ['todos'],
+    clientIdMetadataDocumentEnabled: true
+});
+
+export default {
+    // Browser-based MCP clients must be able to READ the provider's 401 challenge
+    // (WWW-Authenticate) and discovery documents cross-origin. The provider sets its
+    // own CORS on some routes; ours fills in only what is missing.
+    async fetch(request: Request, env: Env, ctx: unknown): Promise<Response> {
+        const response = await (provider as unknown as { fetch(request: Request, env: Env, ctx: unknown): Promise<Response> }).fetch(
+            request,
+            env,
+            ctx
+        );
+        const headers = new Headers(response.headers);
+        for (const [name, value] of Object.entries(corsHeaders(request))) {
+            if (!headers.has(name)) headers.set(name, value);
+        }
+        return new Response(response.body, { status: response.status, statusText: response.statusText, headers });
     }
 };

--- a/examples/todos-server/worker.ts
+++ b/examples/todos-server/worker.ts
@@ -104,6 +104,8 @@ interface Env {
 
 /** Internal relay: the API handler forwards verified auth into the board object. */
 const AUTH_RELAY_HEADER = 'x-todos-authinfo';
+/** Internal relay: how the live view resolved this board, echoed as the stream's first frame. */
+const VIEW_INFO_HEADER = 'x-todos-view-info';
 
 /** A live 2025-era session: its transport, tier, and when its client was last heard from. */
 interface LegacySession {
@@ -243,12 +245,15 @@ export class TodosBoard {
      * snapshot on every change, as server-sent events. Just another bus subscriber — the
      * same seam the durable copy and the pinned sessions use.
      */
-    private boardEventStream(): Response {
+    private boardEventStream(viewInfo: string | null): Response {
         const encoder = new TextEncoder();
         let unsubscribe: (() => void) | undefined;
         let heartbeat: ReturnType<typeof setInterval> | undefined;
         const stream = new ReadableStream<Uint8Array>({
             start: controller => {
+                if (viewInfo !== null) {
+                    controller.enqueue(encoder.encode(`event: info\ndata: ${viewInfo}\n\n`));
+                }
                 const send = (): void => {
                     try {
                         controller.enqueue(encoder.encode(`data: ${JSON.stringify(this.app.snapshot())}\n\n`));
@@ -280,7 +285,7 @@ export class TodosBoard {
 
     async fetch(request: Request): Promise<Response> {
         if (new URL(request.url).pathname === '/board/events') {
-            return this.boardEventStream();
+            return this.boardEventStream(request.headers.get(VIEW_INFO_HEADER));
         }
         // Verified auth relayed by the API handler (never trusted from clients: the
         // anonymous route strips this header before the request reaches any board).
@@ -461,18 +466,27 @@ const defaultHandler = {
                 if (request.method !== 'GET') return new Response(null, { status: 405 });
                 const named = url.searchParams.get('b');
                 let boardName: string | undefined;
+                let viewInfo: { mode: 'named' | 'oauth' | 'address'; label: string } | undefined;
                 if (named) {
-                    boardName = `named:${named.slice(0, 128)}`;
+                    const trimmed = named.slice(0, 128);
+                    boardName = `named:${trimmed}`;
+                    viewInfo = { mode: 'named', label: trimmed };
                 } else {
                     const viewerId = /(?:^|;\s*)todos_viewer=([^;]+)/.exec(request.headers.get('cookie') ?? '')?.[1];
                     if (viewerId) {
                         const record = await env.OAUTH_KV.get(`viewer:${viewerId}`);
-                        if (record !== null) boardName = `auth:${(JSON.parse(record) as { boardId: string }).boardId}`;
+                        if (record !== null) {
+                            const viewer = JSON.parse(record) as { boardId: string; clientName?: string };
+                            boardName = `auth:${viewer.boardId}`;
+                            viewInfo = { mode: 'oauth', label: `${viewer.clientName ?? 'your client'} · ${viewer.boardId.slice(0, 8)}` };
+                        }
                     }
                 }
                 boardName ??= `ip:${request.headers.get('cf-connecting-ip') ?? 'anonymous'}`;
+                viewInfo ??= { mode: 'address', label: 'your network address' };
                 const headers = new Headers(request.headers);
                 headers.delete(AUTH_RELAY_HEADER);
+                headers.set(VIEW_INFO_HEADER, JSON.stringify(viewInfo));
                 return serveBoard(new Request(request, { headers }), env, boardName);
             }
 

--- a/examples/todos-server/worker.ts
+++ b/examples/todos-server/worker.ts
@@ -19,7 +19,7 @@
  *   `WebStandardStreamableHTTPServerTransport` connected to a server instance pinned to that
  *   session, so push-style server→client requests (elicitation/sampling — the interactive
  *   tools) work over HTTP. Each session subscribes its instance to the board's bus
- *   (`app.forwardServerEvent`), so `resources/subscribe` subscribers hear changes made on any
+ *   (`app.subscribeInstance`), so `resources/subscribe` subscribers hear changes made on any
  *   connection; the subscription ends with the session. Session ids embed this object's own
  *   opaque id, and the worker routes session traffic by that prefix, so a session sticks to
  *   its board even when the client's egress IP rotates mid-session. Sessions are in-memory:
@@ -276,15 +276,13 @@ export class TodosBoard {
      * snapshot on every change, as server-sent events. Just another bus subscriber — the
      * same seam the durable copy and the pinned sessions use.
      */
-    private boardEventStream(viewInfo: string | null): Response {
+    private boardEventStream(viewInfo: string): Response {
         const encoder = new TextEncoder();
         let unsubscribe: (() => void) | undefined;
         let heartbeat: ReturnType<typeof setInterval> | undefined;
         const stream = new ReadableStream<Uint8Array>({
             start: controller => {
-                if (viewInfo !== null) {
-                    controller.enqueue(encoder.encode(`event: info\ndata: ${viewInfo}\n\n`));
-                }
+                controller.enqueue(encoder.encode(`event: info\ndata: ${viewInfo}\n\n`));
                 const send = (): void => {
                     try {
                         controller.enqueue(encoder.encode(`data: ${JSON.stringify(this.app.snapshot())}\n\n`));
@@ -319,7 +317,9 @@ export class TodosBoard {
     async fetch(request: Request): Promise<Response> {
         this.origin ??= new URL(request.url).origin;
         if (new URL(request.url).pathname === '/board/events') {
-            return this.boardEventStream(request.headers.get(VIEW_INFO_HEADER));
+            // serveBoard's view route always sets the header; the fallback only guards a
+            // direct DO hit that production routing cannot produce.
+            return this.boardEventStream(request.headers.get(VIEW_INFO_HEADER) ?? '{"mode":"address","label":"your network address"}');
         }
         // Verified auth relayed by the API handler (never trusted from clients: the
         // anonymous route strips this header before the request reaches any board).
@@ -388,10 +388,12 @@ function corsHeaders(request: Request): Record<string, string> {
     };
 }
 
-function withCors(request: Request, response: Response, options?: { fillOnly?: boolean }): Response {
+// Applied once, at the outermost wrapper: fills in whatever CORS headers a response
+// does not already carry (the provider sets its own on some routes).
+function withCors(request: Request, response: Response): Response {
     const headers = new Headers(response.headers);
     for (const [name, value] of Object.entries(corsHeaders(request))) {
-        if (!options?.fillOnly || !headers.has(name)) headers.set(name, value);
+        if (!headers.has(name)) headers.set(name, value);
     }
     return new Response(response.body, { status: response.status, statusText: response.statusText, headers });
 }
@@ -416,8 +418,8 @@ type BoardRoute =
     // The read-only live view. Never routes by session id, never carries identity.
     | { kind: 'view'; board: string; viewInfo: ViewInfo };
 
-function sessionNotFound(status = 404): Response {
-    return Response.json({ jsonrpc: '2.0', error: { code: -32_001, message: 'Session not found' }, id: null }, { status });
+function sessionNotFound(): Response {
+    return Response.json({ jsonrpc: '2.0', error: { code: -32_001, message: 'Session not found' }, id: null }, { status: 404 });
 }
 
 /**
@@ -469,77 +471,73 @@ export class TodosApi extends WorkerEntrypoint<Env> {
         if (!props?.boardId) {
             return Response.json({ error: 'invalid grant' }, { status: 403 });
         }
-        const response = await serveBoard(request, this.env, {
+        return serveBoard(request, this.env, {
             kind: 'mcp',
             board: boardName.auth(props.boardId),
             authInfo: propsToAuthInfo(props, request)
         });
-        return withCors(request, response);
     }
 }
 
 const defaultHandler = {
     async fetch(request: Request, env: Env): Promise<Response> {
         const url = new URL(request.url);
-        const response = await (async (): Promise<Response> => {
-            if (request.method === 'OPTIONS') return new Response(null, { status: 204 });
+        if (request.method === 'OPTIONS') return new Response(null, { status: 204 });
 
-            if (url.pathname === '/mcp') {
-                // Anonymous tier: boards keyed by the X-Todos-Board header (a board of the
-                // client's own naming) or the connecting address.
-                const named = request.headers.get('x-todos-board');
-                return serveBoard(request, env, {
-                    kind: 'mcp',
-                    board: named ? boardName.named(named) : boardName.ip(request)
-                });
-            }
-
-            if (url.pathname === '/authorize' || url.pathname === '/authorize/approve') {
-                return handleAuthorize(request, env.OAUTH_PROVIDER, env.TODOS_AUTO_CONSENT === '1', env.OAUTH_KV);
-            }
-
-            if (url.pathname === '/board') {
-                return new Response(renderBoardPage(url.origin), {
-                    headers: { 'content-type': 'text/html; charset=utf-8', 'cache-control': 'public, max-age=300' }
-                });
-            }
-
-            if (url.pathname === '/board/events') {
-                // Read-only live view. ?b=<name> names an anonymous board; without it, a
-                // viewer cookie claimed at OAuth consent resolves to that grant's own
-                // board, falling back to the viewer's address-keyed board. Board ids and
-                // tokens never appear in URLs.
-                if (request.method !== 'GET') return new Response(null, { status: 405 });
-                const named = url.searchParams.get('b');
-                let route: BoardRoute | undefined;
-                if (named) {
-                    route = { kind: 'view', board: boardName.named(named), viewInfo: { mode: 'named', label: named.slice(0, 128) } };
-                } else {
-                    const viewer = await resolveViewerBoard(request.headers.get('cookie'), env.OAUTH_KV);
-                    if (viewer) {
-                        route = {
-                            kind: 'view',
-                            board: boardName.auth(viewer.boardId),
-                            viewInfo: { mode: 'oauth', label: `${viewer.clientName ?? 'your client'} · ${viewer.boardId.slice(0, 8)}` }
-                        };
-                    }
-                }
-                route ??= { kind: 'view', board: boardName.ip(request), viewInfo: { mode: 'address', label: 'your network address' } };
-                return serveBoard(request, env, route);
-            }
-
-            if (url.pathname === '/') {
-                return new Response(renderLandingPage(url.origin), {
-                    headers: { 'content-type': 'text/html; charset=utf-8', 'cache-control': 'public, max-age=300' }
-                });
-            }
-
-            return new Response('Not found. The MCP endpoint is /mcp (anonymous) or /oauth/mcp (OAuth); see / for how to connect.\n', {
-                status: 404,
-                headers: { 'content-type': 'text/plain; charset=utf-8' }
+        if (url.pathname === '/mcp') {
+            // Anonymous tier: boards keyed by the X-Todos-Board header (a board of the
+            // client's own naming) or the connecting address.
+            const named = request.headers.get('x-todos-board');
+            return serveBoard(request, env, {
+                kind: 'mcp',
+                board: named ? boardName.named(named) : boardName.ip(request)
             });
-        })();
-        return withCors(request, response);
+        }
+
+        if (url.pathname === '/authorize' || url.pathname === '/authorize/approve') {
+            return handleAuthorize(request, env.OAUTH_PROVIDER, env.TODOS_AUTO_CONSENT === '1', env.OAUTH_KV);
+        }
+
+        if (url.pathname === '/board') {
+            return new Response(renderBoardPage(url.origin), {
+                headers: { 'content-type': 'text/html; charset=utf-8', 'cache-control': 'public, max-age=300' }
+            });
+        }
+
+        if (url.pathname === '/board/events') {
+            // Read-only live view. ?b=<name> names an anonymous board; without it, a
+            // viewer cookie claimed at OAuth consent resolves to that grant's own
+            // board, falling back to the viewer's address-keyed board. Board ids and
+            // tokens never appear in URLs.
+            if (request.method !== 'GET') return new Response(null, { status: 405 });
+            const named = url.searchParams.get('b');
+            let route: BoardRoute | undefined;
+            if (named) {
+                route = { kind: 'view', board: boardName.named(named), viewInfo: { mode: 'named', label: named.slice(0, 128) } };
+            } else {
+                const viewer = await resolveViewerBoard(request.headers.get('cookie'), env.OAUTH_KV);
+                if (viewer) {
+                    route = {
+                        kind: 'view',
+                        board: boardName.auth(viewer.boardId),
+                        viewInfo: { mode: 'oauth', label: `${viewer.clientName ?? 'your client'} · ${viewer.boardId.slice(0, 8)}` }
+                    };
+                }
+            }
+            route ??= { kind: 'view', board: boardName.ip(request), viewInfo: { mode: 'address', label: 'your network address' } };
+            return serveBoard(request, env, route);
+        }
+
+        if (url.pathname === '/') {
+            return new Response(renderLandingPage(url.origin), {
+                headers: { 'content-type': 'text/html; charset=utf-8', 'cache-control': 'public, max-age=300' }
+            });
+        }
+
+        return new Response('Not found. The MCP endpoint is /mcp (anonymous) or /oauth/mcp (OAuth); see / for how to connect.\n', {
+            status: 404,
+            headers: { 'content-type': 'text/plain; charset=utf-8' }
+        });
     }
 };
 
@@ -571,6 +569,6 @@ export default {
             env,
             ctx
         );
-        return withCors(request, response, { fillOnly: true });
+        return withCors(request, response);
     }
 };

--- a/examples/todos-server/worker.ts
+++ b/examples/todos-server/worker.ts
@@ -38,7 +38,7 @@ import { WorkerEntrypoint } from 'cloudflare:workers';
 
 import boardHtml from './board.html';
 import indexHtml from './index.html';
-import type { OAuthHelpers, TodosGrantProps } from './oauth';
+import type { OAuthHelpers, TodosGrantProps, ViewerSessionStore } from './oauth';
 import { handleAuthorize, propsToAuthInfo } from './oauth';
 import type { BoardSnapshot, TodosApp } from './todos';
 import { createTodosApp } from './todos';
@@ -94,8 +94,8 @@ interface Env {
     REQUEST_STATE_SECRET?: string;
     /** Optional override for the per-board task cap (a number as a string; wrangler [vars]). */
     MAX_TASKS?: string;
-    /** Grant/token storage for the OAuth provider (wrangler kv namespace). */
-    OAUTH_KV: unknown;
+    /** Grant/token storage for the OAuth provider; also holds live-view viewer sessions. */
+    OAUTH_KV: ViewerSessionStore;
     /** Injected by the provider: parseAuthRequest/lookupClient/completeAuthorization. */
     OAUTH_PROVIDER: OAuthHelpers;
     /** Set to '1' to auto-approve consent — used by the scripted end-to-end dance. */
@@ -443,7 +443,7 @@ const defaultHandler = {
             }
 
             if (url.pathname === '/authorize' || url.pathname === '/authorize/approve') {
-                return handleAuthorize(request, env.OAUTH_PROVIDER, env.TODOS_AUTO_CONSENT === '1');
+                return handleAuthorize(request, env.OAUTH_PROVIDER, env.TODOS_AUTO_CONSENT === '1', env.OAUTH_KV);
             }
 
             if (url.pathname === '/board') {
@@ -453,15 +453,27 @@ const defaultHandler = {
             }
 
             if (url.pathname === '/board/events') {
-                // Read-only live view of anonymous boards: ?b=<name> for a named board,
-                // otherwise the viewer's own address-keyed board. OAuth boards are not
-                // reachable here — their id lives only inside the grant.
+                // Read-only live view. ?b=<name> names an anonymous board; without it,
+                // a viewer cookie claimed at OAuth consent resolves to that grant's own
+                // board, falling back to the viewer's address-keyed board. Board ids
+                // and tokens never appear in URLs — the cookie is an opaque KV-backed
+                // session claimed while the human was provably in the consent flow.
                 if (request.method !== 'GET') return new Response(null, { status: 405 });
                 const named = url.searchParams.get('b');
-                const viewer = named ? `named:${named.slice(0, 128)}` : `ip:${request.headers.get('cf-connecting-ip') ?? 'anonymous'}`;
+                let boardName: string | undefined;
+                if (named) {
+                    boardName = `named:${named.slice(0, 128)}`;
+                } else {
+                    const viewerId = /(?:^|;\s*)todos_viewer=([^;]+)/.exec(request.headers.get('cookie') ?? '')?.[1];
+                    if (viewerId) {
+                        const record = await env.OAUTH_KV.get(`viewer:${viewerId}`);
+                        if (record !== null) boardName = `auth:${(JSON.parse(record) as { boardId: string }).boardId}`;
+                    }
+                }
+                boardName ??= `ip:${request.headers.get('cf-connecting-ip') ?? 'anonymous'}`;
                 const headers = new Headers(request.headers);
                 headers.delete(AUTH_RELAY_HEADER);
-                return serveBoard(new Request(request, { headers }), env, viewer);
+                return serveBoard(new Request(request, { headers }), env, boardName);
             }
 
             if (url.pathname === '/') {

--- a/examples/todos-server/worker.ts
+++ b/examples/todos-server/worker.ts
@@ -39,7 +39,7 @@ import { WorkerEntrypoint } from 'cloudflare:workers';
 import boardScript from './board.client.js';
 import boardHtml from './board.html';
 import indexHtml from './index.html';
-import type { OAuthHelpers, TodosGrantProps, ViewerSessionStore } from './oauth';
+import type { OAuthHelpers, TodosGrantProps } from './oauth';
 import { handleAuthorize, propsToAuthInfo, resolveViewerBoard } from './oauth';
 import type { BoardSnapshot, TodosApp } from './todos';
 import { createTodosApp } from './todos';
@@ -56,34 +56,6 @@ const SESSION_IDLE_MS = 30 * 60 * 1000;
 const BOARD_KEY = 'board:v2';
 const CODEC_KEY_KEY = 'codecKey';
 
-// Minimal structural types for the Workers runtime surface this file touches, so the example
-// typechecks without adding @cloudflare/workers-types to the workspace. If this entry ever
-// grows beyond them, switch to the real types package instead of extending these.
-interface DurableObjectStub {
-    fetch(request: Request): Promise<Response>;
-}
-interface DurableObjectId {
-    toString(): string;
-}
-interface DurableObjectNamespace {
-    idFromName(name: string): DurableObjectId;
-    /** Throws on anything that is not an id minted by this namespace. */
-    idFromString(id: string): DurableObjectId;
-    get(id: DurableObjectId): DurableObjectStub;
-}
-interface DurableObjectStorage {
-    get<T>(key: string): Promise<T | undefined>;
-    put(key: string, value: unknown): Promise<void>;
-    delete(key: string): Promise<boolean>;
-    getAlarm(): Promise<number | null>;
-    setAlarm(scheduledTimeMs: number): Promise<void>;
-}
-interface DurableObjectState {
-    id: DurableObjectId;
-    storage: DurableObjectStorage;
-    blockConcurrencyWhile(callback: () => Promise<void>): Promise<void>;
-}
-
 interface Env {
     BOARDS: DurableObjectNamespace;
     /**
@@ -96,7 +68,7 @@ interface Env {
     /** Optional override for the per-board task cap (a number as a string; wrangler [vars]). */
     MAX_TASKS?: string;
     /** Grant/token storage for the OAuth provider; also holds live-view viewer sessions. */
-    OAUTH_KV: ViewerSessionStore;
+    OAUTH_KV: KVNamespace;
     /** Injected by the provider: parseAuthRequest/lookupClient/completeAuthorization. */
     OAUTH_PROVIDER: OAuthHelpers;
     /** Set to '1' to auto-approve consent — used by the scripted end-to-end dance. */
@@ -465,9 +437,9 @@ async function serveBoard(request: Request, env: Env, route: BoardRoute): Promis
  * verified identity rides an internal header into the board object, where it
  * surfaces to tool handlers as `ctx.authInfo`.
  */
-export class TodosApi extends WorkerEntrypoint<Env> {
+export class TodosApi extends WorkerEntrypoint<Env, TodosGrantProps | undefined> {
     override async fetch(request: Request): Promise<Response> {
-        const props = (this.ctx as { props?: TodosGrantProps }).props;
+        const props = this.ctx.props;
         if (!props?.boardId) {
             return Response.json({ error: 'invalid grant' }, { status: 403 });
         }
@@ -546,12 +518,10 @@ const defaultHandler = {
 // to the default handler. CIMD needs the global_fetch_strictly_public compatibility
 // flag (wrangler.toml): the platform itself guarantees metadata fetches only reach
 // public addresses.
-const provider = new OAuthProvider({
+const provider = new OAuthProvider<Env>({
     apiRoute: '/oauth/mcp',
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    apiHandler: TodosApi as any,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    defaultHandler: defaultHandler as any,
+    apiHandler: TodosApi,
+    defaultHandler,
     authorizeEndpoint: '/authorize',
     tokenEndpoint: '/oauth/token',
     clientRegistrationEndpoint: '/oauth/register',
@@ -563,12 +533,8 @@ export default {
     // Browser-based MCP clients must be able to READ the provider's 401 challenge
     // (WWW-Authenticate) and discovery documents cross-origin. The provider sets its
     // own CORS on some routes; ours fills in only what is missing.
-    async fetch(request: Request, env: Env, ctx: unknown): Promise<Response> {
-        const response = await (provider as unknown as { fetch(request: Request, env: Env, ctx: unknown): Promise<Response> }).fetch(
-            request,
-            env,
-            ctx
-        );
+    async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+        const response = await provider.fetch(request, env, ctx);
         return withCors(request, response);
     }
-};
+} satisfies ExportedHandler<Env>;

--- a/examples/todos-server/worker.ts
+++ b/examples/todos-server/worker.ts
@@ -466,6 +466,21 @@ const defaultHandler = {
             });
         }
 
+        if (url.pathname === '/client-metadata.json') {
+            // A Client ID Metadata Document for the demo's own test client: any CIMD-capable
+            // client can use this URL as its client_id (the cli-client with a pinned
+            // --callback-port matches the registered redirect). Also doubles as the living
+            // proof that the /authorize CIMD lookup path works against a real document.
+            return Response.json({
+                client_id: `${url.origin}/client-metadata.json`,
+                client_name: 'todos demo client (CIMD)',
+                redirect_uris: ['http://127.0.0.1:33418/callback'],
+                grant_types: ['authorization_code', 'refresh_token'],
+                response_types: ['code'],
+                token_endpoint_auth_method: 'none'
+            });
+        }
+
         if (url.pathname === '/authorize' || url.pathname === '/authorize/approve') {
             return handleAuthorize(request, env.OAUTH_PROVIDER, env.TODOS_AUTO_CONSENT === '1', env.OAUTH_KV);
         }

--- a/examples/todos-server/worker.ts
+++ b/examples/todos-server/worker.ts
@@ -36,10 +36,11 @@ import {
 } from '@modelcontextprotocol/server';
 import { WorkerEntrypoint } from 'cloudflare:workers';
 
+import boardScript from './board.client.js';
 import boardHtml from './board.html';
 import indexHtml from './index.html';
 import type { OAuthHelpers, TodosGrantProps, ViewerSessionStore } from './oauth';
-import { handleAuthorize, propsToAuthInfo } from './oauth';
+import { handleAuthorize, propsToAuthInfo, resolveViewerBoard } from './oauth';
 import type { BoardSnapshot, TodosApp } from './todos';
 import { createTodosApp } from './todos';
 
@@ -100,14 +101,36 @@ interface Env {
     OAUTH_PROVIDER: OAuthHelpers;
     /** Set to '1' to auto-approve consent — used by the scripted end-to-end dance. */
     TODOS_AUTO_CONSENT?: string;
-    /** Public origin for user-facing links (wrangler [vars]); unset falls back to a relative path. */
-    PUBLIC_ORIGIN?: string;
 }
 
 /** Internal relay: the API handler forwards verified auth into the board object. */
 const AUTH_RELAY_HEADER = 'x-todos-authinfo';
 /** Internal relay: how the live view resolved this board, echoed as the stream's first frame. */
 const VIEW_INFO_HEADER = 'x-todos-view-info';
+
+/** The live view's identity frame (the SSE stream's first event; board.client.js renders it). */
+interface ViewInfo {
+    mode: 'named' | 'oauth' | 'address';
+    label: string;
+}
+
+// Board names are namespaced so one keying scheme can never collide with (and read)
+// another's boards: a client-chosen header value, a network address, and a grant id
+// live in disjoint prefixes.
+const boardName = {
+    auth: (boardId: string): string => `auth:${boardId}`,
+    named: (raw: string): string => `named:${raw.slice(0, 128)}`,
+    ip: (request: Request): string => `ip:${request.headers.get('cf-connecting-ip') ?? 'anonymous'}`
+};
+
+// A session id is `<minting object's own id>.<uuid>`: opaque, unguessable, and
+// self-routing (the prefix names the board object that owns the session).
+function mintSessionId(doId: DurableObjectId): string {
+    return `${doId.toString()}.${crypto.randomUUID()}`;
+}
+function boardOfSession(sessionId: string): string {
+    return sessionId.split('.')[0] ?? '';
+}
 
 /** A live 2025-era session: its transport, tier, and when its client was last heard from. */
 interface LegacySession {
@@ -137,7 +160,14 @@ export class TodosBoard {
             const requestStateKey = env.REQUEST_STATE_SECRET ?? (await this.loadOrCreateCodecKey());
             const parsedMaxTasks = Number(env.MAX_TASKS);
             const maxTasks = Number.isFinite(parsedMaxTasks) && parsedMaxTasks > 0 ? parsedMaxTasks : DEFAULT_MAX_TASKS;
-            this.app = createTodosApp({ requestStateKey, maxTasks, bus: this.bus, boardViewPath: `${env.PUBLIC_ORIGIN ?? ''}/board` });
+            // The public origin is learned from the first request (fetch stores it),
+            // so links in instructions/whoami are absolute without any configuration.
+            this.app = createTodosApp({
+                requestStateKey,
+                maxTasks,
+                bus: this.bus,
+                boardViewPath: () => `${this.origin ?? ''}/board`
+            });
             this.handler = createMcpHandler(this.app.buildServer, { bus: this.bus });
             // The durable copy of the board follows the same announcements every client does.
             this.bus.subscribe(event => {
@@ -216,10 +246,9 @@ export class TodosBoard {
                 { status: 429 }
             );
         }
-        const prefix = this.state.id.toString();
         const server = this.app.buildServer({ era: 'legacy', ...(authInfo === undefined ? {} : { authInfo }) });
         const transport = new WebStandardStreamableHTTPServerTransport({
-            sessionIdGenerator: () => `${prefix}.${crypto.randomUUID()}`,
+            sessionIdGenerator: () => mintSessionId(this.state.id),
             onsessioninitialized: sessionId => {
                 this.sessions.set(sessionId, { transport, authed: authInfo !== undefined, lastSeenMs: Date.now() });
             }
@@ -285,7 +314,10 @@ export class TodosBoard {
         });
     }
 
+    private origin?: string;
+
     async fetch(request: Request): Promise<Response> {
+        this.origin ??= new URL(request.url).origin;
         if (new URL(request.url).pathname === '/board/events') {
             return this.boardEventStream(request.headers.get(VIEW_INFO_HEADER));
         }
@@ -356,44 +388,68 @@ function corsHeaders(request: Request): Record<string, string> {
     };
 }
 
-function withCors(request: Request, response: Response): Response {
+function withCors(request: Request, response: Response, options?: { fillOnly?: boolean }): Response {
     const headers = new Headers(response.headers);
-    for (const [name, value] of Object.entries(corsHeaders(request))) headers.set(name, value);
+    for (const [name, value] of Object.entries(corsHeaders(request))) {
+        if (!options?.fillOnly || !headers.has(name)) headers.set(name, value);
+    }
     return new Response(response.body, { status: response.status, statusText: response.statusText, headers });
 }
 
-// The landing page is constant per deployment origin — substitute once per isolate.
-let landingPage: { origin: string; html: string } | undefined;
-function renderLandingPage(origin: string): string {
-    if (landingPage?.origin !== origin) landingPage = { origin, html: indexHtml.replaceAll('__HOST__', origin) };
-    return landingPage.html;
+// Pages are constant per deployment origin — substitute once per isolate.
+function pageRenderer(html: string): (origin: string) => string {
+    let cached: { origin: string; rendered: string } | undefined;
+    return origin => {
+        if (cached?.origin !== origin) cached = { origin, rendered: html.replaceAll('__HOST__', origin) };
+        return cached.rendered;
+    };
 }
+const renderLandingPage = pageRenderer(indexHtml);
+const renderBoardPage = pageRenderer(boardHtml.replace('__BOARD_SCRIPT__', () => boardScript));
 
-let boardPage: { origin: string; html: string } | undefined;
-function renderBoardPage(origin: string): string {
-    if (boardPage?.origin !== origin) boardPage = { origin, html: boardHtml.replaceAll('__HOST__', origin) };
-    return boardPage.html;
+/** How a request is allowed to reach a board — the whole tier model in one type. */
+type BoardRoute =
+    // MCP traffic. Sessions may re-route to the object that minted them (that is how a
+    // session survives egress-IP rotation) — but on the token-verified route a session
+    // must belong to the token's own board, and the verified identity rides along.
+    | { kind: 'mcp'; board: string; authInfo?: AuthInfo }
+    // The read-only live view. Never routes by session id, never carries identity.
+    | { kind: 'view'; board: string; viewInfo: ViewInfo };
+
+function sessionNotFound(status = 404): Response {
+    return Response.json({ jsonrpc: '2.0', error: { code: -32_001, message: 'Session not found' }, id: null }, { status });
 }
 
 /**
- * Route one MCP request to its board. Session ids carry the id of the object that
- * minted them (opaque, unguessable, validated by idFromString), so a session survives
- * the client's egress IP rotating; session-less requests route by `fallbackBoardName`.
+ * The single door to a board object. Owns every internal-header and session-routing
+ * rule: inbound copies of the internal headers are always dropped (clients cannot
+ * assert an identity or a view), and only this function decides which object serves
+ * the request. Callers describe intent with a BoardRoute and never touch headers.
  */
-async function serveBoard(request: Request, env: Env, fallbackBoardName: string): Promise<Response> {
-    const sessionId = request.headers.get('mcp-session-id');
-    let id: DurableObjectId | undefined;
+async function serveBoard(request: Request, env: Env, route: BoardRoute): Promise<Response> {
+    const headers = new Headers(request.headers);
+    headers.delete(AUTH_RELAY_HEADER);
+    headers.delete(VIEW_INFO_HEADER);
+
+    let id: DurableObjectId;
+    const sessionId = route.kind === 'mcp' ? request.headers.get('mcp-session-id') : null;
+    if (route.kind === 'view') headers.delete('mcp-session-id');
     if (sessionId === null) {
-        id = env.BOARDS.idFromName(fallbackBoardName);
+        id = env.BOARDS.idFromName(route.board);
     } else {
+        if (route.kind === 'mcp' && route.authInfo && boardOfSession(sessionId) !== env.BOARDS.idFromName(route.board).toString()) {
+            return sessionNotFound();
+        }
         try {
-            id = env.BOARDS.idFromString(sessionId.split('.')[0] ?? '');
+            id = env.BOARDS.idFromString(boardOfSession(sessionId));
         } catch {
-            return Response.json({ jsonrpc: '2.0', error: { code: -32_001, message: 'Session not found' }, id: null }, { status: 404 });
+            return sessionNotFound();
         }
     }
+    if (route.kind === 'mcp' && route.authInfo) headers.set(AUTH_RELAY_HEADER, JSON.stringify(route.authInfo));
+    if (route.kind === 'view') headers.set(VIEW_INFO_HEADER, JSON.stringify(route.viewInfo));
     try {
-        return await env.BOARDS.get(id).fetch(request);
+        return await env.BOARDS.get(id).fetch(new Request(request, { headers }));
     } catch (error) {
         // Details stay server-side; clients get a stable, generic shape.
         console.error('board fetch failed:', error);
@@ -413,19 +469,11 @@ export class TodosApi extends WorkerEntrypoint<Env> {
         if (!props?.boardId) {
             return Response.json({ error: 'invalid grant' }, { status: 403 });
         }
-        // A presented session id must belong to this grant's own board: the token decides
-        // the board, never the session id (which could otherwise route into another grant).
-        const sessionId = request.headers.get('mcp-session-id');
-        if (sessionId !== null && sessionId.split('.')[0] !== this.env.BOARDS.idFromName(`auth:${props.boardId}`).toString()) {
-            return withCors(
-                request,
-                Response.json({ jsonrpc: '2.0', error: { code: -32_001, message: 'Session not found' }, id: null }, { status: 404 })
-            );
-        }
-        const headers = new Headers(request.headers);
-        headers.set(AUTH_RELAY_HEADER, JSON.stringify(propsToAuthInfo(props, request)));
-        const relayed = new Request(request, { headers });
-        const response = await serveBoard(relayed, this.env, `auth:${props.boardId}`);
+        const response = await serveBoard(request, this.env, {
+            kind: 'mcp',
+            board: boardName.auth(props.boardId),
+            authInfo: propsToAuthInfo(props, request)
+        });
         return withCors(request, response);
     }
 }
@@ -437,16 +485,13 @@ const defaultHandler = {
             if (request.method === 'OPTIONS') return new Response(null, { status: 204 });
 
             if (url.pathname === '/mcp') {
-                // Anonymous tier, unchanged: boards keyed by the X-Todos-Board header (a
-                // board of the client's own naming) or the connecting address — namespaced
-                // so a header value can never collide with an address-keyed board. The
-                // internal auth-relay header is stripped: only the provider-verified API
-                // route may assert an identity.
-                const headers = new Headers(request.headers);
-                headers.delete(AUTH_RELAY_HEADER);
+                // Anonymous tier: boards keyed by the X-Todos-Board header (a board of the
+                // client's own naming) or the connecting address.
                 const named = request.headers.get('x-todos-board');
-                const visitor = named ? `named:${named.slice(0, 128)}` : `ip:${request.headers.get('cf-connecting-ip') ?? 'anonymous'}`;
-                return serveBoard(new Request(request, { headers }), env, visitor);
+                return serveBoard(request, env, {
+                    kind: 'mcp',
+                    board: named ? boardName.named(named) : boardName.ip(request)
+                });
             }
 
             if (url.pathname === '/authorize' || url.pathname === '/authorize/approve') {
@@ -460,39 +505,27 @@ const defaultHandler = {
             }
 
             if (url.pathname === '/board/events') {
-                // Read-only live view. ?b=<name> names an anonymous board; without it,
-                // a viewer cookie claimed at OAuth consent resolves to that grant's own
-                // board, falling back to the viewer's address-keyed board. Board ids
-                // and tokens never appear in URLs — the cookie is an opaque KV-backed
-                // session claimed while the human was provably in the consent flow.
+                // Read-only live view. ?b=<name> names an anonymous board; without it, a
+                // viewer cookie claimed at OAuth consent resolves to that grant's own
+                // board, falling back to the viewer's address-keyed board. Board ids and
+                // tokens never appear in URLs.
                 if (request.method !== 'GET') return new Response(null, { status: 405 });
                 const named = url.searchParams.get('b');
-                let boardName: string | undefined;
-                let viewInfo: { mode: 'named' | 'oauth' | 'address'; label: string } | undefined;
+                let route: BoardRoute | undefined;
                 if (named) {
-                    const trimmed = named.slice(0, 128);
-                    boardName = `named:${trimmed}`;
-                    viewInfo = { mode: 'named', label: trimmed };
+                    route = { kind: 'view', board: boardName.named(named), viewInfo: { mode: 'named', label: named.slice(0, 128) } };
                 } else {
-                    const viewerId = /(?:^|;\s*)todos_viewer=([^;]+)/.exec(request.headers.get('cookie') ?? '')?.[1];
-                    if (viewerId) {
-                        const record = await env.OAUTH_KV.get(`viewer:${viewerId}`);
-                        if (record !== null) {
-                            const viewer = JSON.parse(record) as { boardId: string; clientName?: string };
-                            boardName = `auth:${viewer.boardId}`;
-                            viewInfo = { mode: 'oauth', label: `${viewer.clientName ?? 'your client'} · ${viewer.boardId.slice(0, 8)}` };
-                        }
+                    const viewer = await resolveViewerBoard(request.headers.get('cookie'), env.OAUTH_KV);
+                    if (viewer) {
+                        route = {
+                            kind: 'view',
+                            board: boardName.auth(viewer.boardId),
+                            viewInfo: { mode: 'oauth', label: `${viewer.clientName ?? 'your client'} · ${viewer.boardId.slice(0, 8)}` }
+                        };
                     }
                 }
-                boardName ??= `ip:${request.headers.get('cf-connecting-ip') ?? 'anonymous'}`;
-                viewInfo ??= { mode: 'address', label: 'your network address' };
-                const headers = new Headers(request.headers);
-                headers.delete(AUTH_RELAY_HEADER);
-                // The view route must NEVER route by session id: a stale session id would
-                // override the resolved board and stream a private board without a token.
-                headers.delete('mcp-session-id');
-                headers.set(VIEW_INFO_HEADER, JSON.stringify(viewInfo));
-                return serveBoard(new Request(request, { headers }), env, boardName);
+                route ??= { kind: 'view', board: boardName.ip(request), viewInfo: { mode: 'address', label: 'your network address' } };
+                return serveBoard(request, env, route);
             }
 
             if (url.pathname === '/') {
@@ -538,10 +571,6 @@ export default {
             env,
             ctx
         );
-        const headers = new Headers(response.headers);
-        for (const [name, value] of Object.entries(corsHeaders(request))) {
-            if (!headers.has(name)) headers.set(name, value);
-        }
-        return new Response(response.body, { status: response.status, statusText: response.statusText, headers });
+        return withCors(request, response, { fillOnly: true });
     }
 };

--- a/examples/todos-server/workerEnv.d.ts
+++ b/examples/todos-server/workerEnv.d.ts
@@ -16,3 +16,9 @@ declare module 'cloudflare:workers' {
         fetch?(request: Request): Response | Promise<Response>;
     }
 }
+
+/** The board page's client script, bundled as text and inlined at render time. */
+declare module '*.client.js' {
+    const text: string;
+    export default text;
+}

--- a/examples/todos-server/workerEnv.d.ts
+++ b/examples/todos-server/workerEnv.d.ts
@@ -3,3 +3,16 @@ declare module '*.html' {
     const text: string;
     export default text;
 }
+
+/**
+ * Minimal structural declaration for the Workers runtime module, matching what
+ * this example uses (the provider dispatches API requests to a WorkerEntrypoint
+ * subclass). Swap for @cloudflare/workers-types if the surface grows.
+ */
+declare module 'cloudflare:workers' {
+    export class WorkerEntrypoint<Env = unknown> {
+        protected readonly env: Env;
+        protected readonly ctx: { props?: unknown; waitUntil(promise: Promise<unknown>): void };
+        fetch?(request: Request): Response | Promise<Response>;
+    }
+}

--- a/examples/todos-server/workerEnv.d.ts
+++ b/examples/todos-server/workerEnv.d.ts
@@ -4,19 +4,6 @@ declare module '*.html' {
     export default text;
 }
 
-/**
- * Minimal structural declaration for the Workers runtime module, matching what
- * this example uses (the provider dispatches API requests to a WorkerEntrypoint
- * subclass). Swap for @cloudflare/workers-types if the surface grows.
- */
-declare module 'cloudflare:workers' {
-    export class WorkerEntrypoint<Env = unknown> {
-        protected readonly env: Env;
-        protected readonly ctx: { props?: unknown };
-        fetch?(request: Request): Response | Promise<Response>;
-    }
-}
-
 /** The board page's client script, bundled as text and inlined at render time. */
 declare module '*.client.js' {
     const text: string;

--- a/examples/todos-server/workerEnv.d.ts
+++ b/examples/todos-server/workerEnv.d.ts
@@ -1,0 +1,5 @@
+/** Wrangler bundles .html imports as text modules (see the [[rules]] block in wrangler.toml). */
+declare module '*.html' {
+    const text: string;
+    export default text;
+}

--- a/examples/todos-server/workerEnv.d.ts
+++ b/examples/todos-server/workerEnv.d.ts
@@ -12,7 +12,7 @@ declare module '*.html' {
 declare module 'cloudflare:workers' {
     export class WorkerEntrypoint<Env = unknown> {
         protected readonly env: Env;
-        protected readonly ctx: { props?: unknown; waitUntil(promise: Promise<unknown>): void };
+        protected readonly ctx: { props?: unknown };
         fetch?(request: Request): Response | Promise<Response>;
     }
 }

--- a/examples/todos-server/wrangler.toml
+++ b/examples/todos-server/wrangler.toml
@@ -6,7 +6,15 @@ main = "worker.ts"
 compatibility_date = "2026-06-18"
 # CIMD (URL-formatted client ids): the platform guarantees metadata fetches
 # only ever reach public addresses — SSRF protection at the runtime layer.
-compatibility_flags = ["global_fetch_strictly_public"]
+# global_fetch_strictly_public: platform-level SSRF guard the provider requires
+# before it will serve Client ID Metadata Documents.
+# enable_request_signal: OFF BY DEFAULT on Workers, and without it a client
+# disconnect is invisible to the isolate — request.signal never fires, response
+# streams are never cancelled, and 2026-07-28 cancellation (closing the request
+# stream MUST cancel the request) silently does nothing while tools run to
+# completion. With the flag, the signal fires and rides the relayed Request into
+# the board object, where the SDK's per-request transport aborts the handler.
+compatibility_flags = ["global_fetch_strictly_public", "enable_request_signal"]
 tsconfig = "tsconfig.worker.json"
 
 # The landing page ships inside the bundle as a text module.

--- a/examples/todos-server/wrangler.toml
+++ b/examples/todos-server/wrangler.toml
@@ -26,12 +26,17 @@ class_name = "TodosBoard"
 tag = "v1"
 new_sqlite_classes = ["TodosBoard"]
 
-# REQUEST_STATE_SECRET is a deployment secret (wrangler secret put), never in
-# this file: it must be stable across isolates so multi-round input_required
-# flows survive landing on different instances.
+# REQUEST_STATE_SECRET (wrangler secret put) is optional: each board mints and
+# persists its own requestState key, which survives isolate recycling because
+# rounds always route back to the same board. Set a deployment-wide secret only
+# if rounds must verify across boards.
 
 # Grant/token storage for the OAuth provider. The id below is account-specific:
 # create your own with `wrangler kv namespace create OAUTH_KV` and replace it.
 [[kv_namespaces]]
 binding = "OAUTH_KV"
 id = "736937bd5b404370a37eb548ef0311de"
+
+# The port e2e/verify.ts dials by default.
+[dev]
+port = 8850

--- a/examples/todos-server/wrangler.toml
+++ b/examples/todos-server/wrangler.toml
@@ -4,6 +4,9 @@
 name = "todos-demo-ts"
 main = "worker.ts"
 compatibility_date = "2026-06-18"
+# CIMD (URL-formatted client ids): the platform guarantees metadata fetches
+# only ever reach public addresses — SSRF protection at the runtime layer.
+compatibility_flags = ["global_fetch_strictly_public"]
 tsconfig = "tsconfig.worker.json"
 
 # The landing page ships inside the bundle as a text module.
@@ -26,3 +29,9 @@ new_sqlite_classes = ["TodosBoard"]
 # REQUEST_STATE_SECRET is a deployment secret (wrangler secret put), never in
 # this file: it must be stable across isolates so multi-round input_required
 # flows survive landing on different instances.
+
+# Grant/token storage for the OAuth provider. The id below is account-specific:
+# create your own with `wrangler kv namespace create OAUTH_KV` and replace it.
+[[kv_namespaces]]
+binding = "OAUTH_KV"
+id = "736937bd5b404370a37eb548ef0311de"

--- a/examples/todos-server/wrangler.toml
+++ b/examples/todos-server/wrangler.toml
@@ -35,3 +35,8 @@ new_sqlite_classes = ["TodosBoard"]
 [[kv_namespaces]]
 binding = "OAUTH_KV"
 id = "736937bd5b404370a37eb548ef0311de"
+
+# Public origin baked into user-facing links (the live board pointer in the
+# server instructions). Update when the deployment moves.
+[vars]
+PUBLIC_ORIGIN = "https://todos-demo-ts.fweinberger-test.workers.dev"

--- a/examples/todos-server/wrangler.toml
+++ b/examples/todos-server/wrangler.toml
@@ -1,0 +1,28 @@
+# Cloudflare Workers deployment of the todos reference server.
+# Deploys to <name>.<account-subdomain>.workers.dev; no custom domain is
+# configured here — attaching a real hostname is a deliberate, separate step.
+name = "todos-demo-ts"
+main = "worker.ts"
+compatibility_date = "2026-06-18"
+tsconfig = "tsconfig.worker.json"
+
+# The landing page ships inside the bundle as a text module.
+[[rules]]
+type = "Text"
+globs = ["**/*.html"]
+fallthrough = true
+
+# One Durable Object per visitor: holds that visitor's board (memory, hydrated
+# from storage on wake) so requests are coherent regardless of which edge
+# isolate they land on.
+[[durable_objects.bindings]]
+name = "BOARDS"
+class_name = "TodosBoard"
+
+[[migrations]]
+tag = "v1"
+new_sqlite_classes = ["TodosBoard"]
+
+# REQUEST_STATE_SECRET is a deployment secret (wrangler secret put), never in
+# this file: it must be stable across isolates so multi-round input_required
+# flows survive landing on different instances.

--- a/examples/todos-server/wrangler.toml
+++ b/examples/todos-server/wrangler.toml
@@ -12,7 +12,7 @@ tsconfig = "tsconfig.worker.json"
 # The landing page ships inside the bundle as a text module.
 [[rules]]
 type = "Text"
-globs = ["**/*.html"]
+globs = ["**/*.html", "**/*.client.js"]
 fallthrough = true
 
 # One Durable Object per visitor: holds that visitor's board (memory, hydrated
@@ -35,8 +35,3 @@ new_sqlite_classes = ["TodosBoard"]
 [[kv_namespaces]]
 binding = "OAUTH_KV"
 id = "736937bd5b404370a37eb548ef0311de"
-
-# Public origin baked into user-facing links (the live board pointer in the
-# server instructions). Update when the deployment moves.
-[vars]
-PUBLIC_ORIGIN = "https://todos-demo-ts.fweinberger-test.workers.dev"

--- a/examples/tsconfig.json
+++ b/examples/tsconfig.json
@@ -1,7 +1,16 @@
 {
     "extends": "@modelcontextprotocol/tsconfig",
     "include": ["./"],
-    "exclude": ["node_modules", "dist", "shared", "server-quickstart", "client-quickstart"],
+    "exclude": [
+        "node_modules",
+        "dist",
+        "shared",
+        "server-quickstart",
+        "client-quickstart",
+        "todos-server/worker.ts",
+        "todos-server/oauth.ts",
+        "todos-server/workerEnv.d.ts"
+    ],
     "compilerOptions": {
         "noEmit": true,
         "paths": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1025,7 +1025,7 @@ importers:
         version: link:../../packages/server
       better-auth:
         specifier: ^1.6.2
-        version: 1.6.20(@opentelemetry/api@1.9.1)(better-sqlite3@12.8.0)(vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(vite@7.3.0(@types/node@25.5.0)(tsx@4.21.0)(yaml@2.8.3)))(vue@3.5.38(typescript@5.9.3))
+        version: 1.6.20(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-sqlite3@12.8.0)(vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(vite@7.3.0(@types/node@25.5.0)(tsx@4.21.0)(yaml@2.8.3)))(vue@3.5.38(typescript@5.9.3))
       better-sqlite3:
         specifier: ^12.6.2
         version: 12.8.0
@@ -1259,6 +1259,9 @@ importers:
         specifier: catalog:runtimeShared
         version: 4.3.6
     devDependencies:
+      '@cloudflare/workers-types':
+        specifier: ^4.20260629.1
+        version: 4.20260629.1
       tsx:
         specifier: catalog:devTools
         version: 4.21.0
@@ -2127,7 +2130,7 @@ importers:
         version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(vite@7.3.0(@types/node@25.5.0)(tsx@4.21.0)(yaml@2.8.3))
       wrangler:
         specifier: catalog:devTools
-        version: 4.78.0
+        version: 4.78.0(@cloudflare/workers-types@4.20260629.1)
       zod:
         specifier: catalog:runtimeShared
         version: 4.3.6
@@ -2455,6 +2458,9 @@ packages:
 
   '@cloudflare/workers-oauth-provider@0.8.0':
     resolution: {integrity: sha512-Vb2mjT9R+rLS9FcHgd5+ab4u7SP0ZB7x7t9M94JNMdN5e2ogRf3NOUCPW6NhBCTPwKu36VrfrYPPNGjOek4VYQ==}
+
+  '@cloudflare/workers-types@4.20260629.1':
+    resolution: {integrity: sha512-5vq2ErIFVRSQ8Dcw5YOeEoBdZBudqBjHFKTWD3SBGiJR5hD1+/86aRUV/DTpEK9sXXCGOTGgpWBGlPSlW7djVg==}
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -7091,7 +7097,7 @@ snapshots:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
 
-  '@better-auth/core@1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.2)(kysely@0.29.2)(nanostores@1.2.0)':
+  '@better-auth/core@1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.2)(kysely@0.29.2)(nanostores@1.2.0)':
     dependencies:
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
@@ -7103,38 +7109,39 @@ snapshots:
       nanostores: 1.2.0
       zod: 4.3.6
     optionalDependencies:
+      '@cloudflare/workers-types': 4.20260629.1
       '@opentelemetry/api': 1.9.1
 
-  '@better-auth/drizzle-adapter@1.6.20(@better-auth/core@1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.2)(kysely@0.29.2)(nanostores@1.2.0))(@better-auth/utils@0.4.2)':
+  '@better-auth/drizzle-adapter@1.6.20(@better-auth/core@1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.2)(kysely@0.29.2)(nanostores@1.2.0))(@better-auth/utils@0.4.2)':
     dependencies:
-      '@better-auth/core': 1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.2)(kysely@0.29.2)(nanostores@1.2.0)
+      '@better-auth/core': 1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.2)(kysely@0.29.2)(nanostores@1.2.0)
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/kysely-adapter@1.6.20(@better-auth/core@1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.2)(kysely@0.29.2)(nanostores@1.2.0))(@better-auth/utils@0.4.2)(kysely@0.29.2)':
+  '@better-auth/kysely-adapter@1.6.20(@better-auth/core@1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.2)(kysely@0.29.2)(nanostores@1.2.0))(@better-auth/utils@0.4.2)(kysely@0.29.2)':
     dependencies:
-      '@better-auth/core': 1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.2)(kysely@0.29.2)(nanostores@1.2.0)
+      '@better-auth/core': 1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.2)(kysely@0.29.2)(nanostores@1.2.0)
       '@better-auth/utils': 0.4.2
     optionalDependencies:
       kysely: 0.29.2
 
-  '@better-auth/memory-adapter@1.6.20(@better-auth/core@1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.2)(kysely@0.29.2)(nanostores@1.2.0))(@better-auth/utils@0.4.2)':
+  '@better-auth/memory-adapter@1.6.20(@better-auth/core@1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.2)(kysely@0.29.2)(nanostores@1.2.0))(@better-auth/utils@0.4.2)':
     dependencies:
-      '@better-auth/core': 1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.2)(kysely@0.29.2)(nanostores@1.2.0)
+      '@better-auth/core': 1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.2)(kysely@0.29.2)(nanostores@1.2.0)
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/mongo-adapter@1.6.20(@better-auth/core@1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.2)(kysely@0.29.2)(nanostores@1.2.0))(@better-auth/utils@0.4.2)':
+  '@better-auth/mongo-adapter@1.6.20(@better-auth/core@1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.2)(kysely@0.29.2)(nanostores@1.2.0))(@better-auth/utils@0.4.2)':
     dependencies:
-      '@better-auth/core': 1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.2)(kysely@0.29.2)(nanostores@1.2.0)
+      '@better-auth/core': 1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.2)(kysely@0.29.2)(nanostores@1.2.0)
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/prisma-adapter@1.6.20(@better-auth/core@1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.2)(kysely@0.29.2)(nanostores@1.2.0))(@better-auth/utils@0.4.2)':
+  '@better-auth/prisma-adapter@1.6.20(@better-auth/core@1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.2)(kysely@0.29.2)(nanostores@1.2.0))(@better-auth/utils@0.4.2)':
     dependencies:
-      '@better-auth/core': 1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.2)(kysely@0.29.2)(nanostores@1.2.0)
+      '@better-auth/core': 1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.2)(kysely@0.29.2)(nanostores@1.2.0)
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/telemetry@1.6.20(@better-auth/core@1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.2)(kysely@0.29.2)(nanostores@1.2.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)':
+  '@better-auth/telemetry@1.6.20(@better-auth/core@1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.2)(kysely@0.29.2)(nanostores@1.2.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)':
     dependencies:
-      '@better-auth/core': 1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.2)(kysely@0.29.2)(nanostores@1.2.0)
+      '@better-auth/core': 1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.2)(kysely@0.29.2)(nanostores@1.2.0)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
 
@@ -7328,6 +7335,8 @@ snapshots:
     optional: true
 
   '@cloudflare/workers-oauth-provider@0.8.0': {}
+
+  '@cloudflare/workers-types@4.20260629.1': {}
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
@@ -8895,15 +8904,15 @@ snapshots:
 
   before-after-hook@4.0.0: {}
 
-  better-auth@1.6.20(@opentelemetry/api@1.9.1)(better-sqlite3@12.8.0)(vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(vite@7.3.0(@types/node@25.5.0)(tsx@4.21.0)(yaml@2.8.3)))(vue@3.5.38(typescript@5.9.3)):
+  better-auth@1.6.20(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-sqlite3@12.8.0)(vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(vite@7.3.0(@types/node@25.5.0)(tsx@4.21.0)(yaml@2.8.3)))(vue@3.5.38(typescript@5.9.3)):
     dependencies:
-      '@better-auth/core': 1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.2)(kysely@0.29.2)(nanostores@1.2.0)
-      '@better-auth/drizzle-adapter': 1.6.20(@better-auth/core@1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.2)(kysely@0.29.2)(nanostores@1.2.0))(@better-auth/utils@0.4.2)
-      '@better-auth/kysely-adapter': 1.6.20(@better-auth/core@1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.2)(kysely@0.29.2)(nanostores@1.2.0))(@better-auth/utils@0.4.2)(kysely@0.29.2)
-      '@better-auth/memory-adapter': 1.6.20(@better-auth/core@1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.2)(kysely@0.29.2)(nanostores@1.2.0))(@better-auth/utils@0.4.2)
-      '@better-auth/mongo-adapter': 1.6.20(@better-auth/core@1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.2)(kysely@0.29.2)(nanostores@1.2.0))(@better-auth/utils@0.4.2)
-      '@better-auth/prisma-adapter': 1.6.20(@better-auth/core@1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.2)(kysely@0.29.2)(nanostores@1.2.0))(@better-auth/utils@0.4.2)
-      '@better-auth/telemetry': 1.6.20(@better-auth/core@1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.2)(kysely@0.29.2)(nanostores@1.2.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
+      '@better-auth/core': 1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.2)(kysely@0.29.2)(nanostores@1.2.0)
+      '@better-auth/drizzle-adapter': 1.6.20(@better-auth/core@1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.2)(kysely@0.29.2)(nanostores@1.2.0))(@better-auth/utils@0.4.2)
+      '@better-auth/kysely-adapter': 1.6.20(@better-auth/core@1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.2)(kysely@0.29.2)(nanostores@1.2.0))(@better-auth/utils@0.4.2)(kysely@0.29.2)
+      '@better-auth/memory-adapter': 1.6.20(@better-auth/core@1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.2)(kysely@0.29.2)(nanostores@1.2.0))(@better-auth/utils@0.4.2)
+      '@better-auth/mongo-adapter': 1.6.20(@better-auth/core@1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.2)(kysely@0.29.2)(nanostores@1.2.0))(@better-auth/utils@0.4.2)
+      '@better-auth/prisma-adapter': 1.6.20(@better-auth/core@1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.2)(kysely@0.29.2)(nanostores@1.2.0))(@better-auth/utils@0.4.2)
+      '@better-auth/telemetry': 1.6.20(@better-auth/core@1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260629.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.2)(kysely@0.29.2)(nanostores@1.2.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
       '@noble/ciphers': 2.1.1
@@ -11760,7 +11769,7 @@ snapshots:
       '@cloudflare/workerd-linux-arm64': 1.20260317.1
       '@cloudflare/workerd-windows-64': 1.20260317.1
 
-  wrangler@4.78.0:
+  wrangler@4.78.0(@cloudflare/workers-types@4.20260629.1):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.2
       '@cloudflare/unenv-preset': 2.16.0(unenv@2.0.0-rc.24)(workerd@1.20260317.1)
@@ -11771,6 +11780,7 @@ snapshots:
       unenv: 2.0.0-rc.24
       workerd: 1.20260317.1
     optionalDependencies:
+      '@cloudflare/workers-types': 4.20260629.1
       fsevents: 2.3.3
     transitivePeerDependencies:
       - bufferutil

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1246,6 +1246,9 @@ importers:
       '@cloudflare/workers-oauth-provider':
         specifier: 0.8.0
         version: 0.8.0
+      '@hono/node-server':
+        specifier: catalog:runtimeServerOnly
+        version: 1.19.11(hono@4.12.9)
       '@mcp-examples/shared':
         specifier: workspace:*
         version: link:../shared

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1243,9 +1243,9 @@ importers:
 
   examples/todos-server:
     dependencies:
-      '@hono/node-server':
-        specifier: catalog:runtimeServerOnly
-        version: 1.19.11(hono@4.12.9)
+      '@cloudflare/workers-oauth-provider':
+        specifier: 0.8.0
+        version: 0.8.0
       '@mcp-examples/shared':
         specifier: workspace:*
         version: link:../shared
@@ -2452,6 +2452,9 @@ packages:
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
+
+  '@cloudflare/workers-oauth-provider@0.8.0':
+    resolution: {integrity: sha512-Vb2mjT9R+rLS9FcHgd5+ab4u7SP0ZB7x7t9M94JNMdN5e2ogRf3NOUCPW6NhBCTPwKu36VrfrYPPNGjOek4VYQ==}
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -7323,6 +7326,8 @@ snapshots:
 
   '@cloudflare/workerd-windows-64@1.20260317.1':
     optional: true
+
+  '@cloudflare/workers-oauth-provider@0.8.0': {}
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:


### PR DESCRIPTION
Draft for design review — the **auth integration** is what wants eyes. Live at https://todos-demo-ts.fweinberger-test.workers.dev.

Deploys the todos example to Workers with `@cloudflare/workers-oauth-provider` as the Authorization Server (SDK stays RS-only), serving both protocol eras over anonymous and OAuth tiers, plus a live board view (`/board`) and an e2e probe harness (`e2e/verify.ts`, 9 sections, all green against the live deployment). Companion docs page: *Bring your own Authorization Server*.

**Auth review focus:**
- `oauth.ts` — the whole provider integration (~190 lines): grant props → `AuthInfo`, consent + nonce, viewer sessions. The token IS the board; no accounts.
- `worker.ts` — `serveBoard` + `BoardRoute`: all tier/identity rules in one place; a session id is never a credential.
- `wrangler.toml` — two load-bearing compat flags (CIMD; `enable_request_signal` for 2026 cancellation).

No SDK changes on this branch. Adoptions from #2439/#2440 follow if those merge.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update