### PR TITLE
fix(server): fire onsessionclosed once when DELETEs overlap (v1.x)

### DIFF
--- a/.changeset/v1x-delete-race-onsessionclosed.md
+++ b/.changeset/v1x-delete-race-onsessionclosed.md
@@ -2,4 +2,5 @@
 '@modelcontextprotocol/sdk': patch
 ---
 
-Fire `onsessionclosed` at most once when DELETE requests for the same session overlap. The first DELETE awaited the callback before `close()` ran, so `_closed` was still `false` and a second DELETE passed the same guards and invoked the callback again for a session already being torn down. The notification is now claimed synchronously before the await. DELETE remains idempotent — a concurrent or repeat request still terminates the session and answers 200.
+Fire `onsessionclosed` at most once when DELETE requests for the same session overlap. The first DELETE awaited the callback before `close()` ran, so `_closed` was still `false` and a second DELETE passed the same guards and invoked the callback again for a session already being
+torn down. The notification is now claimed synchronously before the await. DELETE remains idempotent — a concurrent or repeat request still terminates the session and answers 200.

--- a/.changeset/v1x-delete-race-onsessionclosed.md
+++ b/.changeset/v1x-delete-race-onsessionclosed.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/sdk': patch
+---
+
+Fire `onsessionclosed` at most once when DELETE requests for the same session overlap. The first DELETE awaited the callback before `close()` ran, so `_closed` was still `false` and a second DELETE passed the same guards and invoked the callback again for a session already being torn down. The notification is now claimed synchronously before the await. DELETE remains idempotent — a concurrent or repeat request still terminates the session and answers 200.

--- a/src/server/webStandardStreamableHttp.ts
+++ b/src/server/webStandardStreamableHttp.ts
@@ -246,6 +246,12 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
     private _retryInterval?: number;
     private _keepAliveMs: number;
     private _closed = false;
+    /**
+     * Set synchronously before `onsessionclosed` is awaited, so a DELETE that arrives while the
+     * callback is in flight does not fire it again. `_closed` cannot serve this purpose: it is set
+     * by `close()`, which only runs once the callback has already settled.
+     */
+    private _sessionClosedNotified = false;
 
     sessionId?: string;
     onclose?: () => void;
@@ -979,7 +985,13 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
         }
 
         try {
-            await Promise.resolve(this._onsessionclosed?.(this.sessionId!));
+            // Claim the notification before awaiting it — see `_sessionClosedNotified`. DELETE stays
+            // idempotent: a concurrent or repeat request still terminates the session and answers 200,
+            // it just does not re-run the callback.
+            if (!this._sessionClosedNotified) {
+                this._sessionClosedNotified = true;
+                await Promise.resolve(this._onsessionclosed?.(this.sessionId!));
+            }
             return new Response(null, { status: 200 });
         } finally {
             await this.close();

--- a/test/server/streamableHttp.test.ts
+++ b/test/server/streamableHttp.test.ts
@@ -3114,6 +3114,56 @@ async function createTestServerWithDnsProtection(config: {
     };
 }
 
+describe('WebStandardStreamableHTTPServerTransport - concurrent DELETE', () => {
+    it('fires onsessionclosed once when two DELETEs overlap', async () => {
+        // The first DELETE parks on the callback await. `_closed` is only set by close(), which runs
+        // in the finally *after* that await, and neither validateSession nor validateProtocolVersion
+        // consults it — so a second DELETE passes the same guards and fires the callback again for a
+        // session already being torn down.
+        //
+        // Driven through handleRequest() rather than a real socket so the second DELETE is known to
+        // have reached the handler before the callback is released; over HTTP the release wins the
+        // race and the two requests simply serialize, which hides the bug.
+        let releaseCallback!: () => void;
+        const callbackGate = new Promise<void>(resolve => {
+            releaseCallback = resolve;
+        });
+        const onsessionclosed = vi.fn().mockReturnValue(callbackGate);
+
+        const mcpServer = new McpServer({ name: 'test-server', version: '1.0.0' });
+        const transport = new WebStandardStreamableHTTPServerTransport({
+            sessionIdGenerator: () => randomUUID(),
+            onsessionclosed
+        });
+        await mcpServer.connect(transport);
+
+        const initResponse = await transport.handleRequest(
+            new Request('http://localhost/mcp', {
+                method: 'POST',
+                headers: { Accept: 'application/json, text/event-stream', 'Content-Type': 'application/json' },
+                body: JSON.stringify(TEST_MESSAGES.initialize)
+            })
+        );
+        const sessionId = initResponse.headers.get('mcp-session-id') as string;
+        expect(sessionId).toBeDefined();
+
+        const sendDelete = (): Promise<Response> =>
+            transport.handleRequest(
+                new Request('http://localhost/mcp', {
+                    method: 'DELETE',
+                    headers: { 'mcp-session-id': sessionId, 'mcp-protocol-version': '2025-11-25' }
+                })
+            );
+
+        const first = sendDelete();
+        const second = sendDelete();
+        releaseCallback();
+        await Promise.all([first, second]);
+
+        expect(onsessionclosed).toHaveBeenCalledTimes(1);
+    });
+});
+
 describe('WebStandardStreamableHTTPServerTransport - onerror callback', () => {
     let transport: WebStandardStreamableHTTPServerTransport;
     let mcpServer: McpServer;


### PR DESCRIPTION
`v1.x` backport of #2583. Refs #2562 (item 2), which notes the item applies to both branches — I offered this on the issue and confirmed the window is present here before writing anything.

> Draft: non-write-access users are capped at one open non-draft PR on this repo and #2582 holds it. Ready for review as-is.

## The race, on this branch

`WebStandardStreamableHTTPServerTransport.handleDeleteRequest` is byte-identical to main's pre-fix code:

```ts
try {
    await Promise.resolve(this._onsessionclosed?.(this.sessionId!));
    return new Response(null, { status: 200 });
} finally {
    await this.close();
}
```

`_closed` is set by `close()`, so it stays `false` for as long as the callback is in flight. Neither `validateSession` nor `validateProtocolVersion` consults it, so a second DELETE arriving in that window passes every guard and fires the callback again for a session already being torn down.

## Fix

Claim the notification synchronously, before the await — `_closed` cannot serve the purpose since by construction it is only set after the callback settles. DELETE stays idempotent: a concurrent or repeat request still terminates the session and answers `200`, it just does not re-run the callback.

## Test — one note worth flagging

The regression test drives `transport.handleRequest()` directly rather than going through a real socket.

My first attempt used `fetch` against `createTestServer`, matching the surrounding `onsessionclosed` tests, and **it passed without the fix** — over HTTP the callback release wins the race, so the two DELETEs simply serialize and the bug never surfaces. Driving the transport in-process makes the second DELETE provably reach the handler while the first is parked. It follows the existing `WebStandardStreamableHTTPServerTransport - onerror callback` block, which already tests this way.

Verified it fails without the src change:

```
× fires onsessionclosed once when two DELETEs overlap
```

## Verification

- `1640/1640` tests pass across 52 files
- `npm run lint` and `npm run typecheck` clean

Changeset included.