### PR TITLE
feat(server): add DPoP (RFC 9449) proof validation

### DIFF
--- a/.changeset/dpop-server-validation.md
+++ b/.changeset/dpop-server-validation.md
@@ -3,4 +3,4 @@
 "@modelcontextprotocol/express": minor
 ---
 
-Add DPoP (RFC 9449 / SEP-1932) proof validation for resource servers. New `requireDpopAuth` gate (`@modelcontextprotocol/express`, backed by `verifyDpopProof`/`verifyDpopToken` in `@modelcontextprotocol/server`) validates DPoP proofs and access-token binding (`cnf.jkt`) by hand-rolled WebCrypto — no new runtime dependency. `verifyBearerToken` now rejects a DPoP-bound token presented under the `Bearer` scheme, per RFC 9449 §7.1.
+Add DPoP (RFC 9449 / SEP-1932) proof validation for resource servers. New `requireDpopAuth` gate (`@modelcontextprotocol/express`, backed by `verifyDpopProof`/`verifyDpopToken` in `@modelcontextprotocol/server`) validates DPoP proofs and access-token binding (`cnf.jkt`) by hand-rolled WebCrypto — no new runtime dependency. `verifyBearerToken` now rejects a DPoP-bound token presented under the `Bearer` scheme, per RFC 9449 §7.2 ("Compatibility with the Bearer Authentication Scheme").

--- a/.changeset/dpop-server-validation.md
+++ b/.changeset/dpop-server-validation.md
@@ -1,0 +1,6 @@
+---
+"@modelcontextprotocol/server": minor
+"@modelcontextprotocol/express": minor
+---
+
+Add DPoP (RFC 9449 / SEP-1932) proof validation for resource servers. New `requireDpopAuth` gate (`@modelcontextprotocol/express`, backed by `verifyDpopProof`/`verifyDpopToken` in `@modelcontextprotocol/server`) validates DPoP proofs and access-token binding (`cnf.jkt`) by hand-rolled WebCrypto — no new runtime dependency. `verifyBearerToken` now rejects a DPoP-bound token presented under the `Bearer` scheme, per RFC 9449 §7.1.

--- a/packages/core-internal/src/auth/errors.ts
+++ b/packages/core-internal/src/auth/errors.ts
@@ -97,7 +97,20 @@ export enum OAuthErrorCode {
     /**
      * The requested resource is invalid, missing, unknown, or malformed. (Custom error for resource indicators - RFC 8707)
      */
-    InvalidTarget = 'invalid_target'
+    InvalidTarget = 'invalid_target',
+
+    /**
+     * The DPoP proof is missing, malformed, or fails validation (signature, `htm`/`htu`/`iat`,
+     * key binding, etc.). (RFC 9449 §4.3 / §7.1, SEP-1932)
+     */
+    InvalidDpopProof = 'invalid_dpop_proof',
+
+    /**
+     * The server requires a fresh DPoP proof carrying a server-provided nonce; the response
+     * carries the nonce in a `DPoP-Nonce` header for the client to retry with.
+     * (RFC 9449 §8 / §9, SEP-1932)
+     */
+    UseDpopNonce = 'use_dpop_nonce'
 }
 
 /**

--- a/packages/core-internal/src/types/types.ts
+++ b/packages/core-internal/src/types/types.ts
@@ -752,6 +752,18 @@ export interface AuthInfo {
     resource?: URL;
 
     /**
+     * RFC 9449 §6 confirmation claim: when set, this token is DPoP-bound and MUST only be
+     * accepted alongside a DPoP proof whose public key's JWK thumbprint matches `cnf.jkt`
+     * (SEP-1932). A verifier that supports DPoP-bound tokens sets this from the access token's
+     * own `cnf.jkt` claim; {@linkcode requireDpopAuth} compares it against the presented proof.
+     *
+     * Also read by {@linkcode verifyBearerToken}: a token with `cnf.jkt` set MUST NOT be accepted
+     * under the plain `Bearer` scheme (RFC 9449 §7.1) — a bound token presented without its proof
+     * would defeat the point of binding it.
+     */
+    cnf?: { jkt?: string };
+
+    /**
      * Additional data associated with the token.
      * This field should be used for any additional data that needs to be attached to the auth info.
      */

