### PR TITLE
fix(deps): widen @hono/node-server past GHSA-frvp-7c67-39w9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.29.0",
             "license": "MIT",
             "dependencies": {
-                "@hono/node-server": "^1.19.9",
+                "@hono/node-server": "^1.19.9 || ^2.0.5",
                 "ajv": "^8.17.1",
                 "ajv-formats": "^3.0.1",
                 "content-type": "^1.0.5",
@@ -667,12 +667,12 @@
             }
         },
         "node_modules/@hono/node-server": {
-            "version": "1.19.11",
-            "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
-            "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+            "version": "2.0.11",
+            "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.11.tgz",
+            "integrity": "sha512-bjD221KPLoJTWUwso1J6fGKiTXEUFedG/s0visavY4zakFPkeGURMRNly+FhBHs7T8Dz4qHaZIMX9ZoJHSJtKA==",
             "license": "MIT",
             "engines": {
-                "node": ">=18.14.1"
+                "node": ">=20"
             },
             "peerDependencies": {
                 "hono": "^4"
@@ -796,6 +796,19 @@
                 "zod": {
                     "optional": false
                 }
+            }
+        },
+        "node_modules/@modelcontextprotocol/sdk/node_modules/@hono/node-server": {
+            "version": "1.19.15",
+            "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.15.tgz",
+            "integrity": "sha512-Za2ai6TLdKjUvnur+eenO6nuYYipVAEhyCAdaV8IRvmU9kK8crOZUSYvIXn72E4f8fJqyAbpcJuTsYYmZp9Deg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.14.1"
+            },
+            "peerDependencies": {
+                "hono": "^4"
             }
         },
         "node_modules/@noble/hashes": {

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
         "test:conformance:client:all": "npx @modelcontextprotocol/conformance client --command 'npx tsx test/conformance/src/everythingClient.ts' --suite all --expected-failures test/conformance/conformance-baseline.yml"
     },
     "dependencies": {
-        "@hono/node-server": "^1.19.9",
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",


### PR DESCRIPTION
## Summary

Widens `@hono/node-server` so consumers can resolve a version that clears [GHSA-frvp-7c67-39w9](https://github.com/advisories/GHSA-frvp-7c67-39w9) (path traversal in `serve-static` on Windows; fixed in `>= 2.0.5`). There is no patched `1.x` line, so `^1.19.9` alone can never satisfy the advisory.

**Range change:** `"^1.19.9"` → `"^1.19.9 || ^2.0.5"`

- Dual range keeps the existing `1.x` floor for Node 18 installs (SDK still declares `engines.node: >=18`).
- `^2.0.5` makes the first patched version (and later 2.x) reachable without requiring every consumer to add an `overrides` entry.
- The SDK only imports `getRequestListener` from `@hono/node-server` (`src/server/streamableHttp.ts`); it does not use `serveStatic`. Downstream reports (see #2531) confirm the 2.x export is a drop-in for that symbol.

Fixes #2531  
Fixes #2548 (duplicate)

## Motivation

Unlike the `hono` / `fast-uri` cases in #2036 / #2042, this cannot be fixed by a lockfile refresh alone: the published range cannot select any patched version. `npm audit` therefore keeps flagging every consumer of `@modelcontextprotocol/sdk@>=1.25.0`, and npm’s suggested remediation incorrectly points at a downgrade to `1.24.3` (before the dependency existed), which breaks `StreamableHTTPServerTransport`.

## Test plan

- [x] `node -e "import { getRequestListener } from '@hono/node-server'"` — function export present on `@hono/node-server@2.0.11`
- [x] `npm run build` (esm + cjs)
- [x] `npm test -- test/server/streamableHttp.test.ts` — 162 passed
- [x] `npm test -- test/integration-tests/stateManagementStreamableHttp.test.ts` — 8 passed
- [x] Direct `@hono/node-server` dependency resolves to `2.0.11` under the new range (lockfile updated)

## Notes

- `@hono/node-server@2.x` declares `node >= 20`. The dual range preserves Node 18 compatibility for consumers who stay on 1.x; Node 20+ installs can take 2.x and clear the advisory.
- Nested vulnerability noise from `@modelcontextprotocol/conformance`’s older SDK copy is out of scope for this PR.