### PR TITLE
fix(client): thread onresumptiontoken and onRequestStreamEnd through the send() resume path

### DIFF
--- a/.changeset/send-resume-threads-callbacks.md
+++ b/.changeset/send-resume-threads-callbacks.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/client': patch
+---
+
+`StreamableHTTPClientTransport.send()` no longer drops `onresumptiontoken` and `onRequestStreamEnd` when called with a `resumptionToken`. The resume branch opened the GET with the correct `Last-Event-ID` but passed neither callback to the reopened stream, so a caller resuming a long-running request stopped receiving newer resumption tokens — its persisted token went permanently stale, and a later resume replayed already-delivered events or fell outside the server event store's retention window — and was never notified when the stream ended non-resumably. Both callbacks are now threaded through, matching the original POST path and `resumeStream()`.

--- a/packages/client/src/client/streamableHttp.ts
+++ b/packages/client/src/client/streamableHttp.ts
@@ -927,10 +927,15 @@ export class StreamableHTTPClientTransport implements Transport {
                 // same per-request abort as the original POST — modern-era
                 // cancel-via-stream-close routes through `requestSignal`, and
                 // without it a resumed long-running request would not cancel.
+                // `onresumptiontoken` and `onRequestStreamEnd` must survive the
+                // resume as well: the caller keeps persisting newer tokens and
+                // must still learn when the stream ends non-resumably.
                 this._startOrAuthSse({
                     resumptionToken,
+                    onresumptiontoken,
                     replayMessageId: isJSONRPCRequest(message) ? message.id : undefined,
-                    requestSignal: options?.requestSignal
+                    requestSignal: options?.requestSignal,
+                    onRequestStreamEnd: options?.onRequestStreamEnd
                 }).catch(error => this.onerror?.(error));
                 return;
             }

--- a/packages/client/test/client/streamableHttp.test.ts
+++ b/packages/client/test/client/streamableHttp.test.ts
@@ -1984,6 +1984,54 @@ describe('StreamableHTTPClientTransport', () => {
             // Resumption token callback may be invoked, but the primary assertion
             // here is that no JSON parse errors occurred for the priming event.
         });
+
+        it('should thread onresumptiontoken and onRequestStreamEnd through the send() resume path', async () => {
+            transport = new StreamableHTTPClientTransport(new URL('http://localhost:1234/mcp'), {
+                reconnectionOptions: {
+                    initialReconnectionDelay: 10,
+                    maxReconnectionDelay: 1000,
+                    reconnectionDelayGrowFactor: 1,
+                    maxRetries: 0
+                }
+            });
+
+            const resumptionTokenSpy = vi.fn();
+            const streamEndSpy = vi.fn();
+
+            // The resumed stream delivers one id-bearing event, then ends
+            // (maxRetries 0 above: the end is non-resumable, no reconnect).
+            const resumedStream = new ReadableStream({
+                start(controller) {
+                    controller.enqueue(new TextEncoder().encode('id: evt-2\ndata: {"jsonrpc":"2.0","result":{},"id":"req-1"}\n\n'));
+                    controller.close();
+                }
+            });
+
+            const fetchMock = globalThis.fetch as Mock;
+            fetchMock.mockResolvedValueOnce({
+                ok: true,
+                status: 200,
+                headers: new Headers({ 'content-type': 'text/event-stream' }),
+                body: resumedStream
+            });
+
+            await transport.start();
+            transport.send(
+                { jsonrpc: '2.0', method: 'tools/call', id: 'req-1', params: {} },
+                { resumptionToken: 'evt-1', onresumptiontoken: resumptionTokenSpy, onRequestStreamEnd: streamEndSpy }
+            );
+
+            await vi.advanceTimersByTimeAsync(50);
+
+            // Sanity: the resume send() opened a GET carrying Last-Event-ID
+            expect(fetchMock.mock.calls[0]![1]?.method).toBe('GET');
+            expect((fetchMock.mock.calls[0]![1]?.headers as Headers).get('last-event-id')).toBe('evt-1');
+            // The caller's callbacks must stay wired across the resume:
+            // new tokens are reported for persistence…
+            expect(resumptionTokenSpy).toHaveBeenCalledWith('evt-2');
+            // …and the non-resumable end of the request stream is surfaced.
+            expect(streamEndSpy).toHaveBeenCalled();
+        });
     });
 
     it('invalidates all credentials on OAuthErrorCode.InvalidClient during auth', async () => {


### PR DESCRIPTION
## What's broken

When `send()` is called with a `resumptionToken` (the documented flow for resuming a long-running request after a disconnect), the resume branch reopens the SSE stream with the correct `Last-Event-ID` — but forwards neither `onresumptiontoken` nor `onRequestStreamEnd` to `_startOrAuthSse()`:

```ts
if (resumptionToken) {
    this._startOrAuthSse({
        resumptionToken,
        replayMessageId: isJSONRPCRequest(message) ? message.id : undefined,
        requestSignal: options?.requestSignal   // threaded — but the two callbacks in the same options object are not
    }).catch(error => this.onerror?.(error));
    return;
}
```

Both callbacks arrive in the same `options` object (`Protocol` forwards `{ resumptionToken, onresumptiontoken, requestSignal }` on every `transport.send`), and the original POST path threads both (`_send`, further down), as does `resumeStream()` for the identical stream. The comment above the resume branch shows `requestSignal` was threaded deliberately; the two callbacks sitting next to it were overlooked.

## Observable failure

For the rest of a resumed request's life — including all of its internal reconnects, which rebuild options from `StartSSEOptions` — the caller's `onresumptiontoken` never fires again. The host's persisted token goes permanently stale, so a later resume replays already-delivered events (duplicate responses/side effects) or falls outside the server event store's retention window entirely. `onRequestStreamEnd` is dropped on the same line, so a resumed per-request stream that dies non-resumably never notifies the caller.

Related but distinct from #2499 / #2509: that fix seeds `_handleSseStream`'s internal `lastEventId` tracker from the token; this one is about the caller-facing callbacks never being attached on the `send()` resume path at all. Even with #2509 merged, the callback still never fires here.

## Fix

Thread `onresumptiontoken` and `onRequestStreamEnd` through the resume branch's `_startOrAuthSse()` call, matching the POST path and `resumeStream()`.

## Tests

New test in `packages/client/test/client/streamableHttp.test.ts`: resumes via `send(..., { resumptionToken, onresumptiontoken, onRequestStreamEnd })` against a mocked GET SSE stream that delivers one id-bearing event and ends non-resumably (`maxRetries: 0`). Before the fix the GET goes out with the right `Last-Event-ID` but neither callback ever fires; after the fix both do. Full `@modelcontextprotocol/client` suite passes (749 tests), typecheck and lint clean. Changeset included (patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N6RtoHuxrDqTUo9Mw9h4Cv