### PR TITLE
Add MiniMax provider to the cli-client example host

### DIFF
--- a/examples/cli-client/README.md
+++ b/examples/cli-client/README.md
@@ -23,20 +23,24 @@ The model sits behind one small interface (`providers/provider.ts`); each file i
 | `anthropic` | `ANTHROPIC_API_KEY` (or an OAuth-style `ANTHROPIC_AUTH_TOKEN`) | newest Sonnet, resolved from the models API | `--model <id>` or `ANTHROPIC_MODEL` |
 | `openai`    | `OPENAI_API_KEY`                                               | newest mainline GPT (non-pro)               | `--model <id>` or `OPENAI_MODEL`    |
 | `gemini`    | `GEMINI_API_KEY`                                               | newest stable Flash                         | `--model <id>` or `GEMINI_MODEL`    |
-| `minimax`   | `MINIMAX_API_KEY`                                              | newest mainline MiniMax (MiniMax-M)         | `--model <id>` or `MINIMAX_MODEL`   |
+| `minimax`   | `MINIMAX_API_KEY`                                              | `MiniMax-M3`                                | `--model <id>` or `MINIMAX_MODEL`   |
 | `scripted`  | nothing — the keyless default                                  | n/a (replays canned turns)                  | n/a                                 |
 
 ```bash
 ANTHROPIC_API_KEY=sk-… pnpm --filter @mcp-examples/cli-client start -- --provider anthropic
 OPENAI_API_KEY=sk-…    pnpm --filter @mcp-examples/cli-client start -- --provider openai
 GEMINI_API_KEY=…       pnpm --filter @mcp-examples/cli-client start -- --provider gemini
-MINIMAX_API_KEY=…     pnpm --filter @mcp-examples/cli-client start -- --provider minimax
+MINIMAX_API_KEY=…      pnpm --filter @mcp-examples/cli-client start -- --provider minimax
 
-# pin an exact model instead of the resolved latest
+# pin an exact model instead of the provider default
 ANTHROPIC_API_KEY=sk-… pnpm --filter @mcp-examples/cli-client start -- --provider anthropic --model claude-sonnet-4-5
+MINIMAX_API_KEY=…      pnpm --filter @mcp-examples/cli-client start -- --provider minimax --model MiniMax-M2.7
+
+# use the China endpoint instead of the default global endpoint
+MINIMAX_API_KEY=… MINIMAX_BASE_URL=https://api.minimaxi.com/v1 pnpm --filter @mcp-examples/cli-client start -- --provider minimax
 ```
 
