### PR TITLE
fix(server): reject a modern POST that omits the required MCP-Protoco…

### DIFF
--- a/.changeset/require-mcp-protocol-version-header.md
+++ b/.changeset/require-mcp-protocol-version-header.md
@@ -1,0 +1,31 @@
+---
+'@modelcontextprotocol/core-internal': patch
+'@modelcontextprotocol/server': patch
+---
+
+Reject a modern (2026-07-28) POST that omits the required `MCP-Protocol-Version` header.
+
+`createMcpHandler` accepted a request whose body carried a valid per-request `_meta`
+envelope but whose `MCP-Protocol-Version` header was absent: the request was classified
+modern, dispatched, and answered `200` — tool handlers ran. Only the _mismatch_ case
+(header present, disagreeing with the body) was rejected, so of the three standard
+headers SEP-2243 requires on every modern POST, presence was enforced for `Mcp-Method`
+and `Mcp-Name` but not for `MCP-Protocol-Version`.
+
+Such a request is now refused with `400 Bad Request` and JSON-RPC `-32020`
+(`HeaderMismatch`), matching the shape the sibling missing-header cells already emit and
+echoing the request id — per the Streamable HTTP spec, which requires the header on every
+POST and lists a missing required standard header as a `HeaderMismatch` failure. The
+spec's allowance to treat a header-less request as `2025-03-26` is available only to a
+server that also serves pre-2025-06-18 clients, and permits routing it to _legacy_
+handling — never serving it as 2026-07-28; under `legacy: 'reject'` the requirement is
+unconditional.
+
+Era classification is deliberately unchanged and stays body-primary: a proxy that strips
+the header still must not change the era, so such a request is still _classified_ modern
+and is refused one rung later, at `standard-header-validation` — the same rung that
+already answers a missing `Mcp-Method`. Legacy-era traffic is untouched, notifications
+are unaffected, and stdio serving (which has no HTTP headers) is not involved.
+
+Clients built with this SDK always send the header, so no first-party client is affected;
+hand-rolled clients that omitted it must add it.

--- a/docs/migration/support-2026-07-28.md
+++ b/docs/migration/support-2026-07-28.md
@@ -636,7 +636,13 @@ present body value, malformed, or disagree with the body — `400 Bad Request` w
 JSON-RPC `-32020` (`HeaderMismatch`). The Streamable HTTP transport also emits the
 `Mcp-Name` standard header on every modern-enveloped request, and `createMcpHandler`
 validates the SEP-2243 standard headers (`MCP-Protocol-Version`, `Mcp-Method`,
-`Mcp-Name`) against the body on the modern path with the same rejection.
+`Mcp-Name`) against the body on the modern path with the same rejection — both their
+**presence** (all three are required on every modern POST; `Mcp-Name` only for the
+methods that mirror `params.name` / `params.uri`) and their agreement with the body. A
+modern-enveloped POST that omits `MCP-Protocol-Version` is refused rather than served,
+even though the body claim alone still determines the era — so a hand-rolled client that
+relied on the body envelope without sending the header must add it. Clients built with
+this SDK send all three already.
 
 **Modern-era exception** to the `SdkHttpError` mapping: on a modern-enveloped request,
 an HTTP `400` whose body is a well-formed JSON-RPC error response addressed to the

--- a/packages/core-internal/src/shared/inboundClassification.ts
+++ b/packages/core-internal/src/shared/inboundClassification.ts
@@ -17,9 +17,13 @@
  *   named revision belongs to (a malformed envelope behind a present claim is
  *   a validation error, never a silent fall back to legacy handling).
  * - A request without a claim is legacy-era traffic.
- * - The `MCP-Protocol-Version` header is a cross-check only: it never
- *   upgrades or downgrades a body-derived classification, and a disagreement
- *   between header and body is an explicit ladder outcome.
+ * - The `MCP-Protocol-Version` header is a cross-check only *for
+ *   classification*: it never upgrades or downgrades a body-derived
+ *   classification, and a disagreement between header and body is an explicit
+ *   ladder outcome. Its absence likewise never changes the era — but the spec
+ *   requires the header on every modern POST, so a modern-classified request
+ *   that omits it is refused one rung later, by
+ *   {@linkcode validateStandardRequestHeaders}, not here.
  * - Notifications carry no envelope claim of their own under the current
  *   spec, so for notification POSTs without a body claim the modern header is
  *   determinative; the `Mcp-Method` header is validated against the body when
