### PR TITLE
docs(core): note that the protocol version constants are legacy-era only

### DIFF
--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -1,5 +1,30 @@
+/* Legacy-era protocol revisions. These three constants describe only the legacy
+ * protocol era — the 2025-11-25 family and earlier, negotiated via the `initialize`
+ * handshake. The modern era (2026-07-28 and later) has no `initialize` handshake and
+ * is versioned separately, so no modern revision ever appears here. */
+
+/**
+ * The newest protocol revision negotiable via the legacy `initialize` handshake.
+ *
+ * This is **not** the newest revision this SDK implements, and it is not a usable
+ * signal for whether the installed version supports a given spec revision — modern-era
+ * (2026-07-28+) support is deliberately kept out of this constant so that a modern
+ * version string can never leak into a legacy handshake.
+ */
 export const LATEST_PROTOCOL_VERSION = '2025-11-25';
+
+/**
+ * The revision assumed for a legacy-era HTTP request that carries no
+ * `MCP-Protocol-Version` header, per the 2025-06-18 spec's backwards-compatibility rule.
+ */
 export const DEFAULT_NEGOTIATED_PROTOCOL_VERSION = '2025-03-26';
+
+/**
+ * Legacy-era revisions this SDK can negotiate via `initialize`, in preference order.
+ *
+ * Used to validate the `MCP-Protocol-Version` header on the legacy HTTP transport.
+ * Modern-era revisions are tracked separately and are never members of this list.
+ */
 export const SUPPORTED_PROTOCOL_VERSIONS = [LATEST_PROTOCOL_VERSION, '2025-06-18', '2025-03-26', '2024-11-05', '2024-10-07'];
 
 /**


### PR DESCRIPTION
## Problem

`@modelcontextprotocol/core` exports three protocol-version constants from its package root — and `@modelcontextprotocol/server` re-exports all three — with no TSDoc on any of them:

```ts
export const LATEST_PROTOCOL_VERSION = '2025-11-25';
export const DEFAULT_NEGOTIATED_PROTOCOL_VERSION = '2025-03-26';
export const SUPPORTED_PROTOCOL_VERSIONS = [LATEST_PROTOCOL_VERSION, '2025-06-18', '2025-03-26', '2024-11-05', '2024-10-07'];
```

They describe the legacy `initialize` era only, but nothing on the public surface says so. From outside the SDK, `LATEST_PROTOCOL_VERSION === '2025-11-25'` in a v2.0.0 install reads as "v2 does not implement 2026-07-28" — which is wrong, since `createMcpHandler` classifies inbound requests via `classifyInboundRequest` and never consults `SUPPORTED_PROTOCOL_VERSIONS` at all. Only `WebStandardStreamableHTTPServerTransport.validateProtocolVersion()` does.

This is not hypothetical: while planning a v1 → v2 migration we read these constants as an era signal and initially concluded v2 lacked `2026-07-28` support, before finding `server/discover` and the `Mcp-Method` / `Mcp-Name` handling in the shipped tarballs.

## Change

Comments only — no behaviour, API, or value changes.

The two-era model is already stated precisely in `packages/core-internal/src/shared/protocolEras.ts`:

> Deliberately separate from `SUPPORTED_PROTOCOL_VERSIONS` (the legacy `initialize` list), so adding a revision here can never leak a modern version string into a 2025-era handshake. Internal — not part of the public API surface.

This PR carries that same reasoning onto the three public constants, so consumers reading the published `.d.ts` see it too. `RELATED_TASK_META_KEY` in the same file already carries a similar clarifying note; these three were the remaining undocumented exports there.

Formatting verified with the repo's Prettier config.
