### PR TITLE
fix(client): don't match WWW-Authenticate field names inside longer param names

### DIFF
--- a/.changeset/fix-www-auth-substring.md
+++ b/.changeset/fix-www-auth-substring.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/client': patch
+---
+
+Fix `WWW-Authenticate` parsing matching a field name inside another auth-param. The OAuth client extracted `resource_metadata`, `scope`, `error`, and `error_description` with a regex that searched for the field name anywhere in the header, so a different parameter whose name ended with the requested field (for example `error_scope` when reading `scope`) could shadow the real value, and a parameter like `x_resource_metadata` could supply a decoy resource metadata URL. The parameter name is now anchored to the header start or a separator.

--- a/packages/client/src/client/auth.ts
+++ b/packages/client/src/client/auth.ts
@@ -1467,7 +1467,10 @@ function extractFieldFromWwwAuth(response: Response, fieldName: string): string 
         return null;
     }
 
-    const pattern = new RegExp(String.raw`${fieldName}=(?:"([^"]+)"|([^\s,]+))`);
+    // Require the parameter name to start at the header start or after a separator (whitespace
+    // or comma) so it is not matched as a substring of another auth-param name (e.g. searching
+    // "scope" must not match the value of "error_scope").
+    const pattern = new RegExp(String.raw`(?:^|[\s,])${fieldName}=(?:"([^"]+)"|([^\s,]+))`);
     const match = wwwAuthHeader.match(pattern);
 
     if (match) {

--- a/packages/client/test/client/auth.test.ts
+++ b/packages/client/test/client/auth.test.ts
@@ -191,6 +191,26 @@ describe('OAuth Authorization', () => {
                 errorDescription: 'needs admin'
             });
         });
+
+        it('does not match a field name inside a longer auth-param name', async () => {
+            const mockResponse = {
+                headers: {
+                    get: vi.fn(name => (name === 'WWW-Authenticate' ? `Bearer error_scope="should-not-be-read", scope="read write"` : null))
+                }
+            } as unknown as Response;
+
+            expect(extractWWWAuthenticateParams(mockResponse)).toEqual({ scope: 'read write' });
+        });
+
+        it('does not match resource_metadata inside a longer auth-param name', async () => {
+            const mockResponse = {
+                headers: {
+                    get: vi.fn(name => (name === 'WWW-Authenticate' ? `Bearer x_resource_metadata="https://decoy.example.com"` : null))
+                }
+            } as unknown as Response;
+
+            expect(extractWWWAuthenticateParams(mockResponse)).toEqual({});
+        });
     });
 
     describe('computeScopeUnion', () => {


### PR DESCRIPTION
`extractFieldFromWwwAuth` builds its regex as `${fieldName}=(?:...)` with nothing anchoring the start of the param name. Asking for `scope` also matches `error_scope="..."`, so whichever param appears first shadows the real value. The worst case is `resource_metadata`: a header like `Bearer x_resource_metadata="https://decoy.example.com"` returns a URL from a param that isn't `resource_metadata` at all, and that value is what `extractWWWAuthenticateParams` feeds into protected-resource-metadata discovery.

Repro on current main:

```ts
const res = new Response(null, {
    status: 401,
    headers: { 'WWW-Authenticate': 'Bearer error_scope="decoy", scope="read write"' }
});
extractWWWAuthenticateParams(res).scope; // 'decoy' (expected 'read write')
```

The fix anchors the param name to the header start or a whitespace/comma separator, so it only matches as a complete auth-param name. Two regression tests cover both shadowing shapes (`scope` inside `error_scope`, and a decoy `x_resource_metadata`); both fail without the one-line change. Changeset included.

The same unanchored pattern exists on `v1.x` (`src/client/auth.ts`). Happy to send the equivalent patch there too if useful.