--- a/packages/core-internal/src/types/types.ts
+++ b/packages/core-internal/src/types/types.ts
@@ -755,9 +755,9 @@ export interface AuthInfo {
      * RFC 9449 §6 confirmation claim: when set, this token is DPoP-bound and MUST only be
      * accepted alongside a DPoP proof whose public key's JWK thumbprint matches `cnf.jkt`
      * (SEP-1932). A verifier that supports DPoP-bound tokens sets this from the access token's
-     * own `cnf.jkt` claim; {@linkcode requireDpopAuth} compares it against the presented proof.
+     * own `cnf.jkt` claim; {@linkcode @modelcontextprotocol/server!server/middleware/dpopAuth.requireDpopAuth | requireDpopAuth} compares it against the presented proof.
      *
-     * Also read by {@linkcode verifyBearerToken}: a token with `cnf.jkt` set MUST NOT be accepted
+     * Also read by {@linkcode @modelcontextprotocol/server!server/middleware/bearerAuth.verifyBearerToken | verifyBearerToken}: a token with `cnf.jkt` set MUST NOT be accepted
      * under the plain `Bearer` scheme (RFC 9449 §7.1) — a bound token presented without its proof
      * would defeat the point of binding it.
      */

--- a/packages/core-internal/src/types/types.ts
+++ b/packages/core-internal/src/types/types.ts
@@ -758,8 +758,9 @@ export interface AuthInfo {
      * own `cnf.jkt` claim; {@linkcode @modelcontextprotocol/server!server/middleware/dpopAuth.requireDpopAuth | requireDpopAuth} compares it against the presented proof.
      *
      * Also read by {@linkcode @modelcontextprotocol/server!server/middleware/bearerAuth.verifyBearerToken | verifyBearerToken}: a token with `cnf.jkt` set MUST NOT be accepted
-     * under the plain `Bearer` scheme (RFC 9449 §7.1) — a bound token presented without its proof
-     * would defeat the point of binding it.
+     * under the plain `Bearer` scheme (RFC 9449 §7.2, "Compatibility with the Bearer
+     * Authentication Scheme") — a bound token presented without its proof would defeat the point
+     * of binding it.
      */
     cnf?: { jkt?: string };
 

--- a/packages/middleware/express/src/auth/dpopAuth.ts
+++ b/packages/middleware/express/src/auth/dpopAuth.ts
@@ -1,0 +1,75 @@
+import type { DpopAuthOptions } from '@modelcontextprotocol/server';
+import { dpopAuthChallengeResponse, OAuthError, OAuthErrorCode, verifyDpopToken } from '@modelcontextprotocol/server';
+import type { Request, RequestHandler } from 'express';
+
+/**
+ * Options for {@link requireDpopAuth}.
+ */
+export type DpopAuthMiddlewareOptions = DpopAuthOptions;
+
+/**
+ * Reconstruct the external request URL — the value a DPoP proof's `htu` claim must match
+ * (RFC 9449 §4.2) — from Express's `req`. `req.originalUrl` (not `req.path`) so a router mounted
+ * at a sub-path still yields the URL the client actually targeted; the query string is stripped
+ * since `htu` MUST NOT contain one.
+ *
+ * Trusts `X-Forwarded-Proto`/`-Host` only when Express's own `trust proxy` setting says to
+ * (`req.protocol` and `req.hostname` already apply that setting); behind an untrusted proxy this
+ * falls back to the raw connection protocol and the `Host` header.
+ */
+function reconstructRequestUrl(req: Request): string {
+    const [pathAndQuery] = req.originalUrl.split('?');
+    return `${req.protocol}://${req.get('host')}${pathAndQuery}`;
+}
+
+/**
+ * Express middleware that requires a valid DPoP-bound token — the `Authorization: DPoP <token>`
+ * header plus the accompanying `DPoP` proof header — in the request (RFC 9449 / SEP-1932).
+ *
+ * The Express adapter over the runtime-neutral core in `@modelcontextprotocol/server`
+ * (`verifyDpopToken` / `dpopAuthChallengeResponse` — or `requireDpopAuth` from that package for
+ * web-standard `fetch(request)` hosts). The token is validated via the supplied
+ * `OAuthTokenVerifier` (shared with `requireBearerAuth` — a verifier that populates `AuthInfo.cnf`
+ * works with either), the proof is validated against the request's method and reconstructed URL,
+ * and the resulting `AuthInfo` is attached to `req.auth` — read by the MCP Streamable HTTP
+ * transport and surfaced to handlers as `ctx.http.authInfo`, exactly as `requireBearerAuth`
+ * attaches it.
+ *
+ * On failure the middleware sends a JSON OAuth error body and a `WWW-Authenticate: DPoP …`
+ * challenge (plus a `DPoP-Nonce` header when `options.nonce` issues one) — see
+ * {@link dpopAuthChallengeResponse} in `@modelcontextprotocol/server`.
+ */
+export function requireDpopAuth(options: DpopAuthMiddlewareOptions): RequestHandler {
+    // Destructure at creation so a plain-JS caller passing undefined or malformed options crashes
+    // at startup, not on the first request.
+    const { verifier, requiredScopes = [], resourceMetadataUrl, iatSkewSeconds, nonce } = options;
+    const resolved = { verifier, requiredScopes, resourceMetadataUrl, iatSkewSeconds, nonce };
+    return async (req, res, next) => {
+        try {
+            req.auth = await verifyDpopToken(
+                {
+                    authorization: req.headers.authorization,
+                    dpop: req.headers.dpop,
+                    method: req.method,
+                    url: reconstructRequestUrl(req)
+                },
+                resolved
+            );
+            next();
+        } catch (error) {
+            // The core Response supplies status and challenge headers; the body is derived
+            // directly rather than parsed back out of the Response.
+            const response = dpopAuthChallengeResponse(error, resolved);
+            const challenge = response.headers.get('WWW-Authenticate');
+            if (challenge !== null) {
+                res.set('WWW-Authenticate', challenge);
+            }
+            const dpopNonce = response.headers.get('DPoP-Nonce');
+            if (dpopNonce !== null) {
+                res.set('DPoP-Nonce', dpopNonce);
+            }
+            const body = error instanceof OAuthError ? error : new OAuthError(OAuthErrorCode.ServerError, 'Internal Server Error');
+            res.status(response.status).json(body.toResponseObject());
+        }
+    };
+}

--- a/packages/middleware/express/src/index.ts
+++ b/packages/middleware/express/src/index.ts
@@ -5,6 +5,10 @@ export * from './middleware/originValidation';
 // OAuth Resource-Server glue: bearer-token middleware + PRM/AS metadata router.
 export type { BearerAuthMiddlewareOptions } from './auth/bearerAuth';
 export { requireBearerAuth } from './auth/bearerAuth';
+// DPoP (RFC 9449 / SEP-1932) sender-constrained tokens: same OAuthTokenVerifier as bearer auth
+// above, plus proof validation against the request.
+export type { DpopAuthMiddlewareOptions } from './auth/dpopAuth';
+export { requireDpopAuth } from './auth/dpopAuth';
 export type { AuthMetadataOptions } from './auth/metadataRouter';
 export { getOAuthProtectedResourceMetadataUrl, mcpAuthMetadataRouter } from './auth/metadataRouter';
 export type { OAuthTokenVerifier } from './auth/types';

--- a/packages/middleware/express/test/auth/dpopAuth.test.ts
+++ b/packages/middleware/express/test/auth/dpopAuth.test.ts
@@ -1,0 +1,294 @@
+// Type-only: see the matching comment in @modelcontextprotocol/server's src/server/middleware/dpop.ts.
+import type { webcrypto } from 'node:crypto';
+
+import type { AuthInfo, DpopAuthOptions, OAuthTokenVerifier } from '@modelcontextprotocol/server';
+import { calculateJwkThumbprint } from '@modelcontextprotocol/server';
+import type { Request, Response } from 'express';
+import express from 'express';
+import supertest from 'supertest';
+import type { Mock } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { requireDpopAuth } from '../../src/auth/dpopAuth';
+
+async function base64url(bytes: ArrayBuffer | Uint8Array): Promise<string> {
+    return Buffer.from(bytes as ArrayBuffer).toString('base64url');
+}
+
+interface Signer {
+    privateKey: webcrypto.CryptoKey;
+    publicJwk: webcrypto.JsonWebKey;
+    jkt: string;
+}
+
+async function generateSigner(): Promise<Signer> {
+    const { publicKey, privateKey } = await crypto.subtle.generateKey({ name: 'ECDSA', namedCurve: 'P-256' }, true, ['sign', 'verify']);
+    const publicJwk = await crypto.subtle.exportKey('jwk', publicKey);
+    return { privateKey, publicJwk, jkt: await calculateJwkThumbprint(publicJwk) };
+}
+
+async function buildProof(signer: Signer, htm: string, htu: string, accessToken: string): Promise<string> {
+    const header = { alg: 'ES256', typ: 'dpop+jwt', jwk: signer.publicJwk };
+    const athDigest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(accessToken));
+    const payload = {
+        jti: await base64url(crypto.getRandomValues(new Uint8Array(16))),
+        htm,
+        htu,
+        iat: Math.floor(Date.now() / 1000),
+        ath: await base64url(athDigest)
+    };
+    const headerSegment = await base64url(new TextEncoder().encode(JSON.stringify(header)));
+    const payloadSegment = await base64url(new TextEncoder().encode(JSON.stringify(payload)));
+    const signingInput = `${headerSegment}.${payloadSegment}`;
+    const signature = await crypto.subtle.sign(
+        { name: 'ECDSA', hash: 'SHA-256' },
+        signer.privateKey,
+        new TextEncoder().encode(signingInput)
+    );
+    return `${signingInput}.${await base64url(signature)}`;
+}
+
+const mockVerifyAccessToken = vi.fn();
+const mockVerifier: OAuthTokenVerifier = { verifyAccessToken: mockVerifyAccessToken };
+
+function createMockReqResNext(authorization?: string, dpop?: string) {
+    const req = {
+        headers: { authorization, dpop },
+        method: 'POST',
+        protocol: 'https',
+        originalUrl: '/mcp',
+        get: () => 'mcp.example.com'
+    } as unknown as Request;
+    const res = {
+        status: vi.fn().mockReturnThis(),
+        json: vi.fn().mockReturnThis(),
+        set: vi.fn().mockReturnThis()
+    } as unknown as Response;
+    const next = vi.fn();
+    return { req, res, next };
+}
+
+describe('requireDpopAuth middleware (mocked req/res)', () => {
+    let signer: Signer;
+    let boundToken: string;
+
+    beforeEach(async () => {
+        vi.clearAllMocks();
+        signer = await generateSigner();
+        boundToken = 'valid-token';
+    });
+
+    it('attaches AuthInfo to req.auth and calls next on a valid DPoP-bound request', async () => {
+        const authInfo: AuthInfo = {
+            token: boundToken,
+            clientId: 'client-123',
+            scopes: ['mcp'],
+            expiresAt: Math.floor(Date.now() / 1000) + 3600,
+            cnf: { jkt: signer.jkt }
+        };
+        mockVerifyAccessToken.mockResolvedValue(authInfo);
+        const proof = await buildProof(signer, 'POST', 'https://mcp.example.com/mcp', boundToken);
+
+        const { req, res, next } = createMockReqResNext(`DPoP ${boundToken}`, proof);
+        const middleware = requireDpopAuth({ verifier: mockVerifier });
+        await middleware(req, res, next);
+
+        expect(mockVerifyAccessToken).toHaveBeenCalledWith(boundToken);
+        expect(req.auth).toEqual(authInfo);
+        expect(next).toHaveBeenCalled();
+        expect(res.status).not.toHaveBeenCalled();
+    });
+
+    it('responds 401 with a DPoP WWW-Authenticate challenge when the proof header is missing', async () => {
+        mockVerifyAccessToken.mockResolvedValue({
+            token: boundToken,
+            clientId: 'client-123',
+            scopes: [],
+            expiresAt: Math.floor(Date.now() / 1000) + 3600,
+            cnf: { jkt: signer.jkt }
+        });
+        const { req, res, next } = createMockReqResNext(`DPoP ${boundToken}`, undefined);
+        const middleware = requireDpopAuth({
+            verifier: mockVerifier,
+            resourceMetadataUrl: 'https://api.example.com/.well-known/oauth-protected-resource'
+        });
+        await middleware(req, res, next);
+
+        expect(res.status).toHaveBeenCalledWith(401);
+        expect(res.set).toHaveBeenCalledWith(
+            'WWW-Authenticate',
+            expect.stringMatching(
+                /^DPoP error="invalid_dpop_proof".*resource_metadata="https:\/\/api\.example\.com\/\.well-known\/oauth-protected-resource".*algs="ES256/
+            )
+        );
+        expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ error: 'invalid_dpop_proof' }));
+        expect(next).not.toHaveBeenCalled();
+    });
+
+    it('responds 401 rejecting the Bearer scheme on a DPoP-only gate', async () => {
+        mockVerifyAccessToken.mockResolvedValue({
+            token: boundToken,
+            clientId: 'client-123',
+            scopes: [],
+            expiresAt: Math.floor(Date.now() / 1000) + 3600,
+            cnf: { jkt: signer.jkt }
+        });
+        const proof = await buildProof(signer, 'POST', 'https://mcp.example.com/mcp', boundToken);
+        const { req, res, next } = createMockReqResNext(`Bearer ${boundToken}`, proof);
+        const middleware = requireDpopAuth({ verifier: mockVerifier });
+        await middleware(req, res, next);
+
+        expect(res.status).toHaveBeenCalledWith(401);
+        expect(next).not.toHaveBeenCalled();
+    });
+
+    it('responds 401 when the proof key does not match the token cnf.jkt', async () => {
+        mockVerifyAccessToken.mockResolvedValue({
+            token: boundToken,
+            clientId: 'client-123',
+            scopes: [],
+            expiresAt: Math.floor(Date.now() / 1000) + 3600,
+            cnf: { jkt: signer.jkt }
+        });
+        const otherSigner = await generateSigner();
+        const wrongProof = await buildProof(otherSigner, 'POST', 'https://mcp.example.com/mcp', boundToken);
+        const { req, res, next } = createMockReqResNext(`DPoP ${boundToken}`, wrongProof);
+        const middleware = requireDpopAuth({ verifier: mockVerifier });
+        await middleware(req, res, next);
+
+        expect(res.status).toHaveBeenCalledWith(401);
+        expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ error_description: expect.stringContaining('cnf.jkt') }));
+        expect(next).not.toHaveBeenCalled();
+    });
+
+    it('responds 403 with scope in WWW-Authenticate when required scopes are missing', async () => {
+        mockVerifyAccessToken.mockResolvedValue({
+            token: boundToken,
+            clientId: 'client-123',
+            scopes: ['read'],
+            expiresAt: Math.floor(Date.now() / 1000) + 3600,
+            cnf: { jkt: signer.jkt }
+        });
+        const proof = await buildProof(signer, 'POST', 'https://mcp.example.com/mcp', boundToken);
+        const { req, res, next } = createMockReqResNext(`DPoP ${boundToken}`, proof);
+        const middleware = requireDpopAuth({ verifier: mockVerifier, requiredScopes: ['read', 'write'] });
+        await middleware(req, res, next);
+
+        expect(res.status).toHaveBeenCalledWith(403);
+        expect(res.set).toHaveBeenCalledWith('WWW-Authenticate', expect.stringContaining('scope="read write"'));
+        expect(next).not.toHaveBeenCalled();
+    });
+
+    it('responds 401 with a DPoP-Nonce header when a nonce is required and issued', async () => {
+        mockVerifyAccessToken.mockResolvedValue({
+            token: boundToken,
+            clientId: 'client-123',
+            scopes: [],
+            expiresAt: Math.floor(Date.now() / 1000) + 3600,
+            cnf: { jkt: signer.jkt }
+        });
+        const proof = await buildProof(signer, 'POST', 'https://mcp.example.com/mcp', boundToken);
+        const { req, res, next } = createMockReqResNext(`DPoP ${boundToken}`, proof);
+        const options: DpopAuthOptions = { verifier: mockVerifier, nonce: { issue: () => 'fresh-nonce', verify: () => false } };
+        const middleware = requireDpopAuth(options);
+        await middleware(req, res, next);
+
+        expect(res.status).toHaveBeenCalledWith(401);
+        expect(res.set).toHaveBeenCalledWith('DPoP-Nonce', 'fresh-nonce');
+        expect(next).not.toHaveBeenCalled();
+    });
+
+    it('responds 500 when the verifier throws a non-OAuth error', async () => {
+        mockVerifyAccessToken.mockRejectedValue(new Error('boom'));
+        const proof = await buildProof(signer, 'POST', 'https://mcp.example.com/mcp', boundToken);
+        const { req, res, next } = createMockReqResNext(`DPoP ${boundToken}`, proof);
+        const middleware = requireDpopAuth({ verifier: mockVerifier });
+        await middleware(req, res, next);
+
+        expect(res.status).toHaveBeenCalledWith(500);
+        expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ error: 'server_error' }));
+        expect(next).not.toHaveBeenCalled();
+    });
+
+    it('throws at creation time for missing options', () => {
+        expect(() => requireDpopAuth(undefined as never)).toThrow(TypeError);
+    });
+});
+
+describe('requireDpopAuth middleware (real HTTP round trip)', () => {
+    // A real listening server (not supertest) — the middleware reconstructs `htu` from
+    // req.protocol/req.get('host')/req.originalUrl, so the proof must be built against the exact
+    // externally-visible URL the client used, which supertest's abstraction obscures.
+    async function withServer<T>(app: express.Express, run: (baseUrl: string) => Promise<T>): Promise<T> {
+        const server = app.listen(0, '127.0.0.1');
+        await new Promise<void>(resolve => server.once('listening', resolve));
+        const address = server.address();
+        if (!address || typeof address === 'string') throw new Error('no address');
+        try {
+            return await run(`http://127.0.0.1:${address.port}`);
+        } finally {
+            server.close();
+        }
+    }
+
+    it('reconstructs htu from the request and accepts a matching proof', async () => {
+        const signer = await generateSigner();
+        const token = 'e2e-token';
+        const verifyAccessToken: Mock = vi.fn().mockResolvedValue({
+            token,
+            clientId: 'client-1',
+            scopes: ['mcp'],
+            expiresAt: Math.floor(Date.now() / 1000) + 3600,
+            cnf: { jkt: signer.jkt }
+        });
+
+        const app = express();
+        app.use('/mcp', requireDpopAuth({ verifier: { verifyAccessToken }, requiredScopes: ['mcp'] }));
+        app.post('/mcp', (req, res) => res.json({ ok: true, clientId: req.auth?.clientId }));
+
+        await withServer(app, async baseUrl => {
+            const proof = await buildProof(signer, 'POST', `${baseUrl}/mcp`, token);
+            const res = await fetch(`${baseUrl}/mcp`, {
+                method: 'POST',
+                headers: { Authorization: `DPoP ${token}`, DPoP: proof, 'content-type': 'application/json' },
+                body: '{}'
+            });
+            expect(res.status).toBe(200);
+            expect(await res.json()).toMatchObject({ ok: true, clientId: 'client-1' });
+        });
+    });
+
+    it('rejects a proof signed for a different path (htu mismatch)', async () => {
+        const signer = await generateSigner();
+        const token = 'e2e-token';
+        const verifyAccessToken: Mock = vi.fn().mockResolvedValue({
+            token,
+            clientId: 'client-1',
+            scopes: [],
+            expiresAt: Math.floor(Date.now() / 1000) + 3600,
+            cnf: { jkt: signer.jkt }
+        });
+
+        const app = express();
+        app.use('/mcp', requireDpopAuth({ verifier: { verifyAccessToken } }));
+        app.post('/mcp', (_req, res) => res.json({ ok: true }));
+
+        await withServer(app, async baseUrl => {
+            const proof = await buildProof(signer, 'POST', `${baseUrl}/wrong-path`, token);
+            const res = await fetch(`${baseUrl}/mcp`, { method: 'POST', headers: { Authorization: `DPoP ${token}`, DPoP: proof } });
+            expect(res.status).toBe(401);
+            const body = (await res.json()) as { error?: string };
+            expect(body.error).toBe('invalid_dpop_proof');
+        });
+    });
+
+    it('rejects a request with no Authorization header at all', async () => {
+        const app = express();
+        app.use('/mcp', requireDpopAuth({ verifier: { verifyAccessToken: vi.fn() } }));
+        app.post('/mcp', (_req, res) => res.json({ ok: true }));
+
+        const res = await supertest(app).post('/mcp');
+        expect(res.status).toBe(401);
+        expect(res.headers['www-authenticate']).toMatch(/^DPoP /);
+    });
+});

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -42,7 +42,14 @@ export { bearerAuthChallengeResponse, requireBearerAuth, verifyBearerToken } fro
 // DPoP (RFC 9449 / SEP-1932) sender-constrained tokens: proof validation primitives plus the
 // runtime-neutral authentication gate for web-standard hosts; the Express middleware in
 // @modelcontextprotocol/express adapts the same core.
-export type { DpopAlg, DpopNonceState, DpopProofClaims, VerifiedDpopProof, VerifyDpopProofOptions } from './server/middleware/dpop';
+export type {
+    DpopAlg,
+    DpopJwk,
+    DpopNonceState,
+    DpopProofClaims,
+    VerifiedDpopProof,
+    VerifyDpopProofOptions
+} from './server/middleware/dpop';
 export { accessTokenHash, calculateJwkThumbprint, DPOP_SUPPORTED_ALGS, verifyDpopProof } from './server/middleware/dpop';
 export type { DpopAuthOptions, DpopRequest } from './server/middleware/dpopAuth';
 export { dpopAuthChallengeResponse, requireDpopAuth, verifyDpopToken } from './server/middleware/dpopAuth';

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -37,6 +37,13 @@ export { McpServer, ResourceTemplate } from './server/mcp';
 // middleware in @modelcontextprotocol/express adapts the same core.
 export type { BearerAuthOptions, OAuthTokenVerifier } from './server/middleware/bearerAuth';
 export { bearerAuthChallengeResponse, requireBearerAuth, verifyBearerToken } from './server/middleware/bearerAuth';
+// DPoP (RFC 9449 / SEP-1932) sender-constrained tokens: proof validation primitives plus the
+// runtime-neutral authentication gate for web-standard hosts; the Express middleware in
+// @modelcontextprotocol/express adapts the same core.
+export type { DpopAlg, DpopNonceState, DpopProofClaims, VerifiedDpopProof, VerifyDpopProofOptions } from './server/middleware/dpop';
+export { accessTokenHash, calculateJwkThumbprint, DPOP_SUPPORTED_ALGS, verifyDpopProof } from './server/middleware/dpop';
+export type { DpopAuthOptions, DpopRequest } from './server/middleware/dpopAuth';
+export { dpopAuthChallengeResponse, requireDpopAuth, verifyDpopToken } from './server/middleware/dpopAuth';
 export type { HostHeaderValidationResult } from './server/middleware/hostHeaderValidation';
 export { hostHeaderValidationResponse, localhostAllowedHostnames, validateHostHeader } from './server/middleware/hostHeaderValidation';
 // OAuth discovery documents (RFC 9728 / RFC 8414) for web-standard hosts; the

