### PR TITLE
fix(server): settle in-flight JSON-mode requests and release their stream mappings (v1.x)

### DIFF
--- a/.changeset/json-mode-lifecycle-v1x.md
+++ b/.changeset/json-mode-lifecycle-v1x.md
@@ -1,0 +1,5 @@
+---
+'@modelcontextprotocol/sdk': patch
+---
+
+Complete the JSON response mode request lifecycle in Streamable HTTP: a completed POST no longer leaks its stream mapping, and close() during an in-flight JSON-mode request settles the pending HTTP response with a 503 JSON-RPC error instead of leaving it hanging until the client times out.

--- a/src/server/webStandardStreamableHttp.ts
+++ b/src/server/webStandardStreamableHttp.ts
@@ -861,6 +861,20 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
                         resolveJson: resolve,
                         cleanup: () => {
                             this._streamMapping.delete(streamId);
+                            // Settle the pending POST as well as dropping the mapping.
+                            // close() runs every mapping's cleanup, so without this a
+                            // JSON-mode request whose handler is still in flight never
+                            // settles and the HTTP request hangs until the client gives
+                            // up. On the success path send() has already resolved by the
+                            // time it calls cleanup(), and resolving a settled promise is
+                            // a no-op, so this only fires when nothing was sent.
+                            resolve(
+                                this.createJsonErrorResponse(
+                                    503,
+                                    -32000,
+                                    'Service Unavailable: transport closed before a response was produced'
+                                )
+                            );
                         }
                     });
 
@@ -1255,6 +1269,9 @@ export class WebStandardStreamableHTTPServerTransport implements Transport {
                     } else {
                         stream.resolveJson(new Response(JSON.stringify(responses), { status: 200, headers }));
                     }
+                    // Release the stream mapping now that the HTTP response is settled;
+                    // leaving it in place leaks one entry per POST for the session's lifetime.
+                    stream.cleanup();
                 } else {
                     // End the SSE stream
                     stream.cleanup();

--- a/test/server/streamableHttp.test.ts
+++ b/test/server/streamableHttp.test.ts
@@ -4094,6 +4094,78 @@ describe('WebStandardStreamableHTTPServerTransport SSE keep-alive lifecycle', ()
         await transport.close();
     });
 
+    it('should settle an in-flight JSON-mode request when the transport closes mid-handler', async () => {
+        const transport = new WebStandardStreamableHTTPServerTransport({
+            sessionIdGenerator: () => randomUUID(),
+            enableJsonResponse: true
+        });
+        const mcpServer = new McpServer({ name: 'test-server', version: '1.0.0' });
+        let releaseTool: (() => void) | undefined;
+        let signalToolStarted: (() => void) | undefined;
+        const toolStarted = new Promise<void>(resolve => {
+            signalToolStarted = resolve;
+        });
+        mcpServer.tool('slow', async () => {
+            signalToolStarted!();
+            await new Promise<void>(resolve => {
+                releaseTool = resolve;
+            });
+            return { content: [] };
+        });
+        await mcpServer.connect(transport);
+        const initResponse = await transport.handleRequest(req('POST', { body: TEST_MESSAGES.initialize }));
+        const sessionId = initResponse.headers.get('mcp-session-id') as string;
+
+        // close() runs while the handler is genuinely parked: signalled by the
+        // handler rather than polled, so the POST is guaranteed registered.
+        const inFlight = transport.handleRequest(
+            req('POST', {
+                body: { jsonrpc: '2.0', method: 'tools/call', params: { name: 'slow', arguments: {} }, id: 'call-1' },
+                headers: { 'mcp-session-id': sessionId, 'mcp-protocol-version': '2025-11-25' }
+            })
+        );
+        await toolStarted;
+        await transport.close();
+
+        // Without settling in cleanup(), the POST would hang until the client
+        // gave up instead of failing fast.
+        const response = await inFlight;
+        expect(response.status).toBe(503);
+        expect(await response.json()).toMatchObject({
+            jsonrpc: '2.0',
+            error: { code: -32000 },
+            id: null
+        });
+
+        releaseTool?.();
+        await vi.advanceTimersByTimeAsync(0);
+    });
+
+    it('should release the JSON-mode stream mapping once the response has been sent', async () => {
+        const transport = new WebStandardStreamableHTTPServerTransport({
+            sessionIdGenerator: () => randomUUID(),
+            enableJsonResponse: true
+        });
+        await new McpServer({ name: 'test-server', version: '1.0.0' }).connect(transport);
+        const initResponse = await transport.handleRequest(req('POST', { body: TEST_MESSAGES.initialize }));
+        const sessionId = initResponse.headers.get('mcp-session-id') as string;
+
+        const response = await transport.handleRequest(
+            req('POST', {
+                body: { jsonrpc: '2.0', method: 'tools/list', params: {}, id: 'list-1' },
+                headers: { 'mcp-session-id': sessionId, 'mcp-protocol-version': '2025-11-25' }
+            })
+        );
+        expect(response.status).toBe(200);
+        await response.arrayBuffer();
+
+        // A completed POST must not leave its mapping behind until close():
+        // long-lived sessions would otherwise accumulate one entry per request.
+        expect(transport['_streamMapping'].size).toBe(0);
+
+        await transport.close();
+    });
+
     it('should close the transport when the onsessionclosed callback throws on DELETE', async () => {
         const transport = new WebStandardStreamableHTTPServerTransport({
             sessionIdGenerator: () => randomUUID(),


### PR DESCRIPTION
Fixes #2559 (v1.x half — the main-branch close-settle half is drafted in #2584)

## What

On v1.x, JSON response mode has two lifecycle gaps:

1. **Leak**: when all responses are ready, `send()` resolves the pending HTTP response but never runs the stream mapping's `cleanup`, so every completed POST leaves one `_streamMapping` entry behind until `close()`. Long-lived sessions accumulate one entry per request. (main got the equivalent fix in #2286; it was never carried to v1.x — as [noted on the issue](https://github.com/modelcontextprotocol/typescript-sdk/issues/2559#issuecomment), this is what currently ships as 1.30.0.)
2. **Hang**: conversely, `cleanup()` only deleted the map entry without settling the `Promise<Response>` returned by `handleRequest()`. `close()` runs every mapping's cleanup, but for a JSON-mode POST still waiting on its handler that cleanup settled nothing — so the HTTP request hung until the client timed out.

## Fix

- The JSON-ready branch of `send()` now calls `stream.cleanup()` right after resolving, mirroring main's #2286.
- The JSON-mode mapping's `cleanup()` now settles the pending POST with a `503` JSON-RPC error (`-32000`), aligned with the approach drafted for main in #2584. On the success path `send()` has already resolved before `cleanup()` runs, and re-resolving a settled promise is a no-op, so the new resolve only fires when nothing was ever sent.

## Tests

- `settles an in-flight JSON-mode request when the transport closes mid-handler` — the tool handler signals it has started, `close()` lands while it is genuinely parked, and the POST must resolve `503` with the JSON-RPC error payload instead of hanging.
- `releases the JSON-mode stream mapping once the response has been sent` — `_streamMapping.size` must be `0` after a completed JSON-mode POST (on unpatched v1.x this fails with `2`: the request's mapping plus initialize's).

Both tests fail on unpatched v1.x and pass with the fix. Full suite: 1647 passed (the two unhandled stdio `SyntaxError`s reproduce on pristine v1.x and are unrelated).
