### PR TITLE
[v1.x] docs(server/auth): document that resourceServerUrl and resourceMetadataUrl are needed for MCP-compliant discovery

### DIFF
--- a/src/server/auth/middleware/bearerAuth.ts
+++ b/src/server/auth/middleware/bearerAuth.ts
@@ -15,7 +15,11 @@ export type BearerAuthMiddlewareOptions = {
     requiredScopes?: string[];
 
     /**
-     * Optional resource metadata URL to include in WWW-Authenticate header.
+     * Resource metadata URL to advertise in the `WWW-Authenticate` challenge on 401/403
+     * responses (RFC 9728 §5.1). The MCP authorization spec requires MCP servers to send it, so
+     * pass `getOAuthProtectedResourceMetadataUrl(mcpServerUrl)` for any protected MCP endpoint.
+     * When omitted, clients must guess the well-known location and strict clients can fail
+     * discovery; leave it out only for non-MCP or legacy deployments.
      */
     resourceMetadataUrl?: string;
 };

--- a/src/server/auth/router.ts
+++ b/src/server/auth/router.ts
@@ -51,6 +51,14 @@ export type AuthRouterOptions = {
     /**
      * The URL of the protected resource (RS) whose metadata we advertise.
      * If not provided, falls back to `baseUrl` and then to `issuerUrl` (AS=RS).
+     *
+     * Pass the MCP endpoint URL itself (e.g. `https://api.example.com/mcp`), not just the
+     * origin. RFC 9728 §3 places the metadata at
+     * `/.well-known/oauth-protected-resource/<path>` and §3.3 requires its `resource` to be
+     * identical to the resource the client connected to. The `baseUrl` fallback therefore only
+     * yields a compliant document when the MCP endpoint is served at the origin root; clients
+     * that enforce §3.3 (Gemini CLI, Antigravity CLI) reject `resource: https://host/` when they
+     * connected to `https://host/mcp`, while the reference SDK client happens to accept it.
      */
     resourceServerUrl?: URL;
 


### PR DESCRIPTION
## Motivation and Context

Follow-up to #2751. When an MCP endpoint lives under a path (the usual `/mcp`), omitting `resourceServerUrl` on `mcpAuthRouter` and `resourceMetadataUrl` on `requireBearerAuth` silently produces discovery that the MCP authorization spec and RFC 9728 do not allow: PRM at the root well-known with `resource: https://host/`, and a 401 challenge without `resource_metadata`. The reference client tolerates this, so the only symptom is that strict clients (Gemini CLI, Antigravity CLI) fail discovery with `ResourceMismatchError`.

Both options are documented as merely "optional". This PR makes the JSDoc say what each one is for, that the MCP spec requires the `resource_metadata` challenge parameter, and what happens when they are left out.

## How Has This Been Tested?

JSDoc-only change, no behaviour change. `prettier --check` passes on the touched files. The underlying behaviour (root-only PRM with origin `resource`, missing `resource_metadata`) was reproduced against v1.x as described in #2751.

## Breaking Changes

None.

## Types of changes

- [x] Documentation update

## Checklist

- [x] I have read the MCP Documentation
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally (not applicable: comments only)
- [x] I have added appropriate error handling (not applicable)
- [x] I have added or updated documentation as needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
