### PR TITLE
fix(server): leave SSE connection policy to adapters

### DIFF
--- a/.changeset/web-standard-connection-policy.md
+++ b/.changeset/web-standard-connection-policy.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/server': patch
+---
+
+Leave hop-by-hop connection policy for Streamable HTTP SSE responses to the HTTP adapter.

--- a/packages/server/src/server/streamableHttp.ts
+++ b/packages/server/src/server/streamableHttp.ts
@@ -480,8 +480,7 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
 
         const headers: Record<string, string> = {
             'Content-Type': 'text/event-stream',
-            'Cache-Control': 'no-cache, no-transform',
-            Connection: 'keep-alive'
+            'Cache-Control': 'no-cache, no-transform'
         };
 
         // After initialization, always include the session ID if we have one
@@ -536,8 +535,7 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
 
             const headers: Record<string, string> = {
                 'Content-Type': 'text/event-stream',
-                'Cache-Control': 'no-cache, no-transform',
-                Connection: 'keep-alive'
+                'Cache-Control': 'no-cache, no-transform'
             };
 
             if (this.sessionId !== undefined) {
@@ -837,8 +835,7 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
 
             const headers: Record<string, string> = {
                 'Content-Type': 'text/event-stream',
-                'Cache-Control': 'no-cache',
-                Connection: 'keep-alive'
+                'Cache-Control': 'no-cache'
             };
 
             // After initialization, always include the session ID if we have one

--- a/packages/server/test/server/streamableHttp.test.ts
+++ b/packages/server/test/server/streamableHttp.test.ts
@@ -166,6 +166,7 @@ describe('Zod v4', () => {
                 expect(response.status).toBe(200);
                 expect(response.headers.get('content-type')).toBe('text/event-stream');
                 expect(response.headers.get('mcp-session-id')).toBeDefined();
+                expect(response.headers.get('connection'), 'connection policy belongs to the HTTP adapter').toBeNull();
             });
 
             it('should reject second initialization request', async () => {
@@ -358,6 +359,7 @@ describe('Zod v4', () => {
                 expect(response.status).toBe(200);
                 expect(response.headers.get('content-type')).toBe('text/event-stream');
                 expect(response.headers.get('mcp-session-id')).toBe(sessionId);
+                expect(response.headers.get('connection'), 'connection policy belongs to the HTTP adapter').toBeNull();
             });
 
             it('should reject GET without Accept: text/event-stream', async () => {
@@ -857,6 +859,7 @@ describe('Zod v4', () => {
                 createRequest('GET', undefined, { sessionId, extraHeaders: { 'Last-Event-ID': primingId! } })
             );
             expect(reconnect.status).toBe(200);
+            expect(reconnect.headers.get('connection'), 'connection policy belongs to the HTTP adapter').toBeNull();
             release();
             const replayed = await readSSEEvent(reconnect);
             expect(replayed).toContain('notifications/progress');


### PR DESCRIPTION
## Summary

- remove `Connection: keep-alive` from the three Web Standard Streamable HTTP SSE response paths
- assert that POST, standalone GET, and Last-Event-ID replay responses do not set hop-by-hop connection policy
- add a patch changeset for `@modelcontextprotocol/server`

Fixes #2553.

## Why

A web-standard `Response` does not own the underlying connection and cannot know its lifetime. Setting `Connection: keep-alive` in the transport suppresses concrete HTTP/1.1 servers from advertising their real `Keep-Alive: timeout=...`, and `Connection` is forbidden on HTTP/2.

Omitting the header does not disable persistent connections. Node HTTP/1.1 can emit its own matching `Connection` and `Keep-Alive` headers, while HTTP/2 and other Fetch adapters remain free to apply their own policy. This adds no `Connection: close`, retry, or timeout behavior.

## Verification

- focused Streamable HTTP tests: 47/47
- full `@modelcontextprotocol/server` tests: 448/448
- server typecheck
- server ESLint and Prettier
- repository pre-push build, typecheck, lint, and snippet checks
- `git diff --check`

## Interaction with #2541

#2541 edits the same three header objects to add SSE heartbeat and anti-buffering behavior. The changes are semantically independent: retain its heartbeat and `X-Accel-Buffering` changes, while omitting only the hop-by-hop `Connection` header.