### PR TITLE
fix: honor notifications/cancelled for request id 0

### DIFF
--- a/packages/core-internal/src/shared/protocol.ts
+++ b/packages/core-internal/src/shared/protocol.ts
@@ -723,7 +723,7 @@ export abstract class Protocol<ContextT extends BaseContext> {
     }
 
     private async _oncancel(notification: CancelledNotification): Promise<void> {
-        if (!notification.params.requestId) {
+        if (notification.params.requestId == null) {
             return;
         }
         // Handle request cancellation

--- a/packages/core-internal/test/shared/protocol.test.ts
+++ b/packages/core-internal/test/shared/protocol.test.ts
@@ -819,6 +819,47 @@ describe('protocol tests', () => {
             // Verify the request was aborted
             expect(wasAborted).toBe(true);
         });
+
+        test('should abort request handler when cancelled request id is 0', async () => {
+            await protocol.connect(transport);
+
+            let wasAborted = false;
+            protocol.setRequestHandler('ping', async (_request, ctx) => {
+                await new Promise(resolve => setTimeout(resolve, 100));
+                wasAborted = ctx.mcpReq.signal.aborted;
+                return {};
+            });
+
+            // Request id 0 is a valid JSON-RPC id (it is the id this SDK
+            // assigns to `initialize`), but was previously treated as absent
+            // by a truthiness check, so its cancellation was ignored.
+            const requestId = 0;
+            if (transport.onmessage) {
+                transport.onmessage({
+                    jsonrpc: '2.0',
+                    id: requestId,
+                    method: 'ping',
+                    params: {}
+                });
+            }
+
+            await new Promise(resolve => setTimeout(resolve, 10));
+
+            if (transport.onmessage) {
+                transport.onmessage({
+                    jsonrpc: '2.0',
+                    method: 'notifications/cancelled',
+                    params: {
+                        requestId: requestId,
+                        reason: 'User cancelled'
+                    }
+                });
+            }
+
+            await new Promise(resolve => setTimeout(resolve, 150));
+
+            expect(wasAborted).toBe(true);
+        });
     });
 
     // Spec basic/patterns/cancellation §Transport-Specific (2026-07-28): on a


### PR DESCRIPTION
Fixes #2283

`_oncancel` guards with `if (!notification.params.requestId) return;`, so a `notifications/cancelled` targeting request id `0` is treated as if no id were present and the in-flight handler is never aborted. `0` is a valid JSON-RPC id; it is in fact the id this SDK assigns to the first request (`initialize`), so cancelling that request is silently dropped.

Changed the guard to `if (notification.params.requestId == null)` so only a genuinely absent id short-circuits, while `0` is handled like any other id.

Added a regression test alongside the existing cancellation test that drives a handler with request id `0`, sends `notifications/cancelled` for it, and asserts the handler's signal aborts. It fails before the change and passes after. `pnpm --filter @modelcontextprotocol/core-internal test -- -t "cancelled"` and the package typecheck both pass.
