### PR TITLE
chore: exit changesets prerelease mode

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "beta",
   "initialVersions": {
     "@modelcontextprotocol/eslint-config": "2.0.0",


### PR DESCRIPTION
Exits changesets pre-release mode so the next Version Packages PR computes stable versions (2.0.0) for the fixed group instead of beta prereleases.

Merge order: after #2564 lands, merge this, then merge the regenerated Version Packages PR (#2555) and approve the publish. Stable versions publish to the `latest` dist-tag automatically.