### PR TITLE
fix(core): surface protocol errors when no onerror handler is set

### DIFF
--- a/.changeset/surface-unhandled-protocol-errors.md
+++ b/.changeset/surface-unhandled-protocol-errors.md
@@ -1,0 +1,17 @@
+---
+'@modelcontextprotocol/core-internal': patch
+'@modelcontextprotocol/client': patch
+'@modelcontextprotocol/server': patch
+---
+
+Report protocol errors on stderr when no `onerror` handler is registered. `_onerror` only
+called the optional handler, and that handler is undefined by default, so in the default
+configuration every error routed through it was dropped.
+
+The case that motivated this is a transport `send()` that fails after a request handler has
+already run: the peer waits for a response that was never sent, nothing explains why, and
+the only signal is the peer's own timeout firing much later.
+
+stderr is used because the stdio transport reserves stdout for protocol messages. Setting
+`onerror` keeps full control of the reporting and suppresses the fallback, so applications
+that already handle errors see no change.

--- a/packages/core-internal/src/shared/protocol.ts
+++ b/packages/core-internal/src/shared/protocol.ts
@@ -856,7 +856,15 @@ export abstract class Protocol<ContextT extends BaseContext> {
     }
 
     private _onerror(error: Error): void {
-        this.onerror?.(error);
+        if (this.onerror) {
+            this.onerror(error);
+            return;
+        }
+
+        // Without a fallback the error is dropped, and a peer waiting on a response that was never
+        // sent only learns about it when its own timeout fires. stderr is used because the stdio
+        // transport reserves stdout for protocol messages.
+        console.error('Unhandled MCP protocol error. Set `onerror` to handle these:', error);
     }
 
     /**

--- a/packages/core-internal/test/shared/protocol.test.ts
+++ b/packages/core-internal/test/shared/protocol.test.ts
@@ -209,6 +209,33 @@ describe('protocol tests', () => {
         expect(onmessageMock).toHaveBeenCalled();
     });
 
+    test('should report protocol errors when no onerror handler is set', async () => {
+        const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+        await protocol.connect(transport);
+
+        const error = new Error('transport failed');
+        transport.onerror!(error);
+
+        expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('Unhandled MCP protocol error'), error);
+
+        consoleErrorSpy.mockRestore();
+    });
+
+    test('should stay quiet when an onerror handler is set', async () => {
+        const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+        const onerrorMock = vi.fn();
+        protocol.onerror = onerrorMock;
+        await protocol.connect(transport);
+
+        const error = new Error('transport failed');
+        transport.onerror!(error);
+
+        expect(onerrorMock).toHaveBeenCalledWith(error);
+        expect(consoleErrorSpy).not.toHaveBeenCalled();
+
+        consoleErrorSpy.mockRestore();
+    });
+
     describe('_meta preservation with onprogress', () => {
         test('should preserve existing _meta when adding progressToken', async () => {
             await protocol.connect(transport);


### PR DESCRIPTION
## Motivation

`_onerror` calls an optional handler and does nothing else:

```ts
private _onerror(error: Error): void {
    this.onerror?.(error);
}
```

`onerror` is undefined by default, so in the default configuration every error routed
through `_onerror` is dropped. When a transport `send()` fails after a request handler has
run, the peer is left waiting for a response that was never sent, and nothing is logged to
explain it, so the only signal is the peer's own timeout firing much later.

That is what #392 reports, and the reason the workaround in the thread
(`server.onerror = err => console.error(err)`) works.

## Description

Fall back to stderr when no handler is registered. The message names `onerror` so the
reader knows how to take over the reporting.

stderr rather than stdout because the stdio transport reserves stdout for protocol
messages, and `toolNameValidation` and `standardSchema` already report diagnostics this
way, so this does not introduce a new pattern.

## Test

Two tests in `packages/core-internal/test/shared/protocol.test.ts`:

- with no handler registered, the error reaches stderr
- with a handler registered, the handler receives the error and nothing is written to stderr

The first fails without this change (`1 failed | 1448 passed`) and passes with it
(`1449 passed`), so it pins the reported behaviour rather than only describing it.

`pnpm typecheck:all` and `pnpm lint:all` pass.

## Links

- Fixes #392
- stdio transport reserves stdout: https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#stdio
