### PR TITLE
fix(client): treat a JSON-RPC error response as a terminal response

### DIFF
--- a/src/client/streamableHttp.ts
+++ b/src/client/streamableHttp.ts
@@ -1,6 +1,13 @@
 import { mediaTypeEssence } from '../shared/mediaType.js';
 import { Transport, FetchLike, createFetchWithInit, normalizeHeaders } from '../shared/transport.js';
-import { isInitializedNotification, isJSONRPCRequest, isJSONRPCResultResponse, JSONRPCMessage, JSONRPCMessageSchema } from '../types.js';
+import {
+    isInitializedNotification,
+    isJSONRPCRequest,
+    isJSONRPCErrorResponse,
+    isJSONRPCResultResponse,
+    JSONRPCMessage,
+    JSONRPCMessageSchema
+} from '../types.js';
 import { auth, AuthResult, extractWWWAuthenticateParams, OAuthClientProvider, UnauthorizedError } from './auth.js';
 import { EventSourceParserStream } from 'eventsource-parser/stream';
 
@@ -351,7 +358,7 @@ export class StreamableHTTPClientTransport implements Transport {
                     if (!event.event || event.event === 'message') {
                         try {
                             const message = JSONRPCMessageSchema.parse(JSON.parse(event.data));
-                            if (isJSONRPCResultResponse(message)) {
+                            if (isJSONRPCResultResponse(message) || isJSONRPCErrorResponse(message)) {
                                 // Mark that we received a response - no need to reconnect for this request
                                 receivedResponse = true;
                                 if (replayMessageId !== undefined) {

--- a/test/client/streamableHttp.test.ts
+++ b/test/client/streamableHttp.test.ts
@@ -941,6 +941,61 @@ describe('StreamableHTTPClientTransport', () => {
             expect(fetchMock.mock.calls[0][1]?.method).toBe('POST');
         });
 
+        it('should NOT reconnect a POST stream when an error response was received', async () => {
+            // ARRANGE
+            transport = new StreamableHTTPClientTransport(new URL('http://localhost:1234/mcp'), {
+                reconnectionOptions: {
+                    initialReconnectionDelay: 10,
+                    maxRetries: 1,
+                    maxReconnectionDelay: 1000,
+                    reconnectionDelayGrowFactor: 1
+                }
+            });
+
+            // A JSON-RPC error response is a terminal response to a request, just
+            // like a result response, so it must also prevent reconnection.
+            const streamWithError = new ReadableStream({
+                start(controller) {
+                    // Priming event with ID (enables potential reconnection)
+                    controller.enqueue(new TextEncoder().encode('id: priming-123\ndata: \n\n'));
+                    // The terminal error response to the request
+                    controller.enqueue(
+                        new TextEncoder().encode(
+                            'id: response-456\ndata: {"jsonrpc":"2.0","error":{"code":-32000,"message":"boom"},"id":"request-1"}\n\n'
+                        )
+                    );
+                    // Stream closes normally
+                    controller.close();
+                }
+            });
+
+            const fetchMock = global.fetch as Mock;
+            fetchMock.mockResolvedValueOnce({
+                ok: true,
+                status: 200,
+                headers: new Headers({ 'content-type': 'text/event-stream' }),
+                body: streamWithError
+            });
+
+            const requestMessage: JSONRPCRequest = {
+                jsonrpc: '2.0',
+                method: 'tools/list',
+                id: 'request-1',
+                params: {}
+            };
+
+            // ACT
+            await transport.start();
+            await transport.send(requestMessage);
+            await vi.advanceTimersByTimeAsync(50);
+
+            // ASSERT
+            // Fetch was called ONCE only - the error response completed the request,
+            // so there is no need to reconnect.
+            expect(fetchMock).toHaveBeenCalledTimes(1);
+            expect(fetchMock.mock.calls[0][1]?.method).toBe('POST');
+        });
+
         it('should not attempt reconnection after close() is called', async () => {
             // ARRANGE
             transport = new StreamableHTTPClientTransport(new URL('http://localhost:1234/mcp'), {


### PR DESCRIPTION
## Summary

In `StreamableHTTPClientTransport`, `_handleSseStream` marks a request as complete only for result responses:

```ts
if (isJSONRPCResultResponse(message)) {
    receivedResponse = true;
    if (replayMessageId !== undefined) {
        message.id = replayMessageId;
    }
}
```

A JSON-RPC 2.0 error response is a terminal response to a request just like a result response (a Response Object carries either `result` or `error`). Because the guard omits the error case, when a request's SSE POST stream ends with an error response and closes gracefully, `receivedResponse` stays `false`, so `needsReconnect = canResume && !receivedResponse` is `true`.

The client then schedules needless GET-SSE reconnections (up to `maxRetries`, replaying with `Last-Event-ID`) for a request that is already complete, and on the resume path it never remaps `message.id` to `replayMessageId`, so a resumed error response can miss request/response correlation.

The v2 code on `main` already handles this correctly (`isJSONRPCResultResponse(message) || isJSONRPCErrorResponse(message)`); this backports the same fix to `v1.x`.

## Fix

Include `isJSONRPCErrorResponse` in the guard so an error response also stops reconnection and gets its id remapped.

## Test

Added a regression test alongside the existing "should NOT reconnect a POST stream when response was received" case, using a JSON-RPC error response as the terminal message. It fails before the fix (fetch is called twice, the second being the needless reconnect) and passes after.
