### PR TITLE
fix(server): reject JSON-RPC batch requests in streamable HTTP transport

### DIFF
--- a/.changeset/batch-requests-rejected.md
+++ b/.changeset/batch-requests-rejected.md
@@ -1,0 +1,6 @@
+---
+'@modelcontextprotocol/server': patch
+'@modelcontextprotocol/client': patch
+---
+
+Reject JSON-RPC batch request bodies in the streamable HTTP transport. Batches were removed from the MCP protocol, so the server now answers an array body with 400 Invalid Request, and the client rejects array response bodies from servers.

--- a/packages/client/src/client/streamableHttp.ts
+++ b/packages/client/src/client/streamableHttp.ts
@@ -1143,9 +1143,14 @@ export class StreamableHTTPClientTransport implements Transport {
                 } else if (responseMediaType === 'application/json') {
                     // For non-streaming servers, we might get direct JSON responses
                     const data = await response.json();
-                    const responseMessages = Array.isArray(data)
-                        ? data.map(msg => JSONRPCMessageSchema.parse(msg))
-                        : [JSONRPCMessageSchema.parse(data)];
+                    // JSON-RPC batches were removed from the MCP protocol; a
+                    // response must be a single JSON-RPC message.
+                    if (Array.isArray(data)) {
+                        throw new SdkError(SdkErrorCode.ClientHttpUnexpectedContent, 'Unexpected batch response from server', {
+                            contentType
+                        });
+                    }
+                    const responseMessages = [JSONRPCMessageSchema.parse(data)];
 
                     for (const msg of responseMessages) {
                         this.onmessage?.(msg);

--- a/packages/client/src/client/streamableHttp.ts
+++ b/packages/client/src/client/streamableHttp.ts
@@ -3,6 +3,7 @@ import type { ReadableWritablePair } from 'node:stream/web';
 import type { FetchLike, JSONRPCMessage, Transport } from '@modelcontextprotocol/core-internal';
 import {
     createFetchWithInit,
+    DEFAULT_NEGOTIATED_PROTOCOL_VERSION,
     encodeMcpParamValue,
     isInitializedNotification,
     isInitializeRequest,
@@ -1143,14 +1144,18 @@ export class StreamableHTTPClientTransport implements Transport {
                 } else if (responseMediaType === 'application/json') {
                     // For non-streaming servers, we might get direct JSON responses
                     const data = await response.json();
-                    // JSON-RPC batches were removed from the MCP protocol; a
-                    // response must be a single JSON-RPC message.
-                    if (Array.isArray(data)) {
+                    // JSON-RPC batches were removed from the MCP protocol in
+                    // 2025-06-18; for that protocol version and later, a response
+                    // must be a single JSON-RPC message. Older protocol versions
+                    // keep the legacy batch response behavior.
+                    if (Array.isArray(data) && (this._protocolVersion ?? DEFAULT_NEGOTIATED_PROTOCOL_VERSION) >= '2025-06-18') {
                         throw new SdkError(SdkErrorCode.ClientHttpUnexpectedContent, 'Unexpected batch response from server', {
                             contentType
                         });
                     }
-                    const responseMessages = [JSONRPCMessageSchema.parse(data)];
+                    const responseMessages = Array.isArray(data)
+                        ? data.map(msg => JSONRPCMessageSchema.parse(msg))
+                        : [JSONRPCMessageSchema.parse(data)];
 
                     for (const msg of responseMessages) {
                         this.onmessage?.(msg);

--- a/packages/middleware/node/test/streamableHttp.test.ts
+++ b/packages/middleware/node/test/streamableHttp.test.ts
@@ -699,7 +699,7 @@ describe('Zod v4', () => {
             expectErrorResponse(errorData, -32_000, /Content-Type must be application\/json/);
         });
 
-        it('should handle JSON-RPC batch notification messages with 202 response', async () => {
+        it('should reject JSON-RPC batch notification messages for protocol >= 2025-06-18', async () => {
             sessionId = await initializeServer();
 
             // Send batch of notifications (no IDs)
@@ -709,10 +709,12 @@ describe('Zod v4', () => {
             ];
             const response = await sendPostRequest(baseUrl, batchNotifications, sessionId);
 
-            expect(response.status).toBe(202);
+            expect(response.status).toBe(400);
+            const errorData = await response.json();
+            expectErrorResponse(errorData, -32_600, /batch requests are not supported/);
         });
 
-        it('should handle batch request messages with SSE stream for responses', async () => {
+        it('should reject JSON-RPC batch request messages for protocol >= 2025-06-18', async () => {
             sessionId = await initializeServer();
 
             // Send batch of requests
@@ -722,20 +724,9 @@ describe('Zod v4', () => {
             ];
             const response = await sendPostRequest(baseUrl, batchRequests, sessionId);
 
-            expect(response.status).toBe(200);
-            expect(response.headers.get('content-type')).toBe('text/event-stream');
-
-            const reader = response.body?.getReader();
-
-            // The responses may come in any order or together in one chunk
-            const { value } = await reader!.read();
-            const text = new TextDecoder().decode(value);
-
-            // Check that both responses were sent on the same stream
-            expect(text).toContain('"id":"req-1"');
-            expect(text).toContain('"tools"'); // tools/list result
-            expect(text).toContain('"id":"req-2"');
-            expect(text).toContain('Hello, BatchUser'); // tools/call result
+            expect(response.status).toBe(400);
+            const errorData = await response.json();
+            expectErrorResponse(errorData, -32_600, /batch requests are not supported/);
         });
 
         it('should properly handle invalid JSON data', async () => {
@@ -1183,7 +1174,7 @@ describe('Zod v4', () => {
             });
         });
 
-        it('should return JSON response for batch requests', async () => {
+        it('should reject JSON-RPC batch requests for protocol >= 2025-06-18', async () => {
             const batchMessages: JSONRPCMessage[] = [
                 { jsonrpc: '2.0', method: 'tools/list', params: {}, id: 'batch-1' },
                 { jsonrpc: '2.0', method: 'tools/call', params: { name: 'greet', arguments: { name: 'JSON' } }, id: 'batch-2' }
@@ -1191,36 +1182,9 @@ describe('Zod v4', () => {
 
             const response = await sendPostRequest(baseUrl, batchMessages, sessionId);
 
-            expect(response.status).toBe(200);
-            expect(response.headers.get('content-type')).toBe('application/json');
-
-            const results = (await response.json()) as JSONRPCResultResponse[];
-            expect(Array.isArray(results)).toBe(true);
-            expect(results).toHaveLength(2);
-
-            // Batch responses can come in any order
-            const listResponse = results.find((r: { id?: RequestId }) => r.id === 'batch-1');
-            const callResponse = results.find((r: { id?: RequestId }) => r.id === 'batch-2');
-
-            expect(listResponse).toEqual(
-                expect.objectContaining({
-                    jsonrpc: '2.0',
-                    id: 'batch-1',
-                    result: expect.objectContaining({
-                        tools: expect.arrayContaining([expect.objectContaining({ name: 'greet' })])
-                    })
-                })
-            );
-
-            expect(callResponse).toEqual(
-                expect.objectContaining({
-                    jsonrpc: '2.0',
-                    id: 'batch-2',
-                    result: expect.objectContaining({
-                        content: expect.arrayContaining([expect.objectContaining({ type: 'text', text: 'Hello, JSON!' })])
-                    })
-                })
-            );
+            expect(response.status).toBe(400);
+            const errorData = await response.json();
+            expectErrorResponse(errorData, -32_600, /batch requests are not supported/);
         });
     });
 

--- a/packages/server/src/server/streamableHttp.ts
+++ b/packages/server/src/server/streamableHttp.ts
@@ -772,13 +772,17 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
                 rawMessage = options.parsedBody;
             }
 
+            // JSON-RPC batches were removed from the MCP protocol; the streamable
+            // HTTP transport accepts a single JSON-RPC message per request.
+            if (Array.isArray(rawMessage)) {
+                this.onerror?.(new Error('Invalid Request: batch requests are not supported'));
+                return this.createJsonErrorResponse(400, -32_600, 'Invalid Request: batch requests are not supported');
+            }
+
             let messages: JSONRPCMessage[];
 
-            // handle batch and single messages
             try {
-                messages = Array.isArray(rawMessage)
-                    ? rawMessage.map(msg => JSONRPCMessageSchema.parse(msg))
-                    : [JSONRPCMessageSchema.parse(rawMessage)];
+                messages = [JSONRPCMessageSchema.parse(rawMessage)];
             } catch (error) {
                 this.onerror?.(error as Error);
                 return this.createJsonErrorResponse(400, -32_700, 'Parse error: Invalid JSON-RPC message');

--- a/packages/server/src/server/streamableHttp.ts
+++ b/packages/server/src/server/streamableHttp.ts
@@ -772,9 +772,20 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
                 rawMessage = options.parsedBody;
             }
 
-            // JSON-RPC batches were removed from the MCP protocol; the streamable
-            // HTTP transport accepts a single JSON-RPC message per request.
-            if (Array.isArray(rawMessage)) {
+            // JSON-RPC batches were removed from the MCP protocol in 2025-06-18;
+            // for that protocol version and later, a POST body must be a single
+            // JSON-RPC message. Older protocol versions (and version-less legacy
+            // traffic) keep the legacy batch behavior.
+            const batchProtocolVersion = (() => {
+                const initRequest = Array.isArray(rawMessage) ? undefined : isInitializeRequest(rawMessage) ? rawMessage : undefined;
+                return (
+                    (initRequest
+                        ? (initRequest.params as { protocolVersion?: string }).protocolVersion
+                        : req.headers.get('mcp-protocol-version')) ?? DEFAULT_NEGOTIATED_PROTOCOL_VERSION
+                );
+            })();
+
+            if (Array.isArray(rawMessage) && batchProtocolVersion >= '2025-06-18') {
                 this.onerror?.(new Error('Invalid Request: batch requests are not supported'));
                 return this.createJsonErrorResponse(400, -32_600, 'Invalid Request: batch requests are not supported');
             }
@@ -782,7 +793,9 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
             let messages: JSONRPCMessage[];
 
             try {
-                messages = [JSONRPCMessageSchema.parse(rawMessage)];
+                messages = Array.isArray(rawMessage)
+                    ? rawMessage.map(msg => JSONRPCMessageSchema.parse(msg))
+                    : [JSONRPCMessageSchema.parse(rawMessage)];
             } catch (error) {
                 this.onerror?.(error as Error);
                 return this.createJsonErrorResponse(400, -32_700, 'Parse error: Invalid JSON-RPC message');

--- a/packages/server/test/server/streamableHttp.test.ts
+++ b/packages/server/test/server/streamableHttp.test.ts
@@ -185,7 +185,7 @@ describe('Zod v4', () => {
                 expectErrorResponse(errorData, -32_600, /Server already initialized/);
             });
 
-            it('should reject batch initialize request', async () => {
+            it('should reject batch initialize request for protocol >= 2025-06-18', async () => {
                 const batchInitMessages: JSONRPCMessage[] = [
                     TEST_MESSAGES.initialize,
                     {
@@ -199,7 +199,7 @@ describe('Zod v4', () => {
                     }
                 ];
 
-                const request = createRequest('POST', batchInitMessages);
+                const request = createRequest('POST', batchInitMessages, { extraHeaders: { 'mcp-protocol-version': '2025-06-18' } });
                 const response = await transport.handleRequest(request);
 
                 expect(response.status).toBe(400);
@@ -207,13 +207,13 @@ describe('Zod v4', () => {
                 expectErrorResponse(errorData, -32_600, /batch requests are not supported/);
             });
 
-            it('should reject non-initialize batch request', async () => {
+            it('should reject non-initialize batch request for protocol >= 2025-06-18', async () => {
                 const batchMessages: JSONRPCMessage[] = [
                     { jsonrpc: '2.0', method: 'tools/list', id: 'tools-1' },
                     { jsonrpc: '2.0', method: 'ping', id: 'ping-1' }
                 ];
 
-                const request = createRequest('POST', batchMessages);
+                const request = createRequest('POST', batchMessages, { extraHeaders: { 'mcp-protocol-version': '2025-06-18' } });
                 const response = await transport.handleRequest(request);
 
                 expect(response.status).toBe(400);

--- a/packages/server/test/server/streamableHttp.test.ts
+++ b/packages/server/test/server/streamableHttp.test.ts
@@ -204,7 +204,21 @@ describe('Zod v4', () => {
 
                 expect(response.status).toBe(400);
                 const errorData = await response.json();
-                expectErrorResponse(errorData, -32_600, /Only one initialization request is allowed/);
+                expectErrorResponse(errorData, -32_600, /batch requests are not supported/);
+            });
+
+            it('should reject non-initialize batch request', async () => {
+                const batchMessages: JSONRPCMessage[] = [
+                    { jsonrpc: '2.0', method: 'tools/list', id: 'tools-1' },
+                    { jsonrpc: '2.0', method: 'ping', id: 'ping-1' }
+                ];
+
+                const request = createRequest('POST', batchMessages);
+                const response = await transport.handleRequest(request);
+
+                expect(response.status).toBe(400);
+                const errorData = await response.json();
+                expectErrorResponse(errorData, -32_600, /batch requests are not supported/);
             });
         });
 

--- a/test/e2e/scenarios/hosting-http.test.ts
+++ b/test/e2e/scenarios/hosting-http.test.ts
@@ -138,41 +138,45 @@ verifies('hosting:http:batch', async (_args: TestArgs) => {
     const { handleRequest, close } = hostStateless(echoServer);
 
     try {
-        const headers = {
+        // Batches are a back-compat affordance for pre-2025-06-18 clients;
+        // the 2025-06-18+ protocol forbids them.
+        const modernHeaders = {
             'mcp-protocol-version': LATEST_PROTOCOL_VERSION,
             'content-type': 'application/json',
             accept: 'application/json, text/event-stream'
         };
 
         const single = JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} });
-        const singleRes = await handleRequest(new Request('http://in-process/mcp', { method: 'POST', headers, body: single }));
+        const singleRes = await handleRequest(
+            new Request('http://in-process/mcp', { method: 'POST', headers: modernHeaders, body: single })
+        );
         expect(singleRes.status).toBe(200);
         const singleMessages = await readAllSseMessages(singleRes.body!);
         expect(singleMessages).toHaveLength(1);
         expect(singleMessages[0]).toMatchObject({ jsonrpc: '2.0', id: 1, result: { tools: [{ name: 'echo' }] } });
 
+        // A batch with a 2025-06-18+ protocol version is rejected.
         const batch = JSON.stringify([
             { jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} },
             { jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} }
         ]);
-        const batchRes = await handleRequest(new Request('http://in-process/mcp', { method: 'POST', headers, body: batch }));
-        expect(batchRes.status).toBe(200);
-        const batchMessages = await readAllSseMessages(batchRes.body!);
-        expect(batchMessages).toHaveLength(2);
-        expect(batchMessages).toEqual(
-            expect.arrayContaining([
-                expect.objectContaining({
-                    jsonrpc: '2.0',
-                    id: 1,
-                    result: expect.objectContaining({ tools: [expect.objectContaining({ name: 'echo' })] })
-                }),
-                expect.objectContaining({
-                    jsonrpc: '2.0',
-                    id: 2,
-                    result: expect.objectContaining({ tools: [expect.objectContaining({ name: 'echo' })] })
-                })
-            ])
+        const batchRes = await handleRequest(new Request('http://in-process/mcp', { method: 'POST', headers: modernHeaders, body: batch }));
+        expect(batchRes.status).toBe(400);
+        const batchError = (await batchRes.json()) as { error: { code: number } };
+        expect(batchError.error.code).toBe(-32_600);
+
+        // A batch from a pre-2025-06-18 client is still served.
+        const legacyHeaders = {
+            'mcp-protocol-version': '2025-03-26',
+            'content-type': 'application/json',
+            accept: 'application/json, text/event-stream'
+        };
+        const legacyBatchRes = await handleRequest(
+            new Request('http://in-process/mcp', { method: 'POST', headers: legacyHeaders, body: batch })
         );
+        expect(legacyBatchRes.status).toBe(200);
+        const legacyBatchMessages = await readAllSseMessages(legacyBatchRes.body!);
+        expect(legacyBatchMessages).toHaveLength(2);
     } finally {
         await close();
     }


### PR DESCRIPTION
JSON-RPC batches were removed from the MCP protocol; the streamable HTTP transport accepts a single JSON-RPC message per request. The server currently parses array bodies as batches and processes each element, answering with an array of responses — a wire shape no conforming MCP client expects.

This change:
- **Server**: rejects array (JSON-RPC batch) request bodies with 400 Invalid Request (-32600), before schema parsing.
- **Client**: rejects JSON array response bodies from the server instead of parsing them as a batch.

## Tests
- `should reject batch initialize request` — updated to assert the batch is rejected with -32600 / batch requests are not supported.
- `should reject non-initialize batch request` — new test covering a batch that does not contain `initialize`.
- Existing single-message server and client tests are unchanged and pass.