### PR TITLE
fix(server): honor `disable()` on resource templates across list, read and completion requests

### DIFF
--- a/.changeset/honor-disable-on-resource-templates.md
+++ b/.changeset/honor-disable-on-resource-templates.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/server': patch
+---
+
+Honor `disable()` on resource templates. `resources/list`, `resources/templates/list`, `resources/read` and `completion/complete` never read the `enabled` flag, so a disabled template stayed listed, readable, and completable.

--- a/packages/server/src/server/mcp.ts
+++ b/packages/server/src/server/mcp.ts
@@ -448,6 +448,7 @@ export class McpServer {
 
             const templateResources: Resource[] = [];
             for (const template of Object.values(this._registeredResourceTemplates)) {
+                if (!template.enabled) continue;
                 if (!template.resourceTemplate.listCallback) {
                     continue;
                 }

--- a/packages/server/src/server/mcp.ts
+++ b/packages/server/src/server/mcp.ts
@@ -467,11 +467,13 @@ export class McpServer {
         });
 
         this.server.setRequestHandler('resources/templates/list', async () => {
-            const resourceTemplates = Object.entries(this._registeredResourceTemplates).map(([name, template]) => ({
-                name,
-                uriTemplate: template.resourceTemplate.uriTemplate.toString(),
-                ...template.metadata
-            }));
+            const resourceTemplates = Object.entries(this._registeredResourceTemplates)
+                .filter(([_, t]) => t.enabled)
+                .map(([name, template]) => ({
+                    name,
+                    uriTemplate: template.resourceTemplate.uriTemplate.toString(),
+                    ...template.metadata
+                }));
 
             return { resourceTemplates };
         });

--- a/packages/server/src/server/mcp.ts
+++ b/packages/server/src/server/mcp.ts
@@ -411,6 +411,10 @@ export class McpServer {
             throw new ProtocolError(ProtocolErrorCode.InvalidParams, `Resource template ${request.params.ref.uri} not found`);
         }
 
+        if (!template.enabled) {
+            throw new ProtocolError(ProtocolErrorCode.InvalidParams, `Resource template ${request.params.ref.uri} disabled`);
+        }
+
         const completer = template.resourceTemplate.completeCallback(request.params.argument.name);
         if (!completer) {
             return EMPTY_COMPLETION_RESULT;

--- a/packages/server/src/server/mcp.ts
+++ b/packages/server/src/server/mcp.ts
@@ -505,6 +505,9 @@ export class McpServer {
             for (const template of Object.values(this._registeredResourceTemplates)) {
                 const variables = template.resourceTemplate.uriTemplate.match(uri.toString());
                 if (variables) {
+                    if (!template.enabled) {
+                        throw new ProtocolError(ProtocolErrorCode.InvalidParams, `Resource template ${uri} disabled`);
+                    }
                     return attachCacheHintFallback(await template.readCallback(uri, variables, ctx), template.cacheHint);
                 }
             }

--- a/test/integration/test/server/mcp.test.ts
+++ b/test/integration/test/server/mcp.test.ts
@@ -2951,6 +2951,53 @@ describe('Zod v4', () => {
         });
 
         /***
+         * Test: ProtocolError for Disabled Resource Template
+         */
+        test('should throw ProtocolError for disabled resource template', async () => {
+            const mcpServer = new McpServer({
+                name: 'test server',
+                version: '1.0'
+            });
+
+            const client = new Client({
+                name: 'test client',
+                version: '1.0'
+            });
+
+            const resourceTemplate = mcpServer.registerResource(
+                'test',
+                new ResourceTemplate('test://resource/{id}', { list: undefined }),
+                {},
+                async uri => ({
+                    contents: [
+                        {
+                            uri: uri.href,
+                            text: 'Template content'
+                        }
+                    ]
+                })
+            );
+
+            resourceTemplate.disable();
+
+            const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+            await Promise.all([client.connect(clientTransport), mcpServer.server.connect(serverTransport)]);
+
+            await expect(
+                client.request({
+                    method: 'resources/read',
+                    params: {
+                        uri: 'test://resource/1'
+                    }
+                })
+            ).rejects.toMatchObject({
+                code: ProtocolErrorCode.InvalidParams,
+                message: expect.stringContaining('disabled')
+            });
+        });
+
+        /***
          * Test: Registering a resource template without a complete callback should not update server capabilities to advertise support for completion
          */
         test('should not advertise support for completion when a resource template without a complete callback is defined', async () => {

--- a/test/integration/test/server/mcp.test.ts
+++ b/test/integration/test/server/mcp.test.ts
@@ -2386,6 +2386,52 @@ describe('Zod v4', () => {
         });
 
         /***
+         * Test: Disabled Resource Templates Are Omitted from resources/templates/list
+         */
+        test('should omit disabled resource templates from resources/templates/list', async () => {
+            const mcpServer = new McpServer({
+                name: 'test server',
+                version: '1.0'
+            });
+            const client = new Client({
+                name: 'test client',
+                version: '1.0'
+            });
+
+            // Register resource template
+            const resourceTemplate = mcpServer.registerResource(
+                'template',
+                new ResourceTemplate('test://resource/{id}', { list: undefined }),
+                {},
+                async uri => ({
+                    contents: [
+                        {
+                            uri: uri.href,
+                            text: 'Template content'
+                        }
+                    ]
+                })
+            );
+
+            const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+            await Promise.all([client.connect(clientTransport), mcpServer.connect(serverTransport)]);
+
+            // Verify template is registered
+            const result = await client.request({ method: 'resources/templates/list' });
+
+            expect(result.resourceTemplates).toHaveLength(1);
+
+            // Disable the template
+            resourceTemplate.disable();
+
+            // Verify the template was disabled
+            const result2 = await client.request({ method: 'resources/templates/list' });
+
+            expect(result2.resourceTemplates).toHaveLength(0);
+        });
+
+        /***
          * Test: Resource Registration with Metadata
          */
         test('should register resource with metadata', async () => {

--- a/test/integration/test/server/mcp.test.ts
+++ b/test/integration/test/server/mcp.test.ts
@@ -2530,6 +2530,52 @@ describe('Zod v4', () => {
         });
 
         /***
+         * Test: Disabled Resources and Resource Templates Are Omitted from resources/list
+         */
+        test('should omit disabled resources and resource template listings from resources/list', async () => {
+            const mcpServer = new McpServer({
+                name: 'test server',
+                version: '1.0'
+            });
+            const client = new Client({
+                name: 'test client',
+                version: '1.0'
+            });
+
+            const disabledResource = mcpServer.registerResource('inactive', 'test://static/inactive', {}, async uri => ({
+                contents: [{ uri: uri.href, text: 'Inactive content' }]
+            }));
+
+            mcpServer.registerResource(
+                'active-template',
+                new ResourceTemplate('test://active/{id}', {
+                    list: async () => ({ resources: [{ name: 'Active 1', uri: 'test://active/1' }] })
+                }),
+                {},
+                async uri => ({ contents: [{ uri: uri.href, text: 'Active template content' }] })
+            );
+            const disabledTemplate = mcpServer.registerResource(
+                'inactive-template',
+                new ResourceTemplate('test://inactive/{id}', {
+                    list: async () => ({ resources: [{ name: 'Inactive 1', uri: 'test://inactive/1' }] })
+                }),
+                {},
+                async uri => ({ contents: [{ uri: uri.href, text: 'Inactive template content' }] })
+            );
+
+            disabledResource.disable();
+            disabledTemplate.disable();
+
+            const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+            await Promise.all([client.connect(clientTransport), mcpServer.server.connect(serverTransport)]);
+
+            const result = await client.request({ method: 'resources/list' });
+
+            expect(result.resources.map(resource => resource.uri)).toEqual(['test://active/1']);
+        });
+
+        /***
          * Test: Template Variables to Read Callback
          */
         test('should pass template variables to readCallback', async () => {

--- a/test/integration/test/server/mcp.test.ts
+++ b/test/integration/test/server/mcp.test.ts
@@ -2998,6 +2998,65 @@ describe('Zod v4', () => {
         });
 
         /***
+         * Test: ProtocolError for Completion on a Disabled Resource Template
+         */
+        test('should throw ProtocolError for completion of a disabled resource template', async () => {
+            const mcpServer = new McpServer({
+                name: 'test server',
+                version: '1.0'
+            });
+
+            const client = new Client({
+                name: 'test client',
+                version: '1.0'
+            });
+
+            const resourceTemplate = mcpServer.registerResource(
+                'test',
+                new ResourceTemplate('test://resource/{category}', {
+                    list: undefined,
+                    complete: {
+                        category: () => ['books', 'movies', 'music']
+                    }
+                }),
+                {},
+                async () => ({
+                    contents: [
+                        {
+                            uri: 'test://resource/test',
+                            text: 'Test content'
+                        }
+                    ]
+                })
+            );
+
+            resourceTemplate.disable();
+
+            const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+            await Promise.all([client.connect(clientTransport), mcpServer.server.connect(serverTransport)]);
+
+            await expect(
+                client.request({
+                    method: 'completion/complete',
+                    params: {
+                        ref: {
+                            type: 'ref/resource',
+                            uri: 'test://resource/{category}'
+                        },
+                        argument: {
+                            name: 'category',
+                            value: ''
+                        }
+                    }
+                })
+            ).rejects.toMatchObject({
+                code: ProtocolErrorCode.InvalidParams,
+                message: expect.stringContaining('disabled')
+            });
+        });
+
+        /***
          * Test: Registering a resource template without a complete callback should not update server capabilities to advertise support for completion
          */
         test('should not advertise support for completion when a resource template without a complete callback is defined', async () => {


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Tools, prompts, resources and resource templates registered on `McpServer` can all be toggled with `enable()`/`disable()`. A disabled one drops out of its list verb and is rejected when invoked.

- #247  added this for all four primitives at once.

**Resource templates are the exception.** `RegisteredResourceTemplate` has the `enabled` field and `disable()` does flip it, but none of these four handlers read it. 

```text
resources/list      : ["demo://users/1"]                                // expected []
templates/list      : ["demo://users/{id}"]                             // expected []
read demo://users/1 : { uri: "demo://users/1", text: "profile of 1" }   // expected a throw
complete {id}       : ["1","2","3"]                                     // expected a throw
```

As a result, a disabled resource template is still exposed in the four responses above.

In order to fix, the missing `enabled` check at all four sites, in two shapes:

* `resources/list` and `resources/templates/list` filter disabled templates out. Nothing was addressed specifically, so there is nobody to report a failure to.
* `resources/read` and `completion/complete` throw `ProtocolError(InvalidParams)`, since the client named a specific resource template.


## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

Four tests in `test/integration/test/server/mcp.test.ts`, one per request path, each committed ahead of its fix so it can be checked red → green.

* `resources/list`: a disabled static resource and a disabled template drop out, the enabled template stays
* `resources/templates/list`: the disabled template's URI pattern is gone
* `resources/read`: a URI matching a disabled template is rejected with `InvalidParams` + `disabled`
* `completion/complete`: a completion aimed at a disabled template is rejected the same way

The first testcase(`resources/list`) also covers the static-resource filtering. That already worked, but it sits in the same handler as the template path, so pinning it down keeps a fix on one side from breaking the other.

* `pnpm --filter @modelcontextprotocol/test-integration exec vitest run test/server/mcp.test.ts`
* `pnpm check:all`

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
No API change. 

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
For `completion/complete` I went with throwing, following the disabled prompt case. The branch below in the same handler returns `EMPTY_COMPLETION_RESULT` for static resources.

If that's the better fit here, I'm happy to change it. Let me know.

```ts
if (!template) {
    if (this._registeredResources[ref.uri]) {
        // Attempting to autocomplete a fixed resource URI is not an error in the spec (but probably should be).
        return EMPTY_COMPLETION_RESULT;
    }

    throw new ProtocolError(ProtocolErrorCode.InvalidParams, `Resource template ${request.params.ref.uri} not found`);
}
```
fixes: #2696