### PR TITLE
fix: resolve .js subpath types in Deno

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,11 @@
             "import": "./dist/esm/experimental/tasks/index.js",
             "require": "./dist/cjs/experimental/tasks/index.js"
         },
+        "./*.js": {
+            "types": "./dist/esm/*.d.ts",
+            "import": "./dist/esm/*.js",
+            "require": "./dist/cjs/*.js"
+        },
         "./*": {
             "types": "./dist/esm/*.d.ts",
             "import": "./dist/esm/*",

--- a/test/issues/test_2701_deno_subpath_exports.test.ts
+++ b/test/issues/test_2701_deno_subpath_exports.test.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+type ExportEntry = {
+    types: string;
+    import: string;
+    require: string;
+};
+
+describe('Issue #2701: Deno resolves .js subpaths to declarations without .js', () => {
+    test('provides an explicit .js export pattern for type resolution', () => {
+        const packageJson = JSON.parse(readFileSync(resolve(import.meta.dirname, '../../package.json'), 'utf8')) as {
+            exports: Record<string, ExportEntry>;
+        };
+        const jsSubpath = packageJson.exports['./*.js'];
+
+        expect(jsSubpath).toEqual({
+            types: './dist/esm/*.d.ts',
+            import: './dist/esm/*.js',
+            require: './dist/cjs/*.js'
+        });
+    });
+});


### PR DESCRIPTION
## Summary

- add an explicit `./*.js` export pattern so Deno maps `.js` subpaths to the emitted declaration files
- preserve Node ESM and CommonJS subpath resolution
- add a regression test for the export targets

Fixes #2701

## Validation

- `npm test -- --run test/issues/test_2701_deno_subpath_exports.test.ts`
- `npm run typecheck`
- Windows-safe ESM/CJS TypeScript compilation
- targeted Prettier and ESLint checks pass
- full `npm test` ran 53 files / 1646 tests but exited 1 because two existing Windows stdio tests emitted unhandled JSON parse errors
