### PR TITLE
Fix Zod 4 tool input schemas

### DIFF
--- a/.changeset/closed-zod-input-schemas.md
+++ b/.changeset/closed-zod-input-schemas.md
@@ -1,0 +1,5 @@
+---
+"@modelcontextprotocol/core-internal": patch
+---
+
+Restore `additionalProperties: false` when converting default Zod object schemas used as input schemas.

--- a/docs/serving/express.md
+++ b/docs/serving/express.md
@@ -78,7 +78,7 @@ The response is a single SSE `message` event carrying the `tools/list` result:
 
 ```
 event: message
-data: {"result":{"tools":[{"name":"add-note","description":"Append a note","inputSchema":{"type":"object","$schema":"https://json-schema.org/draft/2020-12/schema","properties":{"text":{"type":"string"}},"required":["text"]}}]},"jsonrpc":"2.0","id":1}
+data: {"result":{"tools":[{"name":"add-note","description":"Append a note","inputSchema":{"type":"object","$schema":"https://json-schema.org/draft/2020-12/schema","properties":{"text":{"type":"string"}},"required":["text"],"additionalProperties":false}}]},"jsonrpc":"2.0","id":1}
 ```
 
 ## Recap

--- a/docs/serving/fastify.md
+++ b/docs/serving/fastify.md
@@ -78,7 +78,7 @@ The response is a single SSE `message` event carrying the `tools/list` result:
 
 ```
 event: message
-data: {"result":{"tools":[{"name":"add-note","description":"Append a note","inputSchema":{"type":"object","$schema":"https://json-schema.org/draft/2020-12/schema","properties":{"text":{"type":"string"}},"required":["text"]}}]},"jsonrpc":"2.0","id":1}
+data: {"result":{"tools":[{"name":"add-note","description":"Append a note","inputSchema":{"type":"object","$schema":"https://json-schema.org/draft/2020-12/schema","properties":{"text":{"type":"string"}},"required":["text"],"additionalProperties":false}}]},"jsonrpc":"2.0","id":1}
 ```
 
 ## Recap

--- a/docs/serving/hono.md
+++ b/docs/serving/hono.md
@@ -77,7 +77,7 @@ The response is a single SSE `message` event carrying the `tools/list` result:
 
 ```
 event: message
-data: {"result":{"tools":[{"name":"add-note","description":"Append a note","inputSchema":{"type":"object","$schema":"https://json-schema.org/draft/2020-12/schema","properties":{"text":{"type":"string"}},"required":["text"]}}]},"jsonrpc":"2.0","id":1}
+data: {"result":{"tools":[{"name":"add-note","description":"Append a note","inputSchema":{"type":"object","$schema":"https://json-schema.org/draft/2020-12/schema","properties":{"text":{"type":"string"}},"required":["text"],"additionalProperties":false}}]},"jsonrpc":"2.0","id":1}
 ```
 
 ## Recap

--- a/docs/serving/web-standard.md
+++ b/docs/serving/web-standard.md
@@ -76,7 +76,7 @@ The response is a single SSE `message` event carrying the `tools/list` result:
 
 ```
 event: message
-data: {"result":{"tools":[{"name":"add-note","description":"Append a note","inputSchema":{"type":"object","$schema":"https://json-schema.org/draft/2020-12/schema","properties":{"text":{"type":"string"}},"required":["text"]}}]},"jsonrpc":"2.0","id":1}
+data: {"result":{"tools":[{"name":"add-note","description":"Append a note","inputSchema":{"type":"object","$schema":"https://json-schema.org/draft/2020-12/schema","properties":{"text":{"type":"string"}},"required":["text"],"additionalProperties":false}}]},"jsonrpc":"2.0","id":1}
 ```
 
 ## Recap

--- a/examples/guides/serving/express.examples.ts
+++ b/examples/guides/serving/express.examples.ts
@@ -86,7 +86,7 @@ console.log(text);
 const quotedOnPage =
     'event: message\n' +
     'data: {"result":{"tools":[{"name":"add-note","description":"Append a note","inputSchema":{"type":"object",' +
