### PR TITLE
[v1.x] fix(server): read HTTP request bodies with a size limit and bound JSON-RPC batch length

### DIFF
--- a/src/server/express.ts
+++ b/src/server/express.ts
@@ -49,7 +49,6 @@ export function createMcpExpressApp(options: CreateMcpExpressAppOptions = {}): E
     const { host = '127.0.0.1', allowedHosts } = options;
 
     const app = express();
-    app.use(express.json());
 
     // If allowedHosts is explicitly provided, use that for validation
     if (allowedHosts) {
@@ -69,6 +68,10 @@ export function createMcpExpressApp(options: CreateMcpExpressAppOptions = {}): E
             );
         }
     }
+
+    // The JSON body parser runs after the Host header validation, so a request
+    // with a disallowed Host is answered 403 without its body being read.
+    app.use(express.json());
 
     return app;
 }

--- a/src/server/requestBody.ts
+++ b/src/server/requestBody.ts
@@ -1,0 +1,63 @@
+/** Default upper bound, in bytes, on a request body read by the HTTP entry points (4 MiB). */
+export const DEFAULT_MAX_REQUEST_BODY_SIZE = 4 * 1024 * 1024;
+
+/** Upper bound on the number of messages accepted in one JSON-RPC batch array. */
+export const MAX_BATCH_SIZE = 100;
+
+/** The message answered with 413 for a request body over `maxBytes`. */
+export function requestBodyTooLargeMessage(maxBytes: number): string {
+    return `Payload Too Large: Request body must not exceed ${maxBytes} bytes`;
+}
+
+/**
+ * Resolves a `maxRequestBodySize` option to the bound to apply: the default when
+ * omitted, otherwise the value itself, which must be a positive finite number of
+ * bytes (a `RangeError` is thrown at configuration time for anything else).
+ */
+export function resolveMaxRequestBodySize(value: number | undefined): number {
+    if (value === undefined) {
+        return DEFAULT_MAX_REQUEST_BODY_SIZE;
+    }
+    if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+        throw new RangeError(`maxRequestBodySize must be a positive number of bytes, got ${String(value)}`);
+    }
+    return value;
+}
+
+/**
+ * Reads a request body as text, up to `maxBytes` (default
+ * {@linkcode DEFAULT_MAX_REQUEST_BODY_SIZE}). A declared `Content-Length` over the
+ * limit is refused without reading anything; otherwise the read stops as soon as
+ * more than the limit has arrived. Stream failures propagate.
+ */
+export async function readRequestBody(
+    request: Request,
+    maxBytes: number = DEFAULT_MAX_REQUEST_BODY_SIZE
+): Promise<{ tooLarge: true } | { tooLarge: false; text: string }> {
+    if (Number(request.headers.get('content-length')) > maxBytes) {
+        return { tooLarge: true };
+    }
+    if (request.body === null) {
+        return { tooLarge: false, text: '' };
+    }
+    const reader = request.body.getReader();
+    const decoder = new TextDecoder();
+    let received = 0;
+    let text = '';
+    try {
+        for (;;) {
+            const { done, value } = await reader.read();
+            if (done) {
+                break;
+            }
+            received += value.byteLength;
+            if (received > maxBytes) {
+                return { tooLarge: true };
+            }
+            text += decoder.decode(value, { stream: true });
+        }
+    } finally {
+        reader.releaseLock();
+    }
+    return { tooLarge: false, text: text + decoder.decode() };
+}

--- a/src/server/webStandardStreamableHttp.ts
+++ b/src/server/webStandardStreamableHttp.ts
@@ -10,6 +10,7 @@
 import { isJsonContentType } from '../shared/mediaType.js';
 import { Transport } from '../shared/transport.js';
 import { AuthInfo } from './auth/types.js';
