### PR TITLE
fix(server): settle in-flight JSON-mode requests on transport close (v1.x)

### DIFF
--- a/.changeset/v1x-json-mode-close-settles.md
+++ b/.changeset/v1x-json-mode-close-settles.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/sdk': patch
+---
+
+Settle in-flight JSON-mode requests when the transport closes. `close()` runs every stream mapping's `cleanup`, but JSON response mode's `cleanup` only deleted the map entry — the `Promise<Response>` returned by `handleRequest()` was never settled, so a POST whose handler was still running hung until the client timed out. It now resolves with a `503` JSON-RPC error. The success path is unchanged: `send()` resolves before calling `cleanup()`, and re-resolving a settled promise is a no-op.

--- a/.changeset/v1x-json-mode-close-settles.md
+++ b/.changeset/v1x-json-mode-close-settles.md
@@ -2,4 +2,5 @@
 '@modelcontextprotocol/sdk': patch
 ---
 
-Settle in-flight JSON-mode requests when the transport closes. `close()` runs every stream mapping's `cleanup`, but JSON response mode's `cleanup` only deleted the map entry — the `Promise<Response>` returned by `handleRequest()` was never settled, so a POST whose handler was still running hung until the client timed out. It now resolves with a `503` JSON-RPC error. The success path is unchanged: `send()` resolves before calling `cleanup()`, and re-resolving a settled promise is a no-op.
+Settle in-flight JSON-mode requests when the transport closes. `close()` runs every stream mapping's `cleanup`, but JSON response mode's `cleanup` only deleted the map entry — the `Promise<Response>` returned by `handleRequest()` was never settled, so a POST whose handler was
+still running hung until the client timed out. It now resolves with a `503` JSON-RPC error. The success path is unchanged: `send()` resolves before calling `cleanup()`, and re-resolving a settled promise is a no-op.

--- a/src/server/webStandardStreamableHttp.ts
+++ b/src/server/webStandardStreamableHttp.ts
@@ -839,6 +839,19 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
                         resolveJson: resolve,
                         cleanup: () => {
                             this._streamMapping.delete(streamId);
+                            // Settle the pending Response as well as dropping the mapping. close()
+                            // runs every mapping's cleanup, so without this a JSON-mode POST whose
+                            // handler is still in flight never settles and the HTTP request hangs
+                            // until the client gives up. On the success path send() has already
+                            // resolved by the time it calls cleanup(), and a second resolve on a
+                            // settled promise is a no-op, so this only fires when nothing was sent.
+                            resolve(
+                                this.createJsonErrorResponse(
+                                    503,
+                                    -32000,
+                                    'Service Unavailable: transport closed before a response was produced'
+                                )
+                            );
                         }
                     });
 

--- a/test/server/streamableHttp.test.ts
+++ b/test/server/streamableHttp.test.ts
@@ -3114,6 +3114,85 @@ async function createTestServerWithDnsProtection(config: {
     };
 }
 