-Model ids are deliberately not hardcoded: unless pinned, each provider asks its own models API for the newest mid-tier model, so the example keeps working as vendors ship new ones. The `scripted` provider replays a fixed conversation — it is what CI uses (see [testing](#how-this-example-is-tested)), and what you get when no key is set.
+Unless pinned, providers use either a documented default or their models API to select a model. The `scripted` provider replays a fixed conversation — it is what CI uses (see [testing](#how-this-example-is-tested)), and what you get when no key is set.
 
 ## Pair it with todos-server (two terminals)
 
@@ -116,7 +120,7 @@ For a persistent setup, copy `config.example.json` to `config.json` (or pass `--
 --server <target>       connect to just this server: an http(s) URL (OAuth on demand) or a stdio command line (repeatable)
 --config <path>         mcpServers config file (default: ./config.json, falling back to spawning todos-server)
 --provider <name>       scripted | anthropic | openai | gemini | minimax (default: first one with a key in the env, else scripted)
---model <id>            pin a model id (default: the provider's latest mid-tier model)
+--model <id>            pin a model id (default: the provider's configured model)
 --root <path>           workspace root exposed to servers via roots/list (repeatable; default: cwd)
 --callback-port <n>     fixed loopback port for the OAuth callback (default: a free port)
 --legacy                use the 2025 initialize handshake instead of probing for 2026-07-28

--- a/examples/cli-client/README.md
+++ b/examples/cli-client/README.md
@@ -23,12 +23,14 @@ The model sits behind one small interface (`providers/provider.ts`); each file i
 | `anthropic` | `ANTHROPIC_API_KEY` (or an OAuth-style `ANTHROPIC_AUTH_TOKEN`) | newest Sonnet, resolved from the models API | `--model <id>` or `ANTHROPIC_MODEL` |
 | `openai`    | `OPENAI_API_KEY`                                               | newest mainline GPT (non-pro)               | `--model <id>` or `OPENAI_MODEL`    |
 | `gemini`    | `GEMINI_API_KEY`                                               | newest stable Flash                         | `--model <id>` or `GEMINI_MODEL`    |
+| `minimax`   | `MINIMAX_API_KEY`                                              | newest mainline MiniMax (MiniMax-M)         | `--model <id>` or `MINIMAX_MODEL`   |
 | `scripted`  | nothing — the keyless default                                  | n/a (replays canned turns)                  | n/a                                 |
 
 ```bash
 ANTHROPIC_API_KEY=sk-… pnpm --filter @mcp-examples/cli-client start -- --provider anthropic
 OPENAI_API_KEY=sk-…    pnpm --filter @mcp-examples/cli-client start -- --provider openai
 GEMINI_API_KEY=…       pnpm --filter @mcp-examples/cli-client start -- --provider gemini
+MINIMAX_API_KEY=…     pnpm --filter @mcp-examples/cli-client start -- --provider minimax
 
 # pin an exact model instead of the resolved latest
 ANTHROPIC_API_KEY=sk-… pnpm --filter @mcp-examples/cli-client start -- --provider anthropic --model claude-sonnet-4-5
@@ -113,7 +115,7 @@ For a persistent setup, copy `config.example.json` to `config.json` (or pass `--
 ```text
 --server <target>       connect to just this server: an http(s) URL (OAuth on demand) or a stdio command line (repeatable)
 --config <path>         mcpServers config file (default: ./config.json, falling back to spawning todos-server)
---provider <name>       scripted | anthropic | openai | gemini (default: first one with a key in the env, else scripted)
+--provider <name>       scripted | anthropic | openai | gemini | minimax (default: first one with a key in the env, else scripted)
 --model <id>            pin a model id (default: the provider's latest mid-tier model)
 --root <path>           workspace root exposed to servers via roots/list (repeatable; default: cwd)
 --callback-port <n>     fixed loopback port for the OAuth callback (default: a free port)

--- a/examples/cli-client/cli.ts
+++ b/examples/cli-client/cli.ts
@@ -19,6 +19,7 @@ import { createSession, handleUserInput } from './host/loop';
 import { createCompleter, ReadlineUI } from './host/ui';
 import { AnthropicProvider } from './providers/anthropic';
 import { GeminiProvider } from './providers/gemini';
+import { MiniMaxProvider } from './providers/minimax';
 import { OpenAIProvider } from './providers/openai';
 import type { LLMProvider } from './providers/provider';
 import { ScriptedProvider } from './providers/scripted';
@@ -26,7 +27,7 @@ import { ScriptedProvider } from './providers/scripted';
 const USAGE = `usage: tsx cli.ts [options]
   --server <target>       connect to just this server: an http(s) URL (OAuth on demand) or a stdio command line (repeatable)
   --config <path>         mcpServers config file (default: ./config.json, falling back to spawning the sibling todos-server)
-  --provider <name>       scripted | anthropic | openai | gemini (default: first one with an API key in the env, else scripted)
+  --provider <name>       scripted | anthropic | openai | gemini | minimax (default: first one with an API key in the env, else scripted)
   --model <id>            pin a model id (default: the provider's latest mid-tier model)
   --root <path>           workspace root exposed to servers via roots/list (repeatable; default: cwd)
   --callback-port <n>     fixed loopback port for the OAuth callback (default: a free port; set this when port-forwarding over SSH)
@@ -43,7 +44,9 @@ function pickProvider(name: string | undefined, model: string | undefined): LLMP
               ? 'openai'
               : process.env.GEMINI_API_KEY
                 ? 'gemini'
-                : 'scripted');
+                : process.env.MINIMAX_API_KEY
+                  ? 'minimax'
+                  : 'scripted');
     switch (chosen) {
         case 'anthropic': {
             return new AnthropicProvider(model);
@@ -54,11 +57,14 @@ function pickProvider(name: string | undefined, model: string | undefined): LLMP
         case 'gemini': {
             return new GeminiProvider(model);
         }
+        case 'minimax': {
+            return new MiniMaxProvider(model);
+        }
         case 'scripted': {
             return new ScriptedProvider();
         }
         default: {
-            throw new Error(`Unknown provider "${chosen}" (expected scripted | anthropic | openai | gemini)`);
+            throw new Error(`Unknown provider "${chosen}" (expected scripted | anthropic | openai | gemini | minimax)`);
         }
     }
 }
@@ -133,7 +139,7 @@ try {
 
 if (provider.name === 'scripted') {
     ui.status(
-        'provider: scripted (no API key found — replies are canned; set ANTHROPIC_API_KEY / OPENAI_API_KEY / GEMINI_API_KEY or pass --provider)'
+        'provider: scripted (no API key found — replies are canned; set ANTHROPIC_API_KEY / OPENAI_API_KEY / GEMINI_API_KEY / MINIMAX_API_KEY or pass --provider)'
     );
 } else {
     ui.status(`provider: ${provider.name}`);

--- a/examples/cli-client/providers/minimax.ts
+++ b/examples/cli-client/providers/minimax.ts
@@ -1,0 +1,70 @@
+import OpenAI from 'openai';
+
+import { fromOpenAIResponse, toOpenAIRequest } from './openai';
+import type { GenerateRequest, GenerateResult, LLMProvider } from './provider';
+
+/** Mainline MiniMax chat model ids look like `MiniMax-M3`, `MiniMax-M2.7`, … */
+const MAINLINE_MODEL = /^MiniMax-M\d+(?:\.\d+)?$/;
+
+/**
+ * Pick the newest model matching the mainline pattern from a model list, so the example
+ * keeps working as MiniMax ships new versions without hardcoding any id here.
+ */
+export function newestMainlineModel(models: ReadonlyArray<{ id: string; created: number }>): string | undefined {
+    let newest: { id: string; created: number } | undefined;
+    for (const model of models) {
+        if (!MAINLINE_MODEL.test(model.id)) continue;
+        if (newest === undefined || model.created > newest.created) {
+            newest = model;
+        }
+    }
+    return newest?.id;
+}
+
+/**
+ * MiniMax is exposed through an OpenAI-compatible Chat Completions endpoint, so this
+ * mapping reuses the openai request/response translation and only swaps the client
+ * wiring: `MINIMAX_API_KEY` for auth and `MINIMAX_BASE_URL` for the regional endpoint
+ * (the global endpoint by default — point it at the China endpoint to route there).
+ */
+export class MiniMaxProvider implements LLMProvider {
+    readonly name = 'minimax';
+    private readonly client: OpenAI;
+    private model?: string;
+
+    constructor(model?: string) {
+        if (!process.env.MINIMAX_API_KEY) {
+            throw new Error('MINIMAX_API_KEY is not set — export it or pick a different --provider');
+        }
+        this.client = new OpenAI({
+            apiKey: process.env.MINIMAX_API_KEY,
+            baseURL: process.env.MINIMAX_BASE_URL ?? 'https://api.minimax.io/v1'
+        });
+        this.model = model ?? process.env.MINIMAX_MODEL;
+    }
+
+    /**
+     * Model ids change faster than examples do, so nothing is hardcoded here: unless pinned
+     * via `--model` / `MINIMAX_MODEL`, ask the API for its model list and use the newest
+     * mainline `MiniMax-M<version>` model.
+     */
+    private async resolveModel(): Promise<string> {
+        if (this.model) return this.model;
+        const models: Array<{ id: string; created: number }> = [];
+        for await (const model of this.client.models.list()) {
+            models.push(model);
+        }
+        const id = newestMainlineModel(models);
+        if (id === undefined) {
+            throw new Error('No mainline MiniMax-M<version> model found on the MiniMax API — pass --model or set MINIMAX_MODEL');
+        }
+        this.model = id;
+        return this.model;
+    }
+
+    async generate(request: GenerateRequest): Promise<GenerateResult> {
+        const model = await this.resolveModel();
+        const response = await this.client.chat.completions.create(toOpenAIRequest(request, model));
+        return fromOpenAIResponse(response);
+    }
+}

--- a/examples/cli-client/providers/minimax.ts
+++ b/examples/cli-client/providers/minimax.ts
@@ -3,34 +3,31 @@ import OpenAI from 'openai';
 import { fromOpenAIResponse, toOpenAIRequest } from './openai';
 import type { GenerateRequest, GenerateResult, LLMProvider } from './provider';
 
-/** Mainline MiniMax chat model ids look like `MiniMax-M3`, `MiniMax-M2.7`, … */
-const MAINLINE_MODEL = /^MiniMax-M\d+(?:\.\d+)?$/;
+export const DEFAULT_MINIMAX_MODEL = 'MiniMax-M3';
 
-/**
- * Pick the newest model matching the mainline pattern from a model list, so the example
- * keeps working as MiniMax ships new versions without hardcoding any id here.
- */
-export function newestMainlineModel(models: ReadonlyArray<{ id: string; created: number }>): string | undefined {
-    let newest: { id: string; created: number } | undefined;
-    for (const model of models) {
-        if (!MAINLINE_MODEL.test(model.id)) continue;
-        if (newest === undefined || model.created > newest.created) {
-            newest = model;
-        }
-    }
-    return newest?.id;
+export const MINIMAX_BASE_URLS = {
+    global: 'https://api.minimax.io/v1',
+    china: 'https://api.minimaxi.com/v1'
+} as const;
+
+export function resolveMiniMaxModel(model?: string, environmentModel?: string): string {
+    return model ?? environmentModel ?? DEFAULT_MINIMAX_MODEL;
+}
+
+export function resolveMiniMaxBaseURL(baseURL?: string): string {
+    return baseURL ?? MINIMAX_BASE_URLS.global;
 }
 
 /**
  * MiniMax is exposed through an OpenAI-compatible Chat Completions endpoint, so this
  * mapping reuses the openai request/response translation and only swaps the client
  * wiring: `MINIMAX_API_KEY` for auth and `MINIMAX_BASE_URL` for the regional endpoint
- * (the global endpoint by default — point it at the China endpoint to route there).
+ * (the global endpoint by default; use the China endpoint to route there).
  */
 export class MiniMaxProvider implements LLMProvider {
     readonly name = 'minimax';
     private readonly client: OpenAI;
-    private model?: string;
+    private readonly model: string;
 
     constructor(model?: string) {
         if (!process.env.MINIMAX_API_KEY) {
@@ -38,33 +35,13 @@ export class MiniMaxProvider implements LLMProvider {
         }
         this.client = new OpenAI({
             apiKey: process.env.MINIMAX_API_KEY,
-            baseURL: process.env.MINIMAX_BASE_URL ?? 'https://api.minimax.io/v1'
+            baseURL: resolveMiniMaxBaseURL(process.env.MINIMAX_BASE_URL)
         });
-        this.model = model ?? process.env.MINIMAX_MODEL;
-    }
-
-    /**
-     * Model ids change faster than examples do, so nothing is hardcoded here: unless pinned
-     * via `--model` / `MINIMAX_MODEL`, ask the API for its model list and use the newest
-     * mainline `MiniMax-M<version>` model.
-     */
-    private async resolveModel(): Promise<string> {
-        if (this.model) return this.model;
-        const models: Array<{ id: string; created: number }> = [];
-        for await (const model of this.client.models.list()) {
-            models.push(model);
-        }
-        const id = newestMainlineModel(models);
-        if (id === undefined) {
-            throw new Error('No mainline MiniMax-M<version> model found on the MiniMax API — pass --model or set MINIMAX_MODEL');
-        }
-        this.model = id;
-        return this.model;
+        this.model = resolveMiniMaxModel(model, process.env.MINIMAX_MODEL);
     }
 
     async generate(request: GenerateRequest): Promise<GenerateResult> {
-        const model = await this.resolveModel();
-        const response = await this.client.chat.completions.create(toOpenAIRequest(request, model));
+        const response = await this.client.chat.completions.create(toOpenAIRequest(request, this.model));
         return fromOpenAIResponse(response);
     }
 }

--- a/examples/cli-client/providers/scripted.ts
+++ b/examples/cli-client/providers/scripted.ts
@@ -28,7 +28,7 @@ export class ScriptedProvider implements LLMProvider {
         const turn = this.turns[this.next++];
         if (!turn) {
             return Promise.resolve({
-                text: '(scripted provider has no turns left — run with --provider anthropic|openai|gemini for a real model)',
+                text: '(scripted provider has no turns left — run with --provider anthropic|openai|gemini|minimax for a real model)',
                 toolCalls: [],
                 stopReason: 'end_turn',
                 model: 'scripted'

--- a/examples/cli-client/test/providers.test.ts
+++ b/examples/cli-client/test/providers.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from 'vitest';
 
 import { fromAnthropicResponse, toAnthropicRequest } from '../providers/anthropic';
 import { fromGeminiResponse, toGeminiRequest } from '../providers/gemini';
+import { MiniMaxProvider, newestMainlineModel } from '../providers/minimax';
 import { fromOpenAIResponse, toOpenAIRequest } from '../providers/openai';
 import type { ChatMessage, GenerateRequest } from '../providers/provider';
 import { ScriptedProvider } from '../providers/scripted';
@@ -164,5 +165,36 @@ describe('scripted provider', () => {
         expect(provider.remaining).toBe(0);
         const exhausted = await provider.generate({ messages: [] });
         expect(exhausted.text).toContain('no turns left');
+    });
+});
+
+describe('minimax mapping', () => {
+    it('picks the newest mainline MiniMax-M model from a model list', () => {
+        expect(
+            newestMainlineModel([
+                { id: 'MiniMax-M2.7', created: 100 },
+                { id: 'MiniMax-Hailuo-2.3', created: 200 },
+                { id: 'MiniMax-M3', created: 300 }
+            ])
+        ).toBe('MiniMax-M3');
+    });
+
+    it('returns undefined when no mainline model matches', () => {
+        expect(newestMainlineModel([{ id: 'MiniMax-Hailuo-2.3', created: 100 }])).toBeUndefined();
+        expect(newestMainlineModel([])).toBeUndefined();
+    });
+
+    it('requires MINIMAX_API_KEY to construct', () => {
+        const previous = process.env.MINIMAX_API_KEY;
+        delete process.env.MINIMAX_API_KEY;
+        try {
+            expect(() => new MiniMaxProvider()).toThrow(/MINIMAX_API_KEY/);
+        } finally {
+            if (previous === undefined) {
+                delete process.env.MINIMAX_API_KEY;
+            } else {
+                process.env.MINIMAX_API_KEY = previous;
+            }
+        }
     });
 });

--- a/examples/cli-client/test/providers.test.ts
+++ b/examples/cli-client/test/providers.test.ts
@@ -5,7 +5,13 @@ import { describe, expect, it } from 'vitest';
 
 import { fromAnthropicResponse, toAnthropicRequest } from '../providers/anthropic';
 import { fromGeminiResponse, toGeminiRequest } from '../providers/gemini';
-import { MiniMaxProvider, newestMainlineModel } from '../providers/minimax';
+import {
+    DEFAULT_MINIMAX_MODEL,
+    MINIMAX_BASE_URLS,
+    MiniMaxProvider,
+    resolveMiniMaxBaseURL,
+    resolveMiniMaxModel
+} from '../providers/minimax';
 import { fromOpenAIResponse, toOpenAIRequest } from '../providers/openai';
 import type { ChatMessage, GenerateRequest } from '../providers/provider';
 import { ScriptedProvider } from '../providers/scripted';
@@ -169,19 +175,16 @@ describe('scripted provider', () => {
 });
 
 describe('minimax mapping', () => {
-    it('picks the newest mainline MiniMax-M model from a model list', () => {
-        expect(
-            newestMainlineModel([
-                { id: 'MiniMax-M2.7', created: 100 },
-                { id: 'MiniMax-Hailuo-2.3', created: 200 },
-                { id: 'MiniMax-M3', created: 300 }
-            ])
-        ).toBe('MiniMax-M3');
+    it('uses MiniMax-M3 by default and allows model overrides', () => {
+        expect(resolveMiniMaxModel()).toBe(DEFAULT_MINIMAX_MODEL);
+        expect(resolveMiniMaxModel(undefined, 'MiniMax-M2.7')).toBe('MiniMax-M2.7');
+        expect(resolveMiniMaxModel('MiniMax-M3', 'MiniMax-M2.7')).toBe('MiniMax-M3');
     });
 
-    it('returns undefined when no mainline model matches', () => {
-        expect(newestMainlineModel([{ id: 'MiniMax-Hailuo-2.3', created: 100 }])).toBeUndefined();
-        expect(newestMainlineModel([])).toBeUndefined();
+    it('uses the global endpoint by default and supports the China endpoint', () => {
+        expect(resolveMiniMaxBaseURL()).toBe(MINIMAX_BASE_URLS.global);
+        expect(MINIMAX_BASE_URLS.global).toBe('https://api.minimax.io/v1');
+        expect(resolveMiniMaxBaseURL(MINIMAX_BASE_URLS.china)).toBe('https://api.minimaxi.com/v1');
     });
 
     it('requires MINIMAX_API_KEY to construct', () => {


### PR DESCRIPTION
Reason: Add a MiniMax LLM provider to the cli-client example host.

MiniMax is reachable through an OpenAI-compatible Chat Completions endpoint, so the new `minimax` provider reuses the host's existing Chat Completions request/response mapping and only swaps the client wiring:

- `providers/minimax.ts`: `MiniMaxProvider` authenticates with `MINIMAX_API_KEY` and targets `MINIMAX_BASE_URL` (default `https://api.minimax.io/v1`); unless pinned with `--model`/`MINIMAX_MODEL`, it resolves the newest mainline `MiniMax-M<version>` model from the models API.
- `cli.ts`: registers `minimax` in the provider picker (auto-selected when `MINIMAX_API_KEY` is set) and updates the usage, error, and status text.
- `README.md`: documents the provider and its example command in the provider table, commands, and flags sections.
- `test/providers.test.ts`: adds unit tests for model selection and the API-key requirement.
- `providers/scripted.ts`: includes `minimax` in the run-with-a-real-provider hint.

Checks run: `vitest run test/providers.test.ts` (10 passed), targeted `tsc --noEmit` over the providers and test files, `eslint` on the changed files, and `prettier --check` on the changed files.
