### PR TITLE
fix(client): cap and reset server-provided SSE retry delay

### DIFF
--- a/.changeset/server-retry-delay-cap.md
+++ b/.changeset/server-retry-delay-cap.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/client': patch
+---
+
+Cap the server-provided SSE retry delay at `maxReconnectionDelay` and clear it when a new stream is established, so a large or malicious `retry:` value cannot stall reconnects for days.

--- a/packages/client/src/client/streamableHttp.ts
+++ b/packages/client/src/client/streamableHttp.ts
@@ -643,15 +643,17 @@ export class StreamableHTTPClientTransport implements Transport {
      * @returns Time to wait in milliseconds before next reconnection attempt
      */
     private _getNextReconnectionDelay(attempt: number): number {
-        // Use server-provided retry value if available
+        const maxDelay = this._reconnectionOptions.maxReconnectionDelay;
+
+        // Use server-provided retry value if available, but never exceed the
+        // configured maximum reconnection delay.
         if (this._serverRetryMs !== undefined) {
-            return this._serverRetryMs;
+            return Math.min(this._serverRetryMs, maxDelay);
         }
 
         // Fall back to exponential backoff
         const initialDelay = this._reconnectionOptions.initialReconnectionDelay;
         const growFactor = this._reconnectionOptions.reconnectionDelayGrowFactor;
-        const maxDelay = this._reconnectionOptions.maxReconnectionDelay;
 
         // Cap at maximum delay
         return Math.min(initialDelay * Math.pow(growFactor, attempt), maxDelay);
@@ -705,6 +707,11 @@ export class StreamableHTTPClientTransport implements Transport {
     }
 
     private _handleSseStream(stream: ReadableStream<Uint8Array> | null, options: StartSSEOptions, isReconnectable: boolean): void {
+        // A new stream was established: the server-provided retry value from
+        // the previous stream was for that stream's next reconnection only
+        // (WHATWG HTML §9.2.4), so it must not persist across reconnects.
+        this._serverRetryMs = undefined;
+
         if (!stream) {
             // A null body on a per-request stream (or its GET resume) is the
             // same terminal non-resumable outcome as a 405 — fire the

--- a/packages/client/test/client/streamableHttp.test.ts
+++ b/packages/client/test/client/streamableHttp.test.ts
@@ -883,6 +883,53 @@ describe('StreamableHTTPClientTransport', () => {
         expect(getDelay(10)).toBe(5000);
     });
 
+    it('should cap server-provided retry delay at maxReconnectionDelay', () => {
+        transport = new StreamableHTTPClientTransport(new URL('http://localhost:1234/mcp'), {
+            reconnectionOptions: {
+                initialReconnectionDelay: 100,
+                maxReconnectionDelay: 5000,
+                reconnectionDelayGrowFactor: 2,
+                maxRetries: 3
+            }
+        });
+
+        const getDelay = transport['_getNextReconnectionDelay'].bind(transport);
+
+        // A server-provided retry value within the limit is used as-is.
+        transport['_serverRetryMs'] = 1000;
+        expect(getDelay(0)).toBe(1000);
+
+        // A server-provided retry value above the limit is clamped.
+        transport['_serverRetryMs'] = 30_000;
+        expect(getDelay(0)).toBe(5000);
+
+        // An extreme value (e.g. 2^31-1 ms, ~24.8 days) is clamped too.
+        transport['_serverRetryMs'] = 2_147_483_647;
+        expect(getDelay(0)).toBe(5000);
+    });
+
+    it('should clear server-provided retry delay when a new stream is established', () => {
+        transport = new StreamableHTTPClientTransport(new URL('http://localhost:1234/mcp'), {
+            reconnectionOptions: {
+                initialReconnectionDelay: 100,
+                maxReconnectionDelay: 5000,
+                reconnectionDelayGrowFactor: 2,
+                maxRetries: 3
+            }
+        });
+
+        const getDelay = transport['_getNextReconnectionDelay'].bind(transport);
+
+        // Simulate a server sending retry: 600000, then a successful reconnect.
+        transport['_serverRetryMs'] = 600_000;
+        transport['_handleSseStream'](null, {} as StartSSEOptions, false);
+
+        // After the stream is (re)established, the server-provided value no
+        // longer applies; backoff is used again.
+        expect(transport['_serverRetryMs']).toBeUndefined();
+        expect(getDelay(0)).toBe(100);
+    });
+
     it('attempts auth flow on 401 during POST request', async () => {
         const message: JSONRPCMessage = {
             jsonrpc: '2.0',


### PR DESCRIPTION
A server-provided SSE retry value was stored on the transport and returned unconditionally by `_getNextReconnectionDelay`, bypassing the `maxReconnectionDelay` cap. Per WHATWG HTML the retry field applies only to the next reconnection attempt, but the sticky value made every subsequent reconnect wait for the full server-provided interval — a misconfigured or malicious server could stall reconnects for days.

Clamp the server-provided value to `maxReconnectionDelay`, and clear it when a new stream is established so backoff resumes on later reconnects.

## Tests
- `should cap server-provided retry delay at maxReconnectionDelay` — values at/above the cap are clamped (including the 2^31-1 ms extreme).
- `should clear server-provided retry delay when a new stream is established` — backoff resumes after a reconnect.