### PR TITLE
fix(server): fire onsessionclosed once when DELETEs overlap

### DIFF
--- a/.changeset/delete-race-onsessionclosed.md
+++ b/.changeset/delete-race-onsessionclosed.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/server': patch
+---
+
+Fire `onsessionclosed` at most once when DELETE requests for the same session overlap. The first DELETE awaited the callback before `close()` ran, so `_closed` was still `false` and a second DELETE passed the same guards and invoked the callback again for a session already being torn down. The notification is now claimed synchronously before the await. DELETE remains idempotent — a concurrent or repeat request still terminates the session and answers 200.

--- a/packages/server/src/server/streamableHttp.ts
+++ b/packages/server/src/server/streamableHttp.ts
@@ -241,6 +241,12 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
     private sessionIdGenerator: (() => string) | undefined;
     private _started: boolean = false;
     private _closed: boolean = false;
+    /**
+     * Set synchronously before `onsessionclosed` is awaited, so a DELETE that arrives while the
+     * callback is in flight does not fire it again. `_closed` cannot serve this purpose: it is set
+     * by `close()`, which only runs once the callback has already settled.
+     */
+    private _sessionClosedNotified: boolean = false;
     private _streamMapping: Map<string, StreamMapping> = new Map();
     private _requestToStreamMapping: Map<RequestId, string> = new Map();
     private _requestResponseMap: Map<RequestId, JSONRPCMessage> = new Map();
@@ -984,7 +990,13 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
         }
 
         try {
-            await Promise.resolve(this._onsessionclosed?.(this.sessionId!));
+            // Claim the notification before awaiting it — see `_sessionClosedNotified`. DELETE stays
+            // idempotent: a concurrent or repeat request still terminates the session and answers 200,
+            // it just does not re-run the callback.
+            if (!this._sessionClosedNotified) {
+                this._sessionClosedNotified = true;
+                await Promise.resolve(this._onsessionclosed?.(this.sessionId!));
+            }
             return new Response(null, { status: 200 });
         } finally {
             await this.close();

--- a/packages/server/test/server/streamableHttp.test.ts
+++ b/packages/server/test/server/streamableHttp.test.ts
@@ -602,6 +602,36 @@ describe('Zod v4', () => {
 
             expect(onClosed).toHaveBeenCalledWith('test-session-456');
         });
+
+        it('fires onsessionclosed once when two DELETEs arrive concurrently', async () => {
+            // The first DELETE parks on the callback await; `_closed` is only set by close() in the
+            // finally, so a second DELETE passes the same guards and fires the callback again for a
+            // session that is already being torn down.
+            let releaseCallback!: () => void;
+            const callbackGate = new Promise<void>(resolve => {
+                releaseCallback = resolve;
+            });
+            const onClosed = vi.fn().mockReturnValue(callbackGate);
+
+            const mcpServer = new McpServer({ name: 'test-server', version: '1.0.0' }, { capabilities: {} });
+            const transport = new WebStandardStreamableHTTPServerTransport({
+                sessionIdGenerator: () => 'test-session-789',
+                onsessionclosed: onClosed
+            });
+
+            await mcpServer.connect(transport);
+            await transport.handleRequest(createRequest('POST', TEST_MESSAGES.initialize));
+
+            const sendDelete = (): Promise<Response> =>
+                transport.handleRequest(createRequest('DELETE', undefined, { sessionId: 'test-session-789' }));
+
+            const first = sendDelete();
+            const second = sendDelete();
+            releaseCallback();
+            await Promise.all([first, second]);
+
+            expect(onClosed).toHaveBeenCalledTimes(1);
+        });
     });
 
     describe('HTTPServerTransport - Event Store (Resumability)', () => {


### PR DESCRIPTION
Refs #2562 — item 2 of three. Items 1 and 3 are not touched here; item 1 will follow separately, and item 3 looks like it needs a call on the `EventStore` contract first.

> Opened as a draft: non-write-access users are capped at one open PR on this repo, and #2582 is currently using it. Ready for review as-is — happy to mark it ready whenever that one lands or on your say-so.

## The race

`handleDeleteRequest` awaits `onsessionclosed` and only then runs `close()` from the `finally`:

```ts
try {
    await Promise.resolve(this._onsessionclosed?.(this.sessionId!));
    return new Response(null, { status: 200 });
} finally {
    await this.close();
}
```

`_closed` is set by `close()`, so it is still `false` for the whole time the callback is in flight. Neither `validateSession` nor `validateProtocolVersion` consults `_closed` — they check `sessionIdGenerator`, `_initialized`, and the session-id match — so a second DELETE arriving in that window passes every guard and fires the callback a second time for a session already being torn down.

## Fix

Claim the notification synchronously, before the await. `_closed` cannot serve this purpose, since by construction it is only set after the callback has settled — hence the separate flag.

DELETE stays idempotent: a concurrent or repeat request still terminates the session and answers `200`, it just does not re-run the callback.

## Test

Added to the existing `Session Callbacks` block. It holds the callback open on a promise the test controls, issues the second DELETE while the first is parked on it, then releases:

```
× fires onsessionclosed once when two DELETEs arrive concurrently
  AssertionError: expected "vi.fn()" to be called 1 times, but got 2 times
```

That is the failure on `main` without the src change; it passes with it.

## Verification

- `469/469` tests pass in `@modelcontextprotocol/server` (53 in `streamableHttp.test.ts`)
- `pnpm lint` and `pnpm typecheck` clean
- Grepped the workspace: `onsessionclosed` is implemented only in `packages/server/src/server/streamableHttp.ts`, so no sibling transport carries the same window

Changeset included.

You noted the item applies to `v1.x` as well — happy to put up the equivalent there if you'd like it as a separate PR.