### PR TITLE
fix(protocol): distinguish AbortSignal cancellation from request timeout

### DIFF
--- a/.changeset/request-aborted-error-code.md
+++ b/.changeset/request-aborted-error-code.md
@@ -1,0 +1,23 @@
+---
+'@modelcontextprotocol/core-internal': minor
+'@modelcontextprotocol/client': minor
+'@modelcontextprotocol/server': minor
+---
+
+Cancelling a request through `RequestOptions.signal` now rejects with
+`SdkErrorCode.RequestAborted` instead of `SdkErrorCode.RequestTimeout`, so a
+deliberate cancellation is distinguishable from a timeout expiry. Callers that
+gated retry/backoff on `RequestTimeout` were also firing it on every user
+cancellation.
+
+`RequestAborted` is a new `SdkErrorCode` member. Only an elapsed
+`RequestOptions.timeout` still carries `RequestTimeout` — the timeout handler
+constructs a typed `SdkError(RequestTimeout, 'Request timed out')` that passes
+through the abort wrap untouched. An abort `reason` that is already an
+`SdkError` continues to be rethrown verbatim with its own code.
+
+All four wrap sites move together, so the code does not depend on where the
+abort lands: `Protocol.request()` (in-flight abort and pre-aborted signal),
+the client's warm-cache pre-abort guard, and `Client.listen()`'s pre-abort
+guard. A cache hit and a wire request now report the same code for the same
+abort.

