### PR TITLE
fix(server): tear down the request stream when an event store write rejects

### DIFF
--- a/.changeset/storeevent-rejection-teardown.md
+++ b/.changeset/storeevent-rejection-teardown.md
@@ -1,0 +1,18 @@
+---
+'@modelcontextprotocol/server': patch
+---
+
+Fix a rejected event-store write leaking the request stream in
+`WebStandardStreamableHTTPServerTransport`.
+
+`send()` awaits the user-supplied `eventStore.storeEvent()` before writing a response to
+the per-request SSE stream. A rejection propagated straight out of `send()`, skipping
+every teardown below it: the stream mapping and the request correlation stayed in their
+maps, the keep-alive timer stayed armed, and the HTTP response body was never closed — so
+the client waited on a stream that would never carry its response, and the server held the
+request forever.
+
+The write is now wrapped so a rejection retires the request and closes its stream before
+the error is rethrown. `send()` still rejects, so callers continue to see the failure.
+
+Also applies to `NodeStreamableHTTPServerTransport`, which wraps this transport.

--- a/packages/server/src/server/streamableHttp.ts
+++ b/packages/server/src/server/streamableHttp.ts
@@ -1154,7 +1154,24 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
             // interpreted as the client cancelling its request.
             let eventId: string | undefined;
             if (this._eventStore) {
-                eventId = await this._eventStore.storeEvent(streamId, message);
+                try {
+                    eventId = await this._eventStore.storeEvent(streamId, message);
+                } catch (error) {
+                    // The event store is user-supplied. A rejected write used to
+                    // propagate straight out of send(), skipping every teardown
+                    // below: the per-request SSE stream stayed open with its
+                    // keep-alive timer armed, and the stream and correlation
+                    // entries leaked. Retire the request first, then rethrow so
+                    // the caller still sees the failure.
+                    this._streamMapping.get(streamId)?.cleanup();
+                    for (const [id, mappedStreamId] of [...this._requestToStreamMapping.entries()]) {
+                        if (mappedStreamId === streamId) {
+                            this._requestResponseMap.delete(id);
+                            this._requestToStreamMapping.delete(id);
+                        }
+                    }
+                    throw error;
+                }
                 // Re-read after the await: a Last-Event-ID reconnect during
                 // storeEvent() may have registered a resumed stream under this
                 // streamId (mirrors the standalone path's post-await read).

--- a/packages/server/src/server/streamableHttp.ts
+++ b/packages/server/src/server/streamableHttp.ts
@@ -1164,7 +1164,7 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
                     // entries leaked. Retire the request first, then rethrow so
                     // the caller still sees the failure.
                     this._streamMapping.get(streamId)?.cleanup();
-                    for (const [id, mappedStreamId] of [...this._requestToStreamMapping.entries()]) {
+                    for (const [id, mappedStreamId] of this._requestToStreamMapping) {
                         if (mappedStreamId === streamId) {
                             this._requestResponseMap.delete(id);
                             this._requestToStreamMapping.delete(id);

--- a/packages/server/test/server/streamableHttp.test.ts
+++ b/packages/server/test/server/streamableHttp.test.ts
@@ -1406,6 +1406,44 @@ describe('Zod v4', () => {
             expect(cleanupCalls).toEqual(['stream-1']);
         });
     });
+
+    describe('a rejected event store write on the response path', () => {
+        it('should retire the request and close its stream instead of leaking it', async () => {
+            const eventStore: EventStore = {
+                async storeEvent(): Promise<EventId> {
+                    throw new Error('event store write failed');
+                },
+                async replayEventsAfter(): Promise<StreamId> {
+                    return '';
+                }
+            };
+
+            const transport = new WebStandardStreamableHTTPServerTransport({
+                sessionIdGenerator: undefined,
+                eventStore,
+                keepAliveMs: 20
+            });
+            transport.onmessage = () => {};
+
+            const res = await transport.handleRequest(createRequest('POST', { jsonrpc: '2.0', id: 1, method: 'ping' } as JSONRPCMessage));
+            expect(res.status).toBe(200);
+
+            await expect(transport.send({ jsonrpc: '2.0', id: 1, result: {} } as JSONRPCMessage)).rejects.toThrow(
+                'event store write failed'
+            );
+
+            // @ts-expect-error accessing private map for test purposes
+            expect(transport._streamMapping.size).toBe(0);
+            // @ts-expect-error accessing private map for test purposes
+            expect(transport._requestToStreamMapping.size).toBe(0);
+            // @ts-expect-error accessing private map for test purposes
+            expect(transport._requestResponseMap.size).toBe(0);
+
+            // The SSE body is terminated rather than held open by the keep-alive timer.
+            const reader = res.body!.getReader();
+            await expect(reader.read()).resolves.toMatchObject({ done: true });
+        });
+    });
 });
 
 describe('WebStandardStreamableHTTPServerTransport SSE keep-alive', () => {


### PR DESCRIPTION
## Motivation and Context

`send()` awaits the user-supplied `eventStore.storeEvent()` before writing a response to the per-request SSE stream. That `await` is unguarded, so a rejected write propagates straight out of `send()` and skips every teardown below it:

- the entry in `_streamMapping` survives, so the stream is never closed
- the correlation in `_requestToStreamMapping` survives, so the request id is never retired
- the keep-alive timer stays armed and keeps writing `: keepalive` comment frames
- the HTTP response body is never closed

The client is left holding a stream that will never carry its response while the server keeps the request alive indefinitely. Every failed write leaks another one. An event store is user-supplied infrastructure — a transient database or network failure is an expected condition, not a programming error.

This follows the same principle as the existing shutdown-path handling: teardown must not be skippable by a throw from a user-supplied callback (#1735, #1763).

## Changes

`send()` wraps the `storeEvent()` call. On rejection it closes the request's stream via the existing `cleanup()` and retires every correlation and recorded response for that stream, then rethrows. `send()` still rejects with the original error, so callers continue to see the failure — they just no longer leave a leaked stream behind.

## How Has This Been Tested?

New test in `packages/server/test/server/streamableHttp.test.ts` uses an event store that always rejects, asserts `send()` rejects with the store's error, asserts all three internal maps are empty, and asserts the SSE body is terminated rather than held open by the keep-alive timer. Verified to fail before the change and pass after.

Full server suite passes (469 tests), plus `typecheck` and `prettier`.

## Breaking Changes

None. `send()` rejects with the same error it did before.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context

Also reaches `NodeStreamableHTTPServerTransport`, which wraps this transport.