-    '"$schema":"https://json-schema.org/draft/2020-12/schema","properties":{"text":{"type":"string"}},"required":["text"]}}]},"jsonrpc":"2.0","id":1}';
+    '"$schema":"https://json-schema.org/draft/2020-12/schema","properties":{"text":{"type":"string"}},"required":["text"],"additionalProperties":false}}]},"jsonrpc":"2.0","id":1}';
 if (response.status !== 200 || text.trimEnd() !== quotedOnPage) {
     throw new Error(`express.md "Run it and verify" output drifted from the SDK: ${JSON.stringify(text)}`);
 }

--- a/examples/guides/serving/fastify.examples.ts
+++ b/examples/guides/serving/fastify.examples.ts
@@ -80,7 +80,7 @@ console.log(injected.payload);
 const quotedOnPage =
     'event: message\n' +
     'data: {"result":{"tools":[{"name":"add-note","description":"Append a note","inputSchema":{"type":"object",' +
-    '"$schema":"https://json-schema.org/draft/2020-12/schema","properties":{"text":{"type":"string"}},"required":["text"]}}]},"jsonrpc":"2.0","id":1}';
+    '"$schema":"https://json-schema.org/draft/2020-12/schema","properties":{"text":{"type":"string"}},"required":["text"],"additionalProperties":false}}]},"jsonrpc":"2.0","id":1}';
 if (injected.statusCode !== 200 || injected.payload.trimEnd() !== quotedOnPage) {
     throw new Error(`fastify.md "Run it and verify" output drifted from the SDK: ${JSON.stringify(injected.payload)}`);
 }

--- a/examples/guides/serving/hono.examples.ts
+++ b/examples/guides/serving/hono.examples.ts
@@ -71,7 +71,7 @@ console.log(text);
 const quotedOnPage =
     'event: message\n' +
     'data: {"result":{"tools":[{"name":"add-note","description":"Append a note","inputSchema":{"type":"object",' +
-    '"$schema":"https://json-schema.org/draft/2020-12/schema","properties":{"text":{"type":"string"}},"required":["text"]}}]},"jsonrpc":"2.0","id":1}';
+    '"$schema":"https://json-schema.org/draft/2020-12/schema","properties":{"text":{"type":"string"}},"required":["text"],"additionalProperties":false}}]},"jsonrpc":"2.0","id":1}';
 if (response.status !== 200 || text.trimEnd() !== quotedOnPage) {
     throw new Error(`hono.md "Run it and verify" output drifted from the SDK: ${JSON.stringify(text)}`);
 }

--- a/examples/guides/serving/webStandard.examples.ts
+++ b/examples/guides/serving/webStandard.examples.ts
@@ -83,7 +83,7 @@ console.log(text);
 const quotedOnPage =
     'event: message\n' +
     'data: {"result":{"tools":[{"name":"add-note","description":"Append a note","inputSchema":{"type":"object",' +
-    '"$schema":"https://json-schema.org/draft/2020-12/schema","properties":{"text":{"type":"string"}},"required":["text"]}}]},"jsonrpc":"2.0","id":1}';
+    '"$schema":"https://json-schema.org/draft/2020-12/schema","properties":{"text":{"type":"string"}},"required":["text"],"additionalProperties":false}}]},"jsonrpc":"2.0","id":1}';
 if (response.status !== 200 || text.trimEnd() !== quotedOnPage) {
     throw new Error(`web-standard.md "Run it and verify" output drifted from the SDK: ${JSON.stringify(text)}`);
 }

--- a/packages/core-internal/src/util/standardSchema.ts
+++ b/packages/core-internal/src/util/standardSchema.ts
@@ -178,9 +178,18 @@ export const JSON_SCHEMA_CONVERSION_TARGET = 'draft-2020-12';
  * so for `io: 'input'` this function defaults `type` to `"object"` when absent
  * and throws on an explicit non-object `type` (e.g. `z.string()`). For
  * `io: 'output'` a non-object root is returned as-is; the `"object"` default is
- * applied only when the root is provably object-shaped.
+ * applied only when the root is provably object-shaped. Zod input object roots can be
+ * closed for MCP tool compatibility by passing `closeZodInputObjects: true`.
  */
