### PR TITLE
fix(core): never send notifications/cancelled for the initialize hand…

### DIFF
--- a/.changeset/no-cancel-notification-for-initialize.md
+++ b/.changeset/no-cancel-notification-for-initialize.md
@@ -1,0 +1,9 @@
+---
+'@modelcontextprotocol/core-internal': patch
+'@modelcontextprotocol/client': patch
+'@modelcontextprotocol/server': patch
+---
+
+Stop sending `notifications/cancelled` for the `initialize` handshake. The spec is explicit that a client MUST NOT attempt to cancel its `initialize` request, but the outbound cancel path fired for any in-flight request: aborting the `AbortSignal` passed to `connect()`, or letting the handshake hit its timeout, put a forbidden cancellation on the wire naming the initialize request id.
+
+The local behaviour is unchanged — the caller's promise still rejects with the same abort/timeout error, and `connect()` still tears the connection down. Only the wire notification is suppressed. Every other method keeps the existing cancellation path.

--- a/docs/migration/support-2026-07-28.md
+++ b/docs/migration/support-2026-07-28.md
@@ -236,9 +236,11 @@ coverage, spawn `serveStdio` as a child process.
 On a 2026-07-28 Streamable HTTP connection, aborting an in-flight client request
 (`signal` / timeout) closes that request's SSE response stream — the spec cancellation
 signal — instead of POSTing `notifications/cancelled`. Nothing to change in calling
-code. 2025-era connections and stdio at any era still send `notifications/cancelled`.
-Custom `Transport` implementations that open one underlying request per outbound message
-and honor `TransportSendOptions.requestSignal` may opt in by declaring
+code. 2025-era connections and stdio at any era still send `notifications/cancelled`
+(except for the `initialize` handshake, which the spec forbids cancelling — an aborted
+or timed-out `connect()` rejects locally and sends nothing). Custom `Transport`
+implementations that open one underlying request per outbound message and honor
+`TransportSendOptions.requestSignal` may opt in by declaring
 `readonly hasPerRequestStream = true`.
 
 ### `ctx.mcpReq.log()` and the per-request `logLevel`

--- a/docs/migration/upgrade-to-v2.md
+++ b/docs/migration/upgrade-to-v2.md
@@ -1506,7 +1506,11 @@ rewrite required unless noted.
   on those survive verbatim. The cancelled-on-timeout signal is unchanged on legacy-era
   connections and on stdio/in-memory at any era; on 2026-era Streamable HTTP the cancel
   signal is the per-request stream close instead of a `notifications/cancelled` POST
-  (see [support-2026-07-28.md](./support-2026-07-28.md)).
+  (see [support-2026-07-28.md](./support-2026-07-28.md)). The one exemption is the
+  `initialize` handshake: an aborted or timed-out `connect()` still rejects locally, but
+  no `notifications/cancelled` goes on the wire — the spec forbids cancelling
+  `initialize`, and v1 sent one anyway. v1 tests asserting that notification need
+  re-baselining.
 - **Also unchanged: SSE reconnection exhaustion.** `StreamableHTTPClientTransport`'s
   standalone GET-stream reconnection behavior and its exhaustion signal carry over from
   v1: when retries run out, the transport emits `onerror` with a plain `Error` whose

