### PR TITLE
fix: handle cancelled request id zero

### DIFF
--- a/.changeset/calm-bears-cancel.md
+++ b/.changeset/calm-bears-cancel.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/core-internal': patch
+---
+
+Fix handling of cancelled request ID zero.

--- a/packages/core-internal/src/shared/protocol.ts
+++ b/packages/core-internal/src/shared/protocol.ts
@@ -724,7 +724,7 @@ export abstract class Protocol<ContextT extends BaseContext> {
     }
 
     private async _oncancel(notification: CancelledNotification): Promise<void> {
-        if (!notification.params.requestId) {
+        if (notification.params.requestId === undefined) {
             return;
         }
         // Handle request cancellation

--- a/packages/core-internal/test/shared/protocol.test.ts
+++ b/packages/core-internal/test/shared/protocol.test.ts
@@ -819,6 +819,52 @@ describe('protocol tests', () => {
             // Verify the request was aborted
             expect(wasAborted).toBe(true);
         });
+
+        test('should abort request handler for request id 0', async () => {
+            await protocol.connect(transport);
+
+            let handlerStarted!: () => void;
+            const started = new Promise<void>(resolve => {
+                handlerStarted = resolve;
+            });
+            let handlerAborted!: () => void;
+            const aborted = new Promise<void>(resolve => {
+                handlerAborted = resolve;
+            });
+            let abortReason: unknown;
+
+            protocol.setRequestHandler('ping', async (_request, ctx) => {
+                handlerStarted();
+                ctx.mcpReq.signal.addEventListener('abort', () => {
+                    abortReason = ctx.mcpReq.signal.reason;
+                    handlerAborted();
+                });
+                await aborted;
+                return {};
+            });
+
+            transport.onmessage?.({
+                jsonrpc: '2.0',
+                id: 0,
+                method: 'ping',
+                params: {}
+            });
+
+            await started;
+
+            transport.onmessage?.({
+                jsonrpc: '2.0',
+                method: 'notifications/cancelled',
+                params: {
+                    requestId: 0,
+                    reason: 'User cancelled'
+                }
+            });
+
+            await aborted;
+
+            expect(abortReason).toBe('User cancelled');
+        });
     });
 
     // Spec basic/patterns/cancellation §Transport-Specific (2026-07-28): on a


### PR DESCRIPTION
## Summary
- Treat `requestId: 0` as a present cancellation target instead of returning early.
- Add a regression test covering `notifications/cancelled` for in-flight request id `0`.

Fixes #2283.

## Why this helps
`0` is a valid JSON-RPC request id, and the SDK's own per-instance request counter starts at zero. The previous truthiness guard ignored cancellations for that first request, leaving its handler running.

## Test Plan
- `pnpm --filter @modelcontextprotocol/core-internal test -- test/shared/protocol.test.ts -t "request id 0"`
- `pnpm --filter @modelcontextprotocol/core-internal lint -- test/shared/protocol.test.ts src/shared/protocol.ts`
- `pnpm exec prettier --check packages/core-internal/src/shared/protocol.ts packages/core-internal/test/shared/protocol.test.ts`
- `git diff --check`
- pre-push hook also ran `pnpm -r typecheck`, `pnpm -r build`, and `pnpm -r lint`
