### PR TITLE
fix(node): widen @hono/node-server past GHSA-frvp-7c67-39w9

### DIFF
--- a/.changeset/widen-hono-node-server-range.md
+++ b/.changeset/widen-hono-node-server-range.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/node': patch
+---
+
+Widen the `@hono/node-server` range to `^1.19.9 || ^2.0.5` so installs can resolve past GHSA-frvp-7c67-39w9 (Windows-only path traversal in `serve-static`, moderate severity; fixed in 2.0.5 — no patched 1.x exists). This mirrors the v1.x fix (#2549, shipped in 1.30.0), which was merged on a branch that does not use changesets and therefore could not propagate here. `getRequestListener` — the only symbol this package imports — keeps the same signature and contract in 2.x, the root entry's exports are a superset of 1.x's, and the `hono@^4` peer is the same; 2.x does drop the `./vercel` subpath and ships `.d.mts`/`.d.cts` declarations only, neither of which this package relies on. `@hono/node-server@2` requires Node >= 20, matching this package's existing engines floor.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,8 +96,8 @@ catalogs:
       version: 6.2.2
   runtimeServerOnly:
     '@hono/node-server':
-      specifier: ^1.19.9
-      version: 1.19.11
+      specifier: ^1.19.9 || ^2.0.5
+      version: 2.0.11
     cors:
       specifier: ^2.8.5
       version: 2.8.6
@@ -306,7 +306,7 @@ importers:
     dependencies:
       '@hono/node-server':
         specifier: catalog:runtimeServerOnly
-        version: 1.19.11(hono@4.12.9)
+        version: 2.0.11(hono@4.12.9)
       '@mcp-examples/shared':
         specifier: workspace:^
         version: link:shared
@@ -429,7 +429,7 @@ importers:
     dependencies:
       '@hono/node-server':
         specifier: catalog:runtimeServerOnly
-        version: 1.19.11(hono@4.12.9)
+        version: 2.0.11(hono@4.12.9)
       '@mcp-examples/shared':
         specifier: workspace:*
         version: link:../shared
@@ -501,7 +501,7 @@ importers:
     dependencies:
       '@hono/node-server':
         specifier: catalog:runtimeServerOnly
-        version: 1.19.11(hono@4.12.9)
+        version: 2.0.11(hono@4.12.9)
       '@mcp-examples/shared':
         specifier: workspace:*
         version: link:../shared
@@ -526,7 +526,7 @@ importers:
     dependencies:
       '@hono/node-server':
         specifier: catalog:runtimeServerOnly
-        version: 1.19.11(hono@4.12.9)
+        version: 2.0.11(hono@4.12.9)
       '@mcp-examples/shared':
         specifier: workspace:*
         version: link:../shared
@@ -548,7 +548,7 @@ importers:
     dependencies:
       '@hono/node-server':
         specifier: catalog:runtimeServerOnly
-        version: 1.19.11(hono@4.12.9)
+        version: 2.0.11(hono@4.12.9)
       '@mcp-examples/shared':
         specifier: workspace:*
         version: link:../shared
@@ -595,7 +595,7 @@ importers:
     dependencies:
       '@hono/node-server':
         specifier: catalog:runtimeServerOnly
-        version: 1.19.11(hono@4.12.9)
+        version: 2.0.11(hono@4.12.9)
       '@mcp-examples/shared':
         specifier: workspace:*
         version: link:../shared
@@ -639,7 +639,7 @@ importers:
     dependencies:
       '@hono/node-server':
         specifier: catalog:runtimeServerOnly
-        version: 1.19.11(hono@4.12.9)
+        version: 2.0.11(hono@4.12.9)
       '@mcp-examples/shared':
         specifier: workspace:*
         version: link:../shared
@@ -664,7 +664,7 @@ importers:
     dependencies:
       '@hono/node-server':
         specifier: catalog:runtimeServerOnly
-        version: 1.19.11(hono@4.12.9)
+        version: 2.0.11(hono@4.12.9)
       '@mcp-examples/shared':
         specifier: workspace:*
         version: link:../shared
@@ -723,7 +723,7 @@ importers:
     dependencies:
       '@hono/node-server':
         specifier: catalog:runtimeServerOnly
-        version: 1.19.11(hono@4.12.9)
+        version: 2.0.11(hono@4.12.9)
       '@mcp-examples/shared':
         specifier: workspace:*
         version: link:../shared
@@ -807,7 +807,7 @@ importers:
     dependencies:
       '@hono/node-server':
         specifier: catalog:runtimeServerOnly
-        version: 1.19.11(hono@4.12.9)
+        version: 2.0.11(hono@4.12.9)
       '@mcp-examples/shared':
         specifier: workspace:*
         version: link:../shared
@@ -832,7 +832,7 @@ importers:
     dependencies:
       '@hono/node-server':
         specifier: catalog:runtimeServerOnly
-        version: 1.19.11(hono@4.12.9)
+        version: 2.0.11(hono@4.12.9)
       '@mcp-examples/shared':
         specifier: workspace:*
         version: link:../shared
@@ -891,7 +891,7 @@ importers:
     dependencies:
       '@hono/node-server':
         specifier: catalog:runtimeServerOnly
-        version: 1.19.11(hono@4.12.9)
+        version: 2.0.11(hono@4.12.9)
       '@mcp-examples/shared':
         specifier: workspace:*
         version: link:../shared
@@ -913,7 +913,7 @@ importers:
     dependencies:
       '@hono/node-server':
         specifier: catalog:runtimeServerOnly
-        version: 1.19.11(hono@4.12.9)
+        version: 2.0.11(hono@4.12.9)
       '@mcp-examples/shared':
         specifier: workspace:*
         version: link:../shared
@@ -938,7 +938,7 @@ importers:
     dependencies:
       '@hono/node-server':
         specifier: catalog:runtimeServerOnly
-        version: 1.19.11(hono@4.12.9)
+        version: 2.0.11(hono@4.12.9)
       '@mcp-examples/shared':
         specifier: workspace:*
         version: link:../shared
@@ -1145,7 +1145,7 @@ importers:
     dependencies:
       '@hono/node-server':
         specifier: catalog:runtimeServerOnly
-        version: 1.19.11(hono@4.12.9)
+        version: 2.0.11(hono@4.12.9)
       '@mcp-examples/shared':
         specifier: workspace:*
         version: link:../shared
@@ -1170,7 +1170,7 @@ importers:
     dependencies:
       '@hono/node-server':
         specifier: catalog:runtimeServerOnly
-        version: 1.19.11(hono@4.12.9)
+        version: 2.0.11(hono@4.12.9)
       '@mcp-examples/shared':
         specifier: workspace:*
         version: link:../shared
@@ -1195,7 +1195,7 @@ importers:
     dependencies:
       '@hono/node-server':
         specifier: catalog:runtimeServerOnly
-        version: 1.19.11(hono@4.12.9)
+        version: 2.0.11(hono@4.12.9)
       '@mcp-examples/shared':
         specifier: workspace:*
         version: link:../shared
@@ -1220,7 +1220,7 @@ importers:
     dependencies:
       '@hono/node-server':
         specifier: catalog:runtimeServerOnly
-        version: 1.19.11(hono@4.12.9)
+        version: 2.0.11(hono@4.12.9)
       '@mcp-examples/shared':
         specifier: workspace:*
         version: link:../shared
@@ -1245,7 +1245,7 @@ importers:
     dependencies:
       '@hono/node-server':
         specifier: catalog:runtimeServerOnly
-        version: 1.19.11(hono@4.12.9)
+        version: 2.0.11(hono@4.12.9)
       '@mcp-examples/shared':
         specifier: workspace:*
         version: link:../shared
@@ -1267,7 +1267,7 @@ importers:
     dependencies:
       '@hono/node-server':
         specifier: catalog:runtimeServerOnly
-        version: 1.19.11(hono@4.12.9)
+        version: 2.0.11(hono@4.12.9)
       '@mcp-examples/shared':
         specifier: workspace:*
         version: link:../shared
@@ -1725,7 +1725,7 @@ importers:
     dependencies:
       '@hono/node-server':
         specifier: catalog:runtimeServerOnly
-        version: 1.19.11(hono@4.12.9)
+        version: 2.0.11(hono@4.12.9)
       hono:
         specifier: catalog:runtimeServerOnly
         version: 4.12.9
@@ -1986,7 +1986,7 @@ importers:
     devDependencies:
       '@hono/node-server':
         specifier: catalog:runtimeServerOnly
-        version: 1.19.11(hono@4.12.9)
+        version: 2.0.11(hono@4.12.9)
       '@modelcontextprotocol/client':
         specifier: workspace:^
         version: link:../../packages/client
@@ -3019,6 +3019,12 @@ packages:
   '@hono/node-server@1.19.11':
     resolution: {integrity: sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==}
     engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
+  '@hono/node-server@2.0.11':
+    resolution: {integrity: sha512-bjD221KPLoJTWUwso1J6fGKiTXEUFedG/s0visavY4zakFPkeGURMRNly+FhBHs7T8Dz4qHaZIMX9ZoJHSJtKA==}
+    engines: {node: '>=20'}
     peerDependencies:
       hono: ^4
 
@@ -7693,6 +7699,10 @@ snapshots:
       - utf-8-validate
 
   '@hono/node-server@1.19.11(hono@4.12.9)':
+    dependencies:
+      hono: 4.12.9
+
+  '@hono/node-server@2.0.11(hono@4.12.9)':
     dependencies:
       hono: 4.12.9
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -40,7 +40,7 @@ catalogs:
         eventsource-parser: ^3.0.0
         jose: ^6.1.3
     runtimeServerOnly:
-        '@hono/node-server': ^1.19.9
+        '@hono/node-server': ^1.19.9 || ^2.0.5
         cors: ^2.8.5
         express: ^5.2.1
         fastify: ^5.2.0


### PR DESCRIPTION
Closes #2548, closes #2531 — the v1.x half shipped in 1.30.0 via #2549; this is the `main` half.

## What

Widen `@hono/node-server` from `^1.19.9` to `^1.19.9 || ^2.0.5` — the same range #2549 merged for v1.x — and move the lockfile resolution to 2.0.11, as that change did. On `main` the range lives in the `runtimeServerOnly` catalog in `pnpm-workspace.yaml`; that one line feeds `@modelcontextprotocol/node` and the examples. A changeset is included (patch on `@modelcontextprotocol/node`).

## Why a separate PR

#2549 merged to `v1.x`, which doesn't version through changesets, so the fix structurally cannot propagate to the v2 monorepo: `@modelcontextprotocol/node@2.0.0` still declares `^1.19.9`, and GHSA-frvp-7c67-39w9 (Windows-only path traversal in `serve-static` via encoded backslash, moderate severity; fixed in 2.0.5, no patched 1.x exists) remains unreachable for every v2 consumer. #2548 covers why npm's suggested downstream remediation is unusable.

## Why 2.x is safe here

- `getRequestListener` is the only symbol `@modelcontextprotocol/node` imports (`packages/middleware/node/src/streamableHttp.ts:12`); it keeps the same signature and contract in 2.x (the implementation behind it was reworked upstream — the tests covering the affected disconnect and backpressure paths pass), and the `.` entry's exports are a superset of 1.x's (2.x adds the WebSocket API). What 2.x does change: the `./vercel` subpath is removed, and declarations ship as `.d.mts`/`.d.cts` only (no plain `.d.ts`), with `types` nested per condition — nothing in this repo uses either, and there are no type-only imports from the package anywhere in the workspace.
- The examples are fed by the same catalog entry and import `serve` (19 files); they compile and build against 2.0.11 — `pnpm -r typecheck` and `pnpm -r build` both exit 0.
- `@modelcontextprotocol/node` already declares `engines.node >= 20` — exactly `@hono/node-server@2`'s floor, so the engines conflict discussed on the issue for v1.x does not arise on `main`.
- The vulnerable `serve-static` module is never imported by the package or the examples.

## Verification

- `pnpm install --frozen-lockfile` exits 0; the lockfile diff contains only the `@hono/node-server` entries.
- `pnpm -r build` and `pnpm -r typecheck` (all packages + examples): exit 0.
- `pnpm --filter @modelcontextprotocol/node test`: 97 passed, 2 failed — the same two SSE tests (`should handle batch request messages with SSE stream for responses`, `should store and replay MCP server tool notifications`) fail identically on unmodified `main` with `@hono/node-server@1.19.11` in my environment (Node 26.5.0, macOS), so the delta from this change is zero.
- Note for anyone re-checking with `pnpm audit`: the branch still reports GHSA-frvp-7c67-39w9 once, via `examples/cli-client → @google/genai → @modelcontextprotocol/sdk@1.29.0` — the published v1 SDK from before #2549. That transitive path is outside this PR's reach and clears when `@google/genai` moves to 1.30.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)