### PR TITLE
fix(server): retire in-flight request state when the streamable HTTP transport closes

### DIFF
--- a/.changeset/close-retires-in-flight-request-state.md
+++ b/.changeset/close-retires-in-flight-request-state.md
@@ -1,0 +1,19 @@
+---
+'@modelcontextprotocol/server': patch
+---
+
+Fix `WebStandardStreamableHTTPServerTransport.close()` leaving in-flight request state behind.
+
+`close()` cleared `_streamMapping` and `_requestResponseMap` but never cleared
+`_requestToStreamMapping`, so request ids stayed resolvable after the transport was
+closed. A `send()` suspended in `eventStore.storeEvent()` across a `close()` resumed
+against the retired correlation and recorded a response that could never be delivered,
+leaking both the response and its correlation for the lifetime of the process. `close()`
+now retires the correlations, and `send()` re-checks the correlation after the
+`storeEvent()` await — the same reason the stream is already re-read there.
+
+`close()` also now settles JSON-response-mode POSTs that are parked waiting for their
+responses, answering `404 Session not found` instead of leaving the HTTP request hanging
+until the platform's own timeout fires.
+
+Both paths also apply to `NodeStreamableHTTPServerTransport`, which wraps this transport.

--- a/packages/server/src/server/streamableHttp.ts
+++ b/packages/server/src/server/streamableHttp.ts
@@ -1054,14 +1054,22 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
         }
         this._closed = true;
 
-        // Close all SSE connections
-        for (const { cleanup } of this._streamMapping.values()) {
-            cleanup();
+        // Close all SSE connections. JSON-response mode parks the POST's
+        // `Response` promise in `resolveJson` until every response is ready —
+        // settle it here, otherwise closing the transport mid-request leaves
+        // the HTTP request hanging until the platform's own timeout fires.
+        for (const stream of this._streamMapping.values()) {
+            stream.resolveJson?.(this.createJsonErrorResponse(404, -32_001, 'Session not found'));
+            stream.cleanup();
         }
         this._streamMapping.clear();
 
-        // Clear any pending responses
+        // Clear any pending responses, and the in-flight request correlations
+        // they belong to. Leaving `_requestToStreamMapping` populated keeps
+        // retired request ids resolvable in `send()`, so a closed transport
+        // still accepts responses it can never deliver.
         this._requestResponseMap.clear();
+        this._requestToStreamMapping.clear();
         this.onclose?.();
     }
 
@@ -1159,6 +1167,15 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
                 // storeEvent() may have registered a resumed stream under this
                 // streamId (mirrors the standalone path's post-await read).
                 stream = this._streamMapping.get(streamId);
+                // The correlation itself can also disappear across the await —
+                // close() retires every in-flight request id. Re-check it for
+                // the same reason the stream is re-read above: without this,
+                // the response below is recorded into `_requestResponseMap` on
+                // a transport that can never deliver it, and both the entry and
+                // its correlation leak for the lifetime of the process.
+                if (!this._requestToStreamMapping.has(requestId)) {
+                    throw new Error(`No connection established for request ID: ${String(requestId)}`);
+                }
             }
             // Write the event to the response stream — unless the resumed
             // stream's replay already delivered this exact eventId (the store

--- a/packages/server/test/server/streamableHttp.test.ts
+++ b/packages/server/test/server/streamableHttp.test.ts
@@ -1406,6 +1406,96 @@ describe('Zod v4', () => {
             expect(cleanupCalls).toEqual(['stream-1']);
         });
     });
