### PR TITLE
fix: register google-duration format to silence unknown format warnings

### DIFF
--- a/.changeset/register-google-duration-format.md
+++ b/.changeset/register-google-duration-format.md
@@ -1,0 +1,9 @@
+---
+'@modelcontextprotocol/core-internal': patch
+'@modelcontextprotocol/client': patch
+'@modelcontextprotocol/server': patch
+---
+
+Register `google-duration` format on default AJV instances to silence "unknown format" warnings.
+
+Firebase MCP and other Google Cloud API MCP servers use the `google-duration` format in their JSON Schemas (values like `"3600s"`, `"1.5s"`). AJV logs `unknown format "google-duration" ignored` warnings for each schema that references it, creating noisy startup output. The format is registered with a regex matching Google's Duration proto format: a number followed by a time unit suffix (`s`, `ms`, `us`, `ns`, `m`, `h`, `d`).

--- a/packages/core-internal/src/validators/ajvProvider.ts
+++ b/packages/core-internal/src/validators/ajvProvider.ts
@@ -27,6 +27,13 @@ interface AjvValidateFunction {
 /** `ajv-formats` default export, normalised through the CJS/ESM interop wrapper. */
 const addFormats = _addFormats as unknown as typeof _addFormats.default;
 
+/**
+ * Validate the `google-duration` format used by Google Cloud APIs (e.g. Firebase MCP).
+ * Accepts strings like "3600s", "1.5s", "100ms", "2m", "1h", "1d" — a number followed
+ * by a time unit suffix. See https://cloud.google.com/ruby/docs/reference/google-cloud-env/latest/Google/Protobuf/Duration
+ */
+const GOOGLE_DURATION_RE = /^\d+(\.\d+)?(s|ms|us|ns|m|h|d)$/;
+
 function createDefaultAjvInstance(engineClass: typeof Ajv2020 | typeof Ajv2019 | typeof Draft7Ajv): AjvLike {
     const ajv = new engineClass({
         strict: false,
@@ -35,6 +42,14 @@ function createDefaultAjvInstance(engineClass: typeof Ajv2020 | typeof Ajv2019 |
         allErrors: true
     });
     addFormats(ajv);
+    // Register Google Cloud duration format to silence "unknown format" warnings
+    // from MCP servers that use Google API schemas (e.g. Firebase MCP).
+    if ('addFormat' in ajv && typeof ajv.addFormat === 'function') {
+        (ajv as { addFormat: (name: string, format: unknown) => void }).addFormat(
+            'google-duration',
+            GOOGLE_DURATION_RE
+        );
+    }
     return ajv;
 }
 

--- a/packages/core-internal/src/validators/ajvProvider.ts
+++ b/packages/core-internal/src/validators/ajvProvider.ts
@@ -45,10 +45,7 @@ function createDefaultAjvInstance(engineClass: typeof Ajv2020 | typeof Ajv2019 |
     // Register Google Cloud duration format to silence "unknown format" warnings
     // from MCP servers that use Google API schemas (e.g. Firebase MCP).
     if ('addFormat' in ajv && typeof ajv.addFormat === 'function') {
-        (ajv as { addFormat: (name: string, format: unknown) => void }).addFormat(
-            'google-duration',
-            GOOGLE_DURATION_RE
-        );
+        (ajv as { addFormat: (name: string, format: unknown) => void }).addFormat('google-duration', GOOGLE_DURATION_RE);
     }
     return ajv;
 }


### PR DESCRIPTION
## Why

Firebase MCP (and other Google Cloud API MCP servers) use the `google-duration` format in their JSON Schemas — values like `"3600s"`, `"1.5s"`, `"100ms"`. AJV logs `unknown format "google-duration" ignored in schema at path "#/properties/versionRetentionPeriod"` warnings for every schema that references it, creating noisy startup output for every user of these MCP servers.

## What

Register the `google-duration` format on the default AJV instances created by `AjvJsonSchemaValidator`. The regex matches Google's [Duration proto format](https://cloud.google.com/ruby/docs/reference/google-cloud-env/latest/Google/Protobuf/Duration): a number (integer or decimal) followed by a time unit suffix (`s`, `ms`, `us`, `ns`, `m`, `h`, `d`).

## Impact

- Silences the `unknown format "google-duration"` warnings at startup
- No behavior change — AJV already ignores unknown formats; this just registers it so the warning is not emitted
- Applies to all three dialect engines (2020-12, 2019-09, draft-07) since they all go through `createDefaultAjvInstance`
- Users who pass their own AJV instance are unaffected (they own their format registration)

## Testing

No new tests needed — this is a format registration that silences a warning. The existing test suite covers `AjvJsonSchemaValidator` behavior.