### PR TITLE
docs: validate input-required elicitation examples

### DIFF
--- a/docs/servers/input-required.md
+++ b/docs/servers/input-required.md
@@ -14,6 +14,9 @@ const confirmationSchema = z.object({
     confirm: z.boolean().meta({ title: 'Confirm deployment' })
 });
 
+const cacheConfirmationSchema = z.object({ confirm: z.boolean() });
+const cacheScopeSchema = z.object({ scope: z.string() });
+
 server.registerTool(
     'deploy',
     {
@@ -181,13 +184,13 @@ server.registerTool(
         const state = ctx.mcpReq.requestState<{ step: string }>();
 
         if (state?.step !== 'confirmed') {
-            const confirmed = acceptedContent<{ confirm: boolean }>(ctx.mcpReq.inputResponses, 'confirm');
+            const confirmed = acceptedContent(ctx.mcpReq.inputResponses, 'confirm', cacheConfirmationSchema);
             if (confirmed?.confirm !== true) {
                 return inputRequired({
                     inputRequests: {
                         confirm: inputRequired.elicit({
                             message: 'Really wipe the cache?',
-                            requestedSchema: { type: 'object', properties: { confirm: { type: 'boolean' } }, required: ['confirm'] }
+                            requestedSchema: cacheConfirmationSchema
                         })
                     }
                 });
@@ -197,15 +200,23 @@ server.registerTool(
                 inputRequests: {
                     scope: inputRequired.elicit({
                         message: 'Which scope?',
-                        requestedSchema: { type: 'object', properties: { scope: { type: 'string' } }, required: ['scope'] }
+                        requestedSchema: cacheScopeSchema
                     })
                 },
                 requestState: await stateCodec.mint({ step: 'confirmed' })
             });
         }
 
-        const scope = acceptedContent<{ scope: string }>(ctx.mcpReq.inputResponses, 'scope');
-        return { content: [{ type: 'text', text: `Wiped ${scope?.scope ?? 'all'}` }] };
+        const scope = acceptedContent(ctx.mcpReq.inputResponses, 'scope', cacheScopeSchema);
+        if (scope === undefined) {
+            return inputRequired({
+                inputRequests: {
+                    scope: inputRequired.elicit({ message: 'Which scope?', requestedSchema: cacheScopeSchema })
+                },
+                requestState: await stateCodec.mint({ step: 'confirmed' })
+            });
+        }
+        return { content: [{ type: 'text', text: `Wiped ${scope.scope}` }] };
     }
 );
 ```

--- a/examples/guides/servers/input-required.examples.ts
+++ b/examples/guides/servers/input-required.examples.ts
@@ -40,6 +40,9 @@ const confirmationSchema = z.object({
     confirm: z.boolean().meta({ title: 'Confirm deployment' })
 });
 
+const cacheConfirmationSchema = z.object({ confirm: z.boolean() });
+const cacheScopeSchema = z.object({ scope: z.string() });
+
 server.registerTool(
     'deploy',
     {
@@ -132,13 +135,13 @@ server.registerTool(
         const state = ctx.mcpReq.requestState<{ step: string }>();
 
         if (state?.step !== 'confirmed') {
-            const confirmed = acceptedContent<{ confirm: boolean }>(ctx.mcpReq.inputResponses, 'confirm');
+            const confirmed = acceptedContent(ctx.mcpReq.inputResponses, 'confirm', cacheConfirmationSchema);
             if (confirmed?.confirm !== true) {
                 return inputRequired({
                     inputRequests: {
                         confirm: inputRequired.elicit({
                             message: 'Really wipe the cache?',
-                            requestedSchema: { type: 'object', properties: { confirm: { type: 'boolean' } }, required: ['confirm'] }
+                            requestedSchema: cacheConfirmationSchema
                         })
                     }
                 });
@@ -148,15 +151,23 @@ server.registerTool(
                 inputRequests: {
                     scope: inputRequired.elicit({
                         message: 'Which scope?',
-                        requestedSchema: { type: 'object', properties: { scope: { type: 'string' } }, required: ['scope'] }
+                        requestedSchema: cacheScopeSchema
                     })
                 },
                 requestState: await stateCodec.mint({ step: 'confirmed' })
             });
         }
 
-        const scope = acceptedContent<{ scope: string }>(ctx.mcpReq.inputResponses, 'scope');
-        return { content: [{ type: 'text', text: `Wiped ${scope?.scope ?? 'all'}` }] };
+        const scope = acceptedContent(ctx.mcpReq.inputResponses, 'scope', cacheScopeSchema);
+        if (scope === undefined) {
+            return inputRequired({
+                inputRequests: {
+                    scope: inputRequired.elicit({ message: 'Which scope?', requestedSchema: cacheScopeSchema })
+                },
+                requestState: await stateCodec.mint({ step: 'confirmed' })
+            });
+        }
+        return { content: [{ type: 'text', text: `Wiped ${scope.scope}` }] };
     }
 );
 //#endregion requestState_mint

--- a/examples/mrtr/server.ts
+++ b/examples/mrtr/server.ts
@@ -30,7 +30,7 @@ import { acceptedContent, createMcpHandler, createRequestStateCodec, inputRequir
 import { serveStdio } from '@modelcontextprotocol/server/stdio';
 import * as z from 'zod/v4';
 
-const CONFIRM_SCHEMA = { type: 'object' as const, properties: { confirm: { type: 'boolean' as const } }, required: ['confirm'] };
+const CONFIRM_SCHEMA = z.object({ confirm: z.boolean() });
 
 type DeployState = { step: 'confirm' | 'signed-in'; env: string };
 
@@ -67,8 +67,8 @@ function buildServer(): McpServer {
             console.error(`[server] tools/call deploy(${env}) step=${step}`);
 
             if (step === 'confirm') {
-                const confirmed = acceptedContent<{ confirm: boolean }>(ctx.mcpReq.inputResponses, 'confirm');
-                if (!confirmed?.confirm) {
+                const confirmed = acceptedContent(ctx.mcpReq.inputResponses, 'confirm', CONFIRM_SCHEMA);
+                if (confirmed?.confirm !== true) {
                     return inputRequired({
                         inputRequests: {
                             confirm: inputRequired.elicit({ message: `Deploy to ${env}?`, requestedSchema: CONFIRM_SCHEMA })

--- a/packages/core-internal/src/shared/inputRequired.ts
+++ b/packages/core-internal/src/shared/inputRequired.ts
@@ -113,13 +113,14 @@ function buildInputRequired(spec: InputRequiredSpec): InputRequiredResult {
  * @example Write-once tool requesting confirmation
  * ```ts
  * server.registerTool('deploy', { inputSchema: z.object({ env: z.string() }) }, async ({ env }, ctx) => {
- *     const confirmed = acceptedContent<{ confirm: boolean }>(ctx.mcpReq.inputResponses, 'confirm');
- *     if (!confirmed) {
+ *     const confirmationSchema = z.object({ confirm: z.boolean() });
+ *     const confirmed = acceptedContent(ctx.mcpReq.inputResponses, 'confirm', confirmationSchema);
+ *     if (confirmed?.confirm !== true) {
  *         return inputRequired({
  *             inputRequests: {
  *                 confirm: inputRequired.elicit({
  *                     message: `Deploy to ${env}?`,
- *                     requestedSchema: { type: 'object', properties: { confirm: { type: 'boolean' } }, required: ['confirm'] }
+ *                     requestedSchema: confirmationSchema
  *                 })
  *             }
  *         });

--- a/packages/server/test/server/inputRequired.test.ts
+++ b/packages/server/test/server/inputRequired.test.ts
@@ -125,7 +125,7 @@ describe('input-required returns on the 2026-07-28 era', () => {
             { inputSchema: z.object({ env: z.string() }), outputSchema: z.object({ deployed: z.boolean() }) },
             async ({ env }, ctx) => {
                 const confirmed = acceptedContent(ctx.mcpReq.inputResponses, 'confirm', confirmationSchema);
-                if (!confirmed?.confirm) {
+                if (confirmed?.confirm !== true) {
                     return inputRequired({
                         inputRequests: {
                             confirm: inputRequired.elicit({

--- a/packages/server/test/server/inputRequired.test.ts
+++ b/packages/server/test/server/inputRequired.test.ts
@@ -165,12 +165,33 @@ describe('input-required returns on the 2026-07-28 era', () => {
         expect(first.cacheScope).toBeUndefined();
         expect(first.content).toBeUndefined();
 
+        // A schema-valid false value is content, not confirmation. The handler
+        // must inspect the validated value rather than only the object's presence.
+        const declined = resultOf(
+            await request(
+                modernToolCall(
+                    2,
+                    'deploy',
+                    { env: 'prod' },
+                    {
+                        clientCapabilities: { elicitation: { form: {} } },
+                        extraParams: {
+                            inputResponses: { confirm: { action: 'accept', content: { confirm: false } } },
+                            requestState: 'opaque-deploy-state'
+                        }
+                    }
+                )
+            )
+        );
+        expect(declined.resultType).toBe('input_required');
+        expect(declined.requestState).toBe('opaque-deploy-state');
+
         // Retry leg (fresh id, responses + byte-exact echo): full validation
         // applies to the completing result, which is stamped 'complete'.
         const second = resultOf(
             await request(
                 modernToolCall(
-                    2,
+                    3,
                     'deploy',
                     { env: 'prod' },
                     {

--- a/packages/server/test/server/legacyInputRequiredShim.test.ts
+++ b/packages/server/test/server/legacyInputRequiredShim.test.ts
@@ -44,7 +44,7 @@ async function elicitingToolServer(options?: ConstructorParameters<typeof McpSer
     server.registerTool('deploy', { inputSchema: z.object({ env: z.string() }) }, async ({ env }, ctx) => {
         seenResponses.push(ctx.mcpReq.inputResponses);
         const confirmed = acceptedContent(ctx.mcpReq.inputResponses, 'confirm', CONFIRM_SCHEMA);
-        if (!confirmed?.confirm) {
+        if (confirmed?.confirm !== true) {
             return inputRequired({
                 inputRequests: {
                     confirm: inputRequired.elicit({

--- a/test/conformance/src/everythingServer.ts
+++ b/test/conformance/src/everythingServer.ts
@@ -863,17 +863,14 @@ function createMcpServer() {
             inputSchema: z.object({})
         },
         async (_args, ctx): Promise<CallToolResult | InputRequiredResult> => {
-            const confirmation = acceptedContent<{ ok: boolean }>(ctx.mcpReq.inputResponses, 'confirm');
-            if (confirmation === undefined) {
+            const confirmationSchema = z.object({ ok: z.boolean() });
+            const confirmation = acceptedContent(ctx.mcpReq.inputResponses, 'confirm', confirmationSchema);
+            if (confirmation?.ok !== true) {
                 return inputRequired({
                     inputRequests: {
                         confirm: inputRequired.elicit({
                             message: 'Please confirm',
-                            requestedSchema: {
-                                type: 'object',
-                                properties: { ok: { type: 'boolean' } },
-                                required: ['ok']
-                            }
+                            requestedSchema: confirmationSchema
                         })
                     },
                     requestState: await requestStateCodec.mint({ tool: 'request_state', nonce: randomUUID() })

--- a/test/e2e/scenarios/mrtr.test.ts
+++ b/test/e2e/scenarios/mrtr.test.ts
@@ -43,14 +43,14 @@ async function allRecordedBytes(wired: Wired): Promise<string> {
     return [...requests, ...responses].join('\n');
 }
 
-const CONFIRM_SCHEMA = { type: 'object' as const, properties: { confirm: { type: 'boolean' as const } }, required: ['confirm'] };
+const CONFIRM_SCHEMA = z.object({ confirm: z.boolean() });
 
 verifies('typescript:mrtr:tools-call:write-once-roundtrip', async ({ transport }: TestArgs) => {
     const makeServer = () => {
         const server = new McpServer({ name: 'mrtr-server', version: '1.0.0' }, { capabilities: { tools: {} } });
         server.registerTool('deploy', { inputSchema: z.object({ env: z.string() }) }, async ({ env }, ctx) => {
-            const confirmed = acceptedContent<{ confirm: boolean }>(ctx.mcpReq.inputResponses, 'confirm');
-            if (!confirmed?.confirm) {
+            const confirmed = acceptedContent(ctx.mcpReq.inputResponses, 'confirm', CONFIRM_SCHEMA);
+            if (confirmed?.confirm !== true) {
                 return inputRequired({
                     inputRequests: { confirm: inputRequired.elicit({ message: `Deploy to ${env}?`, requestedSchema: CONFIRM_SCHEMA }) },
                     requestState: 'opaque-deploy-state'
@@ -487,8 +487,8 @@ verifies('typescript:mrtr:legacy-shim:write-once-on-2025', async ({ transport }:
         // legacy shim converts the embedded request into a real
         // elicitation/create over the session and re-enters the handler.
         server.registerTool('deploy', { inputSchema: z.object({ env: z.string() }) }, async ({ env }, ctx) => {
-            const confirmed = acceptedContent<{ confirm: boolean }>(ctx.mcpReq.inputResponses, 'confirm');
-            if (!confirmed?.confirm) {
+            const confirmed = acceptedContent(ctx.mcpReq.inputResponses, 'confirm', CONFIRM_SCHEMA);
+            if (confirmed?.confirm !== true) {
                 return inputRequired({
                     inputRequests: { confirm: inputRequired.elicit({ message: `Deploy to ${env}?`, requestedSchema: CONFIRM_SCHEMA }) },
                     requestState: 'shim-opaque-state'


### PR DESCRIPTION
Updates the input-required examples to validate client-provided elicitation content at runtime and fail closed when confirmation or scope responses are invalid.

Fixes #2542.

## Motivation and Context

`ctx.mcpReq.inputResponses` contains client-provided, untrusted data. Several examples used the generic `acceptedContent<T>()` overload, which provides compile-time typing but no runtime validation.

Some confirmation examples also checked only whether the response object existed instead of requiring `confirm === true`. The `wipe-cache` example defaulted a missing or malformed scope to `all`, which is unsafe for a destructive operation.

This change:

- passes Zod schemas to `acceptedContent()` for runtime validation
- requires confirmation to be exactly `true`
- re-requests missing or invalid scope while preserving confirmed request state
- removes the unsafe fallback to the `all` scope
- synchronizes the guide source, generated documentation, exported JSDoc, examples, conformance fixture, and relevant test fixtures

## How Has This Been Tested?

The following checks passed locally:

- `pnpm build:all` — all 52 workspace packages built successfully
- `pnpm sync:snippets --check`
- type-checking for all affected packages
- linting and formatting checks for all affected packages
- core-internal test suite — 1,457 tests passed
- server test suite — 482 tests passed
- isolated MRTR end-to-end scenario — 24 tests passed
- runnable `input-required` guide example

The tested scenarios include:

- valid boolean confirmation is accepted
- confirmation must be exactly `true`
- elicitation responses are validated against their Zod schemas
- missing or invalid scope causes another scope request
- confirmed request state is preserved when scope must be requested again
- valid scope produces the expected cache-wipe response

A broad e2e invocation also executed unrelated stdio lifecycle scenarios. Six environment-sensitive stdio cases failed while 2,633 tests passed; the isolated MRTR scenario affected by this change passes.

## Breaking Changes

No breaking changes.

This updates defensive example usage, generated documentation, and corresponding test fixtures. It does not change the `acceptedContent()` API.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing relevant tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

The same Zod schema instance is used both to describe the requested elicitation input and to validate the accepted response.

For the sequential `wipe-cache` example, an invalid scope response reissues only the scope request and mints `{ step: 'confirmed' }` again. This avoids asking for confirmation again while ensuring an invalid scope can never silently become `all`.