### PR TITLE
feat(hono): add mcp() middleware to serve an McpServer in one call

### DIFF
--- a/docs/serving/hono.md
+++ b/docs/serving/hono.md
@@ -9,29 +9,61 @@ npm install @modelcontextprotocol/server @modelcontextprotocol/hono hono
 
 ## Mount the handler
 
-`createMcpHandler` turns a server factory into a web-standard HTTP handler, and `handler.fetch` takes the `Request` a Hono route already holds as `c.req.raw` — no Node adapter. `createMcpHonoApp` is `new Hono()` with JSON body parsing and DNS rebinding protection already applied.
+`mcp(factory)` is the shortest path: it returns a single Hono middleware that serves MCP over Streamable HTTP, with JSON body parsing and DNS rebinding protection already applied. It builds on `createMcpHandler`, so the endpoint serves the modern 2026-07-28 protocol and falls back to stateless 2025-era serving — a fresh `McpServer` from your factory backs every request. Mount it on a route you already own.
 
-```ts source="../../examples/guides/serving/hono.examples.ts#createMcpHonoApp_mount"
-import { createMcpHonoApp } from '@modelcontextprotocol/hono';
-import { createMcpHandler, McpServer } from '@modelcontextprotocol/server';
-import type { Context } from 'hono';
+```ts source="../../examples/guides/serving/hono.examples.ts#mcp_mount"
+import { mcp } from '@modelcontextprotocol/hono';
+import { McpServer } from '@modelcontextprotocol/server';
+import { Hono } from 'hono';
 import * as z from 'zod/v4';
 
-const handler = createMcpHandler(() => {
-    const server = new McpServer({ name: 'notes', version: '1.0.0' });
-    server.registerTool('add-note', { description: 'Append a note', inputSchema: z.object({ text: z.string() }) }, async ({ text }) => ({
-        content: [{ type: 'text', text: `Saved: ${text}` }]
-    }));
-    return server;
-});
-
-const app = createMcpHonoApp();
-app.all('/mcp', (c: Context) => handler.fetch(c.req.raw, { parsedBody: c.get('parsedBody') }));
+const app = new Hono();
+app.all(
+    '/mcp',
+    mcp(() => {
+        const server = new McpServer({ name: 'notes', version: '1.0.0' });
+        server.registerTool(
+            'add-note',
+            { description: 'Append a note', inputSchema: z.object({ text: z.string() }) },
+            async ({ text }) => ({
+                content: [{ type: 'text', text: `Saved: ${text}` }]
+            })
+        );
+        return server;
+    })
+);
 
 export default app;
 ```
 
-`app` is an ordinary Hono app, and `export default app` is the `{ fetch }` object Cloudflare Workers, Deno, and Bun serve directly; on Node, pass `app` to `serve` from `@hono/node-server`. The factory runs once per request, so a fresh `McpServer` serves every call: [Serve over HTTP](./http.md#understand-the-per-request-factory) covers that model.
+`app` is an ordinary Hono app, and `export default app` is the `{ fetch }` object Cloudflare Workers, Deno, and Bun serve directly; on Node, pass `app` to `serve` from `@hono/node-server`.
+
+### Wire the handler and route yourself
+
+When you want to own the routing — mount multiple endpoints, add your own middleware, or pass `authInfo` per request — drop down to `createMcpHandler` + `createMcpHonoApp` (which is what `mcp()` composes for you). `createMcpHandler` turns the same factory into a web-standard HTTP handler, and `handler.fetch` takes the `Request` a Hono route already holds as `c.req.raw` — no Node adapter. `createMcpHonoApp` is `new Hono()` with the same JSON body parsing and DNS rebinding protection applied.
+
+```ts source="../../examples/guides/serving/hono.examples.ts#createMcpHonoApp_mount"
+import { createMcpHonoApp } from '@modelcontextprotocol/hono';
+import { createMcpHandler } from '@modelcontextprotocol/server';
+import type { Context } from 'hono';
+
+const handler = createMcpHandler(() => {
+    const factoryServer = new McpServer({ name: 'notes', version: '1.0.0' });
+    factoryServer.registerTool(
+        'add-note',
+        { description: 'Append a note', inputSchema: z.object({ text: z.string() }) },
+        async ({ text }) => ({
+            content: [{ type: 'text', text: `Saved: ${text}` }]
+        })
+    );
+    return factoryServer;
+});
+
+const factoryApp = createMcpHonoApp();
+factoryApp.all('/mcp', (c: Context) => handler.fetch(c.req.raw, { parsedBody: c.get('parsedBody') }));
+```
+
+The factory runs once per request, so a fresh `McpServer` serves every call: [Serve over HTTP](./http.md#understand-the-per-request-factory) covers that model.
 
 ::: tip
 Keep the explicit `c: Context` annotation: on an inferred callback context `c.get`'s key parameter narrows to `never` and `c.get('parsedBody')` does not compile.
@@ -39,9 +71,9 @@ Keep the explicit `c: Context` annotation: on an inferred callback context `c.ge
 
 ## Protect against DNS rebinding
 
