### PR TITLE
fix(core): forward `cause` from the SdkError data slot to Error.cause

### DIFF
--- a/.changeset/sdkerror-forward-cause.md
+++ b/.changeset/sdkerror-forward-cause.md
@@ -1,0 +1,7 @@
+---
+'@modelcontextprotocol/core-internal': patch
+'@modelcontextprotocol/client': patch
+'@modelcontextprotocol/server': patch
+---
+
+Forward `cause` from an `SdkError`'s `data` slot to `Error.cause`. Call sites such as `classifyNetworkError` pass the underlying error as `{ cause }` in the `data` parameter, but the constructor called `super(message)` without options, so `Error.cause` stayed `undefined` and cause-chain walkers (pino's default serializer, Sentry) stopped at the `SdkError` — losing the root network error (`ENOTFOUND` / `ECONNREFUSED` / `ETIMEDOUT` all rendered as "fetch failed"). The full `data` object is still retained on `this.data`, and `SdkHttpError`'s status payload is unaffected. Fixes #2657.

--- a/packages/core-internal/src/errors/sdkErrors.ts
+++ b/packages/core-internal/src/errors/sdkErrors.ts
@@ -149,10 +149,23 @@ export class SdkError extends Error {
         message: string,
         public readonly data?: unknown
     ) {
-        super(message);
+        // If a call site passes an underlying error via the `data` slot as
+        // `{ cause }`, forward it to `Error` so the standard `.cause` chain
+        // stays unbroken — loggers and error trackers (pino, Sentry, …) walk
+        // `.cause` to reach the root cause. The full `data` object is still
+        // retained on `this.data`. See modelcontextprotocol/typescript-sdk#2657.
+        super(message, dataHasCause(data) ? { cause: data.cause } : undefined);
         this.name = 'SdkError';
         stampErrorBrands(this, new.target);
     }
+}
+
+/**
+ * Narrow an {@linkcode SdkError.data | data} value to one that carries a
+ * `cause`, so it can be forwarded to the `Error` constructor's `ErrorOptions`.
+ */
+function dataHasCause(data: unknown): data is { cause: unknown } {
+    return typeof data === 'object' && data !== null && 'cause' in data;
 }
 
 /**

--- a/packages/core-internal/test/errors/sdkErrorCause.test.ts
+++ b/packages/core-internal/test/errors/sdkErrorCause.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { SdkError, SdkErrorCode, SdkHttpError } from '../../src/index';
+
+describe('SdkError cause forwarding (#2657)', () => {
+    it('forwards a `cause` from the data slot to Error.cause', () => {
+        const root = new Error('getaddrinfo ENOTFOUND does-not-resolve.invalid');
+        const error = new SdkError(SdkErrorCode.EraNegotiationFailed, 'Version negotiation probe failed: fetch failed', {
+            cause: root
+        });
+
+        // The standard `.cause` chain must reach the underlying error, so
+        // pino/Sentry-style walkers surface the real failure.
+        expect(error.cause).toBe(root);
+    });
+
+    it('still keeps the full object on `data` (does not move it out)', () => {
+        const root = new Error('boom');
+        const error = new SdkError(SdkErrorCode.EraNegotiationFailed, 'msg', { cause: root, extra: 1 });
+
+        expect(error.cause).toBe(root);
+        expect(error.data).toEqual({ cause: root, extra: 1 });
+    });
+
+    it('leaves cause undefined when data carries none', () => {
+        const error = new SdkError(SdkErrorCode.NotConnected, 'Transport is not connected', {
+            status: 401
+        });
+
+        expect(error.cause).toBeUndefined();
+        expect(error.data).toEqual({ status: 401 });
+    });
+
+    it('leaves cause undefined when there is no data', () => {
+        const error = new SdkError(SdkErrorCode.NotConnected, 'Transport is not connected');
+
+        expect(error.cause).toBeUndefined();
+    });
+
+    it('does not treat an HTTP data payload as a cause', () => {
+        const error = new SdkHttpError(SdkErrorCode.ClientHttpAuthentication, 'Unauthorized', {
+            status: 401,
+            statusText: 'Unauthorized'
+        });
+
+        expect(error.cause).toBeUndefined();
+        expect(error.status).toBe(401);
+    });
+});


### PR DESCRIPTION
Closes #2657

## Problem

`classifyNetworkError` (and other call sites) construct an `SdkError` with the underlying error in the **`data`** slot as `{ cause }`:

```ts
new SdkError(SdkErrorCode.EraNegotiationFailed, `Version negotiation probe failed: ${describeError(error)}`, { cause: error })
```

But `SdkError`'s third parameter is `data`, not `ErrorOptions`, and the constructor called `super(message)` with no options — so `Error.cause` stayed `undefined` and the `{ cause }` object just landed on `this.data`. Anything walking the standard `.cause` chain (pino's default `err` serializer, Sentry's exception linking) stops at the `SdkError`, so the root network error is lost:

```
ENOTFOUND / ECONNREFUSED / ETIMEDOUT  →  all render as just "fetch failed"
```

## Fix

Per the issue's preferred **option 1** (safer, since the mismatch is silent at every call site), `SdkError` now forwards `cause` to `super()` when its `data` carries one, so the chain is unbroken:

```
SdkError: Version negotiation probe failed: fetch failed
  └─ TypeError: fetch failed
       └─ Error: getaddrinfo ENOTFOUND does-not-resolve.invalid
```

- The full `data` object is still retained on `this.data` (backwards compatible — `.data.cause` keeps working).
- `SdkHttpError`'s `{ status, statusText }` payload has no `cause`, so it is unaffected.
- Covers any other call site that hands `{ cause }` to the `data` slot.

## Tests

Added `packages/core-internal/test/errors/sdkErrorCause.test.ts`:
- `cause` from the data slot reaches `Error.cause` (fails on `main` without the fix)
- the full object is still retained on `.data`
- no `cause` / no `data` → `.cause` stays `undefined`
- an `SdkHttpError` status payload is not treated as a cause

`pnpm --filter @modelcontextprotocol/core-internal test` (1452 passing), `typecheck`, and `lint` all clean.