### PR TITLE
fix: forward Error.cause in SdkError constructor

### DIFF
--- a/packages/client/src/client/probeClassifier.ts
+++ b/packages/client/src/client/probeClassifier.ts
@@ -311,7 +311,7 @@ function classifyNetworkError(error: unknown, context: ProbeClassifierContext): 
     }
     return {
         kind: 'error',
-        error: new SdkError(SdkErrorCode.EraNegotiationFailed, `Version negotiation probe failed: ${describeError(error)}`, {
+        error: new SdkError(SdkErrorCode.EraNegotiationFailed, `Version negotiation probe failed: ${describeError(error)}`, undefined, {
             cause: error
         })
     };

--- a/packages/client/test/client/probeAuthSeam.test.ts
+++ b/packages/client/test/client/probeAuthSeam.test.ts
@@ -283,6 +283,6 @@ describe('stamped-seam fault injection (identity-preserving auth outcomes, never
         expect(out.settled).toBe('rejected');
         expect(out.error).toBeInstanceOf(SdkError);
         expect((out.error as SdkError).code).toBe(SdkErrorCode.EraNegotiationFailed);
-        expect(((out.error as SdkError).data as { cause?: unknown }).cause).toBe(netError);
+        expect((out.error as SdkError).cause).toBe(netError);
     });
 });

--- a/packages/core-internal/src/errors/sdkErrors.ts
+++ b/packages/core-internal/src/errors/sdkErrors.ts
@@ -147,9 +147,10 @@ export class SdkError extends Error {
     constructor(
         public readonly code: SdkErrorCode,
         message: string,
-        public readonly data?: unknown
+        public readonly data?: unknown,
+        options?: ErrorOptions
     ) {
-        super(message);
+        super(message, options);
         this.name = 'SdkError';
         stampErrorBrands(this, new.target);
     }
@@ -187,8 +188,8 @@ export class SdkHttpError extends SdkError {
 
     declare readonly data: SdkHttpErrorData;
 
-    constructor(code: SdkErrorCode, message: string, data: SdkHttpErrorData) {
-        super(code, message, data);
+    constructor(code: SdkErrorCode, message: string, data: SdkHttpErrorData, options?: ErrorOptions) {
+        super(code, message, data, options);
         this.name = 'SdkHttpError';
     }
 

--- a/packages/core-internal/test/errors/sdkErrorCause.test.ts
+++ b/packages/core-internal/test/errors/sdkErrorCause.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { SdkError, SdkErrorCode, SdkHttpError } from '../../src/index';
+
+describe('SdkError cause chain', () => {
+    it('forwards cause to Error.cause when passed via options', () => {
+        const root = new TypeError('ENOTFOUND');
+        const error = new SdkError(SdkErrorCode.EraNegotiationFailed, 'probe failed', undefined, {
+            cause: root
+        });
+
+        expect(error.cause).toBe(root);
+        expect(error.data).toBeUndefined();
+    });
+
+    it('keeps data and cause independent', () => {
+        const root = new Error('connection refused');
+        const error = new SdkError(
+            SdkErrorCode.RequestTimeout,
+            'timed out',
+            { timeout: 5000 },
+            {
+                cause: root
+            }
+        );
+
+        expect(error.cause).toBe(root);
+        expect(error.data).toEqual({ timeout: 5000 });
+    });
+
+    it('leaves cause undefined when options are omitted', () => {
+        const error = new SdkError(SdkErrorCode.NotConnected, 'not connected');
+        expect(error.cause).toBeUndefined();
+    });
+
+    it('leaves cause undefined when only data is passed', () => {
+        const error = new SdkError(SdkErrorCode.RequestTimeout, 'timed out', { timeout: 5000 });
+        expect(error.cause).toBeUndefined();
+    });
+});
+
+describe('SdkHttpError cause chain', () => {
+    it('forwards cause through to Error.cause', () => {
+        const root = new Error('socket hang up');
+        const error = new SdkHttpError(
+            SdkErrorCode.ClientHttpFailedToOpenStream,
+            'stream failed',
+            { status: 502, statusText: 'Bad Gateway' },
+            { cause: root }
+        );
+
+        expect(error.cause).toBe(root);
+        expect(error.status).toBe(502);
+        expect(error.data.status).toBe(502);
+    });
+
+    it('leaves cause undefined when options are omitted', () => {
+        const error = new SdkHttpError(SdkErrorCode.ClientHttpAuthentication, 'auth failed', { status: 401 });
+
+        expect(error.cause).toBeUndefined();
+    });
+});


### PR DESCRIPTION
## Summary

Fixes #2657.

`SdkError`'s third constructor parameter is `data`, not `ErrorOptions`, so when `classifyNetworkError` passed `{ cause: error }` it landed in `error.data.cause` instead of `error.cause`. This broke standard cause-chain walking used by loggers (pino) and error trackers (Sentry) — the chain terminated at `SdkError` instead of reaching the root network error.

### Changes

- **`SdkError` constructor**: added an optional `options?: ErrorOptions` parameter (4th arg), forwarded to `super(message, options)`. Fully backward-compatible — existing 2- and 3-arg call sites are unaffected.
- **`SdkHttpError` constructor**: same treatment, forwarding `options` through to `super()`.
- **`classifyNetworkError`**: moved `{ cause: error }` from the `data` slot to the new `options` parameter so the underlying network error is reachable via the standard `error.cause` property.
- **Test update**: `probeAuthSeam.test.ts` assertion updated from `error.data.cause` to `error.cause`.

## Test plan

- [x] New `sdkErrorCause.test.ts` verifying:
  - `SdkError` forwards cause to `Error.cause` when passed via options
  - `data` and `cause` remain independent when both are provided
  - `cause` is `undefined` when options are omitted (backward compat)
  - `SdkHttpError` forwards cause through the inheritance chain
- [x] Existing `probeAuthSeam.test.ts` updated and passing
- [x] Full `pnpm typecheck:all` passes
- [x] Full `pnpm build:all` passes
- [x] Full `pnpm lint:all` passes (after prettier formatting)