### PR TITLE
chore(deps): update eventsource to ^4.1.1, eventsource-parser to ^3.1.1

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,11 +86,11 @@ catalogs:
       specifier: ^7.0.5
       version: 7.0.6
     eventsource:
-      specifier: ^3.0.2
-      version: 3.0.7
+      specifier: ^4.1.1
+      version: 4.1.1
     eventsource-parser:
-      specifier: ^3.0.0
-      version: 3.0.6
+      specifier: ^3.1.1
+      version: 3.1.1
     jose:
       specifier: ^6.1.3
       version: 6.2.2
@@ -1301,10 +1301,10 @@ importers:
         version: 7.0.6
       eventsource:
         specifier: catalog:runtimeClientOnly
-        version: 3.0.7
+        version: 4.1.1
       eventsource-parser:
         specifier: catalog:runtimeClientOnly
-        version: 3.0.6
+        version: 3.1.1
       jose:
         specifier: catalog:runtimeClientOnly
         version: 6.2.2
@@ -4986,17 +4986,21 @@ packages:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
 
-  eventsource-parser@3.0.6:
-    resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
-    engines: {node: '>=18.0.0'}
-
   eventsource-parser@3.0.8:
     resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource-parser@3.1.1:
+    resolution: {integrity: sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==}
     engines: {node: '>=18.0.0'}
 
   eventsource@3.0.7:
     resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
     engines: {node: '>=18.0.0'}
+
+  eventsource@4.1.1:
+    resolution: {integrity: sha512-D6bTRWh6KahHTK/m4WnjPQyEinNPf9eFLEZSEoj7d6fTibspnAVYfzHvirL7u/aoX5d9YYfIkBVAhmigUELk9w==}
+    engines: {node: '>=20.0.0'}
 
   expand-template@2.0.3:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
@@ -9654,13 +9658,17 @@ snapshots:
 
   etag@1.8.1: {}
 
-  eventsource-parser@3.0.6: {}
-
   eventsource-parser@3.0.8: {}
+
+  eventsource-parser@3.1.1: {}
 
   eventsource@3.0.7:
     dependencies:
-      eventsource-parser: 3.0.6
+      eventsource-parser: 3.0.8
+
+  eventsource@4.1.1:
+    dependencies:
+      eventsource-parser: 3.1.1
 
   expand-template@2.0.3: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -36,8 +36,8 @@ catalogs:
         vitest: ^4.0.15
     runtimeClientOnly:
         cross-spawn: ^7.0.5
-        eventsource: ^3.0.2
-        eventsource-parser: ^3.0.0
+        eventsource: ^4.1.1
+        eventsource-parser: ^3.1.1
         jose: ^6.1.3
     runtimeServerOnly:
         '@hono/node-server': ^1.19.9


### PR DESCRIPTION
## Motivation and Context

`eventsource` and `eventsource-parser` were pinned at `^3.0.2` / `^3.0.0`. This bumps both to the newest releases that keep the declared `engines: node >=20` floor intact.

| | before | after | latest available |
|---|---|---|---|
| `eventsource` | `^3.0.2` | `^4.1.1` | 5.1.1 (needs Node ≥22.12) |
| `eventsource-parser` | `^3.0.0` | `^3.1.1` | 4.1.0 (needs Node ≥22.12) |

**Why not the latest majors.** `eventsource@5` and `eventsource-parser@4` both require `node >=22.12` and dropped their CommonJS builds. Adopting them would mean raising the `engines` floor from `>=20` across every package, dropping the Node 20 leg from the CI matrix, and breaking `require()` of `@modelcontextprotocol/client`'s CJS bundle (`dist/index.cjs`) on Node 20 — `eventsource` is an external dep there, so it resolves to `ERR_REQUIRE_ESM`. That's a consumer-facing break and felt out of scope for a dependency refresh; happy to open it as a separate PR if a Node floor bump is on the roadmap.

**Why these two versions pair.** `eventsource@4.1.1` declares `eventsource-parser: ^3.0.1`, so parser v3 is the version it actually requires. pnpm dedupes to a single shared copy — the lock resolves `eventsource@4.1.1 -> eventsource-parser: 3.1.1`, the same instance `streamableHttp.ts` imports directly via `eventsource-parser/stream`. Bumping the parser to v4 while holding `eventsource` at v4 would nest a second parser copy in the bundle, so the two have to move together.

## How Has This Been Tested?

- `pnpm typecheck:all`, `pnpm lint:all`, `pnpm build:all` — all clean
- `pnpm test:all` — full suite passes (6,700+ tests across all packages)
- Smoke-tested the CJS path specifically, since it drove the version choice: `require('eventsource')` and `require('eventsource-parser/stream')` both resolve, and the built `dist/index.cjs` loads

One note on `test/e2e`: it exits non-zero from 2 unhandled rejections in `scenarios/protocol.test.ts` (a fake-timer request-timeout case) while reporting `2639 passed | 147 expected fail`. This is **pre-existing on `main`** and unrelated to this change — I re-ran the suite on the unmodified dependency versions and got a byte-identical result.

## Breaking Changes

None. `eventsource@4`'s only removal was the `FetchLikeInit` type (superseded by `EventSourceFetchInit`), which this repo never imported — `packages/client/src/client/sse.ts` uses `ErrorEvent` and `EventSourceInit`, both still exported. No source changes were needed.

## Types of changes

- [x] Chore (no functional changes, e.g. dependency updates)

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed — n/a, no API surface change

## Additional context

Lockfile changes are limited to these two packages and their dedupe. There's no `.changeset/` directory or Renovate/Dependabot config at `HEAD`, so no changeset file is included — let me know if the v2 line expects one and I'll add it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)