### PR TITLE
fix: harden SSE keep-alive lifecycle (v1.x backport of the #2541 review fixes)

### DIFF
--- a/.changeset/keepalive-lifecycle-hardening.md
+++ b/.changeset/keepalive-lifecycle-hardening.md
@@ -2,4 +2,4 @@
 '@modelcontextprotocol/sdk': patch
 ---
 
-Hardens the Streamable HTTP server transport's SSE keep-alive lifecycle: timers can no longer be armed after transport close or leak when a priming event write fails, invalid timer delays safely disable keep-alive, and SSE responses disable nginx-style proxy buffering.
+Hardens the Streamable HTTP server transport's SSE lifecycle: deferred work cannot register streams after transport close, error cleanup preserves successor request mappings, invalid timer delays safely disable keep-alive, and SSE responses disable proxy buffering.

--- a/.changeset/keepalive-lifecycle-hardening.md
+++ b/.changeset/keepalive-lifecycle-hardening.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/sdk': patch
+---
+
+Hardens the Streamable HTTP server transport's SSE keep-alive lifecycle: keep-alive timers can no longer be armed after the transport closes or leak when a priming event write fails, and a non-finite `keepAliveMs` disables keep-alive instead of arming a clamped ~1ms interval.

--- a/.changeset/keepalive-lifecycle-hardening.md
+++ b/.changeset/keepalive-lifecycle-hardening.md
@@ -2,4 +2,4 @@
 '@modelcontextprotocol/sdk': patch
 ---
 
-Hardens the Streamable HTTP server transport's SSE keep-alive lifecycle: keep-alive timers can no longer be armed after the transport closes or leak when a priming event write fails, and a non-finite `keepAliveMs` disables keep-alive instead of arming a clamped ~1ms interval.
+Hardens the Streamable HTTP server transport's SSE keep-alive lifecycle: timers can no longer be armed after transport close or leak when a priming event write fails, invalid timer delays safely disable keep-alive, and SSE responses disable nginx-style proxy buffering.

--- a/src/server/webStandardStreamableHttp.ts
+++ b/src/server/webStandardStreamableHttp.ts
@@ -227,6 +227,7 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
     // when sessionId is not set (undefined), it means the transport is in stateless mode
     private sessionIdGenerator: (() => string) | undefined;
     private _started: boolean = false;
+    private _closed: boolean = false;
     private _hasHandledRequest: boolean = false;
     private _streamMapping: Map<string, StreamMapping> = new Map();
     private _requestToStreamMapping: Map<RequestId, string> = new Map();
@@ -271,7 +272,12 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
      * clears itself if a write fails (stream already closed/cancelled).
      */
     private startKeepAlive(streamId: string, controller: ReadableStreamDefaultController<Uint8Array>, encoder: TextEncoder): void {
-        if (this._keepAliveMs <= 0) {
+        // A deferred arm (e.g. after an event-store await that straddled
+        // close()) must not outlive the transport: close()'s timer sweep has
+        // already run. The `> 0` polarity disables keep-alive for non-finite
+        // values (NaN fails every comparison) instead of arming a
+        // Node-clamped ~1ms interval.
+        if (!(this._keepAliveMs > 0) || this._closed) {
             return;
         }
         this.stopKeepAlive(streamId);
@@ -842,8 +848,6 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
                 }
             }
 
-            this.startKeepAlive(streamId, streamController!, encoder);
-
             // Write priming event if event store is configured (after mapping is set up)
             await this.writePrimingEvent(streamController!, encoder, streamId, clientProtocolVersion);
 
@@ -868,6 +872,14 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
             }
             // The server SHOULD NOT close the SSE stream before sending all JSON-RPC responses
             // This will be handled by the send() method when responses are ready