+import { MAX_BATCH_SIZE, readRequestBody, requestBodyTooLargeMessage, resolveMaxRequestBodySize } from './requestBody.js';
 import { armSseKeepAlive, DEFAULT_SSE_KEEP_ALIVE_MS } from './sseKeepAlive.js';
 import {
     MessageExtraInfo,
@@ -159,6 +160,15 @@ export interface WebStandardStreamableHTTPServerTransportOptions {
      * Defaults to `15000`; values below 1 (including `0`) disable keep-alive.
      */
     keepAliveMs?: number;
+
+    /**
+     * Upper bound, in bytes, on a POST body the transport reads itself. A body
+     * over the bound (declared `Content-Length`, or observed while streaming)
+     * is answered `413` before anything is parsed. Not applied when the caller
+     * supplies `parsedBody`. Must be a positive number.
+     * @default 4194304 (4 MiB)
+     */
+    maxRequestBodySize?: number;
 }
 
 /**
@@ -166,7 +176,7 @@ export interface WebStandardStreamableHTTPServerTransportOptions {
  */
 export interface HandleRequestOptions {
     /**
-     * Pre-parsed request body. If provided, the transport will use this instead of parsing req.json().
+     * Pre-parsed request body. If provided, the transport will use this instead of reading and parsing the request body.
      * Useful when using body-parser middleware that has already parsed the body.
      */
     parsedBody?: unknown;
@@ -245,6 +255,7 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
     private _enableDnsRebindingProtection: boolean;
     private _retryInterval?: number;
     private _keepAliveMs: number;
+    private _maxRequestBodySize: number;
     private _closed = false;
 
     sessionId?: string;
@@ -263,6 +274,7 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
         this._enableDnsRebindingProtection = options.enableDnsRebindingProtection ?? false;
         this._retryInterval = options.retryInterval;
         this._keepAliveMs = options.keepAliveMs ?? DEFAULT_SSE_KEEP_ALIVE_MS;
+        this._maxRequestBodySize = resolveMaxRequestBodySize(options.maxRequestBodySize);
     }
 
     /**
@@ -735,11 +747,21 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
                 rawMessage = options.parsedBody;
             } else {
                 try {
-                    rawMessage = await req.json();
+                    const body = await readRequestBody(req, this._maxRequestBodySize);
+                    if (body.tooLarge) {
+                        const message = requestBodyTooLargeMessage(this._maxRequestBodySize);
+                        this.onerror?.(new Error(message));
+                        return this.createJsonErrorResponse(413, -32000, message);
+                    }
+                    rawMessage = JSON.parse(body.text);
                 } catch {
                     this.onerror?.(new Error('Parse error: Invalid JSON'));
                     return this.createJsonErrorResponse(400, -32700, 'Parse error: Invalid JSON');
                 }
+            }
+            if (Array.isArray(rawMessage) && rawMessage.length > MAX_BATCH_SIZE) {
+                this.onerror?.(new Error(`Invalid Request: Batch must not exceed ${MAX_BATCH_SIZE} messages`));
+                return this.createJsonErrorResponse(400, -32600, `Invalid Request: Batch must not exceed ${MAX_BATCH_SIZE} messages`);
             }
 
             let messages: JSONRPCMessage[];

--- a/test/server/index.test.ts
+++ b/test/server/index.test.ts
@@ -2062,6 +2062,35 @@ describe('createMcpExpressApp', () => {
         expect(app).toBeDefined();
     });
 
+    test('validates the Host header before the JSON body parser runs', async () => {
+        const app = createMcpExpressApp();
+        app.post('/mcp', (req, res) => {
+            res.json({ parsed: req.body });
+        });
+
+        const disallowedHost = await supertest(app)
+            .post('/mcp')
+            .set('Host', 'evil.example.com')
+            .set('Content-Type', 'application/json')
+            .send('{not json');
+        expect(disallowedHost.status).toBe(403);
+
+        const invalidJson = await supertest(app)
+            .post('/mcp')
+            .set('Host', 'localhost:3000')
+            .set('Content-Type', 'application/json')
+            .send('{not json');
+        expect(invalidJson.status).toBe(400);
+
+        const allowed = await supertest(app)
+            .post('/mcp')
+            .set('Host', 'localhost:3000')
+            .set('Content-Type', 'application/json')
+            .send({ ok: true });
+        expect(allowed.status).toBe(200);
+        expect(allowed.body).toEqual({ parsed: { ok: true } });
+    });
+
     test('should parse JSON bodies', async () => {
         const app = createMcpExpressApp({ host: '0.0.0.0' }); // Disable host validation for this test
         app.post('/test', (req, res) => {

--- a/test/server/streamableHttp.test.ts
+++ b/test/server/streamableHttp.test.ts
@@ -4324,3 +4324,112 @@ describe('WebStandardStreamableHTTPServerTransport SSE keep-alive lifecycle', ()
         expect(oncloseCalls).toBe(1);
     });
 });
+
+describe('WebStandardStreamableHTTPServerTransport request body limits', () => {
+    /** A fresh stateless transport per request (a stateless transport serves one request). */
+    function stateless(maxRequestBodySize?: number): WebStandardStreamableHTTPServerTransport {
+        return new WebStandardStreamableHTTPServerTransport({ sessionIdGenerator: undefined, maxRequestBodySize });
+    }
+
+    function post(body: unknown, headers: Record<string, string> = {}): Request {
+        return new Request('http://localhost/mcp', {
+            method: 'POST',
+            headers: { Accept: 'application/json, text/event-stream', 'Content-Type': 'application/json', ...headers },
+            body: JSON.stringify(body)
+        });
+    }
+
+    /** A POST whose body yields up to `chunks` 1 MiB chunks on demand, counting pulls. */
+    function streamedPost(chunks: number, headers: Record<string, string> = {}): { request: Request; pulls: () => number } {
+        let pulled = 0;
+        const body = new ReadableStream<Uint8Array>(
+            {
+                pull(controller) {
+                    if (pulled >= chunks) {
+                        return controller.close();
+                    }
+                    pulled++;
+                    controller.enqueue(new Uint8Array(1024 * 1024).fill(32));
+                }
+            },
+            { highWaterMark: 0 }
+        );
+        const request = new Request('http://localhost/mcp', {
+            method: 'POST',
+            headers: { Accept: 'application/json, text/event-stream', 'Content-Type': 'application/json', ...headers },
+            body,
+            duplex: 'half'
+        } as RequestInit);
+        return { request, pulls: () => pulled };
+    }
+
+    it('answers 413 when Content-Length exceeds the body size limit without reading the body', async () => {
+        const { request, pulls } = streamedPost(1, { 'Content-Length': String(4 * 1024 * 1024 + 1) });
+        const response = await stateless().handleRequest(request);
+        expect(response.status).toBe(413);
+        expectErrorResponse(await response.json(), -32000, /Payload Too Large/);
+        expect(pulls()).toBe(0);
+    });
+
+    it('answers 413 once a streamed body without Content-Length exceeds the limit', async () => {
+        const { request, pulls } = streamedPost(8);
+        const response = await stateless().handleRequest(request);
+        expect(response.status).toBe(413);
+        expect(pulls()).toBeLessThan(8);
+    });
+
+    it('maxRequestBodySize sets the bound on both read paths and is validated at construction', async () => {
+        const declared = await stateless(1024).handleRequest(streamedPost(1, { 'Content-Length': '1025' }).request);
+        expect(declared.status).toBe(413);
+        expectErrorResponse(await declared.json(), -32000, /must not exceed 1024 bytes/);
+        const streamed = streamedPost(2);
+        const overLimit = await stateless(1024).handleRequest(streamed.request);
+        expect(overLimit.status).toBe(413);
+        expect(streamed.pulls()).toBe(1);
+
+        const roomy = stateless(8 * 1024 * 1024);
+        const onmessage = vi.fn();
+        roomy.onmessage = onmessage;
+        const padded: JSONRPCMessage = {
+            jsonrpc: '2.0',
+            method: 'notifications/initialized',
+            params: { pad: 'x'.repeat(5 * 1024 * 1024) }
+        };
+        const accepted = await roomy.handleRequest(post(padded));
+        expect(accepted.status).toBe(202);
+        expect(onmessage).toHaveBeenCalledTimes(1);
+
+        for (const invalid of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+            expect(() => stateless(invalid)).toThrow(RangeError);
+        }
+    });
+
+    it('answers 400 for a JSON-RPC batch longer than 100 messages and dispatches none of it', async () => {
+        const batch = Array.from({ length: 101 }, (_, i): JSONRPCMessage => ({ jsonrpc: '2.0', method: 'ping', id: i }));
+        const onmessage = vi.fn();
+        const [reading, preParsing] = [stateless(), stateless()];
+        reading.onmessage = preParsing.onmessage = onmessage;
+        const read = await reading.handleRequest(post(batch));
+        const preParsed = await preParsing.handleRequest(post(batch), { parsedBody: batch });
+        for (const response of [read, preParsed]) {
+            expect(response.status).toBe(400);
+            expectErrorResponse(await response.json(), -32600, /Batch must not exceed 100 messages/);
+        }
+        expect(onmessage).not.toHaveBeenCalled();
+    });
+
+    it('StreamableHTTPServerTransport applies maxRequestBodySize to the Node request body', async () => {
+        const nodeTransport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined, maxRequestBodySize: 1024 });
+        const server = createServer((req, res) => void nodeTransport.handleRequest(req, res));
+        const baseUrl = await listenOnRandomPort(server);
+        try {
+            const padded = { jsonrpc: '2.0', method: 'notifications/initialized', params: { pad: 'x'.repeat(2048) } } as JSONRPCMessage;
+            const response = await sendPostRequest(baseUrl, padded);
+            expect(response.status).toBe(413);
+            expectErrorResponse(await response.json(), -32000, /must not exceed 1024 bytes/);
+        } finally {
+            await nodeTransport.close();
+            server.close();
+        }
+    });
+});


