### PR TITLE
fix(server): reject userinfo in Origin and Host headers

### DIFF
--- a/.changeset/reject-header-userinfo.md
+++ b/.changeset/reject-header-userinfo.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/server': patch
+---
+
+Reject Origin and Host header values containing URL userinfo before matching their hostnames against an allowlist.

--- a/packages/server/src/server/middleware/hostHeaderValidation.ts
+++ b/packages/server/src/server/middleware/hostHeaderValidation.ts
@@ -20,13 +20,17 @@ export function validateHostHeader(hostHeader: string | null | undefined, allowe
     }
 
     // Use URL API to parse hostname (handles IPv4, IPv6, and regular hostnames)
-    let hostname: string;
+    let host: URL;
     try {
-        hostname = new URL(`http://${hostHeader}`).hostname;
+        host = new URL(`http://${hostHeader}`);
     } catch {
         return { ok: false, errorCode: 'invalid_host_header', message: `Invalid Host header: ${hostHeader}`, hostHeader };
     }
+    if (host.username !== '' || host.password !== '') {
+        return { ok: false, errorCode: 'invalid_host_header', message: `Invalid Host header: ${hostHeader}`, hostHeader };
+    }
 
+    const hostname = host.hostname;
     if (!allowedHostnames.includes(hostname)) {
         return { ok: false, errorCode: 'invalid_host', message: `Invalid Host: ${hostname}`, hostHeader, hostname };
     }

--- a/packages/server/src/server/middleware/hostHeaderValidation.ts
+++ b/packages/server/src/server/middleware/hostHeaderValidation.ts
@@ -26,7 +26,7 @@ export function validateHostHeader(hostHeader: string | null | undefined, allowe
     } catch {
         return { ok: false, errorCode: 'invalid_host_header', message: `Invalid Host header: ${hostHeader}`, hostHeader };
     }
