### PR TITLE
docs: comprehensive GA pass — stable-release wording, released-spec links, install tags

### DIFF
--- a/.github/ISSUE_TEMPLATE/v2-feedback.yml
+++ b/.github/ISSUE_TEMPLATE/v2-feedback.yml
@@ -6,7 +6,7 @@ body:
     - type: markdown
       attributes:
           value: |
-              Thanks for trying v2. Anything that broke, surprised you, or slowed you down is useful — API feedback is explicitly welcome while v2 is in beta.
+              Thanks for trying v2. Anything that broke, surprised you, or slowed you down is useful — API feedback is explicitly welcome while v2 settles.
 
               Docs: https://ts.sdk.modelcontextprotocol.io/v2/ · Migration from v1: https://ts.sdk.modelcontextprotocol.io/v2/migration/
     - type: textarea

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ By the time you open a PR, the "what" and "why" should already be settled in an 
 
 This repository has two main branches:
 
-- **`main`** – v2 of the SDK (currently in development). This is a monorepo with split packages.
+- **`main`** – v2 of the SDK (the stable release line). This is a monorepo with split packages.
 - **`v1.x`** – stable v1 release. Bug fixes and patches for v1 should target this branch.
 
 **Which branch should I use as a base?**

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ This repository contains the TypeScript SDK implementation of the MCP specificat
 
 - MCP **server** libraries (tools/resources/prompts, Streamable HTTP, stdio, auth helpers)
 - MCP **client** libraries (transports, high-level helpers, OAuth helpers)
