### PR TITLE
Fix streamable HTTP SSE tests for Node v26.7.0+ (Fixes #2661)

### DIFF
--- a/packages/middleware/node/test/streamableHttp.test.ts
+++ b/packages/middleware/node/test/streamableHttp.test.ts
@@ -727,9 +727,22 @@ describe('Zod v4', () => {
 
             const reader = response.body?.getReader();
 
-            // The responses may come in any order or together in one chunk
-            const { value } = await reader!.read();
-            const text = new TextDecoder().decode(value);
+            // Read from the SSE stream until we have both responses or timeout
+            // On Node v26.7.0+, SSE events may arrive in separate chunks, so we need to
+            // keep reading until we have all expected responses or timeout
+            let text = '';
+            const startTime = Date.now();
+            const timeout = 5000; // 5 second timeout
+
+            while (Date.now() - startTime < timeout) {
+                const { value, done } = await reader!.read();
+                if (done) break;
+                text += new TextDecoder().decode(value);
+                // Check if we have both responses
+                if (text.includes('"id":"req-1"') && text.includes('"id":"req-2"')) {
+                    break;
+                }
+            }
 
             // Check that both responses were sent on the same stream
             expect(text).toContain('"id":"req-1"');
@@ -1481,9 +1494,21 @@ describe('Zod v4', () => {
             await mcpServer.server.sendLoggingMessage({ level: 'info', data: 'First notification from MCP server' });
 
             // Read the notification from the SSE stream
+            // On Node v26.7.0+, SSE events may arrive in separate chunks, so we need to
+            // keep reading until we get the expected notification
             const reader = sseResponse.body?.getReader();
-            const { value } = await reader!.read();
-            const text = new TextDecoder().decode(value);
+            let text = '';
+            const startTime = Date.now();
+            const timeout = 5000;
+
+            while (Date.now() - startTime < timeout) {
+                const { value, done } = await reader!.read();
+                if (done) break;
+                text += new TextDecoder().decode(value);
+                if (text.includes('First notification from MCP server')) {
+                    break;
+                }
+            }
 
             // Verify the notification was sent with an event ID
             expect(text).toContain('id: ');
@@ -1515,8 +1540,17 @@ describe('Zod v4', () => {
 
             // Read the replayed notification
             const reconnectReader = reconnectResponse.body?.getReader();
-            const reconnectData = await reconnectReader!.read();
-            const reconnectText = new TextDecoder().decode(reconnectData.value);
+            let reconnectText = '';
+            const reconnectStartTime = Date.now();
+
+            while (Date.now() - reconnectStartTime < 5000) {
+                const { value, done } = await reconnectReader!.read();
+                if (done) break;
+                reconnectText += new TextDecoder().decode(value);
+                if (reconnectText.includes('Second notification from MCP server')) {
+                    break;
+                }
+            }
 
             // Verify we received the second notification that was sent after our stored eventId
             expect(reconnectText).toContain('Second notification from MCP server');


### PR DESCRIPTION
## Summary

This PR fixes the streamable HTTP SSE tests that were failing on Node v26.7.0+.

## Problem

On Node v26.7.0+, the `fetch` API can deliver SSE events in separate chunks rather than delivering multiple SSE events in a single chunk. The existing tests assumed that multiple SSE events would arrive in a single `reader.read()` call, causing them to fail when events were split across multiple chunks.

## Changes

1. **Batch request SSE test** (`should handle batch request messages with SSE stream for responses`): Updated to read from the SSE stream in a loop until all expected responses are received or a timeout occurs.

2. **Notification replay test** (`should store and replay MCP server tool notifications`): Updated both the initial read and the reconnect read to keep reading until the expected notifications are received.

## Testing

- All existing tests pass (99 tests in streamableHttp.test.ts)
- The modified tests now correctly handle SSE events that arrive in separate chunks

## Related Issues

Fixes #2661