+describe('WebStandardStreamableHTTPServerTransport - JSON response mode lifecycle', () => {
+    it('settles an in-flight request when the transport closes mid-handler', async () => {
+        // close() runs every stream mapping's cleanup. JSON mode's cleanup only dropped the map
+        // entry, leaving the Promise returned by handleRequest() unsettled — so the HTTP request
+        // hung until the client gave up rather than failing.
+        //
+        // Driven through handleRequest() rather than a real socket so close() is known to land
+        // while the handler is genuinely parked.
+        let releaseTool!: () => void;
+        const toolGate = new Promise<void>(resolve => {
+            releaseTool = resolve;
+        });
+        let signalToolStarted!: () => void;
+        const toolStarted = new Promise<void>(resolve => {
+            signalToolStarted = resolve;
+        });
+
+        const mcpServer = new McpServer({ name: 'test-server', version: '1.0.0' });
+        mcpServer.tool('slow', 'Parks until released', {}, async (): Promise<CallToolResult> => {
+            signalToolStarted();
+            await toolGate;
+            return { content: [] };
+        });
+
+        const transport = new WebStandardStreamableHTTPServerTransport({
+            sessionIdGenerator: () => randomUUID(),
+            enableJsonResponse: true
+        });
+        await mcpServer.connect(transport);
+
+        const initResponse = await transport.handleRequest(
+            new Request('http://localhost/mcp', {
+                method: 'POST',
+                headers: { Accept: 'application/json, text/event-stream', 'Content-Type': 'application/json' },
+                body: JSON.stringify(TEST_MESSAGES.initialize)
+            })
+        );
+        const sessionId = initResponse.headers.get('mcp-session-id') as string;
+        expect(sessionId).toBeDefined();
+
+        const inFlight = transport.handleRequest(
+            new Request('http://localhost/mcp', {
+                method: 'POST',
+                headers: {
+                    Accept: 'application/json, text/event-stream',
+                    'Content-Type': 'application/json',
+                    'mcp-session-id': sessionId,
+                    'mcp-protocol-version': '2025-11-25'
+                },
+                body: JSON.stringify({
+                    jsonrpc: '2.0',
+                    method: 'tools/call',
+                    params: { name: 'slow', arguments: {} },
+                    id: 'slow-1'
+                })
+            })
+        );
+
+        await toolStarted;
+        await transport.close();
+
+        // The only timer here fires solely on a regression: with the fix the response is already
+        // resolved by the time close() returns. Cleared either way so a pass leaves nothing pending.
+        let hangTimer: ReturnType<typeof setTimeout> | undefined;
+        const outcome = await Promise.race([
+            inFlight.then(response => ({ hung: false, status: response.status })),
+            new Promise<{ hung: true; status: number }>(resolve => {
+                hangTimer = setTimeout(() => resolve({ hung: true, status: 0 }), 2000);
+            })
+        ]).finally(() => {
+            if (hangTimer !== undefined) clearTimeout(hangTimer);
+        });
+        releaseTool();
+
+        expect(outcome.hung).toBe(false);
+        expect(outcome.status).toBe(503);
+    });
+});
+
 describe('WebStandardStreamableHTTPServerTransport - onerror callback', () => {
     let transport: WebStandardStreamableHTTPServerTransport;
     let mcpServer: McpServer;


### PR DESCRIPTION
`v1.x` backport of #2584. Refs #2559, which notes the item applies to both branches — I offered this on the issue and confirmed the gap is present here before writing anything.

> Draft: non-write-access users are capped at one open non-draft PR on this repo and #2582 holds it. Ready for review as-is.

## The gap, on this branch

JSON response mode's cleanup in `WebStandardStreamableHTTPServerTransport` is byte-identical to main's pre-fix code:

```ts
cleanup: () => {
    this._streamMapping.delete(streamId);
}
```

`close()` runs every stream mapping's `cleanup`, so a JSON-mode POST whose handler is still running has its map entry dropped while the `Promise<Response>` returned by `handleRequest()` is never settled — the HTTP request hangs until the client gives up.

It now resolves with a `503` JSON-RPC error. The success path is untouched: `send()` resolves before it calls `cleanup()`, and re-resolving a settled promise is a no-op, so this only fires when nothing was sent.

## Scope note

Only the hang is backported. The companion half of #2559 — the `_streamMapping` leak on completed JSON-mode POSTs — does not reproduce on `main` (fixed by #2286) and I did not find it here either; `send()` calls `stream.cleanup()` on both branches. I left it alone rather than write a no-op change.

## Test

Added a `JSON response mode lifecycle` block driving `handleRequest()` directly, alongside the existing `WebStandardStreamableHTTPServerTransport` describes. The handler signals that it has parked via a promise the test awaits, so `close()` is known to land mid-flight without depending on runner speed, and the hang-detector timer is cleared on the passing path.

Verified it fails without the src change:

```
× settles an in-flight request when the transport closes mid-handler
  AssertionError: expected true to be false
```

## Verification

- `1640/1640` tests pass across 52 files
- `npm run lint` and `npm run typecheck` clean

Changeset included.