### PR TITLE
fix(test): classify runtime dependencies in test workspaces

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1938,10 +1938,29 @@ importers:
         version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(vite@7.3.0(@types/node@25.5.0)(tsx@4.21.0)(yaml@2.8.3))
 
   test/conformance:
-    devDependencies:
+    dependencies:
       '@modelcontextprotocol/client':
         specifier: workspace:^
         version: link:../../packages/client
+      '@modelcontextprotocol/express':
+        specifier: workspace:^
+        version: link:../../packages/middleware/express
+      '@modelcontextprotocol/node':
+        specifier: workspace:^
+        version: link:../../packages/middleware/node
+      '@modelcontextprotocol/server':
+        specifier: workspace:^
+        version: link:../../packages/server
+      cors:
+        specifier: catalog:runtimeServerOnly
+        version: 2.8.6
+      express:
+        specifier: catalog:runtimeServerOnly
+        version: 5.2.1
+      zod:
+        specifier: catalog:runtimeShared
+        version: 4.3.6
+    devDependencies:
       '@modelcontextprotocol/conformance':
         specifier: 0.2.0-alpha.10
         version: 0.2.0-alpha.10(@cfworker/json-schema@4.1.1)
@@ -1951,15 +1970,6 @@ importers:
       '@modelcontextprotocol/eslint-config':
         specifier: workspace:^
         version: link:../../common/eslint-config
-      '@modelcontextprotocol/express':
-        specifier: workspace:^
-        version: link:../../packages/middleware/express
-      '@modelcontextprotocol/node':
-        specifier: workspace:^
-        version: link:../../packages/middleware/node
-      '@modelcontextprotocol/server':
-        specifier: workspace:^
-        version: link:../../packages/server
       '@modelcontextprotocol/test-helpers':
         specifier: workspace:^
         version: link:../helpers
@@ -1969,36 +1979,43 @@ importers:
       '@modelcontextprotocol/vitest-config':
         specifier: workspace:^
         version: link:../../common/vitest-config
-      cors:
-        specifier: catalog:runtimeServerOnly
-        version: 2.8.6
-      express:
-        specifier: catalog:runtimeServerOnly
-        version: 5.2.1
       tsx:
         specifier: catalog:devTools
         version: 4.21.0
-      zod:
-        specifier: catalog:runtimeShared
-        version: 4.3.6
 
   test/e2e:
-    devDependencies:
-      '@hono/node-server':
-        specifier: catalog:runtimeServerOnly
-        version: 1.19.11(hono@4.12.9)
+    dependencies:
       '@modelcontextprotocol/client':
         specifier: workspace:^
         version: link:../../packages/client
       '@modelcontextprotocol/core-internal':
         specifier: workspace:^
         version: link:../../packages/core-internal
-      '@modelcontextprotocol/eslint-config':
-        specifier: workspace:^
-        version: link:../../common/eslint-config
       '@modelcontextprotocol/express':
         specifier: workspace:^
         version: link:../../packages/middleware/express
+      '@modelcontextprotocol/server':
+        specifier: workspace:^
+        version: link:../../packages/server
+      '@modelcontextprotocol/server-legacy':
+        specifier: workspace:^
+        version: link:../../packages/server-legacy
+      express:
+        specifier: catalog:runtimeServerOnly
+        version: 5.2.1
+      vitest:
+        specifier: catalog:devTools
+        version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(vite@7.3.0(@types/node@25.5.0)(tsx@4.21.0)(yaml@2.8.3))
+      zod:
+        specifier: catalog:runtimeShared
+        version: 4.3.6
+    devDependencies:
+      '@hono/node-server':
+        specifier: catalog:runtimeServerOnly
+        version: 1.19.11(hono@4.12.9)
+      '@modelcontextprotocol/eslint-config':
+        specifier: workspace:^
+        version: link:../../common/eslint-config
       '@modelcontextprotocol/fastify':
         specifier: workspace:^
         version: link:../../packages/middleware/fastify
@@ -2008,12 +2025,6 @@ importers:
       '@modelcontextprotocol/node':
         specifier: workspace:^
         version: link:../../packages/middleware/node
-      '@modelcontextprotocol/server':
-        specifier: workspace:^
-        version: link:../../packages/server
-      '@modelcontextprotocol/server-legacy':
-        specifier: workspace:^
-        version: link:../../packages/server-legacy
       '@modelcontextprotocol/test-helpers':
         specifier: workspace:^
         version: link:../helpers
@@ -2038,9 +2049,6 @@ importers:
       cors:
         specifier: catalog:runtimeServerOnly
         version: 2.8.6
-      express:
-        specifier: catalog:runtimeServerOnly
-        version: 5.2.1
       fastify:
         specifier: catalog:runtimeServerOnly
         version: 5.8.4
@@ -2059,14 +2067,12 @@ importers:
       valibot:
         specifier: catalog:devTools
         version: 1.3.1(typescript@5.9.3)
+
+  test/helpers:
+    dependencies:
       vitest:
         specifier: catalog:devTools
         version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(vite@7.3.0(@types/node@25.5.0)(tsx@4.21.0)(yaml@2.8.3))
