### PR TITLE
docs: NodeStreamableHTTPServerTransport's own examples now show DNS rebinding protection

### DIFF
--- a/packages/middleware/node/src/streamableHttp.examples.ts
+++ b/packages/middleware/node/src/streamableHttp.examples.ts
@@ -9,9 +9,12 @@
 
 import { randomUUID } from 'node:crypto';
 import type { IncomingMessage, ServerResponse } from 'node:http';
+import http from 'node:http';
 
 import { McpServer } from '@modelcontextprotocol/server';
 
+import { localhostHostValidation } from './middleware/hostHeaderValidation';
+import { localhostOriginValidation } from './middleware/originValidation';
 import { NodeStreamableHTTPServerTransport } from './streamableHttp';
 
 /**
@@ -39,6 +42,39 @@ async function NodeStreamableHTTPServerTransport_stateless() {
     });
     //#endregion NodeStreamableHTTPServerTransport_stateless
     return transport;
+}
+
+/**
+ * Example: Unauthenticated Streamable HTTP transport on localhost, with DNS
+ * rebinding protection (CVE-2025-66414 / GHSA-w48q-cv73-mx4w).
+ *
+ * Neither `NodeStreamableHTTPServerTransport` nor a raw `node:http` server
+ * validates the `Host`/`Origin` headers on its own — that guard has to be
+ * wired in explicitly. Without it, a page in the victim's browser can use
+ * DNS rebinding to reach this server and invoke its tools, bypassing the
+ * browser's same-origin checks entirely. This is only needed when the
+ * server has no other authentication; an authenticated server is not
+ * exposed to this attack the same way.
+ */
+async function NodeStreamableHTTPServerTransport_secure() {
+    //#region NodeStreamableHTTPServerTransport_secure
+    const server = new McpServer({ name: 'my-server', version: '1.0.0' });
+
+    const transport = new NodeStreamableHTTPServerTransport({
+        sessionIdGenerator: () => randomUUID()
+    });
+
+    await server.connect(transport);
+
+    const validateHost = localhostHostValidation();
+    const validateOrigin = localhostOriginValidation();
+
+    http.createServer((req, res) => {
+        if (!validateHost(req, res)) return;
+        if (!validateOrigin(req, res)) return;
+        void transport.handleRequest(req, res);
+    });
+    //#endregion NodeStreamableHTTPServerTransport_secure
 }
 
 // Stubs for Express-style app

--- a/packages/middleware/node/src/streamableHttp.ts
+++ b/packages/middleware/node/src/streamableHttp.ts
@@ -45,6 +45,34 @@ export type StreamableHTTPServerTransportOptions = WebStandardStreamableHTTPServ
  * - No Session ID is included in any responses
  * - No session validation is performed
  *
+ * **Security:** this transport does not validate the `Host`/`Origin` headers on its own.
+ * If the server has no other authentication (a common setup for local development), a
+ * malicious website can reach it via DNS rebinding and invoke its tools as the local user
+ * — see CVE-2025-66414 / GHSA-w48q-cv73-mx4w. Apply `localhostHostValidation()` and
+ * `localhostOriginValidation()` (or the underlying `hostHeaderValidation()` /
+ * `originValidation()` for a custom allowlist) as shown below whenever the server isn't
+ * otherwise authenticated.
+ *
+ * @example Unauthenticated localhost setup, with DNS rebinding protection
+ * ```ts source="./streamableHttp.examples.ts#NodeStreamableHTTPServerTransport_secure"
+ * const server = new McpServer({ name: 'my-server', version: '1.0.0' });
+ *
+ * const transport = new NodeStreamableHTTPServerTransport({
+ *     sessionIdGenerator: () => randomUUID()
+ * });
+ *
+ * await server.connect(transport);
+ *
+ * const validateHost = localhostHostValidation();
+ * const validateOrigin = localhostOriginValidation();
+ *
+ * http.createServer((req, res) => {
+ *     if (!validateHost(req, res)) return;
+ *     if (!validateOrigin(req, res)) return;
+ *     void transport.handleRequest(req, res);
+ * });
+ * ```
+ *
  * @example Stateful setup
  * ```ts source="./streamableHttp.examples.ts#NodeStreamableHTTPServerTransport_stateful"
  * const server = new McpServer({ name: 'my-server', version: '1.0.0' });


### PR DESCRIPTION
## What

Adds a new `@example` ("Unauthenticated localhost setup, with DNS rebinding protection") to `NodeStreamableHTTPServerTransport`'s class-level JSDoc, the corresponding `NodeStreamableHTTPServerTransport_secure` function in `streamableHttp.examples.ts`, and a short Security note pointing to CVE-2025-66414 / GHSA-w48q-cv73-mx4w.

## Why

`docs/serving/http.md` already documents this correctly: the framework app factories (`createMcpExpressApp`, `createMcpHonoApp`, `createMcpFastifyApp`) arm `localhostHostValidation`/`localhostOriginValidation` by default, and the guide's own `node:http` section shows wiring them in manually.

But `NodeStreamableHTTPServerTransport`'s own class-level `@example` blocks — what a developer sees on hover in their editor, independent of whether they've read that guide page — currently show three setups (stateful, stateless, Express-with-pre-parsed-body) with no mention of header validation at all. Someone who reaches for this lower-level class directly via IntelliSense, rather than the docs site, has no signal from the class's own documentation that an unauthenticated localhost server needs this guard — the exact gap CVE-2025-66414 was about, just not fully closed at this particular surface yet.

## How

The new example mirrors the existing "Stateful setup" example (same transport construction) plus the exact `node:http` + `localhostHostValidation` + `localhostOriginValidation` composition already shown in `hostHeaderValidation.ts`'s and `originValidation.ts`'s own JSDoc, and in `docs/serving/http.md`'s "Mount it on your runtime" section — no new pattern introduced, just surfaced on the class most directly affected by it.

## Testing

- `pnpm --filter @modelcontextprotocol/node exec tsc --noEmit`: clean
- `pnpm --filter @modelcontextprotocol/node exec eslint`: clean
- `pnpm --filter @modelcontextprotocol/node exec vitest run streamableHttp`: 74 passed
- `pnpm sync:snippets`: ran to regenerate the docs-site snippet mirrors (no content changes to any existing snippet region, since the new example is purely additive)
- Full pre-push hook (build + typecheck + lint across the monorepo): passing

Happy to adjust wording, placement, or fold this into the existing examples differently if you'd shape it another way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)