### PR TITLE
fix(core): enforce maxTotalTimeout without progress notifications

### DIFF
--- a/packages/core-internal/src/shared/protocol.ts
+++ b/packages/core-internal/src/shared/protocol.ts
@@ -743,8 +743,7 @@ export abstract class Protocol<ContextT extends BaseContext> {
     ) {
         // Arm for whichever limit comes first so maxTotalTimeout is a hard
         // ceiling even when no progress notifications arrive (#2695).
-        const initialDelay =
-            maxTotalTimeout === undefined ? timeout : Math.min(timeout, maxTotalTimeout);
+        const initialDelay = maxTotalTimeout === undefined ? timeout : Math.min(timeout, maxTotalTimeout);
         this._timeoutInfo.set(messageId, {
             timeoutId: setTimeout(onTimeout, initialDelay),
             startTime: Date.now(),
@@ -768,10 +767,8 @@ export abstract class Protocol<ContextT extends BaseContext> {
             });
         }
 
-        const remainingBudget =
-            info.maxTotalTimeout === undefined ? undefined : info.maxTotalTimeout - totalElapsed;
-        const nextDelay =
-            remainingBudget === undefined ? info.timeout : Math.min(info.timeout, remainingBudget);
+        const remainingBudget = info.maxTotalTimeout === undefined ? undefined : info.maxTotalTimeout - totalElapsed;
+        const nextDelay = remainingBudget === undefined ? info.timeout : Math.min(info.timeout, remainingBudget);
 
         clearTimeout(info.timeoutId);
         info.timeoutId = setTimeout(info.onTimeout, nextDelay);

--- a/packages/core-internal/src/shared/protocol.ts
+++ b/packages/core-internal/src/shared/protocol.ts
@@ -741,8 +741,12 @@ export abstract class Protocol<ContextT extends BaseContext> {
         onTimeout: () => void,
         resetTimeoutOnProgress: boolean = false
     ) {
+        // Arm for whichever limit comes first so maxTotalTimeout is a hard
+        // ceiling even when no progress notifications arrive (#2695).
+        const initialDelay =
+            maxTotalTimeout === undefined ? timeout : Math.min(timeout, maxTotalTimeout);
         this._timeoutInfo.set(messageId, {
-            timeoutId: setTimeout(onTimeout, timeout),
+            timeoutId: setTimeout(onTimeout, initialDelay),
             startTime: Date.now(),
             timeout,
             maxTotalTimeout,
@@ -764,8 +768,13 @@ export abstract class Protocol<ContextT extends BaseContext> {
             });
         }
 
+        const remainingBudget =
+            info.maxTotalTimeout === undefined ? undefined : info.maxTotalTimeout - totalElapsed;
+        const nextDelay =
+            remainingBudget === undefined ? info.timeout : Math.min(info.timeout, remainingBudget);
+
         clearTimeout(info.timeoutId);
-        info.timeoutId = setTimeout(info.onTimeout, info.timeout);
+        info.timeoutId = setTimeout(info.onTimeout, nextDelay);
         return true;
     }
 
@@ -1564,7 +1573,22 @@ export abstract class Protocol<ContextT extends BaseContext> {
             options?.signal?.addEventListener('abort', onAbort, { once: true });
 
             const timeout = options?.timeout ?? DEFAULT_REQUEST_TIMEOUT_MSEC;
-            const timeoutHandler = () => cancel(new SdkError(SdkErrorCode.RequestTimeout, 'Request timed out', { timeout }));
+            const timeoutHandler = () => {
+                const info = this._timeoutInfo.get(messageId);
+                if (info?.maxTotalTimeout !== undefined) {
+                    const totalElapsed = Date.now() - info.startTime;
+                    if (totalElapsed >= info.maxTotalTimeout) {
+                        cancel(
+                            new SdkError(SdkErrorCode.RequestTimeout, 'Maximum total timeout exceeded', {
+                                maxTotalTimeout: info.maxTotalTimeout,
+                                totalElapsed
+                            })
+                        );
+                        return;
+                    }
+                }
+                cancel(new SdkError(SdkErrorCode.RequestTimeout, 'Request timed out', { timeout }));
+            };
 
             this._setupTimeout(messageId, timeout, options?.maxTotalTimeout, timeoutHandler, options?.resetTimeoutOnProgress ?? false);
 

--- a/packages/core-internal/test/shared/protocol.test.ts
+++ b/packages/core-internal/test/shared/protocol.test.ts
@@ -619,6 +619,68 @@ describe('protocol tests', () => {
         });
     });
 
