### PR TITLE
fix(client): follow repeated opaque cursors

### DIFF
--- a/.changeset/follow-opaque-cursors.md
+++ b/.changeset/follow-opaque-cursors.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/client': patch
+---
+
+Follow repeated opaque cursors during automatic list pagination until the configured `listMaxPages` limit or server termination, instead of silently truncating results based on cursor values.

--- a/packages/client/src/client/client.ts
+++ b/packages/client/src/client/client.ts
@@ -1698,8 +1698,9 @@ export class Client extends Protocol<ClientContext> {
      * methods' no-`cursor` auto-aggregate path. Page 1's result object is
      * mutated in place (its items array is extended; `nextCursor` is
      * cleared); page-1 metadata (`ttlMs`, `cacheScope`, `_meta`) is preserved.
-     * A `nextCursor` that repeats stops the walk (defence against a
-     * non-converging server, mcp.d's `drainList` guard);
+     * The walk is bounded by `listMaxPages`, which prevents a non-converging
+     * server from keeping the aggregate request open without interpreting
+     * opaque cursor values.
      * {@linkcode ClientOptions.listMaxPages} is a hard cap — hitting it
      * throws, so a partial aggregate is never cached. The
      * captured-generation guard skips the write when a `list_changed` landed
@@ -1732,9 +1733,8 @@ export class Client extends Protocol<ClientContext> {
         const generation = this._cache.captureGeneration(method);
         const acc = (await this.request({ method, ...(baseParams && { params: { ...baseParams } }) }, options)) as R;
         let cursor = acc.nextCursor;
-        const seen = new Set<string>();
         let pages = 1;
-        while (cursor !== undefined && !seen.has(cursor)) {
+        while (cursor !== undefined) {
             if (this._listMaxPages !== 0 && pages >= this._listMaxPages) {
                 throw new SdkError(
                     SdkErrorCode.ListPaginationExceeded,
@@ -1742,7 +1742,6 @@ export class Client extends Protocol<ClientContext> {
                     { method, listMaxPages: this._listMaxPages }
                 );
             }
-            seen.add(cursor);
             const page = (await this.request({ method, params: { ...baseParams, cursor } }, options)) as R;
             append(acc, page);
             cursor = page.nextCursor;

--- a/packages/client/test/client/responseCache.test.ts
+++ b/packages/client/test/client/responseCache.test.ts
@@ -357,9 +357,12 @@ async function scriptedModernServer(pages: Tool[][], opts: ScriptOptions = {}): 
             // Cursor values are opaque: advance the scripted page by request
             // order instead of interpreting the cursor as a page number.
             const idx = cursor === undefined ? (pageIndex = 0) : ++pageIndex;
-            const next = opts.nextCursors && lists - 1 < opts.nextCursors.length
-                ? opts.nextCursors[lists - 1]
-                : idx + 1 < pages.length ? String(idx + 1) : undefined;
+            const next =
+                opts.nextCursors && lists - 1 < opts.nextCursors.length
+                    ? opts.nextCursors[lists - 1]
+                    : idx + 1 < pages.length
+                      ? String(idx + 1)
+                      : undefined;
             void serverTx.send({
                 jsonrpc: '2.0',
                 id: r.id,
@@ -443,10 +446,9 @@ describe('Client response-cache substrate', () => {
     });
 
     it('listTools() follows repeated opaque cursors until the page limit or server termination', async () => {
-        const { clientTx, listParams } = await scriptedModernServer(
-            [[TOOL_A], [TOOL_B], [TOOL_A]],
-            { nextCursors: ['same', 'same', undefined] }
-        );
+        const { clientTx, listParams } = await scriptedModernServer([[TOOL_A], [TOOL_B], [TOOL_A]], {
+            nextCursors: ['same', 'same', undefined]
+        });
         const client = modernClient();
         await client.connect(clientTx);
 

--- a/packages/client/test/client/responseCache.test.ts
+++ b/packages/client/test/client/responseCache.test.ts
@@ -326,6 +326,7 @@ interface ScriptOptions {
     listHint?: { ttlMs?: number; cacheScope?: 'public' | 'private' };
     readHint?: { ttlMs?: number; cacheScope?: 'public' | 'private' };
     serverInfo?: { name: string; version: string };
+    nextCursors?: (string | undefined)[];
 }
 
 async function scriptedModernServer(pages: Tool[][], opts: ScriptOptions = {}): Promise<Scripted> {
@@ -353,7 +354,9 @@ async function scriptedModernServer(pages: Tool[][], opts: ScriptOptions = {}): 
             params.push(r.params as { cursor?: string; _meta?: unknown } | undefined);
             const cursor = (r.params as { cursor?: string } | undefined)?.cursor;
             const idx = cursor === undefined ? 0 : Number(cursor);
-            const next = idx + 1 < pages.length ? String(idx + 1) : undefined;
+            const next = opts.nextCursors && lists - 1 < opts.nextCursors.length
+                ? opts.nextCursors[lists - 1]
+                : idx + 1 < pages.length ? String(idx + 1) : undefined;
             void serverTx.send({
                 jsonrpc: '2.0',
                 id: r.id,
@@ -434,6 +437,19 @@ describe('Client response-cache substrate', () => {
 
         const entry = store.get({ method: 'tools/list', partition: part() });
         expect((JSON.parse(entry!.value) as { tools: Tool[] }).tools.map(t => t.name)).toEqual(['a', 'b']);
+    });
+
+    it('listTools() follows repeated opaque cursors until the page limit or server termination', async () => {
+        const { clientTx, listParams } = await scriptedModernServer(
+            [[TOOL_A], [TOOL_B], [TOOL_A]],
+            { nextCursors: ['same', 'same', undefined] }
+        );
+        const client = modernClient();
+        await client.connect(clientTx);
+
+        const { tools } = await client.listTools();
+        expect(tools.map(t => t.name)).toEqual(['a', 'b', 'a']);
+        expect(listParams().map(p => p?.cursor)).toEqual([undefined, 'same', 'same']);
     });
 
     it('the auto-aggregate path threads caller params (e.g. _meta trace context) into every page request', async () => {

--- a/packages/client/test/client/responseCache.test.ts
+++ b/packages/client/test/client/responseCache.test.ts
@@ -332,6 +332,7 @@ interface ScriptOptions {
 async function scriptedModernServer(pages: Tool[][], opts: ScriptOptions = {}): Promise<Scripted> {
     const [clientTx, serverTx] = InMemoryTransport.createLinkedPair();
     let lists = 0;
+    let pageIndex = 0;
     const wireCounts = new Map<string, number>();
     const params: ({ cursor?: string; _meta?: unknown } | undefined)[] = [];
     serverTx.onmessage = m => {
@@ -353,7 +354,9 @@ async function scriptedModernServer(pages: Tool[][], opts: ScriptOptions = {}): 
             lists++;
             params.push(r.params as { cursor?: string; _meta?: unknown } | undefined);
             const cursor = (r.params as { cursor?: string } | undefined)?.cursor;
-            const idx = cursor === undefined ? 0 : Number(cursor);
+            // Cursor values are opaque: advance the scripted page by request
+            // order instead of interpreting the cursor as a page number.
+            const idx = cursor === undefined ? (pageIndex = 0) : ++pageIndex;
             const next = opts.nextCursors && lists - 1 < opts.nextCursors.length
                 ? opts.nextCursors[lists - 1]
                 : idx + 1 < pages.length ? String(idx + 1) : undefined;


### PR DESCRIPTION
Fixes #2735

## Background

The automatic list pagination path treated repeated cursor values as a reason to stop. MCP cursors are opaque, so a conforming server may return the same cursor for multiple pages. Stopping on repetition silently returned an incomplete list.

## Changes

- Remove cursor-value deduplication from `Client._listAllPages`.
- Continue requesting pages until the server omits `nextCursor`.
- Retain the existing `listMaxPages` hard cap so non-terminating pagination still fails with `ListPaginationExceeded`.
- Add a regression test covering repeated cursors and a patch changeset for `@modelcontextprotocol/client`.

## Compatibility

This preserves the public pagination API and follows opaque cursor semantics. Servers that do not terminate pagination remain bounded by `listMaxPages`; only the prior silent truncation behavior changes.

## Verification

- `pnpm install --frozen-lockfile` — blocked by Windows `EPERM` while copying files from the pnpm store into `node_modules`.
- `pnpm install --frozen-lockfile --force` — same Windows `EPERM` during dependency installation.
- `pnpm test:all` and `pnpm lint:all` could not run because the locked dependency installation did not complete.
- `git diff --check` — passed.

The focused Vitest and typecheck commands remain to be run in CI or another environment where the locked workspace dependencies can be installed.
