### PR TITLE
fix(core-internal): preserve error cause and support ErrorOptions in SdkError

### DIFF
--- a/packages/core-internal/src/errors/sdkErrors.ts
+++ b/packages/core-internal/src/errors/sdkErrors.ts
@@ -147,9 +147,15 @@ export class SdkError extends Error {
     constructor(
         public readonly code: SdkErrorCode,
         message: string,
-        public readonly data?: unknown
+        public readonly data?: unknown,
+        options?: ErrorOptions
     ) {
-        super(message);
+        const errorOptions =
+            options ??
+            (data && typeof data === 'object' && 'cause' in data && (data as { cause: unknown }).cause !== undefined
+                ? { cause: (data as { cause: unknown }).cause }
+                : undefined);
+        super(message, errorOptions);
         this.name = 'SdkError';
         stampErrorBrands(this, new.target);
     }

--- a/packages/core-internal/test/types/errorSurfacePins.test.ts
+++ b/packages/core-internal/test/types/errorSurfacePins.test.ts
@@ -196,6 +196,19 @@ describe('SdkError', () => {
         expect(error.message).toBe('Request timed out');
     });
 
+    test('preserves error cause in Error.cause when passed via data.cause or options', () => {
+        const underlyingError = new TypeError('fetch failed: getaddrinfo ENOTFOUND host.invalid');
+        
+        // When cause is passed via data object (as in classifyNetworkError)
+        const errorFromData = new SdkError(SdkErrorCode.EraNegotiationFailed, 'Version negotiation probe failed', { cause: underlyingError });
+        expect(errorFromData.cause).toBe(underlyingError);
+        expect(errorFromData.data).toEqual({ cause: underlyingError });
+
+        // When cause is passed via standard ErrorOptions
+        const errorFromOptions = new SdkError(SdkErrorCode.EraNegotiationFailed, 'Version negotiation probe failed', undefined, { cause: underlyingError });
+        expect(errorFromOptions.cause).toBe(underlyingError);
+    });
+
     test('SdkHttpError carries the HTTP status in data', () => {
         const error = new SdkHttpError(SdkErrorCode.ClientHttpFailedToOpenStream, 'Failed to open SSE stream: Not Found', {
             status: 404,

--- a/packages/core-internal/test/types/errorSurfacePins.test.ts
+++ b/packages/core-internal/test/types/errorSurfacePins.test.ts
@@ -198,14 +198,18 @@ describe('SdkError', () => {
 
     test('preserves error cause in Error.cause when passed via data.cause or options', () => {
         const underlyingError = new TypeError('fetch failed: getaddrinfo ENOTFOUND host.invalid');
-        
+
         // When cause is passed via data object (as in classifyNetworkError)
-        const errorFromData = new SdkError(SdkErrorCode.EraNegotiationFailed, 'Version negotiation probe failed', { cause: underlyingError });
+        const errorFromData = new SdkError(SdkErrorCode.EraNegotiationFailed, 'Version negotiation probe failed', {
+            cause: underlyingError
+        });
         expect(errorFromData.cause).toBe(underlyingError);
         expect(errorFromData.data).toEqual({ cause: underlyingError });
 
         // When cause is passed via standard ErrorOptions
-        const errorFromOptions = new SdkError(SdkErrorCode.EraNegotiationFailed, 'Version negotiation probe failed', undefined, { cause: underlyingError });
+        const errorFromOptions = new SdkError(SdkErrorCode.EraNegotiationFailed, 'Version negotiation probe failed', undefined, {
+            cause: underlyingError
+        });
         expect(errorFromOptions.cause).toBe(underlyingError);
     });
 


### PR DESCRIPTION
### Summary

Fixes #2657

When network or protocol errors occur, telemetry collectors and error tracers (e.g. Sentry, Pino, OpenTelemetry) rely on the standard ECMAScript 2022 `Error.cause` property on `Error` instances.

Previously, `SdkError` accepted `data?: ErrorData` but did not pass `options?: ErrorOptions` to `super(message, options)`. As a result, when `classifyNetworkError` or custom error handlers constructed an `SdkError`, the underlying root cause (e.g. `ENOTFOUND`, `ECONNREFUSED`, or `TypeError`) was not accessible via standard `error.cause`.

### Changes
1. Updated `SdkError` constructor to support `options?: ErrorOptions` while maintaining full backward compatibility with `data?: ErrorData`.
2. Automatically extracted `cause` from `data.cause` or direct `options.cause` and passed to `super(message, errorOptions)`.
3. Added unit tests in `packages/core-internal/test/types/errorSurfacePins.test.ts` verifying that `error.cause` is preserved across construction styles.

### Verification
```bash
pnpm --filter @modelcontextprotocol/core-internal test test/types/errorSurfacePins.test.ts
# 13 passed
```