### PR TITLE
fix(core): clear consumed stdio read buffer

### DIFF
--- a/packages/core-internal/src/shared/stdio.ts
+++ b/packages/core-internal/src/shared/stdio.ts
@@ -31,7 +31,8 @@ export class ReadBuffer {
             }
 
             const line = this._buffer.toString('utf8', 0, index).replace(/\r$/, '');
-            this._buffer = this._buffer.subarray(index + 1);
+            const remainder = this._buffer.subarray(index + 1);
+            this._buffer = remainder.length === 0 ? undefined : remainder;
 
             try {
                 return deserializeMessage(line);

--- a/packages/core-internal/test/shared/stdio.test.ts
+++ b/packages/core-internal/test/shared/stdio.test.ts
@@ -22,6 +22,18 @@ test('should only yield a message after a newline', () => {
     expect(readBuffer.readMessage()).toBeNull();
 });
 
+test('should clear consumed buffer when newline is the final byte', () => {
+    const readBuffer = new ReadBuffer();
+
+    readBuffer.append(Buffer.from(JSON.stringify(testMessage) + '\n'));
+    expect(readBuffer.readMessage()).toEqual(testMessage);
+    expect((readBuffer as unknown as { _buffer?: Buffer })._buffer).toBeUndefined();
+
+    const nextChunk = Buffer.from(JSON.stringify(testMessage));
+    readBuffer.append(nextChunk);
+    expect((readBuffer as unknown as { _buffer?: Buffer })._buffer).toBe(nextChunk);
+});
+
 test('should be reusable after clearing', () => {
     const readBuffer = new ReadBuffer();
 


### PR DESCRIPTION
## Summary

- Clear `ReadBuffer`'s internal buffer when `readMessage()` consumes through the final byte.
- Preserve the existing zero-copy behavior for non-empty remainders.
- Add regression coverage that verifies the empty-buffer state is released and the next append keeps the incoming chunk instead of taking the concat path.

Fixes #2536.

## Verification

- `npx pnpm --filter @modelcontextprotocol/core-internal test -- test/shared/stdio.test.ts`
- `npx pnpm --filter @modelcontextprotocol/core-internal typecheck`
- `npx prettier --check packages/core-internal/src/shared/stdio.ts packages/core-internal/test/shared/stdio.test.ts`
- `npx eslint src/shared/stdio.ts` from `packages/core-internal`

Note: `pnpm --filter @modelcontextprotocol/core-internal lint` currently fails on repo-wide Prettier checks for many pre-existing files in my Windows checkout, so I ran Prettier/eslint on the touched files directly.