@@ -320,10 +324,14 @@ export const INBOUND_VALIDATION_LADDER: readonly InboundValidationRungDescriptor
         codes: [HEADER_MISMATCH_ERROR_CODE],
         conformance: ['http-header-validation'],
         rationale:
-            'SEP-2243 standard `Mcp-Method` / `Mcp-Name` headers — presence, sentinel decoding, and `Mcp-Name` ↔ body cross-check ' +
-            '— are validated by the HTTP entry on a modern-classified request after the supported-revision gate and before ' +
-            'dispatch. The classifier’s own header-mismatch cells (protocol-version, `Mcp-Method` mismatch) stay on the edge ' +
-            '`era-classification` rung; this rung carries the entry-layer presence/`Mcp-Name` half. Evaluated before the ' +
+            'SEP-2243 standard `MCP-Protocol-Version` / `Mcp-Method` / `Mcp-Name` headers — presence, sentinel decoding, and ' +
+            '`Mcp-Name` ↔ body cross-check — are validated by the HTTP entry on a modern-classified request after the ' +
+            'supported-revision gate and before dispatch. The spec requires all three on every modern POST and names them in that ' +
+            'order, so a request missing several is answered by the earliest. The classifier’s own header-mismatch cells ' +
+            '(protocol-version, `Mcp-Method` mismatch) stay on the edge ' +
+            '`era-classification` rung; this rung carries the entry-layer presence/`Mcp-Name` half — including the missing ' +
+            '`MCP-Protocol-Version` cell, which cannot live on the edge rung without breaking body-primary classification. ' +
+            'Evaluated before the ' +
             'capability gate, the factory call, and the `Mcp-Param-*` rung so a request that fails several rungs is answered by ' +
             'the standard-header rung first. The documented order (after method-registry 5 and request-params 6) is NOT the ' +
             'observed precedence: serveModern evaluates this rung immediately after the supported-revision gate, so a request ' +
@@ -494,6 +502,10 @@ function stripHttpOws(value: string): string {
  * `era-classification` rung for the `MCP-Protocol-Version` and
  * `Mcp-Method` *mismatch* cells) when:
  *
+ * - the required `MCP-Protocol-Version` header is absent (SEP-2243 requires it
+ *   on every modern POST, and lists it first among the required standard
+ *   headers — so a request missing it *and* `Mcp-Method` is answered by this
+ *   cell);
  * - the required `Mcp-Method` header is absent;
  * - the required `Mcp-Name` header is absent on a `tools/call`,
  *   `prompts/get`, or `resources/read` request whose body carries the
