### PR TITLE
fix(server): parse Accept media types exactly

### DIFF
--- a/.changeset/accept-header-media-types.md
+++ b/.changeset/accept-header-media-types.md
@@ -1,0 +1,6 @@
+---
+'@modelcontextprotocol/server': patch
+'@modelcontextprotocol/core-internal': patch
+---
+
+Validate Streamable HTTP `Accept` values by parsed media type instead of substring matching, so invalid tokens such as `application/jsonx` and `text/event-stream-bogus` no longer satisfy the required response types.

--- a/.changeset/accept-header-media-types.md
+++ b/.changeset/accept-header-media-types.md
@@ -3,4 +3,4 @@
 '@modelcontextprotocol/core-internal': patch
 ---
 
-Validate Streamable HTTP `Accept` values by parsed media type instead of substring matching, so invalid tokens such as `application/jsonx` and `text/event-stream-bogus` no longer satisfy the required response types.
+Validate Streamable HTTP `Accept` values by parsed media type and positive quality instead of substring matching, so invalid tokens such as `application/jsonx`, `text/event-stream-bogus`, and required types with `q=0` no longer satisfy the response requirements.

--- a/packages/core-internal/src/shared/mediaType.ts
+++ b/packages/core-internal/src/shared/mediaType.ts
@@ -55,3 +55,39 @@ export function isJsonContentType(header: string | null | undefined): boolean {
     }
     return mediaTypeEssence(header) === 'application/json';
 }
+
+function splitHttpList(header: string): string[] {
+    const values: string[] = [];
+    let start = 0;
+    let quoted = false;
+    let escaped = false;
+
+    for (let index = 0; index < header.length; index += 1) {
+        const char = header[index];
+        if (escaped) {
+            escaped = false;
+        } else if (quoted && char === '\\') {
+            escaped = true;
+        } else if (char === '"') {
+            quoted = !quoted;
+        } else if (char === ',' && !quoted) {
+            values.push(header.slice(start, index));
+            start = index + 1;
+        }
+    }
+
+    values.push(header.slice(start));
+    return values;
+}
+
+/**
+ * Whether an `Accept` header lists a concrete media type. Parameters and
+ * quality values are ignored; wildcards intentionally do not match because MCP
+ * transport requirements name exact response media types.
+ */
+export function listsMediaType(header: string | null | undefined, mediaType: string): boolean {
+    const expected = mediaType.toLowerCase();
+    return splitHttpList(header ?? '')
+        .map(part => mediaTypeEssence(part))
+        .includes(expected);
+}

--- a/packages/core-internal/src/shared/mediaType.ts
+++ b/packages/core-internal/src/shared/mediaType.ts
@@ -56,38 +56,51 @@ export function isJsonContentType(header: string | null | undefined): boolean {
     return mediaTypeEssence(header) === 'application/json';
 }
 