### PR DESCRIPTION

v1.x backport of #2698.

`WebStandardStreamableHTTPServerTransport` (and `StreamableHTTPServerTransport`, which wraps it) read the whole POST body into memory with `req.json()` before doing anything with it, and accepted a JSON-RPC batch array of any length. It now reads with a 4 MiB limit by default and answers `413` past that, and caps batch arrays at 100 messages (`400` / `-32600`).

## Motivation and Context

Same as #2698: the other body reads on this line already have a ceiling (`createMcpExpressApp` via `express.json()`, the SSE transport via `raw-body` at `'4mb'`, stdio via `maxBufferSize`); the web-standard transport was the exception.

- A declared `Content-Length` over the limit is refused without reading; otherwise reading stops as soon as the limit is crossed, so chunked bodies are covered too. Unchanged when a pre-parsed body is passed as `parsedBody` (e.g. `req.body` behind `express.json()`), which remains the way to opt out of the SDK's read entirely.
- The limit is configurable with `maxRequestBodySize` (bytes, default `DEFAULT_MAX_REQUEST_BODY_SIZE` = 4 MiB) on the transport options; a non-positive or non-finite value throws a `RangeError` at construction.
- A batch array longer than 100 is answered `400` before any element is parsed, on both the read path and a supplied `parsedBody`.
- `createMcpExpressApp` now installs `express.json()` after the Host header validation, so a request from a disallowed Host is answered `403` without its body being read.