-export function standardSchemaToJsonSchema(schema: StandardJSONSchemaV1, io: 'input' | 'output' = 'input'): Record<string, unknown> {
+export interface StandardSchemaToJsonSchemaOptions {
+    closeZodInputObjects?: boolean;
+}
+
+export function standardSchemaToJsonSchema(
+    schema: StandardJSONSchemaV1,
+    io: 'input' | 'output' = 'input',
+    options: StandardSchemaToJsonSchemaOptions = {}
+): Record<string, unknown> {
     const std = schema['~standard'];
     let result: Record<string, unknown>;
     if (std.jsonSchema) {
@@ -230,6 +239,15 @@ export function standardSchemaToJsonSchema(schema: StandardJSONSchemaV1, io: 'in
             `MCP tool and prompt schemas must describe objects (got type: ${JSON.stringify(result.type)}). ` +
                 `Wrap your schema in z.object({...}) or equivalent.`
         );
+    }
+    if (
+        options.closeZodInputObjects === true &&
+        io === 'input' &&
+        std.vendor === 'zod' &&
+        result.type === 'object' &&
+        !Object.hasOwn(result, 'additionalProperties')
+    ) {
+        return { type: 'object', ...result, additionalProperties: false };
     }
     return { type: 'object', ...result };
 }

--- a/packages/core-internal/test/util/standardSchema.test.ts
+++ b/packages/core-internal/test/util/standardSchema.test.ts
@@ -11,6 +11,58 @@ describe('standardSchemaToJsonSchema', () => {
         expect(result.properties).toBeDefined();
     });
 
+    test('closes plain object input schemas', () => {
+        const schema = z.object({ name: z.string() });
+        const result = standardSchemaToJsonSchema(schema, 'input', { closeZodInputObjects: true });
+
+        expect(result.additionalProperties).toBe(false);
+    });
+
+    test('preserves default object conversion semantics', () => {
+        const schema = z.object({ name: z.string() });
+        const result = standardSchemaToJsonSchema(schema, 'input');
+
+        expect(result.additionalProperties).toBeUndefined();
+    });
+
+    test('preserves explicit open object schemas', () => {
+        const schema = z.looseObject({ value: z.string() });
+        const result = standardSchemaToJsonSchema(schema, 'input');
+
+        expect(result.additionalProperties).toEqual({});
+    });
+
+    test('preserves union compositions without adding a root default', () => {
+        const schema = z.discriminatedUnion('action', [
+            z.object({ action: z.literal('create'), name: z.string() }),
+            z.object({ action: z.literal('delete'), id: z.string() })
+        ]);
+        const result = standardSchemaToJsonSchema(schema, 'input');
+        const members = result.oneOf as Array<Record<string, unknown>>;
+
+        expect(result.additionalProperties).toBeUndefined();
+        expect(members.every(member => member.additionalProperties === undefined)).toBe(true);
+    });
+
+    test('leaves non-Zod and output object schemas unchanged', () => {
+        const schema = {
+            '~standard': {
+                version: 1,
+                vendor: 'test',
+                validate: (value: unknown) => ({ value }),
+                jsonSchema: {
+                    input: () => ({ type: 'object' }),
+                    output: () => ({ type: 'object' })
+                }
+            }
+        } as never;
+        const inputResult = standardSchemaToJsonSchema(schema, 'input');
+        const result = standardSchemaToJsonSchema(schema, 'output');
+
+        expect(inputResult.additionalProperties).toBeUndefined();
+        expect(result.additionalProperties).toBeUndefined();
+    });
+
     test('emits type:object for discriminated unions', () => {
         const schema = z.discriminatedUnion('action', [
             z.object({ action: z.literal('create'), name: z.string() }),

--- a/packages/server/src/server/mcp.ts
+++ b/packages/server/src/server/mcp.ts
@@ -186,7 +186,9 @@ export class McpServer {
                             title: tool.title,
                             description: tool.description,
                             inputSchema: tool.inputSchema
-                                ? (standardSchemaToJsonSchema(tool.inputSchema, 'input', { closeZodInputObjects: true }) as Tool['inputSchema'])
+                                ? (standardSchemaToJsonSchema(tool.inputSchema, 'input', {
+                                      closeZodInputObjects: true
+                                  }) as Tool['inputSchema'])
                                 : EMPTY_OBJECT_JSON_SCHEMA,
                             annotations: tool.annotations,
                             icons: tool.icons,

--- a/packages/server/src/server/mcp.ts
+++ b/packages/server/src/server/mcp.ts
@@ -106,7 +106,7 @@ export class McpServer {
         // A successful re-derive is memoized so the per-request-factory
         // `createMcpHandler` model does not re-convert on every call.
         try {
-            const json = standardSchemaToJsonSchema(tool.inputSchema, 'input');
+            const json = standardSchemaToJsonSchema(tool.inputSchema, 'input', { closeZodInputObjects: true });
             this._toolInputSchemaJson[name] = json;
             return json;
         } catch {
@@ -186,7 +186,7 @@ export class McpServer {
                             title: tool.title,
                             description: tool.description,
                             inputSchema: tool.inputSchema
-                                ? (standardSchemaToJsonSchema(tool.inputSchema, 'input') as Tool['inputSchema'])
+                                ? (standardSchemaToJsonSchema(tool.inputSchema, 'input', { closeZodInputObjects: true }) as Tool['inputSchema'])
                                 : EMPTY_OBJECT_JSON_SCHEMA,
                             annotations: tool.annotations,
                             icons: tool.icons,
@@ -828,7 +828,7 @@ export class McpServer {
         // the "warn, never throw" contract.
         if (inputSchema !== undefined) {
             try {
-                const json = standardSchemaToJsonSchema(inputSchema, 'input');
+                const json = standardSchemaToJsonSchema(inputSchema, 'input', { closeZodInputObjects: true });
                 this._toolInputSchemaJson[name] = json;
                 const scan = scanXMcpHeaderDeclarations(json);
                 if (!scan.valid) {

--- a/packages/server/test/server/mcp.compat.test.ts
+++ b/packages/server/test/server/mcp.compat.test.ts
@@ -46,6 +46,38 @@ describe('registerTool/registerPrompt accept raw Zod shape (auto-wrapped)', () =
         expect(isStandardSchema(tools['c']?.inputSchema)).toBe(true);
     });
 
+    it('advertises closed Zod input schemas in tools/list', async () => {
+        const server = new McpServer({ name: 't', version: '1.0.0' });
+        server.registerTool('echo', { inputSchema: { text: z.string() } }, async () => ({ content: [] }));
+
+        const [client, srv] = InMemoryTransport.createLinkedPair();
+        await server.connect(srv);
+        await client.start();
+
+        const responses: JSONRPCMessage[] = [];
+        client.onmessage = message => responses.push(message);
+        await client.send({
+            jsonrpc: '2.0',
+            id: 1,
+            method: 'initialize',
+            params: {
+                protocolVersion: LATEST_PROTOCOL_VERSION,
+                capabilities: {},
+                clientInfo: { name: 'c', version: '1.0.0' }
+            }
+        } as JSONRPCMessage);
+        await client.send({ jsonrpc: '2.0', method: 'notifications/initialized' } as JSONRPCMessage);
+        await client.send({ jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} } as JSONRPCMessage);
+
+        await vi.waitFor(() => expect(responses.some(message => 'id' in message && message.id === 2)).toBe(true));
+        const response = responses.find(message => 'id' in message && message.id === 2) as {
+            result?: { tools?: Array<{ inputSchema?: Record<string, unknown> }> };
+        };
+        expect(response.result?.tools?.[0]?.inputSchema).toMatchObject({ type: 'object', additionalProperties: false });
+
+        await server.close();
+    });
+
     it('registerPrompt accepts a raw shape for argsSchema', () => {
         const server = new McpServer({ name: 't', version: '1.0.0' });
 


### PR DESCRIPTION
## Summary

Zod 4 does not include `additionalProperties: false` when the SDK converts a default `z.object(...)` input shape. That leaves the schema advertised by `tools/list` different from the closed object schema produced by the Zod 3 path.

This keeps the generic Standard Schema conversion unchanged for elicitation and other callers, and opts into closed Zod object input schemas only when the server builds MCP tool declarations. The regression coverage checks the wire-level `tools/list` result as well as the converter behavior.

Fixes #2636

## Verification

- `./node_modules/.bin/vitest run` in `packages/core-internal` (1,438 passed)
- `./node_modules/.bin/vitest run` in `packages/server` (469 passed)
- `tsgo -p tsconfig.json --noEmit` in both packages
- ESLint passed for both changed source packages
- `git diff --check`

Changeset included for `@modelcontextprotocol/core-internal`.

AI assistance was used while preparing this patch. The implementation and regression tests were checked against the existing core and server test suites.