+
+            // Arm keep-alive only after the fallible awaits above — an error
+            // path returning 400 discards the Response, so nothing could ever
+            // cancel the stream and clear an already-armed timer. Skip if the
+            // responses already completed and cleaned the stream up.
+            if (this._streamMapping.get(streamId)?.controller === streamController!) {
+                this.startKeepAlive(streamId, streamController!, encoder);
+            }
 
             return new Response(readable, { status: 200, headers });
         } catch (error) {
@@ -961,6 +973,8 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
     }
 
     async close(): Promise<void> {
+        this._closed = true;
+
         // Close all SSE connections
         this._streamMapping.forEach(({ cleanup }) => {
             cleanup();

--- a/src/server/webStandardStreamableHttp.ts
+++ b/src/server/webStandardStreamableHttp.ts
@@ -156,7 +156,8 @@ export interface WebStandardStreamableHTTPServerTransportOptions {
      *
      * Comment frames are ignored by SSE parsers and never surface as messages.
      * Defaults to 15000 (per the WHATWG SSE spec recommendation of roughly every
-     * 15 seconds). Set to 0 to disable keep-alive frames.
+     * 15 seconds). Set to 0 to disable keep-alive frames; values below 1, above
+     * 2147483647, or non-finite values also disable the timer.
      */
     keepAliveMs?: number;
 }
@@ -276,7 +277,7 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
         // close()) must not outlive the transport: close()'s timer sweep has
         // already run. Invalid timer delays disable keep-alive rather than
         // letting setInterval clamp them to ~1ms and flood every stream.
-        if (!Number.isFinite(this._keepAliveMs) || this._keepAliveMs <= 0 || this._keepAliveMs > 2_147_483_647 || this._closed) {
+        if (!Number.isFinite(this._keepAliveMs) || this._keepAliveMs < 1 || this._keepAliveMs > 2_147_483_647 || this._closed) {
             return;
         }
         this.stopKeepAlive(streamId);
@@ -493,7 +494,8 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
         const headers: Record<string, string> = {
             'Content-Type': 'text/event-stream',
             'Cache-Control': 'no-cache, no-transform',
-            Connection: 'keep-alive'
+            Connection: 'keep-alive',
+            'X-Accel-Buffering': 'no'
         };
 
         // After initialization, always include the session ID if we have one
@@ -552,7 +554,8 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
             const headers: Record<string, string> = {
                 'Content-Type': 'text/event-stream',
                 'Cache-Control': 'no-cache, no-transform',
-                Connection: 'keep-alive'
+                Connection: 'keep-alive',
+                'X-Accel-Buffering': 'no'
             };
 
             if (this.sessionId !== undefined) {
@@ -839,7 +842,8 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
             const headers: Record<string, string> = {
                 'Content-Type': 'text/event-stream',
                 'Cache-Control': 'no-cache',
-                Connection: 'keep-alive'
+                Connection: 'keep-alive',
+                'X-Accel-Buffering': 'no'
             };
 
             // After initialization, always include the session ID if we have one

--- a/src/server/webStandardStreamableHttp.ts
+++ b/src/server/webStandardStreamableHttp.ts
@@ -274,10 +274,10 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
     private startKeepAlive(streamId: string, controller: ReadableStreamDefaultController<Uint8Array>, encoder: TextEncoder): void {
         // A deferred arm (e.g. after an event-store await that straddled
         // close()) must not outlive the transport: close()'s timer sweep has
-        // already run. The `> 0` polarity disables keep-alive for non-finite
-        // values (NaN fails every comparison) instead of arming a
-        // Node-clamped ~1ms interval.
-        if (!(this._keepAliveMs > 0) || this._closed) {
+        // already run. Non-finite intervals (NaN, Infinity) and non-positive
+        // ones disable keep-alive: setInterval would clamp them to ~1ms and
+        // flood every stream with comment frames.
+        if (!Number.isFinite(this._keepAliveMs) || this._keepAliveMs <= 0 || this._closed) {
             return;
         }
         this.stopKeepAlive(streamId);
@@ -589,6 +589,21 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
                 }
             });
 
+            // The transport may have closed while the replay await was parked:
+            // its cleanup sweep ran before this stream was registered, so
+            // registering now would strand a mapping (and an open controller)
+            // on a dead transport, hang the client on a stream that never
+            // ends, and 409-block a later resume of this stream id. End the
+            // stream instead so the client observes termination.
+            if (this._closed) {
+                try {
+                    streamController!.close();
+                } catch {
+                    // Controller might already be closed
+                }
+                return new Response(readable, { headers });
+            }
+
             this._streamMapping.set(replayedStreamId, {
                 controller: streamController!,
                 encoder,
@@ -664,6 +679,12 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
      * Handles POST requests containing JSON-RPC messages
      */
     private async handlePostRequest(req: Request, options?: HandleRequestOptions): Promise<Response> {
+        // Set once the SSE stream bookkeeping has been registered, so the
+        // catch below can reclaim it: an error after registration (a failed
+        // priming event write, a throwing message handler) returns 400 and
+        // discards the Response, leaving nothing that could ever cancel the
+        // stream or retire the request mappings.
+        let reclaimSseBookkeeping: (() => void) | undefined;
         try {
             // Validate the Accept header
             const acceptHeader = req.headers.get('accept');
@@ -848,6 +869,15 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
                 }
             }
 
+            reclaimSseBookkeeping = () => {
+                this._streamMapping.get(streamId)?.cleanup();
+                for (const message of messages) {
+                    if (isJSONRPCRequest(message)) {
+                        this._requestToStreamMapping.delete(message.id);
+                    }
+                }
+            };
+
             // Write priming event if event store is configured (after mapping is set up)
             await this.writePrimingEvent(streamController!, encoder, streamId, clientProtocolVersion);
 
@@ -885,6 +915,7 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
         } catch (error) {
             // return JSON-RPC formatted error
             this.onerror?.(error as Error);
+            reclaimSseBookkeeping?.();
             return this.createJsonErrorResponse(400, -32700, 'Parse error', { data: String(error) });
         }
     }

--- a/src/server/webStandardStreamableHttp.ts
+++ b/src/server/webStandardStreamableHttp.ts
@@ -382,6 +382,10 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
      * Returns a Response object (Web Standard)
      */
     async handleRequest(req: Request, options?: HandleRequestOptions): Promise<Response> {
+        if (this._closed) {
+            return this.createJsonErrorResponse(404, -32001, 'Session not found');
+        }
+
         // In stateless mode (no sessionIdGenerator), each request must use a fresh transport.
         // Reusing a stateless transport causes message ID collisions between clients.
         if (!this.sessionIdGenerator && this._hasHandledRequest) {
@@ -779,6 +783,12 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
                 }
             }
 
+            // Request parsing and session initialization may await user/runtime
+            // work. Do not register or dispatch after close() has swept state.
+            if (this._closed) {
+                return this.createJsonErrorResponse(404, -32001, 'Session not found');
+            }
+
             // check if it contains requests
             const hasRequests = messages.some(isJSONRPCRequest);
 
@@ -841,7 +851,7 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
 
             const headers: Record<string, string> = {
                 'Content-Type': 'text/event-stream',
-                'Cache-Control': 'no-cache',
+                'Cache-Control': 'no-cache, no-transform',
                 Connection: 'keep-alive',
                 'X-Accel-Buffering': 'no'
             };
@@ -875,7 +885,7 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
             reclaimSseBookkeeping = () => {
                 this._streamMapping.get(streamId)?.cleanup();
                 for (const message of messages) {
-                    if (isJSONRPCRequest(message)) {
+                    if (isJSONRPCRequest(message) && this._requestToStreamMapping.get(message.id) === streamId) {
                         this._requestToStreamMapping.delete(message.id);
                     }
                 }

--- a/src/server/webStandardStreamableHttp.ts
+++ b/src/server/webStandardStreamableHttp.ts
@@ -274,10 +274,9 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
     private startKeepAlive(streamId: string, controller: ReadableStreamDefaultController<Uint8Array>, encoder: TextEncoder): void {
         // A deferred arm (e.g. after an event-store await that straddled
         // close()) must not outlive the transport: close()'s timer sweep has
-        // already run. Non-finite intervals (NaN, Infinity) and non-positive
-        // ones disable keep-alive: setInterval would clamp them to ~1ms and
-        // flood every stream with comment frames.
-        if (!Number.isFinite(this._keepAliveMs) || this._keepAliveMs <= 0 || this._closed) {
+        // already run. Invalid timer delays disable keep-alive rather than
+        // letting setInterval clamp them to ~1ms and flood every stream.
+        if (!Number.isFinite(this._keepAliveMs) || this._keepAliveMs <= 0 || this._keepAliveMs > 2_147_483_647 || this._closed) {
             return;
         }
         this.stopKeepAlive(streamId);
@@ -681,8 +680,8 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
     private async handlePostRequest(req: Request, options?: HandleRequestOptions): Promise<Response> {
         // Set once the SSE stream bookkeeping has been registered, so the
         // catch below can reclaim it: an error after registration (a failed
-        // priming event write, a throwing message handler) returns 400 and
-        // discards the Response, leaving nothing that could ever cancel the
+        // priming event write, a throwing message handler) returns an error
+        // response, leaving nothing that could ever cancel the discarded
         // stream or retire the request mappings.
         let reclaimSseBookkeeping: (() => void) | undefined;
         try {

--- a/test/server/streamableHttp.test.ts
+++ b/test/server/streamableHttp.test.ts
@@ -3290,6 +3290,10 @@ describe('WebStandardStreamableHTTPServerTransport SSE keep-alive', () => {
         });
     }
 
+    function withSession(sessionId: string, extra?: Record<string, string>): Record<string, string> {
+        return { 'mcp-session-id': sessionId, 'mcp-protocol-version': '2025-11-25', ...extra };
+    }
+
     async function createTransport(options?: { keepAliveMs?: number }): Promise<{
         transport: WebStandardStreamableHTTPServerTransport;
         sessionId: string;
@@ -3444,6 +3448,98 @@ describe('WebStandardStreamableHTTPServerTransport SSE keep-alive', () => {
         await vi.advanceTimersByTimeAsync(15000);
         const { value } = await reader.read();
         expect(new TextDecoder().decode(value)).toBe(': keepalive\n\n');
+
+        await transport.close();
+    });
+
+    it('should disable keep-alive for a non-finite keepAliveMs instead of arming a clamped interval', async () => {
+        const { transport, sessionId } = await createTransport({ keepAliveMs: Number.NaN });
+
+        const response = await transport.handleRequest(req('GET', { headers: withSession(sessionId) }));
+        expect(response.status).toBe(200);
+
+        // No timer may be armed: setInterval(fn, NaN) would be clamped by
+        // Node to ~1ms and flood the stream with keep-alive frames.
+        expect(vi.getTimerCount()).toBe(0);
+        const reader = response.body!.getReader();
+        await vi.advanceTimersByTimeAsync(60000);
+        const raced = await Promise.race([reader.read(), Promise.resolve('pending')]);
+        expect(raced).toBe('pending');
+
+        await transport.close();
+    });
+
+    it('should not arm keep-alive when the transport closes during an event-store replay await', async () => {
+        let releaseReplay: (() => void) | undefined;
+        const eventStore: EventStore = {
+            async storeEvent(): Promise<EventId> {
+                return 'evt-1';
+            },
+            async replayEventsAfter(): Promise<StreamId> {
+                await new Promise<void>(resolve => {
+                    releaseReplay = resolve;
+                });
+                return '_GET_stream';
+            }
+        };
+        const transport = new WebStandardStreamableHTTPServerTransport({ sessionIdGenerator: () => randomUUID(), eventStore });
+        await new McpServer({ name: 'test-server', version: '1.0.0' }).connect(transport);
+        const initResponse = await transport.handleRequest(req('POST', { body: TEST_MESSAGES.initialize }));
+        const sessionId = initResponse.headers.get('mcp-session-id') as string;
+
+        // Enter replayEvents and park on the replayEventsAfter await
+        const pendingGet = transport.handleRequest(req('GET', { headers: { ...withSession(sessionId), 'Last-Event-ID': 'evt-1' } }));
+        await vi.advanceTimersByTimeAsync(0);
+        expect(releaseReplay).toBeDefined();
+
+        // Close the transport mid-await, then let the replay continuation run
+        await transport.close();
+        releaseReplay?.();
+        await pendingGet;
+
+        // The deferred continuation must not have armed a timer close() can never sweep
+        expect(vi.getTimerCount()).toBe(0);
+    });
+
+    it('should not leak a keep-alive timer when the priming event write fails on a POST SSE stream', async () => {
+        // Healthy during initialization, then the store starts failing — the
+        // tool call's priming event write must reject inside handlePostRequest
+        let storeFails = false;
+        const eventStore: EventStore = {
+            async storeEvent(): Promise<EventId> {
+                if (storeFails) {
+                    throw new Error('event store unavailable');
+                }
+                return `evt-${randomUUID()}`;
+            },
+            async replayEventsAfter(): Promise<StreamId> {
+                return 'stream-1';
+            }
+        };
+        const transport = new WebStandardStreamableHTTPServerTransport({ sessionIdGenerator: () => randomUUID(), eventStore });
+        const mcpServer = new McpServer({ name: 'test-server', version: '1.0.0' });
+        mcpServer.registerTool('noop', { description: 'noop' }, async () => ({ content: [] }));
+        await mcpServer.connect(transport);
+
+        const initResponse = await transport.handleRequest(req('POST', { body: TEST_MESSAGES.initialize }));
+        expect(initResponse.status).toBe(200);
+        const sessionId = initResponse.headers.get('mcp-session-id') as string;
+        // Let the init response finish sending (its send() stores an event and
+        // then cleans up the init stream's keep-alive) before failing the store
+        await vi.advanceTimersByTimeAsync(0);
+        expect(vi.getTimerCount()).toBe(0);
+        storeFails = true;
+
+        const response = await transport.handleRequest(
+            req('POST', {
+                body: { jsonrpc: '2.0', method: 'tools/call', params: { name: 'noop', arguments: {} }, id: 'call-1' },
+                headers: withSession(sessionId)
+            })
+        );
+        expect(response.status).toBe(400);
+
+        // The discarded stream must not carry a permanently-firing timer
+        expect(vi.getTimerCount()).toBe(0);
 
         await transport.close();
     });

--- a/test/server/streamableHttp.test.ts
+++ b/test/server/streamableHttp.test.ts
@@ -3452,8 +3452,8 @@ describe('WebStandardStreamableHTTPServerTransport SSE keep-alive', () => {
         await transport.close();
     });
 
-    it.each([Number.NaN, Number.POSITIVE_INFINITY])(
-        'should disable keep-alive for non-finite keepAliveMs %s instead of arming a clamped interval',
+    it.each([Number.NaN, Number.POSITIVE_INFINITY, 2_147_483_648])(
+        'should disable keep-alive for invalid keepAliveMs %s instead of arming a clamped interval',
         async keepAliveMs => {
             const { transport, sessionId } = await createTransport({ keepAliveMs });
 
@@ -3542,13 +3542,12 @@ describe('WebStandardStreamableHTTPServerTransport SSE keep-alive', () => {
         expect(vi.getTimerCount()).toBe(0);
         storeFails = true;
 
-        const response = await transport.handleRequest(
+        await transport.handleRequest(
             req('POST', {
                 body: { jsonrpc: '2.0', method: 'tools/call', params: { name: 'noop', arguments: {} }, id: 'call-1' },
                 headers: withSession(sessionId)
             })
         );
-        expect(response.status).toBe(400);
 
         // The discarded stream must not carry a permanently-firing timer
         expect(vi.getTimerCount()).toBe(0);

--- a/test/server/streamableHttp.test.ts
+++ b/test/server/streamableHttp.test.ts
@@ -270,6 +270,7 @@ describe.each(zodTestMatrix)('$zodVersionLabel', (entry: ZodMatrixEntry) => {
 
             expect(response.status).toBe(200);
             expect(response.headers.get('content-type')).toBe('text/event-stream');
+            expect(response.headers.get('cache-control')).toBe('no-cache, no-transform');
             expect(response.headers.get('x-accel-buffering')).toBe('no');
             expect(response.headers.get('mcp-session-id')).toBeDefined();
         });
@@ -487,6 +488,7 @@ describe.each(zodTestMatrix)('$zodVersionLabel', (entry: ZodMatrixEntry) => {
 
             expect(sseResponse.status).toBe(200);
             expect(sseResponse.headers.get('content-type')).toBe('text/event-stream');
+            expect(sseResponse.headers.get('cache-control')).toBe('no-cache, no-transform');
             expect(sseResponse.headers.get('x-accel-buffering')).toBe('no');
 
             // Send a notification (server-initiated message) that should appear on SSE stream
@@ -1446,6 +1448,7 @@ describe.each(zodTestMatrix)('$zodVersionLabel', (entry: ZodMatrixEntry) => {
             });
 
             expect(reconnectResponse.status).toBe(200);
+            expect(reconnectResponse.headers.get('cache-control')).toBe('no-cache, no-transform');
             expect(reconnectResponse.headers.get('x-accel-buffering')).toBe('no');
 
             // Read the replayed notification
@@ -3566,5 +3569,87 @@ describe('WebStandardStreamableHTTPServerTransport SSE keep-alive', () => {
         expect(internals._requestToStreamMapping.size).toBe(0);
 
         await transport.close();
+    });
+
+    it('should not reclaim a successor mapping that reused the failed POST request id', async () => {
+        let failPriming = false;
+        let rejectPriming: (() => void) | undefined;
+        const eventStore: EventStore = {
+            async storeEvent(): Promise<EventId> {
+                if (failPriming) {
+                    return new Promise<EventId>((_resolve, reject) => {
+                        rejectPriming = () => reject(new Error('event store unavailable'));
+                    });
+                }
+                return `evt-${randomUUID()}`;
+            },
+            async replayEventsAfter(): Promise<StreamId> {
+                return 'stream-1';
+            }
+        };
+        const transport = new WebStandardStreamableHTTPServerTransport({ sessionIdGenerator: () => randomUUID(), eventStore });
+        const mcpServer = new McpServer({ name: 'test-server', version: '1.0.0' });
+        mcpServer.registerTool('noop', { description: 'noop' }, async () => ({ content: [] }));
+        await mcpServer.connect(transport);
+
+        const initResponse = await transport.handleRequest(req('POST', { body: TEST_MESSAGES.initialize }));
+        const sessionId = initResponse.headers.get('mcp-session-id') as string;
+        await vi.advanceTimersByTimeAsync(0);
+        failPriming = true;
+
+        const pending = transport.handleRequest(
+            req('POST', {
+                body: { jsonrpc: '2.0', method: 'tools/call', params: { name: 'noop', arguments: {} }, id: 'same-id' },
+                headers: withSession(sessionId)
+            })
+        );
+        await vi.advanceTimersByTimeAsync(0);
+        expect(rejectPriming).toBeDefined();
+
+        const internals = transport as unknown as {
+            _streamMapping: Map<string, unknown>;
+            _requestToStreamMapping: Map<unknown, string>;
+        };
+        const failedStreamId = internals._requestToStreamMapping.get('same-id');
+        expect(failedStreamId).toBeDefined();
+        internals._requestToStreamMapping.set('same-id', 'successor-stream');
+
+        rejectPriming?.();
+        await pending;
+
+        expect(internals._streamMapping.has(failedStreamId!)).toBe(false);
+        expect(internals._requestToStreamMapping.get('same-id')).toBe('successor-stream');
+        internals._requestToStreamMapping.delete('same-id');
+        await transport.close();
+    });
+
+    it('should not register a POST stream after close races session initialization', async () => {
+        let releaseInitialization: (() => void) | undefined;
+        const transport = new WebStandardStreamableHTTPServerTransport({
+            sessionIdGenerator: () => randomUUID(),
+            onsessioninitialized: async () => {
+                await new Promise<void>(resolve => {
+                    releaseInitialization = resolve;
+                });
+            }
+        });
+        await new McpServer({ name: 'test-server', version: '1.0.0' }).connect(transport);
+
+        const pendingInit = transport.handleRequest(req('POST', { body: TEST_MESSAGES.initialize }));
+        await vi.advanceTimersByTimeAsync(0);
+        expect(releaseInitialization).toBeDefined();
+
+        await transport.close();
+        releaseInitialization?.();
+        const response = await pendingInit;
+
+        expect(response.status).toBe(404);
+        expect(vi.getTimerCount()).toBe(0);
+        const internals = transport as unknown as {
+            _streamMapping: Map<string, unknown>;
+            _requestToStreamMapping: Map<unknown, string>;
+        };
+        expect(internals._streamMapping.size).toBe(0);
+        expect(internals._requestToStreamMapping.size).toBe(0);
     });
 });

--- a/test/server/streamableHttp.test.ts
+++ b/test/server/streamableHttp.test.ts
@@ -270,6 +270,7 @@ describe.each(zodTestMatrix)('$zodVersionLabel', (entry: ZodMatrixEntry) => {
 
             expect(response.status).toBe(200);
             expect(response.headers.get('content-type')).toBe('text/event-stream');
+            expect(response.headers.get('x-accel-buffering')).toBe('no');
             expect(response.headers.get('mcp-session-id')).toBeDefined();
         });
 
@@ -486,6 +487,7 @@ describe.each(zodTestMatrix)('$zodVersionLabel', (entry: ZodMatrixEntry) => {
 
             expect(sseResponse.status).toBe(200);
             expect(sseResponse.headers.get('content-type')).toBe('text/event-stream');
+            expect(sseResponse.headers.get('x-accel-buffering')).toBe('no');
 
             // Send a notification (server-initiated message) that should appear on SSE stream
             const notification: JSONRPCMessage = {
@@ -1444,6 +1446,7 @@ describe.each(zodTestMatrix)('$zodVersionLabel', (entry: ZodMatrixEntry) => {
             });
 
             expect(reconnectResponse.status).toBe(200);
+            expect(reconnectResponse.headers.get('x-accel-buffering')).toBe('no');
 
             // Read the replayed notification
             const reconnectReader = reconnectResponse.body?.getReader();
@@ -3452,7 +3455,7 @@ describe('WebStandardStreamableHTTPServerTransport SSE keep-alive', () => {
         await transport.close();
     });
 
-    it.each([Number.NaN, Number.POSITIVE_INFINITY, 2_147_483_648])(
+    it.each([0.5, Number.NaN, Number.POSITIVE_INFINITY, 2_147_483_648])(
         'should disable keep-alive for invalid keepAliveMs %s instead of arming a clamped interval',
         async keepAliveMs => {
             const { transport, sessionId } = await createTransport({ keepAliveMs });

--- a/test/server/streamableHttp.test.ts
+++ b/test/server/streamableHttp.test.ts
@@ -3452,22 +3452,26 @@ describe('WebStandardStreamableHTTPServerTransport SSE keep-alive', () => {
         await transport.close();
     });
 
-    it('should disable keep-alive for a non-finite keepAliveMs instead of arming a clamped interval', async () => {
-        const { transport, sessionId } = await createTransport({ keepAliveMs: Number.NaN });
+    it.each([Number.NaN, Number.POSITIVE_INFINITY])(
+        'should disable keep-alive for non-finite keepAliveMs %s instead of arming a clamped interval',
+        async keepAliveMs => {
+            const { transport, sessionId } = await createTransport({ keepAliveMs });
 
-        const response = await transport.handleRequest(req('GET', { headers: withSession(sessionId) }));
-        expect(response.status).toBe(200);
+            const response = await transport.handleRequest(req('GET', { headers: withSession(sessionId) }));
+            expect(response.status).toBe(200);
 
-        // No timer may be armed: setInterval(fn, NaN) would be clamped by
-        // Node to ~1ms and flood the stream with keep-alive frames.
-        expect(vi.getTimerCount()).toBe(0);
-        const reader = response.body!.getReader();
-        await vi.advanceTimersByTimeAsync(60000);
-        const raced = await Promise.race([reader.read(), Promise.resolve('pending')]);
-        expect(raced).toBe('pending');
+            // No timer may be armed: setInterval with a NaN/out-of-range delay
+            // is clamped by Node to ~1ms and would flood the stream with
+            // keep-alive frames.
+            expect(vi.getTimerCount()).toBe(0);
+            const reader = response.body!.getReader();
+            await vi.advanceTimersByTimeAsync(60000);
+            const raced = await Promise.race([reader.read(), Promise.resolve('pending')]);
+            expect(raced).toBe('pending');
 
-        await transport.close();
-    });
+            await transport.close();
+        }
+    );
 
     it('should not arm keep-alive when the transport closes during an event-store replay await', async () => {
         let releaseReplay: (() => void) | undefined;
@@ -3495,10 +3499,18 @@ describe('WebStandardStreamableHTTPServerTransport SSE keep-alive', () => {
         // Close the transport mid-await, then let the replay continuation run
         await transport.close();
         releaseReplay?.();
-        await pendingGet;
+        const replayResponse = await pendingGet;
 
         // The deferred continuation must not have armed a timer close() can never sweep
         expect(vi.getTimerCount()).toBe(0);
+
+        // The continuation must not re-register the stream on the closed
+        // transport: the client observes stream end instead of hanging on a
+        // dead session, and a later resume isn't 409-blocked by a stale entry.
+        const { done } = await replayResponse.body!.getReader().read();
+        expect(done).toBe(true);
+        const internals = transport as unknown as { _streamMapping: Map<string, unknown> };
+        expect(internals._streamMapping.size).toBe(0);
     });
 
     it('should not leak a keep-alive timer when the priming event write fails on a POST SSE stream', async () => {
@@ -3540,6 +3552,16 @@ describe('WebStandardStreamableHTTPServerTransport SSE keep-alive', () => {
 
         // The discarded stream must not carry a permanently-firing timer
         expect(vi.getTimerCount()).toBe(0);
+
+        // The stream bookkeeping registered before the failed priming write
+        // must be reclaimed too: repeated failures during an event-store
+        // outage must not accrete orphaned stream entries or request mappings.
+        const internals = transport as unknown as {
+            _streamMapping: Map<string, unknown>;
+            _requestToStreamMapping: Map<unknown, string>;
+        };
+        expect(internals._streamMapping.size).toBe(0);
+        expect(internals._requestToStreamMapping.size).toBe(0);
 
         await transport.close();
     });


### PR DESCRIPTION
Follow-up to #2538 (merged). Review of the v2 port (#2541) found lifecycle defects in the keep-alive implementation after #2538 had already merged, so `v1.x` carries them; this PR backports the fixes.

## Fix

- **Close races:** deferred replay/POST continuations re-check closed state before registering streams; requests on a terminated transport receive the spec's `404 Session not found` response.
- **POST error-path cleanup:** keep-alive is armed only after the fallible priming write and message dispatch. If either fails, the discarded response's stream and request mappings are reclaimed as well as its timer. Request-map deletion is ownership-checked so a failed retry cannot erase a successor using the same JSON-RPC id.
- **Safe interval validation:** sub-millisecond, non-finite, non-positive, and overflowing values disable keep-alive instead of being clamped to a ~1 ms frame flood.
- **Proxy delivery:** GET, POST, and replay SSE responses use `Cache-Control: no-cache, no-transform` and `X-Accel-Buffering: no`, matching v2.

## Verification

- transport suite: **170 tests passed**
- typecheck and lint passed
- ESM and CJS builds passed
- close-race test is mutation-verified (removing the `_closed` guard fails it)
- error-path tests cover timer teardown, empty maps, successor-map ownership, and post-await close races
- patch changeset included

This is intentionally a targeted hardening backport of #2541's review fixes. The separate pre-existing request-scoped replay defect in untouched `send()` behavior is tracked by #2151.