-    if (host.username !== '' || host.password !== '') {
+    if (hostHeader.includes('@')) {
         return { ok: false, errorCode: 'invalid_host_header', message: `Invalid Host header: ${hostHeader}`, hostHeader };
     }
 

--- a/packages/server/src/server/middleware/originValidation.ts
+++ b/packages/server/src/server/middleware/originValidation.ts
@@ -40,18 +40,19 @@ export function validateOriginHeader(originHeader: string | null | undefined, al
         return { ok: true };
     }
 
-    let hostname: string;
+    let origin: URL;
     try {
-        hostname = new URL(originHeader).hostname;
+        origin = new URL(originHeader);
     } catch {
         return { ok: false, errorCode: 'invalid_origin_header', message: `Invalid Origin header: ${originHeader}`, originHeader };
     }
-    if (hostname === '') {
+    if (origin.hostname === '' || origin.username !== '' || origin.password !== '') {
         // Opaque origins ("null") and other non-hierarchical values parse without a
-        // hostname; they can never be allowlisted.
+        // hostname; userinfo is not part of the serialized Origin grammar.
         return { ok: false, errorCode: 'invalid_origin_header', message: `Invalid Origin header: ${originHeader}`, originHeader };
     }
 
+    const hostname = origin.hostname;
     if (!allowedOriginHostnames.includes(hostname)) {
         return { ok: false, errorCode: 'invalid_origin', message: `Invalid Origin: ${hostname}`, originHeader, hostname };
     }

--- a/packages/server/src/server/middleware/originValidation.ts
+++ b/packages/server/src/server/middleware/originValidation.ts
@@ -46,7 +46,7 @@ export function validateOriginHeader(originHeader: string | null | undefined, al
     } catch {
         return { ok: false, errorCode: 'invalid_origin_header', message: `Invalid Origin header: ${originHeader}`, originHeader };
     }
-    if (origin.hostname === '' || origin.username !== '' || origin.password !== '') {
+    if (origin.hostname === '' || originHeader.includes('@')) {
         // Opaque origins ("null") and other non-hierarchical values parse without a
         // hostname; userinfo is not part of the serialized Origin grammar.
         return { ok: false, errorCode: 'invalid_origin_header', message: `Invalid Origin header: ${originHeader}`, originHeader };

--- a/packages/server/test/server/hostHeaderValidation.test.ts
+++ b/packages/server/test/server/hostHeaderValidation.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    hostHeaderValidationResponse,
+    localhostAllowedHostnames,
+    validateHostHeader
+} from '../../src/server/middleware/hostHeaderValidation';
+
+describe('validateHostHeader', () => {
+    it('allows hostnames with ports, including IPv4 and bracketed IPv6', () => {
+        expect(validateHostHeader('localhost:3000', localhostAllowedHostnames()).ok).toBe(true);
+        expect(validateHostHeader('127.0.0.1:8080', localhostAllowedHostnames()).ok).toBe(true);
+        expect(validateHostHeader('[::1]:8080', localhostAllowedHostnames()).ok).toBe(true);
+    });
+
+    it('rejects userinfo before an allowed hostname', () => {
+        for (const malformed of ['user@localhost:3000', 'user:pass@localhost:3000']) {
+            const result = validateHostHeader(malformed, localhostAllowedHostnames());
+            expect(result.ok).toBe(false);
+            if (!result.ok) {
+                expect(result.errorCode).toBe('invalid_host_header');
+            }
+        }
+    });
+});
+
+describe('hostHeaderValidationResponse', () => {
+    it('returns a 403 response when a Host with userinfo resolves to an allowed hostname', () => {
+        const request = new Request('http://localhost/mcp', { headers: { host: 'user@localhost:3000' } });
+        expect(hostHeaderValidationResponse(request, localhostAllowedHostnames())?.status).toBe(403);
+    });
+});

--- a/packages/server/test/server/hostHeaderValidation.test.ts
+++ b/packages/server/test/server/hostHeaderValidation.test.ts
@@ -14,7 +14,7 @@ describe('validateHostHeader', () => {
     });
 
     it('rejects userinfo before an allowed hostname', () => {
-        for (const malformed of ['user@localhost:3000', 'user:pass@localhost:3000']) {
+        for (const malformed of ['@localhost:3000', ':@localhost:3000', 'user@localhost:3000', 'user:pass@localhost:3000']) {
             const result = validateHostHeader(malformed, localhostAllowedHostnames());
             expect(result.ok).toBe(false);
             if (!result.ok) {
@@ -26,7 +26,7 @@ describe('validateHostHeader', () => {
 
 describe('hostHeaderValidationResponse', () => {
     it('returns a 403 response when a Host with userinfo resolves to an allowed hostname', () => {
-        const request = new Request('http://localhost/mcp', { headers: { host: 'user@localhost:3000' } });
+        const request = new Request('http://localhost/mcp', { headers: { host: '@localhost:3000' } });
         expect(hostHeaderValidationResponse(request, localhostAllowedHostnames())?.status).toBe(403);
     });
 });

--- a/packages/server/test/server/originValidation.test.ts
+++ b/packages/server/test/server/originValidation.test.ts
@@ -42,6 +42,16 @@ describe('validateOriginHeader', () => {
             }
         }
     });
+
+    it('rejects userinfo before an allowed hostname', () => {
+        for (const malformed of ['http://user@localhost', 'http://user:pass@localhost']) {
+            const result = validateOriginHeader(malformed, localhostAllowedOrigins());
+            expect(result.ok).toBe(false);
+            if (!result.ok) {
+                expect(result.errorCode).toBe('invalid_origin_header');
+            }
+        }
+    });
 });
 
 describe('originValidationResponse', () => {
@@ -63,5 +73,10 @@ describe('originValidationResponse', () => {
         expect(body.error.code).toBe(-32_000);
         expect(body.error.message).toContain('Invalid Origin');
         expect(body.id).toBeNull();
+    });
+
+    it('returns a 403 response when an Origin with userinfo resolves to an allowed hostname', () => {
+        const request = new Request('http://localhost/mcp', { headers: { origin: 'http://user@localhost' } });
+        expect(originValidationResponse(request, localhostAllowedOrigins())?.status).toBe(403);
     });
 });

--- a/packages/server/test/server/originValidation.test.ts
+++ b/packages/server/test/server/originValidation.test.ts
@@ -44,7 +44,7 @@ describe('validateOriginHeader', () => {
     });
 
     it('rejects userinfo before an allowed hostname', () => {
-        for (const malformed of ['http://user@localhost', 'http://user:pass@localhost']) {
+        for (const malformed of ['http://@localhost', 'http://:@localhost', 'http://user@localhost', 'http://user:pass@localhost']) {
             const result = validateOriginHeader(malformed, localhostAllowedOrigins());
             expect(result.ok).toBe(false);
             if (!result.ok) {
@@ -76,7 +76,7 @@ describe('originValidationResponse', () => {
     });
 
     it('returns a 403 response when an Origin with userinfo resolves to an allowed hostname', () => {
-        const request = new Request('http://localhost/mcp', { headers: { origin: 'http://user@localhost' } });
+        const request = new Request('http://localhost/mcp', { headers: { origin: 'http://@localhost' } });
         expect(originValidationResponse(request, localhostAllowedOrigins())?.status).toBe(403);
     });
 });


### PR DESCRIPTION
Fixes #2489.

## Summary

Reject Origin and Host header values containing URL userinfo before matching their hostnames against an allowlist.

The validators previously compared only the hostname returned by `URL`. Because URL parsing removes userinfo components, values such as `http://user@localhost`, `http://@localhost`, and `user@localhost:3000` were normalized to the allowlisted hostname `localhost`.

## What changed

- Reject the raw `@` userinfo delimiter before matching the parsed hostname against an allowlist.
- Return `invalid_origin_header` or `invalid_host_header` when the delimiter is present.
- Add direct regression coverage for empty, username, and username/password forms.
- Verify the public response helpers return HTTP 403.
- Preserve valid hostname, port, IPv4, and bracketed IPv6 behavior.

The shared server helpers are consumed by the Node, Express, Fastify, and Hono middleware, so the adapters inherit the corrected parsing behavior without adapter-specific changes.

## Behavior and scope

This prevents invalid Origin and Host syntax from being normalized into an allowlisted hostname.

Browsers do not normally emit userinfo in Origin or permit JavaScript to set Host directly, so this change is scoped as parser-boundary hardening rather than a demonstrated browser exploit. Valid hostname, port, IPv4, and bracketed IPv6 forms remain unchanged.

## How has this been tested?

- Before the fix, the focused regression suite had four failures: both direct validators accepted userinfo, and both response helpers omitted the HTTP 403 rejection.
- `pnpm --filter @modelcontextprotocol/server exec vitest run test/server/originValidation.test.ts test/server/hostHeaderValidation.test.ts` — 12 tests passed.
- `pnpm --filter @modelcontextprotocol/server test` — 470 tests passed.
- `pnpm --filter @modelcontextprotocol/node exec vitest run test/validation.test.ts` — 5 tests passed.
- `pnpm --filter @modelcontextprotocol/server build`
- ESLint and Prettier checks for all changed files.

## Breaking changes

None. Valid Origin and Host values retain their existing behavior.

## Types of changes

- [x] Bug fix (non-breaking change)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] I have read the MCP documentation.
- [x] My code follows the repository's style guidelines.
- [x] New and existing tests pass locally.
- [x] I have added appropriate error handling.
- [x] I added a patch changeset.