## Differences from #2698

- 1.x has a single body read site: there is no `createMcpHandler`, `toNodeHandler` or Hono adapter on this line, so only the transport and `createMcpExpressApp` change. `StreamableHTTPServerTransportOptions` is an alias of the web-standard options, so the Node wrapper takes `maxRequestBodySize` with no code change (one test pins it).
- The helper module is `src/server/requestBody.ts`, identical to main's and importable as `@modelcontextprotocol/sdk/server/requestBody.js` through the existing `./*` export; `DEFAULT_MAX_REQUEST_BODY_SIZE` and `readRequestBody` are the supported names.
- `createMcpExpressApp` on 1.x has no Origin validation or `jsonLimit`, so the moved line is `express.json()` after the Host header validation only.
- The transport's existing `catch {}` at the read site is kept, so a body read failure is still reported to `onerror` as "Parse error: Invalid JSON" on this line (main forwards the underlying error); the HTTP response is the same.
- No changeset (not used on 1.x) and no version bump.

## How Has This Been Tested?

New tests mirroring #2698's transport tests (declared and streamed over-limit bodies → `413` without the stream being pulled further; `maxRequestBodySize` applied on both read paths and validated at construction; 101-message batch → `400` with nothing dispatched, read path and `parsedBody`), one through `StreamableHTTPServerTransport` over `node:http` to pin that the wrapper honours the option, and the Express ordering test. Each fails on `v1.x` before the change. `npm run check`, `npm test` pass.

## Breaking Changes

None to the API (one new optional transport option, one new module). Behavioural: POST bodies over 4 MiB get `413` when the transport reads the body itself; batch arrays over 100 entries get `400` (including via `parsedBody`); `createMcpExpressApp` answers a disallowed Host with an invalid JSON body `403` rather than `400`.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

<sub>[AI Disclaimer](https://gist.github.com/maxisbey/6123d132484e4c533eab519a2800693d)</sub>
