### PR TITLE
fix(client): default resultSchema to CallToolResultSchema in getTaskResult (#2742)

### DIFF
--- a/.changeset/default-get-task-result-schema.md
+++ b/.changeset/default-get-task-result-schema.md
@@ -2,5 +2,4 @@
 '@modelcontextprotocol/sdk': patch
 ---
 
-Default 
-esultSchema to CallToolResultSchema in ExperimentalClientTasks.getTaskResult, preventing unhandled type errors when called without an explicit schema argument.
+Default `resultSchema` to `CallToolResultSchema` in `ExperimentalClientTasks.getTaskResult`

--- a/.changeset/default-get-task-result-schema.md
+++ b/.changeset/default-get-task-result-schema.md
@@ -1,0 +1,6 @@
+---
+'@modelcontextprotocol/sdk': patch
+---
+
+Default 
+esultSchema to CallToolResultSchema in ExperimentalClientTasks.getTaskResult, preventing unhandled type errors when called without an explicit schema argument.

--- a/src/experimental/tasks/client.ts
+++ b/src/experimental/tasks/client.ts
@@ -178,13 +178,15 @@ export class ExperimentalClientTasks<
      * Retrieves the result of a completed task.
      *
      * @param taskId - The task identifier
-     * @param resultSchema - Zod schema for validating the result
+     * @param resultSchema - Zod schema for validating the result (defaults to CallToolResultSchema)
      * @param options - Optional request options
      * @returns The task result
      *
      * @experimental
      */
-    async getTaskResult<T extends AnyObjectSchema>(taskId: string, resultSchema?: T, options?: RequestOptions): Promise<SchemaOutput<T>> {
+    async getTaskResult<
+        T extends typeof CallToolResultSchema | typeof CompatibilityCallToolResultSchema | AnyObjectSchema = typeof CallToolResultSchema
+    >(taskId: string, resultSchema: T = CallToolResultSchema as T, options?: RequestOptions): Promise<SchemaOutput<T>> {
         // Delegate to the client's underlying Protocol method
         return (
             this._client as unknown as {

--- a/test/client/index.test.ts
+++ b/test/client/index.test.ts
@@ -2576,9 +2576,13 @@ describe('Task-based execution', () => {
 
             expect(taskId).toBeDefined();
 
-            // Query task result using the captured task ID
-            const result = await client.experimental.tasks.getTaskResult(taskId!, CallToolResultSchema);
-            expect(result.content).toEqual([{ type: 'text', text: 'Result data!' }]);
+            // Query task result using the captured task ID with default schema
+            const defaultResult = await client.experimental.tasks.getTaskResult(taskId!);
+            expect(defaultResult.content).toEqual([{ type: 'text', text: 'Result data!' }]);
+
+            // Query task result with explicit schema
+            const explicitResult = await client.experimental.tasks.getTaskResult(taskId!, CallToolResultSchema);
+            expect(explicitResult.content).toEqual([{ type: 'text', text: 'Result data!' }]);
         });
 
         test('should query task list from server using listTasks', async () => {


### PR DESCRIPTION
## Summary
Fixes #2742

`client.experimental.tasks.getTaskResult(taskId)` declared `resultSchema?: T`, but when omitted, `undefined` was forwarded to the underlying protocol request, causing `TypeError: Cannot read properties of undefined (reading '_zod')` in `isZ4Schema` during response validation.

This change:
- Defaults `resultSchema` to `CallToolResultSchema` both at runtime and in type generics for `ExperimentalClientTasks.getTaskResult`, matching the convention used by `callToolStream()`.
- Adds test assertions verifying that `getTaskResult(taskId)` works when omitting `resultSchema` (using default) as well as when supplying an explicit schema.

## Motivation and Context
Resolves #2742. Callers omitting the optional schema parameter previously experienced an uncaught runtime error in the transport handler. Defaulting to `CallToolResultSchema` provides the expected behavior.

## How Has This Been Tested?
- Verified reproduction of `TypeError: Cannot read properties of undefined (reading '_zod')` before fix when omitting `resultSchema`.
- Ran `npx vitest run test/client/index.test.ts -t "getTaskResult"` — passed.
- Ran all 100 tests in `test/experimental/tasks` — 100% passed.
- Ran full `npx tsc --noEmit` — clean with zero errors.
- Verified ESLint and Prettier compliance.
