### PR TITLE
[v1.x] fix(server): parse Accept media types exactly

### DIFF
--- a/.changeset/accept-header-media-types-v1.md
+++ b/.changeset/accept-header-media-types-v1.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/sdk': patch
+---
+
+Validate Streamable HTTP `Accept` values by parsed media type and positive quality instead of substring matching. Invalid tokens such as `application/jsonx` and `text/event-stream-bogus`, plus required types with `q=0`, no longer satisfy the response requirements.

--- a/src/server/webStandardStreamableHttp.ts
+++ b/src/server/webStandardStreamableHttp.ts
@@ -7,7 +7,7 @@
  * For Node.js Express/HTTP compatibility, use `StreamableHTTPServerTransport` which wraps this transport.
  */
 
-import { isJsonContentType } from '../shared/mediaType.js';
+import { isJsonContentType, listsMediaType } from '../shared/mediaType.js';
 import { Transport } from '../shared/transport.js';
 import { AuthInfo } from './auth/types.js';
 import { MAX_BATCH_SIZE, readRequestBody, requestBodyTooLargeMessage, resolveMaxRequestBodySize } from './requestBody.js';
@@ -446,7 +446,7 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
     private async handleGetRequest(req: Request): Promise<Response> {
         // The client MUST include an Accept header, listing text/event-stream as a supported content type.
         const acceptHeader = req.headers.get('accept');
-        if (!acceptHeader?.includes('text/event-stream')) {
+        if (!listsMediaType(acceptHeader, 'text/event-stream')) {
             this.onerror?.(new Error('Not Acceptable: Client must accept text/event-stream'));
             return this.createJsonErrorResponse(406, -32000, 'Not Acceptable: Client must accept text/event-stream');
         }
@@ -718,9 +718,10 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
             // Validate the Accept header
             const acceptHeader = req.headers.get('accept');
             // The client MUST include an Accept header, listing both application/json and text/event-stream as supported content types.
-            // Accept is a comma-separated list, so a substring check is the intended semantics here (unlike Content-Type below).
-            // eslint-disable-next-line no-restricted-syntax
-            if (!acceptHeader?.includes('application/json') || !acceptHeader.includes('text/event-stream')) {
+            // Accept is a comma-separated list of media ranges. Match parsed
+            // media types rather than substrings so values like
+            // `application/jsonx` or `text/event-stream-bogus` are not accepted.
+            if (!listsMediaType(acceptHeader, 'application/json') || !listsMediaType(acceptHeader, 'text/event-stream')) {
                 this.onerror?.(new Error('Not Acceptable: Client must accept both application/json and text/event-stream'));
                 return this.createJsonErrorResponse(
                     406,

--- a/src/shared/mediaType.ts
+++ b/src/shared/mediaType.ts
@@ -55,3 +55,52 @@ export function isJsonContentType(header: string | null | undefined): boolean {
     }
     return mediaTypeEssence(header) === 'application/json';
 }
+
+function splitOutsideQuotes(value: string, separator: string): string[] {
+    const values: string[] = [];
+    let start = 0;
+    let quoted = false;
+    let escaped = false;
+
+    for (let index = 0; index < value.length; index += 1) {
+        const char = value[index];
+        if (escaped) {
+            escaped = false;
+        } else if (quoted && char === '\\') {
+            escaped = true;
+        } else if (char === '"') {
+            quoted = !quoted;
+        } else if (char === separator && !quoted) {
+            values.push(value.slice(start, index));
+            start = index + 1;
+        }
+    }
+
+    values.push(value.slice(start));
+    return values;
+}
+
+const QVALUE_PATTERN = /^(?:0(?:\.\d{0,3})?|1(?:\.0{0,3})?)$/;
+
+function hasPositiveQuality(mediaRange: string): boolean {
+    try {
+        const quality = contentType.parse(mediaRange).parameters.q;
+        return quality === undefined || (QVALUE_PATTERN.test(quality) && Number(quality) > 0);
+    } catch {
+        // Keep the existing tolerant behavior for malformed non-quality
+        // parameters, but do not treat a malformed q parameter as support.
+        return !splitOutsideQuotes(mediaRange, ';')
+            .slice(1)
+            .some(parameter => parameter.split('=', 1)[0]?.trim().toLowerCase() === 'q');
+    }
+}
+
+/**
+ * Whether an `Accept` header lists a concrete media type with a positive
+ * quality value. Other parameters are ignored; wildcards intentionally do not
+ * match because MCP transport requirements name exact response media types.
+ */
+export function listsMediaType(header: string | null | undefined, mediaType: string): boolean {
+    const expected = mediaType.toLowerCase();
+    return splitOutsideQuotes(header ?? '', ',').some(part => mediaTypeEssence(part) === expected && hasPositiveQuality(part));
+}

--- a/test/server/streamableHttp.test.ts
+++ b/test/server/streamableHttp.test.ts
@@ -593,6 +593,40 @@ describe.each(zodTestMatrix)('$zodVersionLabel', (entry: ZodMatrixEntry) => {
             expectErrorResponse(errorData, -32000, /Client must accept text\/event-stream/);
         });
 
+        it('should reject GET when text/event-stream appears only as a substring', async () => {
+            sessionId = await initializeServer();
+
+            const response = await fetch(baseUrl, {
+                method: 'GET',
+                headers: {
+                    Accept: 'text/event-stream-bogus',
+                    'mcp-session-id': sessionId,
+                    'mcp-protocol-version': '2025-11-25'
+                }
+            });
+
+            expect(response.status).toBe(406);
+            const errorData = await response.json();
+            expectErrorResponse(errorData, -32000, /Client must accept text\/event-stream/);
+        });
+
+        it('should reject GET when text/event-stream has q=0', async () => {
+            sessionId = await initializeServer();
+
+            const response = await fetch(baseUrl, {
+                method: 'GET',
+                headers: {
+                    Accept: 'text/event-stream; q=0',
+                    'mcp-session-id': sessionId,
+                    'mcp-protocol-version': '2025-11-25'
+                }
+            });
+
+            expect(response.status).toBe(406);
+            const errorData = await response.json();
+            expectErrorResponse(errorData, -32000, /Client must accept text\/event-stream/);
+        });
+
         it('should reject POST requests without proper Accept header', async () => {
             sessionId = await initializeServer();
 
@@ -610,6 +644,41 @@ describe.each(zodTestMatrix)('$zodVersionLabel', (entry: ZodMatrixEntry) => {
             expect(response.status).toBe(406);
             const errorData = await response.json();
             expectErrorResponse(errorData, -32000, /Client must accept both application\/json and text\/event-stream/);
+        });
+
+        it('should reject POST when required media types appear only as substrings', async () => {
+            sessionId = await initializeServer();
+
+            const response = await sendPostRequest(baseUrl, TEST_MESSAGES.toolsList, sessionId, {
+                Accept: 'application/jsonx, text/event-stream-bogus'
+            });
+
+            expect(response.status).toBe(406);
+            const errorData = await response.json();
+            expectErrorResponse(errorData, -32000, /Client must accept both application\/json and text\/event-stream/);
+        });
+
+        it('should reject POST when a required media type has q=0', async () => {
+            sessionId = await initializeServer();
+
+            const response = await sendPostRequest(baseUrl, TEST_MESSAGES.toolsList, sessionId, {
+                Accept: 'application/json; q=0, text/event-stream'
+            });
+
+            expect(response.status).toBe(406);
+            const errorData = await response.json();
+            expectErrorResponse(errorData, -32000, /Client must accept both application\/json and text\/event-stream/);
+        });
+
+        it('should accept required media types with parameters and positive quality', async () => {
+            sessionId = await initializeServer();
+
+            const response = await sendPostRequest(baseUrl, TEST_MESSAGES.toolsList, sessionId, {
+                Accept: 'Application/JSON; q=0.9, text/event-stream; charset=utf-8'
+            });
+
+            expect(response.status).toBe(200);
+            await response.body?.cancel();
         });
 
         it('should reject unsupported Content-Type', async () => {

--- a/test/shared/mediaType.test.ts
+++ b/test/shared/mediaType.test.ts
@@ -1,4 +1,4 @@
-import { isJsonContentType, mediaTypeEssence } from '../../src/shared/mediaType.js';
+import { isJsonContentType, listsMediaType, mediaTypeEssence } from '../../src/shared/mediaType.js';
 
 describe('mediaTypeEssence', () => {
     it('parses well-formed headers', () => {
@@ -62,5 +62,35 @@ describe('isJsonContentType', () => {
         expect(isJsonContentType('')).toBe(false);
         expect(isJsonContentType('text/plain')).toBe(false);
         expect(isJsonContentType('multipart/form-data')).toBe(false);
+    });
+});
+
+describe('listsMediaType', () => {
+    it('matches comma-separated Accept values by parsed media type', () => {
+        expect(listsMediaType('application/json, text/event-stream', 'application/json')).toBe(true);
+        expect(listsMediaType('application/json, text/event-stream', 'text/event-stream')).toBe(true);
+        expect(listsMediaType('Application/JSON; q=0.9, text/event-stream; charset=utf-8', 'application/json')).toBe(true);
+        expect(listsMediaType('application/json; q=0.001, text/event-stream', 'application/json')).toBe(true);
+        expect(listsMediaType('text/plain; note="a,b", application/json', 'application/json')).toBe(true);
+    });
+
+    it('never matches required media types by substring or wildcard', () => {
+        expect(listsMediaType('application/jsonx, text/event-stream-bogus', 'application/json')).toBe(false);
+        expect(listsMediaType('application/jsonx, text/event-stream-bogus', 'text/event-stream')).toBe(false);
+        expect(listsMediaType('text/plain; note=application/json', 'application/json')).toBe(false);
+        expect(listsMediaType('*/*, application/*', 'application/json')).toBe(false);
+    });
+
+    it('rejects media ranges with zero or invalid quality values', () => {
+        expect(listsMediaType('application/json; q=0, text/event-stream', 'application/json')).toBe(false);
+        expect(listsMediaType('application/json; q=0.000, text/event-stream', 'application/json')).toBe(false);
+        expect(listsMediaType('application/json; q=bogus, text/event-stream', 'application/json')).toBe(false);
+        expect(listsMediaType('application/json; q=1.1, text/event-stream', 'application/json')).toBe(false);
+    });
+
+    it('rejects missing or empty Accept values', () => {
+        expect(listsMediaType(null, 'application/json')).toBe(false);
+        expect(listsMediaType(undefined, 'application/json')).toBe(false);
+        expect(listsMediaType('', 'application/json')).toBe(false);
     });
 });


### PR DESCRIPTION
Backport of #2481 to `v1.x`. Related to #2480.

## Motivation and Context

The v1 Streamable HTTP server still validates `Accept` with raw substring checks. Values such as `application/jsonx` and `text/event-stream-bogus` therefore satisfy the required concrete media types, and `q=0` exclusions are treated as support.

This backport parses the comma-separated media ranges, compares exact media-type essences case-insensitively, handles quoted commas, and requires a positive RFC 9110 quality value.

## How Has This Been Tested?

- `npx vitest run test/shared/mediaType.test.ts` — 12 passing
- `npx vitest run test/server/streamableHttp.test.ts` — 197 passing
- `npm run typecheck` — clean
- `npm run lint` — clean
- ESM and CJS TypeScript builds — clean
- full non-E2E suite — 52 files and 1659 assertions passed locally; native Windows emitted two pre-existing post-test stdio JSON parse errors
- GitHub CI — all applicable checks green: build, Node 18/24 unit and E2E suites, client/server conformance, and package preview; the publish job is expectedly skipped for a PR

## Breaking Changes

None. This tightens invalid `Accept` negotiation only.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally (all assertions pass; see the Windows stdio note above)
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

The companion `main` implementation is #2481. This follows the same two-branch delivery pattern used for the related Content-Type fixes #2441 and #2444.