@@ -511,13 +523,34 @@ function stripHttpOws(value: string): string {
  * call to the classifier (no headers passed) keeps routing a modern request
  * unchanged: the classifier remains a pure body-primary router, and this
  * function is the presence/`Mcp-Name` half of the standard-header rung the
- * entry layers on top.
+ * entry layers on top. That separation is what lets the missing
+ * `MCP-Protocol-Version` cell live here without disturbing the body-primary
+ * rule — classification still resolves from the body (a proxy stripping the
+ * header must not change the era), and only this rung refuses to serve it.
  */
 export function validateStandardRequestHeaders(request: InboundHttpRequest, route: InboundModernRoute): InboundLadderRejection | undefined {
     if (route.messageKind !== 'request') {
         return undefined;
     }
     const method = route.message.method;
+
+    // SEP-2243 names `MCP-Protocol-Version` first among the required standard
+    // headers, so a request missing both it and `Mcp-Method` is answered by
+    // the header the spec names first. The presence check lives here rather
+    // than in `classifyInboundRequest` on purpose: classification stays
+    // body-primary (a proxy stripping the header must not change the era), and
+    // only this rung refuses to serve the request.
+    if (request.protocolVersionHeader === undefined) {
+        const claimed = route.classification.revision;
+        return crossCheckMismatch(
+            'version-header-missing',
+            '(missing)',
+            claimed === undefined
+                ? 'the body carries a modern per-request envelope but the required MCP-Protocol-Version header is absent'
+                : `the body envelope names protocol version ${claimed} but the required MCP-Protocol-Version header is absent`,
+            'standard-header-validation'
+        );
+    }
 
     if (request.mcpMethodHeader === undefined) {
         return crossCheckMismatch(

--- a/packages/core-internal/test/shared/inboundLadderCellSheet.test.ts
+++ b/packages/core-internal/test/shared/inboundLadderCellSheet.test.ts
@@ -76,7 +76,10 @@ const SHEET: readonly SheetRow[] = [
         conformance: ['server-stateless'],
         input: post(enveloped('tools/call', { name: 'echo', arguments: {} })),
         route: 'modern',
-        rationale: 'Body-primary classification: a proxy stripping the protocol-version header must not change the era.'
+        rationale:
+            'Body-primary classification: a proxy stripping the protocol-version header must not change the era. This cell pins ' +
+            'the CLASSIFICATION only — such a request is still refused before dispatch by the standard-header rung, which requires ' +
+            'the header the spec mandates on every modern POST (see validateStandardRequestHeaders / version-header-missing).'
     },
     {
         cell: 'legacy-claimless-request',

--- a/packages/core-internal/test/shared/standardHeaderValidation.test.ts
+++ b/packages/core-internal/test/shared/standardHeaderValidation.test.ts
@@ -4,7 +4,8 @@
  *
  * Evaluated by the HTTP entry on a modern-classified request immediately
  * after `classifyInboundRequest` returns a modern route: rejects `400` /
- * `-32020` (`HeaderMismatch`) when the required `Mcp-Method` header is
+ * `-32020` (`HeaderMismatch`) when the required `MCP-Protocol-Version` header
+ * is absent, when the required `Mcp-Method` header is
  * absent, when the required `Mcp-Name` header is absent on a `tools/call` /
  * `prompts/get` / `resources/read` request, when the `Mcp-Name` header
  * carries an invalid Base64 sentinel, and when its (decoded) value disagrees
@@ -60,6 +61,50 @@ function expectRejection(result: InboundLadderRejection | undefined, cell: strin
     expect(result?.settled).toBe(true);
 }
 
+describe('SEP-2243 standard-header validation (MCP-Protocol-Version presence)', () => {
+    test('a modern request without an MCP-Protocol-Version header is rejected (version-header-missing)', () => {
+        const request: InboundHttpRequest = {
+            httpMethod: 'POST',
+            mcpMethodHeader: 'tools/list',
+            body: { jsonrpc: '2.0', id: 1, method: 'tools/list', params: { _meta: ENVELOPE } }
+        };
+        const outcome = classifyInboundRequest(request);
+        // Body-primary classification is deliberately untouched: a proxy that
+        // strips the header must not change the era, so the request still
+        // routes modern and the rejection belongs to this rung — not to the
+        // classifier.
+        expect(outcome.kind).toBe('modern');
+        expectRejection(validateStandardRequestHeaders(request, outcome as InboundModernRoute), 'version-header-missing');
+    });
+
+    test('the missing-version cell outranks the missing-method cell (spec header order)', () => {
+        const request: InboundHttpRequest = {
+            httpMethod: 'POST',
+            body: { jsonrpc: '2.0', id: 1, method: 'tools/list', params: { _meta: ENVELOPE } }
+        };
+        const outcome = classifyInboundRequest(request);
+        expect(outcome.kind).toBe('modern');
+        expectRejection(validateStandardRequestHeaders(request, outcome as InboundModernRoute), 'version-header-missing');
+    });
+
+    test('the header/body version mismatch cell stays inside classifyInboundRequest (this rung never sees it)', () => {
+        // The protocol-version check is split across two rungs: *absence* is
+        // this rung's cell, *disagreement* stays on the classifier's edge
+        // `era-classification` rung. Pinned so the split stays observable —
+        // the same guard the Mcp-Method pair carries below.
+        const outcome = classifyInboundRequest({
+            httpMethod: 'POST',
+            protocolVersionHeader: '2025-11-25',
+            mcpMethodHeader: 'tools/list',
+            body: { jsonrpc: '2.0', id: 1, method: 'tools/list', params: { _meta: ENVELOPE } }
+        });
+        expect(outcome.kind).toBe('reject');
+        expect((outcome as InboundLadderRejection).cell).toBe('header-body-version-mismatch');
+        expect((outcome as InboundLadderRejection).rung).toBe('era-classification');
+        expect((outcome as InboundLadderRejection).code).toBe(-32_020);
+    });
+});
+
 describe('SEP-2243 standard-header validation (Mcp-Method presence)', () => {
     test('a modern request without an Mcp-Method header is rejected (method-header-missing)', () => {
         const { request, route } = modernPost('tools/list', {});
@@ -86,7 +131,14 @@ describe('SEP-2243 standard-header validation (Mcp-Method presence)', () => {
         expect((outcome as InboundLadderRejection).cell).toBe('method-header-mismatch');
     });
 
-    test('notifications are never enforced', () => {
+    test('notifications are never enforced — including the MCP-Protocol-Version presence cell', () => {
+        // Deliberate, not an oversight. The Streamable HTTP "Sending Messages"
+        // note states that "header requirements for notification POSTs are not
+        // defined by this revision" (the revision defines no client-to-server
+        // notifications over Streamable HTTP at all), so the "Every POST
+        // request MUST include an MCP-Protocol-Version header" rule does not
+        // reach a posted notification and this rung stays request-only.
+        // The request below carries NO standard headers whatsoever.
         const route: InboundModernRoute = {
             kind: 'modern',
             messageKind: 'notification',

--- a/packages/middleware/node/test/toNodeHandler.test.ts
+++ b/packages/middleware/node/test/toNodeHandler.test.ts
@@ -40,8 +40,9 @@ function modernToolsCall(name: string, args: Record<string, unknown>): unknown {
 function bodyDerivedStandardHeaders(body: unknown): Record<string, string> {
     if (body === null || typeof body !== 'object' || Array.isArray(body)) return {};
     const b = body as { method?: unknown; params?: { name?: unknown; uri?: unknown; _meta?: Record<string, unknown> } };
-    if (typeof b.params?._meta?.[PROTOCOL_VERSION_META_KEY] !== 'string') return {};
-    const out: Record<string, string> = {};
+    const claimedVersion = b.params?._meta?.[PROTOCOL_VERSION_META_KEY];
+    if (b.params === undefined || typeof claimedVersion !== 'string') return {};
+    const out: Record<string, string> = { 'mcp-protocol-version': claimedVersion };
     if (typeof b.method === 'string') out['mcp-method'] = b.method;
     const name = b.method === 'resources/read' ? b.params.uri : b.params.name;
     if (typeof name === 'string') out['mcp-name'] = name;

--- a/packages/server/src/server/createMcpHandler.ts
+++ b/packages/server/src/server/createMcpHandler.ts
@@ -675,6 +675,7 @@ export function createMcpHandler(factory: McpServerFactory, options: CreateMcpHa
         const stdHeaderRejection = validateStandardRequestHeaders(
             {
                 httpMethod: request.method,
+                protocolVersionHeader: request.headers.get('mcp-protocol-version') ?? undefined,
                 mcpMethodHeader: request.headers.get('mcp-method') ?? undefined,
                 mcpNameHeader: request.headers.get('mcp-name') ?? undefined
             },

--- a/packages/server/test/server/createMcpHandler.test.ts
+++ b/packages/server/test/server/createMcpHandler.test.ts
@@ -48,8 +48,9 @@ function modernToolsCall(name: string, args: Record<string, unknown>, envelope: 
 function bodyDerivedStandardHeaders(body: unknown): Record<string, string> {
     if (body === null || typeof body !== 'object' || Array.isArray(body)) return {};
     const b = body as { method?: unknown; params?: { name?: unknown; uri?: unknown; _meta?: Record<string, unknown> } };
-    if (typeof b.params?._meta?.[PROTOCOL_VERSION_META_KEY] !== 'string') return {};
-    const out: Record<string, string> = {};
+    const claimedVersion = b.params?._meta?.[PROTOCOL_VERSION_META_KEY];
+    if (b.params === undefined || typeof claimedVersion !== 'string') return {};
+    const out: Record<string, string> = { 'mcp-protocol-version': claimedVersion };
     if (typeof b.method === 'string') out['mcp-method'] = b.method;
     const name = b.method === 'resources/read' ? b.params.uri : b.params.name;
     if (typeof name === 'string') out['mcp-name'] = name;

--- a/packages/server/test/server/createMcpHandlerCapabilityGate.test.ts
+++ b/packages/server/test/server/createMcpHandlerCapabilityGate.test.ts
@@ -36,6 +36,7 @@ function postEcho(clientCapabilities: ClientCapabilities): Request {
         headers: {
             'Content-Type': 'application/json',
             Accept: 'application/json, text/event-stream',
+            'mcp-protocol-version': MODERN_REVISION,
             'mcp-method': 'tools/call',
             'mcp-name': 'echo'
         },

--- a/packages/server/test/server/createMcpHandlerListen.test.ts
+++ b/packages/server/test/server/createMcpHandlerListen.test.ts
@@ -19,8 +19,9 @@ import { createMcpHandler } from '../../src/server/createMcpHandler';
 import { McpServer } from '../../src/server/mcp';
 import type { ServerEventBus } from '../../src/server/serverEventBus';
 
+const MODERN_REVISION = '2026-07-28';
 const ENVELOPE = {
-    [PROTOCOL_VERSION_META_KEY]: '2026-07-28',
+    [PROTOCOL_VERSION_META_KEY]: MODERN_REVISION,
     [CLIENT_INFO_META_KEY]: { name: 'listen-test-client', version: '1.0.0' },
     [CLIENT_CAPABILITIES_META_KEY]: {}
 };
@@ -31,6 +32,7 @@ function listenRequest(id: string | number, filter: Record<string, unknown>): Re
         headers: {
             'Content-Type': 'application/json',
             Accept: 'application/json, text/event-stream',
+            'mcp-protocol-version': MODERN_REVISION,
             'mcp-method': 'subscriptions/listen'
         },
         body: JSON.stringify({
@@ -212,6 +214,7 @@ describe('createMcpHandler — subscriptions/listen', () => {
                 headers: {
                     'Content-Type': 'application/json',
                     Accept: 'application/json, text/event-stream',
+                    'mcp-protocol-version': MODERN_REVISION,
                     'mcp-method': 'subscriptions/listen'
                 },
                 body: JSON.stringify({ jsonrpc: '2.0', id: 9, method: 'subscriptions/listen', params: { _meta: ENVELOPE } })

--- a/packages/server/test/server/stdHeaderValidation.test.ts
+++ b/packages/server/test/server/stdHeaderValidation.test.ts
@@ -4,7 +4,8 @@
  *
  * The presence and `Mcp-Name` cross-check half of the standard-header rung,
  * evaluated by the entry on a modern-classified request immediately after the
- * body-primary classifier returns a modern route. A missing `Mcp-Method`
+ * body-primary classifier returns a modern route. A missing
+ * `MCP-Protocol-Version` header, a missing `Mcp-Method`
  * header, a missing `Mcp-Name` header on a `tools/call` / `prompts/get` /
  * `resources/read` request, an `Mcp-Name` value disagreeing with
  * `params.name` / `params.uri`, and an invalid `Mcp-Name` Base64 sentinel are
@@ -72,6 +73,87 @@ describe('SEP-2243 standard-header validation (createMcpHandler, modern era)', (
         expect(response.status).toBe(200);
         const body = (await response.json()) as { result: { content: Array<{ text: string }> } };
         expect(body.result.content[0]?.text).toBe('hi');
+    });
+
+    it('a missing MCP-Protocol-Version header is rejected 400/-32020', async () => {
+        const handler = createMcpHandler(makeFactory());
+        const error = await expectHeaderMismatch(
+            await handler.fetch(
+                new Request('http://localhost/mcp', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        Accept: 'application/json, text/event-stream',
+                        'mcp-method': 'tools/list'
+                    },
+                    body: JSON.stringify({ jsonrpc: '2.0', id: 5, method: 'tools/list', params: { _meta: ENVELOPE } })
+                })
+            )
+        );
+        expect(error.message).toContain('MCP-Protocol-Version header is absent');
+    });
+
+    it('a missing MCP-Protocol-Version header is rejected under the strict (legacy: reject) posture', async () => {
+        // The spec's "MAY treat a header-less request as 2025-03-26" allowance
+        // is available only to a server that also serves pre-2025-06-18
+        // clients; a modern-only endpoint MUST reject.
+        const handler = createMcpHandler(makeFactory(), { legacy: 'reject' });
+        await expectHeaderMismatch(
+            await handler.fetch(
+                new Request('http://localhost/mcp', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        Accept: 'application/json, text/event-stream',
+                        'mcp-method': 'tools/list'
+                    },
+                    body: JSON.stringify({ jsonrpc: '2.0', id: 5, method: 'tools/list', params: { _meta: ENVELOPE } })
+                })
+            )
+        );
+    });
+
+    it('a tools/call missing the MCP-Protocol-Version header never reaches the handler', async () => {
+        let ran = false;
+        const handler = createMcpHandler(() => {
+            const s = new McpServer({ name: 'std-header-server', version: '1.0.0' });
+            s.registerTool('echo', { inputSchema: z.object({ text: z.string().optional() }) }, async ({ text }) => {
+                ran = true;
+                return { content: [{ type: 'text', text: text ?? 'ok' }] };
+            });
+            return s;
+        });
+        await expectHeaderMismatch(
+            await handler.fetch(
+                new Request('http://localhost/mcp', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        Accept: 'application/json, text/event-stream',
+                        'mcp-method': 'tools/call',
+                        'mcp-name': 'echo'
+                    },
+                    body: JSON.stringify({
+                        jsonrpc: '2.0',
+                        id: 5,
+                        method: 'tools/call',
+                        params: { name: 'echo', arguments: { text: 'ran' }, _meta: ENVELOPE }
+                    })
+                })
+            )
+        );
+        expect(ran).toBe(false);
+    });
+
+    it('a present-but-disagreeing MCP-Protocol-Version header is still rejected 400/-32020', async () => {
+        // The absence cell added above must not displace the pre-existing
+        // disagreement cell, which the classifier still answers on its edge
+        // `era-classification` rung before serveModern runs this rung at all.
+        const handler = createMcpHandler(makeFactory());
+        const error = await expectHeaderMismatch(
+            await handler.fetch(modernRequest('tools/list', {}, { 'mcp-protocol-version': '2025-11-25', 'mcp-method': 'tools/list' }))
+        );
+        expect(error.message).toContain('MCP-Protocol-Version header names 2025-11-25');
     });
 
     it('a missing Mcp-Method header is rejected 400/-32020', async () => {
@@ -165,5 +247,17 @@ describe('SEP-2243 standard-header validation is era-gated', () => {
         );
         // The default 'stateless' legacy posture answers initialize.
         expect(response.status).toBe(200);
+    });
+
+    it.each(['GET', 'DELETE'])('a body-less %s is method-routed, never standard-header validated', async httpMethod => {
+        // The modern era is POST-only, so a body-less session operation never
+        // reaches a modern route and the presence rung cannot fire on it —
+        // whatever it lacks in standard headers. It is answered by the
+        // http-method rung instead: 405 / -32000, never 400 / -32020.
+        const handler = createMcpHandler(makeFactory());
+        const response = await handler.fetch(new Request('http://localhost/mcp', { method: httpMethod }));
+        expect(response.status).toBe(405);
+        const body = (await response.json()) as { error: { code: number } };
+        expect(body.error.code).toBe(-32_000);
     });
 });

--- a/test/e2e/helpers/index.ts
+++ b/test/e2e/helpers/index.ts
@@ -357,6 +357,21 @@ export function modernEnvelopeMeta(clientInfo?: Implementation): Record<string, 
 }
 
 /**
+ * The SEP-2243 standard request headers a conformant 2026-07-28 client sends
+ * alongside {@linkcode modernEnvelopeMeta}, for scenario bodies that put raw
+ * HTTP requests on the wire. `MCP-Protocol-Version` and `Mcp-Method` are
+ * required on every modern POST; `Mcp-Name` is additionally required for the
+ * methods that mirror `params.name` / `params.uri`.
+ */
+export function modernStandardHeaders(method: string, name?: string): Record<string, string> {
+    return {
+        'mcp-protocol-version': MODERN_REVISION,
+        'mcp-method': method,
+        ...(name !== undefined && { 'mcp-name': name })
+    };
+}
+
+/**
  * Fail fast if an entryModern connection did not actually negotiate the
  * 2026-07-28 revision. Every cell on the arm asserts modern-path behavior, so
  * a broken negotiation pin (or a regression in the discover negotiation) would

--- a/test/e2e/scenarios/hosting-entry-session.test.ts
+++ b/test/e2e/scenarios/hosting-entry-session.test.ts
@@ -31,7 +31,7 @@ import { createMcpHandler, isLegacyRequest, McpServer, WebStandardStreamableHTTP
 import { expect, vi } from 'vitest';
 import { z } from 'zod/v4';
 
-import { modernEnvelopeMeta } from '../helpers/index';
+import { modernEnvelopeMeta, modernStandardHeaders } from '../helpers/index';
 import { verifies } from '../helpers/verifies';
 
 const LEGACY = '2025-11-25';
@@ -172,8 +172,7 @@ verifies('typescript:hosting:entry:byo-sessionful-legacy', async () => {
             headers: {
                 'content-type': 'application/json',
                 accept: 'application/json, text/event-stream',
-                'mcp-method': 'tools/call',
-                'mcp-name': 'greet'
+                ...modernStandardHeaders('tools/call', 'greet')
             },
             body: JSON.stringify({
                 jsonrpc: '2.0',

--- a/test/e2e/scenarios/subscriptions.test.ts
+++ b/test/e2e/scenarios/subscriptions.test.ts
@@ -11,7 +11,7 @@ import { createMcpHandler, McpServer, SUBSCRIPTION_ID_META_KEY } from '@modelcon
 import { expect } from 'vitest';
 import { z } from 'zod/v4';
 
-import { modernEnvelopeMeta, wire } from '../helpers/index';
+import { modernEnvelopeMeta, modernStandardHeaders, wire } from '../helpers/index';
 import { verifies } from '../helpers/verifies';
 import type { TestArgs } from '../types';
 
@@ -72,7 +72,7 @@ verifies('subscriptions:listen:ack-first-stamped', async () => {
             headers: {
                 'Content-Type': 'application/json',
                 Accept: 'application/json, text/event-stream',
-                'mcp-method': 'subscriptions/listen'
+                ...modernStandardHeaders('subscriptions/listen')
             },
             body: JSON.stringify({
                 jsonrpc: '2.0',
@@ -270,7 +270,7 @@ verifies('subscriptions:listen:capacity-guard', async () => {
                 headers: {
                     'Content-Type': 'application/json',
                     Accept: 'application/json, text/event-stream',
-                    'mcp-method': 'subscriptions/listen'
+                    ...modernStandardHeaders('subscriptions/listen')
                 },
                 body: JSON.stringify({
                     jsonrpc: '2.0',

--- a/test/integration/test/server/createMcpHandler.test.ts
+++ b/test/integration/test/server/createMcpHandler.test.ts
@@ -173,6 +173,7 @@ describe('createMcpHandler over HTTP — subscriptions/listen honored filter', (
             headers: {
                 'Content-Type': 'application/json',
                 Accept: 'application/json, text/event-stream',
+                'mcp-protocol-version': MODERN,
                 'mcp-method': 'subscriptions/listen'
             },
             body: JSON.stringify({


### PR DESCRIPTION
Fixes #2589.

`createMcpHandler` served a modern (2026-07-28) POST whose body carried a valid per-request `_meta` envelope but whose required `MCP-Protocol-Version` header was absent: the request classified modern, dispatched, and answered **HTTP 200** — tool handlers ran. It is now refused with **HTTP 400** and JSON-RPC **`-32020`** (`HeaderMismatch`), echoing the request id, on the existing `standard-header-validation` rung.

## Motivation and Context

The 2026-07-28 Streamable HTTP spec is unambiguous on both the requirement and the remedy:

> Every POST request to the MCP endpoint **MUST** include an `MCP-Protocol-Version` header.

and, under **Server Validation**, among the listed failure conditions:

> A required standard header (`MCP-Protocol-Version`, `Mcp-Method`, `Mcp-Name`) is missing.

answered by `-32020` `HeaderMismatch`, whose own description covers "*or required headers are missing/malformed*".

Two halves of the inbound ladder each assumed the other covered this:

- `classifyInboundRequest` treats the protocol-version header as a **cross-check only** — it compares header against envelope claim under `headerVersion !== undefined`, so an absent header is simply never compared.
- `validateStandardRequestHeaders` checked presence of `Mcp-Method` and, where applicable, `Mcp-Name` — but not of `MCP-Protocol-Version`. The entry did not even pass the header into it.

So of the three standard headers the spec requires, presence was enforced for two and the third was enforced only when present.

**Why rejecting is correct in both legacy postures.** The spec's backward-compatibility allowance is narrower than it first reads:

> A server that supports clients implementing protocol versions earlier than `2025-06-18` … **MAY** treat a request that omits the header as protocol version `2025-03-26`. A server that does not support such clients **MUST** reject a request without the header per Server Validation.

That permits routing such a request to *legacy* handling — never serving it as 2026-07-28 — and under `legacy: 'reject'` the requirement is unconditional. Since the body here explicitly claims 2026-07-28, treating it as 2025-03-26 is not a live option either way.

**Design constraint honoured.** Era classification stays body-primary and is deliberately untouched: a proxy that strips the header must not change the era. Such a request is therefore still *classified* modern and refused one rung later, rather than being reclassified. The new cell reuses the existing `crossCheckMismatch` constructor — same rung, same code, same HTTP status, same `{ mismatch: { header, body } }` data shape. No new error type, no new code path.

The new `version-header-missing` cell is ordered ahead of `method-header-missing` to match the order Server Validation names the required headers in, so a request missing several is answered by the one the spec names first.

## How Has This Been Tested?

Not against a third-party production deployment — the change is server-side request validation, and the authoritative external check is the published conformance suite, which is included below.

**The issue's exact repro** (`server/discover`, `mcp-method` present, version header omitted) was asserted before and after: HTTP 200 → HTTP 400 / `-32020` with request id `1` echoed.

**Full local suite:**

| Suite | Result |
| --- | --- |
| `packages/core-internal` | 69 files, 1436 tests passed |
| `packages/server` | 42 files, 474 tests passed |
| `packages/client` | 33 files, 797 tests passed |
| `packages/middleware/{node,express,hono}` | 9 files, 155 tests passed |
| `test/integration` | 19 files, 371 tests passed |
| `test/e2e` | 44 files, 2637 passed + 155 expected-fail |
| `test:conformance:server:2026` | **114 passed, 0 failed** — incl. `http-header-validation` 13/13, `http-custom-header-server-validation` 9/9 |
| `test:conformance:server:all` | baseline check passed |
| `typecheck:all` | clean |
| `lint` (affected packages, prettier included) | clean |
| `sync:snippets --check` | clean |

**Scenarios explicitly pinned by new tests**, so the tightening cannot silently widen later:

- Missing header on a modern request → `version-header-missing`, 400 / `-32020`, id echoed.
- The same under the strict `legacy: 'reject'` posture, where the spec's MAY-allowance is unavailable.
- A `tools/call` missing the header never reaches the tool handler (asserted via a side-effect flag).
- The missing-version cell outranks the missing-`Mcp-Method` cell.
- A *present but disagreeing* header is still answered earlier, by the classifier's edge `header-body-version-mismatch` cell — the absence cell did not displace it.
- Body-primary classification is unchanged: a header-less modern body still classifies `modern`, and the rejection belongs to the rung, not the classifier.
- Legacy-era traffic byte-untouched (a 2025-era `initialize` with no standard headers still serves 200).
- Body-less `GET` / `DELETE` are method-routed to legacy serving and never header-validated (405 / `-32000`, never 400 / `-32020`).
- Posted notifications are still never enforced — see *Additional context*.

**Known pre-existing failure, unrelated:** `protocol:timeout:max-total` on the `sse` arms intermittently fails on `expect(ticks.length).toBeGreaterThanOrEqual(3)`. Verified by stashing this branch's changes — it fails identically on an unmodified tree.

## Breaking Changes

No first-party client is affected, and no configuration change is needed.

The SDK's own `StreamableHTTPClientTransport` derives `MCP-Protocol-Version` from the outgoing envelope on every modern request, so it has always sent the header — including on the very first `server/discover` negotiation probe, before any era is known.

There is, however, a real observable behaviour change for **hand-rolled clients** that relied on the body envelope alone without sending the header: those requests previously returned 200 and now return 400 / `-32020`. Such clients were already non-conformant; the fix is to send the header. Nothing else moves — legacy-era traffic, posted notifications, body-less `GET`/`DELETE`, and stdio serving (which has no HTTP headers) are all untouched.

The changeset is `patch` for `core-internal` + `server`, consistent with how this repository has shipped comparable spec-conformance tightening before (e.g. `content-type-media-type-validation`, which likewise began rejecting previously-accepted POSTs). Flagging the classification explicitly for maintainer judgment rather than assuming it.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

**Why notifications are exempt.** The presence rung returns early for notification routes. This is deliberate and spec-backed, not an oversight — the Streamable HTTP "Sending Messages" note states that this revision defines no client-to-server notifications over Streamable HTTP at all, and that *"header requirements for notification POSTs are not defined by this revision."* So the "Every POST request" rule does not reach a posted notification. A test now pins the exemption and carries that citation inline, so a future reader does not mistake it for a gap and "fix" it.

**Existing fixtures updated, no assertions weakened.** Several in-repo fixtures built modern POSTs from the body envelope alone, without the header a conformant client sends. They now send it. In the two `bodyDerivedStandardHeaders` helpers — whose stated job is to produce the standard headers a conformant client derives from the body — this is a one-line change at the source. The e2e suite gained a `modernStandardHeaders(method, name?)` helper so the raw-POST scenarios stop hand-rolling the header set.

**Ladder cell sheet.** The `modern-enveloped-request-header-stripped` row on the cell sheet asserts that a header-stripped modern POST still *classifies* modern. Its rationale now says so explicitly — that the row pins classification only, and that such a request is still refused before dispatch by the standard-header rung. Without that, the row reads as "classified modern ⇒ served", which is exactly the misreading this fix corrects.

**Documentation.** `docs/migration/support-2026-07-28.md` gains the tightening in its existing SEP-2243 section (grouped rather than added as a standalone section, per the repo's contribution guidance), covering both the presence and agreement halves and telling hand-rolled clients what to add.

**Note on overlap:** #2590 addresses the same issue with the same core approach. The scope-pinning tests it contributed for the mismatch/notification/body-less-`GET` boundaries were valuable and have been incorporated here.

@davidpavlovschi credit for this one