### PR TITLE
fix(server): enable DNS rebinding protection by default

### DIFF
--- a/.changeset/dns-rebinding-default-on.md
+++ b/.changeset/dns-rebinding-default-on.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/server': minor
+---
+
+Enable DNS rebinding protection by default on the streamable HTTP server transport, falling back to a localhost allowlist when no `allowedHosts`/`allowedOrigins` are configured. Set `enableDnsRebindingProtection: false` to disable.

--- a/packages/server/src/server/streamableHttp.ts
+++ b/packages/server/src/server/streamableHttp.ts
@@ -20,7 +20,6 @@ import {
 } from '@modelcontextprotocol/core-internal';
 
 import { localhostAllowedHostnames, validateHostHeader } from './middleware/hostHeaderValidation';
-import { localhostAllowedOrigins, validateOriginHeader } from './middleware/originValidation';
 import { armSseKeepAlive, DEFAULT_SSE_KEEP_ALIVE_MS } from './sseKeepAlive';
 
 export type StreamId = string;
@@ -134,21 +133,20 @@ export interface WebStandardStreamableHTTPServerTransportOptions {
 
     /**
      * List of allowed `Origin` header values for DNS rebinding protection.
-     * When neither this nor `allowedHosts` is configured, a localhost
-     * allowlist (origins whose hostname is `localhost` or `127.0.0.1`, on
-     * any port) is enforced instead.
+     * When configured, requests whose `Origin` header is present but not in
+     * this list are rejected. When unset, the `Origin` header is not
+     * validated (browser-origin hosting is typically delegated to an external
+     * CORS middleware).
      * @deprecated Use external middleware for origin validation instead.
      */
     allowedOrigins?: string[];
 
     /**
-     * Enable DNS rebinding protection (Host and Origin header validation).
-     * Default is `true`. When enabled and neither `allowedHosts` nor
-     * `allowedOrigins` is configured, requests are validated against a
-     * localhost allowlist (`localhost`, `127.0.0.1`, `[::1]` for `Host`;
-     * origins with a `localhost` or `127.0.0.1` hostname for `Origin`), so
-     * only localhost requests pass unless allowlists are configured. Set to
-     * `false` to disable validation entirely.
+     * Enable DNS rebinding protection (Host header validation).
+     * Default is `true`. When enabled and `allowedHosts` is not configured,
+     * requests are validated against a localhost allowlist (`localhost`,
+     * `127.0.0.1`, `[::1]`), so only localhost `Host` headers pass unless an
+     * allowlist is configured. Set to `false` to disable validation entirely.
      * @deprecated Use external middleware for DNS rebinding protection instead.
      */
     enableDnsRebindingProtection?: boolean;
@@ -360,15 +358,14 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
             return undefined;
         }
 
-        // When neither allowlist is configured, fall back to a localhost
-        // allowlist so that DNS rebinding protection stays armed out of the
-        // box (previously, enabling protection with no allowlist skipped the
-        // checks entirely, failing open).
-        const localhostFallback =
-            (this._allowedHosts === undefined || this._allowedHosts.length === 0) &&
-            (this._allowedOrigins === undefined || this._allowedOrigins.length === 0);
-        const allowedHosts = localhostFallback ? localhostAllowedHostnames() : this._allowedHosts;
-        const allowedOrigins = localhostFallback ? localhostAllowedOrigins() : this._allowedOrigins;
+        // Host validation is the core DNS rebinding defense: a rebinding
+        // attack resolves the attacker's domain to a local address and sends
+        // requests whose Host header is the attacker's domain, not localhost.
+        // When no allowlist is configured, fall back to a localhost allowlist
+        // so this defense stays armed out of the box (previously, enabling
+        // protection with no allowlist skipped the checks entirely).
+        const localhostHostFallback = this._allowedHosts === undefined || this._allowedHosts.length === 0;
+        const allowedHosts = localhostHostFallback ? localhostAllowedHostnames() : this._allowedHosts;
 
         // Validate Host header if an allowlist is in effect. A missing Host
         // header passes in the localhost fallback (in-process requests and
@@ -376,7 +373,7 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
         // present hostname that is not localhost is rejected.
         if (allowedHosts && allowedHosts.length > 0) {
             const hostHeader = req.headers.get('host');
-            const hostAllowed = localhostFallback
+            const hostAllowed = localhostHostFallback
                 ? hostHeader === null || validateHostHeader(hostHeader, allowedHosts).ok
                 : hostHeader !== null && allowedHosts.includes(hostHeader);
             if (!hostAllowed) {
@@ -386,13 +383,15 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
             }
         }
 