+    describe('maxTotalTimeout cap enforcement', () => {
+        beforeEach(() => {
+            vi.useFakeTimers();
+        });
+        afterEach(() => {
+            vi.useRealTimers();
+        });
+
+        test('should enforce maxTotalTimeout without progress notifications', async () => {
+            await protocol.connect(transport);
+            const request = { method: 'example', params: {} };
+            const mockSchema: ZodType<{ result: string }> = z.object({
+                result: z.string()
+            });
+            const requestPromise = testRequest(protocol, request, mockSchema, {
+                timeout: 1000,
+                maxTotalTimeout: 150,
+                resetTimeoutOnProgress: false
+            });
+
+            vi.advanceTimersByTime(1001);
+            const error = await requestPromise.catch((caught: unknown) => caught);
+            const cap = (error as SdkError | undefined)?.data as { maxTotalTimeout?: number } | undefined;
+            expect(cap?.maxTotalTimeout ?? -1).toBe(150);
+        });
+
+        test('should re-arm against remaining maxTotalTimeout budget after progress', async () => {
+            await protocol.connect(transport);
+            const request = { method: 'example', params: {} };
+            const mockSchema: ZodType<{ result: string }> = z.object({
+                result: z.string()
+            });
+            const onProgressMock = vi.fn();
+            const requestPromise = testRequest(protocol, request, mockSchema, {
+                timeout: 1000,
+                maxTotalTimeout: 200,
+                resetTimeoutOnProgress: true,
+                onprogress: onProgressMock
+            });
+
+            vi.advanceTimersByTime(50);
+            if (transport.onmessage) {
+                transport.onmessage({
+                    jsonrpc: '2.0',
+                    method: 'notifications/progress',
+                    params: {
+                        progressToken: 0,
+                        progress: 25,
+                        total: 100
+                    }
+                });
+            }
+            await Promise.resolve();
+            expect(onProgressMock).toHaveBeenCalledTimes(1);
+
+            vi.advanceTimersByTime(1001);
+            const error = await requestPromise.catch((caught: unknown) => caught);
+            const cap = (error as SdkError | undefined)?.data as { maxTotalTimeout?: number } | undefined;
+            expect(cap?.maxTotalTimeout ?? -1).toBe(200);
+        });
+    });
+
     describe('Debounced Notifications', () => {
         // We need to flush the microtask queue to test the debouncing logic.
         // This helper function does that.


### PR DESCRIPTION
## Summary

Fixes #2695. `maxTotalTimeout` is documented as a hard ceiling regardless of progress notifications, but `_setupTimeout` only armed the per-request `timeout`. The cap was only consulted in `_resetTimeout`, which runs after progress when `resetTimeoutOnProgress` is true.

## What changed

- Arm the pending timer with `min(timeout, maxTotalTimeout)` in `_setupTimeout`.
- Re-arm against the remaining budget in `_resetTimeout` after progress.
- Distinguish total-budget expiry from per-request timeout in the timeout handler.

## Tests

- `packages/core-internal/test/shared/protocol.test.ts`: fake-timer coverage for the no-progress path and remaining-budget re-arm after progress.

## Verification

```bash
cd packages/core-internal && ./node_modules/.bin/vitest run test/shared/protocol.test.ts -t "without progress notifications|remaining maxTotalTimeout budget"
```
