### PR TITLE
fix(exports): resolve .js subpath imports to real declaration files

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,11 @@
             "import": "./dist/esm/experimental/tasks/index.js",
             "require": "./dist/cjs/experimental/tasks/index.js"
         },
+        "./*.js": {
+            "types": "./dist/esm/*.d.ts",
+            "import": "./dist/esm/*.js",
+            "require": "./dist/cjs/*.js"
+        },
         "./*": {
             "types": "./dist/esm/*.d.ts",
             "import": "./dist/esm/*",

--- a/test/issues/test_2701_js_subpath_exports.test.ts
+++ b/test/issues/test_2701_js_subpath_exports.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Regression test for https://github.com/modelcontextprotocol/typescript-sdk/issues/2701
+ *
+ * Subpath imports such as `@modelcontextprotocol/sdk/server/mcp.js` fell through
+ * the `"./*"` export pattern, whose `types` target is `./dist/esm/*.d.ts`. The
+ * wildcard captures the whole remainder including the extension, so the types
+ * path resolved to `dist/esm/server/mcp.js.d.ts` — a file that does not exist
+ * (the real one is `mcp.d.ts`).
+ *
+ * TypeScript happens to paper over this via the `typesVersions` fallback, so the
+ * breakage is invisible to `tsc`. Resolvers that implement `exports` without
+ * `typesVersions` — notably Deno — fail with TS2307, which then cascades into
+ * implicit-any errors on every inferred callback parameter.
+ *
+ * A `"./*.js"` pattern fixes it: Node prefers the more specific pattern, so the
+ * extension is excluded from the wildcard capture.
+ */
+
+import { readFileSync } from 'node:fs';
+import { existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve as resolvePath } from 'node:path';
+
+const repoRoot = resolvePath(dirname(fileURLToPath(import.meta.url)), '../..');
+
+type ConditionMap = Record<string, string>;
+
+const exportsMap: Record<string, ConditionMap> = JSON.parse(readFileSync(resolvePath(repoRoot, 'package.json'), 'utf8')).exports;
+
+/**
+ * Minimal implementation of Node's subpath resolution: exact keys win, then the
+ * pattern with the longest prefix before `*`.
+ */
+function resolveSubpath(subpath: string, condition: keyof ConditionMap): string | undefined {
+    const exact = exportsMap[subpath];
+    if (exact) {
+        return exact[condition];
+    }
+
+    let best: { target: string; prefixLength: number } | undefined;
+    for (const [pattern, conditions] of Object.entries(exportsMap)) {
+        const starIndex = pattern.indexOf('*');
+        if (starIndex === -1) {
+            continue;
+        }
+        const prefix = pattern.slice(0, starIndex);
+        const suffix = pattern.slice(starIndex + 1);
+        if (!subpath.startsWith(prefix) || !subpath.endsWith(suffix)) {
+            continue;
+        }
+        if (best && prefix.length <= best.prefixLength) {
+            continue;
+        }
+        const captured = subpath.slice(prefix.length, subpath.length - suffix.length);
+        best = { target: conditions[condition].replace('*', captured), prefixLength: prefix.length };
+    }
+    return best?.target;
+}
+
+describe('Issue #2701: .js subpath exports resolve to real declaration files', () => {
+    // Representative of the import style used throughout the README and examples.
+    const subpaths = ['./server/mcp.js', './server/stdio.js', './server/streamableHttp.js', './client/streamableHttp.js'];
+
+    test.each(subpaths)('%s resolves types to a .d.ts, not a .js.d.ts', subpath => {
+        const types = resolveSubpath(subpath, 'types');
+        expect(types).toBeDefined();
+        expect(types).not.toMatch(/\.js\.d\.ts$/);
+        expect(types).toBe(`./dist/esm/${subpath.slice('./'.length).replace(/\.js$/, '')}.d.ts`);
+    });
+
+    test.each(subpaths)('%s maps to source that actually exists', subpath => {
+        const sourceFile = resolvePath(repoRoot, 'src', subpath.slice('./'.length).replace(/\.js$/, '.ts'));
+        expect(existsSync(sourceFile)).toBe(true);
+    });
+
+    test.each(subpaths)('%s keeps runtime targets intact', subpath => {
+        const stem = subpath.slice('./'.length);
+        expect(resolveSubpath(subpath, 'import')).toBe(`./dist/esm/${stem}`);
+        expect(resolveSubpath(subpath, 'require')).toBe(`./dist/cjs/${stem}`);
+    });
+
+    test('explicit subpath keys still take precedence over patterns', () => {
+        expect(resolveSubpath('./server', 'types')).toBe('./dist/esm/server/index.d.ts');
+        expect(resolveSubpath('./validation/ajv', 'types')).toBe('./dist/esm/validation/ajv-provider.d.ts');
+    });
+
+    test('extensionless subpaths still resolve through the generic pattern', () => {
+        expect(resolveSubpath('./server/mcp', 'import')).toBe('./dist/esm/server/mcp');
+    });
+});


### PR DESCRIPTION
Fixes #2701.

### Problem

Subpath imports like `@modelcontextprotocol/sdk/server/mcp.js` have no explicit key in `exports`, so they fall through `"./*"`:

```json
"./*": { "types": "./dist/esm/*.d.ts", "import": "./dist/esm/*", "require": "./dist/cjs/*" }
```

The wildcard captures the entire remainder *including the extension*, so `*` = `server/mcp.js` and the types target becomes `dist/esm/server/mcp.js.d.ts` — which does not exist. The real declaration file is `dist/esm/server/mcp.d.ts`.

`tsc` is unaffected because it falls back to `typesVersions` (`"*": ["./dist/esm/*"]`), which resolves the `.js` → `.d.ts` step itself. Resolvers that implement `exports` but not `typesVersions` — notably Deno — fail with `TS2307`.

Because the failure is a *type resolution* failure, it doesn't stop at one error: once `McpServer` is unresolved, every zod-inferred `server.tool(...)` callback parameter collapses to `any`. A server of mine with 3 SDK imports produced 1 × `TS2307` plus 19 × `TS7031`, all from this single root cause.

This affects the import style used throughout the README and examples, so in practice it blocks type-checking any MCP server under Deno, and blocks publishing one to [JSR](https://jsr.io).

### Fix

Add a `"./*.js"` pattern alongside the existing `"./*"`, so the extension is excluded from the wildcard capture:

```json
"./*.js": { "types": "./dist/esm/*.d.ts", "import": "./dist/esm/*.js", "require": "./dist/cjs/*.js" }
```

Node's resolution algorithm prefers the pattern with the longest prefix before `*`, so `"./*.js"` wins for `.js` specifiers regardless of key order, and everything else continues to fall through `"./*"` exactly as before. `typesVersions` is left alone — it already handles this case.

### Verification

Against 1.30.0, before and after:

| | before | after |
|---|---|---|
| `deno check` on `import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"` | `TS2307` | exit 0 |
| `node --input-type=module` importing the same specifier | resolves | resolves |
| `tsc --module nodenext --moduleResolution nodenext --strict` | exit 0 | exit 0 |

So it fixes Deno without changing Node or tsc behaviour.

### Tests

`test/issues/test_2701_js_subpath_exports.test.ts`, following the existing `test/issues/` convention. It resolves subpaths through the real `exports` map from `package.json` and asserts the types target is a genuine `.d.ts`, that runtime targets are unchanged, that explicit keys still take precedence, and that extensionless subpaths still work.

The four types assertions fail without the `package.json` change and pass with it. The runtime-target assertions pass either way, which is the intended demonstration that runtime resolution is untouched.

Full suite on this branch: **10 failed, 1643 passed**. On unmodified `v1.x` on the same machine: **10 failed, 1629 passed** — the same 10 pre-existing failures (they spawn `/usr/bin/tee`, which doesn't exist on NixOS), plus the 14 new passing tests. `npm run lint` and `npm run typecheck` both clean.

Based on `v1.x` per CONTRIBUTING, since this is a v1 packaging fix.