-A malicious page can DNS-rebind its own domain to `127.0.0.1` and reach a localhost server as if it were same-origin. `createMcpHonoApp` validates the `Host` and `Origin` headers against that: with the default `127.0.0.1` bind (and `localhost` / `::1`), a request carrying a non-localhost value gets `403` before your handler runs.
+A malicious page can DNS-rebind its own domain to `127.0.0.1` and reach a localhost server as if it were same-origin. `mcp()` and `createMcpHonoApp` both validate the `Host` and `Origin` headers against that: with the default `127.0.0.1` bind (and `localhost` / `::1`), a request carrying a non-localhost value gets `403` before your handler runs.
 
-Binding to all interfaces drops that default — name the hosts you serve instead.
+Binding to all interfaces drops that default — name the hosts you serve instead. `mcp()` takes the same `host` / `allowedHosts` / `allowedOrigins` options.
 
 ```ts source="../../examples/guides/serving/hono.examples.ts#createMcpHonoApp_allowedHosts"
 const publicApp = createMcpHonoApp({ host: '0.0.0.0', allowedHosts: ['api.example.com'] });
@@ -82,8 +114,8 @@ data: {"result":{"tools":[{"name":"add-note","description":"Append a note","inpu
 
 ## Recap
 
-- One install line, one file: `createMcpHonoApp()` plus one `app.all('/mcp', …)` route over `createMcpHandler(factory).fetch`.
+- `mcp(factory)` is one Hono middleware — `app.all('/mcp', mcp(factory))` serves the whole endpoint (modern + legacy) with body parsing and Host/Origin validation applied.
+- Want to own the routing? Use `createMcpHonoApp()` plus one `app.all('/mcp', …)` route over `createMcpHandler(factory).fetch` — the same pieces `mcp()` composes.
 - Hono hands `c.req.raw` straight to `handler.fetch` — no Node adapter.
-- A fresh server instance from your factory serves every request.
 - The default `127.0.0.1` bind validates `Host` and `Origin`; pass `allowedHosts` when binding to `0.0.0.0`.
 - `authInfo` and `parsedBody` travel in `handler.fetch`'s second argument; handlers read auth as `ctx.http.authInfo`.

--- a/examples/guides/serving/hono.examples.ts
+++ b/examples/guides/serving/hono.examples.ts
@@ -15,24 +15,50 @@
 /* eslint-disable no-console */
 import type { AuthInfo } from '@modelcontextprotocol/server';
 
-//#region createMcpHonoApp_mount
-import { createMcpHonoApp } from '@modelcontextprotocol/hono';
-import { createMcpHandler, McpServer } from '@modelcontextprotocol/server';
-import type { Context } from 'hono';
+//#region mcp_mount
+import { mcp } from '@modelcontextprotocol/hono';
+import { McpServer } from '@modelcontextprotocol/server';
+import { Hono } from 'hono';
 import * as z from 'zod/v4';
 
-const handler = createMcpHandler(() => {
-    const server = new McpServer({ name: 'notes', version: '1.0.0' });
-    server.registerTool('add-note', { description: 'Append a note', inputSchema: z.object({ text: z.string() }) }, async ({ text }) => ({
-        content: [{ type: 'text', text: `Saved: ${text}` }]
-    }));
-    return server;
-});
-
-const app = createMcpHonoApp();
-app.all('/mcp', (c: Context) => handler.fetch(c.req.raw, { parsedBody: c.get('parsedBody') }));
+const app = new Hono();
+app.all(
+    '/mcp',
+    mcp(() => {
+        const server = new McpServer({ name: 'notes', version: '1.0.0' });
+        server.registerTool(
+            'add-note',
+            { description: 'Append a note', inputSchema: z.object({ text: z.string() }) },
+            async ({ text }) => ({
+                content: [{ type: 'text', text: `Saved: ${text}` }]
+            })
+        );
+        return server;
+    })
+);
 
 export default app;
+//#endregion mcp_mount
+
+//#region createMcpHonoApp_mount
+import { createMcpHonoApp } from '@modelcontextprotocol/hono';
+import { createMcpHandler } from '@modelcontextprotocol/server';
+import type { Context } from 'hono';
+
+const handler = createMcpHandler(() => {
+    const factoryServer = new McpServer({ name: 'notes', version: '1.0.0' });
+    factoryServer.registerTool(
+        'add-note',
+        { description: 'Append a note', inputSchema: z.object({ text: z.string() }) },
+        async ({ text }) => ({
+            content: [{ type: 'text', text: `Saved: ${text}` }]
+        })
+    );
+    return factoryServer;
+});
+
+const factoryApp = createMcpHonoApp();
+factoryApp.all('/mcp', (c: Context) => handler.fetch(c.req.raw, { parsedBody: c.get('parsedBody') }));
 //#endregion createMcpHonoApp_mount
 
 //#region createMcpHonoApp_allowedHosts

--- a/packages/middleware/hono/README.md
+++ b/packages/middleware/hono/README.md
@@ -6,6 +6,7 @@ This package is a thin Hono integration layer for [`@modelcontextprotocol/server
 
 It does **not** implement MCP itself. Instead, it helps you:
 
