### PR TITLE
fix: avoid DOM-only HeadersInit in v1 declarations

### DIFF
--- a/.changeset/node-only-normalize-headers.md
+++ b/.changeset/node-only-normalize-headers.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/sdk': patch
+---
+
+Avoid referencing the DOM-only `HeadersInit` global in emitted transport declarations so Node-only TypeScript projects can compile with `skipLibCheck: false`.

--- a/src/client/sse.ts
+++ b/src/client/sse.ts
@@ -114,7 +114,7 @@ export class SSEClientTransport implements Transport {
     }
 
     private async _commonHeaders(): Promise<Headers> {
-        const headers: HeadersInit & Record<string, string> = {};
+        const headers: RequestInit['headers'] & Record<string, string> = {};
         if (this._authProvider) {
             const tokens = await this._authProvider.tokens();
             if (tokens) {

--- a/src/client/streamableHttp.ts
+++ b/src/client/streamableHttp.ts
@@ -181,7 +181,7 @@ export class StreamableHTTPClientTransport implements Transport {
     }
 
     private async _commonHeaders(): Promise<Headers> {
-        const headers: HeadersInit & Record<string, string> = {};
+        const headers: RequestInit['headers'] & Record<string, string> = {};
         if (this._authProvider) {
             const tokens = await this._authProvider.tokens();
             if (tokens) {

--- a/src/shared/transport.ts
+++ b/src/shared/transport.ts
@@ -3,10 +3,10 @@ import { JSONRPCMessage, MessageExtraInfo, RequestId } from '../types.js';
 export type FetchLike = (url: string | URL, init?: RequestInit) => Promise<Response>;
 
 /**
- * Normalizes HeadersInit to a plain Record<string, string> for manipulation.
+ * Normalizes request headers to a plain Record<string, string> for manipulation.
  * Handles Headers objects, arrays of tuples, and plain objects.
  */
-export function normalizeHeaders(headers: HeadersInit | undefined): Record<string, string> {
+export function normalizeHeaders(headers: RequestInit['headers'] | undefined): Record<string, string> {
     if (!headers) return {};
 
     if (headers instanceof Headers) {


### PR DESCRIPTION
## Summary

Fixes the v1 declaration output so Node-only TypeScript projects do not need the DOM lib just to consume `normalizeHeaders`.

The generated `shared/transport.d.ts` currently exposes the bare global `HeadersInit`, which is not provided by `@types/node` even when Node fetch globals are enabled. This changes the public signature to `RequestInit['headers']`, matching the same runtime inputs without pulling in a DOM-only alias.

Also updates two internal client header annotations for the same reason and adds a patch changeset.

## Verification

```sh
npm run build:esm
npm run build:cjs
npm run typecheck
npm run lint
npm test -- test/client/sse.test.ts test/client/streamableHttp.test.ts
```

Node-only declaration smoke test:

```sh
# temp project with:
#   lib: ["ES2023"]
#   types: ["node"]
#   skipLibCheck: false
#   @types/node@22.20.1
#   TypeScript 5.9

import { normalizeHeaders } from "@modelcontextprotocol/sdk/shared/transport";

const headers = normalizeHeaders({ "x-test": "value" });
headers["x-test"].toUpperCase();
```

Result: `npx tsc -p tsconfig.json` passes.

Fixes #2568