### PR TITLE
fix(client): accept form-encoded token responses

### DIFF
--- a/.changeset/oauth-token-form-responses.md
+++ b/.changeset/oauth-token-form-responses.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/client': patch
+---
+
+Accept OAuth token responses encoded as `application/x-www-form-urlencoded` in addition to JSON.

--- a/packages/client/src/client/auth.ts
+++ b/packages/client/src/client/auth.ts
@@ -2097,7 +2097,11 @@ export async function executeTokenRequest(
         throw await parseErrorResponse(response);
     }
 
-    const json: unknown = await response.json();
+    const contentType = response.headers?.get?.('content-type')?.split(';', 1)[0]?.trim().toLowerCase();
+    const json: unknown =
+        contentType === 'application/x-www-form-urlencoded'
+            ? Object.fromEntries(new URLSearchParams(await response.text()))
+            : await response.json();
 
     try {
         return OAuthTokensSchema.parse(json);

--- a/packages/client/test/client/auth.test.ts
+++ b/packages/client/test/client/auth.test.ts
@@ -2005,6 +2005,33 @@ describe('OAuth Authorization', () => {
             expect(body.get('redirect_uri')).toBe('http://localhost:3000/callback');
             expect(body.get('resource')).toBe('https://api.example.com/mcp-server');
         });
+
+        it('accepts form-encoded token responses', async () => {
+            mockFetch.mockResolvedValueOnce(
+                new Response(
+                    new URLSearchParams({
+                        access_token: validTokens.access_token,
+                        token_type: validTokens.token_type,
+                        expires_in: String(validTokens.expires_in),
+                        refresh_token: validTokens.refresh_token!
+                    }),
+                    {
+                        status: 200,
+                        headers: { 'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8' }
+                    }
+                )
+            );
+
+            const tokens = await exchangeAuthorization('https://auth.example.com', {
+                clientInformation: validClientInfo,
+                authorizationCode: 'code123',
+                codeVerifier: 'verifier123',
+                redirectUri: 'http://localhost:3000/callback'
+            });
+
+            expect(tokens).toEqual(validTokens);
+        });
+
         it('exchanges code for tokens with auth', async () => {
             mockFetch.mockResolvedValueOnce({
                 ok: true,


### PR DESCRIPTION
## Summary

- parse successful OAuth token responses as form data when the response media type is `application/x-www-form-urlencoded`
- preserve the existing JSON path for other response media types
- add regression coverage for a form response whose content type includes a charset parameter
- add a patch changeset for `@modelcontextprotocol/client`

Fixes #759.

## Why

`executeTokenRequest()` unconditionally called `response.json()`. OAuth providers that return a form-encoded token response therefore threw a `SyntaxError` even though the token fields were otherwise valid. The response now goes through the existing `OAuthTokensSchema` after decoding the declared form media type.

## Validation

- `pnpm --filter @modelcontextprotocol/client exec vitest run test/client/auth.test.ts` — 253 passed
- `pnpm --filter @modelcontextprotocol/client test` — 772 passed
- `pnpm lint:all` — passed
- `pnpm typecheck:all` — passed
- `pnpm build:all` — passed
- `pnpm test:all` — reaches two unrelated `@modelcontextprotocol/node` SSE assertions that also fail on untouched `origin/main` under Node 26.5.0 (`streamableHttp.test.ts:737` and `streamableHttp.test.ts:1522`)

## AI assistance

Codex assisted with repository triage and implementation. I reviewed the diff and ran the checks above.