--- a/docs/migration/upgrade-to-v2.md
+++ b/docs/migration/upgrade-to-v2.md
@@ -986,6 +986,7 @@ the third argument — `new SdkHttpError(SdkErrorCode.ClientHttpNotImplemented,
 | `NotInitialized`                      | Protocol is not initialized                                                |
 | `CapabilityNotSupported`              | Required capability is not supported                                       |
 | `RequestTimeout`                      | Request timed out waiting for response                                     |
+| `RequestAborted`                      | Request was cancelled through `RequestOptions.signal`                      |
 | `ConnectionClosed`                    | Connection was closed                                                      |
 | `SendFailed`                          | Failed to send message                                                     |
 | `InvalidResult`                       | Response result failed local schema validation                             |
@@ -1530,8 +1531,12 @@ rewrite required unless noted.
   fires (v1 let them run to completion). `InMemoryTransport.close()` no longer
   double-fires `onclose` on the initiating side.
 - **`Protocol.request()` with an already-aborted signal** rejects with
-  `SdkError(SdkErrorCode.RequestTimeout, reason)` instead of throwing the raw
-  `signal.reason`, matching the in-flight-abort path.
+  `SdkError(SdkErrorCode.RequestAborted, reason)` instead of throwing the raw
+  `signal.reason`, matching the in-flight-abort path. Cancellation through
+  `RequestOptions.signal` — pre-aborted or in-flight — carries `RequestAborted`,
+  not `RequestTimeout`; only an elapsed `RequestOptions.timeout` carries
+  `RequestTimeout`. An abort `reason` that is already an `SdkError` is still
+  rethrown verbatim with its own code.
 - **OAuth discovery (`discoverOAuthProtectedResourceMetadata` / `discoverOAuthMetadata`,
   transitively `auth()`) throws on fetch `TypeError`** (DNS failure, `ECONNREFUSED`,
   invalid URL) in Node and Cloudflare Workers instead of swallowing it as a CORS miss
@@ -1551,7 +1556,7 @@ rewrite required unless noted.
   verbs on top of it — `callTool()` and the cacheable list verbs — perform async work
   first (header-mirroring scan, response-cache freshness, output-validator resolution),
   so an abort fired in the same tick can land before the frame is ever sent: the call
-  rejects with `SdkError(RequestTimeout, reason)` and **no `notifications/cancelled` is
+  rejects with `SdkError(RequestAborted, reason)` and **no `notifications/cancelled` is
   emitted** (nothing was in flight). v1 sent the frame synchronously from these verbs.
   Once the frame is on the wire, aborting still sends `notifications/cancelled` before
   rejecting.

--- a/packages/client/src/client/client.ts
+++ b/packages/client/src/client/client.ts
@@ -1808,12 +1808,12 @@ export class Client extends Protocol<ClientContext> {
         if (hit !== undefined) {
             // A pre-aborted caller signal must reject the same way it would on
             // the wire path (`Protocol.request()` wraps an already-aborted
-            // signal as `SdkError(RequestTimeout, reason)`); without this guard
+            // signal as `SdkError(RequestAborted, reason)`); without this guard
             // a cache hit would resolve successfully and silently swallow the
             // abort.
             if (options?.signal?.aborted) {
                 const reason = options.signal.reason;
-                throw reason instanceof SdkError ? reason : new SdkError(SdkErrorCode.RequestTimeout, String(reason));
+                throw reason instanceof SdkError ? reason : new SdkError(SdkErrorCode.RequestAborted, String(reason));
             }
             return hit.value as R;
         }
@@ -1968,12 +1968,12 @@ export class Client extends Protocol<ClientContext> {
 
         // Honor RequestOptions.signal exactly as request() does: an
         // already-aborted signal rejects synchronously before any setup, and
-        // the rejection is the same `SdkError(RequestTimeout, reason)` wrap
+        // the rejection is the same `SdkError(RequestAborted, reason)` wrap
         // request() / `_serveFromCache` apply (unless `reason` is already an
         // SdkError — preserved verbatim).
         if (options?.signal?.aborted) {
             const reason = options.signal.reason;
-            throw reason instanceof SdkError ? reason : new SdkError(SdkErrorCode.RequestTimeout, String(reason));
+            throw reason instanceof SdkError ? reason : new SdkError(SdkErrorCode.RequestAborted, String(reason));
         }
 
         const requestAbort = new AbortController();

--- a/packages/client/test/client/listen.test.ts
+++ b/packages/client/test/client/listen.test.ts
@@ -379,7 +379,7 @@ describe('Client.listen()', () => {
         await client.close();
     });
 
-    it('options.signal already aborted: listen() rejects with SdkError(RequestTimeout) before any setup (parity with request())', async () => {
+    it('options.signal already aborted: listen() rejects with SdkError(RequestAborted) before any setup (parity with request())', async () => {
         const { clientTx, written } = await scriptedModern();
         const client = new Client({ name: 'c', version: '1' }, { versionNegotiation: { mode: 'auto' } });
         await client.connect(clientTx);
@@ -388,9 +388,9 @@ describe('Client.listen()', () => {
         ac.abort('user cancelled');
         const error = await client.listen({ toolsListChanged: true }, { signal: ac.signal }).catch(e => e as SdkError);
         // Same wrap as `Protocol.request()` / `_serveFromCache`: a non-SdkError
-        // reason is wrapped as RequestTimeout; the reason text is preserved.
+        // reason is wrapped as RequestAborted; the reason text is preserved.
         expect(error).toBeInstanceOf(SdkError);
-        expect((error as SdkError).code).toBe(SdkErrorCode.RequestTimeout);
+        expect((error as SdkError).code).toBe(SdkErrorCode.RequestAborted);
         expect((error as SdkError).message).toContain('user cancelled');
         // No subscriptions/listen reached the wire; no listen state registered.
         await flush();

--- a/packages/client/test/client/responseCache.test.ts
+++ b/packages/client/test/client/responseCache.test.ts
@@ -1079,7 +1079,7 @@ describe('Client honours cacheHints (SEP-2549)', () => {
         expect(wireCount('resources/read')).toBe(3);
     });
 
-    it('a pre-aborted signal on a warm-cache hit rejects with SdkError(RequestTimeout) — the abort is not swallowed by the cache serve', async () => {
+    it('a pre-aborted signal on a warm-cache hit rejects with SdkError(RequestAborted) — the abort is not swallowed by the cache serve', async () => {
         const store = new InMemoryResponseCacheStore();
         const { clientTx, listCount } = await scriptedModernServer([[TOOL_A]], { listHint: { ttlMs: 60_000, cacheScope: 'public' } });
         const client = modernClient(store);
@@ -1094,7 +1094,7 @@ describe('Client honours cacheHints (SEP-2549)', () => {
         ac.abort('user cancelled');
         const error = await client.listTools(undefined, { signal: ac.signal }).catch(e => e as SdkError);
         expect(error).toBeInstanceOf(SdkError);
-        expect((error as SdkError).code).toBe(SdkErrorCode.RequestTimeout);
+        expect((error as SdkError).code).toBe(SdkErrorCode.RequestAborted);
         expect((error as SdkError).message).toContain('user cancelled');
         // The aborted call did not reach the wire.
         expect(listCount()).toBe(1);

--- a/packages/core-internal/src/errors/sdkErrors.ts
+++ b/packages/core-internal/src/errors/sdkErrors.ts
@@ -24,6 +24,14 @@ export enum SdkErrorCode {
     // Transport errors
     /** Request timed out waiting for response */
     RequestTimeout = 'REQUEST_TIMEOUT',
+    /**
+     * Request was cancelled through `RequestOptions.signal`. Distinct from
+     * {@linkcode SdkErrorCode.RequestTimeout} so callers can tell a deliberate
+     * cancellation apart from a timeout expiry. The abort reason is carried in
+     * the message; an abort reason that is already an `SdkError` is rethrown
+     * verbatim and keeps its own code.
+     */
+    RequestAborted = 'REQUEST_ABORTED',
     /** Connection was closed */
     ConnectionClosed = 'CONNECTION_CLOSED',
     /** Failed to send message */

--- a/packages/core-internal/src/shared/protocol.ts
+++ b/packages/core-internal/src/shared/protocol.ts
@@ -1394,14 +1394,14 @@ export abstract class Protocol<ContextT extends BaseContext> {
             }
 
             // An already-aborted caller signal must surface the same way an
-            // in-flight abort does (`SdkError(RequestTimeout, reason)` via
+            // in-flight abort does (`SdkError(RequestAborted, reason)` via
             // `cancel()` below). Bare `throwIfAborted()` would propagate the
             // raw `signal.reason` instead, so callers that introduce an async
             // hop before `request()` (e.g. a cache freshness check) would see
             // a different rejection type depending on where the abort lands.
             if (options?.signal?.aborted) {
                 const reason = options.signal.reason;
-                throw reason instanceof SdkError ? reason : new SdkError(SdkErrorCode.RequestTimeout, String(reason));
+                throw reason instanceof SdkError ? reason : new SdkError(SdkErrorCode.RequestAborted, String(reason));
             }
 
             // Spec basic/patterns/cancellation §Transport-Specific (2026-07-28):
@@ -1473,8 +1473,12 @@ export abstract class Protocol<ContextT extends BaseContext> {
                     requestAbort.abort();
                 }
 
-                // Wrap the reason in an SdkError if it isn't already
-                const error = reason instanceof SdkError ? reason : new SdkError(SdkErrorCode.RequestTimeout, String(reason));
+                // Wrap the reason in an SdkError if it isn't already. Only the
+                // caller-signal path reaches this wrap with a non-SdkError
+                // reason — the timeout handler below passes a typed
+                // `SdkError(RequestTimeout, …)` straight through — so
+                // `RequestAborted` is the correct code here.
+                const error = reason instanceof SdkError ? reason : new SdkError(SdkErrorCode.RequestAborted, String(reason));
                 reject(error);
             };
 

--- a/packages/core-internal/test/shared/abortReasonPassthrough.test.ts
+++ b/packages/core-internal/test/shared/abortReasonPassthrough.test.ts
@@ -50,12 +50,61 @@ describe('request() abort-reason passthrough', () => {
         await expect(protocol.request({ method: 'ping' }, { signal: controller.signal })).rejects.toBe(reason);
     });
 
-    it('wraps a non-SdkError abort reason in SdkError(RequestTimeout)', async () => {
+    it('wraps a non-SdkError abort reason in SdkError(RequestAborted)', async () => {
         const protocol = await connectedProtocol();
         const controller = new AbortController();
         controller.abort(new Error('plain'));
 
         const rejection = await protocol.request({ method: 'ping' }, { signal: controller.signal }).then(
+            () => {
+                throw new Error('request unexpectedly resolved');
+            },
+            (e: unknown) => e
+        );
+        expect(rejection).toBeInstanceOf(SdkError);
+        expect((rejection as SdkError).code).toBe(SdkErrorCode.RequestAborted);
+    });
+
+    it('wraps an in-flight abort in SdkError(RequestAborted), not RequestTimeout', async () => {
+        const protocol = await connectedProtocol();
+        const controller = new AbortController();
+        // Timeout is three orders of magnitude away from the abort, so a
+        // RequestTimeout here could only come from the abort path.
+        const pending = protocol.request({ method: 'ping' }, { signal: controller.signal, timeout: 60_000 }).then(
+            () => {
+                throw new Error('request unexpectedly resolved');
+            },
+            (e: unknown) => e
+        );
+        controller.abort(new DOMException('User cancelled', 'AbortError'));
+
+        const rejection = await pending;
+        expect(rejection).toBeInstanceOf(SdkError);
+        expect((rejection as SdkError).code).toBe(SdkErrorCode.RequestAborted);
+        expect((rejection as SdkError).code).not.toBe(SdkErrorCode.RequestTimeout);
+        expect((rejection as SdkError).message).toContain('User cancelled');
+    });
+
+    it('wraps a bare in-flight abort() with no reason in SdkError(RequestAborted)', async () => {
+        const protocol = await connectedProtocol();
+        const controller = new AbortController();
+        const pending = protocol.request({ method: 'ping' }, { signal: controller.signal, timeout: 60_000 }).then(
+            () => {
+                throw new Error('request unexpectedly resolved');
+            },
+            (e: unknown) => e
+        );
+        controller.abort();
+
+        const rejection = await pending;
+        expect(rejection).toBeInstanceOf(SdkError);
+        expect((rejection as SdkError).code).toBe(SdkErrorCode.RequestAborted);
+    });
+
+    it('leaves the timeout path on RequestTimeout', async () => {
+        const protocol = await connectedProtocol();
+
+        const rejection = await protocol.request({ method: 'ping' }, { timeout: 0 }).then(
             () => {
                 throw new Error('request unexpectedly resolved');
             },

--- a/packages/core-internal/test/types/errorSurfacePins.test.ts
+++ b/packages/core-internal/test/types/errorSurfacePins.test.ts
@@ -73,6 +73,7 @@ describe('SdkErrorCode', () => {
             NotInitialized: 'NOT_INITIALIZED',
             CapabilityNotSupported: 'CAPABILITY_NOT_SUPPORTED',
             RequestTimeout: 'REQUEST_TIMEOUT',
+            RequestAborted: 'REQUEST_ABORTED',
             ConnectionClosed: 'CONNECTION_CLOSED',
             SendFailed: 'SEND_FAILED',
             InvalidResult: 'INVALID_RESULT',


### PR DESCRIPTION
Aborting a request through `RequestOptions.signal` rejected with `SdkErrorCode.RequestTimeout` — the same code an elapsed `RequestOptions.timeout` produces — so callers had no way to tell a deliberate cancellation apart from a real timeout.

Fixes #2165

## Motivation and Context

The `cancel()` fallback in `Protocol._requestWithSchemaViaCodec()` wrapped any non-`SdkError` abort reason as `SdkErrorCode.RequestTimeout`, and `onAbort = () => cancel(options?.signal?.reason)` feeds `AbortSignal.reason` straight into it. Retry/backoff logic gated on `RequestTimeout` therefore fired on every user cancellation:

```ts
if (error.code === SdkErrorCode.RequestTimeout) {
    showRetryMessage(); // also fired on controller.abort()
}
```

This adds `SdkErrorCode.RequestAborted` and moves **all four** non-`SdkError` wrap sites onto it together, per the scope note in the triage comment on #2165:

| Site | File |
| --- | --- |
| `Protocol.request()` in-flight abort (`cancel()` fallback) | `packages/core-internal/src/shared/protocol.ts` |
| `Protocol.request()` pre-aborted signal check | `packages/core-internal/src/shared/protocol.ts` |
| `Client._serveFromCache()` warm-hit pre-abort guard | `packages/client/src/client/client.ts` |
| `Client.listen()` pre-abort guard | `packages/client/src/client/client.ts` |

Moving them together is the point: leaving the cache and `listen()` sites on `RequestTimeout` would make the same abort surface as two different codes depending on whether the cache happened to be warm.

The timeout path is untouched. `timeoutHandler` constructs a typed `SdkError(RequestTimeout, 'Request timed out', { timeout })`, which reaches `cancel()` as an `SdkError` and passes through the wrap via the `instanceof SdkError` branch. An abort `reason` that is already an `SdkError` is likewise still rethrown verbatim with its own code.

### Relationship to #2177

@sakthiveltofficial opened #2177 for this issue first and landed the enum member plus the `cancel()` fallback — credit for the diagnosis and the first fix is theirs. That PR predates the `core-internal` package split, so it now conflicts with `main`, and it covers one of the four wrap sites. This PR rebases the same idea onto current `main` and completes it: the remaining three sites, the two behavior pins and the enum ABI pin that lock the old contract, the migration-guide entries, and a changeset. Happy to close this in favour of an updated #2177 if @sakthiveltofficial would rather carry it — no ownership claim here, the issue had just been idle for a while.

## How Has This Been Tested?

New coverage in `packages/core-internal/test/shared/abortReasonPassthrough.test.ts`:

- in-flight `abort(new DOMException('User cancelled', 'AbortError'))` against a `timeout: 60_000` request → `RequestAborted`, explicitly asserted **not** `RequestTimeout`, reason text preserved
- in-flight bare `abort()` with no reason → `RequestAborted`
- `timeout: 0` control → still `RequestTimeout`

Updated pins that locked the old wrap-as-`RequestTimeout` contract:

- `core-internal/test/shared/abortReasonPassthrough.test.ts` — non-`SdkError` reason pin
- `core-internal/test/types/errorSurfacePins.test.ts` — `SdkErrorCode` enum-membership ABI pin
- `client/test/client/responseCache.test.ts` — warm-hit pre-abort
- `client/test/client/listen.test.ts` — `listen()` pre-abort (the ack-timeout test in the same file correctly stays on `RequestTimeout`)

Run locally:

```
pnpm -r --no-bail test    core-internal 1436 ✓ · client 797 ✓ · server 42 files ✓ ·
                          server-legacy 11 ✓ · middleware ✓ · integration 19 ✓ · e2e 2635 ✓
