### PR TITLE
build: declare zod as a peer dependency alongside the regular dependency; floor ^4.0.0

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -140,6 +140,9 @@
         "pkce-challenge": "catalog:runtimeShared",
         "zod": "catalog:runtimeShared"
     },
+    "peerDependencies": {
+        "zod": "catalog:runtimeShared"
+    },
     "devDependencies": {
         "@modelcontextprotocol/core-internal": "workspace:^",
         "@modelcontextprotocol/tsconfig": "workspace:^",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -51,6 +51,9 @@
     "dependencies": {
         "zod": "catalog:runtimeShared"
     },
+    "peerDependencies": {
+        "zod": "catalog:runtimeShared"
+    },
     "devDependencies": {
         "@eslint/js": "catalog:devTools",
         "@modelcontextprotocol/core-internal": "workspace:^",

--- a/packages/server-legacy/package.json
+++ b/packages/server-legacy/package.json
@@ -91,7 +91,8 @@
         "pkce-challenge": "catalog:runtimeShared"
     },
     "peerDependencies": {
-        "express": "^4.18.0 || ^5.0.0"
+        "express": "^4.18.0 || ^5.0.0",
+        "zod": "catalog:runtimeShared"
     },
     "peerDependenciesMeta": {
         "express": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -135,6 +135,9 @@
     "dependencies": {
         "zod": "catalog:runtimeShared"
     },
+    "peerDependencies": {
+        "zod": "catalog:runtimeShared"
+    },
     "devDependencies": {
         "@cfworker/json-schema": "catalog:runtimeShared",
         "ajv": "catalog:runtimeShared",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -133,7 +133,7 @@ catalogs:
       specifier: ^5.0.0
       version: 5.0.1
     zod:
-      specifier: ^4.2.0
+      specifier: ^4.0.0
       version: 4.3.6
 
 overrides:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -53,7 +53,13 @@ catalogs:
         content-type: ^1.0.5
         json-schema-typed: ^8.0.2
         pkce-challenge: ^5.0.0
-        zod: ^4.2.0
+        # zod is declared as BOTH a regular dependency and a peer dependency in the
+        # published packages (the v1.x pattern): the dependency guarantees a compatible
+        # copy is always installed, while the peer range lets hosts already on zod 4
+        # share a single copy instead of nesting one under each package. The used zod
+        # API surface is 4.0-compatible; the only 4.2 feature (`~standard.jsonSchema`)
+        # is capability-detected with a `z.toJSONSchema` fallback, so the floor is ^4.0.0.
+        zod: ^4.0.0
 
 enableGlobalVirtualStore: false
 


### PR DESCRIPTION
Declares zod in `peerDependencies` alongside the existing regular dependency (the v1.x pattern), and lowers the floor from `^4.2.0` to `^4.0.0`.

## Motivation and Context
With zod as a plain dependency pinned `^4.2.0`, a host application that itself depends on zod ends up with an identical nested zod copy under each of client/core/server — bundle and cold-start cost, plus cross-instance issues like `.describe()` metadata living in a different `globalRegistry` than the one the SDK reads. With the dual declaration, hosts on zod >= 4.0 share one hoisted copy (verified with bun, npm, and pnpm install fixtures: one root zod, zero nested, same module object across host and SDK, `.describe()` survives into tools/list); hosts without zod, or below the floor, keep getting a nested copy from the regular dependency — no install that works today changes behavior.

The floor drop is evidence-backed: every zod API the SDK uses exists in 4.0; `toJSONSchema` output at 4.0.0 is byte-identical to 4.4.3 for ordinary shapes under the explicit `io` option the SDK always passes, and `~standard.validate` behavior is invariant across the line (87/87 corpus agreement, identical output values). The single known emission divergence below 4.3 (exhaustive-enum records missing `required`) is fixed independently in #2457, version-independently.

## How Has This Been Tested?
Full workspace suite green after the change; install-layout fixtures for the three package managers (shared, nested, and no-zod host scenarios); runtime smoke registering a tool with the host's zod instance and asserting metadata and round-trips over InMemoryTransport.

## Breaking Changes
None at install time. One consideration to call out: on shared installs the SDK runs on the host's zod, so host-level zod configuration (`z.config`, locales) also affects error text produced by SDK-internal schemas. A follow-up CI matrix leg pinned to the 4.0 floor would enforce the API-surface discipline mechanically; happy to add it here or separately.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
