### PR TITLE
fix(stdio): release ReadBuffer backing after final byte

### DIFF
--- a/packages/core-internal/src/shared/stdio.ts
+++ b/packages/core-internal/src/shared/stdio.ts
@@ -31,7 +31,8 @@ export class ReadBuffer {
             }
 
             const line = this._buffer.toString('utf8', 0, index).replace(/\r$/, '');
-            this._buffer = this._buffer.subarray(index + 1);
+            const remainder = this._buffer.subarray(index + 1);
+            this._buffer = remainder.length === 0 ? undefined : remainder;
 
             try {
                 return deserializeMessage(line);

--- a/packages/core-internal/test/shared/stdio.test.ts
+++ b/packages/core-internal/test/shared/stdio.test.ts
@@ -1,3 +1,4 @@
+import { vi } from 'vitest';
 import { ReadBuffer, STDIO_DEFAULT_MAX_BUFFER_SIZE } from '../../src/shared/stdio';
 import type { JSONRPCMessage } from '../../src/types/index';
 
@@ -155,4 +156,18 @@ describe('buffer size limit', () => {
         readBuffer.append(Buffer.from(JSON.stringify({ jsonrpc: '2.0', method: 'ping' }) + '\n'));
         expect(readBuffer.readMessage()).not.toBeNull();
     });
+});
+
+test('should clear backing allocation when final byte is consumed', () => {
+    const readBuffer = new ReadBuffer();
+    const largePayload = 'x'.repeat(1024);
+    readBuffer.append(Buffer.from(JSON.stringify({ jsonrpc: '2.0', method: largePayload }) + '\n'));
+    expect(readBuffer.readMessage()).toEqual({ jsonrpc: '2.0', method: largePayload });
+
+    const appendSpy = vi.spyOn(Buffer, 'concat');
+    const nextChunk = Buffer.from(JSON.stringify(testMessage) + '\n');
+    readBuffer.append(nextChunk);
+    expect(appendSpy).not.toHaveBeenCalled();
+    expect(readBuffer.readMessage()).toEqual(testMessage);
+    appendSpy.mockRestore();
 });


### PR DESCRIPTION
## Problem

`ReadBuffer.readMessage()` leaves an empty `Buffer` subarray after consuming a complete line. The subarray still references the accumulated backing allocation, so idle stdio transports retain memory longer than necessary and the next append always copies via `Buffer.concat()` even when no bytes remain buffered.

## Approach

When the remainder after a newline is empty, set `_buffer` to `undefined` instead of an empty subarray. Non-empty remainders are unchanged.

## Test plan

- [x] Added regression test asserting `Buffer.concat` is not called on the next append after a fully consumed message
- [x] `pnpm --filter @modelcontextprotocol/core-internal test` (1294 passed)

Fixes #2536
