### PR TITLE
fix(client): reject stdio send() when the write fails instead of waiting for 'drain'

### DIFF
--- a/.changeset/stdio-client-send-drain-hang.md
+++ b/.changeset/stdio-client-send-drain-hang.md
@@ -1,0 +1,9 @@
+---
+'@modelcontextprotocol/client': patch
+---
+
+Fix `StdioClientTransport.send()` never settling when a backpressured write is still in flight and the pipe to the server dies. `send()` waited for a `'drain'` event, but a destroyed stream never drains, so the returned promise stayed pending and the `'drain'` listener was never removed. It now settles from the `write()` callback, which Node invokes on flush or on failure, so the send rejects with the underlying write error instead. This is what `StdioServerTransport.send()` already does for its own stdout.
+
+The visible symptom was `await client.notification(...)`, which never returned: the notification path awaits the transport send with no timeout, and the connection-closed teardown settles pending responses but not pending sends. Requests were already rescued by that teardown, so `callTool()` and friends now report the actual write error (`EPIPE`, `EOF`) rather than a generic connection-closed error.
+
+Reaching this needs a write the pipe will not accept in one go, which starts anywhere from tens to hundreds of KB depending on the platform pipe buffer and the Node version, sizes that base64 image payloads and file contents in tool arguments reach routinely.

--- a/packages/client/src/client/stdio.ts
+++ b/packages/client/src/client/stdio.ts
@@ -313,16 +313,18 @@ export class StdioClientTransport implements Transport {
     }
 
     send(message: JSONRPCMessage): Promise<void> {
-        return new Promise(resolve => {
+        return new Promise((resolve, reject) => {
             if (!this._process?.stdin) {
                 throw new SdkError(SdkErrorCode.NotConnected, 'Not connected');
             }
 
             const json = serializeMessage(message);
-            if (this._process.stdin.write(json)) {
+            // The write callback runs once the chunk is flushed or the write fails,
+            // so a backpressured send still settles when the server exits and
+            // destroys the pipe. Waiting on 'drain' alone parks forever there,
+            // because a destroyed stream never drains.
+            if (this._process.stdin.write(json, error => (error ? reject(error) : resolve()))) {
                 resolve();
-            } else {
-                this._process.stdin.once('drain', resolve);
             }
         });
     }

--- a/packages/client/test/client/stdio.test.ts
+++ b/packages/client/test/client/stdio.test.ts
@@ -150,3 +150,41 @@ test('_dispose releases the parent-side pipe handles even when a helper process 
     expect(proc.stdout?.destroyed).toBe(true);
     expect(proc.stdin?.destroyed).toBe(true);
 }, 10_000);
+
+test('send() rejects instead of hanging when the server exits before a large write flushes', async () => {
+    // A server that never reads stdin and then exits: the write stays buffered,
+    // and the exit destroys the pipe, so the stream can never flush or drain.
+    const transport = new StdioClientTransport({
+        command: process.execPath,
+        args: ['-e', 'setTimeout(() => process.exit(0), 200)']
+    });
+    transport.onerror = () => {};
+    await transport.start();
+    const stdin = (transport as unknown as { _process: import('node:child_process').ChildProcess })._process.stdin!;
+
+    // 8 MB of params, far past stdin's 16 KB high water mark, so write() returns
+    // false and the send has to wait for the stream instead of resolving at once.
+    const pending = transport.send({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: { name: 'echo', arguments: { blob: 'x'.repeat(8 * 1024 * 1024) } }
+    });
+
+    // Bounded so the unfixed behaviour reports as 'hung' rather than as a suite
+    // timeout. The rejection reason is platform specific (EPIPE, EOF), so only
+    // the fact that it settles is asserted.
+    const outcome = await Promise.race([
+        pending.then(
+            () => 'resolved' as const,
+            () => 'rejected' as const
+        ),
+        new Promise<'hung'>(resolve => {
+            setTimeout(() => resolve('hung'), 3000).unref();
+        })
+    ]);
+
+    expect(outcome).toBe('rejected');
+    expect(stdin.listenerCount('drain')).toBe(0);
+    await transport.close();
+}, 15_000);


### PR DESCRIPTION
`StdioClientTransport.send()` now settles from the `write()` callback, so a backpressured send can't stay pending forever when the pipe to the server dies.

## Motivation and Context

I noticed this while reading the two stdio transports side by side. The server one rejects a failed write, the client one has no error path at all: its promise executor only takes `resolve`, and a backpressured write resolves on `'drain'`. If the server process then exits, or `close()` escalates to SIGTERM and SIGKILL, the stream is destroyed, and a destroyed stream never drains. The promise just stays pending, and the `'drain'` listener is never removed.

The symptom is that `await client.notification(...)` never comes back. The notification path awaits the send with no timeout, and the connection-closed teardown settles pending responses but not pending sends, so nothing rescues it. I tried it against a server that answers `initialize`, stops reading stdin and exits, with 8 MB in flight: the await is still pending after 8 seconds, and with this change it rejects in 0.4 seconds. Requests were already covered by the teardown, so for them the only difference is that they now report the actual `EPIPE` instead of a generic connection-closed error.

You need a write the pipe won't take in one go to get there, which on Linux is between 160 KB and 224 KB depending on the Node version. Base64 image payloads and file contents in tool arguments reach that routinely.

The server transport has rejected on a write failure since #1568, with a test pinning its listener cleanup, so this brings the client side in line. The fast path stays as it was, since a `write()` that returns true still resolves right away and only the failure path differs.

## How Has This Been Tested?

- New test in `packages/client/test/client/stdio.test.ts`, using a server that never reads stdin and then exits with 8 MB of params in flight. Without the change the send never settles and the test reports `hung`; with it the send rejects and no `'drain'` listener is left behind, which is the same leak check the server transport test already makes. I bounded the wait so the old behaviour fails fast instead of timing out the suite, and I don't assert the rejection reason because it is platform specific.
- On Ubuntu the client suite is green on Node 20, 22 and 24, and `pnpm test:all` is green on Node 24. I also ran the new test ten times to make sure it isn't flaky. Typecheck, eslint and prettier are clean, changeset included.

## Breaking Changes

None. `send()` already returns `Promise<void>` and the sibling stdio transport rejects it on a write failure, so callers that awaited it keep working.

`v1.x` has the same pattern in `src/client/stdio.ts`, and in `src/server/stdio.ts` too since #1568 only landed on `main`. Happy to send that separately if you want it.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
