### PR TITLE
chore: bump version to 1.30.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@modelcontextprotocol/sdk",
-    "version": "1.29.0",
+    "version": "1.30.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@modelcontextprotocol/sdk",
-            "version": "1.29.0",
+            "version": "1.30.0",
             "license": "MIT",
             "dependencies": {
                 "@hono/node-server": "^1.19.9 || ^2.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@modelcontextprotocol/sdk",
-    "version": "1.29.0",
+    "version": "1.30.0",
     "description": "Model Context Protocol implementation for TypeScript",
     "license": "MIT",
     "author": "Anthropic, PBC (https://anthropic.com)",


### PR DESCRIPTION
Version bump for the next v1.x release. Since 1.29.0: SSE keep-alive comment frames from the Streamable HTTP server transport (#2538) and the keep-alive timer lifecycle fix on reconnect (#2547), plus the @hono/node-server range widened past GHSA-frvp-7c67-39w9 (#2549). Release flow after merge: publish a GitHub Release tagged v1.30.0 targeting the v1.x branch.