### PR TITLE
fix(client): pin output schema for in-flight tool calls (v1.x)

### DIFF
--- a/.changeset/fix-call-tool-schema-generation.md
+++ b/.changeset/fix-call-tool-schema-generation.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/sdk': patch
+---
+
+Validate each `callTool()` result against the output schema cached when the call begins, so a concurrent tool-list refresh cannot apply a newer schema to an in-flight result.

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -724,10 +724,11 @@ export class Client<
             );
         }
 
+        // Capture the validator before dispatch so a concurrent listTools() refresh cannot change
+        // the schema generation used for this in-flight call.
+        const validator = this.getToolOutputValidator(params.name);
         const result = await this.request({ method: 'tools/call', params }, resultSchema, options);
 
-        // Check if the tool has an outputSchema
-        const validator = this.getToolOutputValidator(params.name);
         if (validator) {
             // If tool has outputSchema, it MUST return structuredContent (unless it's an error)
             if (!result.structuredContent && !result.isError) {

--- a/test/client/index.test.ts
+++ b/test/client/index.test.ts
@@ -1779,6 +1779,77 @@ test('should handle partial listChanged capability support', async () => {
 });
 
 describe('outputSchema validation', () => {
+    test('should validate an in-flight call against the output schema active when it started', async () => {
+        const client = new Client(
+            {
+                name: 'test-client',
+                version: '1.0.0'
+            },
+            {
+                capabilities: {}
+            }
+        );
+
+        let catalogGeneration = 'old';
+        let callCount = 0;
+        let releaseFirstCall!: () => void;
+        const firstCallMayReturn = new Promise<void>(resolve => {
+            releaseFirstCall = resolve;
+        });
+
+        vi.spyOn(client, 'request').mockImplementation(async request => {
+            if (request.method === 'tools/list') {
+                return {
+                    tools: [
+                        {
+                            name: 'versioned-tool',
+                            inputSchema: {
+                                type: 'object',
+                                properties: {}
+                            },
+                            outputSchema: {
+                                type: 'object',
+                                properties: {
+                                    generation: { const: catalogGeneration }
+                                },
+                                required: ['generation'],
+                                additionalProperties: false
+                            }
+                        }
+                    ]
+                };
+            }
+
+            if (request.method === 'tools/call') {
+                callCount += 1;
+                const callGeneration = catalogGeneration;
+                if (callCount === 1) {
+                    await firstCallMayReturn;
+                }
+                return {
+                    content: [],
+                    structuredContent: { generation: callGeneration }
+                };
+            }
+
+            throw new Error(`Unexpected request: ${request.method}`);
+        });
+
+        await client.listTools();
+        const firstCall = client.callTool({ name: 'versioned-tool' });
+
+        catalogGeneration = 'new';
+        await client.listTools();
+        releaseFirstCall();
+
+        await expect(firstCall).resolves.toMatchObject({
+            structuredContent: { generation: 'old' }
+        });
+        await expect(client.callTool({ name: 'versioned-tool' })).resolves.toMatchObject({
+            structuredContent: { generation: 'new' }
+        });
+    });
+
     /***
      * Test: Validate structuredContent Against outputSchema
      */


### PR DESCRIPTION
## Summary

- capture a tool's cached output validator before dispatching `tools/call`
- keep an in-flight response tied to the schema generation that was active when the call began
- add a deterministic regression that refreshes the tool catalog while the first call is parked, then verifies the first call uses the old schema and the next call uses the new one
- add a patch changeset for `@modelcontextprotocol/sdk`

## Why this ordering matters

`Client.callTool()` currently checks required-task metadata before sending the request, but reads the output validator only after the response arrives. A concurrent `listTools()` refresh can replace that cache in between, so a valid response may be rejected against a schema that did not exist when the call was dispatched.

The validator is immutable for the lifetime of a call now: it is captured alongside the other dispatch-time metadata, without preventing later calls from using a refreshed catalog.

Fixes #2612.

## Validation

- regression on unmodified v1.30.0: fails with `McpError -32602` against the newer schema
- focused regression after the change: passes
- client suite: 69/69 passed
- `npm run typecheck`
- `npx eslint src/`
- `npx prettier --check .`
- `npx tsc -p tsconfig.prod.json`
- `npx tsc -p tsconfig.cjs.json`

<details>
<summary>Local full-suite note</summary>

On this Windows host (Node 20.9.0), the resource-safe full run completed with 1,612 passing tests and four unrelated integration timeouts in `processCleanup.test.ts` and the Zod v3 half of `taskResumability.test.ts`; Windows stdio teardown also emitted two pipe errors. The installed Vite/Undici dev dependencies warn that this local Node version is below their current supported 20.x patch level. The changed client suite is green, and the upstream Linux CI matrix is the authoritative full-suite result.

</details>