### PR TITLE
fix(packaging): exclude examples from v1 package artifacts

### DIFF
--- a/test/package-artifacts.test.ts
+++ b/test/package-artifacts.test.ts
@@ -1,0 +1,74 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repositoryRoot = fileURLToPath(new URL('../', import.meta.url));
+const npmCli = process.env.npm_execpath ?? join(dirname(process.execPath), 'node_modules', 'npm', 'bin', 'npm-cli.js');
+const tscCli = join(repositoryRoot, 'node_modules', 'typescript', 'bin', 'tsc');
+
+type PackageExport = Record<string, string>;
+type PackageManifest = {
+    exports: Record<string, PackageExport>;
+};
+type PackResult = {
+    files: Array<{ path: string }>;
+};
+
+function runNode(script: string, args: string[], cwd = repositoryRoot): string {
+    return execFileSync(process.execPath, [script, ...args], {
+        cwd,
+        encoding: 'utf8'
+    });
+}
+
+function runNpm(args: string[], cwd = repositoryRoot): string {
+    return runNode(npmCli, args, cwd);
+}
+
+describe('published package artifacts', () => {
+    let packageRoot: string;
+    let packedPaths: Set<string>;
+
+    beforeAll(() => {
+        packageRoot = mkdtempSync(join(tmpdir(), 'mcp-sdk-package-'));
+        runNode(tscCli, ['-p', join(repositoryRoot, 'tsconfig.prod.json'), '--outDir', join(packageRoot, 'dist', 'esm')]);
+        runNode(tscCli, ['-p', join(repositoryRoot, 'tsconfig.cjs.json'), '--outDir', join(packageRoot, 'dist', 'cjs')]);
+        writeFileSync(join(packageRoot, 'package.json'), readFileSync(join(repositoryRoot, 'package.json')));
+
+        const [packResult] = JSON.parse(runNpm(['pack', '--dry-run', '--json', '--ignore-scripts'], packageRoot)) as PackResult[];
+        packedPaths = new Set(packResult.files.map(file => file.path));
+    }, 120_000);
+
+    afterAll(() => {
+        rmSync(packageRoot, { recursive: true, force: true });
+    });
+
+    test('does not contain compiled example entry points', () => {
+        const compiledExamples = [...packedPaths].filter(path => /^dist\/(esm|cjs)\/examples\//.test(path));
+
+        expect(compiledExamples).toEqual([]);
+    });
+
+    test('contains every supported explicit subpath export target', () => {
+        const manifest = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8')) as PackageManifest;
+        const explicitExportTargets = Object.entries(manifest.exports)
+            .filter(([subpath]) => subpath !== '.' && subpath !== './*')
+            .flatMap(([, conditions]) => Object.values(conditions))
+            .map(target => target.replace(/^\.\//, ''));
+
+        expect(explicitExportTargets.filter(target => !packedPaths.has(target))).toEqual([]);
+    });
+
+    test.each([
+        'dist/esm/client/stdio.js',
+        'dist/cjs/client/stdio.js',
+        'dist/esm/server/stdio.js',
+        'dist/cjs/server/stdio.js',
+        'dist/esm/shared/protocol.js',
+        'dist/cjs/shared/protocol.js'
+    ])('keeps the supported wildcard subpath target %s', target => {
+        expect(packedPaths).toContain(target);
+    });
+});

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -6,5 +6,5 @@
         "outDir": "./dist/cjs"
     },
     "include": ["src/**/*"],
-    "exclude": ["**/*.test.ts", "src/__mocks__/**/*", "src/__fixtures__/**/*"]
+    "exclude": ["**/*.test.ts", "src/__mocks__/**/*", "src/__fixtures__/**/*", "src/examples/**/*"]
 }

--- a/tsconfig.prod.json
+++ b/tsconfig.prod.json
@@ -4,5 +4,5 @@
         "outDir": "./dist/esm"
     },
     "include": ["src/**/*"],
-    "exclude": ["**/*.test.ts", "src/__mocks__/**/*", "src/__fixtures__/**/*"]
+    "exclude": ["**/*.test.ts", "src/__mocks__/**/*", "src/__fixtures__/**/*", "src/examples/**/*"]
 }


### PR DESCRIPTION
## Summary

Exclude `src/examples/**` from both v1 production TypeScript builds and add package-level regression coverage.

The regression test compiles the ESM and CJS production artifacts into a clean temporary package, inspects the result of `npm pack --dry-run`, and verifies that:

- no compiled `dist/esm/examples/**` or `dist/cjs/examples/**` entry points are published;
- every supported explicit package export target remains present;
- representative wildcard subpaths for client, server, and shared APIs remain available in both module formats.

## Root cause

Both `tsconfig.prod.json` and `tsconfig.cjs.json` included all of `src/**/*`, so repository examples were compiled into the production `dist` directories. Because the package publishes `dist` and exposes a `"./*"` wildcard export, those compiled example paths became importable package subpaths.

Some server examples register `process` signal handlers at module scope. Importing one of those accidentally published example entry points could therefore attach a `SIGINT` handler as an import side effect.

## Fix

Add `src/examples/**/*` to the exclusion lists in both production TypeScript configurations.

Excluding the examples at the production-build boundary is safer than changing individual examples: examples remain runnable from source, while no current or future example implementation can accidentally become part of the supported package surface.

## Compatibility verification

The packed artifact retains all explicit export targets declared by the v1 package manifest. The regression test also checks these wildcard-backed targets in both ESM and CJS output:

- `client/stdio`
- `server/stdio`
- `shared/protocol`

## Validation

- `npm ci` — passed.
- `npx vitest run test/package-artifacts.test.ts` — 1 file passed, 8 tests passed.
- `npx vitest run --exclude "test/e2e/**" --exclude "test/client/stdio.test.ts"` — 51 files passed, 1609 tests passed.
- `npm run typecheck` — passed.
- `npx eslint src/ test/package-artifacts.test.ts` — passed.
- `npx prettier --check test/package-artifacts.test.ts tsconfig.prod.json tsconfig.cjs.json` — passed.
- `npm run build` with Git Bash configured as `npm_config_script_shell` on Windows — passed for ESM and CJS.
- `npm pack --dry-run --json --ignore-scripts` against the production build — 477 packed files, 0 compiled example paths, 14 verified export targets, 0 missing targets.
- Full `npm test` — 52 test files and 1614 assertions passed, but the command exited non-zero because `test/client/stdio.test.ts` produced two existing Windows-only `Unexpected end of JSON input` unhandled errors.
- Full `npm run lint` — ESLint passed; the repository-wide Prettier check reported 219 unchanged files due to CRLF checkout normalization on Windows. Focused formatting checks for all changed files passed.

## Related work

PR #1939 contains the same production configuration exclusion but does not include package-level regression coverage. This draft keeps the configuration change minimal while proving that published examples are removed and supported SDK subpaths remain intact.

Fixes #817