+- serve MCP as a single Hono middleware with `mcp(factory)`
 - create a Hono app with sensible defaults for MCP servers
 - parse JSON request bodies and expose them as `c.get('parsedBody')` for Streamable HTTP transports
 - add DNS rebinding protection via Host header validation (recommended for localhost servers)
@@ -18,17 +19,56 @@ npm install @modelcontextprotocol/server @modelcontextprotocol/hono hono
 
 ## Exports
 
+- `mcp(factory, options?)` — the one-call way to serve MCP as a Hono middleware
 - `createMcpHonoApp(options?)`
 - `hostHeaderValidation(allowedHostnames)`
 - `localhostHostValidation()`
 
 ## Usage
 
-### Streamable HTTP endpoint (Hono)
+### Serve MCP in one call (recommended)
+
+`mcp(factory)` returns a single Hono middleware that serves MCP over Streamable
+HTTP. It builds on `createMcpHandler`, so the endpoint serves the modern
+2026-07-28 protocol and falls back to stateless 2025-era serving — a fresh
+`McpServer` from your factory backs every request. JSON body parsing and
+localhost DNS-rebinding / origin protection are wired for you; mount it on a
+route you already own:
 
 ```ts
-import { McpServer, WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/server';
+import { mcp } from '@modelcontextprotocol/hono';
+import { McpServer } from '@modelcontextprotocol/server';
+import { Hono } from 'hono';
+
+const app = new Hono();
+app.all(
+    '/mcp',
+    mcp(() => new McpServer({ name: 'my-server', version: '1.0.0' }))
+);
+```
+
+Binding to a public interface? Pass `allowedHosts` / `allowedOrigins` the same way
+as `createMcpHonoApp`, plus any `createMcpHandler` options under `handler`:
+
+```ts
+app.all(
+    '/mcp',
+    mcp(factory, {
+        host: '0.0.0.0',
+        allowedHosts: ['api.example.com'],
+        handler: { legacy: 'reject' } // modern-only strict
+    })
+);
+```
+
+### Build the app yourself (`createMcpHonoApp`)
+
+When you need full control over routing or want to wire the transport by hand,
+`createMcpHonoApp()` returns a `Hono` app with the same defaults pre-applied:
+
+```ts
 import { createMcpHonoApp } from '@modelcontextprotocol/hono';
+import { McpServer, WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/server';
 
 const server = new McpServer({ name: 'my-server', version: '1.0.0' });
 const transport = new WebStandardStreamableHTTPServerTransport({ sessionIdGenerator: undefined });

--- a/packages/middleware/hono/package.json
+++ b/packages/middleware/hono/package.json
@@ -55,6 +55,7 @@
         "hono": "catalog:runtimeServerOnly"
     },
     "devDependencies": {
+        "@modelcontextprotocol/client": "workspace:^",
         "@modelcontextprotocol/server": "workspace:^",
         "@modelcontextprotocol/tsconfig": "workspace:^",
         "@modelcontextprotocol/vitest-config": "workspace:^",

--- a/packages/middleware/hono/src/hono.ts
+++ b/packages/middleware/hono/src/hono.ts
@@ -1,5 +1,6 @@
-import { isJsonContentType } from '@modelcontextprotocol/server';
-import type { Context } from 'hono';
+import type { CreateMcpHandlerOptions, McpServerFactory } from '@modelcontextprotocol/server';
+import { createMcpHandler, isJsonContentType } from '@modelcontextprotocol/server';
+import type { Context, MiddlewareHandler } from 'hono';
 import { Hono } from 'hono';
 
 import { hostHeaderValidation, localhostHostValidation } from './middleware/hostHeaderValidation';
@@ -112,4 +113,49 @@ export function createMcpHonoApp(options: CreateMcpHonoAppOptions = {}): Hono {
     }
 
     return app;
+}
+
+/**
+ * Options for the {@link mcp} middleware.
+ *
+ * Extends {@link CreateMcpHonoAppOptions} (host/origin protection) with the
+ * options forwarded to {@link createMcpHandler}.
+ */
+export interface McpMiddlewareOptions extends CreateMcpHonoAppOptions {
+    /**
+     * Options forwarded to {@link createMcpHandler} — e.g. `legacy: 'reject'`
+     * for a modern-only strict endpoint.
+     */
+    handler?: CreateMcpHandlerOptions;
+}
+
+/**
+ * Serves MCP as a single Hono middleware — the one-call way to mount MCP on a
+ * route you already own.
+ *
+ * It wires the same defaults as {@link createMcpHonoApp} (JSON body parsing and
+ * localhost DNS-rebinding / origin protection) in front of a
+ * {@link createMcpHandler}, so the endpoint serves the modern 2026-07-28
+ * protocol and falls back to stateless 2025-era serving. A fresh server is
+ * built from your factory for each request.
+ *
+ * @example
+ * ```ts
+ * const app = new Hono();
+ * app.all('/mcp', mcp(() => new McpServer({ name: 'my-server', version: '1.0.0' })));
+ * ```
+ *
+ * @param factory - Builds a fresh MCP server per request.
+ * @param options - Host/origin protection and handler options.
+ * @returns A Hono `MiddlewareHandler` that serves the MCP endpoint.
+ */
+export function mcp(factory: McpServerFactory, options?: McpMiddlewareOptions): MiddlewareHandler {
+    const { handler: handlerOptions, ...appOptions } = options ?? {};
+    const handler = createMcpHandler(factory, handlerOptions);
+    const app = createMcpHonoApp(appOptions);
+    app.all('*', (c: Context<{ Variables: { parsedBody: unknown } }>) => handler.fetch(c.req.raw, { parsedBody: c.get('parsedBody') }));
+    // The inner app is self-contained (its body parser and Host/Origin guards
+    // read only the request), so forwarding just the raw request is enough —
+    // and it avoids `c.executionCtx`, which throws off Cloudflare Workers.
+    return async c => app.fetch(c.req.raw);
 }

--- a/packages/middleware/hono/test/mcp.test.ts
+++ b/packages/middleware/hono/test/mcp.test.ts
@@ -1,0 +1,161 @@
+import { Client, StreamableHTTPClientTransport } from '@modelcontextprotocol/client';
+import { McpServer } from '@modelcontextprotocol/server';
+import { Hono } from 'hono';
+
+import { mcp } from '../src/hono';
+
+function recipeServer(): McpServer {
+    const server = new McpServer({ name: 'recipe-server', version: '1.2.0' });
+    server.registerTool('get_recipe', { description: 'Returns the preparation steps for a dish.' }, () => ({
+        content: [{ type: 'text', text: 'Steps: mix, bake, serve.' }]
+    }));
+    return server;
+}
+
+/**
+ * A `fetch` that routes a client request straight into the Hono app in process —
+ * no port bound. Localhost `Host`/`Origin` are set so the app's default DNS
+ * rebinding protection lets the request through.
+ */
+function inProcessFetch(app: Hono): (url: string | URL, init?: RequestInit) => Promise<Response> {
+    return (url, init) => {
+        const request = new Request(url, init);
+        request.headers.set('Host', 'localhost');
+        request.headers.set('Origin', 'http://localhost');
+        return Promise.resolve(app.fetch(request));
+    };
+}
+
+/** JSON-RPC `initialize` body, for the raw-request DNS rebinding probes. */
+function initializeBody(): string {
+    return JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: { protocolVersion: '2025-06-18', capabilities: {}, clientInfo: { name: 'probe', version: '0.0.1' } }
+    });
+}
+
+describe('@modelcontextprotocol/hono mcp() middleware', () => {
+    test('serves a client over the legacy (2025) stateless path', async () => {
+        const app = new Hono();
+        app.all('/mcp', mcp(recipeServer));
+
+        const client = new Client({ name: 'test-client', version: '1.0.0' });
+        const transport = new StreamableHTTPClientTransport(new URL('http://localhost/mcp'), { fetch: inProcessFetch(app) });
+
+        try {
+            await client.connect(transport);
+            expect(client.getServerVersion()).toEqual({ name: 'recipe-server', version: '1.2.0' });
+
+            const { tools } = await client.listTools();
+            expect(tools.map(t => t.name)).toEqual(['get_recipe']);
+        } finally {
+            await client.close();
+        }
+    });
+
+    test('serves a client over the modern (2026-07-28) path', async () => {
+        const app = new Hono();
+        app.all('/mcp', mcp(recipeServer));
+
+        const client = new Client({ name: 'test-client', version: '1.0.0' });
+        client.setVersionNegotiation({ mode: { pin: '2026-07-28' } });
+        const transport = new StreamableHTTPClientTransport(new URL('http://localhost/mcp'), { fetch: inProcessFetch(app) });
+
+        try {
+            await client.connect(transport);
+
+            const { tools } = await client.listTools();
+            expect(tools.map(t => t.name)).toEqual(['get_recipe']);
+
+            const result = await client.callTool({ name: 'get_recipe' });
+            expect(result.content).toEqual([{ type: 'text', text: 'Steps: mix, bake, serve.' }]);
+        } finally {
+            await client.close();
+        }
+    });
+
+    test('builds a fresh server per request (factory is per-request)', async () => {
+        let built = 0;
+        const app = new Hono();
+        app.all(
+            '/mcp',
+            mcp(() => {
+                built += 1;
+                return recipeServer();
+            })
+        );
+
+        const connect = async () => {
+            const client = new Client({ name: 'test-client', version: '1.0.0' });
+            const transport = new StreamableHTTPClientTransport(new URL('http://localhost/mcp'), { fetch: inProcessFetch(app) });
+            await client.connect(transport);
+            await client.close();
+        };
+
+        await connect();
+        await connect();
+
+        // Stateless serving builds one server per request (initialize + listTools
+        // during connect count as separate exchanges), so it is strictly > 1.
+        expect(built).toBeGreaterThan(1);
+    });
+
+    test('arms localhost DNS rebinding protection by default (rejects hostile Host)', async () => {
+        const app = new Hono();
+        app.all('/mcp', mcp(recipeServer));
+
+        const res = await app.request('http://localhost/mcp', {
+            method: 'POST',
+            headers: { Host: 'evil.example.com', 'content-type': 'application/json', Accept: 'application/json, text/event-stream' },
+            body: initializeBody()
+        });
+
+        expect(res.status).toBe(403);
+    });
+
+    test('arms localhost origin validation by default (rejects hostile Origin)', async () => {
+        const app = new Hono();
+        app.all('/mcp', mcp(recipeServer));
+
+        const res = await app.request('http://localhost/mcp', {
+            method: 'POST',
+            headers: {
+                Host: 'localhost:3000',
+                Origin: 'http://evil.example.com',
+                'content-type': 'application/json',
+                Accept: 'application/json, text/event-stream'
+            },
+            body: initializeBody()
+        });
+
+        expect(res.status).toBe(403);
+    });
+
+    test('uses allowedHosts / allowedOrigins when provided', async () => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const app = new Hono();
+        app.all('/mcp', mcp(recipeServer, { host: '0.0.0.0', allowedHosts: ['myapp.local'], allowedOrigins: ['myapp.local'] }));
+        warn.mockRestore();
+
+        const good = await app.request('http://localhost/mcp', {
+            method: 'POST',
+            headers: {
+                Host: 'myapp.local:3000',
+                Origin: 'https://myapp.local',
+                'content-type': 'application/json',
+                Accept: 'application/json, text/event-stream'
+            },
+            body: initializeBody()
+        });
+        expect(good.status).toBe(200);
+
+        const bad = await app.request('http://localhost/mcp', {
+            method: 'POST',
+            headers: { Host: 'evil.example.com', 'content-type': 'application/json', Accept: 'application/json, text/event-stream' },
+            body: initializeBody()
+        });
+        expect(bad.status).toBe(403);
+    });
+});

--- a/packages/middleware/hono/tsconfig.json
+++ b/packages/middleware/hono/tsconfig.json
@@ -5,6 +5,8 @@
     "compilerOptions": {
         "paths": {
             "*": ["./*"],
+            "@modelcontextprotocol/client": ["./node_modules/@modelcontextprotocol/client/src/index.ts"],
+            "@modelcontextprotocol/client/_shims": ["./node_modules/@modelcontextprotocol/client/src/shimsNode.ts"],
             "@modelcontextprotocol/server": ["./node_modules/@modelcontextprotocol/server/src/index.ts"],
             "@modelcontextprotocol/server/_shims": ["./node_modules/@modelcontextprotocol/server/src/shimsNode.ts"],
             "@modelcontextprotocol/core-internal": [
@@ -15,6 +17,9 @@
             ],
             "@modelcontextprotocol/core-internal/public": [
                 "./node_modules/@modelcontextprotocol/server/node_modules/@modelcontextprotocol/core-internal/src/exports/public/index.ts"
+            ],
+            "@modelcontextprotocol/core-internal/validators/ajv": [
+                "./node_modules/@modelcontextprotocol/server/node_modules/@modelcontextprotocol/core-internal/src/validators/ajvProvider.ts"
             ]
         }
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1681,6 +1681,9 @@ importers:
       '@eslint/js':
         specifier: catalog:devTools
         version: 9.39.4
+      '@modelcontextprotocol/client':
+        specifier: workspace:^
+        version: link:../../client
       '@modelcontextprotocol/eslint-config':
         specifier: workspace:^
         version: link:../../../common/eslint-config


### PR DESCRIPTION
## What

Adds `mcp(factory, options?)` to `@modelcontextprotocol/hono` — a single Hono `MiddlewareHandler` that serves MCP over Streamable HTTP in one call:

```ts
import { mcp } from '@modelcontextprotocol/hono';
import { McpServer } from '@modelcontextprotocol/server';
import { Hono } from 'hono';

