### PR TITLE
fix(core-internal): percent-encode multi-variable URI template expansions

### DIFF
--- a/.changeset/uri-template-multi-variable-encoding.md
+++ b/.changeset/uri-template-multi-variable-encoding.md
@@ -1,0 +1,7 @@
+---
+'@modelcontextprotocol/core-internal': patch
+'@modelcontextprotocol/client': patch
+'@modelcontextprotocol/server': patch
+---
+
+`UriTemplate.expand()` now percent-encodes the values of multi-variable expressions. A template with two or more variables in one expression (`{x,y}`) interpolated its values raw, so a value carrying a space or a reserved character produced a malformed URI — `new UriTemplate('{x,y}').expand({ x: 'value with spaces', y: 'a/b?c&d' })` returned `value with spaces,a/b?c&d` instead of `value%20with%20spaces,a%2Fb%3Fc%26d`. Single-variable expressions already encoded correctly, so the defect only showed once a second variable was added to the same expression. Encoding is operator-aware, matching the single-variable path: `{+x,y}` and `{#x,y}` keep reserved characters and encode the rest.

--- a/packages/core-internal/src/shared/uriTemplate.ts
+++ b/packages/core-internal/src/shared/uriTemplate.ts
@@ -138,7 +138,7 @@ export class UriTemplate {
         if (part.names.length > 1) {
             const values = part.names.map(name => variables[name]).filter(v => v !== undefined);
             if (values.length === 0) return '';
-            return values.map(v => (Array.isArray(v) ? v[0] : v)).join(',');
+            return values.map(v => this.encodeValue(Array.isArray(v) ? (v[0] ?? '') : v, part.operator)).join(',');
         }
 
         const value = variables[part.name];

--- a/packages/core-internal/test/shared/uriTemplate.test.ts
+++ b/packages/core-internal/test/shared/uriTemplate.test.ts
@@ -35,6 +35,11 @@ describe('UriTemplate', () => {
             const template = new UriTemplate('{var}');
             expect(template.expand({ var: 'value with spaces' })).toBe('value%20with%20spaces');
         });
+
+        it('should encode reserved characters in multiple variables', () => {
+            const template = new UriTemplate('{x,y}');
+            expect(template.expand({ x: 'value with spaces', y: 'a/b?c&d' })).toBe('value%20with%20spaces,a%2Fb%3Fc%26d');
+        });
     });
 
     describe('reserved expansion', () => {
@@ -42,6 +47,11 @@ describe('UriTemplate', () => {
             const template = new UriTemplate('{+path}/here');
             expect(template.expand({ path: '/foo/bar' })).toBe('/foo/bar/here');
             expect(template.variableNames).toEqual(['path']);
+        });
+
+        it('should keep reserved characters but encode spaces for multiple variables with + operator', () => {
+            const template = new UriTemplate('{+path,name}');
+            expect(template.expand({ path: '/foo/bar', name: 'a b' })).toBe('/foo/bar,a%20b');
         });
     });
 


### PR DESCRIPTION
## Problem

`UriTemplate.expand()` encoded single-variable expressions but interpolated multi-variable expressions such as `{x,y}` without calling the encoder. For example:

```ts
new UriTemplate('{x,y}').expand({
  x: 'value with spaces',
  y: 'a/b?c&d'
})
```

returned `value with spaces,a/b?c&d`, which contains raw spaces and reserved characters where a simple expansion must percent-encode them.

## Change

Route every value in the multi-variable branch through the same operator-aware `encodeValue()` helper used by single-variable expansions. This keeps reserved characters for reserved (`+`) expansions while encoding them for simple expansions.

The change is internal and focused, with no new public API. A patch changeset is included for the affected v2 packages.

## Verification

- `pnpm --filter @modelcontextprotocol/core-internal test -- uriTemplate` — 40 passed.
- `pnpm --filter @modelcontextprotocol/core-internal lint` — passed, including Prettier check.
- `pnpm --filter @modelcontextprotocol/core-internal typecheck` — passed.

The new tests cover both `{x,y}` and `{+path,name}`; they fail against the unpatched multi-variable branch and pass with this change.