### PR TITLE
fix(core): reject x-mcp-header on number-typed parameters

### DIFF
--- a/.changeset/x-mcp-header-reject-number.md
+++ b/.changeset/x-mcp-header-reject-number.md
@@ -1,0 +1,7 @@
+---
+'@modelcontextprotocol/core-internal': patch
+'@modelcontextprotocol/client': patch
+'@modelcontextprotocol/server': patch
+---
+
+`x-mcp-header` on a `number`-typed tool parameter is now rejected, matching the 2026-07-28 spec ("Parameters with type `number` are not permitted"; clients MUST exclude such tools from `tools/list`). Previously `number` was accepted only to satisfy an older conformance fixture that has since been corrected. `integer`, `string` and `boolean` are unaffected.

--- a/packages/core-internal/src/shared/mcpParamHeaders.ts
+++ b/packages/core-internal/src/shared/mcpParamHeaders.ts
@@ -58,16 +58,13 @@ export type XMcpHeaderScanResult = { valid: true; declarations: readonly XMcpHea
 const RFC9110_TOKEN = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/;
 
 /**
- * JSON Schema `type` values the spec admits on an `x-mcp-header` property.
- *
- * The spec text names `integer`, `string`, `boolean` and explicitly excludes
- * `number`. The published conformance referee at the pinned release ships its
- * `http-custom-headers` scenario with two `type: "number"` `x-mcp-header`
- * parameters and expects the client to mirror them, so `number` is accepted
- * here so that the conformance gate passes; the discrepancy is tracked
- * upstream. Everything else (`object`, `array`, `null`, absent) is rejected.
+ * JSON Schema `type` values the spec admits on an `x-mcp-header` property:
+ * `integer`, `string` and `boolean`. `number` is explicitly not permitted
+ * (2026-07-28 Streamable HTTP, "Schema Extension"), so a tool that annotates a
+ * `number`-typed property is rejected like any other invalid declaration.
+ * Everything else (`object`, `array`, `null`, absent) is rejected too.
  */
-const PERMITTED_X_MCP_HEADER_TYPES: ReadonlySet<string> = new Set(['string', 'integer', 'boolean', 'number']);
+const PERMITTED_X_MCP_HEADER_TYPES: ReadonlySet<string> = new Set(['string', 'integer', 'boolean']);
 
 /**
  * Scan a tool's JSON-serialized `inputSchema` for `x-mcp-header` declarations

--- a/packages/core-internal/test/shared/mcpParamHeaders.test.ts
+++ b/packages/core-internal/test/shared/mcpParamHeaders.test.ts
@@ -144,6 +144,10 @@ describe('scanXMcpHeaderDeclarations — constraint table', () => {
         expect(invalid({ type: 'object', properties: { a: { type: 'array', [X_MCP_HEADER_KEY]: 'Items' } } })).toMatch(/primitive/);
     });
 
+    test('number-typed property is rejected (only integer, string, boolean are permitted)', () => {
+        expect(invalid({ type: 'object', properties: { a: { type: 'number', [X_MCP_HEADER_KEY]: 'Score' } } })).toMatch(/primitive/);
+    });
+
     test('null-typed property is rejected', () => {
         expect(invalid({ type: 'object', properties: { a: { type: 'null', [X_MCP_HEADER_KEY]: 'Nil' } } })).toMatch(/primitive/);
     });


### PR DESCRIPTION
## Motivation and Context

The 2026-07-28 Streamable HTTP spec restricts `x-mcp-header` to primitive parameters, *"MUST only be applied to parameters with primitive types (integer, string, boolean). Parameters with type `number` are not permitted"*, and requires clients to *"reject tool definitions where any `x-mcp-header` value violates these constraints"* by excluding the tool from `tools/list`.

`PERMITTED_X_MCP_HEADER_TYPES` in `core-internal` still allow-listed `'number'`. The comment on it explains why: an older conformance fixture shipped `type: "number"` header parameters and expected clients to mirror them. That fixture was corrected in modelcontextprotocol/conformance#371 (the release this repo pins already uses `integer`), and modelcontextprotocol/conformance#444 adds the negative case, a `number`-typed `x-mcp-header` tool that a conforming client must drop, under the existing `sep-2243-x-mcp-header-primitive-only` check in the scored `http-invalid-tool-headers` scenario. With `'number'` still permitted, this SDK would keep and call that tool and report a failure there once the conformance pin moves past 0.2.0-alpha.11. The python, go, csharp and rust SDKs already reject `number`.

## What changed

- `packages/core-internal/src/shared/mcpParamHeaders.ts`: drop `'number'` from `PERMITTED_X_MCP_HEADER_TYPES`; replace the stale comment.
- `packages/core-internal/test/shared/mcpParamHeaders.test.ts`: add "number-typed property is rejected" alongside the object/array/null cases.
- Changeset (patch: core-internal, client, server).

The numeric comparison paths in `validateMcpParamHeaders` / `mcpParamPrimitiveToString` are untouched (they still serve `integer`).

## How Has This Been Tested?

`pnpm exec vitest run` for `core-internal/test/shared/mcpParamHeaders.test.ts` (61 passed), `client/test/client/mcpParamMirroring.test.ts` (18), `server/test/server/mcpParamValidation.test.ts` (7); `pnpm typecheck` + `pnpm lint` in core-internal; pre-push build/typecheck/lint hooks green.

## Breaking Changes

A tool whose `inputSchema` puts `x-mcp-header` on a `type: "number"` property is now treated as an invalid declaration (client: excluded from `listTools()`; server: registration rejected), as the spec requires. Use `type: "integer"` for numeric header parameters.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the MCP Documentation
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
