### PR TITLE
fix(server): preserve explicit tool listChanged capability

### DIFF
--- a/.changeset/preserve-tool-list-changed.md
+++ b/.changeset/preserve-tool-list-changed.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/sdk': patch
+---
+
+Preserve an explicitly configured `tools.listChanged` capability when registering tools with `McpServer`.

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -445,7 +445,10 @@ export class Server<
         return this._clientVersion;
     }
 
-    private getCapabilities(): ServerCapabilities {
+    /**
+     * Returns the current server capabilities.
+     */
+    public getCapabilities(): ServerCapabilities {
         return this._capabilities;
     }
 

--- a/src/server/mcp.ts
+++ b/src/server/mcp.ts
@@ -131,7 +131,7 @@ export class McpServer {
 
         this.server.registerCapabilities({
             tools: {
-                listChanged: true
+                listChanged: this.server.getCapabilities().tools?.listChanged ?? true
             }
         });
 

--- a/test/server/mcp.test.ts
+++ b/test/server/mcp.test.ts
@@ -56,6 +56,53 @@ describe.each(zodTestMatrix)('$zodVersionLabel', (entry: ZodMatrixEntry) => {
             expect(mcpServer.server).toBeDefined();
         });
 
+        test('should preserve an explicitly disabled tool listChanged capability', async () => {
+            const mcpServer = new McpServer(
+                {
+                    name: 'test server',
+                    version: '1.0'
+                },
+                {
+                    capabilities: {
+                        tools: { listChanged: false }
+                    }
+                }
+            );
+            const client = new Client({
+                name: 'test client',
+                version: '1.0'
+            });
+
+            mcpServer.registerTool('test', {}, async () => ({
+                content: [{ type: 'text', text: 'Test response' }]
+            }));
+
+            const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+            await Promise.all([client.connect(clientTransport), mcpServer.connect(serverTransport)]);
+
+            expect(client.getServerCapabilities()?.tools?.listChanged).toBe(false);
+        });
+
+        test('should enable the tool listChanged capability by default', async () => {
+            const mcpServer = new McpServer({
+                name: 'test server',
+                version: '1.0'
+            });
+            const client = new Client({
+                name: 'test client',
+                version: '1.0'
+            });
+
+            mcpServer.registerTool('test', {}, async () => ({
+                content: [{ type: 'text', text: 'Test response' }]
+            }));
+
+            const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+            await Promise.all([client.connect(clientTransport), mcpServer.connect(serverTransport)]);
+
+            expect(client.getServerCapabilities()?.tools?.listChanged).toBe(true);
+        });
+
         /***
          * Test: Notification Sending via Server
          */


### PR DESCRIPTION
## Summary

- preserve an explicitly configured `tools.listChanged: false` value when the first tool is registered
- expose the server's current capabilities so `McpServer` can merge its default without overwriting caller configuration
- keep the existing `listChanged: true` default when no value is provided

## Root cause

`McpServer.setToolRequestHandlers()` unconditionally registered `tools.listChanged: true`, and the capability merge allowed that internal default to overwrite the constructor-provided value. The v2 server already reads the current capability before applying the default; this brings the same tool behavior to `v1.x`.

Closes #2622.

## Validation

- `npx vitest run test/server/mcp.test.ts` (236 passed)
- `npm run typecheck`
- `npm run lint`

AI assistance disclosure: Codex was used to help investigate and implement this change. I reviewed the diff and validated the code and tests locally.