--- a/packages/core-internal/src/shared/protocol.ts
+++ b/packages/core-internal/src/shared/protocol.ts
@@ -1451,19 +1451,29 @@ export abstract class Protocol<ContextT extends BaseContext> {
                 this._progressHandlers.delete(messageId);
 
                 if (requestAbort === undefined) {
-                    this._transport
-                        ?.send(
-                            this._envelopeOutbound({
-                                jsonrpc: '2.0',
-                                method: 'notifications/cancelled',
-                                params: {
-                                    requestId: messageId,
-                                    reason: String(reason)
-                                }
-                            }),
-                            { relatedRequestId, resumptionToken, onresumptiontoken }
-                        )
-                        .catch(error => this._onerror(new Error(`Failed to send cancellation: ${error}`)));
+                    // "A client MUST NOT attempt to cancel its `initialize`
+                    // request" (spec basic/lifecycle, mirrored on
+                    // `CancelledNotification`). The handshake is the one request
+                    // whose cancellation is forbidden outright, so an abort or
+                    // timeout on it settles purely locally: the promise still
+                    // rejects below, but nothing goes on the wire. Only the
+                    // legacy era can reach this — `initialize` is absent from the
+                    // modern registry, which negotiates via `server/discover`.
+                    if (request.method !== 'initialize') {
+                        this._transport
+                            ?.send(
+                                this._envelopeOutbound({
+                                    jsonrpc: '2.0',
+                                    method: 'notifications/cancelled',
+                                    params: {
+                                        requestId: messageId,
+                                        reason: String(reason)
+                                    }
+                                }),
+                                { relatedRequestId, resumptionToken, onresumptiontoken }
+                            )
+                            .catch(error => this._onerror(new Error(`Failed to send cancellation: ${error}`)));
+                    }
                 } else {
                     // Modern-era per-request-stream transport: aborting the
                     // request's underlying stream IS the spec cancel signal.

--- a/packages/core-internal/test/shared/protocol.test.ts
+++ b/packages/core-internal/test/shared/protocol.test.ts
@@ -911,6 +911,74 @@ describe('protocol tests', () => {
             expect(tx.lastRequestSignal?.aborted).toBe(true);
             expect(cancelledSent(tx.sent)).toHaveLength(0);
         });
+
+        // "A client MUST NOT attempt to cancel its `initialize` request." The
+        // handshake is exempt from the POST path above on every transport: an
+        // abort or timeout rejects the caller locally and sends nothing. Both
+        // triggers are covered because they reach cancel() by different routes
+        // (the caller's signal vs the timeout handler).
+        describe('the initialize handshake is never cancelled on the wire', () => {
+            test('aborting an in-flight initialize sends NO notifications/cancelled', async () => {
+                // ARRANGE
+                const sent: JSONRPCMessage[] = [];
+                const tx = new MockTransport();
+                tx.send = async (m: JSONRPCMessage, _opts?: TransportSendOptions) => {
+                    sent.push(m);
+                };
+                const proto = createTestProtocol();
+                await proto.connect(tx);
+                setNegotiatedProtocolVersion(proto, '2025-11-25');
+
+                // ACT
+                const ac = new AbortController();
+                const pending = testRequest(proto, { method: 'initialize', params: {} }, z.object({}), { signal: ac.signal });
+                ac.abort('user cancel');
+
+                // ASSERT — rejects locally, wire stays clean
+                await expect(pending).rejects.toThrow();
+                expect(cancelledSent(sent)).toHaveLength(0);
+            });
+
+            test('timing out an in-flight initialize sends NO notifications/cancelled', async () => {
+                // ARRANGE
+                const sent: JSONRPCMessage[] = [];
+                const tx = new MockTransport();
+                tx.send = async (m: JSONRPCMessage, _opts?: TransportSendOptions) => {
+                    sent.push(m);
+                };
+                const proto = createTestProtocol();
+                await proto.connect(tx);
+                setNegotiatedProtocolVersion(proto, '2025-11-25');
+
+                // ACT
+                const pending = testRequest(proto, { method: 'initialize', params: {} }, z.object({}), { timeout: 0 });
+
+                // ASSERT
+                await expect(pending).rejects.toThrow();
+                expect(cancelledSent(sent)).toHaveLength(0);
+            });
+
+            test('every other method still POSTs notifications/cancelled (regression guard)', async () => {
+                // ARRANGE
+                const sent: JSONRPCMessage[] = [];
+                const tx = new MockTransport();
+                tx.send = async (m: JSONRPCMessage, _opts?: TransportSendOptions) => {
+                    sent.push(m);
+                };
+                const proto = createTestProtocol();
+                await proto.connect(tx);
+                setNegotiatedProtocolVersion(proto, '2025-11-25');
+
+                // ACT
+                const ac = new AbortController();
+                const pending = testRequest(proto, { method: 'example', params: {} }, z.object({}), { signal: ac.signal });
+                ac.abort('user cancel');
+
+                // ASSERT
+                await expect(pending).rejects.toThrow();
+                expect(cancelledSent(sent)).toHaveLength(1);
+            });
+        });
     });
 });
 

