### PR TITLE
feat(server): limit streamable HTTP request body size

### DIFF
--- a/.changeset/request-body-size-limit.md
+++ b/.changeset/request-body-size-limit.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/server': minor
+---
+
+Add a `maxRequestBodySize` option to the streamable HTTP server transport (default 4 MiB) and reject oversized POST bodies with 413 Payload Too Large, matching the other official SDKs.

--- a/packages/server/src/server/streamableHttp.ts
+++ b/packages/server/src/server/streamableHttp.ts
@@ -25,6 +25,57 @@ export type StreamId = string;
 export type EventId = string;
 
 /**
+ * Default maximum size in bytes for POST request bodies, aligned with the
+ * other official SDKs (Python, Go, Kotlin, Ruby, PHP all cap request bodies
+ * at 4 MiB).
+ */
+const DEFAULT_MAX_REQUEST_BODY_SIZE = 4 * 1024 * 1024;
+
+/**
+ * Error thrown by {@link readJsonBody} when the request body exceeds the
+ * configured size limit.
+ */
+class RequestBodyTooLargeError extends Error {}
+
+/**
+ * Reads and JSON-parses a request body, enforcing a maximum size limit.
+ *
+ * The body is read as text so the byte count is exact even for chunked
+ * transfers where the Content-Length header is absent. If the body exceeds
+ * `maxSize` bytes, a {@link RequestBodyTooLargeError} is thrown and the
+ * remainder of the stream is discarded.
+ */
+async function readJsonBody(req: Request, maxSize: number): Promise<unknown> {
+    const reader = req.body?.getReader();
+    if (reader === undefined) {
+        // No body: fall back to the regular parser, which handles empty bodies.
+        return req.json();
+    }
+    const chunks: Uint8Array[] = [];
+    let total = 0;
+    for (;;) {
+        const { done, value } = await reader.read();
+        if (done) {
+            break;
+        }
+        total += value.byteLength;
+        if (total > maxSize) {
+            await reader.cancel();
+            throw new RequestBodyTooLargeError();
+        }
+        chunks.push(value);
+    }
+    const buffer = new Uint8Array(total);
+    let offset = 0;
+    for (const chunk of chunks) {
+        buffer.set(chunk, offset);
+        offset += chunk.byteLength;
+    }
+    const text = new TextDecoder().decode(buffer);
+    return JSON.parse(text);
+}
+
+/**
  * Interface for resumability support via event storage
  */
 export interface EventStore {
@@ -167,6 +218,14 @@ export interface WebStandardStreamableHTTPServerTransportOptions {
      * @default {@linkcode SUPPORTED_PROTOCOL_VERSIONS}
      */
     supportedProtocolVersions?: string[];
+
+    /**
+     * Maximum size in bytes of the POST request body accepted by the transport.
+     * Requests whose body exceeds this limit are rejected with `413 Payload Too Large`.
+     *
+     * @default 4 * 1024 * 1024 (4 MiB)
+     */
+    maxRequestBodySize?: number;
 }
 
 /**
@@ -256,6 +315,7 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
     private _retryInterval?: number;
     private _supportedProtocolVersions: string[];
     private _keepAliveMs: number;
+    private _maxRequestBodySize: number;
 
     sessionId?: string;
     onclose?: () => void;
@@ -274,6 +334,7 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
         this._retryInterval = options.retryInterval;
         this._supportedProtocolVersions = options.supportedProtocolVersions ?? SUPPORTED_PROTOCOL_VERSIONS;
         this._keepAliveMs = options.keepAliveMs ?? DEFAULT_SSE_KEEP_ALIVE_MS;
+        this._maxRequestBodySize = options.maxRequestBodySize ?? DEFAULT_MAX_REQUEST_BODY_SIZE;
     }
 
     private startKeepAlive(
@@ -762,10 +823,32 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
 
             let rawMessage;
             if (options?.parsedBody === undefined) {
+                // Reject oversized bodies before reading them: check the
+                // Content-Length header when present, and cap the read for
+                // chunked or otherwise unannounced bodies.
+                const contentLength = req.headers.get('content-length');
+                if (contentLength !== null) {
+                    const declared = Number(contentLength);
+                    if (Number.isFinite(declared) && declared > this._maxRequestBodySize) {
+                        this.onerror?.(new Error(`Request body exceeds maximum allowed size of ${this._maxRequestBodySize} bytes`));
+                        return this.createJsonErrorResponse(
+                            413,
+                            -32_000,
+                            `Request body exceeds maximum allowed size of ${this._maxRequestBodySize} bytes`
+                        );
+                    }
+                }
                 try {
-                    rawMessage = await req.json();
+                    rawMessage = await readJsonBody(req, this._maxRequestBodySize);
                 } catch (error) {
                     this.onerror?.(error as Error);
+                    if (error instanceof RequestBodyTooLargeError) {
+                        return this.createJsonErrorResponse(
+                            413,
+                            -32_000,
+                            `Request body exceeds maximum allowed size of ${this._maxRequestBodySize} bytes`
+                        );
+                    }
                     return this.createJsonErrorResponse(400, -32_700, 'Parse error: Invalid JSON');
                 }
             } else {

--- a/packages/server/test/server/streamableHttp.test.ts
+++ b/packages/server/test/server/streamableHttp.test.ts
@@ -472,6 +472,47 @@ describe('Zod v4', () => {
 
             expect(response.status).toBe(200);
         });
+
+        it('should reject oversized request bodies with 413', async () => {
+            const oversizedBody = JSON.stringify({
+                jsonrpc: '2.0',
+                method: 'tools/call',
+                params: { name: 'echo', arguments: { message: 'x'.repeat(4 * 1024 * 1024 + 1) } },
+                id: 'big-1'
+            });
+            const request = new Request('http://localhost/mcp', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json', Accept: 'application/json, text/event-stream' },
+                body: oversizedBody
+            });
+            const response = await transport.handleRequest(request);
+
+            expect(response.status).toBe(413);
+            const errorData = await response.json();
+            expectErrorResponse(errorData, -32_000, /exceeds maximum allowed size/);
+        });
+
+        it('should reject request bodies exceeding a custom limit', async () => {
+            const limitedTransport = new WebStandardStreamableHTTPServerTransport({
+                sessionIdGenerator: undefined,
+                maxRequestBodySize: 1024
+            });
+            await mcpServer.connect(limitedTransport);
+            try {
+                const paddedBody =
+                    JSON.stringify({ jsonrpc: '2.0', method: 'ping', id: 'big-2' }).slice(0, -1) + ',"padding":"' + 'x'.repeat(2048) + '"}';
+                const request = new Request('http://localhost/mcp', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json', Accept: 'application/json, text/event-stream' },
+                    body: paddedBody
+                });
+                const response = await limitedTransport.handleRequest(request);
+
+                expect(response.status).toBe(413);
+            } finally {
+                await limitedTransport.close();
+            }
+        });
     });
 
     describe('HTTPServerTransport - JSON Response Mode', () => {


### PR DESCRIPTION
The streamable HTTP transport reads POST bodies with `req.json()`, which loads the entire body into memory with no size bound. An attacker can exhaust server memory with a single oversized request. Every other official SDK caps request bodies (typically at 4 MiB).

This change adds a `maxRequestBodySize` option to `WebStandardStreamableHTTPServerTransportOptions` (default 4 MiB) and rejects oversized bodies with 413 Payload Too Large:
- The `Content-Length` header is checked when present, rejecting the request before the body is read.
- Chunked or otherwise unannounced bodies are read with an explicit size cap, so a body larger than the limit is never buffered.

## Tests
- `should reject oversized request bodies with 413` — a body over the default 4 MiB limit is rejected with 413.
- `should reject request bodies exceeding a custom limit` — a 1024-byte custom limit rejects a padded body with 413.
- All existing streamable HTTP server tests still pass.