### PR TITLE
fix(validators): key compiled validators by schema body, not $id

### DIFF
--- a/.changeset/validator-cache-content-key.md
+++ b/.changeset/validator-cache-content-key.md
@@ -1,0 +1,7 @@
+---
+'@modelcontextprotocol/core-internal': patch
+'@modelcontextprotocol/client': patch
+'@modelcontextprotocol/server': patch
+---
+
+Key compiled JSON Schema validators by the schema body instead of `$id`, so two schemas that share an `$id` but describe different shapes validate independently.

--- a/packages/core-internal/src/validators/ajvProvider.ts
+++ b/packages/core-internal/src/validators/ajvProvider.ts
@@ -14,6 +14,7 @@ import type { JsonSchemaType, JsonSchemaValidator, jsonSchemaValidator, JsonSche
 interface AjvLike {
     compile: (schema: unknown) => AjvValidateFunction;
     getSchema: (keyRef: string) => AjvValidateFunction | undefined;
+    removeSchema?: (keyRef: string) => void;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     errorsText: (errors?: any) => string;
 }
@@ -85,6 +86,15 @@ export class AjvJsonSchemaValidator implements jsonSchemaValidator {
     private readonly _userAjv: boolean;
 
     /**
+     * Compiled validators keyed by the serialized schema body. Keying by content
+     * (rather than by `$id`) means two schemas that happen to share an `$id` but
+     * describe different shapes are never cross-wired: `$id` is metadata, not a
+     * cache key, and JSON Schema treats it as a canonical identifier only when
+     * the bodies agree.
+     */
+    private readonly _validatorCache = new Map<string, AjvValidateFunction>();
+
+    /**
      * @param ajv - Optional pre-configured AJV-compatible instance. When supplied, this instance is
      * used for **every** schema regardless of its declared `$schema` (the caller owns dialect
      * choice). When omitted, the provider constructs per-dialect engines (`Ajv2020`, `Ajv2019`,
@@ -130,10 +140,26 @@ export class AjvJsonSchemaValidator implements jsonSchemaValidator {
 
     getValidator<T>(schema: JsonSchemaType): JsonSchemaValidator<T> {
         const engine = this._engineFor(schema);
-        const ajvValidator =
-            '$id' in schema && typeof schema.$id === 'string'
-                ? (engine.getSchema(schema.$id) ?? engine.compile(schema))
-                : engine.compile(schema);
+
+        // Cache by schema body, not by $id: JSON Schema defines $id as a
+        // canonical identifier for a schema, so a validator compiled for one
+        // body must never be reused for a different body that happens to carry
+        // the same $id (e.g. schemas copied from a shared template).
+        const cacheKey = JSON.stringify(schema);
+        let ajvValidator = this._validatorCache.get(cacheKey);
+        if (ajvValidator === undefined) {
+            // ajv registers compiled schemas by $id and refuses to compile a
+            // second schema with the same $id. Drop any previous registration
+            // first so a same-$id different-body schema compiles against its
+            // own body; the cache above still reuses validators for identical
+            // bodies.
+            const schemaId = '$id' in schema && typeof schema.$id === 'string' ? schema.$id : undefined;
+            if (schemaId !== undefined) {
+                engine.removeSchema?.(schemaId);
+            }
+            ajvValidator = engine.compile(schema);
+            this._validatorCache.set(cacheKey, ajvValidator);
+        }
 
         return (input: unknown): JsonSchemaValidatorResult<T> => {
             const valid = ajvValidator(input);

--- a/packages/core-internal/test/validators/validatorCaching.test.ts
+++ b/packages/core-internal/test/validators/validatorCaching.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Validator cache behavior: validators are keyed by the schema body, so two
+ * schemas that share an `$id` but describe different shapes validate
+ * independently instead of silently reusing the first-compiled validator.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { AjvJsonSchemaValidator } from '../../src/validators/ajvProvider';
+import type { JsonSchemaType } from '../../src/validators/types';
+
+describe('AjvJsonSchemaValidator schema caching', () => {
+    it('reuses a compiled validator for the identical schema body', () => {
+        const provider = new AjvJsonSchemaValidator();
+        const schema: JsonSchemaType = {
+            $id: 'https://example.com/shared',
+            type: 'object',
+            properties: { a: { type: 'string' } },
+            required: ['a']
+        };
+
+        const first = provider.getValidator(schema);
+        const second = provider.getValidator({ ...schema });
+
+        expect(first({ a: 'x' }).valid).toBe(true);
+        expect(second({ a: 'x' }).valid).toBe(true);
+        expect(first({}).valid).toBe(false);
+        expect(second({}).valid).toBe(false);
+    });
+
+    it('validates independently for schemas sharing an $id with different bodies', () => {
+        const provider = new AjvJsonSchemaValidator();
+        const schemaA: JsonSchemaType = {
+            $id: 'https://example.com/collision',
+            type: 'object',
+            properties: { a: { type: 'string' } },
+            required: ['a']
+        };
+        const schemaB: JsonSchemaType = {
+            $id: 'https://example.com/collision',
+            type: 'object',
+            properties: { b: { type: 'number' } },
+            required: ['b']
+        };
+
+        const validatorA = provider.getValidator(schemaA);
+        const validatorB = provider.getValidator(schemaB);
+
+        // B's own body validates under B's validator even though A was
+        // compiled first with the same $id.
+        expect(validatorB({ b: 1 }).valid).toBe(true);
+        expect(validatorB({ a: 'x' }).valid).toBe(false);
+
+        // A keeps validating under its own body.
+        expect(validatorA({ a: 'x' }).valid).toBe(true);
+        expect(validatorA({ b: 1 }).valid).toBe(false);
+    });
+
+    it('handles more than two colliding schemas', () => {
+        const provider = new AjvJsonSchemaValidator();
+        const keys = ['a', 'b', 'c'] as const;
+        const schemas: JsonSchemaType[] = keys.map(key => ({
+            $id: 'https://example.com/collision',
+            type: 'object',
+            properties: { [key]: { type: 'string' } },
+            required: [key]
+        }));
+
+        const validators = schemas.map(schema => provider.getValidator(schema));
+
+        keys.forEach((key, index) => {
+            const validator = validators[index]!;
+            const payload: Record<string, string> = { [key]: 'value' };
+            expect(validator(payload).valid).toBe(true);
+            // A payload matching a different schema's required key is rejected.
+            const otherKey = keys[(index + 1) % keys.length]!;
+            expect(validator({ [otherKey]: 'value' }).valid).toBe(false);
+        });
+    });
+});


### PR DESCRIPTION
`getValidator` cached compiled validators by `$id`: the first schema registered under an `$id` was reused for any later schema carrying the same `$id`, even when the bodies were different. Since JSON Schema treats `$id` as a canonical identifier for a schema, a validator compiled for one body is not valid for another body that happens to reuse the `$id` (e.g. schemas copied from a shared template). This silently split the advertised contract (tools/list) from the enforced one (tools/call).

Cache by the serialized schema body instead, so identical schemas still share a validator while same-`$id` different-body schemas compile independently. ajv registers compiled schemas by `$id`, so the previous registration is dropped before compiling a same-`$id` schema.

## Tests
- `reuses a compiled validator for the identical schema body`.
- `validates independently for schemas sharing an $id with different bodies`.
- `handles more than two colliding schemas`.