### PR TITLE
fix(core): keep resumption options off cancellation notifications

### DIFF
--- a/.changeset/calm-taxis-cancel.md
+++ b/.changeset/calm-taxis-cancel.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/core': patch
+---
+
+Prevent legacy cancellation notifications from inheriting request resumption options.

--- a/packages/core-internal/src/shared/protocol.ts
+++ b/packages/core-internal/src/shared/protocol.ts
@@ -1472,7 +1472,7 @@ export abstract class Protocol<ContextT extends BaseContext> {
                                         reason: String(reason)
                                     }
                                 }),
-                                { relatedRequestId, resumptionToken, onresumptiontoken }
+                                { relatedRequestId }
                             )
                             .catch(error => this._onerror(new Error(`Failed to send cancellation: ${error}`)));
                     }

--- a/packages/core-internal/src/shared/protocol.ts
+++ b/packages/core-internal/src/shared/protocol.ts
@@ -1461,7 +1461,7 @@ export abstract class Protocol<ContextT extends BaseContext> {
                                     reason: String(reason)
                                 }
                             }),
-                            { relatedRequestId, resumptionToken, onresumptiontoken }
+                            { relatedRequestId }
                         )
                         .catch(error => this._onerror(new Error(`Failed to send cancellation: ${error}`)));
                 } else {

--- a/packages/core-internal/test/shared/protocol.test.ts
+++ b/packages/core-internal/test/shared/protocol.test.ts
@@ -856,9 +856,11 @@ describe('protocol tests', () => {
         class PerRequestStreamTransport extends MockTransport {
             readonly hasPerRequestStream = true;
             sent: JSONRPCMessage[] = [];
+            sentCalls: { message: JSONRPCMessage; options?: TransportSendOptions }[] = [];
             lastRequestSignal: AbortSignal | undefined;
             override async send(message: JSONRPCMessage, options?: TransportSendOptions): Promise<void> {
                 this.sent.push(message);
+                this.sentCalls.push({ message, options });
                 this.lastRequestSignal = options?.requestSignal;
             }
         }
@@ -932,6 +934,29 @@ describe('protocol tests', () => {
             await expect(pending).rejects.toThrow();
 
             expect(cancelledSent(tx.sent)).toHaveLength(1);
+        });
+
+        test('legacy era: cancellation does not inherit request resumption options', async () => {
+            const tx = new PerRequestStreamTransport();
+            const proto = createTestProtocol();
+            await proto.connect(tx);
+            setNegotiatedProtocolVersion(proto, '2025-11-25');
+
+            const ac = new AbortController();
+            const pending = testRequest(proto, { method: 'example', params: {} }, z.object({}), {
+                signal: ac.signal,
+                relatedRequestId: 'parent-request',
+                resumptionToken: 'resume-token',
+                onresumptiontoken: vi.fn()
+            });
+
+            ac.abort('user cancel');
+            await expect(pending).rejects.toThrow();
+
+            const cancellationCall = tx.sentCalls.find(
+                ({ message }) => 'method' in message && message.method === 'notifications/cancelled'
+            );
+            expect(cancellationCall?.options).toEqual({ relatedRequestId: 'parent-request' });
         });
 
         test('modern era + per-request-stream transport: timeout aborts the stream, NO notifications/cancelled', async () => {

--- a/packages/core-internal/test/shared/protocol.test.ts
+++ b/packages/core-internal/test/shared/protocol.test.ts
@@ -830,9 +830,11 @@ describe('protocol tests', () => {
         class PerRequestStreamTransport extends MockTransport {
             readonly hasPerRequestStream = true;
             sent: JSONRPCMessage[] = [];
+            sentCalls: { message: JSONRPCMessage; options?: TransportSendOptions }[] = [];
             lastRequestSignal: AbortSignal | undefined;
             override async send(message: JSONRPCMessage, options?: TransportSendOptions): Promise<void> {
                 this.sent.push(message);
+                this.sentCalls.push({ message, options });
                 this.lastRequestSignal = options?.requestSignal;
             }
         }
@@ -897,6 +899,29 @@ describe('protocol tests', () => {
             await expect(pending).rejects.toThrow();
 
             expect(cancelledSent(tx.sent)).toHaveLength(1);
+        });
+
+        test('legacy era: cancellation does not inherit request resumption options', async () => {
+            const tx = new PerRequestStreamTransport();
+            const proto = createTestProtocol();
+            await proto.connect(tx);
+            setNegotiatedProtocolVersion(proto, '2025-11-25');
+
+            const ac = new AbortController();
+            const pending = testRequest(proto, { method: 'example', params: {} }, z.object({}), {
+                signal: ac.signal,
+                relatedRequestId: 'parent-request',
+                resumptionToken: 'resume-token',
+                onresumptiontoken: vi.fn()
+            });
+
+            ac.abort('user cancel');
+            await expect(pending).rejects.toThrow();
+
+            const cancellationCall = tx.sentCalls.find(
+                ({ message }) => 'method' in message && message.method === 'notifications/cancelled'
+            );
+            expect(cancellationCall?.options).toEqual({ relatedRequestId: 'parent-request' });
         });
 
         test('modern era + per-request-stream transport: timeout aborts the stream, NO notifications/cancelled', async () => {


### PR DESCRIPTION
Fixes #2646.

## Root cause

When a legacy-era request was aborted, `Protocol` reused the original request's full transport options for `notifications/cancelled`. If that request carried a `resumptionToken`, `StreamableHTTPClientTransport` interpreted the cancellation send as a resume operation, swallowed the notification, and opened a resumed GET instead of posting the cancellation.

## Fix

- Keep `relatedRequestId` on the cancellation send so request correlation is preserved.
- Do not pass `resumptionToken` or `onresumptiontoken` to the cancellation notification.
- Add a regression test that records the transport options for the cancellation send.
- Add a patch changeset for `@modelcontextprotocol/core`.

## Validation

- Regression test fails against the previous implementation and passes with this change.
- `pnpm --filter @modelcontextprotocol/core-internal test`: 69 files, 1,434 tests passed.
- Monorepo build passed via the pre-push hook.
- Monorepo typecheck passed via the pre-push hook.
- `pnpm lint:all` passed.
- Changeset status and formatting checks passed.
