### PR TITLE
fix(client): put the probe's network failure on Error.cause, not data

### DIFF
--- a/.changeset/probe-network-error-cause.md
+++ b/.changeset/probe-network-error-cause.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/client': patch
+---
+
+Put the version-negotiation probe's underlying network failure on `Error.cause`. `SdkError`'s third constructor parameter is `data`, not `ErrorOptions`, so `classifyNetworkError` passing `{ cause: error }` left `Error.cause` undefined and stranded the failure at `error.data.cause`. Anything walking the standard `.cause` chain — loggers, error reporters, `util.inspect` — stopped at the `SdkError` and never reached the `TypeError: fetch failed`, nor the DNS or socket error beneath it that names the actual problem.

--- a/packages/client/src/client/probeClassifier.ts
+++ b/packages/client/src/client/probeClassifier.ts
@@ -309,12 +309,14 @@ function classifyNetworkError(error: unknown, context: ProbeClassifierContext): 
         // where the probe's 2026 headers could not.
         return { kind: 'legacy' };
     }
-    return {
-        kind: 'error',
-        error: new SdkError(SdkErrorCode.EraNegotiationFailed, `Version negotiation probe failed: ${describeError(error)}`, {
-            cause: error
-        })
-    };
+    // `SdkError`'s third parameter is `data`, not `ErrorOptions` — passing
+    // `{ cause: error }` there strands the underlying network failure at
+    // `error.data.cause`, where nothing walking the standard `.cause` chain
+    // will find it. Set `cause` on the instance instead, matching the
+    // non-enumerable descriptor the `Error` constructor would have produced.
+    const sdkError = new SdkError(SdkErrorCode.EraNegotiationFailed, `Version negotiation probe failed: ${describeError(error)}`);
+    Object.defineProperty(sdkError, 'cause', { value: error, writable: true, configurable: true });
+    return { kind: 'error', error: sdkError };
 }
 
 function isOpaqueFetchTypeError(error: unknown): boolean {

--- a/packages/client/test/client/probeAuthSeam.test.ts
+++ b/packages/client/test/client/probeAuthSeam.test.ts
@@ -283,6 +283,6 @@ describe('stamped-seam fault injection (identity-preserving auth outcomes, never
         expect(out.settled).toBe('rejected');
         expect(out.error).toBeInstanceOf(SdkError);
         expect((out.error as SdkError).code).toBe(SdkErrorCode.EraNegotiationFailed);
-        expect(((out.error as SdkError).data as { cause?: unknown }).cause).toBe(netError);
+        expect((out.error as SdkError).cause).toBe(netError);
     });
 });

--- a/packages/client/test/client/probeClassifier.test.ts
+++ b/packages/client/test/client/probeClassifier.test.ts
@@ -270,6 +270,20 @@ describe('row: network outage → typed connect error (Node)', () => {
         const verdict = classify({ kind: 'network-error', error: new TypeError('fetch failed') }, { environment: 'node' });
         expect(verdict.kind).toBe('error');
     });
+
+    test('the underlying network error is reachable on the standard `.cause` chain', () => {
+        const dnsError = Object.assign(new Error('getaddrinfo ENOTFOUND unreachable.invalid'), { code: 'ENOTFOUND' });
+        const fetchError = new TypeError('fetch failed', { cause: dnsError });
+        const verdict = classify({ kind: 'network-error', error: fetchError });
+        expect(verdict.kind).toBe('error');
+        if (verdict.kind === 'error') {
+            // Walking `.cause` — what every logger and error reporter does —
+            // must reach the error that actually names the failure, rather
+            // than dead-ending on the SdkError.
+            expect(verdict.error.cause).toBe(fetchError);
+            expect((verdict.error.cause as Error).cause).toBe(dnsError);
+        }
+    });
 });
 
 describe('row: timeout — transport-aware verdict', () => {


### PR DESCRIPTION
Fixes #2657.

## The bug

`SdkError`'s third constructor parameter is `data`, not `ErrorOptions`:

```ts
constructor(
    public readonly code: SdkErrorCode,
    message: string,
    public readonly data?: unknown
) {
    super(message);   // no options forwarded
```

So `classifyNetworkError` passing `{ cause: error }` as the third argument
never reached `Error.cause`. The underlying failure was stranded at
`error.data.cause`, where nothing walking the standard `.cause` chain —
loggers, error reporters, `util.inspect` — will find it. Connecting to an
unreachable host surfaced an `SdkError` whose `.cause` was `undefined`, with
the `TypeError: fetch failed` and the DNS error that actually names the
problem both invisible to normal error handling.

## The fix

Set `cause` on the instance with the same non-enumerable descriptor the
`Error` constructor would have produced.

I grepped the repo: `probeClassifier.ts:314` was the **only** site passing
`{ cause }` into an `SdkError` data slot, so this is self-contained.

## One thing worth your call

`test/client/probeAuthSeam.test.ts` had an assertion pinning the old
behaviour:

```ts
expect(((out.error as SdkError).data as { cause?: unknown }).cause).toBe(netError);
```

I updated it to assert `.cause` instead, on the reading that it was codifying
the bug rather than a contract you intend to keep. **If `data.cause` is
load-bearing for downstream consumers, say so and I'll set both** — the
one-line alternative is to keep passing `{ cause: error }` as `data` in
addition to setting the real `cause`. Happy to go either way.

## Verification

- Added a regression test in `probeClassifier.test.ts` asserting the full
  chain resolves (`SdkError` → `TypeError: fetch failed` → `ENOTFOUND`).
  Verified it fails without the source change:
  `AssertionError: expected undefined to be TypeError: fetch failed`
- `packages/client`: **805/805 tests pass**
- `tsc --noEmit`: clean
- `prettier --check`: clean on all touched files

Note: `pnpm lint:all` fails on this branch, but it fails identically on a
clean checkout of `main` — a `sync:snippets` docs drift unrelated to this
change.
