### PR TITLE
docs(subscriptions): fix client HTTP URL to point at /mcp endpoint

### DIFF
--- a/examples/subscriptions/README.md
+++ b/examples/subscriptions/README.md
@@ -12,5 +12,5 @@ pnpm tsx examples/subscriptions/client.ts
 
 # Streamable HTTP (two terminals):
 pnpm tsx examples/subscriptions/server.ts --http --port 3000
-pnpm tsx examples/subscriptions/client.ts --http http://127.0.0.1:3000/
+pnpm tsx examples/subscriptions/client.ts --http http://127.0.0.1:3000/mcp
 ```


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
The Streamable HTTP instructions in `examples/subscriptions/README.md` pointed at the wrong endpoint. The example server (`examples/subscriptions/server.ts`) mounts the MCP handler at `/mcp` (`app.all('/mcp', ...)`), but the README instructed users to connect the client to `http://127.0.0.1:3000/`. Following the docs as written, the client would hit the root path instead of the MCP endpoint and the example would fail to connect.
## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
