### PR TITLE
fix(core): prevent debouncing notifications when relatedRequestId is 0

### DIFF
--- a/packages/core-internal/src/shared/protocol.ts
+++ b/packages/core-internal/src/shared/protocol.ts
@@ -1611,9 +1611,7 @@ export abstract class Protocol<ContextT extends BaseContext> {
         // A notification can only be debounced if it's in the list AND it's "simple"
         // (i.e., has no parameters and no related request ID that could be lost).
         const canDebounce =
-            debouncedMethods.includes(notification.method) &&
-            !notification.params &&
-            options?.relatedRequestId === undefined;
+            debouncedMethods.includes(notification.method) && !notification.params && options?.relatedRequestId === undefined;
 
         if (canDebounce) {
             // If a notification of this type is already scheduled, do nothing.

--- a/packages/core-internal/src/shared/protocol.ts
+++ b/packages/core-internal/src/shared/protocol.ts
@@ -1610,7 +1610,10 @@ export abstract class Protocol<ContextT extends BaseContext> {
         const debouncedMethods = this._options?.debouncedNotificationMethods ?? [];
         // A notification can only be debounced if it's in the list AND it's "simple"
         // (i.e., has no parameters and no related request ID that could be lost).
-        const canDebounce = debouncedMethods.includes(notification.method) && !notification.params && !options?.relatedRequestId;
+        const canDebounce =
+            debouncedMethods.includes(notification.method) &&
+            !notification.params &&
+            options?.relatedRequestId === undefined;
 
         if (canDebounce) {
             // If a notification of this type is already scheduled, do nothing.

--- a/packages/core-internal/test/shared/protocol.test.ts
+++ b/packages/core-internal/test/shared/protocol.test.ts
@@ -656,6 +656,22 @@ describe('protocol tests', () => {
             expect(sendSpy).toHaveBeenCalledWith(expect.any(Object), { relatedRequestId: 'req-2' });
         });
 
+        it('should NOT debounce a notification that has a relatedRequestId: 0', async () => {
+            // ARRANGE
+            protocol = new TestProtocolImpl({ debouncedNotificationMethods: ['test/debounced_with_options'] });
+            await protocol.connect(transport);
+
+            // ACT
+            void protocol.notification({ method: 'test/debounced_with_options' }, { relatedRequestId: 0 });
+            void protocol.notification({ method: 'test/debounced_with_options' }, { relatedRequestId: 0 });
+            await flushMicrotasks();
+
+            // ASSERT
+            expect(sendSpy).toHaveBeenCalledTimes(2);
+            expect(sendSpy).toHaveBeenNthCalledWith(1, expect.any(Object), { relatedRequestId: 0 });
+            expect(sendSpy).toHaveBeenNthCalledWith(2, expect.any(Object), { relatedRequestId: 0 });
+        });
+
         it('should clear pending debounced notifications on connection close', async () => {
             // ARRANGE
             protocol = new TestProtocolImpl({ debouncedNotificationMethods: ['test/debounced'] });


### PR DESCRIPTION
### Description

This PR fixes a bug in the protocol notification debounce guard where a `relatedRequestId` of `0` was incorrectly treated as falsy/absent.

In JSON-RPC/MCP, `0` is a valid request/notification identifier. It is also the default starting ID for `Protocol` instances in the TypeScript SDK.

Currently, the debounce guard logic uses a truthiness check:
```ts
const canDebounce = debouncedMethods.includes(notification.method) && !notification.params && !options?.relatedRequestId;
```

Because `0` is falsy, `!options?.relatedRequestId` evaluates to `true` when `relatedRequestId` is `0`, causing the notification to be incorrectly debounced and coalesced.

### Fix

We replace the truthiness check with an explicit `undefined` check:
```ts
const canDebounce =
    debouncedMethods.includes(notification.method) &&
    !notification.params &&
    options?.relatedRequestId === undefined;
```

This aligns the behavior of `relatedRequestId: 0` with all other present IDs (such as strings or positive integers), ensuring they bypass the global debounce logic and are sent immediately.

### Testing

1. Added a test case in `packages/core-internal/test/shared/protocol.test.ts` (`should NOT debounce a notification that has a relatedRequestId: 0`) that calls `protocol.notification` twice synchronously with `relatedRequestId: 0` to verify that they are both sent immediately and not coalesced.
2. Ran `pnpm test:all` to verify that all workspace packages compile and all tests pass.

Resolves #2117
