### PR TITLE
fix(server): return Invalid Params for malformed resource URIs

### DIFF
--- a/.changeset/malformed-resource-uri-invalid-params.md
+++ b/.changeset/malformed-resource-uri-invalid-params.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/server': patch
+---
+
+Return JSON-RPC Invalid Params with the original URI and an `invalid_uri` reason when `resources/read` receives a syntactically malformed URI.

--- a/packages/server/src/server/mcp.ts
+++ b/packages/server/src/server/mcp.ts
@@ -476,7 +476,15 @@ export class McpServer {
         });
 
         this.server.setRequestHandler('resources/read', async (request, ctx) => {
-            const uri = new URL(request.params.uri);
+            let uri: URL;
+            try {
+                uri = new URL(request.params.uri);
+            } catch {
+                throw new ProtocolError(ProtocolErrorCode.InvalidParams, `Resource URI ${request.params.uri} is invalid`, {
+                    uri: request.params.uri,
+                    reason: 'invalid_uri'
+                });
+            }
 
             // First check for exact resource match
             const resource = this._registeredResources[uri.toString()];

--- a/test/integration/test/server/mcp.test.ts
+++ b/test/integration/test/server/mcp.test.ts
@@ -2743,6 +2743,80 @@ describe('Zod v4', () => {
             });
         });
 
+        test('should echo the exact requested URI for nonexistent resources', async () => {
+            const mcpServer = new McpServer({
+                name: 'test server',
+                version: '1.0'
+            });
+            const client = new Client({
+                name: 'test client',
+                version: '1.0'
+            });
+            const requestedUri = 'HTTP://example.com:80/docs/../missing file.txt';
+            mcpServer.registerResource('test', 'test://resource', {}, async () => ({
+                contents: [
+                    {
+                        uri: 'test://resource',
+                        text: 'Test content'
+                    }
+                ]
+            }));
+
+            const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+            await Promise.all([client.connect(clientTransport), mcpServer.server.connect(serverTransport)]);
+
+            await expect(
+                client.request({
+                    method: 'resources/read',
+                    params: {
+                        uri: requestedUri
+                    }
+                })
+            ).rejects.toMatchObject({
+                code: ProtocolErrorCode.InvalidParams,
+                message: expect.stringContaining('not found'),
+                data: { uri: requestedUri }
+            });
+        });
+
+        test('should return invalid params for syntactically invalid resource URIs', async () => {
+            const mcpServer = new McpServer({
+                name: 'test server',
+                version: '1.0'
+            });
+            const client = new Client({
+                name: 'test client',
+                version: '1.0'
+            });
+            const requestedUri = 'not a valid URI';
+            mcpServer.registerResource('test', 'test://resource', {}, async () => ({
+                contents: [
+                    {
+                        uri: 'test://resource',
+                        text: 'Test content'
+                    }
+                ]
+            }));
+
+            const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+            await Promise.all([client.connect(clientTransport), mcpServer.server.connect(serverTransport)]);
+
+            await expect(
+                client.request({
+                    method: 'resources/read',
+                    params: {
+                        uri: requestedUri
+                    }
+                })
+            ).rejects.toMatchObject({
+                code: ProtocolErrorCode.InvalidParams,
+                message: expect.stringContaining('invalid'),
+                data: { uri: requestedUri, reason: 'invalid_uri' }
+            });
+        });
+
         /***
          * Test: ProtocolError for Disabled Resource
          */


### PR DESCRIPTION
## Previously unaddressed

#2333 correctly returns `-32602` with `data.uri` for a valid but unknown resource URI. A syntactically malformed URI still throws from `new URL()` and falls through the generic handler-error path.

## This PR

Convert that parse failure to Invalid Params with the exact request value and a distinct data shape:

```json
{ "uri": "...", "reason": "invalid_uri" }
```

The extra `reason` keeps this distinguishable from `ResourceNotFoundError`'s exact `{ uri }` shape.

## Verification

- integration resource/server suite: 120 tests
- `pnpm check:all`
- `pnpm build:all`

Follow-up to #2267, #2333, and #2286.