--- a/packages/core-internal/test/shared/protocol.test.ts
+++ b/packages/core-internal/test/shared/protocol.test.ts
@@ -866,6 +866,23 @@ describe('protocol tests', () => {
         const cancelledSent = (sent: JSONRPCMessage[]): JSONRPCMessage[] =>
             sent.filter(m => 'method' in m && m.method === 'notifications/cancelled');
 
+        /**
+         * Connects a fresh protocol over a single-channel transport (stdio /
+         * in-memory shape: no `hasPerRequestStream`) at `version`, recording
+         * every outbound message.
+         */
+        const connectSingleChannel = async (version: string) => {
+            const sent: JSONRPCMessage[] = [];
+            const tx = new MockTransport();
+            tx.send = async (m: JSONRPCMessage) => {
+                sent.push(m);
+            };
+            const proto = createTestProtocol();
+            await proto.connect(tx);
+            setNegotiatedProtocolVersion(proto, version);
+            return { proto, sent };
+        };
+
         test('modern era + per-request-stream transport: abort closes the stream, NO notifications/cancelled', async () => {
             const tx = new PerRequestStreamTransport();
             const proto = createTestProtocol();
@@ -888,15 +905,7 @@ describe('protocol tests', () => {
         });
 
         test('modern era + single-channel transport (no hasPerRequestStream): POSTs notifications/cancelled', async () => {
-            // stdio / in-memory shape: hasPerRequestStream is undefined.
-            const sent: JSONRPCMessage[] = [];
-            const tx = new MockTransport();
-            tx.send = async (m: JSONRPCMessage, _opts?: TransportSendOptions) => {
-                sent.push(m);
-            };
-            const proto = createTestProtocol();
-            await proto.connect(tx);
-            setNegotiatedProtocolVersion(proto, '2026-07-28');
+            const { proto, sent } = await connectSingleChannel('2026-07-28');
 
             const ac = new AbortController();
             const pending = testRequest(proto, { method: 'example', params: {} }, z.object({}), { signal: ac.signal });
@@ -946,14 +955,7 @@ describe('protocol tests', () => {
         describe('the initialize handshake is never cancelled on the wire', () => {
             test('aborting an in-flight initialize sends NO notifications/cancelled', async () => {
                 // ARRANGE
-                const sent: JSONRPCMessage[] = [];
-                const tx = new MockTransport();
-                tx.send = async (m: JSONRPCMessage, _opts?: TransportSendOptions) => {
-                    sent.push(m);
-                };
-                const proto = createTestProtocol();
-                await proto.connect(tx);
-                setNegotiatedProtocolVersion(proto, '2025-11-25');
+                const { proto, sent } = await connectSingleChannel('2025-11-25');
 
                 // ACT
                 const ac = new AbortController();
@@ -967,14 +969,7 @@ describe('protocol tests', () => {
 
             test('timing out an in-flight initialize sends NO notifications/cancelled', async () => {
                 // ARRANGE
-                const sent: JSONRPCMessage[] = [];
-                const tx = new MockTransport();
-                tx.send = async (m: JSONRPCMessage, _opts?: TransportSendOptions) => {
-                    sent.push(m);
-                };
-                const proto = createTestProtocol();
-                await proto.connect(tx);
-                setNegotiatedProtocolVersion(proto, '2025-11-25');
+                const { proto, sent } = await connectSingleChannel('2025-11-25');
 
                 // ACT
                 const pending = testRequest(proto, { method: 'initialize', params: {} }, z.object({}), { timeout: 0 });
@@ -986,14 +981,7 @@ describe('protocol tests', () => {
 
             test('every other method still POSTs notifications/cancelled (regression guard)', async () => {
                 // ARRANGE
-                const sent: JSONRPCMessage[] = [];
-                const tx = new MockTransport();
-                tx.send = async (m: JSONRPCMessage, _opts?: TransportSendOptions) => {
-                    sent.push(m);
-                };
-                const proto = createTestProtocol();
-                await proto.connect(tx);
-                setNegotiatedProtocolVersion(proto, '2025-11-25');
+                const { proto, sent } = await connectSingleChannel('2025-11-25');
 
                 // ACT
                 const ac = new AbortController();

--- a/test/e2e/requirements.ts
+++ b/test/e2e/requirements.ts
@@ -140,10 +140,10 @@ export const REQUIREMENTS: Record<string, Requirement> = {
         note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
     },
     'protocol:cancel:initialize-not-cancellable': {
-        transports: STATEFUL_TRANSPORTS,
+        transports: ['inMemory'],
         source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/cancellation#behavior-requirements',
         behavior: 'The client never sends notifications/cancelled for the initialize request.',
-        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
+        note: "The behavior itself is transport-agnostic (shared/protocol.ts), but the test must tap the client's outbound messages before connect() resolves, which only the in-memory wiring supports."
     },
     'protocol:cancel:late-response-ignored': {
         source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/cancellation#timing-considerations',

--- a/test/e2e/requirements.ts
+++ b/test/e2e/requirements.ts
@@ -143,12 +143,7 @@ export const REQUIREMENTS: Record<string, Requirement> = {
         transports: STATEFUL_TRANSPORTS,
         source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/cancellation#behavior-requirements',
         behavior: 'The client never sends notifications/cancelled for the initialize request.',
-        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.',
-        knownFailures: [
-            {
-                note: 'SDK sends notifications/cancelled for initialize when connect() is aborted; spec says initialize MUST NOT be cancelled.'
-            }
-        ]
+        note: 'Stateless hosting creates a fresh server per request and has no standalone GET stream, so there is no server→client channel to deliver/observe these.'
     },
     'protocol:cancel:late-response-ignored': {
         source: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/cancellation#timing-considerations',


### PR DESCRIPTION
The SDK puts a spec-forbidden `notifications/cancelled` on the wire for the `initialize` handshake whenever `connect()` is aborted or times out. This guards the send; the local abort/reject path is unchanged.

## Motivation and Context

> A client MUST NOT attempt to cancel its `initialize` request.

— [spec, basic/lifecycle](https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/cancellation#behavior-requirements), mirrored on `CancelledNotification` in `packages/core-internal/src/types/spec.types.2025-11-25.ts`.

The `cancel` closure in `_requestWithSchemaViaCodec` fires for *any* in-flight request, and reaches `initialize` by both routes: the caller's `AbortSignal` (`Client.connect()` passes its `RequestOptions` straight through to the handshake) and the timeout handler. Either one emits a cancellation naming the initialize request id.

This is a long-standing, independently-recorded deviation:

- **#998** — filed 2025-10-02, labelled `bug` / `ready for work` / `P2` / `v2` / `fix proposed`, with the same root cause identified.
- **`test/e2e/requirements.ts`** — the conformance manifest already carried a `knownFailures` entry on `protocol:cancel:initialize-not-cancellable` reading *"SDK sends notifications/cancelled for initialize when connect() is aborted; spec says initialize MUST NOT be cancelled."*

Blast radius is modest but real. `_legacyHandshake` closes the connection on any handshake failure, so the peer is torn down regardless — but a server that honours the cancel aborts its in-flight `initialize` handler and suppresses the response before that. The defect is conformance: the SDK emits a message the spec forbids, and every non-SDK server sees it.

## The fix

Guard the notification send on the request method:

```ts
if (request.method !== 'initialize') {
    this._transport?.send(/* notifications/cancelled */);
}
```

- The caller's promise still rejects with the same abort/timeout error, and `connect()` still tears the connection down. Only the wire notification is suppressed.
- The guard sits inside the non-stream-close branch, so the modern per-request-stream path is untouched — `initialize` is legacy-era only, absent from the modern registry, which negotiates via `server/discover`.
- Every other method keeps the existing cancellation path.

Removing the `knownFailures` entry is the required companion change, not incidental cleanup: `verifies()` runs those cells as `test.fails()`, so they *fail* once the SDK is fixed. All 8 transport × era cells now pass as real assertions.

## How Has This Been Tested?

Three new unit tests in the existing `outbound request cancellation: stream-close vs notifications/cancelled` block, covering both triggers plus a regression guard. Verified they actually catch the bug — with the guard removed, the two initialize cases fail and the regression guard still passes.

| Suite | Result |
| --- | --- |
| `core-internal` | 1436 passed |
| `client` / `server` / `server-legacy` | 797 / 468 / 168 passed |
| `test/integration` | 371 passed |
| e2e `protocol:cancel:initialize-not-cancellable` | 8/8 passed (previously `test.fails`) |
| e2e `coverage.test.ts` manifest gates | 6 passed |
| `pnpm typecheck:all`, `pnpm lint:all` | clean |

One pre-existing flake, attributed rather than assumed: `protocol:timeout:max-total [sse]` fails under full-suite load. It passes in isolation, and it also fails on an untouched base with this change reverted — unrelated to this PR.

## Breaking Changes

No API surface change; ships as a `patch`. The observable change is on the wire: a peer no longer receives `notifications/cancelled` for `initialize`. Any server depending on that was depending on behaviour the spec forbids, and the handshake still fails and closes exactly as before.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

**Supersedes #1932.** That PR proposed the same guard back in April and never got a human review; it has been `CONFLICTING` since, because it patches `packages/core/src/shared/protocol.ts` — a path that no longer exists after the protocol moved to `core-internal`. This is that fix ported to the current layout, with the e2e manifest update it predates. Credit to @ameenalkhaldi for the original.

**Adjacent work on the same closure:**

- **#2646** — the cancellation notification inherits the originating request's `resumptionToken`, so on legacy-era Streamable HTTP the transport treats the cancel as a stream resume. Same `cancel` closure; worth sequencing.
- **#2654** — fixes the receive side of cancellation (`requestId: 0` swallowed by a truthiness guard). Independent lines, no conflict.

Fixes #998.
