### PR TITLE
test: bump conformance referee to 0.2.0-alpha.10, unbaseline server-stateless

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1943,8 +1943,8 @@ importers:
         specifier: workspace:^
         version: link:../../packages/client
       '@modelcontextprotocol/conformance':
-        specifier: 0.2.0-alpha.9
-        version: 0.2.0-alpha.9(@cfworker/json-schema@4.1.1)
+        specifier: 0.2.0-alpha.10
+        version: 0.2.0-alpha.10(@cfworker/json-schema@4.1.1)
       '@modelcontextprotocol/core-internal':
         specifier: workspace:^
         version: link:../../packages/core-internal
@@ -3228,8 +3228,8 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
-  '@modelcontextprotocol/conformance@0.2.0-alpha.9':
-    resolution: {integrity: sha512-Bi5P5TQlOQGPJxCT7UAHbpG7wsR7sNZskHGtCoZBo6vDu416D2FXPgM4wKbg91teIgj4HjGkhnzlvP7U2dszfQ==}
+  '@modelcontextprotocol/conformance@0.2.0-alpha.10':
+    resolution: {integrity: sha512-0V/HZDdWHcg6j0zVBzBsXcPZ571IVi6umKgTpnBhtTx/jm/LONmGF6cIWL2k4Xjyps0OiHV6B37nj2s0pUg0nQ==}
     hasBin: true
 
   '@modelcontextprotocol/sdk@1.29.0':
@@ -7851,7 +7851,7 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@modelcontextprotocol/conformance@0.2.0-alpha.9(@cfworker/json-schema@4.1.1)':
+  '@modelcontextprotocol/conformance@0.2.0-alpha.10(@cfworker/json-schema@4.1.1)':
     dependencies:
       '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
       '@octokit/rest': 22.0.1

--- a/test/conformance/expected-failures.2026-07-28.yaml
+++ b/test/conformance/expected-failures.2026-07-28.yaml
@@ -28,17 +28,8 @@ client: []
     # --- Same gaps as the 2025 baseline (fail identically when forced to 2026-07-28) ---
     # (empty: SEP-2468/2352/2350/837 burned by the auth bundle; SEP-2106 burned earlier)
 
-server:
+server: []
     # --- Carried-forward scenarios (also run by the 2025 legs) ---
     # (json-schema-2020-12 burned by the SEP-2106 fixture;
     # sep-2164-resource-not-found burned by the spec#2907 error-code renumber +
     # alpha.5 referee.)
-    #
-    # --- spec PR #3002 — referee pinned at alpha.9 asserts the OLD shape ---
-    # Same three failing checks as the 2025-leg baseline entry
-    # (sep-2575-request-meta-invalid-missing-client-info, the
-    # missing-client-info iteration of sep-2575-http-server-meta-invalid-400,
-    # and sep-2575-server-implements-discover which requires body serverInfo):
-    # this SDK follows the final revision. Remove when the pin bumps to a
-    # conformance release that incorporates #3002 (alpha.10+).
-    - server-stateless

--- a/test/conformance/expected-failures.yaml
+++ b/test/conformance/expected-failures.yaml
@@ -2,7 +2,7 @@
 # CI exits 0 if only these fail, exits 1 on unexpected failures or stale entries.
 #
 # Baseline established against the published @modelcontextprotocol/conformance
-# release pinned in package.json (0.2.0-alpha.9). Newer conformance releases
+# release pinned in package.json (0.2.0-alpha.10). Newer conformance releases
 # are adopted by deliberately bumping the package.json pin and reconciling
 # this file in the same change.
 #
@@ -17,25 +17,24 @@
 # corresponding scenarios start passing and MUST be removed from this list (the
 # runner fails on stale entries), so the baseline burns down per milestone.
 
-client: []
+client:
     # --- Draft-spec scenarios (in `--suite draft`, also part of `--suite all`) ---
-    # (empty: SEP-2468/2352/2350/837/2207/990 burned by the auth bundle; the
+    # (none: SEP-2468/2352/2350/837/2207/990 burned by the auth bundle; the
     # last referee-side gap — conformance#361 callback-iss — closed at alpha.6)
+    #
+    # --- SEP-1932 (DPoP) / SEP-1933 (WIF) — extension-tagged auth scenarios, new in the alpha.10 referee ---
+    # The OAuth client implements neither DPoP proofs (RFC 9449) nor the
+    # urn:ietf:params:oauth:grant-type:jwt-bearer grant, so every check in
+    # these scenarios fails. Client-side extension scenarios are selected only
+    # by `--suite all`; the 2026 leg cannot flag them stale (extension
+    # scenarios never match a --spec-version filter).
+    - auth/dpop
+    - auth/dpop-nonce
+    - auth/wif-jwt-bearer
 
 server:
-    # --- spec PR #3002 — referee pinned at alpha.9 asserts the OLD shape ---
-    # The alpha.9 `server-stateless` scenario still enforces the pre-#3002
-    # spec: clientInfo required in the envelope, serverInfo a DiscoverResult
-    # body field. This SDK follows the final revision (clientInfo optional;
-    # identity in the result _meta), so exactly three checks fail:
-    #   - sep-2575-request-meta-invalid-missing-client-info
-    #   - sep-2575-http-server-meta-invalid-400 (the missing-client-info iteration)
-    #   - sep-2575-server-implements-discover (requires body serverInfo)
-    # Remove this entry when the pin bumps to a conformance release that
-    # incorporates #3002 (alpha.10+).
-    - server-stateless
     # --- SEP-2663 (io.modelcontextprotocol/tasks) — server SDK does not implement the tasks extension ---
-    # Extension-tagged scenarios; selected only by `--suite all` (the alpha.9 referee
+    # Extension-tagged scenarios; selected only by `--suite all` (the alpha.10 referee
     # has no server-side `--suite extensions`). The active/draft/2026 legs never select
     # them, so they cannot flag these entries as stale. `tasks-status-notifications` is
     # intentionally absent: the referee SKIPs it unconditionally (harness rewrite pending

--- a/test/conformance/package.json
+++ b/test/conformance/package.json
@@ -38,7 +38,7 @@
         "test:conformance:all": "pnpm run test:conformance:client:all && pnpm run test:conformance:server:all"
     },
     "devDependencies": {
-        "@modelcontextprotocol/conformance": "0.2.0-alpha.9",
+        "@modelcontextprotocol/conformance": "0.2.0-alpha.10",
         "@modelcontextprotocol/client": "workspace:^",
         "@modelcontextprotocol/server": "workspace:^",
         "@modelcontextprotocol/core-internal": "workspace:^",


### PR DESCRIPTION
conformance `0.2.0-alpha.10` incorporates [#403](https://github.com/modelcontextprotocol/conformance/pull/403), which flips the sep-2575 checks to the final spec [#3002](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/3002) discover shape (clientInfo optional on requests, serverInfo in the result `_meta` instead of the discover body) — the shape this SDK already implements. The `server-stateless` scenario now passes, so its entries and the accompanying spec-#3002 comment blocks leave both expected-failures baselines.

alpha.10 also ships the extension-tagged SEP-1932 (DPoP, [#394](https://github.com/modelcontextprotocol/conformance/pull/394)) and SEP-1933 (WIF, [#268](https://github.com/modelcontextprotocol/conformance/pull/268)) client auth scenarios, which the client `--suite all` leg selects ([#401](https://github.com/modelcontextprotocol/conformance/pull/401)). The OAuth client implements neither surface yet, so those three scenarios enter the client baseline.

All six CI legs (server active/draft/extensions/2026, client all/2026) pass locally against the new referee.