--- a/packages/server/src/server/middleware/authChallenge.ts
+++ b/packages/server/src/server/middleware/authChallenge.ts
@@ -1,0 +1,42 @@
+/**
+ * Shared `WWW-Authenticate` challenge-header construction for the SDK's OAuth resource-server
+ * gates (`bearerAuth.ts`, `dpopAuth.ts`). Internal — not part of the public API surface; each gate
+ * exports its own scheme-specific wrapper around {@linkcode buildWwwAuthenticateHeader}.
+ */
+
+/**
+ * HTTP quoted-string encoding per RFC 7235: escape backslash and double quote, and replace
+ * characters a header cannot carry (controls, anything beyond printable ASCII) so a
+ * verifier-authored message can never make the challenge `Response` constructor throw.
+ */
+export function headerQuotedValue(value: string): string {
+    return value.replaceAll(/[\\"]/g, String.raw`\$&`).replaceAll(/[^ -~]/g, ' ');
+}
+
+/**
+ * Build a `WWW-Authenticate` challenge header for `scheme` (`Bearer` or `DPoP`), with the standard
+ * `error`/`error_description`/`scope`/`resource_metadata` parameters plus any scheme-specific ones
+ * (e.g. DPoP's `algs`), in that order.
+ */
+export function buildWwwAuthenticateHeader(
+    scheme: string,
+    errorCode: string,
+    description: string,
+    requiredScopes: string[],
+    resourceMetadataUrl: string | undefined,
+    extraParams?: Record<string, string>
+): string {
+    let header = `${scheme} error="${headerQuotedValue(errorCode)}", error_description="${headerQuotedValue(description)}"`;
+    if (requiredScopes.length > 0) {
+        header += `, scope="${requiredScopes.join(' ')}"`;
+    }
+    if (resourceMetadataUrl) {
+        header += `, resource_metadata="${resourceMetadataUrl}"`;
+    }
+    if (extraParams) {
+        for (const [key, value] of Object.entries(extraParams)) {
+            header += `, ${key}="${headerQuotedValue(value)}"`;
+        }
+    }
+    return header;
+}

--- a/packages/server/src/server/middleware/bearerAuth.ts
+++ b/packages/server/src/server/middleware/bearerAuth.ts
@@ -92,8 +92,9 @@ export async function verifyBearerToken(authorizationHeader: string | null | und
 
     const authInfo = await verifier.verifyAccessToken(token);
 
-    // RFC 9449 §7.1: a DPoP-bound token (cnf.jkt set) MUST NOT be honored under the plain
-    // Bearer scheme — accepting it here would defeat the point of binding it to a proof key.
+    // RFC 9449 §7.2 ("Compatibility with the Bearer Authentication Scheme"): a DPoP-bound token
+    // (cnf.jkt set) MUST NOT be honored under the plain Bearer scheme — accepting it here would
+    // defeat the point of binding it to a proof key.
     // Only reachable when a verifier shared between bearerAuth and DPoP's requireDpopAuth
     // returns a bound token's AuthInfo to this (Bearer-only) gate.
     if (authInfo.cnf?.jkt) {

--- a/packages/server/src/server/middleware/bearerAuth.ts
+++ b/packages/server/src/server/middleware/bearerAuth.ts
@@ -1,6 +1,8 @@
 import type { AuthInfo } from '@modelcontextprotocol/core-internal';
 import { OAuthError, OAuthErrorCode } from '@modelcontextprotocol/core-internal';
 
+import { buildWwwAuthenticateHeader as buildChallengeHeader } from './authChallenge';
+
 /**
  * Minimal token-verifier interface for MCP servers acting as an OAuth 2.0
  * Resource Server. Implementations introspect or locally validate an access
@@ -54,28 +56,13 @@ export interface BearerAuthOptions {
     resourceMetadataUrl?: string;
 }
 
-function headerQuotedValue(value: string): string {
-    // HTTP quoted-string per RFC 7235: escape backslash and double quote, and
-    // replace characters a header cannot carry (controls, anything beyond
-    // printable ASCII) so a verifier-authored message can never make the
-    // challenge Response constructor throw.
-    return value.replaceAll(/[\\"]/g, String.raw`\$&`).replaceAll(/[^\u0020-\u007E]/g, ' ');
-}
-
 function buildWwwAuthenticateHeader(
     errorCode: string,
     description: string,
     requiredScopes: string[],
     resourceMetadataUrl: string | undefined
 ): string {
-    let header = `Bearer error="${headerQuotedValue(errorCode)}", error_description="${headerQuotedValue(description)}"`;
-    if (requiredScopes.length > 0) {
-        header += `, scope="${requiredScopes.join(' ')}"`;
-    }
-    if (resourceMetadataUrl) {
-        header += `, resource_metadata="${resourceMetadataUrl}"`;
-    }
-    return header;
+    return buildChallengeHeader('Bearer', errorCode, description, requiredScopes, resourceMetadataUrl);
 }
 
 /**
@@ -104,6 +91,14 @@ export async function verifyBearerToken(authorizationHeader: string | null | und
     }
 
     const authInfo = await verifier.verifyAccessToken(token);
+
+    // RFC 9449 §7.1: a DPoP-bound token (cnf.jkt set) MUST NOT be honored under the plain
+    // Bearer scheme — accepting it here would defeat the point of binding it to a proof key.
+    // Only reachable when a verifier shared between bearerAuth and DPoP's requireDpopAuth
+    // returns a bound token's AuthInfo to this (Bearer-only) gate.
+    if (authInfo.cnf?.jkt) {
+        throw new OAuthError(OAuthErrorCode.InvalidToken, 'Token is DPoP-bound and must be presented with the DPoP scheme, not Bearer');
+    }
 
     // Check if token has the required scopes (if any)
     if (requiredScopes.length > 0) {

--- a/packages/server/src/server/middleware/dpop.ts
+++ b/packages/server/src/server/middleware/dpop.ts
@@ -314,6 +314,11 @@ export async function verifyDpopProof(options: VerifyDpopProofOptions): Promise<
     if (typeof payload.jti !== 'string' || payload.jti.length === 0) {
         throw invalidProof("DPoP proof is missing the 'jti' claim");
     }
+    // TODO: this only checks `jti` is present, not that it's unused — RFC 9449 §11.1 treats
+    // jti-replay tracking as a SHOULD, defense-in-depth measure, so a captured (proof, token) pair
+    // can be replayed for the rest of the `iatSkewSeconds` window. Left to the caller for now (the
+    // returned `claims.jti` is exactly for that); DpopAuthOptions.nonce has a first-class hook,
+    // jti-replay doesn't yet.
     if (typeof payload.htm !== 'string' || payload.htm.toUpperCase() !== method.toUpperCase()) {
         throw invalidProof("DPoP proof 'htm' does not match the request method");
     }

--- a/packages/server/src/server/middleware/dpop.ts
+++ b/packages/server/src/server/middleware/dpop.ts
@@ -25,7 +25,7 @@ export const DPOP_SUPPORTED_ALGS = ['ES256', 'ES384', 'ES512', 'RS256', 'RS384',
 export type DpopAlg = (typeof DPOP_SUPPORTED_ALGS)[number];
 
 /** Minimal JWK shape this module reads — not a full RFC 7517 type, only the members DPoP proof verification and thumbprinting need. */
-interface DpopJwk {
+export interface DpopJwk {
     kty?: unknown;
     crv?: unknown;
     x?: unknown;
@@ -260,7 +260,7 @@ export interface VerifiedDpopProof {
 /**
  * Validate a DPoP proof presented alongside an access token, per RFC 9449 §4.3. Throws an
  * {@linkcode OAuthError} (`invalid_dpop_proof` or, when a nonce is required and missing/wrong,
- * `use_dpop_nonce`) on any failure; {@linkcode dpopAuthChallengeResponse} maps that to the HTTP
+ * `use_dpop_nonce`) on any failure; {@linkcode server/middleware/dpopAuth.dpopAuthChallengeResponse | dpopAuthChallengeResponse} maps that to the HTTP
  * response.
  *
  * Checks, in RFC 9449 §4.3 order: exactly one well-formed `dpop+jwt` proof header → asymmetric
@@ -270,7 +270,7 @@ export interface VerifiedDpopProof {
  * server-provided nonce, if required. Does **not** compare the proof key's thumbprint against an
  * access token's `cnf.jkt` — that requires the verified token claims, which only the caller (the
  * `OAuthTokenVerifier`) has; compare the returned {@linkcode VerifiedDpopProof.jkt} yourself (see
- * {@linkcode verifyDpopToken} for the composed version).
+ * {@linkcode server/middleware/dpopAuth.verifyDpopToken | verifyDpopToken} for the composed version).
  */
 export async function verifyDpopProof(options: VerifyDpopProofOptions): Promise<VerifiedDpopProof> {
     const { proof, method, url, accessToken, iatSkewSeconds = 300, nonce } = options;

--- a/packages/server/src/server/middleware/dpop.ts
+++ b/packages/server/src/server/middleware/dpop.ts
@@ -1,0 +1,359 @@
+/**
+ * DPoP (Demonstrating Proof of Possession) proof validation — the resource-server half of
+ * {@link https://datatracker.ietf.org/doc/html/rfc9449 | RFC 9449}, adopted by MCP as the draft
+ * extension {@link https://github.com/modelcontextprotocol/ext-auth/blob/main/specification/draft/dpop-extension.mdx | SEP-1932}.
+ *
+ * Implemented from scratch against RFC 9449 §4.3 using only Web Crypto (`crypto.subtle`), so
+ * `@modelcontextprotocol/server` gains no new dependency and this stays usable in any runtime
+ * that implements the Web Crypto API (Node ≥20, browsers, edge/worker runtimes) — deliberately an
+ * independent code path from the client-side proof builder in `@modelcontextprotocol/client`,
+ * rather than a shared module, so a bug in one is unlikely to be mirrored in the other.
+ */
+
+// Type-only: borrows the WebCrypto algorithm-parameter shapes Node's ambient types declare
+// under `node:crypto`'s `webcrypto` namespace. Erased at build time (no runtime import of
+// `node:crypto`) — the actual code below calls only the WHATWG `crypto.subtle` global, which
+// every runtime targeted here (Node ≥20, browsers, edge/worker runtimes) implements.
+import type { webcrypto } from 'node:crypto';
+
+import { OAuthError, OAuthErrorCode } from '@modelcontextprotocol/core-internal';
+
+/** Asymmetric JWS algorithms a DPoP proof may be signed with (RFC 9449 §11.6 forbids `none` and symmetric algs). */
+export const DPOP_SUPPORTED_ALGS = ['ES256', 'ES384', 'ES512', 'RS256', 'RS384', 'RS512', 'PS256', 'PS384', 'PS512', 'EdDSA'] as const;
+
+/** A DPoP JWS algorithm this SDK can verify proofs signed with. */
+export type DpopAlg = (typeof DPOP_SUPPORTED_ALGS)[number];
+
+/** Minimal JWK shape this module reads — not a full RFC 7517 type, only the members DPoP proof verification and thumbprinting need. */
+interface DpopJwk {
+    kty?: unknown;
+    crv?: unknown;
+    x?: unknown;
+    y?: unknown;
+    n?: unknown;
+    e?: unknown;
+    k?: unknown;
+    d?: unknown;
+}
+
+function invalidProof(message: string): OAuthError {
+    return new OAuthError(OAuthErrorCode.InvalidDpopProof, message);
+}
+
+function base64UrlDecode(input: string): Uint8Array {
+    const binary = atob(input.replaceAll('-', '+').replaceAll('_', '/'));
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) bytes[i] = binary.codePointAt(i) ?? 0;
+    return bytes;
+}
+
+function base64UrlEncode(bytes: Uint8Array): string {
+    let binary = '';
+    for (const byte of bytes) binary += String.fromCodePoint(byte);
+    return btoa(binary).replaceAll('+', '-').replaceAll('/', '_').replaceAll('=', '');
+}
+
+/**
+ * Compute the `ath` claim for a DPoP proof presented alongside an access token: the
+ * base64url-encoded SHA-256 digest of the ASCII access-token value (RFC 9449 §4.1).
+ */
+export async function accessTokenHash(accessToken: string): Promise<string> {
+    const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(accessToken));
+    return base64UrlEncode(new Uint8Array(digest));
+}
+
+/**
+ * RFC 7638 JWK SHA-256 thumbprint: SHA-256 over the JSON serialization of exactly the key type's
+ * required members, included with no whitespace and in the lexicographic member order RFC 7638
+ * §3.2 (and RFC 8037 §2 for OKP) mandates. `Object.fromEntries`/object-literal insertion order
+ * matches that order for every branch below, so `JSON.stringify` emits the fields correctly
+ * without a separate sort step.
+ */
+export async function calculateJwkThumbprint(jwk: DpopJwk): Promise<string> {
+    let members: Record<string, unknown>;
+    switch (jwk.kty) {
+        case 'EC': {
+            members = { crv: jwk.crv, kty: jwk.kty, x: jwk.x, y: jwk.y };
+            break;
+        }
+        case 'RSA': {
+            members = { e: jwk.e, kty: jwk.kty, n: jwk.n };
+            break;
+        }
+        case 'OKP': {
+            members = { crv: jwk.crv, kty: jwk.kty, x: jwk.x };
+            break;
+        }
+        case 'oct': {
+            members = { k: jwk.k, kty: jwk.kty };
+            break;
+        }
+        default: {
+            throw invalidProof(`unsupported JWK key type: ${String(jwk.kty)}`);
+        }
+    }
+    const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(JSON.stringify(members)));
+    return base64UrlEncode(new Uint8Array(digest));
+}
+
+interface ParsedDpopJwt {
+    header: Record<string, unknown>;
+    payload: Record<string, unknown>;
+    signingInput: string;
+    signature: Uint8Array;
+}
+
+function decodeJwtJsonSegment(segment: string): Record<string, unknown> {
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(new TextDecoder().decode(base64UrlDecode(segment)));
+    } catch {
+        throw invalidProof('DPoP proof is not a well-formed JWT');
+    }
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+        throw invalidProof('DPoP proof is not a well-formed JWT');
+    }
+    return parsed as Record<string, unknown>;
+}
+
+function parseDpopJwt(token: string): ParsedDpopJwt {
+    const parts = token.split('.');
+    if (parts.length !== 3 || parts.some(part => part.length === 0)) {
+        throw invalidProof('DPoP proof is not a well-formed JWT');
+    }
+    const [headerSegment, payloadSegment, signatureSegment] = parts as [string, string, string];
+    return {
+        header: decodeJwtJsonSegment(headerSegment),
+        payload: decodeJwtJsonSegment(payloadSegment),
+        signingInput: `${headerSegment}.${payloadSegment}`,
+        signature: base64UrlDecode(signatureSegment)
+    };
+}
+
+/** WebCrypto `importKey`/`verify` parameters for a DPoP JWS algorithm (RFC 9449 §4.3 step 6). */
+function webCryptoParams(
+    alg: DpopAlg,
+    jwk: DpopJwk
+): {
+    importParams: webcrypto.AlgorithmIdentifier | webcrypto.RsaHashedImportParams | webcrypto.EcKeyImportParams;
+    verifyParams: webcrypto.AlgorithmIdentifier | webcrypto.EcdsaParams | webcrypto.RsaPssParams;
+} {
+    switch (alg) {
+        case 'ES256': {
+            return { importParams: { name: 'ECDSA', namedCurve: 'P-256' }, verifyParams: { name: 'ECDSA', hash: 'SHA-256' } };
+        }
+        case 'ES384': {
+            return { importParams: { name: 'ECDSA', namedCurve: 'P-384' }, verifyParams: { name: 'ECDSA', hash: 'SHA-384' } };
+        }
+        case 'ES512': {
+            return { importParams: { name: 'ECDSA', namedCurve: 'P-521' }, verifyParams: { name: 'ECDSA', hash: 'SHA-512' } };
+        }
+        case 'RS256': {
+            return { importParams: { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' }, verifyParams: { name: 'RSASSA-PKCS1-v1_5' } };
+        }
+        case 'RS384': {
+            return { importParams: { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-384' }, verifyParams: { name: 'RSASSA-PKCS1-v1_5' } };
+        }
+        case 'RS512': {
+            return { importParams: { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-512' }, verifyParams: { name: 'RSASSA-PKCS1-v1_5' } };
+        }
+        case 'PS256': {
+            return { importParams: { name: 'RSA-PSS', hash: 'SHA-256' }, verifyParams: { name: 'RSA-PSS', saltLength: 32 } };
+        }
+        case 'PS384': {
+            return { importParams: { name: 'RSA-PSS', hash: 'SHA-384' }, verifyParams: { name: 'RSA-PSS', saltLength: 48 } };
+        }
+        case 'PS512': {
+            return { importParams: { name: 'RSA-PSS', hash: 'SHA-512' }, verifyParams: { name: 'RSA-PSS', saltLength: 64 } };
+        }
+        case 'EdDSA': {
+            // WebCrypto has no generic "EdDSA" algorithm name; the curve (from the JWK's own
+            // `crv`) selects Ed25519 or Ed448 (RFC 8037 §3.1 / §3.2).
+            const name = jwk.crv === 'Ed448' ? 'Ed448' : 'Ed25519';
+            return { importParams: { name }, verifyParams: { name } };
+        }
+    }
+}
+
+/**
+ * Verify a JWS signature over `signingInput` using the public key embedded in `jwk`, for one of
+ * {@linkcode DPOP_SUPPORTED_ALGS}. Any failure — unsupported key shape, a runtime lacking the
+ * algorithm, or a genuine bad signature — resolves to `false` rather than throwing, so a caller
+ * always gets a clean reject instead of having to distinguish infrastructure errors from forged
+ * proofs.
+ */
+async function verifyJwsSignature(alg: DpopAlg, jwk: DpopJwk, signingInput: string, signature: Uint8Array): Promise<boolean> {
+    const { importParams, verifyParams } = webCryptoParams(alg, jwk);
+    try {
+        const key = await crypto.subtle.importKey('jwk', jwk as webcrypto.JsonWebKey, importParams, false, ['verify']);
+        return await crypto.subtle.verify(verifyParams, key, signature, new TextEncoder().encode(signingInput));
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * Canonicalize an `htu` for comparison per RFC 9449 §4.3 (RFC 3986 scheme-based normalization):
+ * lowercase scheme/host, drop the default port (handled by `URL` itself), tolerate a single
+ * trailing slash. Query/fragment are rejected by {@linkcode verifyDpopProof} outright, not
+ * silently stripped here.
+ */
+function normalizeHtu(raw: string): string {
+    try {
+        const u = new URL(raw);
+        return `${u.protocol}//${u.host}${u.pathname.replace(/\/$/, '')}`;
+    } catch {
+        return raw;
+    }
+}
+
+/**
+ * Server-provided nonce policy consulted by {@linkcode verifyDpopProof} (RFC 9449 §9). Left
+ * entirely to the host — a stateless HMAC-derived nonce, an in-memory set with rotation, or "off"
+ * — this module only calls {@linkcode verify}.
+ */
+export interface DpopNonceState {
+    /**
+     * Whether `nonce` (the proof's `nonce` claim, or `undefined` if it carried none) is currently
+     * acceptable. Return `true` unconditionally to never require a nonce.
+     */
+    verify(nonce: string | undefined): boolean;
+}
+
+export interface VerifyDpopProofOptions {
+    /**
+     * Raw `DPoP` request header value(s), exactly as the framework adapter read them. Pass an
+     * array when the runtime preserves repeated headers separately (RFC 9449 §4.3 step 1
+     * requires **exactly one** — an array with more than one entry is rejected, distinctly from a
+     * single value that merely *contains* a comma, e.g. Node's `http` module folding repeated
+     * headers into one comma-joined string).
+     */
+    proof: string | string[] | undefined;
+    /** HTTP method of the request the proof accompanies (`htm`). Compared case-insensitively. */
+    method: string;
+    /** HTTP target URI of the request (`htu`) — the full URL the server received the request at. */
+    url: string | URL;
+    /** When set, the proof's `ath` claim MUST bind to this access token (RFC 9449 §4.3 step 12a). */
+    accessToken?: string;
+    /** Acceptance window for `iat`, in seconds either side of now. @default 300 (SEP-1932). */
+    iatSkewSeconds?: number;
+    /** Server-provided nonce requirement (RFC 9449 §9). Omit to not require a nonce. */
+    nonce?: DpopNonceState;
+}
+
+/** The subset of a verified proof's claims a caller (e.g. replay-protection logic) might need. */
+export interface DpopProofClaims {
+    jti: string;
+    htm: string;
+    htu: string;
+    iat: number;
+    ath?: string;
+    nonce?: string;
+}
+
+export interface VerifiedDpopProof {
+    /** RFC 7638 thumbprint of the proof's public key — compare against the access token's `cnf.jkt` (§4.3 step 12b). */
+    jkt: string;
+    claims: DpopProofClaims;
+}
+
+/**
+ * Validate a DPoP proof presented alongside an access token, per RFC 9449 §4.3. Throws an
+ * {@linkcode OAuthError} (`invalid_dpop_proof` or, when a nonce is required and missing/wrong,
+ * `use_dpop_nonce`) on any failure; {@linkcode dpopAuthChallengeResponse} maps that to the HTTP
+ * response.
+ *
+ * Checks, in RFC 9449 §4.3 order: exactly one well-formed `dpop+jwt` proof header → asymmetric
+ * `alg` → `jwk` present with no private-key members → signature verifies against that key →
+ * `jti`/`htm`/`htu` present and matching (with `htu` query/fragment rejected outright, not
+ * stripped) → `iat` within the acceptance window → `ath` matches the presented token → the
+ * server-provided nonce, if required. Does **not** compare the proof key's thumbprint against an
+ * access token's `cnf.jkt` — that requires the verified token claims, which only the caller (the
+ * `OAuthTokenVerifier`) has; compare the returned {@linkcode VerifiedDpopProof.jkt} yourself (see
+ * {@linkcode verifyDpopToken} for the composed version).
+ */
+export async function verifyDpopProof(options: VerifyDpopProofOptions): Promise<VerifiedDpopProof> {
+    const { proof, method, url, accessToken, iatSkewSeconds = 300, nonce } = options;
+
+    if (proof === undefined) {
+        throw invalidProof('missing DPoP proof header');
+    }
+    if (Array.isArray(proof) && proof.length !== 1) {
+        throw invalidProof(proof.length === 0 ? 'missing DPoP proof header' : 'more than one DPoP proof header field');
+    }
+    const proofValue = Array.isArray(proof) ? proof[0]! : proof;
+    // A single header value containing a comma indicates duplicate headers were folded together
+    // by the transport (Node's http collapses repeated headers with ", ") — a genuine single
+    // proof JWT never contains a comma.
+    if (proofValue.includes(',')) {
+        throw invalidProof('more than one DPoP proof header field');
+    }
+
+    const { header, payload, signingInput, signature } = parseDpopJwt(proofValue);
+
+    if (header.typ !== 'dpop+jwt') {
+        throw invalidProof("DPoP proof header 'typ' must be 'dpop+jwt'");
+    }
+    const alg = header.alg;
+    if (typeof alg !== 'string' || !DPOP_SUPPORTED_ALGS.includes(alg as DpopAlg)) {
+        throw invalidProof('DPoP proof alg must be a supported asymmetric algorithm');
+    }
+    const jwk = header.jwk;
+    if (typeof jwk !== 'object' || jwk === null || Array.isArray(jwk)) {
+        throw invalidProof("DPoP proof header is missing the 'jwk' parameter");
+    }
+    if ('d' in jwk || 'k' in jwk) {
+        throw invalidProof("DPoP proof 'jwk' must not contain a private key");
+    }
+
+    const verified = await verifyJwsSignature(alg as DpopAlg, jwk as DpopJwk, signingInput, signature);
+    if (!verified) {
+        throw invalidProof('DPoP proof signature does not verify');
+    }
+
+    if (typeof payload.jti !== 'string' || payload.jti.length === 0) {
+        throw invalidProof("DPoP proof is missing the 'jti' claim");
+    }
+    if (typeof payload.htm !== 'string' || payload.htm.toUpperCase() !== method.toUpperCase()) {
+        throw invalidProof("DPoP proof 'htm' does not match the request method");
+    }
+    if (typeof payload.htu !== 'string') {
+        throw invalidProof("DPoP proof is missing the 'htu' claim");
+    }
+    if (payload.htu.includes('?') || payload.htu.includes('#')) {
+        throw invalidProof("DPoP proof 'htu' MUST NOT contain a query or fragment (RFC 9449 §4.2)");
+    }
+    if (normalizeHtu(payload.htu) !== normalizeHtu(url.toString())) {
+        throw invalidProof("DPoP proof 'htu' does not match the request URI");
+    }
+    if (typeof payload.iat !== 'number') {
+        throw invalidProof("DPoP proof is missing the 'iat' claim");
+    }
+    if (Math.abs(Math.floor(Date.now() / 1000) - payload.iat) > iatSkewSeconds) {
+        throw invalidProof("DPoP proof 'iat' is outside the acceptance window");
+    }
+
+    if (accessToken !== undefined) {
+        const expectedAth = await accessTokenHash(accessToken);
+        if (payload.ath !== expectedAth) {
+            throw invalidProof("DPoP proof 'ath' does not match the presented access token");
+        }
+    }
+
+    if (nonce && !nonce.verify(typeof payload.nonce === 'string' ? payload.nonce : undefined)) {
+        throw new OAuthError(OAuthErrorCode.UseDpopNonce, 'a fresh server-provided nonce is required');
+    }
+
+    const jkt = await calculateJwkThumbprint(jwk as DpopJwk);
+    return {
+        jkt,
+        claims: {
+            jti: payload.jti,
+            htm: payload.htm,
+            htu: payload.htu,
+            iat: payload.iat,
+            ath: typeof payload.ath === 'string' ? payload.ath : undefined,
+            nonce: typeof payload.nonce === 'string' ? payload.nonce : undefined
+        }
+    };
+}

--- a/packages/server/src/server/middleware/dpopAuth.examples.ts
+++ b/packages/server/src/server/middleware/dpopAuth.examples.ts
@@ -1,0 +1,30 @@
+/**
+ * Type-checked examples for `dpopAuth.ts`.
+ *
+ * These examples are synced into JSDoc comments via the sync-snippets script.
+ * Each function's region markers define the code snippet that appears in the docs.
+ *
+ * @module
+ */
+
+import type { AuthInfo } from '@modelcontextprotocol/core-internal';
+
+import type { McpHttpHandler } from '../createMcpHandler';
+import type { DpopAuthOptions } from './dpopAuth';
+import { requireDpopAuth } from './dpopAuth';
+
+/**
+ * Example: gating a web-standard fetch handler with a DPoP-bound token.
+ */
+function requireDpopAuth_fetchGate(verifier: DpopAuthOptions['verifier'], handler: McpHttpHandler) {
+    //#region requireDpopAuth_fetchGate
+    const gate = requireDpopAuth({ verifier, requiredScopes: ['mcp'] });
+
+    async function fetchHandler(request: Request): Promise<Response> {
+        const auth: AuthInfo | Response = await gate(request);
+        if (auth instanceof Response) return auth;
+        return handler.fetch(request, { authInfo: auth });
+    }
+    //#endregion requireDpopAuth_fetchGate
+    return fetchHandler;
+}

--- a/packages/server/src/server/middleware/dpopAuth.ts
+++ b/packages/server/src/server/middleware/dpopAuth.ts
@@ -50,7 +50,7 @@ export interface DpopRequest {
     /** Raw `Authorization` header value. */
     authorization: string | null | undefined;
     /**
-     * Raw `DPoP` header value(s) — see {@linkcode VerifyDpopProofOptions.proof} in `dpop.ts` for
+     * Raw `DPoP` header value(s) — see {@linkcode server/middleware/dpop.VerifyDpopProofOptions.proof | VerifyDpopProofOptions.proof} in `dpop.ts` for
      * why this is `string | string[] | undefined` rather than always a single string.
      */
     dpop: string | string[] | undefined;
@@ -64,7 +64,7 @@ export interface DpopRequest {
  * Validate a DPoP-bound request — the `Authorization: DPoP <token>` header and the accompanying
  * `DPoP` proof header, together — and return the verified {@linkcode AuthInfo}.
  *
- * The runtime-neutral core of DPoP authentication, mirroring {@linkcode verifyBearerToken}: parses
+ * The runtime-neutral core of DPoP authentication, mirroring {@linkcode server/middleware/bearerAuth.verifyBearerToken | verifyBearerToken}: parses
  * the `Authorization` header (requiring the `DPoP` scheme, not `Bearer`), runs `options.verifier`,
  * verifies the proof against the request's method/URL via {@linkcode verifyDpopProof}, then checks
  * that the proof key's RFC 7638 thumbprint matches the verified token's `cnf.jkt` (RFC 9449 §4.3

--- a/packages/server/src/server/middleware/dpopAuth.ts
+++ b/packages/server/src/server/middleware/dpopAuth.ts
@@ -1,0 +1,211 @@
+/**
+ * DPoP (RFC 9449 / SEP-1932) authentication gate for MCP servers acting as an OAuth 2.0 Resource
+ * Server. Mirrors the shape of `bearerAuth.ts`: {@linkcode verifyDpopToken} validates a request
+ * end to end (token + proof, both required), {@linkcode dpopAuthChallengeResponse} maps a failure
+ * to the matching HTTP response, and {@linkcode requireDpopAuth} composes both for web-standard
+ * `fetch(request)` hosts. Framework adapters (e.g. `@modelcontextprotocol/express`) build on
+ * {@linkcode verifyDpopToken} / {@linkcode dpopAuthChallengeResponse} directly.
+ */
+
+import type { AuthInfo } from '@modelcontextprotocol/core-internal';
+import { OAuthError, OAuthErrorCode } from '@modelcontextprotocol/core-internal';
+
+import { buildWwwAuthenticateHeader } from './authChallenge';
+import type { BearerAuthOptions } from './bearerAuth';
+import type { DpopNonceState } from './dpop';
+import { DPOP_SUPPORTED_ALGS, verifyDpopProof } from './dpop';
+
+// Re-exported so a `requireDpopAuth` caller building `DpopAuthOptions` doesn't need a second
+// import from `./bearerAuth` for the token-verifier type it shares with Bearer auth.
+export type { OAuthTokenVerifier } from './bearerAuth';
+
+/** RFC 9449 §5.1: the JWS algorithms this SDK's DPoP validator accepts, advertised in the `algs` challenge parameter. */
+const ADVERTISED_ALGS = DPOP_SUPPORTED_ALGS.join(' ');
+
+/**
+ * Options for {@linkcode verifyDpopToken}, {@linkcode dpopAuthChallengeResponse}, and
+ * {@linkcode requireDpopAuth}.
+ */
+export interface DpopAuthOptions extends BearerAuthOptions {
+    /**
+     * Acceptance window for the proof's `iat`, in seconds either side of the server's clock.
+     * @default 300 (SEP-1932's recommended ±5 minutes)
+     */
+    iatSkewSeconds?: number;
+
+    /**
+     * Server-provided nonce support (RFC 9449 §9 — a SHOULD, not a MUST). Omit to never require
+     * a nonce. When set, {@linkcode dpopAuthChallengeResponse} calls `issue()` to mint the nonce
+     * returned in a `use_dpop_nonce` challenge's `DPoP-Nonce` header, and {@linkcode verifyDpopToken}
+     * calls `verify()` (via {@linkcode DpopNonceState}) to check a presented proof's nonce.
+     */
+    nonce?: {
+        /** Mint the nonce to include in the next `use_dpop_nonce` challenge. */
+        issue(): string;
+    } & DpopNonceState;
+}
+
+/** A raw incoming request's fields relevant to DPoP validation, framework-neutral. */
+export interface DpopRequest {
+    /** Raw `Authorization` header value. */
+    authorization: string | null | undefined;
+    /**
+     * Raw `DPoP` header value(s) — see {@linkcode VerifyDpopProofOptions.proof} in `dpop.ts` for
+     * why this is `string | string[] | undefined` rather than always a single string.
+     */
+    dpop: string | string[] | undefined;
+    /** HTTP method of the request. */
+    method: string;
+    /** Full URL the request arrived at — the value the proof's `htu` claim must match. */
+    url: string | URL;
+}
+
+/**
+ * Validate a DPoP-bound request — the `Authorization: DPoP <token>` header and the accompanying
+ * `DPoP` proof header, together — and return the verified {@linkcode AuthInfo}.
+ *
+ * The runtime-neutral core of DPoP authentication, mirroring {@linkcode verifyBearerToken}: parses
+ * the `Authorization` header (requiring the `DPoP` scheme, not `Bearer`), runs `options.verifier`,
+ * verifies the proof against the request's method/URL via {@linkcode verifyDpopProof}, then checks
+ * that the proof key's RFC 7638 thumbprint matches the verified token's `cnf.jkt` (RFC 9449 §4.3
+ * step 12b — the actual sender-constraint check; everything upstream of it only confirms the
+ * caller holds *some* valid token and *some* well-formed proof, not that they're bound together).
+ * Finally enforces `requiredScopes` and token expiry exactly as `verifyBearerToken` does.
+ *
+ * On any failure throws an {@linkcode OAuthError} — pass that to
+ * {@linkcode dpopAuthChallengeResponse} for the matching HTTP answer, or use
+ * {@linkcode requireDpopAuth} to get both steps as one call.
+ */
+export async function verifyDpopToken(request: DpopRequest, options: DpopAuthOptions): Promise<AuthInfo> {
+    const { verifier, requiredScopes = [], iatSkewSeconds, nonce } = options;
+
+    if (!request.authorization) {
+        throw new OAuthError(OAuthErrorCode.InvalidToken, 'Missing Authorization header');
+    }
+    const [scheme, token] = request.authorization.split(' ');
+    if (scheme?.toLowerCase() !== 'dpop' || !token) {
+        throw new OAuthError(OAuthErrorCode.InvalidToken, "Invalid Authorization header format, expected 'DPoP TOKEN'");
+    }
+
+    const authInfo = await verifier.verifyAccessToken(token);
+
+    const { jkt } = await verifyDpopProof({
+        proof: request.dpop,
+        method: request.method,
+        url: request.url,
+        accessToken: token,
+        iatSkewSeconds,
+        nonce
+    });
+
+    // RFC 9449 §4.3 step 12b: the proof's key must be the one this token is bound to. A verifier
+    // that never populates `cnf.jkt` (does not support DPoP-bound tokens) cannot pass this gate —
+    // every token it issues is rejected here rather than silently accepted as unbound.
+    if (authInfo.cnf?.jkt !== jkt) {
+        throw new OAuthError(OAuthErrorCode.InvalidToken, 'Access token is not bound to this proof key (cnf.jkt mismatch)');
+    }
+
+    if (requiredScopes.length > 0) {
+        const hasAllScopes = requiredScopes.every(scope => authInfo.scopes.includes(scope));
+        if (!hasAllScopes) {
+            throw new OAuthError(OAuthErrorCode.InsufficientScope, 'Insufficient scope');
+        }
+    }
+
+    if (typeof authInfo.expiresAt !== 'number' || Number.isNaN(authInfo.expiresAt)) {
+        throw new OAuthError(OAuthErrorCode.InvalidToken, 'Token has no expiration time');
+    } else if (authInfo.expiresAt < Date.now() / 1000) {
+        throw new OAuthError(OAuthErrorCode.InvalidToken, 'Token has expired');
+    }
+
+    return authInfo;
+}
+
+/**
+ * Build the HTTP answer for a DPoP authentication failure.
+ *
+ * Maps an {@linkcode OAuthError} to its status — `401` for `invalid_token`/`invalid_dpop_proof`
+ * and `use_dpop_nonce` (all carrying a `WWW-Authenticate: DPoP …` challenge advertising the
+ * accepted `algs`, plus `resource_metadata` when configured), `403` for `insufficient_scope`,
+ * `500` for `server_error`, `400` for anything else. `use_dpop_nonce` additionally carries a fresh
+ * `DPoP-Nonce` response header (from `options.nonce.issue()`) for the client to retry with — see
+ * RFC 9449 §9. A non-`OAuthError` value answers `500 server_error`. The body is the OAuth error JSON.
+ */
+export function dpopAuthChallengeResponse(
+    error: unknown,
+    options?: Pick<DpopAuthOptions, 'requiredScopes' | 'resourceMetadataUrl' | 'nonce'>
+): Response {
+    const { requiredScopes = [], resourceMetadataUrl, nonce } = options ?? {};
+
+    if (!(error instanceof OAuthError)) {
+        const serverError = new OAuthError(OAuthErrorCode.ServerError, 'Internal Server Error');
+        return Response.json(serverError.toResponseObject(), { status: 500 });
+    }
+
+    const challenge = (): string =>
+        buildWwwAuthenticateHeader('DPoP', error.code, error.message, requiredScopes, resourceMetadataUrl, { algs: ADVERTISED_ALGS });
+
+    switch (error.code) {
+        case OAuthErrorCode.InvalidToken:
+        case OAuthErrorCode.InvalidDpopProof: {
+            return Response.json(error.toResponseObject(), { status: 401, headers: { 'WWW-Authenticate': challenge() } });
+        }
+        case OAuthErrorCode.UseDpopNonce: {
+            const headers: Record<string, string> = { 'WWW-Authenticate': challenge() };
+            if (nonce) headers['DPoP-Nonce'] = nonce.issue();
+            return Response.json(error.toResponseObject(), { status: 401, headers });
+        }
+        case OAuthErrorCode.InsufficientScope: {
+            return Response.json(error.toResponseObject(), { status: 403, headers: { 'WWW-Authenticate': challenge() } });
+        }
+        case OAuthErrorCode.ServerError: {
+            return Response.json(error.toResponseObject(), { status: 500 });
+        }
+        default: {
+            return Response.json(error.toResponseObject(), { status: 400 });
+        }
+    }
+}
+
+/**
+ * Require a valid DPoP-bound token on web-standard requests.
+ *
+ * The framework-free counterpart of `requireDpopAuth` from `@modelcontextprotocol/express`, for
+ * hosts whose HTTP surface is a `fetch(request)` handler — edge/serverless runtimes, Deno, Bun,
+ * Hono. The returned gate resolves to the verified {@linkcode AuthInfo}, or to the ready-to-return
+ * challenge `Response` when the request must be refused.
+ *
+ * @example
+ * ```ts source="./dpopAuth.examples.ts#requireDpopAuth_fetchGate"
+ * const gate = requireDpopAuth({ verifier, requiredScopes: ['mcp'] });
+ *
+ * async function fetchHandler(request: Request): Promise<Response> {
+ *     const auth: AuthInfo | Response = await gate(request);
+ *     if (auth instanceof Response) return auth;
+ *     return handler.fetch(request, { authInfo: auth });
+ * }
+ * ```
+ */
+export function requireDpopAuth(options: DpopAuthOptions): (request: Request) => Promise<AuthInfo | Response> {
+    // Destructure at creation so a plain-JS caller passing undefined or malformed options crashes
+    // at startup, not on the first request.
+    const { verifier, requiredScopes = [], resourceMetadataUrl, iatSkewSeconds, nonce } = options;
+    const resolved = { verifier, requiredScopes, resourceMetadataUrl, iatSkewSeconds, nonce };
+    return async request => {
+        // Outside the try: a wrong-framework misuse (no web-standard Request) should throw
+        // loudly, not surface as a 500 challenge.
+        const [authorization] = (request.headers.get('authorization') ?? '').split(',');
+        // Headers.get comma-joins repeated headers (fetch's Headers behavior, unlike Node's
+        // `http` which keeps the first) — verifyDpopProof's own comma check catches a genuine
+        // duplicate DPoP header this way; a single proof JWT never contains a comma.
+        const dpop = request.headers.get('dpop') ?? undefined;
+        try {
+            return await verifyDpopToken(
+                { authorization: authorization || undefined, dpop, method: request.method, url: request.url },
+                resolved
+            );
+        } catch (error) {
+            return dpopAuthChallengeResponse(error, resolved);
+        }
+    };
+}

--- a/packages/server/src/server/middleware/dpopAuth.ts
+++ b/packages/server/src/server/middleware/dpopAuth.ts
@@ -43,6 +43,10 @@ export interface DpopAuthOptions extends BearerAuthOptions {
         /** Mint the nonce to include in the next `use_dpop_nonce` challenge. */
         issue(): string;
     } & DpopNonceState;
+
+    // TODO: there's no equivalent hook here for jti-replay tracking (see the TODO on the `jti`
+    // check in dpop.ts) — nonce gets a first-class option, jti-uniqueness doesn't yet. A caller
+    // who wants both has to bypass requireDpopAuth/verifyDpopToken and re-implement this gate.
 }
 
 /** A raw incoming request's fields relevant to DPoP validation, framework-neutral. */

--- a/packages/server/test/server/bearerAuth.test.ts
+++ b/packages/server/test/server/bearerAuth.test.ts
@@ -62,6 +62,14 @@ describe('verifyBearerToken', () => {
         });
     });
 
+    it('rejects a DPoP-bound token (cnf.jkt set) presented under the Bearer scheme (RFC 9449 §7.2)', async () => {
+        const verifier = verifierReturning({ ...validAuthInfo, cnf: { jkt: 'thumbprint-1' } });
+        await expect(verifyBearerToken('Bearer valid-token', { verifier })).rejects.toMatchObject({
+            code: OAuthErrorCode.InvalidToken,
+            message: 'Token is DPoP-bound and must be presented with the DPoP scheme, not Bearer'
+        });
+    });
+
     it('enforces requiredScopes before expiry (matching the Express middleware order)', async () => {
         // Expired AND missing a scope: the scope failure wins, as it always has.
         const verifier = verifierReturning({ ...validAuthInfo, scopes: ['read'], expiresAt: Date.now() / 1000 - 100 });

--- a/packages/server/test/server/dpop.test.ts
+++ b/packages/server/test/server/dpop.test.ts
@@ -1,0 +1,420 @@
+// Type-only: see the matching comment in src/server/middleware/dpop.ts.
+import type { webcrypto } from 'node:crypto';
+
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { accessTokenHash, calculateJwkThumbprint, DPOP_SUPPORTED_ALGS, verifyDpopProof } from '../../src/server/middleware/dpop';
+
+/**
+ * Minimal, hand-rolled DPoP proof builder for these tests — deliberately independent of
+ * `dpop.ts`'s own validator (built on the same raw WebCrypto primitives, not through it), so a
+ * shared bug in signing/encoding can't hide from the tests that exercise the validator.
+ */
+async function base64url(bytes: ArrayBuffer | Uint8Array): Promise<string> {
+    return Buffer.from(bytes as ArrayBuffer).toString('base64url');
+}
+
+interface TestKeyPair {
+    privateKey: webcrypto.CryptoKey;
+    publicJwk: webcrypto.JsonWebKey;
+}
+
+async function generateEcKeyPair(): Promise<TestKeyPair> {
+    const { publicKey, privateKey } = await crypto.subtle.generateKey({ name: 'ECDSA', namedCurve: 'P-256' }, true, ['sign', 'verify']);
+    const publicJwk = await crypto.subtle.exportKey('jwk', publicKey);
+    return { privateKey, publicJwk };
+}
+
+interface BuildProofOptions {
+    kp: TestKeyPair;
+    htm: string;
+    htu: string;
+    accessToken?: string;
+    nonce?: string;
+    iat?: number;
+    alg?: string;
+    typ?: string;
+    jwk?: unknown;
+    omit?: Array<'jti' | 'htm' | 'htu' | 'iat' | 'jwk'>;
+    tamperSignature?: boolean;
+}
+
+async function buildProof(opts: BuildProofOptions): Promise<string> {
+    const omit = new Set(opts.omit);
+    const header: Record<string, unknown> = { alg: opts.alg ?? 'ES256', typ: opts.typ === undefined ? 'dpop+jwt' : opts.typ };
+    if (!omit.has('jwk')) header.jwk = opts.jwk ?? opts.kp.publicJwk;
+
+    const payload: Record<string, unknown> = {};
+    if (!omit.has('jti')) payload.jti = await base64url(crypto.getRandomValues(new Uint8Array(16)));
+    if (!omit.has('htm')) payload.htm = opts.htm;
+    if (!omit.has('htu')) payload.htu = opts.htu;
+    if (!omit.has('iat')) payload.iat = opts.iat ?? Math.floor(Date.now() / 1000);
+    if (opts.accessToken !== undefined) payload.ath = await accessTokenHash(opts.accessToken);
+    if (opts.nonce !== undefined) payload.nonce = opts.nonce;
+
+    const headerSegment = await base64url(new TextEncoder().encode(JSON.stringify(header)));
+    const payloadSegment = await base64url(new TextEncoder().encode(JSON.stringify(payload)));
+    const signingInput = `${headerSegment}.${payloadSegment}`;
+    const signature = await crypto.subtle.sign(
+        { name: 'ECDSA', hash: 'SHA-256' },
+        opts.kp.privateKey,
+        new TextEncoder().encode(signingInput)
+    );
+    let signatureSegment = await base64url(signature);
+    if (opts.tamperSignature) {
+        signatureSegment = (signatureSegment[0] === 'A' ? 'B' : 'A') + signatureSegment.slice(1);
+    }
+    return `${signingInput}.${signatureSegment}`;
+}
+
+async function buildHs256Proof(kp: TestKeyPair, htm: string, htu: string, accessToken: string): Promise<string> {
+    const secretKey = await crypto.subtle.generateKey({ name: 'HMAC', hash: 'SHA-256' }, true, ['sign']);
+    const header = { alg: 'HS256', typ: 'dpop+jwt', jwk: kp.publicJwk };
+    const payload = {
+        jti: await base64url(crypto.getRandomValues(new Uint8Array(16))),
+        htm,
+        htu,
+        iat: Math.floor(Date.now() / 1000),
+        ath: await accessTokenHash(accessToken)
+    };
+    const headerSegment = await base64url(new TextEncoder().encode(JSON.stringify(header)));
+    const payloadSegment = await base64url(new TextEncoder().encode(JSON.stringify(payload)));
+    const signingInput = `${headerSegment}.${payloadSegment}`;
+    const signature = await crypto.subtle.sign('HMAC', secretKey, new TextEncoder().encode(signingInput));
+    return `${signingInput}.${await base64url(signature)}`;
+}
+
+function unsignedNoneProof(htm: string, htu: string): string {
+    const header = Buffer.from(JSON.stringify({ alg: 'none', typ: 'dpop+jwt' })).toString('base64url');
+    const payload = Buffer.from(JSON.stringify({ jti: 'x', htm, htu, iat: Math.floor(Date.now() / 1000) })).toString('base64url');
+    return `${header}.${payload}.`;
+}
+
+describe('calculateJwkThumbprint', () => {
+    it('produces the RFC 7638 §3.1 example thumbprint for an RSA key', async () => {
+        // RFC 7638 §3.1 test vector — the published expected thumbprint for this exact JWK.
+        const rsaJwk = {
+            kty: 'RSA',
+            n: '0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw',
+            e: 'AQAB'
+        };
+        expect(await calculateJwkThumbprint(rsaJwk)).toBe('NzbLsXh8uDCcd-6MNwXF4W_7noWXFZAfHkxZsRGC9Xs');
+    });
+
+    it('is order-independent — permuting the input JWK member order yields the same thumbprint', async () => {
+        const kp = await generateEcKeyPair();
+        const a = await calculateJwkThumbprint(kp.publicJwk);
+        const permuted = {
+            y: (kp.publicJwk as { y: string }).y,
+            crv: kp.publicJwk.crv,
+            x: (kp.publicJwk as { x: string }).x,
+            kty: kp.publicJwk.kty
+        };
+        const b = await calculateJwkThumbprint(permuted);
+        expect(a).toBe(b);
+    });
+
+    it('differs for two distinct keys', async () => {
+        const a = await generateEcKeyPair();
+        const b = await generateEcKeyPair();
+        expect(await calculateJwkThumbprint(a.publicJwk)).not.toBe(await calculateJwkThumbprint(b.publicJwk));
+    });
+});
+
+describe('accessTokenHash', () => {
+    it('matches an independently computed SHA-256/base64url digest', async () => {
+        const expected = await base64url(await crypto.subtle.digest('SHA-256', new TextEncoder().encode('tok-123')));
+        expect(await accessTokenHash('tok-123')).toBe(expected);
+    });
+});
+
+describe('verifyDpopProof', () => {
+    const url = 'https://mcp.example.com/mcp';
+    let kp: TestKeyPair;
+
+    beforeEach(async () => {
+        kp = await generateEcKeyPair();
+    });
+
+    it('accepts a valid proof and returns the matching jkt + claims', async () => {
+        const proof = await buildProof({ kp, htm: 'POST', htu: url, accessToken: 'tok-1' });
+        const result = await verifyDpopProof({ proof, method: 'POST', url, accessToken: 'tok-1' });
+        expect(result.jkt).toBe(await calculateJwkThumbprint(kp.publicJwk));
+        expect(typeof result.claims.jti).toBe('string');
+        expect(result.claims.htm).toBe('POST');
+        expect(result.claims.htu).toBe(url);
+    });
+
+    it('compares htm case-insensitively', async () => {
+        const proof = await buildProof({ kp, htm: 'POST', htu: url });
+        await expect(verifyDpopProof({ proof, method: 'post', url })).resolves.toBeDefined();
+    });
+
+    for (const alg of DPOP_SUPPORTED_ALGS) {
+        it(`accepts a valid ${alg} proof`, async () => {
+            let signAlgorithm: webcrypto.AlgorithmIdentifier | webcrypto.EcdsaParams | webcrypto.RsaPssParams;
+            let genAlgorithm: webcrypto.RsaHashedKeyGenParams | webcrypto.EcKeyGenParams | webcrypto.AlgorithmIdentifier;
+            switch (alg) {
+                case 'ES256': {
+                    genAlgorithm = { name: 'ECDSA', namedCurve: 'P-256' };
+                    signAlgorithm = { name: 'ECDSA', hash: 'SHA-256' };
+                    break;
+                }
+                case 'ES384': {
+                    genAlgorithm = { name: 'ECDSA', namedCurve: 'P-384' };
+                    signAlgorithm = { name: 'ECDSA', hash: 'SHA-384' };
+                    break;
+                }
+                case 'ES512': {
+                    genAlgorithm = { name: 'ECDSA', namedCurve: 'P-521' };
+                    signAlgorithm = { name: 'ECDSA', hash: 'SHA-512' };
+                    break;
+                }
+                case 'RS256': {
+                    genAlgorithm = {
+                        name: 'RSASSA-PKCS1-v1_5',
+                        modulusLength: 2048,
+                        publicExponent: new Uint8Array([1, 0, 1]),
+                        hash: 'SHA-256'
+                    };
+                    signAlgorithm = { name: 'RSASSA-PKCS1-v1_5' };
+                    break;
+                }
+                case 'RS384': {
+                    genAlgorithm = {
+                        name: 'RSASSA-PKCS1-v1_5',
+                        modulusLength: 2048,
+                        publicExponent: new Uint8Array([1, 0, 1]),
+                        hash: 'SHA-384'
+                    };
+                    signAlgorithm = { name: 'RSASSA-PKCS1-v1_5' };
+                    break;
+                }
+                case 'RS512': {
+                    genAlgorithm = {
+                        name: 'RSASSA-PKCS1-v1_5',
+                        modulusLength: 2048,
+                        publicExponent: new Uint8Array([1, 0, 1]),
+                        hash: 'SHA-512'
+                    };
+                    signAlgorithm = { name: 'RSASSA-PKCS1-v1_5' };
+                    break;
+                }
+                case 'PS256': {
+                    genAlgorithm = { name: 'RSA-PSS', modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]), hash: 'SHA-256' };
+                    signAlgorithm = { name: 'RSA-PSS', saltLength: 32 };
+                    break;
+                }
+                case 'PS384': {
+                    genAlgorithm = { name: 'RSA-PSS', modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]), hash: 'SHA-384' };
+                    signAlgorithm = { name: 'RSA-PSS', saltLength: 48 };
+                    break;
+                }
+                case 'PS512': {
+                    genAlgorithm = { name: 'RSA-PSS', modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]), hash: 'SHA-512' };
+                    signAlgorithm = { name: 'RSA-PSS', saltLength: 64 };
+                    break;
+                }
+                case 'EdDSA': {
+                    genAlgorithm = { name: 'Ed25519' };
+                    signAlgorithm = { name: 'Ed25519' };
+                    break;
+                }
+            }
+            const { publicKey, privateKey } = (await crypto.subtle.generateKey(genAlgorithm, true, [
+                'sign',
+                'verify'
+            ])) as webcrypto.CryptoKeyPair;
+            const signKp: TestKeyPair = { privateKey, publicJwk: await crypto.subtle.exportKey('jwk', publicKey) };
+
+            const header = { alg, typ: 'dpop+jwt', jwk: signKp.publicJwk };
+            const payload = {
+                jti: await base64url(crypto.getRandomValues(new Uint8Array(16))),
+                htm: 'POST',
+                htu: url,
+                iat: Math.floor(Date.now() / 1000)
+            };
+            const headerSegment = await base64url(new TextEncoder().encode(JSON.stringify(header)));
+            const payloadSegment = await base64url(new TextEncoder().encode(JSON.stringify(payload)));
+            const signingInput = `${headerSegment}.${payloadSegment}`;
+            const signature = await crypto.subtle.sign(signAlgorithm, signKp.privateKey, new TextEncoder().encode(signingInput));
+            const proof = `${signingInput}.${await base64url(signature)}`;
+
+            const result = await verifyDpopProof({ proof, method: 'POST', url });
+            expect(result.jkt).toBe(await calculateJwkThumbprint(signKp.publicJwk));
+        });
+    }
+
+    describe('rejections (RFC 9449 §4.3)', () => {
+        it('rejects a missing proof', async () => {
+            await expect(verifyDpopProof({ proof: undefined, method: 'POST', url })).rejects.toMatchObject({ code: 'invalid_dpop_proof' });
+        });
+
+        it('rejects a non-JWT string', async () => {
+            await expect(verifyDpopProof({ proof: 'not-a-jwt', method: 'POST', url })).rejects.toMatchObject({
+                code: 'invalid_dpop_proof'
+            });
+        });
+
+        it('rejects a tampered signature', async () => {
+            const proof = await buildProof({ kp, htm: 'POST', htu: url, tamperSignature: true });
+            await expect(verifyDpopProof({ proof, method: 'POST', url })).rejects.toMatchObject({ code: 'invalid_dpop_proof' });
+        });
+
+        it('rejects wrong typ', async () => {
+            const proof = await buildProof({ kp, htm: 'POST', htu: url, typ: 'jwt' });
+            await expect(verifyDpopProof({ proof, method: 'POST', url })).rejects.toMatchObject({ code: 'invalid_dpop_proof' });
+        });
+
+        it('rejects alg: none', async () => {
+            const proof = unsignedNoneProof('POST', url);
+            await expect(verifyDpopProof({ proof, method: 'POST', url })).rejects.toMatchObject({ code: 'invalid_dpop_proof' });
+        });
+
+        it('rejects a symmetric algorithm (HS256)', async () => {
+            const proof = await buildHs256Proof(kp, 'POST', url, 'tok-1');
+            await expect(verifyDpopProof({ proof, method: 'POST', url, accessToken: 'tok-1' })).rejects.toMatchObject({
+                code: 'invalid_dpop_proof'
+            });
+        });
+
+        it('rejects a private key embedded in jwk', async () => {
+            const privateJwk = await crypto.subtle.exportKey('jwk', kp.privateKey);
+            const proof = await buildProof({ kp, htm: 'POST', htu: url, jwk: privateJwk });
+            await expect(verifyDpopProof({ proof, method: 'POST', url })).rejects.toMatchObject({ code: 'invalid_dpop_proof' });
+        });
+
+        it('rejects a missing jwk', async () => {
+            const proof = await buildProof({ kp, htm: 'POST', htu: url, omit: ['jwk'] });
+            await expect(verifyDpopProof({ proof, method: 'POST', url })).rejects.toMatchObject({ code: 'invalid_dpop_proof' });
+        });
+
+        it('rejects a missing jti', async () => {
+            const proof = await buildProof({ kp, htm: 'POST', htu: url, omit: ['jti'] });
+            await expect(verifyDpopProof({ proof, method: 'POST', url })).rejects.toMatchObject({ code: 'invalid_dpop_proof' });
+        });
+
+        it('rejects a missing htm', async () => {
+            const proof = await buildProof({ kp, htm: 'POST', htu: url, omit: ['htm'] });
+            await expect(verifyDpopProof({ proof, method: 'POST', url })).rejects.toMatchObject({ code: 'invalid_dpop_proof' });
+        });
+
+        it('rejects an htm mismatch', async () => {
+            const proof = await buildProof({ kp, htm: 'GET', htu: url });
+            await expect(verifyDpopProof({ proof, method: 'POST', url })).rejects.toMatchObject({ code: 'invalid_dpop_proof' });
+        });
+
+        it('rejects a missing htu', async () => {
+            const proof = await buildProof({ kp, htm: 'POST', htu: url, omit: ['htu'] });
+            await expect(verifyDpopProof({ proof, method: 'POST', url })).rejects.toMatchObject({ code: 'invalid_dpop_proof' });
+        });
+
+        it('rejects an htu mismatch', async () => {
+            const proof = await buildProof({ kp, htm: 'POST', htu: 'https://wrong.example.com/mcp' });
+            await expect(verifyDpopProof({ proof, method: 'POST', url })).rejects.toMatchObject({ code: 'invalid_dpop_proof' });
+        });
+
+        it('rejects an htu carrying a query string (even if it matches after stripping)', async () => {
+            const proof = await buildProof({ kp, htm: 'POST', htu: `${url}?x=1` });
+            await expect(verifyDpopProof({ proof, method: 'POST', url })).rejects.toMatchObject({ code: 'invalid_dpop_proof' });
+        });
+
+        it('rejects an htu carrying a fragment', async () => {
+            const proof = await buildProof({ kp, htm: 'POST', htu: `${url}#frag` });
+            await expect(verifyDpopProof({ proof, method: 'POST', url })).rejects.toMatchObject({ code: 'invalid_dpop_proof' });
+        });
+
+        it('rejects a missing iat', async () => {
+            const proof = await buildProof({ kp, htm: 'POST', htu: url, omit: ['iat'] });
+            await expect(verifyDpopProof({ proof, method: 'POST', url })).rejects.toMatchObject({ code: 'invalid_dpop_proof' });
+        });
+
+        it('rejects a stale iat (outside ±300s default window)', async () => {
+            const proof = await buildProof({ kp, htm: 'POST', htu: url, iat: Math.floor(Date.now() / 1000) - 301 });
+            await expect(verifyDpopProof({ proof, method: 'POST', url })).rejects.toMatchObject({ code: 'invalid_dpop_proof' });
+        });
+
+        it('rejects a future iat (outside ±300s default window)', async () => {
+            const proof = await buildProof({ kp, htm: 'POST', htu: url, iat: Math.floor(Date.now() / 1000) + 301 });
+            await expect(verifyDpopProof({ proof, method: 'POST', url })).rejects.toMatchObject({ code: 'invalid_dpop_proof' });
+        });
+
+        it('accepts an iat just inside a custom acceptance window', async () => {
+            const proof = await buildProof({ kp, htm: 'POST', htu: url, iat: Math.floor(Date.now() / 1000) - 50 });
+            await expect(verifyDpopProof({ proof, method: 'POST', url, iatSkewSeconds: 60 })).resolves.toBeDefined();
+        });
+
+        it('rejects a missing ath when an access token is presented', async () => {
+            const proof = await buildProof({ kp, htm: 'POST', htu: url }); // no accessToken -> no ath claim
+            await expect(verifyDpopProof({ proof, method: 'POST', url, accessToken: 'tok-1' })).rejects.toMatchObject({
+                code: 'invalid_dpop_proof'
+            });
+        });
+
+        it('rejects a wrong ath', async () => {
+            const proof = await buildProof({ kp, htm: 'POST', htu: url, accessToken: 'tok-1' });
+            await expect(verifyDpopProof({ proof, method: 'POST', url, accessToken: 'tok-2' })).rejects.toMatchObject({
+                code: 'invalid_dpop_proof'
+            });
+        });
+
+        it('rejects a duplicate DPoP header presented as an array of two', async () => {
+            const proof = await buildProof({ kp, htm: 'POST', htu: url });
+            await expect(verifyDpopProof({ proof: [proof, proof], method: 'POST', url })).rejects.toMatchObject({
+                code: 'invalid_dpop_proof'
+            });
+        });
+
+        it('rejects a duplicate DPoP header collapsed into one comma-joined string (Node http behavior)', async () => {
+            const proof = await buildProof({ kp, htm: 'POST', htu: url });
+            await expect(verifyDpopProof({ proof: `${proof}, ${proof}`, method: 'POST', url })).rejects.toMatchObject({
+                code: 'invalid_dpop_proof'
+            });
+        });
+
+        it('rejects an empty array (no proof at all, distinctly from "too many")', async () => {
+            await expect(verifyDpopProof({ proof: [], method: 'POST', url })).rejects.toMatchObject({ code: 'invalid_dpop_proof' });
+        });
+    });
+
+    describe('htu normalization', () => {
+        it('tolerates the default port and a single trailing slash', async () => {
+            const proof = await buildProof({ kp, htm: 'POST', htu: 'https://mcp.example.com:443/mcp/' });
+            await expect(verifyDpopProof({ proof, method: 'POST', url: 'https://mcp.example.com/mcp' })).resolves.toBeDefined();
+        });
+
+        it('does not tolerate a non-default port mismatch', async () => {
+            const proof = await buildProof({ kp, htm: 'POST', htu: 'https://mcp.example.com:8443/mcp' });
+            await expect(verifyDpopProof({ proof, method: 'POST', url: 'https://mcp.example.com/mcp' })).rejects.toMatchObject({
+                code: 'invalid_dpop_proof'
+            });
+        });
+    });
+
+    describe('server-provided nonce (RFC 9449 §9)', () => {
+        it('accepts a nonce-less proof when no nonce is currently required', async () => {
+            const proof = await buildProof({ kp, htm: 'POST', htu: url });
+            const nonce = { verify: () => true };
+            await expect(verifyDpopProof({ proof, method: 'POST', url, nonce })).resolves.toBeDefined();
+        });
+
+        it('rejects a nonce-less proof when a nonce is required', async () => {
+            const proof = await buildProof({ kp, htm: 'POST', htu: url });
+            const nonce = { verify: (n: string | undefined) => n === 'expected-nonce' };
+            await expect(verifyDpopProof({ proof, method: 'POST', url, nonce })).rejects.toMatchObject({ code: 'use_dpop_nonce' });
+        });
+
+        it('rejects a wrong nonce', async () => {
+            const proof = await buildProof({ kp, htm: 'POST', htu: url, nonce: 'not-it' });
+            const nonce = { verify: (n: string | undefined) => n === 'expected-nonce' };
+            await expect(verifyDpopProof({ proof, method: 'POST', url, nonce })).rejects.toMatchObject({ code: 'use_dpop_nonce' });
+        });
+
+        it('accepts the correct nonce', async () => {
+            const proof = await buildProof({ kp, htm: 'POST', htu: url, nonce: 'expected-nonce' });
+            const nonce = { verify: (n: string | undefined) => n === 'expected-nonce' };
+            const result = await verifyDpopProof({ proof, method: 'POST', url, nonce });
+            expect(result.claims.nonce).toBe('expected-nonce');
+        });
+    });
+});

--- a/packages/server/test/server/dpopAuth.test.ts
+++ b/packages/server/test/server/dpopAuth.test.ts
@@ -101,7 +101,7 @@ describe('verifyDpopToken', () => {
         });
     });
 
-    it('rejects the Bearer scheme (RFC 9449 §7.1 — a DPoP-bound token must be presented as DPoP)', async () => {
+    it('rejects the Bearer scheme (RFC 9449 §7.2 — a DPoP-bound token must be presented as DPoP)', async () => {
         const proof = await buildProof(signer, 'POST', url, boundToken);
         await expect(
             verifyDpopToken({ authorization: `Bearer ${boundToken}`, dpop: proof, method: 'POST', url }, options)
@@ -188,6 +188,76 @@ describe('verifyDpopToken', () => {
             await expect(
                 verifyDpopToken({ authorization: `DPoP ${boundToken}`, dpop: proofWithNonce, method: 'POST', url }, nonceOptions)
             ).resolves.toMatchObject({ token: boundToken });
+        });
+    });
+});
+
+describe('verifyDpopToken with a JWT-shaped access token', () => {
+    // The tests above all use short opaque strings as the access token, matching an
+    // introspection-backed OAuthTokenVerifier. This proves the same flow when the access token is
+    // itself a signed JWT (header.payload.signature) whose own payload carries `cnf.jkt` — the
+    // shape a self-contained JWT-access-token verifier decodes instead of looking up.
+    function buildJwtAccessToken(payload: Record<string, unknown>): string {
+        const encode = (value: unknown) => Buffer.from(JSON.stringify(value)).toString('base64url');
+        const header = encode({ alg: 'RS256', typ: 'JWT' });
+        const body = encode(payload);
+        // Verifying the access token's own signature is the OAuthTokenVerifier's job, not
+        // dpop.ts's, so a placeholder signature segment is enough to keep the token JWT-shaped.
+        return `${header}.${body}.${Buffer.from('sig').toString('base64url')}`;
+    }
+
+    function jwtDecodingVerifier(): OAuthTokenVerifier {
+        return {
+            verifyAccessToken: vi.fn(async (token: string) => {
+                const [, payloadSegment] = token.split('.');
+                if (!payloadSegment) throw new OAuthError(OAuthErrorCode.InvalidToken, 'not a JWT');
+                const claims = JSON.parse(Buffer.from(payloadSegment, 'base64url').toString('utf8')) as Record<string, unknown>;
+                return {
+                    token,
+                    clientId: claims.client_id as string,
+                    scopes: (claims.scope as string).split(' '),
+                    expiresAt: claims.exp as number,
+                    cnf: claims.cnf as { jkt?: string } | undefined
+                };
+            })
+        };
+    }
+
+    it('accepts a DPoP-bound token when the access token is a real JWT, decoded (not looked up) by the verifier', async () => {
+        const signer = await generateSigner();
+        const jwtAccessToken = buildJwtAccessToken({
+            client_id: 'client-1',
+            scope: 'mcp',
+            exp: Math.floor(Date.now() / 1000) + 3600,
+            cnf: { jkt: signer.jkt }
+        });
+        const proof = await buildProof(signer, 'POST', url, jwtAccessToken);
+        const authInfo = await verifyDpopToken(
+            { authorization: `DPoP ${jwtAccessToken}`, dpop: proof, method: 'POST', url },
+            { verifier: jwtDecodingVerifier(), requiredScopes: ['mcp'] }
+        );
+        expect(authInfo.token).toBe(jwtAccessToken);
+        expect(authInfo.cnf?.jkt).toBe(signer.jkt);
+    });
+
+    it('rejects when the JWT access token is bound to a different proof key', async () => {
+        const signer = await generateSigner();
+        const otherSigner = await generateSigner();
+        const jwtAccessToken = buildJwtAccessToken({
+            client_id: 'client-1',
+            scope: 'mcp',
+            exp: Math.floor(Date.now() / 1000) + 3600,
+            cnf: { jkt: otherSigner.jkt }
+        });
+        const proof = await buildProof(signer, 'POST', url, jwtAccessToken);
+        await expect(
+            verifyDpopToken(
+                { authorization: `DPoP ${jwtAccessToken}`, dpop: proof, method: 'POST', url },
+                { verifier: jwtDecodingVerifier() }
+            )
+        ).rejects.toMatchObject({
+            code: OAuthErrorCode.InvalidToken,
+            message: 'Access token is not bound to this proof key (cnf.jkt mismatch)'
         });
     });
 });

--- a/packages/server/test/server/dpopAuth.test.ts
+++ b/packages/server/test/server/dpopAuth.test.ts
@@ -1,0 +1,279 @@
+// Type-only: see the matching comment in src/server/middleware/dpop.ts.
+import type { webcrypto } from 'node:crypto';
+
+import type { AuthInfo } from '@modelcontextprotocol/core-internal';
+import { OAuthError, OAuthErrorCode } from '@modelcontextprotocol/core-internal';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { calculateJwkThumbprint } from '../../src/server/middleware/dpop';
+import type { DpopAuthOptions, OAuthTokenVerifier } from '../../src/server/middleware/dpopAuth';
+import { dpopAuthChallengeResponse, requireDpopAuth, verifyDpopToken } from '../../src/server/middleware/dpopAuth';
+
+async function base64url(bytes: ArrayBuffer | Uint8Array): Promise<string> {
+    return Buffer.from(bytes as ArrayBuffer).toString('base64url');
+}
+
+interface Signer {
+    privateKey: webcrypto.CryptoKey;
+    publicJwk: webcrypto.JsonWebKey;
+    jkt: string;
+}
+
+async function generateSigner(): Promise<Signer> {
+    const { publicKey, privateKey } = await crypto.subtle.generateKey({ name: 'ECDSA', namedCurve: 'P-256' }, true, ['sign', 'verify']);
+    const publicJwk = await crypto.subtle.exportKey('jwk', publicKey);
+    return { privateKey, publicJwk, jkt: await calculateJwkThumbprint(publicJwk) };
+}
+
+async function buildProof(signer: Signer, htm: string, htu: string, accessToken: string, nonce?: string): Promise<string> {
+    const header = { alg: 'ES256', typ: 'dpop+jwt', jwk: signer.publicJwk };
+    const athDigest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(accessToken));
+    const payload: Record<string, unknown> = {
+        jti: await base64url(crypto.getRandomValues(new Uint8Array(16))),
+        htm,
+        htu,
+        iat: Math.floor(Date.now() / 1000),
+        ath: await base64url(athDigest)
+    };
+    if (nonce !== undefined) payload.nonce = nonce;
+    const headerSegment = await base64url(new TextEncoder().encode(JSON.stringify(header)));
+    const payloadSegment = await base64url(new TextEncoder().encode(JSON.stringify(payload)));
+    const signingInput = `${headerSegment}.${payloadSegment}`;
+    const signature = await crypto.subtle.sign(
+        { name: 'ECDSA', hash: 'SHA-256' },
+        signer.privateKey,
+        new TextEncoder().encode(signingInput)
+    );
+    return `${signingInput}.${await base64url(signature)}`;
+}
+
+function verifierFor(tokens: Record<string, AuthInfo>): OAuthTokenVerifier {
+    return {
+        verifyAccessToken: vi.fn(async (token: string) => {
+            const info = tokens[token];
+            if (!info) throw new OAuthError(OAuthErrorCode.InvalidToken, 'unknown token');
+            return info;
+        })
+    };
+}
+
+const url = 'https://mcp.example.com/mcp';
+
+describe('verifyDpopToken', () => {
+    let signer: Signer;
+    let boundToken: string;
+    let options: DpopAuthOptions;
+
+    beforeEach(async () => {
+        signer = await generateSigner();
+        boundToken = 'bound-token';
+        options = {
+            verifier: verifierFor({
+                [boundToken]: {
+                    token: boundToken,
+                    clientId: 'client-1',
+                    scopes: ['mcp'],
+                    expiresAt: Math.floor(Date.now() / 1000) + 3600,
+                    cnf: { jkt: signer.jkt }
+                }
+            }),
+            requiredScopes: ['mcp']
+        };
+    });
+
+    it('accepts a DPoP-bound token with a matching proof', async () => {
+        const proof = await buildProof(signer, 'POST', url, boundToken);
+        const authInfo = await verifyDpopToken({ authorization: `DPoP ${boundToken}`, dpop: proof, method: 'POST', url }, options);
+        expect(authInfo.token).toBe(boundToken);
+    });
+
+    it('accepts a case-insensitive DPoP scheme', async () => {
+        const proof = await buildProof(signer, 'POST', url, boundToken);
+        await expect(
+            verifyDpopToken({ authorization: `dPoP ${boundToken}`, dpop: proof, method: 'POST', url }, options)
+        ).resolves.toMatchObject({ token: boundToken });
+    });
+
+    it('rejects a missing Authorization header', async () => {
+        await expect(verifyDpopToken({ authorization: undefined, dpop: undefined, method: 'POST', url }, options)).rejects.toMatchObject({
+            code: OAuthErrorCode.InvalidToken,
+            message: 'Missing Authorization header'
+        });
+    });
+
+    it('rejects the Bearer scheme (RFC 9449 §7.1 — a DPoP-bound token must be presented as DPoP)', async () => {
+        const proof = await buildProof(signer, 'POST', url, boundToken);
+        await expect(
+            verifyDpopToken({ authorization: `Bearer ${boundToken}`, dpop: proof, method: 'POST', url }, options)
+        ).rejects.toMatchObject({
+            code: OAuthErrorCode.InvalidToken,
+            message: "Invalid Authorization header format, expected 'DPoP TOKEN'"
+        });
+    });
+
+    it('rejects a missing/malformed proof, surfacing the invalid_dpop_proof error from verifyDpopProof', async () => {
+        await expect(
+            verifyDpopToken({ authorization: `DPoP ${boundToken}`, dpop: undefined, method: 'POST', url }, options)
+        ).rejects.toMatchObject({ code: 'invalid_dpop_proof' });
+    });
+
+    it('rejects when the proof key does not match the token cnf.jkt (RFC 9449 §4.3 step 12b)', async () => {
+        const otherSigner = await generateSigner();
+        const proof = await buildProof(otherSigner, 'POST', url, boundToken);
+        await expect(
+            verifyDpopToken({ authorization: `DPoP ${boundToken}`, dpop: proof, method: 'POST', url }, options)
+        ).rejects.toMatchObject({
+            code: OAuthErrorCode.InvalidToken,
+            message: 'Access token is not bound to this proof key (cnf.jkt mismatch)'
+        });
+    });
+
+    it('rejects a token the verifier never bound (no cnf at all) presented under DPoP', async () => {
+        const unboundToken = 'unbound-token';
+        const unboundOptions: DpopAuthOptions = {
+            verifier: verifierFor({
+                [unboundToken]: { token: unboundToken, clientId: 'c', scopes: ['mcp'], expiresAt: Math.floor(Date.now() / 1000) + 3600 }
+            })
+        };
+        const proof = await buildProof(signer, 'POST', url, unboundToken);
+        await expect(
+            verifyDpopToken({ authorization: `DPoP ${unboundToken}`, dpop: proof, method: 'POST', url }, unboundOptions)
+        ).rejects.toMatchObject({
+            code: OAuthErrorCode.InvalidToken,
+            message: 'Access token is not bound to this proof key (cnf.jkt mismatch)'
+        });
+    });
+
+    it('enforces requiredScopes after the proof/binding checks', async () => {
+        const scopedOptions: DpopAuthOptions = { ...options, requiredScopes: ['admin'] };
+        const proof = await buildProof(signer, 'POST', url, boundToken);
+        await expect(
+            verifyDpopToken({ authorization: `DPoP ${boundToken}`, dpop: proof, method: 'POST', url }, scopedOptions)
+        ).rejects.toMatchObject({ code: OAuthErrorCode.InsufficientScope });
+    });
+
+    it('rejects an expired token', async () => {
+        const expiredToken = 'expired-token';
+        const expiredOptions: DpopAuthOptions = {
+            verifier: verifierFor({
+                [expiredToken]: {
+                    token: expiredToken,
+                    clientId: 'c',
+                    scopes: ['mcp'],
+                    expiresAt: Math.floor(Date.now() / 1000) - 100,
+                    cnf: { jkt: signer.jkt }
+                }
+            })
+        };
+        const proof = await buildProof(signer, 'POST', url, expiredToken);
+        await expect(
+            verifyDpopToken({ authorization: `DPoP ${expiredToken}`, dpop: proof, method: 'POST', url }, expiredOptions)
+        ).rejects.toMatchObject({ code: OAuthErrorCode.InvalidToken, message: 'Token has expired' });
+    });
+
+    describe('server-provided nonce', () => {
+        it('rejects when a nonce is required and absent, and accepts once the correct one is presented', async () => {
+            const currentNonce = 'nonce-1';
+            const nonceOptions: DpopAuthOptions = {
+                ...options,
+                nonce: { issue: () => currentNonce, verify: (n: string | undefined) => n === currentNonce }
+            };
+
+            const proofNoNonce = await buildProof(signer, 'POST', url, boundToken);
+            await expect(
+                verifyDpopToken({ authorization: `DPoP ${boundToken}`, dpop: proofNoNonce, method: 'POST', url }, nonceOptions)
+            ).rejects.toMatchObject({ code: 'use_dpop_nonce' });
+
+            const proofWithNonce = await buildProof(signer, 'POST', url, boundToken, currentNonce);
+            await expect(
+                verifyDpopToken({ authorization: `DPoP ${boundToken}`, dpop: proofWithNonce, method: 'POST', url }, nonceOptions)
+            ).resolves.toMatchObject({ token: boundToken });
+        });
+    });
+});
+
+describe('dpopAuthChallengeResponse', () => {
+    it('answers 401 with a DPoP challenge (advertising algs) for invalid_dpop_proof', async () => {
+        const response = dpopAuthChallengeResponse(new OAuthError('invalid_dpop_proof', 'DPoP proof signature does not verify'), {
+            requiredScopes: ['mcp'],
+            resourceMetadataUrl: 'https://api.example.com/.well-known/oauth-protected-resource'
+        });
+        expect(response.status).toBe(401);
+        const challenge = response.headers.get('WWW-Authenticate') ?? '';
+        expect(challenge).toMatch(/^DPoP error="invalid_dpop_proof"/);
+        expect(challenge).toContain('scope="mcp"');
+        expect(challenge).toContain('resource_metadata="https://api.example.com/.well-known/oauth-protected-resource"');
+        expect(challenge).toContain('algs="ES256 ES384 ES512 RS256 RS384 RS512 PS256 PS384 PS512 EdDSA"');
+    });
+
+    it('answers 401 for invalid_token with the same DPoP challenge shape', async () => {
+        const response = dpopAuthChallengeResponse(new OAuthError(OAuthErrorCode.InvalidToken, 'Token has expired'));
+        expect(response.status).toBe(401);
+        expect(response.headers.get('WWW-Authenticate')).toMatch(/^DPoP error="invalid_token"/);
+    });
+
+    it('answers 401 with a DPoP-Nonce header for use_dpop_nonce, minted by options.nonce.issue()', async () => {
+        const issue = vi.fn().mockReturnValue('fresh-nonce-1');
+        const response = dpopAuthChallengeResponse(new OAuthError('use_dpop_nonce', 'a fresh server-provided nonce is required'), {
+            nonce: { issue, verify: () => false }
+        });
+        expect(response.status).toBe(401);
+        expect(response.headers.get('DPoP-Nonce')).toBe('fresh-nonce-1');
+        expect(issue).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not set DPoP-Nonce for use_dpop_nonce when no nonce option is configured', async () => {
+        const response = dpopAuthChallengeResponse(new OAuthError('use_dpop_nonce', 'x'));
+        expect(response.headers.get('DPoP-Nonce')).toBeNull();
+    });
+
+    it('answers 403 for insufficient_scope', async () => {
+        const response = dpopAuthChallengeResponse(new OAuthError(OAuthErrorCode.InsufficientScope, 'Insufficient scope'), {
+            requiredScopes: ['admin']
+        });
+        expect(response.status).toBe(403);
+        expect(response.headers.get('WWW-Authenticate')).toContain('scope="admin"');
+    });
+
+    it('answers 500 without a challenge for server_error and for non-OAuthError values', async () => {
+        const a = dpopAuthChallengeResponse(new OAuthError(OAuthErrorCode.ServerError, 'boom'));
+        expect(a.status).toBe(500);
+        expect(a.headers.get('WWW-Authenticate')).toBeNull();
+
+        const b = dpopAuthChallengeResponse(new Error('boom'));
+        expect(b.status).toBe(500);
+        expect(await b.json()).toMatchObject({ error: 'server_error' });
+    });
+
+    it('answers 400 without a challenge for any other OAuth error code', async () => {
+        const response = dpopAuthChallengeResponse(new OAuthError(OAuthErrorCode.InvalidRequest, 'nope'));
+        expect(response.status).toBe(400);
+        expect(response.headers.get('WWW-Authenticate')).toBeNull();
+    });
+});
+
+describe('requireDpopAuth (web-standard)', () => {
+    it('resolves to AuthInfo for a valid request', async () => {
+        const signer = await generateSigner();
+        const token = 'tok-1';
+        const gate = requireDpopAuth({
+            verifier: verifierFor({
+                [token]: { token, clientId: 'c', scopes: [], expiresAt: Math.floor(Date.now() / 1000) + 3600, cnf: { jkt: signer.jkt } }
+            })
+        });
+        const proof = await buildProof(signer, 'POST', url, token);
+        const result = await gate(new Request(url, { method: 'POST', headers: { Authorization: `DPoP ${token}`, DPoP: proof } }));
+        expect(result).toMatchObject({ token });
+    });
+
+    it('resolves to the 401 challenge Response for a missing proof', async () => {
+        const gate = requireDpopAuth({ verifier: verifierFor({}) });
+        const result = await gate(new Request(url, { method: 'POST', headers: { Authorization: 'DPoP whatever' } }));
+        expect(result).toBeInstanceOf(Response);
+        expect((result as Response).status).toBe(401);
+    });
+
+    it('throws at creation time for missing options', () => {
+        expect(() => requireDpopAuth(undefined as never)).toThrow(TypeError);
+    });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2070,6 +2070,10 @@ importers:
         version: 4.3.6
 
   test/helpers:
+    dependencies:
+      vitest:
+        specifier: catalog:devTools
+        version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(vite@7.3.0(@types/node@25.5.0)(tsx@4.21.0)(yaml@2.8.3))
     devDependencies:
       '@modelcontextprotocol/core-internal':
         specifier: workspace:^
@@ -2083,9 +2087,6 @@ importers:
       '@modelcontextprotocol/vitest-config':
         specifier: workspace:^
         version: link:../../common/vitest-config
-      vitest:
-        specifier: catalog:devTools
-        version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(vite@7.3.0(@types/node@25.5.0)(tsx@4.21.0)(yaml@2.8.3))
       zod:
         specifier: catalog:runtimeShared
         version: 4.3.6

--- a/test/helpers/package.json
+++ b/test/helpers/package.json
@@ -26,10 +26,12 @@
         "lint:fix": "eslint src/ --fix && prettier --ignore-path ../../.prettierignore --write .",
         "check": "npm run typecheck && npm run lint"
     },
+    "dependencies": {
+        "vitest": "catalog:devTools"
+    },
     "devDependencies": {
         "@modelcontextprotocol/core-internal": "workspace:^",
         "zod": "catalog:runtimeShared",
-        "vitest": "catalog:devTools",
         "@modelcontextprotocol/tsconfig": "workspace:^",
         "@modelcontextprotocol/vitest-config": "workspace:^",
         "@modelcontextprotocol/eslint-config": "workspace:^"


### PR DESCRIPTION
## Motivation and Context

Adds server-side DPoP (RFC 9449 / SEP-1932) proof validation for MCP resource servers, hand-rolled on WebCrypto so it introduces no new dependency. It adds a requireDpopAuth gate mirroring the existing Bearer-auth gate (plus an Express adapter), and teaches verifyBearerToken to reject a DPoP-bound token sent under the plain Bearer scheme, as RFC 9449 requires.

MCP servers acting as OAuth 2.0 resource servers currently only support plain Bearer tokens. DPoP (RFC 9449, adopted by MCP as SEP-1932) lets a resource server cryptographically verify that whoever is presenting an access token also holds the private key it's bound to, closing the token-theft/replay gap plain Bearer tokens have. This completes the resource-server half, alongside the client-side support already merged in #2629.

## How Has This Been Tested?

81 unit + integration tests, all passing locally (typecheck and lint clean for the touched packages):
- `dpop.ts`: proof validation against RFC 9449 §4.3's checking order, with real generated WebCrypto keys across all 10 supported algorithms and RFC 7638 thumbprint calculation.
- `dpopAuth.ts`: `verifyDpopToken`/`requireDpopAuth`, covering both a JWT-shaped and an opaque-string access token, the Bearer-scheme rejection path, scope/expiry enforcement, and the server-nonce retry flow.
- `bearerAuth.ts`: the new DPoP-bound-token-rejected-under-Bearer branch.
- `@modelcontextprotocol/express`'s `requireDpopAuth` adapter: real listening-server HTTP round trips, not mocked requests.

## Breaking Changes

None for existing callers. The one behavior change - `verifyBearerToken` rejecting a token under Bearer when its `AuthInfo.cnf.jkt` is set - only affects verifiers that opt into populating `cnf.jkt`, which didn't exist before this PR.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

Part of a 3-PR DPoP rollout: client-side (#2629, merged), server-side proof validation (this PR), and a server-side conformance fixture stacked on top (#2631).