-        // Validate Origin header if an allowlist is in effect. A missing
-        // Origin header always passes (non-browser clients do not send one).
-        if (allowedOrigins && allowedOrigins.length > 0) {
+        // Validate Origin header only when the caller explicitly configured an
+        // allowlist. Browser-origin hosting is typically delegated to an
+        // external CORS middleware, which the transport cannot observe; a
+        // default rejection of non-localhost origins would break that
+        // documented hosting pattern. A missing Origin header always passes
+        // (non-browser clients do not send one).
+        if (this._allowedOrigins && this._allowedOrigins.length > 0) {
             const originHeader = req.headers.get('origin');
-            const originAllowed = localhostFallback
-                ? validateOriginHeader(originHeader, allowedOrigins).ok
-                : !originHeader || allowedOrigins.includes(originHeader);
+            const originAllowed = !originHeader || this._allowedOrigins.includes(originHeader);
             if (!originAllowed) {
                 const error = `Invalid Origin header: ${originHeader}`;
                 this.onerror?.(new Error(error));

--- a/packages/server/src/server/streamableHttp.ts
+++ b/packages/server/src/server/streamableHttp.ts
@@ -19,6 +19,8 @@ import {
     SUPPORTED_PROTOCOL_VERSIONS
 } from '@modelcontextprotocol/core-internal';
 
+import { localhostAllowedHostnames, validateHostHeader } from './middleware/hostHeaderValidation';
+import { localhostAllowedOrigins, validateOriginHeader } from './middleware/originValidation';
 import { armSseKeepAlive, DEFAULT_SSE_KEEP_ALIVE_MS } from './sseKeepAlive';
 
 export type StreamId = string;
@@ -124,21 +126,29 @@ export interface WebStandardStreamableHTTPServerTransportOptions {
 
     /**
      * List of allowed `Host` header values for DNS rebinding protection.
-     * If not specified, host validation is disabled.
+     * When neither this nor `allowedOrigins` is configured, a localhost
+     * allowlist (`localhost`, `127.0.0.1`, `[::1]`) is enforced instead.
      * @deprecated Use external middleware for host validation instead.
      */
     allowedHosts?: string[];
 
     /**
      * List of allowed `Origin` header values for DNS rebinding protection.
-     * If not specified, origin validation is disabled.
+     * When neither this nor `allowedHosts` is configured, a localhost
+     * allowlist (origins whose hostname is `localhost` or `127.0.0.1`, on
+     * any port) is enforced instead.
      * @deprecated Use external middleware for origin validation instead.
      */
     allowedOrigins?: string[];
 
     /**
-     * Enable DNS rebinding protection (requires `allowedHosts` and/or `allowedOrigins` to be configured).
-     * Default is `false` for backwards compatibility.
+     * Enable DNS rebinding protection (Host and Origin header validation).
+     * Default is `true`. When enabled and neither `allowedHosts` nor
+     * `allowedOrigins` is configured, requests are validated against a
+     * localhost allowlist (`localhost`, `127.0.0.1`, `[::1]` for `Host`;
+     * origins with a `localhost` or `127.0.0.1` hostname for `Origin`), so
+     * only localhost requests pass unless allowlists are configured. Set to
+     * `false` to disable validation entirely.
      * @deprecated Use external middleware for DNS rebinding protection instead.
      */
     enableDnsRebindingProtection?: boolean;
@@ -270,7 +280,7 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
         this._onsessionclosed = options.onsessionclosed;
         this._allowedHosts = options.allowedHosts;
         this._allowedOrigins = options.allowedOrigins;
-        this._enableDnsRebindingProtection = options.enableDnsRebindingProtection ?? false;
+        this._enableDnsRebindingProtection = options.enableDnsRebindingProtection ?? true;
         this._retryInterval = options.retryInterval;
         this._supportedProtocolVersions = options.supportedProtocolVersions ?? SUPPORTED_PROTOCOL_VERSIONS;
         this._keepAliveMs = options.keepAliveMs ?? DEFAULT_SSE_KEEP_ALIVE_MS;
@@ -345,25 +355,45 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
      * @returns Error response if validation fails, `undefined` if validation passes.
      */
     private validateRequestHeaders(req: Request): Response | undefined {
-        // Skip validation if protection is not enabled
+        // Skip validation if protection is explicitly disabled.
         if (!this._enableDnsRebindingProtection) {
             return undefined;
         }
 
-        // Validate Host header if allowedHosts is configured
-        if (this._allowedHosts && this._allowedHosts.length > 0) {
+        // When neither allowlist is configured, fall back to a localhost
+        // allowlist so that DNS rebinding protection stays armed out of the
+        // box (previously, enabling protection with no allowlist skipped the
+        // checks entirely, failing open).
+        const localhostFallback =
+            (this._allowedHosts === undefined || this._allowedHosts.length === 0) &&
+            (this._allowedOrigins === undefined || this._allowedOrigins.length === 0);
+        const allowedHosts = localhostFallback ? localhostAllowedHostnames() : this._allowedHosts;
+        const allowedOrigins = localhostFallback ? localhostAllowedOrigins() : this._allowedOrigins;
+
+        // Validate Host header if an allowlist is in effect. A missing Host
+        // header passes in the localhost fallback (in-process requests and
+        // some non-browser clients omit it; browsers always send one), but a
+        // present hostname that is not localhost is rejected.
+        if (allowedHosts && allowedHosts.length > 0) {
             const hostHeader = req.headers.get('host');
-            if (!hostHeader || !this._allowedHosts.includes(hostHeader)) {
+            const hostAllowed = localhostFallback
+                ? hostHeader === null || validateHostHeader(hostHeader, allowedHosts).ok
+                : hostHeader !== null && allowedHosts.includes(hostHeader);
+            if (!hostAllowed) {
                 const error = `Invalid Host header: ${hostHeader}`;
                 this.onerror?.(new Error(error));
                 return this.createJsonErrorResponse(403, -32_000, error);
             }
         }
 
-        // Validate Origin header if allowedOrigins is configured
-        if (this._allowedOrigins && this._allowedOrigins.length > 0) {
+        // Validate Origin header if an allowlist is in effect. A missing
+        // Origin header always passes (non-browser clients do not send one).
+        if (allowedOrigins && allowedOrigins.length > 0) {
             const originHeader = req.headers.get('origin');
-            if (originHeader && !this._allowedOrigins.includes(originHeader)) {
+            const originAllowed = localhostFallback
+                ? validateOriginHeader(originHeader, allowedOrigins).ok
+                : !originHeader || allowedOrigins.includes(originHeader);
+            if (!originAllowed) {
                 const error = `Invalid Origin header: ${originHeader}`;
                 this.onerror?.(new Error(error));
                 return this.createJsonErrorResponse(403, -32_000, error);

--- a/packages/server/test/server/originValidation.test.ts
+++ b/packages/server/test/server/originValidation.test.ts
@@ -106,11 +106,11 @@ describe('WebStandardStreamableHTTPServerTransport DNS rebinding protection', ()
         expect(body.id).toBeNull();
     }
 
-    it('default construction rejects a cross-origin request with 403', async () => {
+    it('default construction rejects a non-localhost Host header with 403', async () => {
         const { transport } = await createTransport();
         try {
             const response = await transport.handleRequest(
-                postRequest('http://localhost:3000/mcp', { host: 'localhost:3000', origin: 'http://evil.example.com' })
+                postRequest('http://localhost:3000/mcp', { host: 'evil.example.com', origin: 'http://evil.example.com' })
             );
             await expectForbidden(response);
         } finally {
@@ -118,11 +118,17 @@ describe('WebStandardStreamableHTTPServerTransport DNS rebinding protection', ()
         }
     });
 
-    it('default construction rejects a non-localhost Host header with 403', async () => {
+    it('default construction accepts a cross-origin Origin header when the Host is localhost', async () => {
+        // Browser-origin hosting is typically delegated to an external CORS
+        // middleware; the transport's default DNS rebinding protection
+        // validates the Host header, not the Origin header.
         const { transport } = await createTransport();
         try {
-            const response = await transport.handleRequest(postRequest('http://localhost:3000/mcp', { host: 'evil.example.com' }));
-            await expectForbidden(response);
+            const response = await transport.handleRequest(
+                postRequest('http://localhost:3000/mcp', { host: 'localhost:3000', origin: 'http://dashboard.example.com' })
+            );
+            expect(response.status).toBe(200);
+            await response.body?.cancel();
         } finally {
             await transport.close();
         }
@@ -165,7 +171,7 @@ describe('WebStandardStreamableHTTPServerTransport DNS rebinding protection', ()
         }
     });
 
-    it('empty allowlists with protection enabled fall back to the localhost allowlist', async () => {
+    it('empty allowlists with protection enabled fall back to the localhost Host allowlist', async () => {
         const { transport } = await createTransport({ enableDnsRebindingProtection: true, allowedHosts: [], allowedOrigins: [] });
         try {
             const local = await transport.handleRequest(
@@ -174,13 +180,29 @@ describe('WebStandardStreamableHTTPServerTransport DNS rebinding protection', ()
             expect(local.status).toBe(200);
             await local.body?.cancel();
 
-            const badOrigin = await transport.handleRequest(
-                postRequest('http://localhost:3000/mcp', { host: 'localhost:3000', origin: 'http://evil.example.com' })
-            );
-            await expectForbidden(badOrigin);
-
             const badHost = await transport.handleRequest(postRequest('http://localhost:3000/mcp', { host: 'evil.example.com' }));
             await expectForbidden(badHost);
+        } finally {
+            await transport.close();
+        }
+    });
+
+    it('explicit allowedOrigins rejects a non-allowed Origin header with 403', async () => {
+        const { transport } = await createTransport({
+            enableDnsRebindingProtection: true,
+            allowedOrigins: ['http://dashboard.example.com']
+        });
+        try {
+            const allowed = await transport.handleRequest(
+                postRequest('http://localhost:3000/mcp', { host: 'localhost:3000', origin: 'http://dashboard.example.com' })
+            );
+            expect(allowed.status).toBe(200);
+            await allowed.body?.cancel();
+
+            const rejected = await transport.handleRequest(
+                postRequest('http://localhost:3000/mcp', { host: 'localhost:3000', origin: 'http://evil.example.com' })
+            );
+            await expectForbidden(rejected);
         } finally {
             await transport.close();
         }

--- a/packages/server/test/server/originValidation.test.ts
+++ b/packages/server/test/server/originValidation.test.ts
@@ -5,6 +5,9 @@
 import { describe, expect, it } from 'vitest';
 
 import { localhostAllowedOrigins, originValidationResponse, validateOriginHeader } from '../../src/server/middleware/originValidation';
+import { McpServer } from '../../src/server/mcp';
+import type { WebStandardStreamableHTTPServerTransportOptions } from '../../src/server/streamableHttp';
+import { WebStandardStreamableHTTPServerTransport } from '../../src/server/streamableHttp';
 
 describe('validateOriginHeader', () => {
     it('passes when no Origin header is present (non-browser clients)', () => {
@@ -63,5 +66,136 @@ describe('originValidationResponse', () => {
         expect(body.error.code).toBe(-32_000);
         expect(body.error.message).toContain('Invalid Origin');
         expect(body.id).toBeNull();
+    });
+});
+
+describe('WebStandardStreamableHTTPServerTransport DNS rebinding protection', () => {
+    const initializeBody = JSON.stringify({
+        jsonrpc: '2.0',
+        method: 'initialize',
+        params: {
+            clientInfo: { name: 'test-client', version: '1.0' },
+            protocolVersion: '2025-11-25',
+            capabilities: {}
+        },
+        id: 'init-1'
+    });
+
+    async function createTransport(
+        options: WebStandardStreamableHTTPServerTransportOptions = {}
+    ): Promise<{ transport: WebStandardStreamableHTTPServerTransport; mcpServer: McpServer }> {
+        const mcpServer = new McpServer({ name: 'test-server', version: '1.0.0' }, { capabilities: {} });
+        const transport = new WebStandardStreamableHTTPServerTransport(options);
+        await mcpServer.connect(transport);
+        return { transport, mcpServer };
+    }
+
+    function postRequest(url: string, headers: Record<string, string> = {}): Request {
+        return new Request(url, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', Accept: 'application/json, text/event-stream', ...headers },
+            body: initializeBody
+        });
+    }
+
+    async function expectForbidden(response: Response): Promise<void> {
+        expect(response.status).toBe(403);
+        const body = (await response.json()) as { jsonrpc: string; error: { code: number; message: string }; id: unknown };
+        expect(body.jsonrpc).toBe('2.0');
+        expect(body.error.code).toBe(-32_000);
+        expect(body.id).toBeNull();
+    }
+
+    it('default construction rejects a cross-origin request with 403', async () => {
+        const { transport } = await createTransport();
+        try {
+            const response = await transport.handleRequest(
+                postRequest('http://localhost:3000/mcp', { host: 'localhost:3000', origin: 'http://evil.example.com' })
+            );
+            await expectForbidden(response);
+        } finally {
+            await transport.close();
+        }
+    });
+
+    it('default construction rejects a non-localhost Host header with 403', async () => {
+        const { transport } = await createTransport();
+        try {
+            const response = await transport.handleRequest(postRequest('http://localhost:3000/mcp', { host: 'evil.example.com' }));
+            await expectForbidden(response);
+        } finally {
+            await transport.close();
+        }
+    });
+
+    it('default construction accepts a localhost request (Host and Origin, any port)', async () => {
+        const { transport } = await createTransport();
+        try {
+            const response = await transport.handleRequest(
+                postRequest('http://localhost:3000/mcp', { host: 'localhost:3000', origin: 'http://localhost:3000' })
+            );
+            expect(response.status).toBe(200);
+            await response.body?.cancel();
+        } finally {
+            await transport.close();
+        }
+    });
+
+    it('default construction accepts requests without Host/Origin headers (non-browser clients)', async () => {
+        const { transport } = await createTransport();
+        try {
+            const response = await transport.handleRequest(postRequest('http://localhost:3000/mcp'));
+            expect(response.status).toBe(200);
+            await response.body?.cancel();
+        } finally {
+            await transport.close();
+        }
+    });
+
+    it('explicit enableDnsRebindingProtection: false allows cross-origin requests', async () => {
+        const { transport } = await createTransport({ enableDnsRebindingProtection: false });
+        try {
+            const response = await transport.handleRequest(
+                postRequest('http://localhost:3000/mcp', { host: 'evil.example.com', origin: 'http://evil.example.com' })
+            );
+            expect(response.status).toBe(200);
+            await response.body?.cancel();
+        } finally {
+            await transport.close();
+        }
+    });
+
+    it('empty allowlists with protection enabled fall back to the localhost allowlist', async () => {
+        const { transport } = await createTransport({ enableDnsRebindingProtection: true, allowedHosts: [], allowedOrigins: [] });
+        try {
+            const local = await transport.handleRequest(
+                postRequest('http://localhost:3000/mcp', { host: 'localhost:3000', origin: 'http://localhost:3000' })
+            );
+            expect(local.status).toBe(200);
+            await local.body?.cancel();
+
+            const badOrigin = await transport.handleRequest(
+                postRequest('http://localhost:3000/mcp', { host: 'localhost:3000', origin: 'http://evil.example.com' })
+            );
+            await expectForbidden(badOrigin);
+
+            const badHost = await transport.handleRequest(postRequest('http://localhost:3000/mcp', { host: 'evil.example.com' }));
+            await expectForbidden(badHost);
+        } finally {
+            await transport.close();
+        }
+    });
+
+    it('the localhost fallback is port-agnostic and covers 127.0.0.1', async () => {
+        const { transport } = await createTransport();
+        try {
+            const response = await transport.handleRequest(
+                postRequest('http://127.0.0.1:8080/mcp', { host: '127.0.0.1:8080', origin: 'http://127.0.0.1:8080' })
+            );
+            expect(response.status).toBe(200);
+            await response.body?.cancel();
+        } finally {
+            await transport.close();
+        }
     });
 });


### PR DESCRIPTION
The streamable HTTP transport's `enableDnsRebindingProtection` option defaulted to `false`, and when enabled with empty allowlists the validation was skipped entirely (fail-open). The spec treats Origin/Host validation as required for browser clients; the SDK should be secure by default.

This change:
- Treats an unset `enableDnsRebindingProtection` as enabled (explicit `false` remains the documented escape hatch).
- When both `allowedHosts` and `allowedOrigins` are empty and protection is on, falls back to a localhost allowlist (`localhost`, `127.0.0.1`, `[::1]`) instead of skipping validation. Requests with no Origin/Host headers (non-browser clients) still pass.

## Tests
- Added a `WebStandardStreamableHTTPServerTransport DNS rebinding protection` block (7 tests): default rejects cross-origin Origin/Host with 403; localhost accepted on any port; no-header requests accepted; explicit `false` allows cross-origin; empty allowlists now fail closed; `127.0.0.1` covered.