-function splitHttpList(header: string): string[] {
+function splitOutsideQuotes(value: string, separator: string): string[] {
     const values: string[] = [];
     let start = 0;
     let quoted = false;
     let escaped = false;
 
-    for (let index = 0; index < header.length; index += 1) {
-        const char = header[index];
+    for (let index = 0; index < value.length; index += 1) {
+        const char = value[index];
         if (escaped) {
             escaped = false;
         } else if (quoted && char === '\\') {
             escaped = true;
         } else if (char === '"') {
             quoted = !quoted;
-        } else if (char === ',' && !quoted) {
-            values.push(header.slice(start, index));
+        } else if (char === separator && !quoted) {
+            values.push(value.slice(start, index));
             start = index + 1;
         }
     }
 
-    values.push(header.slice(start));
+    values.push(value.slice(start));
     return values;
 }
 
+const QVALUE_PATTERN = /^(?:0(?:\.\d{0,3})?|1(?:\.0{0,3})?)$/;
+
+function hasPositiveQuality(mediaRange: string): boolean {
+    try {
+        const quality = contentType.parse(mediaRange).parameters.q;
+        return quality === undefined || (QVALUE_PATTERN.test(quality) && Number(quality) > 0);
+    } catch {
+        // Keep the existing tolerant behavior for malformed non-quality
+        // parameters, but do not treat a malformed q parameter as support.
+        return !splitOutsideQuotes(mediaRange, ';')
+            .slice(1)
+            .some(parameter => parameter.split('=', 1)[0]?.trim().toLowerCase() === 'q');
+    }
+}
+
 /**
- * Whether an `Accept` header lists a concrete media type. Parameters and
- * quality values are ignored; wildcards intentionally do not match because MCP
- * transport requirements name exact response media types.
+ * Whether an `Accept` header lists a concrete media type with a positive
+ * quality value. Other parameters are ignored; wildcards intentionally do not
+ * match because MCP transport requirements name exact response media types.
  */
 export function listsMediaType(header: string | null | undefined, mediaType: string): boolean {
     const expected = mediaType.toLowerCase();
-    return splitHttpList(header ?? '')
-        .map(part => mediaTypeEssence(part))
-        .includes(expected);
+    return splitOutsideQuotes(header ?? '', ',').some(part => mediaTypeEssence(part) === expected && hasPositiveQuality(part));
 }

--- a/packages/core-internal/test/shared/mediaType.test.ts
+++ b/packages/core-internal/test/shared/mediaType.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { isJsonContentType, mediaTypeEssence } from '../../src/shared/mediaType';
+import { isJsonContentType, listsMediaType, mediaTypeEssence } from '../../src/shared/mediaType';
 
 describe('mediaTypeEssence', () => {
     it('parses well-formed headers', () => {
@@ -64,5 +64,27 @@ describe('isJsonContentType', () => {
         expect(isJsonContentType('')).toBe(false);
         expect(isJsonContentType('text/plain')).toBe(false);
         expect(isJsonContentType('multipart/form-data')).toBe(false);
+    });
+});
+
+describe('listsMediaType', () => {
+    it('matches comma-separated Accept values by parsed media type', () => {
+        expect(listsMediaType('application/json, text/event-stream', 'application/json')).toBe(true);
+        expect(listsMediaType('application/json, text/event-stream', 'text/event-stream')).toBe(true);
+        expect(listsMediaType('Application/JSON; q=0.9, text/event-stream; charset=utf-8', 'application/json')).toBe(true);
+        expect(listsMediaType('text/plain; note="a,b", application/json', 'application/json')).toBe(true);
+    });
+
+    it('never matches required media types by substring or wildcard', () => {
+        expect(listsMediaType('application/jsonx, text/event-stream-bogus', 'application/json')).toBe(false);
+        expect(listsMediaType('application/jsonx, text/event-stream-bogus', 'text/event-stream')).toBe(false);
+        expect(listsMediaType('text/plain; note=application/json', 'application/json')).toBe(false);
+        expect(listsMediaType('*/*, application/*', 'application/json')).toBe(false);
+    });
+
+    it('rejects missing or empty Accept values', () => {
+        expect(listsMediaType(null, 'application/json')).toBe(false);
+        expect(listsMediaType(undefined, 'application/json')).toBe(false);
+        expect(listsMediaType('', 'application/json')).toBe(false);
     });
 });

--- a/packages/core-internal/test/shared/mediaType.test.ts
+++ b/packages/core-internal/test/shared/mediaType.test.ts
@@ -72,6 +72,7 @@ describe('listsMediaType', () => {
         expect(listsMediaType('application/json, text/event-stream', 'application/json')).toBe(true);
         expect(listsMediaType('application/json, text/event-stream', 'text/event-stream')).toBe(true);
         expect(listsMediaType('Application/JSON; q=0.9, text/event-stream; charset=utf-8', 'application/json')).toBe(true);
+        expect(listsMediaType('application/json; q=0.001, text/event-stream', 'application/json')).toBe(true);
         expect(listsMediaType('text/plain; note="a,b", application/json', 'application/json')).toBe(true);
     });
 
@@ -80,6 +81,13 @@ describe('listsMediaType', () => {
         expect(listsMediaType('application/jsonx, text/event-stream-bogus', 'text/event-stream')).toBe(false);
         expect(listsMediaType('text/plain; note=application/json', 'application/json')).toBe(false);
         expect(listsMediaType('*/*, application/*', 'application/json')).toBe(false);
+    });
+
+    it('rejects media ranges with zero or invalid quality values', () => {
+        expect(listsMediaType('application/json; q=0, text/event-stream', 'application/json')).toBe(false);
+        expect(listsMediaType('application/json; q=0.000, text/event-stream', 'application/json')).toBe(false);
+        expect(listsMediaType('application/json; q=bogus, text/event-stream', 'application/json')).toBe(false);
+        expect(listsMediaType('application/json; q=1.1, text/event-stream', 'application/json')).toBe(false);
     });
 
     it('rejects missing or empty Accept values', () => {

--- a/packages/server/src/server/streamableHttp.ts
+++ b/packages/server/src/server/streamableHttp.ts
@@ -16,6 +16,7 @@ import {
     isJSONRPCRequest,
     isJSONRPCResultResponse,
     JSONRPCMessageSchema,
+    listsMediaType,
     SUPPORTED_PROTOCOL_VERSIONS
 } from '@modelcontextprotocol/core-internal';
 
@@ -458,7 +459,7 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
     private async handleGetRequest(req: Request): Promise<Response> {
         // The client MUST include an Accept header, listing text/event-stream as a supported content type.
         const acceptHeader = req.headers.get('accept');
-        if (!acceptHeader?.includes('text/event-stream')) {
+        if (!listsMediaType(acceptHeader, 'text/event-stream')) {
             this.onerror?.(new Error('Not Acceptable: Client must accept text/event-stream'));
             return this.createJsonErrorResponse(406, -32_000, 'Not Acceptable: Client must accept text/event-stream');
         }
@@ -737,9 +738,10 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
             // Validate the Accept header
             const acceptHeader = req.headers.get('accept');
             // The client MUST include an Accept header, listing both application/json and text/event-stream as supported content types.
-            // Accept is a comma-separated list, so a substring check is the intended semantics here (unlike Content-Type below).
-            // eslint-disable-next-line no-restricted-syntax
-            if (!acceptHeader?.includes('application/json') || !acceptHeader.includes('text/event-stream')) {
+            // Accept is a comma-separated list of media ranges. Match parsed
+            // media types rather than substrings so values like
+            // `application/jsonx` or `text/event-stream-bogus` are not accepted.
+            if (!listsMediaType(acceptHeader, 'application/json') || !listsMediaType(acceptHeader, 'text/event-stream')) {
                 this.onerror?.(new Error('Not Acceptable: Client must accept both application/json and text/event-stream'));
                 return this.createJsonErrorResponse(
                     406,

--- a/packages/server/src/server/streamableHttp.ts
+++ b/packages/server/src/server/streamableHttp.ts
@@ -16,6 +16,7 @@ import {
     isJSONRPCRequest,
     isJSONRPCResultResponse,
     JSONRPCMessageSchema,
+    listsMediaType,
     SUPPORTED_PROTOCOL_VERSIONS
 } from '@modelcontextprotocol/core-internal';
 
@@ -470,7 +471,7 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
     private async handleGetRequest(req: Request): Promise<Response> {
         // The client MUST include an Accept header, listing text/event-stream as a supported content type.
         const acceptHeader = req.headers.get('accept');
-        if (!acceptHeader?.includes('text/event-stream')) {
+        if (!listsMediaType(acceptHeader, 'text/event-stream')) {
             this.onerror?.(new Error('Not Acceptable: Client must accept text/event-stream'));
             return this.createJsonErrorResponse(406, -32_000, 'Not Acceptable: Client must accept text/event-stream');
         }
@@ -749,9 +750,10 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
             // Validate the Accept header
             const acceptHeader = req.headers.get('accept');
             // The client MUST include an Accept header, listing both application/json and text/event-stream as supported content types.
-            // Accept is a comma-separated list, so a substring check is the intended semantics here (unlike Content-Type below).
-            // eslint-disable-next-line no-restricted-syntax
-            if (!acceptHeader?.includes('application/json') || !acceptHeader.includes('text/event-stream')) {
+            // Accept is a comma-separated list of media ranges. Match parsed
+            // media types rather than substrings so values like
+            // `application/jsonx` or `text/event-stream-bogus` are not accepted.
+            if (!listsMediaType(acceptHeader, 'application/json') || !listsMediaType(acceptHeader, 'text/event-stream')) {
                 this.onerror?.(new Error('Not Acceptable: Client must accept both application/json and text/event-stream'));
                 return this.createJsonErrorResponse(
                     406,

--- a/packages/server/test/server/streamableHttp.test.ts
+++ b/packages/server/test/server/streamableHttp.test.ts
@@ -301,6 +301,26 @@ describe('Zod v4', () => {
                 expectErrorResponse(errorData, -32_000, /Not Acceptable/);
             });
 
+            it('should reject Accept headers whose media types only contain the required values as substrings', async () => {
+                const request = createRequest('POST', TEST_MESSAGES.initialize, {
+                    accept: 'application/jsonx, text/event-stream-bogus'
+                });
+                const response = await transport.handleRequest(request);
+
+                expect(response.status).toBe(406);
+                const errorData = await response.json();
+                expectErrorResponse(errorData, -32_000, /Not Acceptable/);
+            });
+
+            it('should accept media types with parameters in the Accept header', async () => {
+                const request = createRequest('POST', TEST_MESSAGES.initialize, {
+                    accept: 'Application/JSON; q=0.9, text/event-stream; charset=utf-8'
+                });
+                const response = await transport.handleRequest(request);
+
+                expect(response.status).toBe(200);
+            });
+
             it('should reject request with wrong Content-Type header', async () => {
                 const request = new Request('http://localhost/mcp', {
                     method: 'POST',
@@ -364,6 +384,17 @@ describe('Zod v4', () => {
                 sessionId = await initializeServer();
 
                 const request = createRequest('GET', undefined, { sessionId, accept: 'application/json' });
+                const response = await transport.handleRequest(request);
+
+                expect(response.status).toBe(406);
+                const errorData = await response.json();
+                expectErrorResponse(errorData, -32_000, /Not Acceptable/);
+            });
+
+            it('should reject GET when text/event-stream appears only as a substring', async () => {
+                sessionId = await initializeServer();
+
+                const request = createRequest('GET', undefined, { sessionId, accept: 'text/event-stream-bogus' });
                 const response = await transport.handleRequest(request);
 
                 expect(response.status).toBe(406);

--- a/packages/server/test/server/streamableHttp.test.ts
+++ b/packages/server/test/server/streamableHttp.test.ts
@@ -321,6 +321,17 @@ describe('Zod v4', () => {
                 expect(response.status).toBe(200);
             });
 
+            it('should reject Accept media types with q=0', async () => {
+                const request = createRequest('POST', TEST_MESSAGES.initialize, {
+                    accept: 'application/json; q=0, text/event-stream'
+                });
+                const response = await transport.handleRequest(request);
+
+                expect(response.status).toBe(406);
+                const errorData = await response.json();
+                expectErrorResponse(errorData, -32_000, /Not Acceptable/);
+            });
+
             it('should reject request with wrong Content-Type header', async () => {
                 const request = new Request('http://localhost/mcp', {
                     method: 'POST',
@@ -395,6 +406,17 @@ describe('Zod v4', () => {
                 sessionId = await initializeServer();
 
                 const request = createRequest('GET', undefined, { sessionId, accept: 'text/event-stream-bogus' });
+                const response = await transport.handleRequest(request);
+
+                expect(response.status).toBe(406);
+                const errorData = await response.json();
+                expectErrorResponse(errorData, -32_000, /Not Acceptable/);
+            });
+
+            it('should reject GET when text/event-stream has q=0', async () => {
+                sessionId = await initializeServer();
+
+                const request = createRequest('GET', undefined, { sessionId, accept: 'text/event-stream; q=0' });
                 const response = await transport.handleRequest(request);
 
                 expect(response.status).toBe(406);


### PR DESCRIPTION
Fixes #2480.

## Summary

Streamable HTTP server `Accept` validation used raw substring checks, so values such as `application/jsonx` and `text/event-stream-bogus` incorrectly satisfied the required concrete media types. This affected both POST negotiation and GET SSE requests.

This change:

- adds an internal `listsMediaType` helper that parses the comma-separated `Accept` list and compares media-type essences case-insensitively;
- handles parameters and quoted parameter values without splitting on commas inside quoted strings;
- requires a positive RFC 9110 quality value, so a required media type with `q=0` is not treated as supported;
- updates GET and POST Streamable HTTP validation to use exact media-type matching;
- adds regression coverage for substring false positives, valid case/parameter variants, quoted commas, zero/invalid quality values, wildcards, and missing headers;
- includes a patch changeset for the server and core-internal packages.

This follows the same parsed-media-type approach recently applied to `Content-Type` in #2441 / #2444, while keeping `Accept`-specific list parsing internal.

## Testing

Validated after merging current `main` (`70de0c8b`):

- `pnpm --filter @modelcontextprotocol/core-internal exec vitest run test/shared/mediaType.test.ts` — 12 passing
- `pnpm --filter @modelcontextprotocol/server exec vitest run test/server/streamableHttp.test.ts` — 61 passing
- core-internal and server typechecks — clean
- core-internal and server lint/format checks — clean
- full workspace typecheck, lint, and formatting — clean
- `pnpm build:all` — clean

The remaining platform-local `check:all` docs step is covered by CI; TypeDoc rejects native Windows backslash entry-point globs before documentation generation.
