### PR TITLE
fix(server): reject DELETE requests in stateless streamable HTTP mode

### DIFF
--- a/packages/server/src/server/streamableHttp.ts
+++ b/packages/server/src/server/streamableHttp.ts
@@ -974,6 +974,15 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
      * Handles `DELETE` requests to terminate sessions
      */
     private async handleDeleteRequest(req: Request): Promise<Response> {
+        // Session termination requires session management. In stateless mode
+        // there is no session to terminate; rejecting the request also avoids
+        // closing the transport underneath a stateless deployment.
+        if (this.sessionIdGenerator === undefined) {
+            this.onerror?.(new Error('Method Not Allowed: session termination not supported in stateless mode'));
+            return this.createJsonErrorResponse(405, -32_000, 'Method Not Allowed: session termination not supported in stateless mode', {
+                headers: { Allow: 'GET, POST' }
+            });
+        }
         const sessionError = this.validateSession(req);
         if (sessionError) {
             return sessionError;

--- a/packages/server/test/server/streamableHttp.test.ts
+++ b/packages/server/test/server/streamableHttp.test.ts
@@ -472,6 +472,28 @@ describe('Zod v4', () => {
 
             expect(response.status).toBe(200);
         });
+
+        it('should reject DELETE in stateless mode', async () => {
+            const request = createRequest('DELETE', undefined);
+            const response = await transport.handleRequest(request);
+
+            expect(response.status).toBe(405);
+            expect(response.headers.get('Allow')).toContain('POST');
+        });
+
+        it('should remain functional after a rejected stateless DELETE', async () => {
+            const deleteRequest = createRequest('DELETE', undefined);
+            const deleteResponse = await transport.handleRequest(deleteRequest);
+            expect(deleteResponse.status).toBe(405);
+
+            const initRequest = createRequest('POST', TEST_MESSAGES.initialize);
+            const initResponse = await transport.handleRequest(initRequest);
+            expect(initResponse.status).toBe(200);
+
+            const request = createRequest('POST', TEST_MESSAGES.toolsList);
+            const response = await transport.handleRequest(request);
+            expect(response.status).toBe(200);
+        });
     });
 
     describe('HTTPServerTransport - JSON Response Mode', () => {


### PR DESCRIPTION
## Summary

A stateless transport (`sessionIdGenerator: undefined`) has no session to terminate, but `handleDeleteRequest` currently proceeds anyway and closes the transport permanently via `close()`. Any subsequent request on the same transport instance — including a fresh `initialize` — is then rejected with 404, and the transport cannot be reused.

The transport is a public API that supports being reused across requests, so a single unauthenticated DELETE can brick a shared deployment until the process restarts.

This change returns `405 Method Not Allowed` for DELETE when session management is disabled, and leaves the transport fully functional.

## Tests

- `should reject DELETE in stateless mode` — DELETE returns 405 with an `Allow` header.
- `should remain functional after a rejected stateless DELETE` — `initialize` and `tools/list` still succeed with 200 after the rejected DELETE.

The existing stateful DELETE tests (200 on valid session, 404 on invalid session) are unchanged.