### PR TITLE
docs: add @modelcontextprotocol/fastify to middleware listings

### DIFF
--- a/docs/clients/middleware.md
+++ b/docs/clients/middleware.md
@@ -26,7 +26,7 @@ const transport = new StreamableHTTPClientTransport(new URL('http://localhost:30
 Every request this transport sends now carries the header — including the requests the SDK sends that you never wrote, like `initialize`.
 
 ::: info Not the framework middleware packages
-This page is about client request middleware: functions that wrap the `fetch` inside `@modelcontextprotocol/client`. The `@modelcontextprotocol/express`, `@modelcontextprotocol/hono`, and `@modelcontextprotocol/node` packages also carry the word "middleware" — those are server-side framework adapters for mounting a handler. See [Express](../serving/express.md) and [Hono](../serving/hono.md).
+This page is about client request middleware: functions that wrap the `fetch` inside `@modelcontextprotocol/client`. The `@modelcontextprotocol/express`, `@modelcontextprotocol/fastify`, `@modelcontextprotocol/hono`, and `@modelcontextprotocol/node` packages also carry the word "middleware" — those are server-side framework adapters for mounting a handler. See [Express](../serving/express.md), [Fastify](../serving/fastify.md), and [Hono](../serving/hono.md).
 :::
 
 ## Compose several middlewares


### PR DESCRIPTION
Fixes #2112

`@modelcontextprotocol/fastify` is published on npm (private: false, currently 2.0.0-beta.4, same shape as the other three middleware packages) but it wasn't mentioned in any of the prose listings. This adds it to:

- root `README.md`: the overview parenthetical, the middleware packages bullet list, and the install commands block (the three spots from the issue)
- `packages/middleware/README.md`: the packages list
- `packages/server/README.md`: the optional framework adapters line
- `docs/clients/middleware.md`: the "not the framework middleware packages" info note (also linked the Fastify serving page next to Express and Hono)

I found the last three by grepping for listings that mention hono but not fastify, and mentioned them on the issue before starting. Wording for the new fastify bullets copies the express one (app defaults + Host header validation) since that matches what the fastify package README says it does.

Checked locally: `pnpm typecheck:all`, `pnpm build:all`, `pnpm lint:all` and `pnpm docs:check` all pass (the docs build catches dead links, so the new fastify.md link is covered). Also confirmed the package page exists on npm so the npmjs link in the server README doesn't 404.

Docs only, so no changeset added (matching earlier docs PRs like #2426 and #2427).

---

small disclosure: i'm a college freshman getting started with OSS and i used claude code to help verify the sites and run the checks. the edits went through me and i double checked each spot, but if i missed a convention here i'm happy to fix it :)