### PR TITLE
fix: add root src/index.ts so the advertised root export resolves

### DIFF
--- a/.changeset/fix-root-export-missing-index.md
+++ b/.changeset/fix-root-export-missing-index.md
@@ -2,4 +2,5 @@
 '@modelcontextprotocol/sdk': patch
 ---
 
-Fix the root package export: add `src/index.ts` so the advertised `dist/{esm,cjs}/index.js` and `dist/esm/index.d.ts` are actually emitted and published. The root entry re-exports the shared protocol types/schemas and the in-memory transport; `Client` and `Server` remain on their `./client` and `./server` subpaths.
+Fix the root package export: add `src/index.ts` so the advertised `dist/{esm,cjs}/index.js` and `dist/esm/index.d.ts` are actually emitted and published. The root entry re-exports the shared protocol types/schemas and the in-memory transport; `Client` and `Server` remain on their
+`./client` and `./server` subpaths.

--- a/.changeset/fix-root-export-missing-index.md
+++ b/.changeset/fix-root-export-missing-index.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/sdk': patch
+---
+
+Fix the root package export: add `src/index.ts` so the advertised `dist/{esm,cjs}/index.js` and `dist/esm/index.d.ts` are actually emitted and published. The root entry re-exports the shared protocol types/schemas and the in-memory transport; `Client` and `Server` remain on their `./client` and `./server` subpaths.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,13 @@
+// Root entry for `@modelcontextprotocol/sdk`.
+//
+// package.json exposes this file via the `.` export. Without a source file
+// here, tsc emits nothing for the advertised dist/{esm,cjs}/index.{js,d.ts}
+// paths and the root import of the published package fails to resolve
+// (issue #2273).
+//
+// Re-export the shared protocol schemas/types and the in-memory transport.
+// `Client` and `Server` intentionally stay on their `./client` and `./server`
+// subpath exports: re-exporting both here would collide on identically named
+// symbols (TS2308).
+export * from './types.js';
+export * from './inMemory.js';

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import * as rootExport from '../src/index.js';
+
+// Regression tests for #2273: package.json advertises a root `.` export, so a
+// root source entry must exist and re-export the shared protocol surface.
+describe('root package export', () => {
+    it('exposes the shared protocol types and schemas', () => {
+        expect(rootExport.LATEST_PROTOCOL_VERSION).toBeDefined();
+        expect(rootExport.CallToolResultSchema).toBeDefined();
+        expect(rootExport.JSONRPCMessageSchema).toBeDefined();
+    });
+
+    it('exposes the in-memory transport', () => {
+        expect(rootExport.InMemoryTransport).toBeTypeOf('function');
+    });
+
+    it('matches the paths advertised in the package.json exports map', () => {
+        const pkg = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf8'));
+        const root = pkg.exports['.'];
+        // The `.` export must keep pointing at the root index build outputs
+        // that src/index.ts produces.
+        expect(root.import).toBe('./dist/esm/index.js');
+        expect(root.require).toBe('./dist/cjs/index.js');
+        expect(root.types).toBe('./dist/esm/index.d.ts');
+    });
+});


### PR DESCRIPTION
Fixes #2273

## Problem

`package.json` maps the root `.` export to `./dist/esm/index.js`, `./dist/cjs/index.js`, and `./dist/esm/index.d.ts`, but there is no `src/index.ts`, so `tsc` never emits those files and they are absent from the published tarball. Both `await import("@modelcontextprotocol/sdk")` and `require("@modelcontextprotocol/sdk")` fail with `ERR_MODULE_NOT_FOUND` / `MODULE_NOT_FOUND` before consumer code runs. Subpath exports (`/client`, `/server`, …) are unaffected.

Targets `v1.x` — `main` is now a monorepo without a root package, so it does not have this bug.

## Fix

Adds `src/index.ts` re-exporting the shared protocol surface, per the direction in the issue triage comment:

- `export * from "./types.js"` — protocol types, schemas, and constants
- `export * from "./inMemory.js"` — `InMemoryTransport`

`Client` and `Server` intentionally stay on their `./client` and `./server` subpath exports: re-exporting both from the root would collide on identically named symbols (TS2308).

Includes a regression test (`test/index.test.ts`) asserting the root entry exposes the protocol surface and that the `exports` map keeps pointing at the emitted paths, plus a patch changeset.

## Verification

- `npm run build` now emits all three previously missing files.
- Root import resolves in both module systems: ESM and CJS each expose **172 symbols**, including `LATEST_PROTOCOL_VERSION`, `CallToolResultSchema`, and `InMemoryTransport`.
- Full unit suite: **1609 tests pass**. (The 2 unhandled errors from `src/shared/stdio.ts` suites reproduce on clean `v1.x` and are unrelated.)
- `npm run typecheck`, `eslint`, and `prettier --check` all clean.