### PR TITLE
Fix notification debouncing for request ID zero

### DIFF
--- a/.changeset/related-request-id-zero.md
+++ b/.changeset/related-request-id-zero.md
@@ -1,0 +1,7 @@
+---
+'@modelcontextprotocol/client': patch
+'@modelcontextprotocol/server': patch
+'@modelcontextprotocol/server-legacy': patch
+---
+
+Treat numeric related request ID `0` as present when deciding whether to debounce notifications. Request-associated notifications for the first request ID are no longer coalesced, and send failures now reject the notification promise consistently with other request IDs.

--- a/packages/core-internal/src/shared/protocol.ts
+++ b/packages/core-internal/src/shared/protocol.ts
@@ -1610,7 +1610,8 @@ export abstract class Protocol<ContextT extends BaseContext> {
         const debouncedMethods = this._options?.debouncedNotificationMethods ?? [];
         // A notification can only be debounced if it's in the list AND it's "simple"
         // (i.e., has no parameters and no related request ID that could be lost).
-        const canDebounce = debouncedMethods.includes(notification.method) && !notification.params && !options?.relatedRequestId;
+        const canDebounce =
+            debouncedMethods.includes(notification.method) && !notification.params && options?.relatedRequestId === undefined;
 
         if (canDebounce) {
             // If a notification of this type is already scheduled, do nothing.

--- a/packages/core-internal/test/shared/protocol.test.ts
+++ b/packages/core-internal/test/shared/protocol.test.ts
@@ -656,6 +656,22 @@ describe('protocol tests', () => {
             expect(sendSpy).toHaveBeenCalledWith(expect.any(Object), { relatedRequestId: 'req-2' });
         });
 
+        it('should NOT debounce a notification with relatedRequestId 0', async () => {
+            // ARRANGE
+            protocol = new TestProtocolImpl({ debouncedNotificationMethods: ['test/debounced_with_numeric_id'] });
+            await protocol.connect(transport);
+
+            // ACT
+            const first = protocol.notification({ method: 'test/debounced_with_numeric_id' }, { relatedRequestId: 0 });
+            const second = protocol.notification({ method: 'test/debounced_with_numeric_id' }, { relatedRequestId: 0 });
+            await Promise.all([first, second]);
+
+            // ASSERT
+            expect(sendSpy).toHaveBeenCalledTimes(2);
+            expect(sendSpy).toHaveBeenNthCalledWith(1, expect.any(Object), { relatedRequestId: 0 });
+            expect(sendSpy).toHaveBeenNthCalledWith(2, expect.any(Object), { relatedRequestId: 0 });
+        });
+
         it('should clear pending debounced notifications on connection close', async () => {
             // ARRANGE
             protocol = new TestProtocolImpl({ debouncedNotificationMethods: ['test/debounced'] });


### PR DESCRIPTION
## Summary

- treat numeric `relatedRequestId: 0` as present when checking notification debounce eligibility
- preserve immediate send and rejection behavior for notifications associated with the first request ID
- add regression coverage and a patch changeset

Fixes #2117

## Validation

- `pnpm --filter @modelcontextprotocol/core-internal exec vitest run test/shared/protocol.test.ts`
- `pnpm --filter @modelcontextprotocol/core-internal exec vitest run --exclude test/wire/schemaTwinConformance.test.ts`
- `pnpm run typecheck:all`
- `pnpm run build:all`
- `pnpm exec changeset status --since origin/main`