### PR TITLE
chore: version the codemod with the core SDK fixed group

### DIFF
--- a/.changeset/codemod-fixed-group.md
+++ b/.changeset/codemod-fixed-group.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/codemod': patch
+---
+
+Version the codemod together with the core SDK packages, matching the migration guide's shared-version guarantee.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,18 +1,27 @@
 {
     "$schema": "https://unpkg.com/@changesets/config@3.1.2/schema.json",
-    "changelog": ["@changesets/changelog-github", { "repo": "modelcontextprotocol/typescript-sdk" }],
+    "changelog": [
+        "@changesets/changelog-github",
+        {
+            "repo": "modelcontextprotocol/typescript-sdk"
+        }
+    ],
     "commit": false,
     "fixed": [
         [
             "@modelcontextprotocol/core",
             "@modelcontextprotocol/client",
             "@modelcontextprotocol/server",
-            "@modelcontextprotocol/server-legacy"
+            "@modelcontextprotocol/server-legacy",
+            "@modelcontextprotocol/codemod"
         ]
     ],
     "linked": [],
     "access": "public",
     "baseBranch": "main",
     "updateInternalDependencies": "patch",
-    "ignore": ["@modelcontextprotocol/examples", "@mcp-examples/*"]
+    "ignore": [
+        "@modelcontextprotocol/examples",
+        "@mcp-examples/*"
+    ]
 }


### PR DESCRIPTION
The migration guide states all v2 packages share one version number since 2.0.0-beta.1, but `@modelcontextprotocol/codemod` only tracked the shared version when it happened to carry its own changeset each round — the pending beta.4 release would leave it at beta.3, and `npm install @modelcontextprotocol/codemod@2.0.0-beta.4` would fail with no matching version.

Add the codemod to the changesets `fixed` group (with a changeset so it joins the current round). Cost: an occasional republish with no code changes; benefit: the doc's guarantee is enforced by the release tooling instead of by luck.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed