### PR TITLE
fix(server): settle in-flight JSON-mode requests on transport close

### DIFF
--- a/.changeset/json-mode-close-settles-request.md
+++ b/.changeset/json-mode-close-settles-request.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/server': patch
+---
+
+Settle in-flight JSON-mode requests when the transport closes. `close()` runs every stream mapping's `cleanup`, but JSON response mode's `cleanup` only deleted the map entry — the `Promise<Response>` returned by `handleRequest()` was never settled, so a POST whose handler was still running hung until the client timed out. It now resolves with a `503` JSON-RPC error. The success path is unchanged: `send()` resolves before calling `cleanup()`, and re-resolving a settled promise is a no-op.

--- a/packages/server/src/server/streamableHttp.ts
+++ b/packages/server/src/server/streamableHttp.ts
@@ -864,6 +864,19 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
                         resolveJson: resolve,
                         cleanup: () => {
                             this._streamMapping.delete(streamId);
+                            // Settle the pending Response as well as dropping the mapping. close()
+                            // runs every mapping's cleanup, so without this a JSON-mode POST whose
+                            // handler is still in flight never settles and the HTTP request hangs
+                            // until the client gives up. On the success path send() has already
+                            // resolved by the time it calls cleanup(), and a second resolve on a
+                            // settled promise is a no-op, so this only fires when nothing was sent.
+                            resolve(
+                                this.createJsonErrorResponse(
+                                    503,
+                                    -32_000,
+                                    'Service Unavailable: transport closed before a response was produced'
+                                )
+                            );
                         }
                     });
 

--- a/packages/server/test/server/streamableHttp.test.ts
+++ b/packages/server/test/server/streamableHttp.test.ts
@@ -539,9 +539,15 @@ describe('Zod v4', () => {
             const toolGate = new Promise<void>(resolve => {
                 releaseTool = resolve;
             });
-            let toolStarted = false;
+            // Signalled by the handler rather than polled: close() has to land while the handler is
+            // genuinely parked. Landing earlier means the POST is not yet validated and the test
+            // passes for the wrong reason, and a poll loop would make that depend on runner speed.
+            let signalToolStarted!: () => void;
+            const toolStarted = new Promise<void>(resolve => {
+                signalToolStarted = resolve;
+            });
             mcpServer.registerTool('slow', { description: 'Parks', inputSchema: z.object({}) }, async (): Promise<CallToolResult> => {
-                toolStarted = true;
+                signalToolStarted();
                 await toolGate;
                 return { content: [] };
             });
@@ -556,18 +562,14 @@ describe('Zod v4', () => {
                 )
             );
 
-            // Only close once the handler is genuinely parked, or close() lands before the POST
-            // is even validated and the test proves nothing.
-            for (let i = 0; i < 200 && !toolStarted; i++) {
-                await new Promise(resolve => setTimeout(resolve, 5));
-            }
-            expect(toolStarted).toBe(true);
-
+            await toolStarted;
             await transport.close();
 
+            // The only remaining timer, and it fires solely on a regression: with the fix the
+            // response is already resolved by the time close() returns.
             const outcome = await Promise.race([
                 inFlight.then(response => ({ hung: false, status: response.status })),
-                new Promise<{ hung: true; status: number }>(resolve => setTimeout(() => resolve({ hung: true, status: 0 }), 1000))
+                new Promise<{ hung: true; status: number }>(resolve => setTimeout(() => resolve({ hung: true, status: 0 }), 2000))
             ]);
             releaseTool();
 

--- a/packages/server/test/server/streamableHttp.test.ts
+++ b/packages/server/test/server/streamableHttp.test.ts
@@ -566,11 +566,17 @@ describe('Zod v4', () => {
             await transport.close();
 
             // The only remaining timer, and it fires solely on a regression: with the fix the
-            // response is already resolved by the time close() returns.
+            // response is already resolved by the time close() returns. Cleared either way so a
+            // passing run leaves no pending timer behind for the rest of the suite.
+            let hangTimer: ReturnType<typeof setTimeout> | undefined;
             const outcome = await Promise.race([
                 inFlight.then(response => ({ hung: false, status: response.status })),
-                new Promise<{ hung: true; status: number }>(resolve => setTimeout(() => resolve({ hung: true, status: 0 }), 2000))
-            ]);
+                new Promise<{ hung: true; status: number }>(resolve => {
+                    hangTimer = setTimeout(() => resolve({ hung: true, status: 0 }), 2000);
+                })
+            ]).finally(() => {
+                if (hangTimer !== undefined) clearTimeout(hangTimer);
+            });
             releaseTool();
 
             expect(outcome.hung).toBe(false);

--- a/packages/server/test/server/streamableHttp.test.ts
+++ b/packages/server/test/server/streamableHttp.test.ts
@@ -531,6 +531,50 @@ describe('Zod v4', () => {
             });
         });
 
+        it('settles an in-flight request when the transport closes mid-handler', async () => {
+            // close() runs every stream mapping's cleanup. JSON mode's cleanup only dropped the
+            // map entry, leaving the Promise returned by handleRequest() unsettled — so the HTTP
+            // request hung until the client gave up rather than failing.
+            let releaseTool!: () => void;
+            const toolGate = new Promise<void>(resolve => {
+                releaseTool = resolve;
+            });
+            let toolStarted = false;
+            mcpServer.registerTool('slow', { description: 'Parks', inputSchema: z.object({}) }, async (): Promise<CallToolResult> => {
+                toolStarted = true;
+                await toolGate;
+                return { content: [] };
+            });
+
+            sessionId = await initializeServer();
+
+            const inFlight = transport.handleRequest(
+                createRequest(
+                    'POST',
+                    { jsonrpc: '2.0', method: 'tools/call', params: { name: 'slow', arguments: {} }, id: 'slow-1' } as JSONRPCMessage,
+                    { sessionId }
+                )
+            );
+
+            // Only close once the handler is genuinely parked, or close() lands before the POST
+            // is even validated and the test proves nothing.
+            for (let i = 0; i < 200 && !toolStarted; i++) {
+                await new Promise(resolve => setTimeout(resolve, 5));
+            }
+            expect(toolStarted).toBe(true);
+
+            await transport.close();
+
+            const outcome = await Promise.race([
+                inFlight.then(response => ({ hung: false, status: response.status })),
+                new Promise<{ hung: true; status: number }>(resolve => setTimeout(() => resolve({ hung: true, status: 0 }), 1000))
+            ]);
+            releaseTool();
+
+            expect(outcome.hung).toBe(false);
+            expect(outcome.status).toBe(503);
+        });
+
         it('should handle tool calls in JSON response mode', async () => {
             sessionId = await initializeServer();
 


### PR DESCRIPTION
Refs #2559.

> Draft because non-write-access users are capped at one open PR here and #2582 holds it. Ready for review as-is.

## One half reproduces, one no longer does

**The hang — real, fixed here.** `close()` runs every stream mapping's `cleanup`. JSON response mode's cleanup only deleted the map entry:

```ts
cleanup: () => {
    this._streamMapping.delete(streamId);
}
```

so the `Promise<Response>` returned by `handleRequest()` was never settled and a POST whose handler was still running hung indefinitely. Probed by parking a tool handler, waiting until it had genuinely started, then closing:

```
toolStarted before close = true
request after close()    = hung
```

It now resolves with a `503` JSON-RPC error:

```
request after close() = settled, status 503
{"jsonrpc":"2.0","error":{"code":-32000,"message":"Service Unavailable: transport closed before a response was produced"},"id":null}
```

The success path is untouched — `send()` resolves before it calls `cleanup()`, and re-resolving a settled promise is a no-op, so this only fires when nothing was sent.

**The leak — no longer reproduces on `main`.** The issue notes `send()` "never runs the mapping's `cleanup`", but it has since #2286 (merged 2026-06-26); `stream.cleanup()` is called on both branches at `streamableHttp.ts:1229`/`:1232`. Measured directly:

```
_streamMapping.size after a completed JSON-mode POST = 0
```

So I've left that half alone rather than write a no-op change. Shout if you're seeing it on a path I haven't hit.

## Test

Added to the existing JSON-response-mode block. It waits until the handler is genuinely parked before closing — closing earlier lands before the POST is even validated and the test proves nothing (my first attempt did exactly that and passed for the wrong reason).

Fails without the src change:

```
× settles an in-flight request when the transport closes mid-handler
  AssertionError: expected true to be false
```

## Verification

- `469/469` tests pass in `@modelcontextprotocol/server`; `99/99` in `@modelcontextprotocol/node` (which wraps this transport)
- `pnpm lint` and `pnpm typecheck` clean

Changeset included.

On your note that this applies to `v1.x` too — happy to put up the equivalent there, and I asked on the issue whether you'd prefer that as its own PR or a backport after this lands.