pnpm typecheck:all        ✓
pnpm lint:all             ✓ (incl. prettier + sync:snippets --check)
```

Three suites fail on my Windows box for environment reasons and fail identically on an unmodified `main` (verified by stashing): the codemod symlink-cycle test (`EPERM` — Windows needs elevation to create symlinks), and two `scenarios/stdio.test.ts` shutdown-escalation cases (no POSIX signal escalation on Windows). `pnpm docs:check` also can't run on Windows — typedoc rejects `\` path separators.

## Breaking Changes

Behavioral, and deliberately so — it is the fix. Code that reached the `catch` on a user cancellation and compared against `SdkErrorCode.RequestTimeout` now sees `RequestAborted`. Anything checking `signal.aborted` first, or comparing against `RequestTimeout` only for genuine timeouts, is unaffected. `RequestAborted` is a new enum member, so nothing existing can be reading it yet.

Changeset is `minor` for `core-internal`, `client`, and `server` (the enum is re-exported through `core-internal/public` onto both package roots). Migration guide updated in `docs/migration/upgrade-to-v2.md`: the `SdkErrorCode` table gains a row, and the two already-aborted-signal entries now name `RequestAborted`.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

Two follow-ups, deliberately kept out of this PR to keep it reviewable — happy to take either on:

1. **`v1.x` backport.** The triage comment notes `v1.x` carries the same shape with `McpError` / `ErrorCode.RequestTimeout` at `src/shared/protocol.ts:1185`. I'd rather send that as a separate PR against `v1.x` than mix branches here.
2. **`inputRequiredDriver.ts`.** `packages/core-internal/src/shared/inputRequiredDriver.ts:163` and `:172` wrap a `signal.reason` with the identical pattern. They are outside the four sites the triage comment scoped, so I left them alone rather than widen the diff — but if you consider them part of the same contract, say the word and I'll fold them in (they'd need their pins in `inputRequiredDriver.test.ts` updated too).
