### PR TITLE
fix(core): preserve zero related request IDs

### DIFF
--- a/.changeset/falsey-related-request-id.md
+++ b/.changeset/falsey-related-request-id.md
@@ -1,0 +1,7 @@
+---
+'@modelcontextprotocol/client': patch
+'@modelcontextprotocol/server': patch
+'@modelcontextprotocol/core-internal': patch
+---
+
+Notifications with `relatedRequestId: 0` are now sent immediately instead of being treated as unassociated notifications eligible for debounce coalescing. JSON-RPC request ID `0` is valid and must preserve its request association.

--- a/packages/core-internal/src/shared/protocol.ts
+++ b/packages/core-internal/src/shared/protocol.ts
@@ -1610,7 +1610,8 @@ export abstract class Protocol<ContextT extends BaseContext> {
         const debouncedMethods = this._options?.debouncedNotificationMethods ?? [];
         // A notification can only be debounced if it's in the list AND it's "simple"
         // (i.e., has no parameters and no related request ID that could be lost).
-        const canDebounce = debouncedMethods.includes(notification.method) && !notification.params && !options?.relatedRequestId;
+        const canDebounce =
+            debouncedMethods.includes(notification.method) && !notification.params && options?.relatedRequestId === undefined;
 
         if (canDebounce) {
             // If a notification of this type is already scheduled, do nothing.

--- a/packages/core-internal/test/shared/protocol.test.ts
+++ b/packages/core-internal/test/shared/protocol.test.ts
@@ -656,6 +656,22 @@ describe('protocol tests', () => {
             expect(sendSpy).toHaveBeenCalledWith(expect.any(Object), { relatedRequestId: 'req-2' });
         });
 
+        it('should NOT debounce notifications with relatedRequestId 0 in the same tick', async () => {
+            // ARRANGE
+            protocol = new TestProtocolImpl({ debouncedNotificationMethods: ['test/debounced_with_zero_id'] });
+            await protocol.connect(transport);
+
+            // ACT
+            const first = protocol.notification({ method: 'test/debounced_with_zero_id' }, { relatedRequestId: 0 });
+            const second = protocol.notification({ method: 'test/debounced_with_zero_id' }, { relatedRequestId: 0 });
+            await Promise.all([first, second]);
+
+            // ASSERT
+            expect(sendSpy).toHaveBeenCalledTimes(2);
+            expect(sendSpy).toHaveBeenNthCalledWith(1, expect.any(Object), { relatedRequestId: 0 });
+            expect(sendSpy).toHaveBeenNthCalledWith(2, expect.any(Object), { relatedRequestId: 0 });
+        });
+
         it('should clear pending debounced notifications on connection close', async () => {
             // ARRANGE
             protocol = new TestProtocolImpl({ debouncedNotificationMethods: ['test/debounced'] });


### PR DESCRIPTION
## Summary

- treat only an undefined `relatedRequestId` as absent when deciding whether a notification can be debounced
- add a same-tick regression proving two notifications associated with JSON-RPC request ID `0` are both sent
- add patch changesets for the affected client, server, and core packages

Fixes #2117.

## Verification

- Regression test fails on unmodified `origin/main` with one send instead of two.
- `pnpm --filter @modelcontextprotocol/core-internal exec vitest run test/shared/protocol.test.ts -t 'relatedRequestId 0 in the same tick'` passes with the fix.
- `pnpm --filter @modelcontextprotocol/core-internal check` passes.
- `pnpm lint:all` passes.
- `pnpm test:all`: all test files passed on the second run, but Vitest exited non-zero because the existing `protocol:timeout:max-total [sse 2025-11-25]` E2E left two unhandled timeout rejections. Its direct targeted rerun passed (1 test, 411 skipped).