### PR TITLE
fix: add root src/index.ts so the advertised root export resolves (#2273)

### DIFF
--- a/.changeset/fix-root-export-missing-index.md
+++ b/.changeset/fix-root-export-missing-index.md
@@ -1,0 +1,7 @@
+---
+'@modelcontextprotocol/sdk': patch
+---
+
+Fix the advertised root package export failing with `ERR_MODULE_NOT_FOUND`. `package.json` maps the `.` export to `dist/{esm,cjs}/index.{js,d.ts}`, but there was no `src/index.ts`, so `tsc` never emitted those files and they were absent from the published tarball — both
+`import '@modelcontextprotocol/sdk'` and `require('@modelcontextprotocol/sdk')` threw before consumer code ran. Adds a side-effect-free `src/index.ts` re-exporting the shared protocol surface (`./types.js`) and the in-memory transport (`./inMemory.js`); `Client` and `Server`
+remain on their `./client` / `./server` subpath exports to avoid ambiguous re-export collisions. Subpath imports are unchanged.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,16 @@
+/**
+ * Root entry point for `@modelcontextprotocol/sdk`.
+ *
+ * `package.json` maps the root `.` export to `dist/{esm,cjs}/index.{js,d.ts}`,
+ * but there was no `src/index.ts`, so `tsc` never emitted those files and they
+ * were absent from the published tarball. Importing the package root therefore
+ * failed with `ERR_MODULE_NOT_FOUND` before any consumer code ran (#2273).
+ *
+ * Re-export the shared protocol surface (types, schemas, constants) and the
+ * in-memory transport. `Client` and `Server` intentionally stay on their
+ * `./client` / `./server` subpath exports to avoid TS2308 ambiguous re-export
+ * collisions at the root.
+ */
+
+export * from './types.js';
+export * from './inMemory.js';

--- a/test/issues/test_2273_root_export.test.ts
+++ b/test/issues/test_2273_root_export.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Regression test for https://github.com/modelcontextprotocol/typescript-sdk/issues/2273
+ *
+ * `package.json` advertises a root `.` export that maps to
+ * `dist/{esm,cjs}/index.{js,d.ts}`, but v1.x had no `src/index.ts`, so `tsc`
+ * emitted nothing for the root and importing `@modelcontextprotocol/sdk` failed
+ * with `ERR_MODULE_NOT_FOUND` before any consumer code ran.
+ *
+ * This exercises the root barrel directly (the same module `tsc` compiles into
+ * the advertised dist files): it must resolve and re-export the shared protocol
+ * surface and the in-memory transport.
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as root from '../../src/index.js';
+import { LATEST_PROTOCOL_VERSION, SUPPORTED_PROTOCOL_VERSIONS, JSONRPC_VERSION, InMemoryTransport } from '../../src/index.js';
+
+describe('root package export (#2273)', () => {
+    it('re-exports the shared protocol constants', () => {
+        expect(LATEST_PROTOCOL_VERSION).toBe('2025-11-25');
+        expect(SUPPORTED_PROTOCOL_VERSIONS).toContain(LATEST_PROTOCOL_VERSION);
+        expect(JSONRPC_VERSION).toBe('2.0');
+    });
+
+    it('re-exports the in-memory transport as a working class', () => {
+        expect(typeof InMemoryTransport).toBe('function');
+        const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+        expect(clientTransport).toBeInstanceOf(InMemoryTransport);
+        expect(serverTransport).toBeInstanceOf(InMemoryTransport);
+    });
+
+    it('re-exports a non-empty protocol surface', () => {
+        expect(Object.keys(root).length).toBeGreaterThan(0);
+    });
+});


### PR DESCRIPTION
## Summary

Fixes #2273

`package.json` (v1.x) advertises a root `.` export:

```json
"exports": { ".": {
  "types": "./dist/esm/index.d.ts",
  "import": "./dist/esm/index.js",
  "require": "./dist/cjs/index.js"
} }
```

but there was no `src/index.ts`, so `tsc` never emitted those files and they were absent from the published tarball. Both an ESM `import` and a CJS `require` of the package root threw `ERR_MODULE_NOT_FOUND` before any consumer code ran. Subpath exports (`/client`, `/server`, …) were unaffected.

This adds a side-effect-free root barrel per the direction in the issue triage:

- `export * from './types.js'` — protocol types, schemas, constants
- `export * from './inMemory.js'` — `InMemoryTransport`

`Client` and `Server` intentionally stay on their `./client` / `./server` subpath exports to avoid `TS2308` ambiguous re-export collisions. The change is additive and non-breaking; `main` is unaffected (it is a monorepo with no root package).

## Test verification (RED → GREEN)

New regression test `test/issues/test_2273_root_export.test.ts` imports the root barrel and asserts it resolves and re-exports the protocol surface + a working `InMemoryTransport`.

**RED** — new test on unmodified `v1.x` (no `src/index.ts`):

```
FAIL  test/issues/test_2273_root_export.test.ts
Error: Cannot find module '../../src/index.js' imported from '.../test/issues/test_2273_root_export.test.ts'
 Test Files  1 failed (1)
```

**GREEN** — with `src/index.ts` added:

```
✓ test/issues/test_2273_root_export.test.ts (3 tests) 7ms
 Test Files  1 passed (1)
      Tests  3 passed (3)
```

**End-to-end packaging check** — after `npm run build`, the previously-missing root files now emit and both loaders resolve:

```
dist/esm/index.js EXISTS
dist/cjs/index.js EXISTS
dist/esm/index.d.ts EXISTS
ESM OK — symbols: 172 — LATEST: 2025-11-25 — InMemoryTransport: function
CJS OK — symbols: 172 — JSONRPC_VERSION: 2.0
npm pack --dry-run: all three root files present in the tarball
```

## Full local suite

- `npm run typecheck` (tsgo), `npm run lint` (eslint + prettier), `npm run build`, `npm test` (vitest): all green.
- No regressions: baseline `52 files / 1639 tests` → with fix `53 files / 1642 tests` (+1 file, +3 new tests, 0 failures).

## Files changed

| File | Change |
|------|--------|
| `src/index.ts` | New side-effect-free root barrel re-exporting `./types.js` + `./inMemory.js` |
| `test/issues/test_2273_root_export.test.ts` | Regression test for the root export |
| `.changeset/fix-root-export-missing-index.md` | Changeset (sdk package, patch) |