-- Optional **middleware packages** for specific runtimes/frameworks (Express, Hono, Node.js HTTP)
+- Optional **middleware packages** for specific runtimes/frameworks (Express, Fastify, Hono, Node.js HTTP)
 - Runnable **examples** (under [`examples/`](https://github.com/modelcontextprotocol/typescript-sdk/tree/main/examples))
 
 ## Packages
@@ -58,6 +58,7 @@ They are intentionally thin adapters: they should not introduce new MCP function
 
 - **`@modelcontextprotocol/node`**: Node.js Streamable HTTP transport wrapper for `IncomingMessage` / `ServerResponse`
 - **`@modelcontextprotocol/express`**: Express helpers (app defaults + Host header validation)
+- **`@modelcontextprotocol/fastify`**: Fastify helpers (app defaults + Host header validation)
 - **`@modelcontextprotocol/hono`**: Hono helpers (app defaults + JSON body parsing hook + Host header validation)
 
 ## Installation
@@ -94,6 +95,9 @@ npm install @modelcontextprotocol/node
 
 # Express integration:
 npm install @modelcontextprotocol/express express
+
+# Fastify integration:
+npm install @modelcontextprotocol/fastify fastify
 
 # Hono integration:
 npm install @modelcontextprotocol/hono hono

--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@
 
 <!-- prettier-ignore -->
 > [!IMPORTANT]
-> **This is the `main` branch — v2 of the SDK, now in beta** (`@modelcontextprotocol/server`, `@modelcontextprotocol/client`), implementing the [2026-07-28 MCP spec](https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/).
+> **This is the `main` branch — v2 of the SDK** (`@modelcontextprotocol/server`, `@modelcontextprotocol/client`), implementing the [2026-07-28 MCP spec](https://modelcontextprotocol.io/specification/2026-07-28).
 >
 > **Have feedback? Please [open a v2 issue](https://github.com/modelcontextprotocol/typescript-sdk/issues/new?template=v2-feedback.yml)** — it is the most useful thing you can do for the SDK right now. The [v2 documentation](https://ts.sdk.modelcontextprotocol.io/v2/) starts with a ten-minute server tutorial.
 >
-> We expect a stable release alongside the full release of the 2026-07-28 spec on July 28, 2026. Until then, **v1.x remains the supported release for production**; it keeps receiving bug fixes and security updates for at least 6 months after v2 ships. v1 documentation: [ts.sdk.modelcontextprotocol.io](https://ts.sdk.modelcontextprotocol.io/) · v2: [`/v2/`](https://ts.sdk.modelcontextprotocol.io/v2/).
+> **v2 is the stable release line**, released alongside the 2026-07-28 spec. v1.x continues to receive bug fixes and security updates for at least 6 months after v2's release. v1 documentation: [ts.sdk.modelcontextprotocol.io](https://ts.sdk.modelcontextprotocol.io/) · v2: [`/v2/`](https://ts.sdk.modelcontextprotocol.io/v2/).
 
 <!-- prettier-ignore -->
 > [!WARNING]
-> **We're limiting pull requests to 1 per new contributor while we land the [2026-07-28 spec](https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/) implementation.**
+> **We're limiting pull requests to 1 per new contributor while v2 settles after the [2026-07-28 spec](https://modelcontextprotocol.io/specification/2026-07-28) release.**
 >
 > [Issues](https://github.com/modelcontextprotocol/typescript-sdk/issues/new?template=v2-feedback.yml) are the most useful feedback right now — we'll reopen PRs as v2 stabilizes.
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ deno add npm:@modelcontextprotocol/client
 
 ### Optional middleware packages
 
-The SDK also publishes optional “middleware” packages that help you **wire MCP into a specific runtime or web framework** (for example Express, Hono, or Node.js `http`).
+The SDK also publishes optional “middleware” packages that help you **wire MCP into a specific runtime or web framework** (for example Express, Fastify, Hono, or Node.js `http`).
 
 These packages are intentionally thin adapters and should not introduce additional MCP features or business logic. See [`packages/middleware/README.md`](packages/middleware/README.md) for details.
 

--- a/docs/.vitepress/llms.ts
+++ b/docs/.vitepress/llms.ts
@@ -172,7 +172,7 @@ export function generateLlmsArtifacts(docsDir: string, outDir: string, site: str
     const header = [
         '# MCP TypeScript SDK',
         '',
-        '> The official TypeScript SDK for the Model Context Protocol (MCP): build MCP servers and clients on Node.js, Bun, Deno, and Workers. This is the v2 beta documentation, tracking the 2026-07-28 spec revision.',
+        '> The official TypeScript SDK for the Model Context Protocol (MCP): build MCP servers and clients on Node.js, Bun, Deno, and Workers. This is the v2 documentation, covering the 2026-07-28 spec revision.',
         '',
         'Every page below is also served as plain markdown at its `.md` URL — fetch any page directly.',
         ''

--- a/docs/.vitepress/theme/Banner.vue
+++ b/docs/.vitepress/theme/Banner.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="version-banner">
-        This is the documentation for the v2 beta — looking for the
+        This is the documentation for v2 — looking for the
         <a href="https://ts.sdk.modelcontextprotocol.io/" target="_self">v1 documentation</a>?
     </div>
 </template>

--- a/docs/clients/roots.md
+++ b/docs/clients/roots.md
@@ -4,7 +4,7 @@ shape: how-to
 # Provide roots
 
 ::: warning Deprecated — SEP-2577
-Pass paths through tool arguments, resource URIs, or host configuration instead. **Roots** are deprecated as of protocol version 2026-07-28 (SEP-2577) and stay functional on 2025-era connections for at least twelve months — see the [deprecated features registry](https://modelcontextprotocol.io/specification/draft/deprecated).
+Pass paths through tool arguments, resource URIs, or host configuration instead. **Roots** are deprecated as of protocol version 2026-07-28 (SEP-2577) and stay functional on 2025-era connections for at least twelve months — see the [deprecated features registry](https://modelcontextprotocol.io/specification/2026-07-28/deprecated).
 :::
 
 ## Migrate away first

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,8 +4,8 @@ shape: landing
 
 # MCP TypeScript SDK
 
-::: info v2 beta
-This is the documentation for **v2** of the SDK, currently in **beta**: the API is settling but can still change before the stable release alongside the [2026-07-28 spec](https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/). [Tell us what you find](https://github.com/modelcontextprotocol/typescript-sdk/issues/new?template=v2-feedback.yml) — and if you need the stable v1, its documentation is at [ts.sdk.modelcontextprotocol.io](https://ts.sdk.modelcontextprotocol.io/).
+::: info v2
+This is the documentation for **v2** of the SDK, the stable release line implementing the [2026-07-28 spec](https://modelcontextprotocol.io/specification/2026-07-28). [Report issues](https://github.com/modelcontextprotocol/typescript-sdk/issues/new/choose) — and if you need v1, its documentation is at [ts.sdk.modelcontextprotocol.io](https://ts.sdk.modelcontextprotocol.io/).
 :::
 
 The **Model Context Protocol** (MCP) is an open standard that connects AI applications to the systems where your data and tools live. You write a **server** that exposes tools, resources, and prompts; any MCP **host** — Claude Code, VS Code, Cursor, your own application — connects to it and lets a model use them. The protocol is defined by [the MCP specification](https://modelcontextprotocol.io/specification/latest); this SDK is its TypeScript implementation, on Node.js, Bun, and Deno.

--- a/docs/migration/index.md
+++ b/docs/migration/index.md
@@ -19,7 +19,7 @@ v2 packages (`@modelcontextprotocol/client`, `@modelcontextprotocol/server`, …
 Start by running the codemod:
 
 ```bash
-npx @modelcontextprotocol/codemod@beta v1-to-v2 .
+npx @modelcontextprotocol/codemod@latest v1-to-v2 .
 ```
 
 Run it at the package root (`.`) — real projects import the SDK from `test/`,

--- a/docs/migration/support-2026-07-28.md
+++ b/docs/migration/support-2026-07-28.md
@@ -9,11 +9,6 @@ protocol revision — and for code written against an earlier **v2 alpha** that 
 wire-only members directly. If you are on `@modelcontextprotocol/sdk` (v1.x), start with
 [upgrade-to-v2.md](./upgrade-to-v2.md) instead.
 
-> **Schema artifact:** until the revision is finalized, the spec repository publishes
-> the 2026-07-28 schema under `schema/draft/` — there is no `schema/2026-07-28/`
-> directory yet. Tooling that vendors per-revision schema artifacts should track
-> `draft/` and note the divergence.
-
 Nothing in v2 puts a 2026-07-28 byte on the wire by default: a hand-constructed
 `Client` / `Server` / `McpServer` keeps speaking the 2025-era protocol it was written
 for. Serving or speaking 2026-07-28 is always an explicit opt-in via one of the entries
@@ -366,7 +361,7 @@ tightening that **does** affect v1 code (custom-handler `_meta` passthrough,
 `CallToolResult.content` keeps its v1 default on the legacy era (2026-07-28
 connections require it explicitly).
 
-> **If you were on a v2 alpha:** the 2026-07-28 draft error codes were renumbered:
+> **If you were on a v2 alpha:** the 2026-07-28 error codes were renumbered:
 > `HeaderMismatch` `-32001`→`-32020`, `MissingRequiredClientCapability` `-32003`→`-32021`,
 > `UnsupportedProtocolVersion` `-32004`→`-32022`. No v1.x impact (these codes never
 > existed in v1); v2-alpha code that hard-coded the old literals must update — prefer

--- a/docs/migration/upgrade-to-v2.md
+++ b/docs/migration/upgrade-to-v2.md
@@ -235,8 +235,7 @@ changed: v2 emits `.mjs`/`.cjs` siblings in a flat `dist/`, so v1's `/dist/cjs/`
 
 #### Registry availability
 
-All v2 packages are published on the public npm registry. Two notes
-window:
+All v2 packages are published on the public npm registry. Two notes:
 
 - As of `2.0.0-beta.1` all v2 packages share one version number (earlier alphas
   did not). The codemod writes ranges that match what is published, so prefer its

--- a/docs/migration/upgrade-to-v2.md
+++ b/docs/migration/upgrade-to-v2.md
@@ -19,7 +19,7 @@ If you are already on v2 and want to adopt the **2026-07-28 protocol revision**,
    both `import` and `require('@modelcontextprotocol/…')` resolve natively.
 2. **Run the codemod.**
     ```bash
-    npx @modelcontextprotocol/codemod@beta v1-to-v2 .
+    npx @modelcontextprotocol/codemod@latest v1-to-v2 .
     ```
     Run it at the **package root** (`.`), not `./src` — it also rewrites `package.json`,
     and real projects import the SDK from `test/`, `scripts/`, and fixtures too.

--- a/docs/migration/upgrade-to-v2.md
+++ b/docs/migration/upgrade-to-v2.md
@@ -233,9 +233,9 @@ quote-anchored pattern misses silently — match either quote. The build layout 
 changed: v2 emits `.mjs`/`.cjs` siblings in a flat `dist/`, so v1's `/dist/cjs/` ↔
 `/dist/esm/` flavor-pair path swaps have no equivalent.
 
-#### Registry availability during the beta
+#### Registry availability
 
-All v2 packages are published on the public npm registry. Two notes for the beta
+All v2 packages are published on the public npm registry. Two notes
 window:
 
 - As of `2.0.0-beta.1` all v2 packages share one version number (earlier alphas

--- a/docs/servers/logging-progress-cancellation.md
+++ b/docs/servers/logging-progress-cancellation.md
@@ -74,7 +74,7 @@ Only the result comes back:
 ## Log to the client
 
 ::: warning Deprecated — SEP-2577
-Log to `stderr` (stdio servers) or use OpenTelemetry instead. **MCP logging** is deprecated as of protocol version 2026-07-28 (SEP-2577) and stays functional through the deprecation window (at least twelve months) — see the [deprecated features registry](https://modelcontextprotocol.io/specification/draft/deprecated).
+Log to `stderr` (stdio servers) or use OpenTelemetry instead. **MCP logging** is deprecated as of protocol version 2026-07-28 (SEP-2577) and stays functional through the deprecation window (at least twelve months) — see the [deprecated features registry](https://modelcontextprotocol.io/specification/2026-07-28/deprecated).
 :::
 
 Declare the `logging` capability when you construct the server.

--- a/docs/servers/sampling.md
+++ b/docs/servers/sampling.md
@@ -4,7 +4,7 @@ shape: how-to
 # Sampling
 
 ::: warning Deprecated — SEP-2577
-Call your LLM provider's API directly from your server instead. **Sampling** is deprecated as of protocol version 2026-07-28 (SEP-2577) and stays functional on 2025-era connections for at least twelve months — see the [deprecated features registry](https://modelcontextprotocol.io/specification/draft/deprecated).
+Call your LLM provider's API directly from your server instead. **Sampling** is deprecated as of protocol version 2026-07-28 (SEP-2577) and stays functional on 2025-era connections for at least twelve months — see the [deprecated features registry](https://modelcontextprotocol.io/specification/2026-07-28/deprecated).
 :::
 
 ## Replace sampling with a direct provider call

--- a/docs/v1/.vitepress/theme/Banner.vue
+++ b/docs/v1/.vitepress/theme/Banner.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="version-banner">
         This is the documentation for v1.x — looking for the
-        <a href="https://ts.sdk.modelcontextprotocol.io/v2/" target="_self">v2 beta documentation</a>?
+        <a href="https://ts.sdk.modelcontextprotocol.io/v2/" target="_self">v2 documentation</a>?
     </div>
 </template>

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -4,7 +4,7 @@ The MCP (Model Context Protocol) TypeScript client SDK. Build MCP clients that c
 
 <!-- prettier-ignore -->
 > [!WARNING]
-> **This is a beta release.** The API surface is settling but breaking changes remain possible until v2 stabilizes. Please try it and open issues — feedback during the beta directly shapes the stable release.
+> **v2 is the stable release line**, implementing the [2026-07-28 MCP spec](https://modelcontextprotocol.io/specification/2026-07-28). Migrating from v1? Start with the [migration guide](https://ts.sdk.modelcontextprotocol.io/v2/migration/).
 
 <!-- prettier-ignore -->
 > [!NOTE]
@@ -13,7 +13,7 @@ The MCP (Model Context Protocol) TypeScript client SDK. Build MCP clients that c
 ## Install
 
 ```bash
-npm install @modelcontextprotocol/client@latest
+npm install @modelcontextprotocol/client
 ```
 
 TypeScript ≥6.0 no longer auto-includes `@types/*` — add `"types": ["node"]` to your `tsconfig.json` `compilerOptions` (the published `.d.mts` references `Buffer`).

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -13,7 +13,7 @@ The MCP (Model Context Protocol) TypeScript client SDK. Build MCP clients that c
 ## Install
 
 ```bash
-npm install @modelcontextprotocol/client@beta
+npm install @modelcontextprotocol/client@latest
 ```
 
 TypeScript ≥6.0 no longer auto-includes `@types/*` — add `"types": ["node"]` to your `tsconfig.json` `compilerOptions` (the published `.d.mts` references `Buffer`).

--- a/packages/client/src/client/authExtensions.ts
+++ b/packages/client/src/client/authExtensions.ts
@@ -572,7 +572,7 @@ export interface CrossAppAccessProviderOptions {
  * a callback function that you provide. This allows flexibility in how you obtain and
  * cache ID Tokens from the IdP.
  *
- * @see https://github.com/modelcontextprotocol/ext-auth/blob/main/specification/draft/enterprise-managed-authorization.mdx
+ * @see https://github.com/modelcontextprotocol/ext-auth/blob/main/specification/stable/enterprise-managed-authorization.mdx
  *
  * @example
  * ```ts

--- a/packages/client/src/client/crossAppAccess.ts
+++ b/packages/client/src/client/crossAppAccess.ts
@@ -4,7 +4,7 @@
  * Provides standalone functions for RFC 8693 Token Exchange and RFC 7523 JWT Authorization Grant
  * flows as specified in the Enterprise Managed Authorization specification (SEP-990).
  *
- * @see https://github.com/modelcontextprotocol/ext-auth/blob/main/specification/draft/enterprise-managed-authorization.mdx
+ * @see https://github.com/modelcontextprotocol/ext-auth/blob/main/specification/stable/enterprise-managed-authorization.mdx
  * @module
  */
 

--- a/packages/codemod/README.md
+++ b/packages/codemod/README.md
@@ -5,10 +5,10 @@ Codemods for migrating MCP TypeScript SDK code between major versions.
 ## Usage
 
 ```bash
-npx @modelcontextprotocol/codemod@beta v1-to-v2 .
+npx @modelcontextprotocol/codemod@latest v1-to-v2 .
 
 # or a single source file (manifest changes are reported, not applied)
-npx @modelcontextprotocol/codemod@beta v1-to-v2 src/server.ts
+npx @modelcontextprotocol/codemod@latest v1-to-v2 src/server.ts
 ```
 
 The codemod rewrites TypeScript and JavaScript source files

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -49,7 +49,7 @@ export const RequestMetaSchema = z.looseObject({
  */
 export const BaseRequestParamsSchema = z.object({
     /**
-     * See [General fields: `_meta`](/specification/draft/basic/index#meta) for notes on `_meta` usage.
+     * See [General fields: `_meta`](https://modelcontextprotocol.io/specification/2026-07-28/basic/index#meta) for notes on `_meta` usage.
      */
     _meta: RequestMetaSchema.optional()
 });
@@ -78,7 +78,7 @@ export const RequestSchema = z.object({
 
 export const NotificationsParamsSchema = z.object({
     /**
-     * See [MCP specification](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/47339c03c143bb4ec01a26e721a1b8fe66634ebe/docs/specification/draft/basic/index.mdx#general-fields)
+     * See [MCP specification](https://modelcontextprotocol.io/specification/2026-07-28/basic/index#general-fields)
      * for notes on `_meta` usage.
      */
     _meta: RequestMetaSchema.optional()
@@ -113,7 +113,7 @@ export const ResultMetaObjectSchema = z.looseObject({
 
 export const ResultSchema = z.looseObject({
     /**
-     * See [MCP specification](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/47339c03c143bb4ec01a26e721a1b8fe66634ebe/docs/specification/draft/basic/index.mdx#general-fields)
+     * See [MCP specification](https://modelcontextprotocol.io/specification/2026-07-28/basic/index#general-fields)
      * for notes on `_meta` usage.
      */
     _meta: ResultMetaObjectSchema.optional()
@@ -695,7 +695,7 @@ export const ResourceContentsSchema = z.object({
      */
     mimeType: z.optional(z.string()),
     /**
-     * See [MCP specification](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/47339c03c143bb4ec01a26e721a1b8fe66634ebe/docs/specification/draft/basic/index.mdx#general-fields)
+     * See [MCP specification](https://modelcontextprotocol.io/specification/2026-07-28/basic/index#general-fields)
      * for notes on `_meta` usage.
      */
     _meta: z.record(z.string(), z.unknown()).optional()
@@ -795,7 +795,7 @@ export const ResourceSchema = z.object({
     annotations: AnnotationsSchema.optional(),
 
     /**
-     * See [MCP specification](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/47339c03c143bb4ec01a26e721a1b8fe66634ebe/docs/specification/draft/basic/index.mdx#general-fields)
+     * See [MCP specification](https://modelcontextprotocol.io/specification/2026-07-28/basic/index#general-fields)
      * for notes on `_meta` usage.
      */
     _meta: z.optional(z.looseObject({}))
@@ -830,7 +830,7 @@ export const ResourceTemplateSchema = z.object({
     annotations: AnnotationsSchema.optional(),
 
     /**
-     * See [MCP specification](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/47339c03c143bb4ec01a26e721a1b8fe66634ebe/docs/specification/draft/basic/index.mdx#general-fields)
+     * See [MCP specification](https://modelcontextprotocol.io/specification/2026-07-28/basic/index#general-fields)
      * for notes on `_meta` usage.
      */
     _meta: z.optional(z.looseObject({}))
@@ -1054,7 +1054,7 @@ export const PromptSchema = z.object({
      */
     arguments: z.optional(z.array(PromptArgumentSchema)),
     /**
-     * See [MCP specification](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/47339c03c143bb4ec01a26e721a1b8fe66634ebe/docs/specification/draft/basic/index.mdx#general-fields)
+     * See [MCP specification](https://modelcontextprotocol.io/specification/2026-07-28/basic/index#general-fields)
      * for notes on `_meta` usage.
      */
     _meta: z.optional(z.looseObject({}))
@@ -1111,7 +1111,7 @@ export const TextContentSchema = z.object({
     annotations: AnnotationsSchema.optional(),
 
     /**
-     * See [MCP specification](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/47339c03c143bb4ec01a26e721a1b8fe66634ebe/docs/specification/draft/basic/index.mdx#general-fields)
+     * See [MCP specification](https://modelcontextprotocol.io/specification/2026-07-28/basic/index#general-fields)
      * for notes on `_meta` usage.
      */
     _meta: z.record(z.string(), z.unknown()).optional()
@@ -1137,7 +1137,7 @@ export const ImageContentSchema = z.object({
     annotations: AnnotationsSchema.optional(),
 
     /**
-     * See [MCP specification](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/47339c03c143bb4ec01a26e721a1b8fe66634ebe/docs/specification/draft/basic/index.mdx#general-fields)
+     * See [MCP specification](https://modelcontextprotocol.io/specification/2026-07-28/basic/index#general-fields)
      * for notes on `_meta` usage.
      */
     _meta: z.record(z.string(), z.unknown()).optional()
@@ -1163,7 +1163,7 @@ export const AudioContentSchema = z.object({
     annotations: AnnotationsSchema.optional(),
 
     /**
-     * See [MCP specification](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/47339c03c143bb4ec01a26e721a1b8fe66634ebe/docs/specification/draft/basic/index.mdx#general-fields)
+     * See [MCP specification](https://modelcontextprotocol.io/specification/2026-07-28/basic/index#general-fields)
      * for notes on `_meta` usage.
      */
     _meta: z.record(z.string(), z.unknown()).optional()
@@ -1195,7 +1195,7 @@ export const ToolUseContentSchema = z.object({
      */
     input: z.record(z.string(), z.unknown()),
     /**
-     * See [MCP specification](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/47339c03c143bb4ec01a26e721a1b8fe66634ebe/docs/specification/draft/basic/index.mdx#general-fields)
+     * See [MCP specification](https://modelcontextprotocol.io/specification/2026-07-28/basic/index#general-fields)
      * for notes on `_meta` usage.
      */
     _meta: z.record(z.string(), z.unknown()).optional()
@@ -1212,7 +1212,7 @@ export const EmbeddedResourceSchema = z.object({
      */
     annotations: AnnotationsSchema.optional(),
     /**
-     * See [MCP specification](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/47339c03c143bb4ec01a26e721a1b8fe66634ebe/docs/specification/draft/basic/index.mdx#general-fields)
+     * See [MCP specification](https://modelcontextprotocol.io/specification/2026-07-28/basic/index#general-fields)
      * for notes on `_meta` usage.
      */
     _meta: z.record(z.string(), z.unknown()).optional()
@@ -1375,7 +1375,7 @@ export const ToolSchema = z.object({
     execution: ToolExecutionSchema.optional(),
 
     /**
-     * See [MCP specification](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/47339c03c143bb4ec01a26e721a1b8fe66634ebe/docs/specification/draft/basic/index.mdx#general-fields)
+     * See [MCP specification](https://modelcontextprotocol.io/specification/2026-07-28/basic/index#general-fields)
      * for notes on `_meta` usage.
      */
     _meta: z.record(z.string(), z.unknown()).optional()
@@ -1649,7 +1649,7 @@ export const ToolResultContentSchema = z.object({
     isError: z.boolean().optional(),
 
     /**
-     * See [MCP specification](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/47339c03c143bb4ec01a26e721a1b8fe66634ebe/docs/specification/draft/basic/index.mdx#general-fields)
+     * See [MCP specification](https://modelcontextprotocol.io/specification/2026-07-28/basic/index#general-fields)
      * for notes on `_meta` usage.
      */
     _meta: z.record(z.string(), z.unknown()).optional()
@@ -1692,7 +1692,7 @@ export const SamplingMessageSchema = z.object({
     role: RoleSchema,
     content: z.union([SamplingMessageContentBlockSchema, z.array(SamplingMessageContentBlockSchema)]),
     /**
-     * See [MCP specification](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/47339c03c143bb4ec01a26e721a1b8fe66634ebe/docs/specification/draft/basic/index.mdx#general-fields)
+     * See [MCP specification](https://modelcontextprotocol.io/specification/2026-07-28/basic/index#general-fields)
      * for notes on `_meta` usage.
      */
     _meta: z.record(z.string(), z.unknown()).optional()
@@ -2179,7 +2179,7 @@ export const RootSchema = z.object({
     name: z.string().optional(),
 
     /**
-     * See [MCP specification](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/47339c03c143bb4ec01a26e721a1b8fe66634ebe/docs/specification/draft/basic/index.mdx#general-fields)
+     * See [MCP specification](https://modelcontextprotocol.io/specification/2026-07-28/basic/index#general-fields)
      * for notes on `_meta` usage.
      */
     _meta: z.record(z.string(), z.unknown()).optional()

--- a/packages/middleware/README.md
+++ b/packages/middleware/README.md
@@ -11,6 +11,7 @@ They intentionally **do not** add new MCP features or “business logic”. MCP 
 ## Packages
 
 - `@modelcontextprotocol/express` — Express helpers (app defaults + Host header validation for DNS rebinding protection).
+- `@modelcontextprotocol/fastify` — Fastify helpers (app defaults + Host header validation).
 - `@modelcontextprotocol/hono` — Hono helpers (app defaults + JSON body parsing hook + Host header validation).
 - `@modelcontextprotocol/node` — Node.js Streamable HTTP transport wrapper for `IncomingMessage`/`ServerResponse`.
 

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -18,7 +18,7 @@ npm install @modelcontextprotocol/server
 
 TypeScript ≥6.0 no longer auto-includes `@types/*` — add `"types": ["node"]` to your `tsconfig.json` `compilerOptions` (the published `.d.mts` references `Buffer`).
 
-Optional framework adapters: [`@modelcontextprotocol/express`](https://www.npmjs.com/package/@modelcontextprotocol/express), [`@modelcontextprotocol/hono`](https://www.npmjs.com/package/@modelcontextprotocol/hono),
+Optional framework adapters: [`@modelcontextprotocol/express`](https://www.npmjs.com/package/@modelcontextprotocol/express), [`@modelcontextprotocol/fastify`](https://www.npmjs.com/package/@modelcontextprotocol/fastify), [`@modelcontextprotocol/hono`](https://www.npmjs.com/package/@modelcontextprotocol/hono),
 [`@modelcontextprotocol/node`](https://www.npmjs.com/package/@modelcontextprotocol/node).
 
 ## Documentation

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -4,7 +4,7 @@ The MCP (Model Context Protocol) TypeScript server SDK. Build MCP servers that e
 
 <!-- prettier-ignore -->
 > [!WARNING]
-> **This is a beta release.** The API surface is settling but breaking changes remain possible until v2 stabilizes. Please try it and open issues — feedback during the beta directly shapes the stable release.
+> **v2 is the stable release line**, implementing the [2026-07-28 MCP spec](https://modelcontextprotocol.io/specification/2026-07-28). Migrating from v1? Start with the [migration guide](https://ts.sdk.modelcontextprotocol.io/v2/migration/).
 
 <!-- prettier-ignore -->
 > [!NOTE]
@@ -13,7 +13,7 @@ The MCP (Model Context Protocol) TypeScript server SDK. Build MCP servers that e
 ## Install
 
 ```bash
-npm install @modelcontextprotocol/server@latest
+npm install @modelcontextprotocol/server
 ```
 
 TypeScript ≥6.0 no longer auto-includes `@types/*` — add `"types": ["node"]` to your `tsconfig.json` `compilerOptions` (the published `.d.mts` references `Buffer`).

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -13,7 +13,7 @@ The MCP (Model Context Protocol) TypeScript server SDK. Build MCP servers that e
 ## Install
 
 ```bash
-npm install @modelcontextprotocol/server@beta
+npm install @modelcontextprotocol/server@latest
 ```
 
 TypeScript ≥6.0 no longer auto-includes `@types/*` — add `"types": ["node"]` to your `tsconfig.json` `compilerOptions` (the published `.d.mts` references `Buffer`).

--- a/packages/server/src/server/server.ts
+++ b/packages/server/src/server/server.ts
@@ -1238,7 +1238,7 @@ export class Server extends Protocol<ServerContext> {
      * notification for the specified elicitation ID.
      *
      * The notification (and the `elicitationId` it references) exists only on protocol revision
-     * 2025-11-25 — the 2026-07-28 draft removed both. On a connection negotiated at 2026-07-28 the
+     * 2025-11-25 — the 2026-07-28 revision removed both. On a connection negotiated at 2026-07-28 the
      * returned callback rejects with a typed local error before anything reaches the transport
      * (the method is not part of that revision's wire registry).
      *


### PR DESCRIPTION
Comprehensive sweep flipping all documentation surfaces to the stable release ahead of 2.0.0, so nothing published claims v2 is prerelease or points at the draft spec:

- Install commands: `@beta` tags removed everywhere (bare `npm install`; `npx codemod@latest` keeps the tag as a cache-buster).
- Beta banners rewritten to stable-release wording: package READMEs (baked into the npm tarballs), root README (including the v1-support note), docs-site landing banner, the site-wide banner component, the generated llms.txt header, CONTRIBUTING, and the v2-feedback issue template.
- Draft-spec references now point at the released revision (`/specification/2026-07-28/…`): three guide pages, the migration guides (including deleting a note that instructed tooling to track the draft schema directory), and the 16 spec links in the published `core` schemas module that render on IDE hover. Two links to ext-auth documents that moved from `draft/` to `stable/` were dead and are fixed.
- Staleness found en route: the fastify adapter was missing from every package list (server README, middleware README, root README features/install sections).

Historical alpha/beta references in the migration guides ("if you were on a v2 alpha…") are deliberately kept — that is what a migration guide is for.

One deferred item: `spec.types.2026-07-28.ts` regeneration onto the versioned upstream schema directory can only run once the spec repository publishes `schema/2026-07-28/`; the fetch script already anticipates the flip.