### PR TITLE
fix: handle notifications/cancelled for valid request ID 0

### DIFF
--- a/.changeset/cancelled-notification-id-zero.md
+++ b/.changeset/cancelled-notification-id-zero.md
@@ -1,0 +1,6 @@
+---
+'@modelcontextprotocol/client': patch
+'@modelcontextprotocol/server': patch
+---
+
+Handle `notifications/cancelled` for request ID `0`. JSON-RPC allows `0` as a valid request ID, but the cancellation handler used a truthiness check and silently dropped cancellations for requests numbered `0`; the handler now checks for `undefined` explicitly, so those requests are cancelled correctly.

--- a/packages/core-internal/src/shared/protocol.ts
+++ b/packages/core-internal/src/shared/protocol.ts
@@ -723,7 +723,7 @@ export abstract class Protocol<ContextT extends BaseContext> {
     }
 
     private async _oncancel(notification: CancelledNotification): Promise<void> {
-        if (!notification.params.requestId) {
+        if (notification.params.requestId === undefined) {
             return;
         }
         // Handle request cancellation

--- a/packages/core-internal/test/shared/protocol.test.ts
+++ b/packages/core-internal/test/shared/protocol.test.ts
@@ -819,6 +819,50 @@ describe('protocol tests', () => {
             // Verify the request was aborted
             expect(wasAborted).toBe(true);
         });
+
+        test('should handle notifications/cancelled for request ID 0', async () => {
+            await protocol.connect(transport);
+
+            // Set up a request handler that checks if it was aborted
+            let wasAborted = false;
+            protocol.setRequestHandler('ping', async (_request, ctx) => {
+                await new Promise(resolve => setTimeout(resolve, 100));
+                wasAborted = ctx.mcpReq.signal.aborted;
+                return {};
+            });
+
+            // Simulate an incoming request with ID 0 (a valid JSON-RPC id)
+            const requestId = 0;
+            if (transport.onmessage) {
+                transport.onmessage({
+                    jsonrpc: '2.0',
+                    id: requestId,
+                    method: 'ping',
+                    params: {}
+                });
+            }
+
+            // Wait a bit for the handler to start
+            await new Promise(resolve => setTimeout(resolve, 10));
+
+            // Send cancellation notification with requestId 0
+            if (transport.onmessage) {
+                transport.onmessage({
+                    jsonrpc: '2.0',
+                    method: 'notifications/cancelled',
+                    params: {
+                        requestId: requestId,
+                        reason: 'User cancelled'
+                    }
+                });
+            }
+
+            // Wait for the handler to complete
+            await new Promise(resolve => setTimeout(resolve, 150));
+
+            // Verify the request was aborted even with ID 0
+            expect(wasAborted).toBe(true);
+        });
     });
 
     // Spec basic/patterns/cancellation §Transport-Specific (2026-07-28): on a


### PR DESCRIPTION
Fixes #2283

JSON-RPC allows request ID 0 as a valid identifier, but the SDK's cancelled notification handler treats it as falsy and silently drops the cancellation. This means agent orchestrators cannot cancel tool calls numbered with ID 0.

**Fix**: Replace truthiness check with explicit undefined check so that `0` is treated as a valid request ID for cancellation.

**Changes**:
- `packages/core-internal/src/shared/protocol.ts`: Change `!notification.params.requestId` to `notification.params.requestId === undefined` in `_oncancel`
- `packages/core-internal/test/shared/protocol.test.ts`: Add test verifying cancellation works for request ID 0