### PR TITLE
docs: add fastify middleware to top-level README listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ This repository contains the TypeScript SDK implementation of the MCP specificat
 
 - MCP **server** libraries (tools/resources/prompts, Streamable HTTP, stdio, auth helpers)
 - MCP **client** libraries (transports, high-level helpers, OAuth helpers)
-- Optional **middleware packages** for specific runtimes/frameworks (Express, Hono, Node.js HTTP)
+- Optional **middleware packages** for specific runtimes/frameworks (Express, Fastify, Hono, Node.js HTTP)
 - Runnable **examples** (under [`examples/`](https://github.com/modelcontextprotocol/typescript-sdk/tree/main/examples))
 
 ## Packages
@@ -58,6 +58,7 @@ They are intentionally thin adapters: they should not introduce new MCP function
 
 - **`@modelcontextprotocol/node`**: Node.js Streamable HTTP transport wrapper for `IncomingMessage` / `ServerResponse`
 - **`@modelcontextprotocol/express`**: Express helpers (app defaults + Host header validation)
+- **`@modelcontextprotocol/fastify`**: Fastify helpers (app defaults + Host header validation)
 - **`@modelcontextprotocol/hono`**: Hono helpers (app defaults + JSON body parsing hook + Host header validation)
 
 ## Installation
@@ -84,7 +85,7 @@ deno add npm:@modelcontextprotocol/client
 
 ### Optional middleware packages
 
-The SDK also publishes optional “middleware” packages that help you **wire MCP into a specific runtime or web framework** (for example Express, Hono, or Node.js `http`).
+The SDK also publishes optional “middleware” packages that help you **wire MCP into a specific runtime or web framework** (for example Express, Fastify, Hono, or Node.js `http`).
 
 These packages are intentionally thin adapters and should not introduce additional MCP features or business logic. See [`packages/middleware/README.md`](packages/middleware/README.md) for details.
 
@@ -94,6 +95,9 @@ npm install @modelcontextprotocol/node
 
 # Express integration:
 npm install @modelcontextprotocol/express express
+
+# Fastify integration:
+npm install @modelcontextprotocol/fastify fastify
 
 # Hono integration:
 npm install @modelcontextprotocol/hono hono


### PR DESCRIPTION
## Summary

Adds the `@modelcontextprotocol/fastify` package to the main repository `README.md` in three places (Overview, Middleware packages listing, and Installation examples) alongside the other middleware integrations.

Closes #2112.

## Test Plan

- Inspected `README.md` formatting visually.
- Verified that all installation snippets and references are correct and align with the other middleware packages.