+
+    describe('close() retires in-flight request state', () => {
+        const tick = (): Promise<void> => new Promise(resolve => setTimeout(resolve, 10));
+
+        /**
+         * Event store whose `storeEvent` can be parked mid-write, so a close()
+         * can be interleaved with an in-flight send().
+         */
+        function createGatedEventStore(): EventStore & { park: () => void; release: () => void } {
+            let gate: Promise<void> | undefined;
+            let open: () => void = () => {};
+            let counter = 0;
+
+            return {
+                park(): void {
+                    gate = new Promise<void>(resolve => (open = resolve));
+                },
+                release(): void {
+                    gate = undefined;
+                    open();
+                },
+                async storeEvent(streamId: StreamId): Promise<EventId> {
+                    if (gate) {
+                        await gate;
+                    }
+                    return `${streamId}_${counter++}`;
+                },
+                async replayEventsAfter(): Promise<StreamId> {
+                    return '';
+                }
+            };
+        }
+
+        const request = (id: number): JSONRPCMessage => ({ jsonrpc: '2.0', id, method: 'ping' }) as JSONRPCMessage;
+        const response = (id: number): JSONRPCMessage => ({ jsonrpc: '2.0', id, result: {} }) as JSONRPCMessage;
+
+        it('should reject a send parked in storeEvent across close() rather than recording an undeliverable response', async () => {
+            const eventStore = createGatedEventStore();
+            const transport = new WebStandardStreamableHTTPServerTransport({ sessionIdGenerator: undefined, eventStore });
+            transport.onmessage = () => {};
+
+            const res = await transport.handleRequest(createRequest('POST', [request(1), request(2)]));
+            expect(res.status).toBe(200);
+
+            // First response lands; the batch is not complete, so nothing is retired yet.
+            await transport.send(response(1));
+
+            // Second response parks inside storeEvent, and close() sweeps while it is suspended.
+            eventStore.park();
+            const parked = transport.send(response(2));
+            await tick();
+            await transport.close();
+            eventStore.release();
+
+            await expect(parked).rejects.toThrow(/No connection established for request ID: 2/);
+
+            // @ts-expect-error accessing private map for test purposes
+            expect(transport._requestToStreamMapping.size).toBe(0);
+            // @ts-expect-error accessing private map for test purposes
+            expect(transport._requestResponseMap.size).toBe(0);
+        });
+
+        it('should settle a JSON-mode POST parked across close() instead of leaving the HTTP request hanging', async () => {
+            const transport = new WebStandardStreamableHTTPServerTransport({
+                sessionIdGenerator: undefined,
+                enableJsonResponse: true
+            });
+            transport.onmessage = () => {};
+
+            // JSON mode parks the Response promise until every response is ready.
+            const pending = transport.handleRequest(createRequest('POST', request(1)));
+            await tick();
+            await transport.close();
+
+            const res = await Promise.race([pending, tick().then(() => 'still pending' as const)]);
+            expect(res).not.toBe('still pending');
+            expect((res as Response).status).toBe(404);
+            expectErrorResponse(await (res as Response).json(), -32_001, /Session not found/);
+        });
+
+        it('should not accept a response for a request id retired by close()', async () => {
+            const transport = new WebStandardStreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+            transport.onmessage = () => {};
+
+            await transport.handleRequest(createRequest('POST', request(1)));
+            await transport.close();
+
+            await expect(transport.send(response(1))).rejects.toThrow(/No connection established for request ID: 1/);
+        });
+    });
 });
 
 describe('WebStandardStreamableHTTPServerTransport SSE keep-alive', () => {


### PR DESCRIPTION
## Motivation and Context

`WebStandardStreamableHTTPServerTransport.close()` clears `_streamMapping` and `_requestResponseMap`, but never clears `_requestToStreamMapping`. Request ids therefore stay resolvable on a closed transport, which leaks state on two paths.

**1. A `send()` suspended across `close()` records an undeliverable response.**

`send()` resolves `streamId` from `_requestToStreamMapping` *before* awaiting `eventStore.storeEvent()`. If `close()` lands during that await, the resumed `send()` still holds a stale `streamId` and falls through to `_requestResponseMap.set(requestId, message)`. For a batched POST the sibling response was already dropped by `close()`, so `allResponsesReady` is `false` forever, the cleanup loop never runs, and the response plus both correlations leak for the lifetime of the process. The closed transport also keeps accepting further responses for those ids and writing them to the event store.

**2. JSON-response mode hangs the HTTP request.**

In `enableJsonResponse` mode `handleRequest()` returns a promise parked in `resolveJson` until every response is ready. `close()` runs that stream's `cleanup()`, which only deletes the map entry — it never resolves. The POST promise never settles, so the request hangs until the platform's own timeout fires.

Both paths also reach `NodeStreamableHTTPServerTransport`, which is a thin wrapper around this transport.

## How Has This Been Tested?

Three tests in `packages/server/test/server/streamableHttp.test.ts`, each verified to fail before the change and pass after:

- a `send()` parked in `storeEvent()` across `close()` now rejects and leaves both maps empty
- a JSON-mode POST parked across `close()` settles as `404 Session not found` instead of hanging
- a closed transport rejects a response for a retired request id

Full monorepo suite passes (`pnpm test:all`), plus `typecheck` and `prettier`.

## Breaking Changes

None. `close()` and `send()` keep their signatures. A `send()` that previously resolved after `close()` while recording an undeliverable response now rejects with the module's existing `No connection established for request ID: …` error — the same error a `send()` issued after `close()` already produced, so the mid-flight case just becomes consistent with it.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context

`send()`'s new post-await correlation re-check mirrors the re-read of `stream` that already sits directly above it, and for the same reason: state can change across that await.