### PR TITLE
fix(examples): resume streams whose IDs contain underscores

### DIFF
--- a/examples/shared/src/inMemoryEventStore.ts
+++ b/examples/shared/src/inMemoryEventStore.ts
@@ -19,8 +19,7 @@ export class InMemoryEventStore implements EventStore {
      * Extracts the stream ID from an event ID
      */
     private getStreamIdFromEventId(eventId: string): string {
-        const parts = eventId.split('_');
-        return parts.length > 0 ? parts[0]! : '';
+        return this.events.get(eventId)?.streamId ?? '';
     }
 
     /**
@@ -53,10 +52,8 @@ export class InMemoryEventStore implements EventStore {
 
         let foundLastEvent = false;
 
-        // Sort events by eventId for chronological ordering
-        const sortedEvents = [...this.events.entries()].toSorted((a, b) => a[0].localeCompare(b[0]));
-
-        for (const [eventId, { streamId: eventStreamId, message }] of sortedEvents) {
+        // Map iteration preserves insertion order, which is the event chronology.
+        for (const [eventId, { streamId: eventStreamId, message }] of this.events) {
             // Only include events from the same stream
             if (eventStreamId !== streamId) {
                 continue;

--- a/examples/shared/test/inMemoryEventStore.test.ts
+++ b/examples/shared/test/inMemoryEventStore.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import type { JSONRPCMessage } from '@modelcontextprotocol/server';
+import { InMemoryEventStore } from '../src/inMemoryEventStore';
+
+describe('InMemoryEventStore', () => {
+    it('resumes the standalone GET stream in event insertion order', async () => {
+        const store = new InMemoryEventStore();
+        const streamId = '_GET_stream';
+        const firstMessage: JSONRPCMessage = {
+            jsonrpc: '2.0',
+            method: 'test/event1',
+            params: {}
+        };
+        const secondMessage: JSONRPCMessage = {
+            jsonrpc: '2.0',
+            method: 'test/event2',
+            params: {}
+        };
+        const thirdMessage: JSONRPCMessage = {
+            jsonrpc: '2.0',
+            method: 'test/event3',
+            params: {}
+        };
+
+        const firstEventId = await store.storeEvent(streamId, firstMessage);
+        const secondEventId = await store.storeEvent(streamId, secondMessage);
+        const thirdEventId = await store.storeEvent(streamId, thirdMessage);
+
+        const replayedEvents: { eventId: string; message: JSONRPCMessage }[] = [];
+        const returnedStreamId = await store.replayEventsAfter(firstEventId, {
+            send: async (eventId, message) => {
+                replayedEvents.push({ eventId, message });
+            }
+        });
+
+        expect(returnedStreamId).toBe(streamId);
+        expect(replayedEvents).toEqual([
+            { eventId: secondEventId, message: secondMessage },
+            { eventId: thirdEventId, message: thirdMessage }
+        ]);
+    });
+});


### PR DESCRIPTION
## Summary

Fixes #2560.

- Resolve an event's stream ID from the metadata already stored for that event instead of parsing an underscore-delimited ID.
- Replay stored events in `Map` insertion order, which is their actual chronology.
- Add a regression test for the standalone `_GET_stream` that verifies the returned stream ID and replay order.

## Why

Splitting an event ID on the first underscore returns an empty stream ID for `_GET_stream`. That prevents `Last-Event-ID` resume from reconnecting the standalone stream correctly. Parsing is also inherently ambiguous for any stream ID containing underscores.

## Validation

- `pnpm --filter @mcp-examples/shared run check`
- `pnpm --filter @mcp-examples/shared run test` — 2 test files, 3 tests passed

No changeset is included because `@mcp-examples/shared` is a private examples workspace package.
