### PR TITLE
docs: clarify v1 and v2 tool schema shapes

### DIFF
--- a/docs/migration/upgrade-to-v2.md
+++ b/docs/migration/upgrade-to-v2.md
@@ -659,6 +659,14 @@ are still **accepted via `@deprecated` overloads** on `registerTool`/`registerPr
 (auto-wrapped with `z.object()`), and `completable()` accepts any `StandardSchemaV1`;
 prefer wrapping explicitly. Zod v4, ArkType, and Valibot all implement the spec.
 
+The v1 positional `server.tool()` API has a different contract: its schema argument is a
+raw shape. Passing `z.object({ name: z.string() })` there can publish an empty
+`inputSchema` to clients on older v1 releases or fail during registration on newer ones.
+On v1.12.0 through v1.21.0, passing the complete schema to `registerTool()` can instead
+make `tools/list` fail with `Cannot read properties of null (reading '_def')`.
+When the codemod rewrites that call to `registerTool()`, it wraps the raw shape for the v2
+`inputSchema` slot; keep the generated `z.object(...)` wrapper in the v2 code.
+
 For **optional completable arguments**, apply `.optional()` to the _result_ of
 `completable()` — `completable(z.string(), cb).optional()`, not
 `completable(z.string().optional(), cb)`. v2 resolves completion metadata on the schema

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -49,6 +49,27 @@ Align everything on one Zod 4 version. When a transitive dependency pins another
 
 `npm ls zod` reporting a single version means the duplicate is gone and the error with it.
 
+## `tools/list` returns an empty `inputSchema`
+
+The v1 positional `server.tool()` API expects a raw Zod shape. Passing a complete
+`z.object()` into that slot can publish `{"type":"object"}` without any properties, so
+clients omit the arguments when they call the tool. With `server.tool()`, v1.12.0
+through v1.26.0 can show the empty schema; v1.28.0 through v1.30.0 reject the shape at
+registration. If you pass the same complete schema to v1 `registerTool()`, v1.12.0
+through v1.21.0 can instead fail `tools/list` with
+`Cannot read properties of null (reading '_def')`; v1.22.0 and later normalize it.
+
+Use a raw shape with the v1 positional API:
+
+```diff
+- server.tool('greet', 'Greet a user', z.object({ name: z.string() }), handler);
++ server.tool('greet', 'Greet a user', { name: z.string() }, handler);
+```
+
+When you move to v2, use `registerTool()` and pass a Standard Schema object such as
+`z.object({ name: z.string() })` as `inputSchema`. The [v1 to v2 migration guide](./migration/upgrade-to-v2.md#server-registration-api)
+covers the complete call-shape change.
+
 ## `ReferenceError: crypto is not defined`
 
 The OAuth client helpers sign and verify through the Web Crypto API at `globalThis.crypto`. Every `@modelcontextprotocol/*` package requires Node.js 20, where that global is always defined — this error means the process is running on an older runtime (Node.js 18 and earlier).
@@ -172,6 +193,7 @@ HTTP SSE streams emit a `: keepalive` comment every 15 seconds by default so cli
 - Every heading on this page is the exact message you searched for.
 - On stdio, `stdout` carries JSON-RPC; log with `console.error`.
 - `TS2589` means two `zod` copies in the dependency tree.
+- v1 positional `server.tool()` takes a raw shape; v2 `registerTool()` takes a Standard Schema object.
 - The SDK raises `ERA_NEGOTIATION_FAILED` and `METHOD_NOT_SUPPORTED_BY_PROTOCOL_VERSION` locally — neither is a wire error.
 - Server SSE and the Authorization Server helpers live in `@modelcontextprotocol/server-legacy`.
 


### PR DESCRIPTION
## Summary

- Document the v1 positional `server.tool()` raw-shape contract alongside the v2 `registerTool()` Standard Schema contract.
- Add troubleshooting guidance for the empty `inputSchema` and the `_def` crash reported on older v1 releases.
- Add a concise reminder to the troubleshooting checklist.

Fixes #2627

## Validation

- `git diff --check`
- Attempted `pnpm run docs:check`; this checkout is missing the generated `docs/api/typedoc-sidebar.json`, and VitePress then reported dead links in the unchanged `clients/machine-auth.md` and `index.md` pages.
- The pre-push hook also attempted the repository-wide pnpm checks, but the local dependency setup aborted while installing ignored build scripts; no source or lockfile changes are included in this PR.

This is a docs-only change with no runtime code changes.