### PR TITLE
fix(core): merge request headers case-insensitively

### DIFF
--- a/.changeset/case-insensitive-request-headers.md
+++ b/.changeset/case-insensitive-request-headers.md
@@ -1,0 +1,6 @@
+---
+'@modelcontextprotocol/core-internal': patch
+'@modelcontextprotocol/client': patch
+---
+
+`createFetchWithInit()` now applies per-request header overrides case-insensitively. Previously, a base `Authorization` header and a request-specific `authorization` header survived as separate object keys and were combined into an invalid comma-separated credential by `Headers`.

--- a/packages/core-internal/src/shared/transport.ts
+++ b/packages/core-internal/src/shared/transport.ts
@@ -20,6 +20,16 @@ export function normalizeHeaders(headers: RequestInit['headers'] | undefined): R
     return { ...(headers as Record<string, string>) };
 }
 
+function mergeHeaders(base: RequestInit['headers'], override: RequestInit['headers']): Record<string, string> {
+    const overrideHeaders = normalizeHeaders(override);
+    const overrideNames = new Set(Object.keys(overrideHeaders).map(name => name.toLowerCase()));
+
+    return {
+        ...Object.fromEntries(Object.entries(normalizeHeaders(base)).filter(([name]) => !overrideNames.has(name.toLowerCase()))),
+        ...overrideHeaders
+    };
+}
+
 /**
  * Creates a fetch function that includes base `RequestInit` options.
  * This ensures requests inherit settings like credentials, mode, headers, etc. from the base init.
@@ -39,7 +49,7 @@ export function createFetchWithInit(baseFetch: FetchLike = fetch, baseInit?: Req
             ...baseInit,
             ...init,
             // Headers need special handling - merge instead of replace
-            headers: init?.headers ? { ...normalizeHeaders(baseInit.headers), ...normalizeHeaders(init.headers) } : baseInit.headers
+            headers: init?.headers ? mergeHeaders(baseInit.headers, init.headers) : baseInit.headers
         };
         return baseFetch(url, mergedInit);
     };

--- a/packages/core-internal/test/shared/transport.test.ts
+++ b/packages/core-internal/test/shared/transport.test.ts
@@ -111,6 +111,21 @@ describe('createFetchWithInit', () => {
         );
     });
 
+    test('call headers override base headers case-insensitively', async () => {
+        const mockFetch: FetchLike = vi.fn();
+        const wrappedFetch = createFetchWithInit(mockFetch, {
+            headers: { Authorization: 'Bearer base-token' }
+        });
+
+        await wrappedFetch('https://example.com', {
+            headers: { authorization: 'Bearer request-token' }
+        });
+
+        const init = vi.mocked(mockFetch).mock.calls[0]![1];
+        const headers = new Headers(init?.headers);
+        expect(headers.get('authorization')).toBe('Bearer request-token');
+    });
+
     test('uses baseInit headers when call init has no headers', async () => {
         const mockFetch: FetchLike = vi.fn();
         const baseInit: RequestInit = {


### PR DESCRIPTION
## Summary

- Merge per-request headers over base `RequestInit` headers case-insensitively.
- Preserve unrelated base headers and the caller's header spelling.
- Add a regression test for differently cased `Authorization` overrides and a patch changeset for the affected packages.

## Root cause

`createFetchWithInit()` merged normalized header objects with object spread. HTTP field names are case-insensitive, but JavaScript object keys are not. A base `Authorization: Bearer base-token` and a per-request `authorization: Bearer request-token` therefore both survived the merge; constructing the final `Headers` combined them into the invalid value `Bearer base-token, Bearer request-token`.

The client Streamable HTTP and legacy SSE transports both use this helper to combine caller-provided `requestInit` with SDK request headers, so request-specific credentials must replace the base header regardless of casing.

## Validation

- Regression test failed before the fix with the combined credential and passes after the fix.
- `@modelcontextprotocol/core-internal`: 69 test files, 1448 tests passed.
- Client auth tests: 259 passed.
- Streamable HTTP custom-header tests: 3 passed.
- SSE custom-header tests: 4 passed.
- Repository pre-push gate passed in full: Build, Typecheck, and Lint.

AI assistance disclosure: OpenAI Codex helped identify the header-merge edge case and prepare the focused implementation and test. The production call paths, behavior, and test results were verified locally.