const app = new Hono();
app.all(
    '/mcp',
    mcp(() => new McpServer({ name: 'my-server', version: '1.0.0' }))
);
```

It builds on `createMcpHandler` (not a raw transport), so the endpoint serves the modern 2026-07-28 protocol and falls back to stateless 2025-era serving, with a fresh server per request. JSON body parsing + localhost DNS-rebinding / origin protection are wired in front via `createMcpHonoApp`. `createMcpHonoApp` + `createMcpHandler` stay as the own-your-routing form.

## Why

Mounting MCP on a Hono app you already own means building an app via `createMcpHonoApp`, wiring the handler, and adding a `/mcp` route by hand. `mcp(factory)` collapses that to one line while composing the exact same pieces, so it stays consistent with the rest of the SDK and dual-era by default.

## Changes

- `packages/middleware/hono/src/hono.ts`: `mcp()` + `McpMiddlewareOptions` (host/origin options plus `handler` forwarded to `createMcpHandler`). The inner app is self-contained, so only the raw request is forwarded to it — this also avoids `c.executionCtx`, which throws off Cloudflare Workers.
- `packages/middleware/hono/test/mcp.test.ts`: driven by a real `Client` over both the legacy (2025) and modern (2026-07-28) paths, plus Host/Origin protection tests.
- `packages/middleware/hono/README.md` and `docs/serving/hono.md`: feature `mcp()` on top; keep `createMcpHonoApp` + `createMcpHandler` documented as the own-your-routing form. Docs snippets are synced from the runnable, type-checked `examples/guides/serving/hono.examples.ts` harness.

## Credit

Feature and API shape inspired by [@yusukebe](https://github.com/yusukebe)'s [`mcp-server-hono-middleware`](https://github.com/yusukebe/mcp-server-hono-middleware). Discussion: https://x.com/yusukebe/status/2083147644592128080

## Checklist

- [x] `pnpm --filter @modelcontextprotocol/hono check` (typecheck + lint)
- [x] `pnpm --filter @modelcontextprotocol/hono test` (20 passing)
- [x] `pnpm sync:snippets --check` (docs snippets in sync)
- [ ] Discussed in an issue first (per CONTRIBUTING.md — opening as **draft** for maintainer alignment)