-      zod:
-        specifier: catalog:runtimeShared
-        version: 4.3.6
-
-  test/helpers:
     devDependencies:
       '@modelcontextprotocol/core-internal':
         specifier: workspace:^
@@ -2080,9 +2086,6 @@ importers:
       '@modelcontextprotocol/vitest-config':
         specifier: workspace:^
         version: link:../../common/vitest-config
-      vitest:
-        specifier: catalog:devTools
-        version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(vite@7.3.0(@types/node@25.5.0)(tsx@4.21.0)(yaml@2.8.3))
       zod:
         specifier: catalog:runtimeShared
         version: 4.3.6

--- a/test/conformance/package.json
+++ b/test/conformance/package.json
@@ -37,20 +37,22 @@
         "test:conformance:server:run": "node --import tsx ./src/everythingServer.ts",
         "test:conformance:all": "pnpm run test:conformance:client:all && pnpm run test:conformance:server:all"
     },
-    "devDependencies": {
-        "@modelcontextprotocol/conformance": "0.2.0-alpha.10",
+    "dependencies": {
         "@modelcontextprotocol/client": "workspace:^",
-        "@modelcontextprotocol/server": "workspace:^",
-        "@modelcontextprotocol/core-internal": "workspace:^",
         "@modelcontextprotocol/express": "workspace:^",
         "@modelcontextprotocol/node": "workspace:^",
+        "@modelcontextprotocol/server": "workspace:^",
+        "cors": "catalog:runtimeServerOnly",
+        "express": "catalog:runtimeServerOnly",
+        "zod": "catalog:runtimeShared"
+    },
+    "devDependencies": {
+        "@modelcontextprotocol/conformance": "0.2.0-alpha.10",
+        "@modelcontextprotocol/core-internal": "workspace:^",
         "@modelcontextprotocol/tsconfig": "workspace:^",
         "@modelcontextprotocol/vitest-config": "workspace:^",
         "@modelcontextprotocol/eslint-config": "workspace:^",
         "@modelcontextprotocol/test-helpers": "workspace:^",
-        "cors": "catalog:runtimeServerOnly",
-        "express": "catalog:runtimeServerOnly",
-        "tsx": "catalog:devTools",
-        "zod": "catalog:runtimeShared"
+        "tsx": "catalog:devTools"
     }
 }

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -29,13 +29,18 @@
         "test": "vitest run",
         "test:watch": "vitest"
     },
-    "devDependencies": {
-        "@hono/node-server": "catalog:runtimeServerOnly",
+    "dependencies": {
         "@modelcontextprotocol/client": "workspace:^",
         "@modelcontextprotocol/core-internal": "workspace:^",
+        "@modelcontextprotocol/express": "workspace:^",
         "@modelcontextprotocol/server": "workspace:^",
         "@modelcontextprotocol/server-legacy": "workspace:^",
-        "@modelcontextprotocol/express": "workspace:^",
+        "express": "catalog:runtimeServerOnly",
+        "vitest": "catalog:devTools",
+        "zod": "catalog:runtimeShared"
+    },
+    "devDependencies": {
+        "@hono/node-server": "catalog:runtimeServerOnly",
         "@modelcontextprotocol/fastify": "workspace:^",
         "@modelcontextprotocol/hono": "workspace:^",
         "@modelcontextprotocol/node": "workspace:^",
@@ -48,14 +53,11 @@
         "@valibot/to-json-schema": "catalog:devTools",
         "arktype": "catalog:devTools",
         "cors": "catalog:runtimeServerOnly",
-        "express": "catalog:runtimeServerOnly",
         "fastify": "catalog:runtimeServerOnly",
         "hono": "catalog:runtimeServerOnly",
         "jose": "catalog:runtimeClientOnly",
         "tsx": "catalog:devTools",
         "typescript": "catalog:devTools",
-        "valibot": "catalog:devTools",
-        "vitest": "catalog:devTools",
-        "zod": "catalog:runtimeShared"
+        "valibot": "catalog:devTools"
     }
 }

--- a/test/helpers/package.json
+++ b/test/helpers/package.json
@@ -26,10 +26,12 @@
         "lint:fix": "eslint src/ --fix && prettier --ignore-path ../../.prettierignore --write .",
         "check": "npm run typecheck && npm run lint"
     },
+    "dependencies": {
+        "vitest": "catalog:devTools"
+    },
     "devDependencies": {
         "@modelcontextprotocol/core-internal": "workspace:^",
         "zod": "catalog:runtimeShared",
-        "vitest": "catalog:devTools",
         "@modelcontextprotocol/tsconfig": "workspace:^",
         "@modelcontextprotocol/vitest-config": "workspace:^",
         "@modelcontextprotocol/eslint-config": "workspace:^"


### PR DESCRIPTION
## Summary

- move packages imported by executable test helpers and fixtures from devDependencies to dependencies
- update the workspace lockfile importer classifications
- restore the repository-wide lint:all gate

## Validation

- pnpm lint:all
- pre-push hook: full workspace build, lint, and typecheck

The affected packages are private test workspaces, so no changeset is required.